### PR TITLE
feat(org-tokens): Add `org:ci` scope

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2061,6 +2061,7 @@ SENTRY_SCOPES = {
     "org:write",
     "org:admin",
     "org:integrations",
+    "org:ci",
     "member:read",
     "member:write",
     "member:admin",

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -20,6 +20,8 @@ from sentry.models.organizationonboardingtask import OnboardingTask, OnboardingT
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
 
+default_owner_scopes = frozenset(filter(lambda scope: scope != "org:ci", settings.SENTRY_SCOPES))
+
 mock_options_as_features = {
     "sentry:set_no_value": [
         ("frontend-flag-1-1", lambda opt: True),
@@ -142,7 +144,7 @@ class DetailedOrganizationSerializerTest(TestCase):
 
         assert result["id"] == str(organization.id)
         assert result["role"] == "owner"
-        assert result["access"] == settings.SENTRY_SCOPES
+        assert result["access"] == default_owner_scopes
         assert result["relayPiiConfig"] is None
         assert isinstance(result["orgRoleList"], list)
         assert isinstance(result["teamRoleList"], list)
@@ -160,7 +162,7 @@ class DetailedOrganizationSerializerWithProjectsAndTeamsTest(TestCase):
 
         assert result["id"] == str(self.organization.id)
         assert result["role"] == "owner"
-        assert result["access"] == settings.SENTRY_SCOPES
+        assert result["access"] == default_owner_scopes
         assert result["relayPiiConfig"] is None
         assert len(result["teams"]) == 1
         assert len(result["projects"]) == 1


### PR DESCRIPTION
This is only added to the list of allowed/available scopes, but not actually used anywhere yet. In a follow up, we can use this for the UI to create org tokens.

## Some background

This relates to the RFC https://github.com/getsentry/rfcs/blob/main/text/0091-ci-upload-tokens.md.

We decided that we want to introduce new tokens, first primarily focused on the CI use case.
The goal is that users can provision a new org-bound auth token, put it into their CI and use it for their projects - e.g. for source map upload, release creation etc.

One goal of this initiative is that we do not want users to have to re-issue tokens when our recommended/proposed CI flow changes. For example, let's say we add some new codecov-related things - we want our existing tokens to be able to also do this. In order to realize this, there are two basic options: Either we ensure anything we want CI to do can be done by the initial scopes we chose for the Org tokens (e.g. tie codecov uploads to project:releases ??), or we add a new scope that is tailored to this use case.

Another benefit of having a new scope is that we can make it as undestructive as possible. This scope should never be able to update or delete things, and only be able to create and read the lowest level of things necessary. So org:ci should be considered a pretty low-security scope, overall.

We will not allow to add this scope for user tokens/other places for now (it is not shown in the UI), and only make it available (eventually) for the org auth tokens. We _may_ revisit this later and also make it possible to add this for e.g. user tokens, but it is not a primary goal as of now.

ref https://github.com/getsentry/sentry/issues/50140