### PR TITLE
ref(crons): Paginate main monitor listing page

### DIFF
--- a/static/app/views/monitors/components/overviewTable.tsx
+++ b/static/app/views/monitors/components/overviewTable.tsx
@@ -1,7 +1,5 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
 import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
@@ -15,10 +13,9 @@ import {MonitorRow} from './row';
 
 interface Props {
   monitorList: Monitor[];
-  monitorListPageLinks?: string | null;
 }
 
-export function OverviewTable({monitorList, monitorListPageLinks}: Props) {
+export function OverviewTable({monitorList}: Props) {
   const location = useLocation();
   const organization = useOrganization();
   const queryClient = useQueryClient();
@@ -56,30 +53,27 @@ export function OverviewTable({monitorList, monitorListPageLinks}: Props) {
   );
 
   return (
-    <Fragment>
-      <StyledPanelTable
-        headers={[
-          t('Monitor Name'),
-          t('Status'),
-          t('Schedule'),
-          t('Next Checkin'),
-          t('Project'),
-          t('Environment'),
-          t('Actions'),
-        ]}
-      >
-        {monitorList
-          ?.map(monitor =>
-            monitor.environments.length > 0
-              ? monitor.environments.map(monitorEnv =>
-                  renderMonitorRow(monitor, monitorEnv)
-                )
-              : renderMonitorRow(monitor)
-          )
-          .flat()}
-      </StyledPanelTable>
-      {monitorListPageLinks && <Pagination pageLinks={monitorListPageLinks} />}
-    </Fragment>
+    <StyledPanelTable
+      headers={[
+        t('Monitor Name'),
+        t('Status'),
+        t('Schedule'),
+        t('Next Checkin'),
+        t('Project'),
+        t('Environment'),
+        t('Actions'),
+      ]}
+    >
+      {monitorList
+        ?.map(monitor =>
+          monitor.environments.length > 0
+            ? monitor.environments.map(monitorEnv =>
+                renderMonitorRow(monitor, monitorEnv)
+              )
+            : renderMonitorRow(monitor)
+        )
+        .flat()}
+    </StyledPanelTable>
   );
 }
 

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import Link from 'sentry/components/links/link';
-import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
 import Placeholder from 'sentry/components/placeholder';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
@@ -28,10 +27,9 @@ import {getStartFromTimeWindow, timeWindowData} from './utils';
 
 interface Props {
   monitorList: Monitor[];
-  monitorListPageLinks?: string | null;
 }
 
-export function OverviewTimeline({monitorList, monitorListPageLinks}: Props) {
+export function OverviewTimeline({monitorList}: Props) {
   const {replace, location} = useRouter();
   const organization = useOrganization();
 
@@ -71,56 +69,49 @@ export function OverviewTimeline({monitorList, monitorListPageLinks}: Props) {
   );
 
   return (
-    <Fragment>
-      <MonitorListPanel>
-        <ListFilters>
-          <Button
-            size="xs"
-            icon={<IconSort size="xs" />}
-            aria-label={t('Reverse sort')}
-          />
-          <SegmentedControl<TimeWindow>
-            value={timeWindow}
-            onChange={handleResolutionChange}
-            size="xs"
-            aria-label={t('Time Scale')}
-          >
-            <SegmentedControl.Item key="1h">{t('Hour')}</SegmentedControl.Item>
-            <SegmentedControl.Item key="24h">{t('Day')}</SegmentedControl.Item>
-            <SegmentedControl.Item key="7d">{t('Week')}</SegmentedControl.Item>
-            <SegmentedControl.Item key="30d">{t('Month')}</SegmentedControl.Item>
-          </SegmentedControl>
-        </ListFilters>
-        <TimelineWidthTracker ref={elementRef} />
-        <GridLineTimeLabels
-          timeWindow={timeWindow}
-          end={nowRef.current}
-          width={timelineWidth}
-        />
-        <GridLineOverlay
-          timeWindow={timeWindow}
-          end={nowRef.current}
-          width={timelineWidth}
-        />
+    <MonitorListPanel>
+      <ListFilters>
+        <Button size="xs" icon={<IconSort size="xs" />} aria-label={t('Reverse sort')} />
+        <SegmentedControl<TimeWindow>
+          value={timeWindow}
+          onChange={handleResolutionChange}
+          size="xs"
+          aria-label={t('Time Scale')}
+        >
+          <SegmentedControl.Item key="1h">{t('Hour')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="24h">{t('Day')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="7d">{t('Week')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="30d">{t('Month')}</SegmentedControl.Item>
+        </SegmentedControl>
+      </ListFilters>
+      <TimelineWidthTracker ref={elementRef} />
+      <GridLineTimeLabels
+        timeWindow={timeWindow}
+        end={nowRef.current}
+        width={timelineWidth}
+      />
+      <GridLineOverlay
+        timeWindow={timeWindow}
+        end={nowRef.current}
+        width={timelineWidth}
+      />
 
-        {monitorList.map(monitor => (
-          <Fragment key={monitor.id}>
-            <MonitorDetails monitor={monitor} />
-            {isLoading || !monitorStats ? (
-              <Placeholder />
-            ) : (
-              <CheckInTimeline
-                bucketedData={monitorStats[monitor.slug]}
-                end={nowRef.current}
-                start={start}
-                width={timelineWidth}
-              />
-            )}
-          </Fragment>
-        ))}
-      </MonitorListPanel>
-      {monitorListPageLinks && <Pagination pageLinks={monitorListPageLinks} />}
-    </Fragment>
+      {monitorList.map(monitor => (
+        <Fragment key={monitor.id}>
+          <MonitorDetails monitor={monitor} />
+          {isLoading || !monitorStats ? (
+            <Placeholder />
+          ) : (
+            <CheckInTimeline
+              bucketedData={monitorStats[monitor.slug]}
+              end={nowRef.current}
+              start={start}
+              width={timelineWidth}
+            />
+          )}
+        </Fragment>
+      ))}
+    </MonitorListPanel>
   );
 }
 

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import Link from 'sentry/components/links/link';
+import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
 import Placeholder from 'sentry/components/placeholder';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
@@ -30,7 +31,7 @@ interface Props {
   monitorListPageLinks?: string | null;
 }
 
-export function OverviewTimeline({monitorList}: Props) {
+export function OverviewTimeline({monitorList, monitorListPageLinks}: Props) {
   const {replace, location} = useRouter();
   const organization = useOrganization();
 
@@ -70,49 +71,56 @@ export function OverviewTimeline({monitorList}: Props) {
   );
 
   return (
-    <MonitorListPanel>
-      <ListFilters>
-        <Button size="xs" icon={<IconSort size="xs" />} aria-label={t('Reverse sort')} />
-        <SegmentedControl<TimeWindow>
-          value={timeWindow}
-          onChange={handleResolutionChange}
-          size="xs"
-          aria-label={t('Time Scale')}
-        >
-          <SegmentedControl.Item key="1h">{t('Hour')}</SegmentedControl.Item>
-          <SegmentedControl.Item key="24h">{t('Day')}</SegmentedControl.Item>
-          <SegmentedControl.Item key="7d">{t('Week')}</SegmentedControl.Item>
-          <SegmentedControl.Item key="30d">{t('Month')}</SegmentedControl.Item>
-        </SegmentedControl>
-      </ListFilters>
-      <TimelineWidthTracker ref={elementRef} />
-      <GridLineTimeLabels
-        timeWindow={timeWindow}
-        end={nowRef.current}
-        width={timelineWidth}
-      />
-      <GridLineOverlay
-        timeWindow={timeWindow}
-        end={nowRef.current}
-        width={timelineWidth}
-      />
+    <Fragment>
+      <MonitorListPanel>
+        <ListFilters>
+          <Button
+            size="xs"
+            icon={<IconSort size="xs" />}
+            aria-label={t('Reverse sort')}
+          />
+          <SegmentedControl<TimeWindow>
+            value={timeWindow}
+            onChange={handleResolutionChange}
+            size="xs"
+            aria-label={t('Time Scale')}
+          >
+            <SegmentedControl.Item key="1h">{t('Hour')}</SegmentedControl.Item>
+            <SegmentedControl.Item key="24h">{t('Day')}</SegmentedControl.Item>
+            <SegmentedControl.Item key="7d">{t('Week')}</SegmentedControl.Item>
+            <SegmentedControl.Item key="30d">{t('Month')}</SegmentedControl.Item>
+          </SegmentedControl>
+        </ListFilters>
+        <TimelineWidthTracker ref={elementRef} />
+        <GridLineTimeLabels
+          timeWindow={timeWindow}
+          end={nowRef.current}
+          width={timelineWidth}
+        />
+        <GridLineOverlay
+          timeWindow={timeWindow}
+          end={nowRef.current}
+          width={timelineWidth}
+        />
 
-      {monitorList.map(monitor => (
-        <Fragment key={monitor.id}>
-          <MonitorDetails monitor={monitor} />
-          {isLoading || !monitorStats ? (
-            <Placeholder />
-          ) : (
-            <CheckInTimeline
-              bucketedData={monitorStats[monitor.slug]}
-              end={nowRef.current}
-              start={start}
-              width={timelineWidth}
-            />
-          )}
-        </Fragment>
-      ))}
-    </MonitorListPanel>
+        {monitorList.map(monitor => (
+          <Fragment key={monitor.id}>
+            <MonitorDetails monitor={monitor} />
+            {isLoading || !monitorStats ? (
+              <Placeholder />
+            ) : (
+              <CheckInTimeline
+                bucketedData={monitorStats[monitor.slug]}
+                end={nowRef.current}
+                start={start}
+                width={timelineWidth}
+              />
+            )}
+          </Fragment>
+        ))}
+      </MonitorListPanel>
+      {monitorListPageLinks && <Pagination pageLinks={monitorListPageLinks} />}
+    </Fragment>
   );
 }
 

--- a/static/app/views/monitors/overview.tsx
+++ b/static/app/views/monitors/overview.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
@@ -13,6 +14,7 @@ import OnboardingPanel from 'sentry/components/onboardingPanel';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
+import Pagination from 'sentry/components/pagination';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -123,17 +125,14 @@ export default function Monitors() {
             {isLoading ? (
               <LoadingIndicator />
             ) : monitorList?.length ? (
-              monitorsTimelineView ? (
-                <OverviewTimeline
-                  monitorList={monitorList}
-                  monitorListPageLinks={monitorListPageLinks}
-                />
-              ) : (
-                <OverviewTable
-                  monitorList={monitorList}
-                  monitorListPageLinks={monitorListPageLinks}
-                />
-              )
+              <Fragment>
+                {monitorsTimelineView ? (
+                  <OverviewTimeline monitorList={monitorList} />
+                ) : (
+                  <OverviewTable monitorList={monitorList} />
+                )}
+                {monitorListPageLinks && <Pagination pageLinks={monitorListPageLinks} />}
+              </Fragment>
             ) : (
               <OnboardingPanel image={<img src={onboardingImg} />}>
                 <h3>{t('Let Sentry monitor your recurring jobs')}</h3>

--- a/static/app/views/monitors/utils.tsx
+++ b/static/app/views/monitors/utils.tsx
@@ -9,7 +9,7 @@ import {MonitorConfig, ScheduleType} from 'sentry/views/monitors/types';
 export function makeMonitorListQueryKey(organization: Organization, location: Location) {
   return [
     `/organizations/${organization.slug}/monitors/`,
-    {query: {...location.query, includeNew: true}},
+    {query: {...location.query, includeNew: true, per_page: 20}},
   ] as const;
 }
 


### PR DESCRIPTION
Paginates overview pages (timeline view, table view) to 20 items. 

<img width="1268" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/698b6668-dd5f-4f2d-aece-caf170300558">


<img width="1278" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/d9912de8-a0be-4295-8678-4f2c676b5c91">
