### PR TITLE
fix(starfish) Prevent frontend query refetching

### DIFF
--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -142,9 +142,11 @@ export function useWrappedDiscoverTimeseriesQuery({
 export function useWrappedDiscoverQuery({
   eventView,
   initialData,
+  enabled,
   referrer,
   limit,
 }: {
+  enabled: boolean;
   eventView: EventView;
   initialData?: any;
   limit?: number;
@@ -158,6 +160,10 @@ export function useWrappedDiscoverQuery({
     location,
     referrer,
     limit,
+    options: {
+      enabled,
+      refetchOnWindowFocus: false,
+    },
   });
   return {isLoading, data: isLoading && initialData ? initialData : data?.data};
 }

--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -146,8 +146,8 @@ export function useWrappedDiscoverQuery({
   referrer,
   limit,
 }: {
-  enabled: boolean;
   eventView: EventView;
+  enabled?: boolean;
   initialData?: any;
   limit?: number;
   referrer?: string;


### PR DESCRIPTION
There was one case where we forgot to turn it off. A very common case, sorry!
