### PR TITLE
feat(perf): Add clusterer soak messaging

### DIFF
--- a/static/app/views/performance/table.spec.tsx
+++ b/static/app/views/performance/table.spec.tsx
@@ -151,6 +151,21 @@ describe('Performance > Table', function () {
         user_misery: 0.114,
         project_threshold_config: ['duration', 300],
       },
+      {
+        team_key_transaction: 0,
+        transaction: '<< unparameterized >>',
+        project: '3',
+        user: 'uhoh@example.com',
+        tpm: 1,
+        p50: 100,
+        p95: 500,
+        failure_rate: 0.1,
+        apdex: 0.6,
+        count_unique_user: 500,
+        count_miserable_user: 31,
+        user_misery: 0.514,
+        project_threshold_config: ['duration', 300],
+      },
     ];
     eventsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
@@ -199,7 +214,7 @@ describe('Performance > Table', function () {
       );
 
       const cellActionContainers = screen.getAllByTestId('cell-action-container');
-      expect(cellActionContainers).toHaveLength(18); // 9 cols x 2 rows
+      expect(cellActionContainers).toHaveLength(27); // 9 cols x 3 rows
       const cellActionTriggers = screen.getAllByRole('button', {name: 'Actions'});
       expect(cellActionTriggers[8]).toBeInTheDocument();
       await userEvent.click(cellActionTriggers[8]);
@@ -247,6 +262,65 @@ describe('Performance > Table', function () {
 
       const cellActionContainers = screen.queryByTestId('cell-action-container');
       expect(cellActionContainers).not.toBeInTheDocument();
+    });
+
+    it('shows unparameterized tooltip when project only recently sent events', async function () {
+      const projects = [
+        TestStubs.Project({id: '1', slug: '1'}),
+        TestStubs.Project({id: '2', slug: '2'}),
+        TestStubs.Project({id: '3', slug: '3', firstEvent: new Date().toISOString()}),
+      ];
+      const data = initializeData({
+        query: 'event.type:transaction transaction:/api*',
+        projects,
+      });
+
+      ProjectsStore.loadInitialData(data.organization.projects);
+
+      render(
+        <WrappedComponent
+          data={data}
+          eventView={mockEventView(data)}
+          setError={jest.fn()}
+          summaryConditions=""
+          projects={data.projects}
+        />
+      );
+
+      const indicatorContainer = await screen.findByTestId('unparameterized-indicator');
+      expect(indicatorContainer).toBeInTheDocument();
+    });
+
+    it('does not show unparameterized tooltip when project only recently sent events', async function () {
+      const projects = [
+        TestStubs.Project({id: '1', slug: '1'}),
+        TestStubs.Project({id: '2', slug: '2'}),
+        TestStubs.Project({
+          id: '3',
+          slug: '3',
+          firstEvent: new Date(+new Date() - 25920e5).toISOString(),
+        }),
+      ];
+      const data = initializeData({
+        query: 'event.type:transaction transaction:/api*',
+        projects,
+      });
+
+      ProjectsStore.loadInitialData(data.organization.projects);
+
+      render(
+        <WrappedComponent
+          data={data}
+          eventView={mockEventView(data)}
+          setError={jest.fn()}
+          summaryConditions=""
+          projects={data.projects}
+        />
+      );
+
+      await screen.findByTestId('grid-editable');
+      const indicatorContainer = screen.queryByTestId('unparameterized-indicator');
+      expect(indicatorContainer).not.toBeInTheDocument();
     });
 
     it('sends MEP param when setting enabled', function () {

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -42,7 +42,6 @@ import {
 } from './transactionSummary/utils';
 import {COLUMN_TITLES} from './data';
 import {
-  areMultipleProjectsSelected,
   createUnnamedTransactionsDiscoverTarget,
   getProject,
   getProjectID,

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -12,10 +12,11 @@ import GridEditable, {
 } from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
 import Link from 'sentry/components/links/link';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconStar} from 'sentry/icons';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import DiscoverQuery, {
@@ -43,6 +44,7 @@ import {COLUMN_TITLES} from './data';
 import {
   areMultipleProjectsSelected,
   createUnnamedTransactionsDiscoverTarget,
+  getProject,
   getProjectID,
   getSelectedProjectPlatforms,
   UNPARAMETERIZED_TRANSACTION,
@@ -98,48 +100,40 @@ class _Table extends Component<Props, State> {
   unparameterizedMetricSet = false;
   tableMetricSet = false;
 
-  sendUnparameterizedAnalytic() {
+  sendUnparameterizedAnalytic(project: Project | undefined) {
     const {organization, eventView} = this.props;
     const statsPeriod = eventView.statsPeriod ?? 'other';
-    const firstEventData = this.getFirstEventData();
+    const projectMetadata = this.getProjectWithinMetadata(project);
 
     trackAnalytics('performance_views.landing.table.unparameterized', {
       organization,
-      first_event: firstEventData.firstEventWithin,
-      sent_transaction: firstEventData.singleProject?.firstTransactionEvent ?? false,
-      single_project: firstEventData.isSingleProject,
+      first_event: projectMetadata.firstEventWithin,
+      sent_transaction: projectMetadata.sentTransaction,
+      single_project: projectMetadata.isSingleProject,
       stats_period: statsPeriod,
-      hit_multi_project_cap: firstEventData.isAtMultiCap,
+      hit_multi_project_cap: projectMetadata.isAtMultiCap,
     });
   }
 
   /**
    * Used for cluster warning and analytics.
    */
-  getFirstEventData() {
-    const {eventView, projects} = this.props;
-    const isSingleProject = !areMultipleProjectsSelected(eventView);
-
-    const selectedProjects = eventView.getFullSelectedProjects(projects);
-    const isAtMultiCap = selectedProjects.length > 1000;
-    const singleProject = selectedProjects[0];
-    let firstEventWithin: 'none' | '14d' | '30d' | '>30d' = '>30d';
-    if (isSingleProject) {
-      firstEventWithin = getProjectFirstEventGroup(singleProject);
-    } else if (!isAtMultiCap) {
-      const dateGroups = selectedProjects.map(getProjectFirstEventGroup);
-      if (dateGroups.every(g => g === '14d')) {
-        firstEventWithin = '14d';
-      }
-      if (dateGroups.every(g => g === '14d' || g === '30d')) {
-        firstEventWithin = '30d';
-      }
+  getProjectWithinMetadata(project: Project | undefined) {
+    let firstEventWithin: 'none' | '14d' | '30d' | '>30d' = 'none';
+    if (!project) {
+      return {
+        isSingleProject: false,
+        firstEventWithin,
+        sentTransaction: false,
+        isAtMultiCap: false,
+      };
     }
+    firstEventWithin = getProjectFirstEventGroup(project);
     return {
+      isSingleProject: true,
       firstEventWithin,
-      isSingleProject,
-      singleProject,
-      isAtMultiCap,
+      sentTransaction: project?.firstTransactionEvent ?? false,
+      isAtMultiCap: false,
     };
   }
 
@@ -236,7 +230,8 @@ class _Table extends Component<Props, State> {
     const isUnparameterizedRow = dataRow.transaction === UNPARAMETERIZED_TRANSACTION;
 
     if (field === 'transaction') {
-      const projectID = getProjectID(dataRow, projects);
+      const project = getProject(dataRow, projects);
+      const projectID = project?.id;
       const summaryView = eventView.clone();
       if (dataRow['http.method']) {
         summaryView.additionalConditions.setFilterValues('http.method', [
@@ -245,7 +240,7 @@ class _Table extends Component<Props, State> {
       }
       summaryView.query = summaryView.getQueryWithAdditionalConditions();
       if (isUnparameterizedRow && !this.unparameterizedMetricSet) {
-        this.sendUnparameterizedAnalytic();
+        this.sendUnparameterizedAnalytic(project);
         this.unparameterizedMetricSet = true;
       }
       const target = isUnparameterizedRow
@@ -280,6 +275,29 @@ class _Table extends Component<Props, State> {
 
     if (field.startsWith('team_key_transaction')) {
       // don't display per cell actions for team_key_transaction
+
+      const project = getProject(dataRow, projects);
+      const projectMetadata = this.getProjectWithinMetadata(project);
+      if (isUnparameterizedRow) {
+        if (projectMetadata.firstEventWithin === '14d') {
+          return (
+            <Tooltip
+              title={t(
+                'Transactions are grouped together until we receive enough data to identify parameter patterns.'
+              )}
+            >
+              <UnparameterizedTooltipWrapper data-test-id="unparameterized-indicator">
+                <LoadingIndicator
+                  mini
+                  size={16}
+                  style={{margin: 0, width: 16, height: 16}}
+                />
+              </UnparameterizedTooltipWrapper>
+            </Tooltip>
+          );
+        }
+        return <span />;
+      }
       return rendered;
     }
 
@@ -552,6 +570,12 @@ function Table(props: Omit<Props, 'summaryConditions'> & {summaryConditions?: st
 // rows, which have 2px padding + 1px border.
 const TeamKeyTransactionWrapper = styled('div')`
   padding: 3px;
+`;
+
+const UnparameterizedTooltipWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 export default Table;

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -356,17 +356,24 @@ export function getSelectedProjectPlatforms(location: Location, projects: Projec
   return selectedProjectPlatforms.join(', ');
 }
 
-export function getProjectID(
+export function getProject(
   eventData: EventData,
   projects: Project[]
-): string | undefined {
+): Project | undefined {
   const projectSlug = (eventData?.project as string) || undefined;
 
   if (typeof projectSlug === undefined) {
     return undefined;
   }
 
-  return projects.find(currentProject => currentProject.slug === projectSlug)?.id;
+  return projects.find(currentProject => currentProject.slug === projectSlug);
+}
+
+export function getProjectID(
+  eventData: EventData,
+  projects: Project[]
+): string | undefined {
+  return getProject(eventData, projects)?.id;
 }
 
 export function transformTransaction(


### PR DESCRIPTION
### Summary
While we wait for changes to the clusterer to automatically let through new accounts source:url transactions, this should inform users that they can just wait for transactions to come in and that we will be automatically grouping them shortly.

Other:
- Removes key transactions for unparameterized

#### Screenshots
![Screenshot 2023-06-14 at 11 52 01 AM](https://github.com/getsentry/sentry/assets/6111995/aa41b6b9-5b22-4bd7-9079-c68973c98034)
![Screenshot 2023-06-14 at 11 51 46 AM](https://github.com/getsentry/sentry/assets/6111995/83d5930e-1672-48c9-b9e5-d36326f7ee9f)



