### PR TITLE
CI: Updating lock-threads action to latest version for node 16 support

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -7,10 +7,10 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/forked-action-lock-threads@486f7380c15596f92b724e4260e4981c68d6bde6  # master
+      - uses: dessant/lock-threads@be8aa5be94131386884a6da4189effda9b14aa21  # v4.0.1
         with:
           github-token: ${{ github.token }}
-          issue-lock-inactive-days: 15
+          issue-inactive-days: 15
           issue-lock-reason: ''
-          pr-lock-inactive-days: 15
+          pr-inactive-days: 15
           pr-lock-reason: ''


### PR DESCRIPTION
Switching back to using [lock-threads](https://github.com/dessant/lock-threads) from [forked-action-lock-threads](https://github.com/getsentry/forked-action-lock-threads) to move the action to node 16 (from node 12) since GitHub will be [enforcing this change as of tomorrow](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/). A few input parameters were updated in accordance with [v3.0.0's changes](https://github.com/dessant/lock-threads/blob/main/CHANGELOG.md#300-2021-09-27).