### PR TITLE
feat(starfish): Use `sps()` instead of `spm()`

### DIFF
--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -25,7 +25,7 @@ export type SpanMetrics = {
   'span.domain': string;
   'span.group': string;
   'span.op': string;
-  'spm()': number;
+  'sps()': number;
   'sps_percent_change()': number;
   'sum(span.duration)': number;
   'time_spent_percentage()': number;
@@ -142,7 +142,7 @@ function getEventView(
         'span.group',
         'span.description',
         'span.domain',
-        'spm()',
+        'sps()',
         'sps_percent_change()',
         'sum(span.duration)',
         'p95(span.duration)',

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -19,7 +19,7 @@ const INTERVAL = 12;
 export type SpanMetrics = {
   interval: number;
   'p95(span.duration)': number;
-  'spm()': number;
+  'sps()': number;
   'sum(span.duration)': number;
   'time_spent_percentage()': number;
 };

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -117,7 +117,7 @@ function ThroughputChart({moduleName, filters}: ChartProps): JSX.Element {
       {
         seriesName: label ?? 'Throughput',
         data: groupData.map(datum => ({
-          value: datum['spm()'] / 60,
+          value: datum['sps()'],
           name: datum.interval,
         })),
       },
@@ -307,7 +307,7 @@ const getEventView = (
     {
       name: '',
       fields: [''],
-      yAxis: ['spm()', 'p50(span.duration)', 'p95(span.duration)'],
+      yAxis: ['sps()', 'p50(span.duration)', 'p95(span.duration)'],
       query,
       dataset: DiscoverDatasets.SPANS_METRICS,
       projects: [1],

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -32,7 +32,7 @@ export type SpanDataRow = {
   'span.domain': string;
   'span.group': string;
   'span.op': string;
-  'spm()': number;
+  'sps()': number;
   'sps_percent_change()': number;
   'time_spent_percentage()': number;
 };
@@ -41,7 +41,7 @@ export type Keys =
   | 'span.description'
   | 'span.op'
   | 'span.domain'
-  | 'spm()'
+  | 'sps()'
   | 'p95(span.duration)'
   | 'sps_percent_change()'
   | 'sum(span.duration)'
@@ -132,10 +132,10 @@ function renderBodyCell(
     );
   }
 
-  if (column.key === 'spm()') {
+  if (column.key === 'sps()') {
     return (
       <ThroughputCell
-        throughputPerSecond={row['spm()']}
+        throughputPerSecond={row['sps()']}
         delta={row['sps_percent_change()']}
       />
     );
@@ -198,7 +198,7 @@ function getColumns(moduleName: ModuleName): TableColumnHeader[] {
         ]
       : []),
     {
-      key: 'spm()',
+      key: 'sps()',
       name: 'Throughput',
       width: 175,
     },


### PR DESCRIPTION
We were using `spm()` and dividing by 60 in a few different spots in the application, but now we have access to `sps()` in metrics, so this PR updates the codebase to use that instead