### PR TITLE
fix(rulesnooze): Change text in email

### DIFF
--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -34,7 +34,7 @@
       <div class="container">
         {% with rule_details=rules_details|get_item:rule.id snooze_alert_url=snooze_alert_urls|get_item:rule.id %}
         {% if snooze_alert %}
-            <a class="mute" href="{% absolute_uri snooze_alert_url %}">Mute alert for me</a>
+            <a class="mute" href="{% absolute_uri snooze_alert_url %}">Mute this alert</a>
         {% endif %}
             This email was triggered by <a href="{% absolute_uri rule_details.status_url %}">{{ rule_details.label }}</a>
         {% endwith %}

--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -249,7 +249,7 @@
 
     <p class="info-box">
       {% if snooze_alert %}
-         <a class='mute' href="{% absolute_uri snooze_alert_url %}">Mute for me</a>
+         <a class='mute' href="{% absolute_uri snooze_alert_url %}">Mute this alert</a>
       {% endif %}
       This email was triggered by
       {% for rule in rules %}


### PR DESCRIPTION
this pr changes the text in the email for muting alerts to match the changes made in https://github.com/getsentry/sentry/pull/49573/ . Now, clicking mute will essentially "click" whatever the default mute button is for that alert (which depends on the notifications send for the alert). For example, clicking "Mute this alert" for an alert that just sends the default notification will only mute for the user. 