### PR TITLE
fix(onboarding): Fix python doc not loading for existing projects

### DIFF
--- a/static/app/views/onboarding/components/createProjectsFooter.tsx
+++ b/static/app/views/onboarding/components/createProjectsFooter.tsx
@@ -64,14 +64,12 @@ export function CreateProjectsFooter({
       let createProjectForPlatform: OnboardingSelectedSDK | undefined = undefined;
 
       if (selectedFramework) {
-        createProjectForPlatform = projects.find(
-          p => p.platform === selectedFramework.key
-        )
+        createProjectForPlatform = projects.find(p => p.slug === selectedFramework.key)
           ? undefined
           : selectedFramework;
       } else {
         createProjectForPlatform = projects.find(
-          p => p.platform === onboardingContext.data.selectedSDK?.key
+          p => p.slug === onboardingContext.data.selectedSDK?.key
         )
           ? undefined
           : onboardingContext.data.selectedSDK;


### PR DESCRIPTION
In the current implementation, we are checking if the `key` (platform)  saved in the context corresponds to the `project.platform` but in reality, we want to compare the `key` with `project.slug` since the projects in the onboarding of new organizations are created based on slugs 