### PR TITLE
chore(profiling): Add instrumentation to profile sizes

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -23,6 +23,7 @@ from sentry.signals import first_profile_received
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json, metrics
 from sentry.utils.outcomes import Outcome, track_outcome
+from sentry.utils.sdk import set_measurement
 
 Profile = MutableMapping[str, Any]
 CallTrees = Mapping[str, List[Any]]
@@ -91,6 +92,9 @@ def process_profile_task(
 
     sentry_sdk.set_tag("platform", profile["platform"])
     sentry_sdk.set_tag("format", "sample" if "version" in profile else "legacy")
+    set_measurement("profile.samples", len(profile["profile"]["samples"]))
+    set_measurement("profile.stacks", len(profile["profile"]["stacks"]))
+    set_measurement("profile.frames", len(profile["profile"]["frames"]))
 
     if not _symbolicate_profile(profile, project):
         return
@@ -100,6 +104,10 @@ def process_profile_task(
 
     if not _normalize_profile(profile, organization, project):
         return
+
+    set_measurement("profile.samples.processed", len(profile["profile"]["samples"]))
+    set_measurement("profile.stacks.processed", len(profile["profile"]["stacks"]))
+    set_measurement("profile.frames.processed", len(profile["profile"]["frames"]))
 
     if not _push_profile_to_vroom(profile, project):
         return


### PR DESCRIPTION
Trying to track down VROOM-2Z. This will let us narrow down when the frames list was truncated to empty.