### PR TITLE
feat(sdk-options): Split up allowUrls and tracePropagationTargets options

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1639,8 +1639,11 @@ SENTRY_FRONTEND_DSN = None
 # DSN for tracking all client HTTP requests (which can be noisy) [experimental]
 SENTRY_FRONTEND_REQUESTS_DSN = None
 
-# Configuration for JavaScript's whitelistUrls - defaults to ALLOWED_HOSTS
+# Configuration for the JavaScript SDK's allowUrls option - defaults to ALLOWED_HOSTS
 SENTRY_FRONTEND_WHITELIST_URLS = None
+
+# Configuration for the JavaScript SDK's tracePropagationTargets option - defaults to an empty array
+SENTRY_FRONTEND_TRACE_PROPAGATION_TARGETS = None
 
 # ----
 # APM config

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -219,6 +219,16 @@ def get_client_config(request=None):
                 if settings.SENTRY_FRONTEND_WHITELIST_URLS
                 else list("" if settings.ALLOWED_HOSTS == ["*"] else settings.ALLOWED_HOSTS)
             ),
+            "allowUrls": (
+                settings.SENTRY_FRONTEND_WHITELIST_URLS
+                if settings.SENTRY_FRONTEND_WHITELIST_URLS
+                else list("" if settings.ALLOWED_HOSTS == ["*"] else settings.ALLOWED_HOSTS)
+            ),
+            "tracePropagationTargets": (
+                settings.SENTRY_FRONTEND_TRACE_PROPAGATION_TARGETS
+                if settings.SENTRY_FRONTEND_TRACE_PROPAGATION_TARGETS
+                else []
+            ),
         },
         "demoMode": settings.DEMO_MODE,
         "enableAnalytics": settings.ENABLE_ANALYTICS,


### PR DESCRIPTION
Splits up the `SENTRY_FRONTEND_WHITELIST_URLS` option with `SENTRY_FRONTEND_TRACE_PROPAGATION_TARGETS` so that we can pass separate values for `allowUrls` and `tracePropagationTargets` to the JS SDK init.