### PR TITLE
ref(sort): Add experiment feature flag

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -283,14 +283,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         :qparam list expand: an optional list of strings to opt in to additional data. Supports `inbox`
         :qparam list collapse: an optional list of strings to opt out of certain pieces of data. Supports `stats`, `lifetime`, `base`
         """
-
-        if request.GET.get("sort") == "betterPriority" and not features.has(
-            "organizations:issue-list-better-priority-sort", organization, actor=request.user
-        ):
-            return Response(
-                {"detail": "This organization does not have the better priority sort feature."},
-                status=400,
-            )
         stats_period = request.GET.get("groupStatsPeriod")
         try:
             start, end = get_date_range_from_stats_period(request.GET)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1388,6 +1388,8 @@ SENTRY_FEATURES = {
     "organizations:issue-list-prefetch-issue-on-hover": False,
     # Enable better priority sort algorithm.
     "organizations:issue-list-better-priority-sort": False,
+    # Enable better priority sort experiment
+    "organizations:better-priority-sort-experiment": False,
     # Adds the ttid & ttfd vitals to the frontend
     "organizations:mobile-vitals": False,
     # Display CPU and memory metrics in transactions with profiles

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -90,6 +90,7 @@ default_manager.add("organizations:issue-details-replay-event", OrganizationFeat
 default_manager.add("organizations:issue-details-tag-improvements", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-list-prefetch-issue-on-hover", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-list-better-priority-sort", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:better-priority-sort-experiment", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-platform", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-use-cdc-primary", OrganizationFeature, FeatureHandlerStrategy.REMOTE)


### PR DESCRIPTION
Add another feature flag to manage the priority sort experiment rollout (and remove an unnecessary flag check for the other flag). 