### PR TITLE
fix(group): don't dupe update group when its regressed in post_process_group

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -703,15 +703,15 @@ def process_inbox_adds(job: PostProcessJob) -> None:
                         event.group.substatus = GroupSubStatus.NEW
                         add_group_to_inbox(event.group, GroupInboxReason.NEW)
                 elif is_regression:
-                    updated = (
-                        Group.objects.filter(id=event.group.id)
-                        .exclude(substatus=GroupSubStatus.REGRESSED)
-                        .update(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.REGRESSED)
-                    )
-                    if updated:
-                        event.group.status = GroupStatus.UNRESOLVED
-                        event.group.substatus = GroupSubStatus.REGRESSED
-                        add_group_to_inbox(event.group, GroupInboxReason.REGRESSION)
+                    # updated = (
+                    #     Group.objects.filter(id=event.group.id)
+                    #     .exclude(substatus=GroupSubStatus.REGRESSED)
+                    #     .update(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.REGRESSED)
+                    # )
+
+                    event.group.status = GroupStatus.UNRESOLVED
+                    event.group.substatus = GroupSubStatus.REGRESSED
+                    add_group_to_inbox(event.group, GroupInboxReason.REGRESSION)
 
 
 def process_snoozes(job: PostProcessJob) -> None:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -703,12 +703,8 @@ def process_inbox_adds(job: PostProcessJob) -> None:
                         event.group.substatus = GroupSubStatus.NEW
                         add_group_to_inbox(event.group, GroupInboxReason.NEW)
                 elif is_regression:
-                    # updated = (
-                    #     Group.objects.filter(id=event.group.id)
-                    #     .exclude(substatus=GroupSubStatus.REGRESSED)
-                    #     .update(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.REGRESSED)
-                    # )
-
+                    # we don't need to update the group since that should've already been
+                    # handled on event ingest
                     event.group.status = GroupStatus.UNRESOLVED
                     event.group.substatus = GroupSubStatus.REGRESSED
                     add_group_to_inbox(event.group, GroupInboxReason.REGRESSION)


### PR DESCRIPTION
Fixes a bug where we incorrectly try to conditionally update the Group row in post_process_group for regressed issues leading to a `GroupInbox` not getting created for regressed issues.



