### PR TITLE
fix(txnames): Prevent scan of all redis keys

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/__init__.py
+++ b/src/sentry/ingest/transaction_clusterer/__init__.py
@@ -24,7 +24,7 @@ class NamespaceOption:
 class ClustererNamespace(Enum):
     TRANSACTIONS = NamespaceOption(
         name="transactions",
-        data="txnames",
+        data="txnames2",
         rules="txrules",
         persistent_storage="sentry:transaction_name_cluster_rules",
         tracker="txcluster.rules_per_project",
@@ -32,7 +32,7 @@ class ClustererNamespace(Enum):
     )
     SPANS = NamespaceOption(
         name="spans",
-        data="span.descs.data",
+        data="span.descs.data2",
         rules="span.descs.rules",
         persistent_storage="sentry:span_description_cluster_rules",
         tracker="span.descs.rules_per_project",

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -47,7 +47,7 @@ def get_redis_client() -> Any:
 def _get_all_keys(namespace: ClustererNamespace) -> Iterator[str]:
     client = get_redis_client()
     prefix = namespace.value.data
-    return client.scan_iter(match=f"{prefix}:*")
+    return client.sscan_iter(f"{prefix}:projects")
 
 
 def get_active_projects(namespace: ClustererNamespace) -> Iterator[Project]:

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -58,7 +58,7 @@ def _get_all_keys(namespace: ClustererNamespace) -> Iterator[str]:
 def get_active_projects(namespace: ClustererNamespace) -> Iterator[Project]:
     """Scan redis for projects and fetch their db models"""
     for key in _get_all_keys(namespace):
-        project_id = int(key.split(":")[-1])
+        project_id = int(key)
         # NOTE: Would be nice to do a `select_related` on project.organization
         # because we need it for the feature flag, but I don't know how to do
         # it with `get_from_cache`.
@@ -94,10 +94,10 @@ def clear_samples(namespace: ClustererNamespace, project: Project) -> None:
     client = get_redis_client()
 
     projects_key = _get_projects_key(namespace)
-    client.srem(projects_key, str(project.id))  # TODO(jjbayer): test me
+    client.srem(projects_key, project.id)
 
     redis_key = _get_redis_key(namespace, project)
-    client.delete(redis_key)
+    client.unlink(redis_key)
 
 
 def record_transaction_name(project: Project, event_data: Mapping[str, Any], **kwargs: Any) -> None:

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -85,7 +85,7 @@ def cluster_projects(projects: Sequence[Project]) -> None:
 
                 # Clear transaction names to prevent the set from picking up
                 # noise over a long time range.
-                redis.clear_transaction_names(project)
+                redis.clear_samples(ClustererNamespace.TRANSACTIONS, project)
             num_clustered += 1
     finally:
         unclustered = len(projects) - num_clustered
@@ -155,7 +155,7 @@ def cluster_projects_span_descs(projects: Sequence[Project]) -> None:
 
                 # Clear transaction names to prevent the set from picking up
                 # noise over a long time range.
-                redis.clear_span_descriptions(project)
+                redis.clear_samples(ClustererNamespace.SPANS, project)
             num_clustered += 1
     finally:
         unclustered = len(projects) - num_clustered

--- a/src/sentry/scripts/utils/sadd_capped.lua
+++ b/src/sentry/scripts/utils/sadd_capped.lua
@@ -7,6 +7,7 @@ local value = ARGV[1]
 local max_size = tonumber(ARGV[2])
 local ttl = ARGV[3]
 
+local existed = redis.call("EXISTS", key)
 local inserted = redis.call("SADD", key, value)
 if inserted then
     local current_size = redis.call("SCARD", key)
@@ -19,3 +20,6 @@ if inserted then
 end
 
 redis.call("EXPIRE", key, ttl)
+
+local created = (existed == 0)
+return created

--- a/src/sentry/scripts/utils/sadd_capped.lua
+++ b/src/sentry/scripts/utils/sadd_capped.lua
@@ -9,7 +9,7 @@ local ttl = ARGV[3]
 
 local existed = redis.call("EXISTS", key)
 local inserted = redis.call("SADD", key, value)
-if inserted then
+if inserted and existed then
     local current_size = redis.call("SCARD", key)
     local overflow = current_size - max_size
     if overflow > 0 then

--- a/tests/sentry/ingest/test_span_desc_clusterer.py
+++ b/tests/sentry/ingest/test_span_desc_clusterer.py
@@ -7,7 +7,7 @@ from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.ingest.transaction_clusterer.base import ReplacementRule
 from sentry.ingest.transaction_clusterer.datasource.redis import (
     _record_sample,
-    clear_span_descriptions,
+    clear_samples,
     get_active_projects,
     get_span_descriptions,
     record_span_descriptions,
@@ -61,12 +61,12 @@ def test_clear_redis():
     project = Project(id=101, name="p1", organization=Organization(pk=66))
     _record_sample(ClustererNamespace.SPANS, project, "foo")
     assert set(get_span_descriptions(project)) == {"foo"}
-    clear_span_descriptions(project)
+    clear_samples(ClustererNamespace.SPANS, project)
     assert set(get_span_descriptions(project)) == set()
 
     # Deleting for a none-existing project does not crash:
     project2 = Project(id=666, name="project2", organization=Organization(pk=66))
-    clear_span_descriptions(project2)
+    clear_samples(ClustererNamespace.SPANS, project2)
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 100)

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.ingest.transaction_clusterer.base import ReplacementRule
 from sentry.ingest.transaction_clusterer.datasource.redis import (
-    _store_transaction_name,
+    _record_sample,
     clear_transaction_names,
     get_active_projects,
     get_transaction_names,
@@ -66,8 +66,8 @@ def test_collection():
 
     for project in (project1, project2):
         for i in range(len(project.name)):
-            _store_transaction_name(project, f"tx-{project.name}-{i}")
-            _store_transaction_name(project, f"tx-{project.name}-{i}")
+            _record_sample(ClustererNamespace.TRANSACTIONS, project, f"tx-{project.name}-{i}")
+            _record_sample(ClustererNamespace.TRANSACTIONS, project, f"tx-{project.name}-{i}")
 
     set_entries1 = set(get_transaction_names(project1))
     assert set_entries1 == {"tx-p1-0", "tx-p1-1"}
@@ -84,7 +84,7 @@ def test_collection():
 
 def test_clear_redis():
     project = Project(id=101, name="p1", organization=Organization(pk=66))
-    _store_transaction_name(project, "foo")
+    _record_sample(ClustererNamespace.TRANSACTIONS, project, "foo")
     assert set(get_transaction_names(project)) == {"foo"}
     clear_transaction_names(project)
     assert set(get_transaction_names(project)) == set()
@@ -99,7 +99,7 @@ def test_distribution():
     """Make sure that the redis set prefers newer entries"""
     project = Project(id=103, name="", organization=Organization(pk=66))
     for i in range(1000):
-        _store_transaction_name(project, str(i))
+        _record_sample(ClustererNamespace.TRANSACTIONS, project, str(i))
 
     freshness = sum(map(int, get_transaction_names(project))) / 100
 
@@ -107,7 +107,7 @@ def test_distribution():
     assert freshness > 800, freshness
 
 
-@mock.patch("sentry.ingest.transaction_clusterer.datasource.redis._store_transaction_name")
+@mock.patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "source, txname, tags, expected",
@@ -205,8 +205,8 @@ def test_save_rules(default_project):
 def test_run_clusterer_task(cluster_projects_delay, default_organization):
     def _add_mock_data(proj, number):
         for i in range(0, number):
-            _store_transaction_name(proj, f"/user/tx-{proj.name}-{i}")
-            _store_transaction_name(proj, f"/org/tx-{proj.name}-{i}")
+            _record_sample(ClustererNamespace.TRANSACTIONS, proj, f"/user/tx-{proj.name}-{i}")
+            _record_sample(ClustererNamespace.TRANSACTIONS, proj, f"/org/tx-{proj.name}-{i}")
 
     project1 = Project(id=123, name="project1", organization_id=default_organization.id)
     project2 = Project(id=223, name="project2", organization_id=default_organization.id)
@@ -244,11 +244,13 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
 
     # add more transactions to the project 1
     for i in range(5):
-        _store_transaction_name(project1, f"/users/trans/tx-{project1.id}-{i}")
-        _store_transaction_name(project1, f"/test/path/{i}")
+        _record_sample(
+            ClustererNamespace.TRANSACTIONS, project1, f"/users/trans/tx-{project1.id}-{i}"
+        )
+        _record_sample(ClustererNamespace.TRANSACTIONS, project1, f"/test/path/{i}")
 
     # Add a transaction to project2 so it runs again
-    _store_transaction_name(project2, "foo")
+    _record_sample(ClustererNamespace.TRANSACTIONS, project2, "foo")
 
     with mock.patch("sentry.ingest.transaction_clusterer.tasks.PROJECTS_PER_TASK", 1), freeze_time(
         "2000-01-01 01:00:01"
@@ -281,7 +283,7 @@ def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default
     project = default_project
     assert get_rules(ClustererNamespace.TRANSACTIONS, project) == {}
 
-    _store_transaction_name(project, "/transaction/number/1")
+    _record_sample(ClustererNamespace.TRANSACTIONS, project, "/transaction/number/1")
     cluster_projects([project])
     # Clusterer didn't create rules. Still, it updates the stores.
     assert mock_update_rules.call_count == 1
@@ -289,8 +291,8 @@ def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default
     # Transaction names are deleted if there aren't enough
     assert get_rules(ClustererNamespace.TRANSACTIONS, project) == {}
 
-    _store_transaction_name(project, "/transaction/number/1")
-    _store_transaction_name(project, "/transaction/number/2")
+    _record_sample(ClustererNamespace.TRANSACTIONS, project, "/transaction/number/1")
+    _record_sample(ClustererNamespace.TRANSACTIONS, project, "/transaction/number/2")
     cluster_projects([project])
     assert mock_update_rules.call_count == 2
     assert mock_update_rules.call_args == mock.call(
@@ -301,7 +303,7 @@ def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default
 @pytest.mark.django_db
 def test_get_deleted_project():
     deleted_project = Project(pk=666, organization=Organization(pk=666))
-    _store_transaction_name(deleted_project, "foo")
+    _record_sample(ClustererNamespace.TRANSACTIONS, deleted_project, "foo")
     assert list(get_active_projects(ClustererNamespace.TRANSACTIONS)) == []
 
 
@@ -354,7 +356,9 @@ def test_transaction_clusterer_bumps_rules(_, default_organization):
 
     with override_options({"txnames.bump-lifetime-sample-rate": 1.0}):
         for i in range(10):
-            _store_transaction_name(project1, f"/user/tx-{project1.name}-{i}/settings")
+            _record_sample(
+                ClustererNamespace.TRANSACTIONS, project1, f"/user/tx-{project1.name}-{i}/settings"
+            )
 
         with mock.patch("sentry.ingest.transaction_clusterer.rules._now", lambda: 1):
             spawn_clusterers()
@@ -417,7 +421,9 @@ def test_dont_store_inexisting_rules(_, default_organization):
         project1 = Project(id=234, name="project1", organization_id=default_organization.id)
         project1.save()
         for i in range(3):
-            _store_transaction_name(project1, f"/user/tx-{project1.name}-{i}/settings")
+            _record_sample(
+                ClustererNamespace.TRANSACTIONS, project1, f"/user/tx-{project1.name}-{i}/settings"
+            )
 
         with mock.patch("sentry.ingest.transaction_clusterer.rules._now", lambda: 1):
             spawn_clusterers()

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -7,7 +7,7 @@ from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.ingest.transaction_clusterer.base import ReplacementRule
 from sentry.ingest.transaction_clusterer.datasource.redis import (
     _record_sample,
-    clear_transaction_names,
+    clear_samples,
     get_active_projects,
     get_transaction_names,
     record_transaction_name,
@@ -86,12 +86,13 @@ def test_clear_redis():
     project = Project(id=101, name="p1", organization=Organization(pk=66))
     _record_sample(ClustererNamespace.TRANSACTIONS, project, "foo")
     assert set(get_transaction_names(project)) == {"foo"}
-    clear_transaction_names(project)
+    clear_samples(ClustererNamespace.TRANSACTIONS, project)
     assert set(get_transaction_names(project)) == set()
+    # TODO: test main set gone
 
     # Deleting for a none-existing project does not crash:
     project2 = Project(id=666, name="project2", organization=Organization(pk=66))
-    clear_transaction_names(project2)
+    clear_samples(ClustererNamespace.TRANSACTIONS, project2)
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 100)

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -108,19 +108,19 @@ def test_clear_redis_projects():
 
     _record_sample(ClustererNamespace.TRANSACTIONS, project1, "foo")
 
-    assert client.exists(_get_projects_key(ClustererNamespace.TRANSACTIONS))
+    assert client.smembers(_get_projects_key(ClustererNamespace.TRANSACTIONS)) == {"101"}
     assert client.exists(_get_redis_key(ClustererNamespace.TRANSACTIONS, project1))
     assert not client.exists(_get_redis_key(ClustererNamespace.TRANSACTIONS, project2))
 
     _record_sample(ClustererNamespace.TRANSACTIONS, project2, "bar")
 
-    assert client.exists(_get_projects_key(ClustererNamespace.TRANSACTIONS))
+    assert client.smembers(_get_projects_key(ClustererNamespace.TRANSACTIONS)) == {"101", "102"}
     assert client.exists(_get_redis_key(ClustererNamespace.TRANSACTIONS, project1))
     assert client.exists(_get_redis_key(ClustererNamespace.TRANSACTIONS, project2))
 
     clear_samples(ClustererNamespace.TRANSACTIONS, project1)
 
-    assert client.exists(_get_projects_key(ClustererNamespace.TRANSACTIONS))
+    assert client.smembers(_get_projects_key(ClustererNamespace.TRANSACTIONS)) == {"102"}
     assert not client.exists(_get_redis_key(ClustererNamespace.TRANSACTIONS, project1))
     assert client.exists(_get_redis_key(ClustererNamespace.TRANSACTIONS, project2))
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -16,6 +16,7 @@ from sentry.buffer.redis import RedisBuffer
 from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.eventstore.models import Event
 from sentry.eventstore.processing import event_processing_store
+from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.issues.escalating import manage_issue_states
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType, ProfileFileIOGroupType
 from sentry.issues.ingest import save_issue_occurrence
@@ -1714,7 +1715,9 @@ class TransactionClustererTestCase(TestCase, SnubaTestCase):
             group_states=None,
         )
 
-        assert mock_store_transaction_name.mock_calls == [mock.call(self.project, "foo")]
+        assert mock_store_transaction_name.mock_calls == [
+            mock.call(ClustererNamespace.TRANSACTIONS, self.project, "foo")
+        ]
 
 
 @region_silo_test

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1683,7 +1683,7 @@ class PostProcessGroupPerformanceTest(
 
 
 class TransactionClustererTestCase(TestCase, SnubaTestCase):
-    @patch("sentry.ingest.transaction_clusterer.datasource.redis._store_transaction_name")
+    @patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
     def test_process_transaction_event_clusterer(
         self,
         mock_store_transaction_name,


### PR DESCRIPTION
Default environments do not define a dedicated redis cluster or redis instance for the transaction name clusterer. Since we use `scan_iter` to iterate through all keys in Redis, the clusterer becomes slower the larger the cluster is overall, independent of how many keys we actually hit.

To prevent scanning all keys, introduce a new "meta" set of project IDs. Whenever a set of samples is newly created for a project, its ID is added to this "meta" set in redis. When spawning clusterers, we iterate only over this set instead.

This PR also unifies some of the helper functions of transaction name and span description clustering, such that the change affects both.

ref https://github.com/getsentry/team-ingest/issues/141