### PR TITLE
fix(mute-metric-alerts): Use organization alert rule endpoint

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -164,7 +164,6 @@ class AlertRuleSerializer(Serializer):
             "dateModified": obj.date_modified,
             "dateCreated": obj.date_added,
             "createdBy": attrs.get("created_by", None),
-            "snooze": False,
         }
         if "latestIncident" in self.expand:
             data["latestIncident"] = attrs.get("latestIncident", None)
@@ -198,6 +197,7 @@ class DetailedAlertRuleSerializer(AlertRuleSerializer):
         data = super().serialize(obj, attrs, user)
         data["excludedProjects"] = sorted(attrs.get("excluded_projects", []))
         data["eventTypes"] = sorted(attrs.get("event_types", []))
+        data["snooze"] = False
         return data
 
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -11,6 +12,8 @@ from sentry.incidents.logic import AlreadyDeletedError, delete_alert_rule
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.models import OrganizationMemberTeam, SentryAppComponent, SentryAppInstallation
 from sentry.models.actor import ACTOR_TYPES
+from sentry.models.rulesnooze import RuleSnooze
+from sentry.services.hybrid_cloud.user.service import user_service
 
 
 @region_silo_endpoint
@@ -57,6 +60,19 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
 
         if len(errors):
             serialized_rule["errors"] = errors
+
+        rule_snooze = RuleSnooze.objects.filter(
+            Q(user_id=request.user.id) | Q(user_id=None), alert_rule=alert_rule
+        ).first()
+        if rule_snooze:
+            serialized_rule["snooze"] = True
+            if request.user.id == rule_snooze.owner_id:
+                serialized_rule["snoozeCreatedBy"] = "You"
+            else:
+                user = user_service.get_user(rule_snooze.owner_id)
+                if user:
+                    serialized_rule["snoozeCreatedBy"] = user.get_display_name()
+            serialized_rule["snoozeForEveryone"] = rule_snooze.user_id is None
 
         return Response(serialized_rule)
 

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -1,4 +1,3 @@
-from django.db.models import Q
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -15,8 +14,6 @@ from sentry.incidents.logic import (
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.utils.sentry_apps import trigger_sentry_app_action_creators_for_incidents
 from sentry.integrations.slack.utils import RedisRuleStatus
-from sentry.models.rulesnooze import RuleSnooze
-from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.tasks.integrations.slack import find_channel_id_for_alert_rule
 
 
@@ -29,19 +26,6 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
         :auth: required
         """
         serialized_alert_rule = serialize(alert_rule, request.user, AlertRuleSerializer())
-
-        rule_snooze = RuleSnooze.objects.filter(
-            Q(user_id=request.user.id) | Q(user_id=None), alert_rule=alert_rule
-        ).first()
-        if rule_snooze:
-            serialized_alert_rule["snooze"] = True
-            if request.user.id == rule_snooze.owner_id:
-                serialized_alert_rule["snoozeCreatedBy"] = "You"
-            else:
-                user = user_service.get_user(rule_snooze.owner_id)
-                if user:
-                    serialized_alert_rule["snoozeCreatedBy"] = user.get_display_name()
-            serialized_alert_rule["snoozeForEveryone"] = rule_snooze.user_id is None
 
         return Response(serialized_alert_rule)
 

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -15,7 +15,7 @@ from sentry.incidents.models import (
     IncidentStatus,
 )
 from sentry.integrations.slack.client import SlackClient
-from sentry.models import AuditLogEntry, Integration, RuleSnooze
+from sentry.models import AuditLogEntry, Integration
 from sentry.models.actor import get_actor_for_user
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.testutils import APITestCase
@@ -132,42 +132,6 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             )
             assert resp.data["aggregate"] == "count_unique(user)"
             assert alert_rule.snuba_query.aggregate == "count_unique(tags[sentry:user])"
-
-    def test_with_snooze_rule(self):
-        self.login_as(self.member_user)
-
-        RuleSnooze.objects.create(
-            user_id=self.member_user.id,
-            owner_id=self.member_user.id,
-            alert_rule=self.alert_rule,
-            until=None,
-        )
-
-        with self.feature("organizations:incidents"):
-            response = self.get_success_response(
-                self.organization.slug, self.project.slug, self.alert_rule.id
-            )
-
-        assert response.data["snooze"]
-        assert response.data["snoozeCreatedBy"] == "You"
-
-    def test_with_snooze_rule_everyone(self):
-        user2 = self.create_user("user2@example.com")
-        self.login_as(self.member_user)
-
-        RuleSnooze.objects.create(
-            owner_id=user2.id,
-            alert_rule=self.alert_rule,
-            until=None,
-        )
-
-        with self.feature("organizations:incidents"):
-            response = self.get_success_response(
-                self.organization.slug, self.project.slug, self.alert_rule.id
-            )
-
-        assert response.data["snooze"]
-        assert response.data["snoozeCreatedBy"] == user2.get_display_name()
 
 
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):


### PR DESCRIPTION
this fixes https://github.com/getsentry/sentry/pull/50769 by moving all the code into OrganizationAlertRuleDetailsEndpoint instead of having it in ProjectAlertRuleDetailsEndpoint