### PR TITLE
feat(frame): Store 'lock' property of frame on event json

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -154,6 +154,7 @@ class Frame(Interface):
             "trust",
             "vars",
             "snapshot",
+            "lock",
         ):
             data.setdefault(key, None)
 
@@ -184,6 +185,7 @@ class Frame(Interface):
                 "errors": self.errors or None,
                 "lineno": self.lineno,
                 "colno": self.colno,
+                "lock": self.lock,
             }
         )
 
@@ -213,6 +215,7 @@ class Frame(Interface):
             "inApp": self.in_app,
             "trust": self.trust,
             "errors": self.errors,
+            "lock": self.lock,
         }
         if not is_public:
             data["vars"] = self.vars
@@ -274,6 +277,7 @@ class Frame(Interface):
             "inApp": meta.get("in_app"),
             "trust": meta.get("trust"),
             "errors": meta.get("errors"),
+            "lock": meta.get("lock"),
         }
 
     def is_url(self):

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_basic.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_basic.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2019-04-30T08:25:08.305752Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_exception.py
 ---
 errors: null
@@ -22,6 +20,7 @@ get_api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null
@@ -50,6 +49,7 @@ get_api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_mechanism.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_mechanism.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2023-05-05T19:28:49.089651Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_exception.py
 ---
 errors: null
@@ -25,6 +23,7 @@ get_api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_mixed_frames.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_mixed_frames.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2019-04-30T08:25:08.353517Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_exception.py
 ---
 errors: null
@@ -22,6 +20,7 @@ get_api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null
@@ -50,6 +49,7 @@ get_api_context:
         inApp: false
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_only_app_frames.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_only_app_frames.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2021-02-15T10:54:23.648255Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_exception.py
 ---
 errors: null
@@ -22,6 +20,7 @@ get_api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null
@@ -50,6 +49,7 @@ get_api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_only_system_frames.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_only_system_frames.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2019-04-30T08:25:08.388370Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_exception.py
 ---
 errors: null
@@ -22,6 +20,7 @@ get_api_context:
         inApp: false
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null
@@ -50,6 +49,7 @@ get_api_context:
         inApp: false
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_raw_stacks.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_raw_stacks.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2019-04-30T08:25:08.423212Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_exception.py
 ---
 errors: null
@@ -21,6 +19,7 @@ get_api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null
@@ -43,6 +42,7 @@ get_api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_symbols.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_symbols.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2019-04-30T08:25:08.369051Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_exception.py
 ---
 errors: null
@@ -22,6 +20,7 @@ get_api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_two_exceptions_having_mechanism.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_two_exceptions_having_mechanism.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2023-05-05T19:28:49.100372Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_exception.py
 ---
 errors: null
@@ -27,6 +25,7 @@ get_api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null
@@ -60,6 +59,7 @@ get_api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_threads/test_basics.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_threads/test_basics.pysnap
@@ -25,6 +25,7 @@ api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null
@@ -47,6 +48,7 @@ api_context:
         inApp: true
         instructionAddr: null
         lineNo: 1
+        lock: null
         module: null
         package: null
         platform: null


### PR DESCRIPTION
We want to extract this field to display it later in the UI. Related to https://github.com/getsentry/relay/pull/2171