### PR TITLE
fix: remove reviewers from jest balance

### DIFF
--- a/.github/workflows/jest-balance.yml
+++ b/.github/workflows/jest-balance.yml
@@ -35,9 +35,6 @@ jobs:
             tests/js/test-balancer/jest-balance.json
           commit-message: 'ci(jest): regenerate jest-balance.json'
           branch: 'ci/jest/rebalance-tests'
-          reviewers: ${{ github.triggering_actor }}
-          team-reviewers: |
-            getsentry/app-frontend
           delete-branch: true
           base: master
           title: 'ci(jest): regenerate jest-balance.json'


### PR DESCRIPTION
This seems to have been failing for a while now because getsentry/app-frontend is not a collaborator to sentry? Not sure what changed, but we can just remove the reviewers and manually approve the changes (it will just keep updating the PR in case nobody approves)