### PR TITLE
fix(hybridcloud) Fix a few pydantic warnings and improve error capturing

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -239,7 +239,7 @@ class GroupSerializerBase(Serializer, ABC):
         release_resolutions, commit_resolutions = self._resolve_resolutions(item_list, user)
 
         user_ids = {r[-1] for r in release_resolutions.values()}
-        user_ids.update(r.actor_id for r in ignore_items.values())
+        user_ids.update(r.actor_id for r in ignore_items.values() if r.actor_id is not None)
         if user_ids:
             serialized_users = user_service.serialize_many(
                 filter={"user_ids": user_ids, "is_active": True},

--- a/src/sentry/api/serializers/models/grouptombstone.py
+++ b/src/sentry/api/serializers/models/grouptombstone.py
@@ -8,7 +8,7 @@ from sentry.services.hybrid_cloud.user.service import user_service
 class GroupTombstoneSerializer(Serializer):
     def get_attrs(self, item_list, user):
         user_list = user_service.serialize_many(
-            filter={"user_ids": [item.actor_id for item in item_list]}
+            filter={"user_ids": [item.actor_id for item in item_list if item.actor_id is not None]}
         )
         users = {int(u["id"]): u for u in user_list}
 

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from typing import Mapping, Sequence, TypedDict, Union
 
+from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
 from django.db.models import Sum
 
@@ -248,6 +249,9 @@ def get_users_for_authors(organization_id, authors, user=None) -> Mapping[str, U
         missed = authors
 
     if missed:
+        if isinstance(user, AnonymousUser):
+            user = None
+
         # Filter users based on the emails provided in the commits
         # and that belong to the organization associated with the release
         users: Sequence[UserSerializerResponse] = user_service.serialize_many(

--- a/src/sentry/services/hybrid_cloud/__init__.py
+++ b/src/sentry/services/hybrid_cloud/__init__.py
@@ -54,7 +54,6 @@ def report_pydantic_type_validation_error(
     model_class: Optional[Type[Any]],
 ) -> None:
     with sentry_sdk.push_scope() as scope:
-        scope.set_level("warning")
         scope.set_context(
             "pydantic_validation",
             {
@@ -64,7 +63,7 @@ def report_pydantic_type_validation_error(
                 "model_class": str(model_class),
             },
         )
-        sentry_sdk.capture_exception(TypeError("Pydantic type validation error"))
+        logger.warning("Pydantic type validation error", exc_info=True)
 
 
 def _hack_pydantic_type_validation() -> None:

--- a/src/sentry/services/hybrid_cloud/user/serial.py
+++ b/src/sentry/services/hybrid_cloud/user/serial.py
@@ -18,7 +18,7 @@ def serialize_rpc_user(user: User) -> RpcUser:
     args["display_name"] = user.get_display_name()
     args["label"] = user.get_label()
     args["is_superuser"] = user.is_superuser
-    args["is_sentry_app"] = user.is_sentry_app if user.is_sentry_app is not None else False
+    args["is_sentry_app"] = bool(user.is_sentry_app)
     args["password_usable"] = user.has_usable_password()
 
     # Prefer eagerloaded attributes from _base_query


### PR DESCRIPTION
Fix a few pydantic warnings I was able to reproduce in tests. I've changed the error capturing to use `logger.warning()` so that we get stack traces in pydantic warnings as there were a few error instances that I couldn't track down the origin.