### PR TITLE
chore(js): Export TooltipProps

### DIFF
--- a/static/app/components/acceptanceTestTooltip.tsx
+++ b/static/app/components/acceptanceTestTooltip.tsx
@@ -1,6 +1,6 @@
 import {useEffect, useState} from 'react';
 
-import {DO_NOT_USE_TOOLTIP, InternalTooltipProps} from 'sentry/components/tooltip';
+import {DO_NOT_USE_TOOLTIP, TooltipProps} from 'sentry/components/tooltip';
 import domId from 'sentry/utils/domId';
 
 type Tooltip = {
@@ -56,7 +56,7 @@ class TooltipStore {
 
 const tooltipStore = new TooltipStore();
 
-export function AcceptanceTestTooltip(props: InternalTooltipProps) {
+export function AcceptanceTestTooltip(props: TooltipProps) {
   const [forceVisible, setForceVisible] = useState<undefined | boolean>(undefined);
 
   useEffect(() => {

--- a/static/app/components/avatar/actorAvatar.tsx
+++ b/static/app/components/avatar/actorAvatar.tsx
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/react';
 import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import UserAvatar from 'sentry/components/avatar/userAvatar';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {Tooltip} from 'sentry/components/tooltip';
+import {TooltipProps} from 'sentry/components/tooltip';
 import MemberListStore from 'sentry/stores/memberListStore';
 import {Actor} from 'sentry/types';
 import Teams from 'sentry/utils/teams';
@@ -20,7 +20,7 @@ type Props = {
   suggested?: boolean;
   title?: string;
   tooltip?: React.ReactNode;
-  tooltipOptions?: Omit<React.ComponentProps<typeof Tooltip>, 'children' | 'title'>;
+  tooltipOptions?: Omit<TooltipProps, 'children' | 'title'>;
 };
 
 function ActorAvatar({size = 24, hasTooltip = true, actor, ...props}: Props) {

--- a/static/app/components/avatar/baseAvatar.tsx
+++ b/static/app/components/avatar/baseAvatar.tsx
@@ -5,7 +5,7 @@ import * as qs from 'query-string';
 
 import BackgroundAvatar from 'sentry/components/avatar/backgroundAvatar';
 import LetterAvatar from 'sentry/components/letterAvatar';
-import {Tooltip} from 'sentry/components/tooltip';
+import {Tooltip, TooltipProps} from 'sentry/components/tooltip';
 import {Avatar} from 'sentry/types';
 
 import Gravatar from './gravatar';
@@ -100,7 +100,7 @@ type BaseProps = DefaultProps & {
   /**
    * Additional props for the tooltip
    */
-  tooltipOptions?: Omit<React.ComponentProps<typeof Tooltip>, 'children' | 'title'>;
+  tooltipOptions?: Omit<TooltipProps, 'children' | 'title'>;
   uploadId?: string | null | undefined;
 };
 

--- a/static/app/components/featureBadge.tsx
+++ b/static/app/components/featureBadge.tsx
@@ -6,7 +6,7 @@ import type {SeverityLevel} from '@sentry/types';
 
 import Badge from 'sentry/components/badge';
 import CircleIndicator from 'sentry/components/circleIndicator';
-import {InternalTooltipProps, Tooltip} from 'sentry/components/tooltip';
+import {Tooltip, TooltipProps} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space, ValidSize} from 'sentry/styles/space';
 
@@ -14,7 +14,7 @@ type BadgeProps = {
   type: 'alpha' | 'beta' | 'new' | 'experimental';
   expiresAt?: Date;
   title?: string;
-  tooltipProps?: Partial<InternalTooltipProps>;
+  tooltipProps?: Partial<TooltipProps>;
   variant?: 'indicator' | 'badge';
 };
 

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -4,7 +4,7 @@ import {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import {InternalTooltipProps, Tooltip} from 'sentry/components/tooltip';
+import {Tooltip, TooltipProps} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
 import domId from 'sentry/utils/domId';
 import {FormSize} from 'sentry/utils/theme';
@@ -68,7 +68,7 @@ export type MenuListItemProps = {
   /**
    * Additional props to be passed into <Tooltip />.
    */
-  tooltipOptions?: Omit<InternalTooltipProps, 'children' | 'title' | 'className'>;
+  tooltipOptions?: Omit<TooltipProps, 'children' | 'title' | 'className'>;
   /*
    * Items to be added to the right of the label.
    */

--- a/static/app/components/questionTooltip.tsx
+++ b/static/app/components/questionTooltip.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 
-import {Tooltip} from 'sentry/components/tooltip';
+import {Tooltip, TooltipProps} from 'sentry/components/tooltip';
 import {IconQuestion} from 'sentry/icons';
 import type {IconSize} from 'sentry/utils/theme';
 
 interface QuestionProps
   extends Partial<
     Pick<
-      React.ComponentProps<typeof Tooltip>,
+      TooltipProps,
       'containerDisplayMode' | 'isHoverable' | 'overlayStyle' | 'position'
     >
   > {

--- a/static/app/components/segmentedControl.tsx
+++ b/static/app/components/segmentedControl.tsx
@@ -9,7 +9,7 @@ import {CollectionBase, ItemProps, Node} from '@react-types/shared';
 import {LayoutGroup, motion} from 'framer-motion';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import {InternalTooltipProps, Tooltip} from 'sentry/components/tooltip';
+import {Tooltip, TooltipProps} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {FormSize} from 'sentry/utils/theme';
@@ -35,7 +35,7 @@ export interface SegmentedControlItemProps<Value extends string>
   /**
    * Additional props to be passed into <Tooltip />.
    */
-  tooltipOptions?: Omit<InternalTooltipProps, 'children' | 'title' | 'className'>;
+  tooltipOptions?: Omit<TooltipProps, 'children' | 'title' | 'className'>;
 }
 
 type Priority = 'default' | 'primary';

--- a/static/app/components/tag.tsx
+++ b/static/app/components/tag.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link, {LinkProps} from 'sentry/components/links/link';
-import {Tooltip} from 'sentry/components/tooltip';
+import {Tooltip, TooltipProps} from 'sentry/components/tooltip';
 import {IconClose, IconOpen} from 'sentry/icons';
 import {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
@@ -15,8 +15,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import theme, {Color} from 'sentry/utils/theme';
 
 const TAG_HEIGHT = '20px';
-
-type TooltipProps = React.ComponentProps<typeof Tooltip>;
 
 interface Props extends React.HTMLAttributes<HTMLSpanElement> {
   /**

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -11,7 +11,7 @@ import {useHoverOverlay, UseHoverOverlayProps} from 'sentry/utils/useHoverOverla
 
 import {AcceptanceTestTooltip} from './acceptanceTestTooltip';
 
-export interface InternalTooltipProps extends UseHoverOverlayProps {
+interface InternalTooltipProps extends UseHoverOverlayProps {
   /**
    * The content to show in the tooltip popover
    */
@@ -99,4 +99,4 @@ function Tooltip({disableForVisualTest, ...props}: TooltipProps) {
   return <DO_NOT_USE_TOOLTIP {...props} />;
 }
 
-export {Tooltip};
+export {Tooltip, TooltipProps};

--- a/static/app/views/issueList/actions/reviewAction.tsx
+++ b/static/app/views/issueList/actions/reviewAction.tsx
@@ -1,5 +1,5 @@
 import ActionLink from 'sentry/components/actions/actionLink';
-import {Tooltip} from 'sentry/components/tooltip';
+import {TooltipProps} from 'sentry/components/tooltip';
 import {IconIssues} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -8,10 +8,7 @@ type Props = {
   onUpdate: (data: {inbox: boolean}) => void;
   disabled?: boolean;
   tooltip?: string;
-  tooltipProps?: Omit<
-    React.ComponentProps<typeof Tooltip>,
-    'children' | 'title' | 'skipWrapper'
-  >;
+  tooltipProps?: Omit<TooltipProps, 'children' | 'title' | 'skipWrapper'>;
 };
 
 function ReviewAction({disabled, onUpdate, tooltipProps, tooltip}: Props) {


### PR DESCRIPTION
Removes the InternalTooltipProps export in favor of `TooltipProps`.