### PR TITLE
ref(replays): remove unused method on replay File model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -919,7 +919,6 @@ module = [
     "sentry.replays.lib.consumer",
     "sentry.replays.lib.query",
     "sentry.replays.lib.storage",
-    "sentry.replays.models",
     "sentry.replays.query",
     "sentry.replays.serializers",
     "sentry.replays.tasks",

--- a/src/sentry/replays/models.py
+++ b/src/sentry/replays/models.py
@@ -1,9 +1,6 @@
-import mimetypes
-
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.utils import timezone
-from django.utils.functional import cached_property
 
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.bounded import BoundedIntegerField, BoundedPositiveIntegerField
@@ -31,16 +28,6 @@ class ReplayRecordingSegment(Model):
         )
 
     __repr__ = sane_repr("replay_id", "segment_id", "file_id")
-
-    @cached_property
-    def mimetype(self):
-        from sentry.models import File
-
-        file = File.objects.get(id=self.file_id)
-        rv = file.headers.get("Content-Type")
-        if rv:
-            return rv.split(";")[0].strip()
-        return mimetypes.guess_type(self.name)[0] or "application/octet-stream"
 
     def delete(self, *args, **kwargs):
         from sentry.models import File


### PR DESCRIPTION
as mypy points out, there is no `name` property on this model. This method was copied over originally when I copy/pasted the code from EventAttachment to make this model. we do not use this method anywhere, and should be fine to remove. Fixes the typing issue in this file.