### PR TITLE
ref: Make LazyServiceWrapper type-safe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1813,7 +1813,6 @@ module = [
     "tests.sentry.tasks.test_check_auth",
     "tests.sentry.tasks.test_derive_code_mappings",
     "tests.sentry.tasks.test_groupowner",
-    "tests.sentry.tasks.test_low_priority_symbolication",
     "tests.sentry.tasks.test_merge",
     "tests.sentry.tasks.test_post_process",
     "tests.sentry.tasks.test_relay",

--- a/src/sentry/utils/services.py
+++ b/src/sentry/utils/services.py
@@ -7,6 +7,7 @@ import logging
 import threading
 from concurrent import futures
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -18,7 +19,6 @@ from typing import (
     Type,
     TypeVar,
     cast,
-    TYPE_CHECKING
 )
 
 from django.utils.functional import LazyObject, empty
@@ -64,7 +64,6 @@ if TYPE_CHECKING:
     Proxied = TypeVar("Proxied", bound=Service)
 else:
     Proxied = object
-
 
 
 class LazyServiceWrapper(LazyObject, Proxied):
@@ -136,7 +135,6 @@ class LazyServiceWrapper(LazyObject, Proxied):
                 context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)
             else:
                 context[key] = getattr(base_instance, key)
-
 
 
 def resolve_callable(value: str | AnyCallable) -> AnyCallable:

--- a/src/sentry/utils/services.py
+++ b/src/sentry/utils/services.py
@@ -16,7 +16,9 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypeVar,
     cast,
+    TYPE_CHECKING
 )
 
 from django.utils.functional import LazyObject, empty
@@ -58,7 +60,14 @@ class Service:
         """
 
 
-class LazyServiceWrapper(LazyObject):
+if TYPE_CHECKING:
+    Proxied = TypeVar("Proxied", bound=Service)
+else:
+    Proxied = object
+
+
+
+class LazyServiceWrapper(LazyObject, Proxied):
     """
     Lazyily instantiates a standard Sentry service class.
 
@@ -73,7 +82,7 @@ class LazyServiceWrapper(LazyObject):
 
     def __init__(
         self,
-        backend_base: Type[Service],
+        backend_base: Type[Proxied],
         backend_path: str,
         options: Mapping[str, Any],
         dangerous: Optional[Sequence[Type[Service]]] = (),
@@ -127,6 +136,7 @@ class LazyServiceWrapper(LazyObject):
                 context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)
             else:
                 context[key] = getattr(base_instance, key)
+
 
 
 def resolve_callable(value: str | AnyCallable) -> AnyCallable:


### PR DESCRIPTION
Now it should be possible to access `<service_module>.backend.method`
instead of `<service_module>.method` for improved type-safety, while
keeping lazy imports in place.

We can start doing that gradually (some stuff around relay and symbolicator tests already does it), and when that is done also get rid of all the stray `if TYPE_CHECKING:` blocks in service's init files