### PR TITLE
ref(crons): Align timeline ticks to first line of monitor name

### DIFF
--- a/static/app/views/monitors/components/checkInTimeline.tsx
+++ b/static/app/views/monitors/components/checkInTimeline.tsx
@@ -99,7 +99,7 @@ export function CheckInTimeline(props: Props) {
 const TimelineContainer = styled('div')`
   position: relative;
   height: 14px;
-  margin: ${space(4)} 0;
+  margin: ${space(2)} 0;
 `;
 
 const JobTickContainer = styled('div')`


### PR DESCRIPTION
Gets the ticks to align to the first line of the monitor name text:

Before:
<img width="1265" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/238fd3ad-4443-4c2c-b0a6-83ebbcfbf195">


After:
<img width="1229" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/75c8801b-4d49-4445-8a22-0f343206eddc">
