### PR TITLE
fix(mocks) Fix load-mocks usage or OrganizationMember

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -368,11 +368,11 @@ def main(
         org, _ = Organization.objects.get_or_create(slug="default")
 
     OrganizationMember.objects.get_or_create(
-        user=user, organization=org, role=roles.get_top_dog().id
+        user_id=user.id, organization=org, role=roles.get_top_dog().id
     )
 
     dummy_member, _ = OrganizationMember.objects.get_or_create(
-        user=dummy_user, organization=org, defaults={"role": roles.get_default().id}
+        user_id=dummy_user.id, organization=org, defaults={"role": roles.get_default().id}
     )
     # Allow for 0 events, if you only want transactions
     event1 = event2 = event3 = event4 = event5 = None


### PR DESCRIPTION
Patch another problem in load-mocks caused by foreign key breaks.