### PR TITLE
feat(replays): Add logging for rage click breadcrumbs

### DIFF
--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -149,7 +149,7 @@ def get_user_actions(
 
                 report_dead_click_issue(project_id, replay_id, cast(SentryEvent, event))
                 continue
-            elif category == "ui.rageClickDetected":
+            elif category == "ui.multiClick":
                 # Log the event for tracking.
                 log = event["data"].get("payload", {}).copy()
                 log["project_id"] = project_id

--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -149,6 +149,14 @@ def get_user_actions(
 
                 report_dead_click_issue(project_id, replay_id, cast(SentryEvent, event))
                 continue
+            elif category == "ui.rageClickDetected":
+                # Log the event for tracking.
+                log = event["data"].get("payload", {}).copy()
+                log["project_id"] = project_id
+                log["replay_id"] = replay_id
+                log["dom_tree"] = log.pop("message")
+                logger.info("sentry.replays.slow_click", extra=log)
+                continue
             elif category == "ui.click":
                 node = payload.get("data", {}).get("node")
                 if node is None:


### PR DESCRIPTION
Accompanying SDK PR (relevant line highlighted): https://github.com/getsentry/sentry-javascript/pull/8322/files#diff-6c3e4145c4e3faa38194052e4dd68831e16860167c2bee6ad50798c5d94fb416R43