### PR TITLE
ref(django): Prefer django.utils.text.slugify over template.defaultfilters

### DIFF
--- a/src/sentry/api/endpoints/organization_sentry_function.py
+++ b/src/sentry/api/endpoints/organization_sentry_function.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from django.template.defaultfilters import slugify
+from django.utils.text import slugify
 from rest_framework import serializers
 from rest_framework.response import Response
 

--- a/src/sentry/api/serializers/rest_framework/doc_integration.py
+++ b/src/sentry/api/serializers/rest_framework/doc_integration.py
@@ -1,7 +1,7 @@
 from typing import Any, MutableMapping
 
 from django.db import transaction
-from django.template.defaultfilters import slugify
+from django.utils.text import slugify
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 from rest_framework import serializers
 from rest_framework.serializers import Serializer, ValidationError

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -4,8 +4,8 @@ from uuid import uuid4
 
 from django.db.models import F, Field, Model
 from django.db.models.expressions import BaseExpression, CombinedExpression, Value
-from django.template.defaultfilters import slugify
 from django.utils.crypto import get_random_string
+from django.utils.text import slugify
 
 from sentry.db.exceptions import CannotResolveExpression
 

--- a/src/sentry/models/integrations/sentry_app.py
+++ b/src/sentry/models/integrations/sentry_app.py
@@ -5,8 +5,8 @@ from hashlib import sha256
 
 from django.db import models
 from django.db.models import QuerySet
-from django.template.defaultfilters import slugify
 from django.utils import timezone
+from django.utils.text import slugify
 from rest_framework.request import Request
 
 from sentry.constants import (

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -3,7 +3,7 @@ import re
 
 import sentry_sdk
 from django.db import IntegrityError, transaction
-from django.template.defaultfilters import slugify
+from django.utils.text import slugify
 from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework import serializers
 from rest_framework.exceptions import ParseError

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -2,8 +2,8 @@ import time
 from datetime import datetime, timedelta
 from random import Random
 
-from django.template.defaultfilters import slugify
 from django.utils import timezone
+from django.utils.text import slugify
 
 from sentry.models import Group, Organization, Project
 from sentry.tasks.weekly_reports import (

--- a/src/social_auth/backends/pipeline/user.py
+++ b/src/social_auth/backends/pipeline/user.py
@@ -4,9 +4,7 @@ from social_auth.django_compat import get_all_field_names
 from social_auth.models import UserSocialAuth
 from social_auth.utils import module_member, setting
 
-slugify = module_member(
-    setting("SOCIAL_AUTH_SLUGIFY_FUNCTION", "django.template.defaultfilters.slugify")
-)
+slugify = module_member(setting("SOCIAL_AUTH_SLUGIFY_FUNCTION", "django.utils.text.slugify"))
 
 
 def get_username(


### PR DESCRIPTION
the `django.template.defaultfilters.slugify` funciton is just an alias
of the django.text.utils.slugify function.

It simply makes more sense to not import the template filter version of
the function for our usage.

See: https://github.com/django/django/blob/main/django/template/defaultfilters.py#L255-L261