### PR TITLE
feat(trends): Enable any trend request for transaction summary

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -79,11 +79,13 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
     },
   ];
   const rest = {...props, eventView};
-  eventView.additionalConditions.addFilterValues('tpm()', ['>0.01']);
   if (!organization.features.includes('performance-new-trends')) {
+    eventView.additionalConditions.addFilterValues('tpm()', ['>0.01']);
     eventView.additionalConditions.addFilterValues('count_percentage()', ['>0.25', '<4']);
     eventView.additionalConditions.addFilterValues('trend_percentage()', ['>0%']);
     eventView.additionalConditions.addFilterValues('confidence()', ['>6']);
+  } else {
+    eventView.additionalConditions.addFilterValues('tpm()', ['>0.5']);
   }
 
   const chart = useMemo<QueryDefinition<DataType, WidgetDataResult>>(

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -85,7 +85,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
     eventView.additionalConditions.addFilterValues('trend_percentage()', ['>0%']);
     eventView.additionalConditions.addFilterValues('confidence()', ['>6']);
   } else {
-    eventView.additionalConditions.addFilterValues('tpm()', ['>0.5']);
+    eventView.additionalConditions.addFilterValues('tpm()', ['>0.1']);
   }
 
   const chart = useMemo<QueryDefinition<DataType, WidgetDataResult>>(

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
@@ -141,13 +141,7 @@ function TrendChart({
   const trendDisplay = generateTrendFunctionAsString(trendFunction, trendParameter);
 
   const trendView = eventView.clone() as TrendView;
-  modifyTrendView(
-    trendView,
-    location,
-    TrendChangeType.REGRESSION,
-    projects,
-    organization
-  );
+  modifyTrendView(trendView, location, TrendChangeType.ANY, projects, organization);
 
   function transformTimeseriesData(
     data: EventsStatsData,
@@ -192,7 +186,7 @@ function TrendChart({
             // keep trend change type as regression until the backend can support passing the type
             const selectedTransaction = getSelectedTransaction(
               location,
-              TrendChangeType.REGRESSION,
+              TrendChangeType.ANY,
               events
             );
 

--- a/static/app/views/performance/trends/types.tsx
+++ b/static/app/views/performance/trends/types.tsx
@@ -34,6 +34,7 @@ export type TrendParameter = {
 export enum TrendChangeType {
   IMPROVED = 'improved',
   REGRESSION = 'regression',
+  ANY = 'any',
 }
 
 export enum TrendFunctionField {

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -433,6 +433,6 @@ export function transformEventStatsSmoothed(data?: Series[], seriesName?: string
 
 export function modifyTransactionNameTrendsQuery(trendView: TrendView) {
   const query = new MutableSearch(trendView.query);
-  query.setFilterValues('tpm()', ['>0.01']);
+  query.setFilterValues('tpm()', ['>0.5']);
   trendView.query = query.formatString();
 }

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -241,8 +241,7 @@ export function modifyTrendView(
   const trendFunction = getCurrentTrendFunction(location);
   const trendParameter = getCurrentTrendParameter(location, projects, trendView.project);
 
-  const transactionField = ['transaction'];
-  const fields = [...transactionField, 'project'].map(field => ({
+  const fields = ['transaction', 'project'].map(field => ({
     field,
   })) as Field[];
 
@@ -433,6 +432,6 @@ export function transformEventStatsSmoothed(data?: Series[], seriesName?: string
 
 export function modifyTransactionNameTrendsQuery(trendView: TrendView) {
   const query = new MutableSearch(trendView.query);
-  query.setFilterValues('tpm()', ['>0.5']);
+  query.setFilterValues('tpm()', ['>0.1']);
   trendView.query = query.formatString();
 }

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -236,13 +236,12 @@ export function modifyTrendView(
   location: Location,
   trendsType: TrendChangeType,
   projects: Project[],
-  organization: OrganizationSummary,
-  isProjectOnly?: boolean
+  organization: OrganizationSummary
 ) {
   const trendFunction = getCurrentTrendFunction(location);
   const trendParameter = getCurrentTrendParameter(location, projects, trendView.project);
 
-  const transactionField = isProjectOnly ? [] : ['transaction'];
+  const transactionField = ['transaction'];
   const fields = [...transactionField, 'project'].map(field => ({
     field,
   })) as Field[];

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -235,13 +235,15 @@ export function trendsTargetRoute({
 
   const modifiedConditions = initialConditions ?? new MutableSearch([]);
 
-  if (conditions.hasFilter('tpm()')) {
-    modifiedConditions.setFilterValues('tpm()', conditions.getFilterValues('tpm()'));
-  } else {
-    modifiedConditions.setFilterValues('tpm()', ['>0.01']);
-  }
-  // Metrics don't support duration filters
+  // Trends on metrics don't need these conditions
   if (!organization.features.includes('performance-new-trends')) {
+    // No need to carry over tpm filters to transaction summary
+    if (conditions.hasFilter('tpm()')) {
+      modifiedConditions.setFilterValues('tpm()', conditions.getFilterValues('tpm()'));
+    } else {
+      modifiedConditions.setFilterValues('tpm()', ['>0.01']);
+    }
+
     if (conditions.hasFilter('transaction.duration')) {
       modifiedConditions.setFilterValues(
         'transaction.duration',


### PR DESCRIPTION
- make frontend send `TrendChangeType.ANY` to the backend so that the breakpoint analysis can determine whether there was an improvement or a regression
- remove `tpm:>0.1` filter navigating from trends to transaction summary
- relies on https://github.com/getsentry/sentry/pull/50808