### PR TITLE
feat(hybridcloud) Run celery workers for each silo 

### DIFF
--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -121,7 +121,8 @@ class OutboxBase(Model):
 
     @classmethod
     def prepare_next_from_shard(cls, row: Mapping[str, Any]) -> OutboxBase | None:
-        with transaction.atomic(savepoint=False):
+        using = router.db_for_write(cls)
+        with transaction.atomic(using=using, savepoint=False):
             next_outbox: OutboxBase | None
             next_outbox = (
                 cls(**row).selected_messages_in_shard().order_by("id").select_for_update().first()

--- a/src/sentry/tasks/organization_mapping.py
+++ b/src/sentry/tasks/organization_mapping.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import metrics
 from sentry.utils.query import RangeQuerySetWrapper
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
     queue="hybrid_cloud.control_repair",
     default_retry_delay=5,
     max_retries=5,
+    silo_mode=SiloMode.CONTROL,
 )
 @retry
 def repair_mappings() -> None:

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -48,6 +48,12 @@ TASK_OPTIONS = {
     "default_retry_delay": (60 * 5),  # Five minutes.
     "max_retries": 3,
 }
+CONTROL_TASK_OPTIONS = {
+    "queue": "app_platform.control",
+    "default_retry_delay": (60 * 5),  # Five minutes.
+    "max_retries": 3,
+    "silo_mode": SiloMode.CONTROL,
+}
 
 RETRY_OPTIONS = {
     "on": (RequestException, ApiHostError, ApiTimeoutError),
@@ -239,9 +245,7 @@ def process_resource_change_bound(self, action, sender, instance_id, *args, **kw
     _process_resource_change(action, sender, instance_id, retryer=self, *args, **kwargs)
 
 
-@instrumented_task(
-    name="sentry.tasks.sentry_apps.installation_webhook", silo_mode=SiloMode.CONTROL, **TASK_OPTIONS
-)
+@instrumented_task(name="sentry.tasks.sentry_apps.installation_webhook", **CONTROL_TASK_OPTIONS)
 @retry(**RETRY_OPTIONS)
 def installation_webhook(installation_id, user_id, *args, **kwargs):
     from sentry.mediators.sentry_app_installations import InstallationNotifier


### PR DESCRIPTION
When silo mode is enabled with `SENTRY_USE_SILOS=1` we need to run a separate celery worker and celery cron process. I've put the control silo tasks on a separate MQ exchange from the region silo tasks to that we don't get cross silo message delivery.

There are still a few tasks with silo boundary errors, but we can patch those up individually.