### PR TITLE
fix(apidocs): update orgstats query params for new data categories

### DIFF
--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -96,7 +96,7 @@ class OrgStatsQueryParamsSerializer(serializers.Serializer):
     )
 
     category = serializers.ChoiceField(
-        ("error", "transaction", "attachment"),
+        ("error", "transaction", "attachment", "replays", "profiles"),
         required=False,
         help_text=(
             "If filtering by attachments, you cannot filter by any other category due to quantity values becoming nonsensical (combining bytes and event counts).\n\n"


### PR DESCRIPTION
- this param isn't dynamically updated at the moment, so adding the two new categories here.