### PR TITLE
feat: Add function to get debug IDs off an error

### DIFF
--- a/static/app/utils/getErrorDebugIds.ts
+++ b/static/app/utils/getErrorDebugIds.ts
@@ -34,7 +34,7 @@ export async function getErrorDebugIds(e: Error): Promise<{[filename: string]: s
 
     try {
       const text = await fetch(stackFrame.filename).then(res => res.text());
-      const debugIdMatch = text.match(/^\/\/# debugId=(\S+)/mi);
+      const debugIdMatch = text.match(/^\/\/# debugId=(\S+)/im);
 
       if (debugIdMatch === null) {
         return;

--- a/static/app/utils/getErrorDebugIds.ts
+++ b/static/app/utils/getErrorDebugIds.ts
@@ -17,11 +17,11 @@ export async function getErrorDebugIds(e: Error): Promise<{[filename: string]: s
     return {};
   }
 
-  const stack = Sentry.defaultStackParser(e.stack);
+  const stackFrames = Sentry.defaultStackParser(e.stack);
 
   const debugIdMap: Record<string, string> = {};
 
-  const fetchTaskGenerators = stack.map(stackFrame => async () => {
+  const fetchTaskGenerators = stackFrames.map(stackFrame => async () => {
     if (!stackFrame.filename) {
       return;
     }

--- a/static/app/utils/getErrorDebugIds.ts
+++ b/static/app/utils/getErrorDebugIds.ts
@@ -36,7 +36,7 @@ export async function getErrorDebugIds(e: Error): Promise<{[filename: string]: s
       const text = await fetch(stackFrame.filename).then(res => res.text());
       const debugIdMatch = text.match(/^\/\/# debugId=(\S+)/im);
 
-      if (debugIdMatch === null) {
+      if (!debugIdMatch) {
         return;
       }
 

--- a/static/app/utils/getErrorDebugIds.ts
+++ b/static/app/utils/getErrorDebugIds.ts
@@ -1,0 +1,63 @@
+import * as Sentry from '@sentry/react';
+
+const fileDebugIdCache = new Map<string, string>();
+
+/**
+ * This function simulates having a browser API that takes an error and returns
+ * a map of filenames and debug IDs for the error's stack trace.
+ *
+ * A real browser API would probably not be async - we need it to be async
+ * because internally, this functions works by refetching source files to read
+ * the debug ID comment at the bottom from the file's contents.
+ *
+ * RFC related to this: https://github.com/getsentry/rfcs/blob/main/text/0081-sourcemap-debugid.md
+ */
+export async function getErrorDebugIds(e: Error): Promise<{[filename: string]: string}> {
+  if (!e.stack) {
+    return {};
+  }
+
+  const stack = Sentry.defaultStackParser(e.stack);
+
+  const debugIdMap: Record<string, string> = {};
+
+  const fetchTaskGenerators = stack.map(stackFrame => async () => {
+    if (!stackFrame.filename) {
+      return;
+    }
+
+    const cacheEntry = fileDebugIdCache.get(stackFrame.filename);
+    if (cacheEntry) {
+      debugIdMap[stackFrame.filename] = cacheEntry;
+      return;
+    }
+
+    try {
+      const text = await fetch(stackFrame.filename).then(res => res.text());
+      const debugIdMatch = text.match(/^\/\/# debugId=(\S+)/m);
+
+      if (debugIdMatch === null) {
+        return;
+      }
+
+      fileDebugIdCache.set(stackFrame.filename, debugIdMatch[1]);
+      debugIdMap[stackFrame.filename] = debugIdMatch[1];
+    } catch {
+      // noop
+      return;
+    }
+  });
+
+  const worker = async () => {
+    let fetchTaskGenerator = fetchTaskGenerators.pop();
+    while (fetchTaskGenerator) {
+      await fetchTaskGenerator();
+      fetchTaskGenerator = fetchTaskGenerators.pop();
+    }
+  };
+
+  // Only fetch 5 files at once
+  await Promise.all([worker(), worker(), worker(), worker(), worker()]);
+
+  return debugIdMap;
+}

--- a/static/app/utils/getErrorDebugIds.ts
+++ b/static/app/utils/getErrorDebugIds.ts
@@ -34,7 +34,7 @@ export async function getErrorDebugIds(e: Error): Promise<{[filename: string]: s
 
     try {
       const text = await fetch(stackFrame.filename).then(res => res.text());
-      const debugIdMatch = text.match(/^\/\/# debugId=(\S+)/m);
+      const debugIdMatch = text.match(/^\/\/# debugId=(\S+)/mi);
 
       if (debugIdMatch === null) {
         return;


### PR DESCRIPTION
Adds a "polyfill" that simulates having a browser-native API do get debug IDs from errors as long as the debug IDs are embedded inside a `//# debugID={ID}` comment inside the source files part of the error.

Ref: https://github.com/getsentry/rfcs/blob/main/text/0081-sourcemap-debugid.md
Ref: https://github.com/getsentry/sentry/issues/50053