### PR TITLE
fix(crons): Fix positioning of timeline marks/labels

### DIFF
--- a/static/app/views/monitors/components/checkInTimeline.tsx
+++ b/static/app/views/monitors/components/checkInTimeline.tsx
@@ -79,7 +79,7 @@ export function CheckInTimeline(props: Props) {
 
           return (
             <JobTickContainer style={{left}} key={timestamp}>
-              <Tooltip title={<DateTime date={timestampMs} />}>
+              <Tooltip title={<DateTime date={timestampMs} seconds />}>
                 <JobTick status={getAggregateStatus(envData)} />
               </Tooltip>
             </JobTickContainer>
@@ -104,6 +104,7 @@ const TimelineContainer = styled('div')`
 
 const JobTickContainer = styled('div')`
   position: absolute;
+  transform: translateX(-50%);
 `;
 
 const JobTick = styled('div')<{status: CheckInStatus}>`

--- a/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
@@ -16,6 +16,7 @@ interface Props {
 }
 
 function clampTimeBasedOnResolution(date: moment.Moment, resolution: string) {
+  date.startOf('minute');
   if (resolution === '1h') {
     date.minute(date.minutes() - (date.minutes() % 10));
   } else if (resolution === '30d') {
@@ -37,10 +38,11 @@ function getTimeMarkers(end: Date, timeWindow: TimeWindow, width: number): TimeM
   const times: TimeMarker[] = [];
   const start = getStartFromTimeWindow(end, timeWindow);
 
-  // Iterate and generate time markers which represent location of grid lines/time labels
+  const firstTimeMark = moment(start);
+  clampTimeBasedOnResolution(firstTimeMark, timeWindow);
+  // Generate time markers which represent location of grid lines/time labels
   for (let i = 1; i < elapsedMinutes / timeMarkerInterval; i++) {
-    const timeMark = moment(start).add(i * timeMarkerInterval, 'minute');
-    clampTimeBasedOnResolution(timeMark, timeWindow);
+    const timeMark = moment(firstTimeMark).add(i * timeMarkerInterval, 'minute');
     const position = (timeMark.valueOf() - start.valueOf()) / msPerPixel;
     times.push({date: timeMark.toDate(), position});
   }


### PR DESCRIPTION
The function used to clamp the timeline mark lines/labels to a nice interval (every hour, 10 minutes, etc..) was slightly wrong as it didn't clamp to the start of the minute.

This would lead to slightly inaccurate labels, such as a label that read 12:10pm might really be for 12:10:48pm which could result in positioning inconsistencies such as:

<img width="555" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/91a16ce3-9d74-4af4-9ffb-7b26dd0c6a19">

After:
<img width="552" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/f977155d-d06c-4466-8a5d-1e2fb3d744a1">

