### PR TITLE
feat(starfish): Add span metrics tests

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -91,6 +91,32 @@ class BaseQueryBuilder:
     requires_organization_condition: bool = False
     organization_column: str = "organization.id"
 
+    def get_middle(self):
+        """Get the middle for comparison functions"""
+        if self.start is None or self.end is None:
+            raise InvalidSearchQuery("Need both start & end to use percent_change")
+        return self.start + (self.end - self.start) / 2
+
+    def first_half_condition(self):
+        """Create the first half condition for percent_change functions"""
+        return Function(
+            "less",
+            [
+                self.column("timestamp"),
+                Function("toDateTime", [self.get_middle()]),
+            ],
+        )
+
+    def second_half_condition(self):
+        """Create the second half condition for percent_change functions"""
+        return Function(
+            "greaterOrEquals",
+            [
+                self.column("timestamp"),
+                Function("toDateTime", [self.get_middle()]),
+            ],
+        )
+
 
 class QueryBuilder(BaseQueryBuilder):
     """Builds a discover query"""

--- a/src/sentry/search/events/datasets/base.py
+++ b/src/sentry/search/events/datasets/base.py
@@ -1,7 +1,7 @@
 import abc
 from typing import Any, Callable, Dict, List, Mapping, Optional, Set, cast
 
-from snuba_sdk import Function, OrderBy
+from snuba_sdk import OrderBy
 
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import InvalidSearchQuery
@@ -55,29 +55,3 @@ class DatasetConfig(abc.ABC):
                 return cast(str, argument.get_type(value))
 
         return result_type_fn
-
-    def _get_middle(self):
-        """Get the middle for percent change functions"""
-        if self.builder.start is None or self.builder.end is None:
-            raise InvalidSearchQuery("Need both start & end to use percentile_percent_change")
-        return self.builder.start + (self.builder.end - self.builder.start) / 2
-
-    def _first_half_condition(self):
-        """Create the first half condition for percent_change functions"""
-        return Function(
-            "less",
-            [
-                self.builder.column("timestamp"),
-                Function("toDateTime", [self._get_middle()]),
-            ],
-        )
-
-    def _second_half_condition(self):
-        """Create the second half condition for percent_change functions"""
-        return Function(
-            "greaterOrEquals",
-            [
-                self.builder.column("timestamp"),
-                Function("toDateTime", [self._get_middle()]),
-            ],
-        )

--- a/src/sentry/search/events/datasets/base.py
+++ b/src/sentry/search/events/datasets/base.py
@@ -1,7 +1,7 @@
 import abc
 from typing import Any, Callable, Dict, List, Mapping, Optional, Set, cast
 
-from snuba_sdk import OrderBy
+from snuba_sdk import Function, OrderBy
 
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import InvalidSearchQuery
@@ -55,3 +55,29 @@ class DatasetConfig(abc.ABC):
                 return cast(str, argument.get_type(value))
 
         return result_type_fn
+
+    def _get_middle(self):
+        """Get the middle for percent change functions"""
+        if self.builder.start is None or self.builder.end is None:
+            raise InvalidSearchQuery("Need both start & end to use percentile_percent_change")
+        return self.builder.start + (self.builder.end - self.builder.start) / 2
+
+    def _first_half_condition(self):
+        """Create the first half condition for percent_change functions"""
+        return Function(
+            "less",
+            [
+                self.builder.column("timestamp"),
+                Function("toDateTime", [self._get_middle()]),
+            ],
+        )
+
+    def _second_half_condition(self):
+        """Create the second half condition for percent_change functions"""
+        return Function(
+            "greaterOrEquals",
+            [
+                self.builder.column("timestamp"),
+                Function("toDateTime", [self._get_middle()]),
+            ],
+        )

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -1264,8 +1264,8 @@ class MetricsDatasetConfig(DatasetConfig):
         _: Mapping[str, Union[str, Column, SelectType, int, float]],
         alias: Optional[str] = None,
     ) -> SelectType:
-        first_half = self._resolve_http_error_count({}, None, self._first_half_condition())
-        second_half = self._resolve_http_error_count({}, None, self._second_half_condition())
+        first_half = self._resolve_http_error_count({}, None, self.builder.first_half_condition())
+        second_half = self._resolve_http_error_count({}, None, self.builder.second_half_condition())
         return self._resolve_percent_change_function(first_half, second_half, alias)
 
     def _resolve_percentile_percent_change(
@@ -1277,13 +1277,13 @@ class MetricsDatasetConfig(DatasetConfig):
             args=args,
             alias=None,
             fixed_percentile=args["percentile"],
-            extra_conditions=[self._first_half_condition()],
+            extra_conditions=[self.builder.first_half_condition()],
         )
         second_half = function_aliases.resolve_metrics_percentile(
             args=args,
             alias=None,
             fixed_percentile=args["percentile"],
-            extra_conditions=[self._second_half_condition()],
+            extra_conditions=[self.builder.second_half_condition()],
         )
         return self._resolve_percent_change_function(first_half, second_half, alias)
 
@@ -1292,8 +1292,8 @@ class MetricsDatasetConfig(DatasetConfig):
         args: Mapping[str, Union[str, Column, SelectType, int, float]],
         alias: Optional[str] = None,
     ) -> SelectType:
-        first_half = self._resolve_epm(args, None, self._first_half_condition())
-        second_half = self._resolve_epm(args, None, self._second_half_condition())
+        first_half = self._resolve_epm(args, None, self.builder.first_half_condition())
+        second_half = self._resolve_epm(args, None, self.builder.second_half_condition())
         return self._resolve_percent_change_function(first_half, second_half, alias)
 
     def _resolve_eps_percent_change(
@@ -1301,8 +1301,8 @@ class MetricsDatasetConfig(DatasetConfig):
         args: Mapping[str, Union[str, Column, SelectType, int, float]],
         alias: Optional[str] = None,
     ) -> SelectType:
-        first_half = self._resolve_eps(args, None, self._first_half_condition())
-        second_half = self._resolve_eps(args, None, self._second_half_condition())
+        first_half = self._resolve_eps(args, None, self.builder.first_half_condition())
+        second_half = self._resolve_eps(args, None, self.builder.second_half_condition())
         return self._resolve_percent_change_function(first_half, second_half, alias)
 
     def _resolve_percent_change_function(self, first_half, second_half, alias):

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -1259,32 +1259,6 @@ class MetricsDatasetConfig(DatasetConfig):
             alias,
         )
 
-    def _get_middle(self):
-        """Get the middle for percent change functions"""
-        if self.builder.start is None or self.builder.end is None:
-            raise InvalidSearchQuery("Need both start & end to use percentile_percent_change")
-        return self.builder.start + (self.builder.end - self.builder.start) / 2
-
-    def _first_half_condition(self):
-        """Create the first half condition for percent_change functions"""
-        return Function(
-            "less",
-            [
-                Function("toDateTime", [self._get_middle()]),
-                self.builder.column("timestamp"),
-            ],
-        )
-
-    def _second_half_condition(self):
-        """Create the second half condition for percent_change functions"""
-        return Function(
-            "greaterOrEquals",
-            [
-                Function("toDateTime", [self._get_middle()]),
-                self.builder.column("timestamp"),
-            ],
-        )
-
     def _resolve_http_error_count_percent_change(
         self,
         _: Mapping[str, Union[str, Column, SelectType, int, float]],

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -489,8 +489,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         return Function(
             "less",
             [
-                Function("toDateTime", [self._get_middle()]),
                 self.builder.column("timestamp"),
+                Function("toDateTime", [self._get_middle()]),
             ],
         )
 
@@ -499,8 +499,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         return Function(
             "greaterOrEquals",
             [
-                Function("toDateTime", [self._get_middle()]),
                 self.builder.column("timestamp"),
+                Function("toDateTime", [self._get_middle()]),
             ],
         )
 

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -483,8 +483,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         _: Mapping[str, Union[str, Column, SelectType, int, float]],
         alias: Optional[str] = None,
     ) -> SelectType:
-        first_half = self._resolve_http_error_count({}, None, self._first_half_condition())
-        second_half = self._resolve_http_error_count({}, None, self._second_half_condition())
+        first_half = self._resolve_http_error_count({}, None, self.builder.first_half_condition())
+        second_half = self._resolve_http_error_count({}, None, self.builder.second_half_condition())
         return self._resolve_percent_change_function(first_half, second_half, alias)
 
     def _resolve_percentile_percent_change(
@@ -496,13 +496,13 @@ class SpansMetricsDatasetConfig(DatasetConfig):
             args=args,
             alias=None,
             fixed_percentile=args["percentile"],
-            extra_conditions=[self._first_half_condition()],
+            extra_conditions=[self.builder.first_half_condition()],
         )
         second_half = function_aliases.resolve_metrics_percentile(
             args=args,
             alias=None,
             fixed_percentile=args["percentile"],
-            extra_conditions=[self._second_half_condition()],
+            extra_conditions=[self.builder.second_half_condition()],
         )
         return self._resolve_percent_change_function(first_half, second_half, alias)
 
@@ -511,8 +511,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         args: Mapping[str, Union[str, Column, SelectType, int, float]],
         alias: Optional[str] = None,
     ) -> SelectType:
-        first_half = self._resolve_epm(args, None, self._first_half_condition())
-        second_half = self._resolve_epm(args, None, self._second_half_condition())
+        first_half = self._resolve_epm(args, None, self.builder.first_half_condition())
+        second_half = self._resolve_epm(args, None, self.builder.second_half_condition())
         return self._resolve_percent_change_function(first_half, second_half, alias)
 
     def _resolve_eps_percent_change(
@@ -520,8 +520,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         args: Mapping[str, Union[str, Column, SelectType, int, float]],
         alias: Optional[str] = None,
     ) -> SelectType:
-        first_half = self._resolve_eps(args, None, self._first_half_condition())
-        second_half = self._resolve_eps(args, None, self._second_half_condition())
+        first_half = self._resolve_eps(args, None, self.builder.first_half_condition())
+        second_half = self._resolve_eps(args, None, self.builder.second_half_condition())
         return self._resolve_percent_change_function(first_half, second_half, alias)
 
     def _resolve_percent_change_function(self, first_half, second_half, alias):

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -5,7 +5,7 @@ from typing import Callable, Mapping, Optional, Union
 from snuba_sdk import Column, Function, OrderBy
 
 from sentry.api.event_search import SearchFilter
-from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
+from sentry.exceptions import IncompatibleMetricsQuery
 from sentry.search.events import builder, constants, fields
 from sentry.search.events.datasets import function_aliases
 from sentry.search.events.datasets.base import DatasetConfig
@@ -476,32 +476,6 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                 else Function("divide", [args["interval"], interval]),
             ],
             alias,
-        )
-
-    def _get_middle(self):
-        """Get the middle for percent change functions"""
-        if self.builder.start is None or self.builder.end is None:
-            raise InvalidSearchQuery("Need both start & end to use percentile_percent_change")
-        return self.builder.start + (self.builder.end - self.builder.start) / 2
-
-    def _first_half_condition(self):
-        """Create the first half condition for percent_change functions"""
-        return Function(
-            "less",
-            [
-                self.builder.column("timestamp"),
-                Function("toDateTime", [self._get_middle()]),
-            ],
-        )
-
-    def _second_half_condition(self):
-        """Create the second half condition for percent_change functions"""
-        return Function(
-            "greaterOrEquals",
-            [
-                self.builder.column("timestamp"),
-                Function("toDateTime", [self._get_middle()]),
-            ],
         )
 
     def _resolve_http_error_count_percent_change(

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1,0 +1,374 @@
+import pytest
+from django.urls import reverse
+
+from sentry.testutils import MetricsEnhancedPerformanceTestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.silo import region_silo_test
+
+pytestmark = pytest.mark.sentry_metrics
+
+
+@region_silo_test
+class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPerformanceTestCase):
+    viewname = "sentry-api-0-organization-events"
+
+    # Poor intentionally omitted for test_measurement_rating_that_does_not_exist
+    METRIC_STRINGS = [
+        "foo_transaction",
+        "bar_transaction",
+    ]
+
+    def setUp(self):
+        super().setUp()
+        self.min_ago = before_now(minutes=1)
+        self.six_min_ago = before_now(minutes=6)
+        self.features = {
+            "organizations:starfish-view": True,
+        }
+
+    def do_request(self, query, features=None):
+        if features is None:
+            features = {"organizations:discover-basic": True}
+        features.update(self.features)
+        self.login_as(user=self.user)
+        url = reverse(
+            self.viewname,
+            kwargs={"organization_slug": self.organization.slug},
+        )
+        with self.feature(features):
+            return self.client.get(url, query, format="json")
+
+    def test_p50_with_no_data(self):
+        response = self.do_request(
+            {
+                "field": ["p50()"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["p50()"] == 0
+        assert meta["dataset"] == "spansMetrics"
+
+    def test_count(self):
+        self.store_span_metric(
+            1,
+            timestamp=self.min_ago,
+        )
+        response = self.do_request(
+            {
+                "field": ["count()"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["count()"] == 1
+        assert meta["dataset"] == "spansMetrics"
+
+    def test_count_unique(self):
+        self.store_span_metric(
+            1,
+            "user",
+            timestamp=self.min_ago,
+        )
+        self.store_span_metric(
+            2,
+            "user",
+            timestamp=self.min_ago,
+        )
+        response = self.do_request(
+            {
+                "field": ["count_unique(user)"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["count_unique(user)"] == 2
+        assert meta["dataset"] == "spansMetrics"
+
+    def test_sum(self):
+        self.store_span_metric(
+            321,
+            timestamp=self.min_ago,
+        )
+        self.store_span_metric(
+            99,
+            timestamp=self.min_ago,
+        )
+        response = self.do_request(
+            {
+                "field": ["sum(span.duration)"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["sum(span.duration)"] == 420
+        assert meta["dataset"] == "spansMetrics"
+
+    # TODO(wmak)
+    # test_percentile
+
+    def test_p50(self):
+        self.store_span_metric(
+            1,
+            timestamp=self.min_ago,
+        )
+        response = self.do_request(
+            {
+                "field": ["p50()"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["p50()"] == 1
+        assert meta["dataset"] == "spansMetrics"
+
+    def test_eps(self):
+        for _ in range(6):
+            self.store_span_metric(
+                1,
+                timestamp=self.min_ago,
+            )
+        response = self.do_request(
+            {
+                "field": ["eps()", "sps()"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["eps()"] == 0.01
+        assert data[0]["sps()"] == 0.01
+        assert meta["dataset"] == "spansMetrics"
+
+    def test_epm(self):
+        for _ in range(6):
+            self.store_span_metric(
+                1,
+                timestamp=self.min_ago,
+            )
+        response = self.do_request(
+            {
+                "field": ["epm()", "spm()"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["epm()"] == 0.6
+        assert data[0]["spm()"] == 0.6
+        assert meta["dataset"] == "spansMetrics"
+
+    def test_time_spent_percentage(self):
+        for _ in range(4):
+            self.store_span_metric(
+                1,
+                tags={"transaction": "foo_transaction"},
+                timestamp=self.min_ago,
+            )
+        self.store_span_metric(
+            1,
+            tags={"transaction": "bar_transaction"},
+            timestamp=self.min_ago,
+        )
+        response = self.do_request(
+            {
+                "field": ["transaction", "time_spent_percentage()"],
+                "query": "",
+                "orderby": ["-time_spent_percentage()"],
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+        assert data[0]["time_spent_percentage()"] == 0.8
+        assert data[0]["transaction"] == "foo_transaction"
+        assert data[1]["time_spent_percentage()"] == 0.2
+        assert data[1]["transaction"] == "bar_transaction"
+        assert meta["dataset"] == "spansMetrics"
+
+    def test_http_error_rate_and_count(self):
+        for _ in range(4):
+            self.store_span_metric(
+                1,
+                tags={"span.status_code": "500"},
+                timestamp=self.min_ago,
+            )
+        self.store_span_metric(
+            1,
+            tags={"span.status_code": "200"},
+            timestamp=self.min_ago,
+        )
+        response = self.do_request(
+            {
+                "field": ["http_error_count()", "http_error_rate()"],
+                "query": "",
+                "orderby": ["-http_error_rate()"],
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["http_error_rate()"] == 0.8
+        assert meta["dataset"] == "spansMetrics"
+        assert meta["fields"]["http_error_count()"] == "integer"
+        assert meta["fields"]["http_error_rate()"] == "percentage"
+
+    def percentile_percent_change(self):
+        self.store_span_metric(
+            5,
+            timestamp=self.six_min_ago,
+        )
+        self.store_span_metric(
+            10,
+            timestamp=self.min_ago,
+        )
+        response = self.do_request(
+            {
+                "field": ["percentile_percent_change(span.duration)"],
+                "query": "",
+                "orderby": ["-percentile_percent_change()"],
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["percentile_percent_change()"] == 1
+        assert meta["dataset"] == "spansMetrics"
+        assert meta["fields"]["percentile_percent_change()"] == "percentage"
+
+    def test_http_error_count_percent_change(self):
+        for _ in range(4):
+            self.store_span_metric(
+                1,
+                tags={"span.status_code": "500"},
+                timestamp=self.six_min_ago,
+            )
+        self.store_span_metric(
+            1,
+            tags={"span.status_code": "500"},
+            timestamp=self.min_ago,
+        )
+        response = self.do_request(
+            {
+                "field": ["http_error_count_percent_change()"],
+                "query": "",
+                "orderby": ["-http_error_count_percent_change()"],
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["http_error_count_percent_change()"] == -0.75
+        assert meta["dataset"] == "spansMetrics"
+        assert meta["fields"]["http_error_count_percent_change()"] == "percentage"
+
+    def test_epm_percent_change(self):
+        for _ in range(4):
+            self.store_span_metric(
+                1,
+                timestamp=self.six_min_ago,
+            )
+        self.store_span_metric(
+            1,
+            timestamp=self.min_ago,
+        )
+        response = self.do_request(
+            {
+                "field": ["epm_percent_change()", "spm_percent_change()"],
+                "query": "",
+                "orderby": ["-epm_percent_change()"],
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["epm_percent_change()"] == pytest.approx(-0.75)
+        assert data[0]["spm_percent_change()"] == pytest.approx(-0.75)
+        assert meta["dataset"] == "spansMetrics"
+        assert meta["fields"]["epm_percent_change()"] == "percentage"
+        assert meta["fields"]["spm_percent_change()"] == "percentage"
+
+    def test_eps_percent_change(self):
+        for _ in range(4):
+            self.store_span_metric(
+                1,
+                timestamp=self.min_ago,
+            )
+        self.store_span_metric(
+            1,
+            timestamp=self.six_min_ago,
+        )
+        response = self.do_request(
+            {
+                "field": ["eps_percent_change()", "sps_percent_change()"],
+                "query": "",
+                "orderby": ["-eps_percent_change()"],
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["eps_percent_change()"] == pytest.approx(3)
+        assert data[0]["sps_percent_change()"] == pytest.approx(3)
+        assert meta["dataset"] == "spansMetrics"
+        assert meta["fields"]["eps_percent_change()"] == "percentage"
+        assert meta["fields"]["sps_percent_change()"] == "percentage"


### PR DESCRIPTION
- This adds tests for the span metrics dataset
- Fixes a bug where the second half and first half conditions were actually flipped
  - This is cause for example with first_half it was:
    - less(middle, timestamp) -> middle < timestamp
  - When it shoudl instead be
    - less(timestamp, middle) -> timestamp < middle