### PR TITLE
fix(typing): don't overide base class method types on replay serializer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -921,7 +921,6 @@ module = [
     "sentry.replays.lib.storage",
     "sentry.replays.models",
     "sentry.replays.query",
-    "sentry.replays.serializers",
     "sentry.replays.tasks",
     "sentry.replays.testutils",
     "sentry.replays.usecases.ingest.dom_index",

--- a/src/sentry/replays/serializers.py
+++ b/src/sentry/replays/serializers.py
@@ -1,9 +1,8 @@
 from sentry.api.serializers import Serializer
-from sentry.replays.models import ReplayRecordingSegment
 
 
 class ReplayRecordingSegmentSerializer(Serializer):
-    def serialize(self, obj: ReplayRecordingSegment, attrs, user):
+    def serialize(self, obj, attrs, user):
         return {
             "replayId": obj.replay_id,
             "segmentId": obj.segment_id,


### PR DESCRIPTION
superclass method types can't be overriden. (superclass defines obj as `Any`). 

https://github.com/getsentry/sentry/blob/4c846fc441332fcf98c7fde7ec6e8c0f27c5cba0/src/sentry/api/serializers/base.py#L122