### PR TITLE
ref: Update devserver to use unified consumers, add --dev-consumer flag

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from typing import Any, Mapping, Optional, Sequence, TypedDict
 
 import click
+from arroyo.processing.processor import StreamProcessor
 from django.conf import settings
 from typing_extensions import Required
+
+from sentry.utils.imports import import_string
 
 DEFAULT_BLOCK_SIZE = int(32 * 1e6)
 
@@ -151,4 +154,72 @@ def print_deprecation_warning(name, group_id):
     click.echo(
         f"WARNING: Deprecated command, use sentry run consumer {name} "
         f"--consumer-group {group_id} ..."
+    )
+
+
+def get_stream_processor(
+    consumer_name: str,
+    consumer_args: Sequence[str],
+    topic: Optional[str],
+    group_id: str,
+    auto_offset_reset: str,
+    strict_offset_reset: bool,
+    **options,
+) -> StreamProcessor:
+    try:
+        consumer_definition = KAFKA_CONSUMERS[consumer_name]
+    except KeyError:
+        raise click.ClickException(
+            f"No consumer named {consumer_name} in sentry.consumers.KAFKA_CONSUMERS"
+        )
+
+    try:
+        strategy_factory_cls = import_string(consumer_definition["strategy_factory"])
+        default_topic = consumer_definition["topic"]
+    except KeyError:
+        raise click.ClickException(
+            f"The consumer group {consumer_name} does not have a strategy factory"
+            f"registered. Most likely there is another subcommand in 'sentry run' "
+            f"responsible for this consumer"
+        )
+
+    if topic is None:
+        topic = default_topic
+
+    cmd = click.Command(
+        name=consumer_name, params=list(consumer_definition.get("click_options") or ())
+    )
+    cmd_context = cmd.make_context(consumer_name, list(consumer_args))
+    strategy_factory = cmd_context.invoke(
+        strategy_factory_cls, **cmd_context.params, **consumer_definition.get("static_args") or {}
+    )
+
+    from arroyo.backends.kafka.configuration import build_kafka_consumer_configuration
+    from arroyo.backends.kafka.consumer import KafkaConsumer
+    from arroyo.commit import ONCE_PER_SECOND
+    from arroyo.types import Topic
+    from django.conf import settings
+
+    from sentry.utils import kafka_config
+
+    topic_def = settings.KAFKA_TOPICS[topic]
+    assert topic_def is not None
+    cluster_name: str = topic_def["cluster"]
+
+    consumer_config = build_kafka_consumer_configuration(
+        kafka_config.get_kafka_consumer_cluster_options(
+            cluster_name,
+        ),
+        group_id=group_id,
+        auto_offset_reset=auto_offset_reset,
+        strict_offset_reset=strict_offset_reset,
+    )
+
+    consumer = KafkaConsumer(consumer_config)
+
+    return StreamProcessor(
+        consumer=consumer,
+        topic=Topic(topic),
+        processor_factory=strategy_factory,
+        commit_policy=ONCE_PER_SECOND,
     )

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import signal
 import sys
 from multiprocessing import cpu_count
 from typing import Optional
@@ -11,7 +12,6 @@ from sentry.ingest.types import ConsumerType
 from sentry.issues.run import get_occurrences_ingest_consumer
 from sentry.runner.decorators import configuration, log_options
 from sentry.sentry_metrics.consumers.indexer.slicing_router import get_slicing_router
-from sentry.utils.imports import import_string
 from sentry.utils.kafka import run_processor_with_signals
 
 DEFAULT_BLOCK_SIZE = int(32 * 1e6)
@@ -702,36 +702,56 @@ def basic_consumer(consumer_name, consumer_args, topic, **options):
 
         sentry run consumer ingest-occurrences --consumer-group occurrence-consumer -- --help
     """
-    from sentry.consumers import KAFKA_CONSUMERS
+    from sentry.consumers import get_stream_processor
+    from sentry.metrics.middleware import add_global_tags
+    from sentry.utils.arroyo import initialize_arroyo_main
 
-    try:
-        consumer_definition = KAFKA_CONSUMERS[consumer_name]
-    except KeyError:
-        raise click.ClickException(
-            f"No consumer named {consumer_name} in sentry.consumers.KAFKA_CONSUMERS"
+    add_global_tags(kafka_topic=topic, consumer_group=options["group_id"])
+    initialize_arroyo_main()
+
+    processor = get_stream_processor(consumer_name, consumer_args, topic=topic, **options)
+    run_processor_with_signals(processor)
+
+
+@run.command("dev-consumer")
+@click.argument("consumer_names", nargs=-1)
+@log_options()
+@configuration
+def dev_consumer(consumer_names):
+    """
+    Launch multiple "new-style" consumers in the same thread.
+
+    This does the same thing as 'sentry run consumer', but is not configurable,
+    hardcodes consumer groups and is highly imperformant.
+    """
+
+    from sentry.consumers import get_stream_processor
+    from sentry.utils.arroyo import initialize_arroyo_main
+
+    initialize_arroyo_main()
+
+    processors = [
+        get_stream_processor(
+            consumer_name,
+            [],
+            topic=None,
+            group_id="sentry-consumer",
+            auto_offset_reset="latest",
+            strict_offset_reset=False,
         )
+        for consumer_name in consumer_names
+    ]
 
-    try:
-        strategy_factory_cls = import_string(consumer_definition["strategy_factory"])
-        default_topic = consumer_definition["topic"]
-    except KeyError:
-        raise click.ClickException(
-            f"The consumer group {consumer_name} does not have a strategy factory"
-            f"registered. Most likely there is another subcommand in 'sentry run' "
-            f"responsible for this consumer"
-        )
+    def handler(signum, frame):
+        for processor in processors:
+            processor.signal_shutdown()
 
-    cmd = click.Command(
-        name=consumer_name, params=list(consumer_definition.get("click_options") or ())
-    )
-    cmd_context = cmd.make_context(consumer_name, list(consumer_args))
-    strategy_factory = cmd_context.invoke(
-        strategy_factory_cls, **cmd_context.params, **consumer_definition.get("static_args") or {}
-    )
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
 
-    from sentry.utils.arroyo import run_basic_consumer
-
-    run_basic_consumer(topic=topic or default_topic, **options, strategy_factory=strategy_factory)
+    while True:
+        for processor in processors:
+            processor._run_once()
 
 
 @run.command("ingest-replay-recordings")

--- a/src/sentry/utils/arroyo.py
+++ b/src/sentry/utils/arroyo.py
@@ -3,20 +3,14 @@ from __future__ import annotations
 from functools import partial
 from typing import Any, Callable, Mapping, Optional, Union
 
-from arroyo.backends.kafka.configuration import build_kafka_consumer_configuration
-from arroyo.backends.kafka.consumer import KafkaConsumer
-from arroyo.commit import ONCE_PER_SECOND
-from arroyo.processing.processor import StreamProcessor
-from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
 from arroyo.processing.strategies.run_task_with_multiprocessing import (
     RunTaskWithMultiprocessing as ArroyoRunTaskWithMultiprocessing,
 )
 from arroyo.processing.strategies.run_task_with_multiprocessing import TResult
-from arroyo.types import Topic, TStrategyPayload
+from arroyo.types import TStrategyPayload
 from arroyo.utils.metrics import Metrics
 
 from sentry.metrics.base import MetricsBackend
-from sentry.utils import kafka_config
 
 Tags = Mapping[str, str]
 
@@ -93,7 +87,7 @@ def _initialize_arroyo_subprocess(initializer: Optional[Callable[[], None]], tag
     add_global_tags(_all_threads=True, **tags)
 
 
-def _initialize_arroyo_main() -> None:
+def initialize_arroyo_main() -> None:
     from arroyo import configure_metrics
 
     from sentry.utils.metrics import backend
@@ -136,45 +130,3 @@ class RunTaskWithMultiprocessing(ArroyoRunTaskWithMultiprocessing[TStrategyPaylo
             return ArroyoRunTaskWithMultiprocessing(  # type: ignore[return-value]
                 initializer=_get_arroyo_subprocess_initializer(initializer), **kwargs
             )
-
-
-def run_basic_consumer(
-    topic: str,
-    group_id: str,
-    auto_offset_reset: str,
-    strict_offset_reset: bool,
-    strategy_factory: ProcessingStrategyFactory[Any],
-) -> None:
-    from django.conf import settings
-
-    from sentry.metrics.middleware import add_global_tags
-
-    add_global_tags(kafka_topic=topic, consumer_group=group_id)
-
-    _initialize_arroyo_main()
-
-    topic_def = settings.KAFKA_TOPICS[topic]
-    assert topic_def is not None
-    cluster_name: str = topic_def["cluster"]
-
-    consumer_config = build_kafka_consumer_configuration(
-        kafka_config.get_kafka_consumer_cluster_options(
-            cluster_name,
-        ),
-        group_id=group_id,
-        auto_offset_reset=auto_offset_reset,
-        strict_offset_reset=strict_offset_reset,
-    )
-
-    consumer = KafkaConsumer(consumer_config)
-
-    processor = StreamProcessor(
-        consumer=consumer,
-        topic=Topic(topic),
-        processor_factory=strategy_factory,
-        commit_policy=ONCE_PER_SECOND,
-    )
-
-    from sentry.utils.kafka import run_processor_with_signals
-
-    run_processor_with_signals(processor)


### PR DESCRIPTION
Update consumers that have a unified consumer (sentry run consumer) to
be used in devserver using their new CLI invocation. So devserver now
runs `sentry run consumer ingest-events` instead of `sentry run
ingest-consumer --consumer-type ingest-events`.

Additionally there is now a new command `sentry run dev-consumer` that
can run multiple of those "unified" consumers at once, in the same
process. This is a bit sketchy because we don't really have any
assurrance that consumers don't interfere with each other. But it seems
to work for the consumers we have.

Also add a new `--dev-consumer` flag to devserver that allows one to
launch one "dev-consumer" process instead of N consumer processes.

I would like to get rid of "mandatory" process-isolation between
consumers eventually, because everytime I start devserver, my CPU runs
really hot and I get a lot of subprocesses. I still would like to have
the _option_ to run consumers in isolated processes, in case there is
some sort of interference I need to debug.
