### PR TITLE
feat(js): Add `endpoint` tag to all request errors

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -168,6 +168,7 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
       }
 
       handlePossibleUndefinedResponseBodyErrors(event);
+      addEndpointTagToRequestError(event);
 
       return event;
     },
@@ -254,5 +255,17 @@ function handlePossibleUndefinedResponseBodyErrors(event: Event): void {
     event.fingerprint = mainErrorIsURBE
       ? ['UndefinedResponseBodyError as main error']
       : ['UndefinedResponseBodyError as cause error'];
+  }
+}
+
+export function addEndpointTagToRequestError(event: Event): void {
+  const errorMessage = event.exception?.values?.[0].value || '';
+
+  // The capturing group here turns `GET /dogs/are/great 500` into just `GET /dogs/are/great`
+  const requestErrorRegex = new RegExp('^([A-Za-z]+ (/[^/]+)+/) \\d+$');
+  const messageMatch = requestErrorRegex.exec(errorMessage);
+
+  if (messageMatch) {
+    event.tags = {...event.tags, endpoint: messageMatch[1]};
   }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/49558, which added an `endpoint` tag to all error events with a request error as their cause. In this PR, the same tag is added to events whose primary error is a request error, by using a helper function in `beforeSend`.