### PR TITLE
ref(replay): Accept replay attachments in-order so we do not have to manually sort later

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -222,7 +222,7 @@ export function Provider({
 }: Props) {
   const config = useLegacyStore(ConfigStore);
   const organization = useOrganization();
-  const events = replay?.getRRWebEvents();
+  const events = replay?.getRRWebFrames();
   const savedReplayConfigRef = useRef<ReplayConfig>(
     JSON.parse(localStorage.getItem(ReplayLocalstorageKeys.REPLAY_CONFIG) || '{}')
   );

--- a/static/app/utils/replays/replayReader.spec.tsx
+++ b/static/app/utils/replays/replayReader.spec.tsx
@@ -115,7 +115,7 @@ describe('ReplayReader', () => {
 
     it.each([
       {
-        method: 'getSortedRRWebFrames',
+        method: 'getRRWebFrames',
         expected: [
           {
             type: EventType.Custom,

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -132,7 +132,7 @@ export default class ReplayReader {
 
     // Insert extra records to satisfy minimum requirements for the UI
     this._breadcrumbFrames.push(replayInitBreadcrumb(replayRecord));
-    this._rrwebEvents.push(recordingStartFrame(replayRecord));
+    this._rrwebEvents.unshift(recordingStartFrame(replayRecord));
     this._rrwebEvents.push(recordingEndFrame(replayRecord));
 
     /*********************/

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -135,11 +135,6 @@ export default class ReplayReader {
     this._rrwebEvents.push(recordingStartFrame(replayRecord));
     this._rrwebEvents.push(recordingEndFrame(replayRecord));
 
-    // Sort what needs sorting
-    // TODO(replay): We could remove this sort call if useReplayData was more
-    // careful about maintaining cursor order when calling setAttachments()
-    this._rrwebEvents.sort((a, b) => a.timestamp - b.timestamp);
-
     /*********************/
     /** OLD STUFF BELOW **/
     /*********************/
@@ -206,10 +201,6 @@ export default class ReplayReader {
 
   getRRWebFrames = () => this._rrwebEvents;
 
-  getSortedRRWebFrames = memoize(() =>
-    this.getRRWebFrames().sort((a, b) => a.timestamp - b.timestamp)
-  );
-
   getConsoleFrames = memoize(() =>
     this._breadcrumbFrames.filter(frame => frame.category === 'console')
   );
@@ -265,11 +256,6 @@ export default class ReplayReader {
   /*********************/
   /** OLD STUFF BELOW **/
   /*********************/
-
-  getRRWebEvents = () => {
-    return this.rrwebEvents;
-  };
-
   getCrumbsWithRRWebNodes = memoize(() =>
     this.breadcrumbs.filter(
       crumb => crumb.data && typeof crumb.data === 'object' && 'nodeId' in crumb.data
@@ -314,7 +300,7 @@ export default class ReplayReader {
   getDomNodes = memoize(() =>
     extractDomNodes({
       crumbs: this.getCrumbsWithRRWebNodes(),
-      rrwebEvents: this.getRRWebEvents(),
+      rrwebEvents: this.getRRWebFrames(),
       finishedAt: this.replayRecord.finished_at,
     })
   );

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -110,7 +110,7 @@ function ReplayDetails({params: {replaySlug}}: Props) {
     );
   }
 
-  if (!fetching && replay && replay.getRRWebEvents().length < 2) {
+  if (!fetching && replay && replay.getRRWebFrames().length < 2) {
     return (
       <Page
         orgSlug={orgSlug}


### PR DESCRIPTION
This is a followup from https://github.com/getsentry/sentry/pull/50707

Fixes https://github.com/getsentry/sentry/issues/50891
