### PR TITLE
ref(source-maps): Remove deprecated badge

### DIFF
--- a/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
@@ -8,7 +8,6 @@ import {
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
 import Access from 'sentry/components/acl/access';
-import Badge from 'sentry/components/badge';
 import {Button} from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
 import Count from 'sentry/components/count';
@@ -271,24 +270,6 @@ export function ProjectSourceMaps({location, router, project}: Props) {
         </ListLink>
         <ListLink to={releaseBundlesUrl} isActive={() => !tabDebugIdBundlesActive}>
           {t('Release Bundles')}
-          <Tooltip
-            title={tct(
-              'Release Bundles have been deprecated in favor of Artifact Bundles. Learn more about [link:Artifact Bundles].',
-              {
-                link: (
-                  <ExternalLink
-                    href="https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/artifact-bundles/"
-                    onClick={event => {
-                      event.stopPropagation();
-                    }}
-                  />
-                ),
-              }
-            )}
-            isHoverable
-          >
-            <Badge type="warning" text={t('Deprecated')} />
-          </Tooltip>
         </ListLink>
       </NavTabs>
       <SearchBarWithMarginBottom


### PR DESCRIPTION
We have made the decision to remove the deprecated badge from the "Release bundles" tab in source maps. This update is necessary because not all SDKs currently support the new mechanism involving Bundle Ids and the deprecated badge was making things consufing for a few people.

Related to https://github.com/getsentry/sentry-javascript/discussions/8299