### PR TITLE
feat(issues): Filter search recommendations case insensitive

### DIFF
--- a/static/app/components/smartSearchBar/utils.spec.tsx
+++ b/static/app/components/smartSearchBar/utils.spec.tsx
@@ -265,6 +265,12 @@ describe('filterKeysFromQuery', () => {
     ).toMatchObject([FieldKey.DEVICE_ARCH, FieldKey.DEVICE_CHARGING]);
   });
 
+  it('filters via lowercase key', () => {
+    expect(
+      filterKeysFromQuery([FieldKey.FIRST_SEEN, FieldKey.LAST_SEEN], 'firstseen')
+    ).toMatchObject([FieldKey.FIRST_SEEN]);
+  });
+
   it('filters via keywords', () => {
     expect(
       filterKeysFromQuery(

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -504,7 +504,7 @@ export const filterKeysFromQuery = (
 ): string[] =>
   tagKeys
     .flatMap(key => {
-      const keyWithoutFunctionPart = key.replaceAll(/\(.*\)/g, '');
+      const keyWithoutFunctionPart = key.replaceAll(/\(.*\)/g, '').toLocaleLowerCase();
       const definition = fieldDefinitionGetter(keyWithoutFunctionPart);
       const lowerCasedSearchTerm = searchTerm.toLocaleLowerCase();
 


### PR DESCRIPTION
fixes an issue searching for "firstSeen" not matching because we only lowercased part of the comparison

before
![image](https://github.com/getsentry/sentry/assets/1400464/262af703-e7f8-4182-9386-1c1973fee9ff)

after
![image](https://github.com/getsentry/sentry/assets/1400464/c3f3fd34-f71e-4856-b018-ffa611641815)
