### PR TITLE
fix(replays): Remove extra margin below Replay Details>Memory section

### DIFF
--- a/static/app/views/replays/detail/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryChart.tsx
@@ -224,7 +224,6 @@ function MemoryChart({
 }
 
 const MemoryChartWrapper = styled(FluidHeight)`
-  margin-bottom: ${space(3)};
   border-radius: ${space(0.5)};
   border: 1px solid ${p => p.theme.border};
 `;


### PR DESCRIPTION
Before there was extra space you could scroll to see:
![SCR-20230613-ngib](https://github.com/getsentry/sentry/assets/187460/cae51998-b706-48f4-a937-defb0676bdc1)

No longer!