### PR TITLE
fix(mobile): Elide invalid_data errors from Cocoa in the UI

### DIFF
--- a/static/app/components/events/eventErrors.spec.tsx
+++ b/static/app/components/events/eventErrors.spec.tsx
@@ -36,7 +36,7 @@ describe('EventErrors', () => {
         {
           type: 'invalid_data',
           data: {
-            name: 'contexts.trace.sampled',
+            name: 'breadcrumbs.values.2.data',
           },
           message: 'expected an object',
         },
@@ -69,7 +69,7 @@ describe('EventErrors', () => {
         {
           type: 'invalid_data',
           data: {
-            name: 'breadcrumbs.values.2.data',
+            name: 'contexts.trace.sampled',
           },
           message: 'expected an object',
         },

--- a/static/app/components/events/eventErrors.spec.tsx
+++ b/static/app/components/events/eventErrors.spec.tsx
@@ -36,7 +36,7 @@ describe('EventErrors', () => {
         {
           type: 'invalid_data',
           data: {
-            name: 'breadcrumbs.values.2.data',
+            name: 'contexts.trace.sampled',
           },
           message: 'expected an object',
         },

--- a/static/app/components/events/eventErrors.spec.tsx
+++ b/static/app/components/events/eventErrors.spec.tsx
@@ -56,6 +56,38 @@ describe('EventErrors', () => {
     ).toBeInTheDocument();
   });
 
+  it('does not render hidden cocoa errors', async () => {
+    const eventWithErrors = TestStubs.Event({
+      errors: [
+        {
+          type: 'not_invalid_data',
+          data: {
+            name: 'logentry',
+          },
+          message: 'no message present',
+        },
+        {
+          type: 'invalid_data',
+          data: {
+            name: 'breadcrumbs.values.2.data',
+          },
+          message: 'expected an object',
+        },
+      ],
+      sdk: {
+        name: 'sentry.cocoa',
+        version: '8.7.3',
+      },
+    });
+
+    render(<EventErrors {...defaultProps} event={eventWithErrors} />);
+
+    await userEvent.click(screen.getByText(/there was 1 problem processing this event/i));
+    const errorItem = screen.getByTestId('event-error-item');
+    expect(errorItem).toBeInTheDocument();
+    expect(within(errorItem).getByText('logentry')).toBeInTheDocument();
+  });
+
   it('hides source map not found error', () => {
     const eventWithDifferentDist = TestStubs.Event({
       errors: [

--- a/static/app/components/events/eventErrors.tsx
+++ b/static/app/components/events/eventErrors.tsx
@@ -10,7 +10,10 @@ import findBestThread from 'sentry/components/events/interfaces/threads/threadSe
 import getThreadException from 'sentry/components/events/interfaces/threads/threadSelector/getThreadException';
 import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list';
-import {JavascriptProcessingErrors} from 'sentry/constants/eventErrors';
+import {
+  CocoaProcessingErrors,
+  JavascriptProcessingErrors,
+} from 'sentry/constants/eventErrors';
 import {tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Project} from 'sentry/types';
@@ -25,7 +28,10 @@ import {projectProcessingIssuesMessages} from 'sentry/views/settings/project/pro
 
 import {DataSection} from './styles';
 
-const ERRORS_TO_HIDE = [JavascriptProcessingErrors.JS_MISSING_SOURCE];
+const ERRORS_TO_HIDE = [
+  JavascriptProcessingErrors.JS_MISSING_SOURCE,
+  CocoaProcessingErrors.COCOA_INVALID_DATA,
+];
 
 const MAX_ERRORS = 100;
 const MINIFIED_DATA_JAVA_EVENT_REGEX_MATCH =

--- a/static/app/components/events/eventErrors.tsx
+++ b/static/app/components/events/eventErrors.tsx
@@ -56,8 +56,10 @@ function shouldErrorBeShown(error: EventErrorData, event: Event) {
   if (
     error.type === CocoaProcessingErrors.COCOA_INVALID_DATA &&
     event.sdk?.name === 'sentry.cocoa' &&
+    event.data?.name === 'contexts.trace.sampled' &&
     semverCompare(event.sdk?.version || '', '8.7.4') === -1
   ) {
+    // The Cocoa SDK sends wrong values for contexts.trace.sampled before 8.7.4
     return false;
   }
   return true;

--- a/static/app/components/events/eventErrors.tsx
+++ b/static/app/components/events/eventErrors.tsx
@@ -56,7 +56,7 @@ function shouldErrorBeShown(error: EventErrorData, event: Event) {
   if (
     error.type === CocoaProcessingErrors.COCOA_INVALID_DATA &&
     event.sdk?.name === 'sentry.cocoa' &&
-    event.data?.name === 'contexts.trace.sampled' &&
+    error.data?.name === 'contexts.trace.sampled' &&
     semverCompare(event.sdk?.version || '', '8.7.4') === -1
   ) {
     // The Cocoa SDK sends wrong values for contexts.trace.sampled before 8.7.4

--- a/static/app/components/events/eventErrors.tsx
+++ b/static/app/components/events/eventErrors.tsx
@@ -4,7 +4,6 @@ import isEqual from 'lodash/isEqual';
 import uniq from 'lodash/uniq';
 import uniqWith from 'lodash/uniqWith';
 
-import {semverCompare} from 'sentry/utils/versions';
 import {Alert} from 'sentry/components/alert';
 import {ErrorItem, EventErrorData} from 'sentry/components/events/errorItem';
 import findBestThread from 'sentry/components/events/interfaces/threads/threadSelector/findBestThread';
@@ -25,6 +24,7 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import {semverCompare} from 'sentry/utils/versions';
 import {projectProcessingIssuesMessages} from 'sentry/views/settings/project/projectProcessingIssues';
 
 import {DataSection} from './styles';
@@ -55,6 +55,7 @@ function shouldErrorBeShown(error: EventErrorData, event: Event) {
   }
   if (
     error.type === CocoaProcessingErrors.COCOA_INVALID_DATA &&
+    event.sdk?.name === 'sentry.cocoa' &&
     semverCompare(event.sdk?.version || '', '8.7.4') === -1
   ) {
     return false;

--- a/static/app/constants/eventErrors.tsx
+++ b/static/app/constants/eventErrors.tsx
@@ -11,3 +11,7 @@ export enum JavascriptProcessingErrors {
   JS_TOO_LARGE = 'js_too_large',
   JS_FETCH_TIMEOUT = 'js_fetch_timeout',
 }
+
+export enum CocoaProcessingErrors {
+  COCOA_INVALID_DATA = 'invalid_data',
+}

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -1,6 +1,6 @@
 /* global process */
 
-import {t} from 'sentry/locale';
+import { t } from 'sentry/locale';
 import {
   DataCategoryExact,
   DataCategoryInfo,
@@ -126,28 +126,28 @@ export const SENTRY_APP_PERMISSIONS: PermissionObj[] = [
     resource: 'Project',
     help: 'Projects, Tags, Debug Files, and Feedback',
     choices: {
-      'no-access': {label: 'No Access', scopes: []},
-      read: {label: 'Read', scopes: ['project:read']},
-      write: {label: 'Read & Write', scopes: ['project:read', 'project:write']},
-      admin: {label: 'Admin', scopes: ['project:read', 'project:write', 'project:admin']},
+      'no-access': { label: 'No Access', scopes: [] },
+      read: { label: 'Read', scopes: ['project:read'] },
+      write: { label: 'Read & Write', scopes: ['project:read', 'project:write'] },
+      admin: { label: 'Admin', scopes: ['project:read', 'project:write', 'project:admin'] },
     },
   },
   {
     resource: 'Team',
     help: 'Teams of members',
     choices: {
-      'no-access': {label: 'No Access', scopes: []},
-      read: {label: 'Read', scopes: ['team:read']},
-      write: {label: 'Read & Write', scopes: ['team:read', 'team:write']},
-      admin: {label: 'Admin', scopes: ['team:read', 'team:write', 'team:admin']},
+      'no-access': { label: 'No Access', scopes: [] },
+      read: { label: 'Read', scopes: ['team:read'] },
+      write: { label: 'Read & Write', scopes: ['team:read', 'team:write'] },
+      admin: { label: 'Admin', scopes: ['team:read', 'team:write', 'team:admin'] },
     },
   },
   {
     resource: 'Release',
     help: 'Releases, Commits, and related Files',
     choices: {
-      'no-access': {label: 'No Access', scopes: []},
-      admin: {label: 'Admin', scopes: ['project:releases']},
+      'no-access': { label: 'No Access', scopes: [] },
+      admin: { label: 'Admin', scopes: ['project:releases'] },
     },
   },
   {
@@ -155,30 +155,30 @@ export const SENTRY_APP_PERMISSIONS: PermissionObj[] = [
     label: 'Issue & Event',
     help: 'Issues, Events, and workflow statuses',
     choices: {
-      'no-access': {label: 'No Access', scopes: []},
-      read: {label: 'Read', scopes: ['event:read']},
-      write: {label: 'Read & Write', scopes: ['event:read', 'event:write']},
-      admin: {label: 'Admin', scopes: ['event:read', 'event:write', 'event:admin']},
+      'no-access': { label: 'No Access', scopes: [] },
+      read: { label: 'Read', scopes: ['event:read'] },
+      write: { label: 'Read & Write', scopes: ['event:read', 'event:write'] },
+      admin: { label: 'Admin', scopes: ['event:read', 'event:write', 'event:admin'] },
     },
   },
   {
     resource: 'Organization',
     help: 'Manage Organizations, resolve IDs, retrieve Repositories and Commits',
     choices: {
-      'no-access': {label: 'No Access', scopes: []},
-      read: {label: 'Read', scopes: ['org:read']},
-      write: {label: 'Read & Write', scopes: ['org:read', 'org:write']},
-      admin: {label: 'Admin', scopes: ['org:read', 'org:write', 'org:admin']},
+      'no-access': { label: 'No Access', scopes: [] },
+      read: { label: 'Read', scopes: ['org:read'] },
+      write: { label: 'Read & Write', scopes: ['org:read', 'org:write'] },
+      admin: { label: 'Admin', scopes: ['org:read', 'org:write', 'org:admin'] },
     },
   },
   {
     resource: 'Member',
     help: 'Manage Members within Teams',
     choices: {
-      'no-access': {label: 'No Access', scopes: []},
-      read: {label: 'Read', scopes: ['member:read']},
-      write: {label: 'Read & Write', scopes: ['member:read', 'member:write']},
-      admin: {label: 'Admin', scopes: ['member:read', 'member:write', 'member:admin']},
+      'no-access': { label: 'No Access', scopes: [] },
+      read: { label: 'Read', scopes: ['member:read'] },
+      write: { label: 'Read & Write', scopes: ['member:read', 'member:write'] },
+      admin: { label: 'Admin', scopes: ['member:read', 'member:write', 'member:admin'] },
     },
   },
 ];
@@ -306,11 +306,11 @@ export const MAX_QUERY_LENGTH = 400;
 export const DEPLOY_PREVIEW_CONFIG = process.env.DEPLOY_PREVIEW_CONFIG as unknown as
   | undefined
   | {
-      branch: string;
-      commitSha: string;
-      githubOrg: string;
-      githubRepo: string;
-    };
+    branch: string;
+    commitSha: string;
+    githubOrg: string;
+    githubRepo: string;
+  };
 
 // Webpack configures EXPERIMENTAL_SPA.
 export const EXPERIMENTAL_SPA = process.env.EXPERIMENTAL_SPA as unknown as

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -1,6 +1,6 @@
 /* global process */
 
-import { t } from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {
   DataCategoryExact,
   DataCategoryInfo,
@@ -126,28 +126,28 @@ export const SENTRY_APP_PERMISSIONS: PermissionObj[] = [
     resource: 'Project',
     help: 'Projects, Tags, Debug Files, and Feedback',
     choices: {
-      'no-access': { label: 'No Access', scopes: [] },
-      read: { label: 'Read', scopes: ['project:read'] },
-      write: { label: 'Read & Write', scopes: ['project:read', 'project:write'] },
-      admin: { label: 'Admin', scopes: ['project:read', 'project:write', 'project:admin'] },
+      'no-access': {label: 'No Access', scopes: []},
+      read: {label: 'Read', scopes: ['project:read']},
+      write: {label: 'Read & Write', scopes: ['project:read', 'project:write']},
+      admin: {label: 'Admin', scopes: ['project:read', 'project:write', 'project:admin']},
     },
   },
   {
     resource: 'Team',
     help: 'Teams of members',
     choices: {
-      'no-access': { label: 'No Access', scopes: [] },
-      read: { label: 'Read', scopes: ['team:read'] },
-      write: { label: 'Read & Write', scopes: ['team:read', 'team:write'] },
-      admin: { label: 'Admin', scopes: ['team:read', 'team:write', 'team:admin'] },
+      'no-access': {label: 'No Access', scopes: []},
+      read: {label: 'Read', scopes: ['team:read']},
+      write: {label: 'Read & Write', scopes: ['team:read', 'team:write']},
+      admin: {label: 'Admin', scopes: ['team:read', 'team:write', 'team:admin']},
     },
   },
   {
     resource: 'Release',
     help: 'Releases, Commits, and related Files',
     choices: {
-      'no-access': { label: 'No Access', scopes: [] },
-      admin: { label: 'Admin', scopes: ['project:releases'] },
+      'no-access': {label: 'No Access', scopes: []},
+      admin: {label: 'Admin', scopes: ['project:releases']},
     },
   },
   {
@@ -155,30 +155,30 @@ export const SENTRY_APP_PERMISSIONS: PermissionObj[] = [
     label: 'Issue & Event',
     help: 'Issues, Events, and workflow statuses',
     choices: {
-      'no-access': { label: 'No Access', scopes: [] },
-      read: { label: 'Read', scopes: ['event:read'] },
-      write: { label: 'Read & Write', scopes: ['event:read', 'event:write'] },
-      admin: { label: 'Admin', scopes: ['event:read', 'event:write', 'event:admin'] },
+      'no-access': {label: 'No Access', scopes: []},
+      read: {label: 'Read', scopes: ['event:read']},
+      write: {label: 'Read & Write', scopes: ['event:read', 'event:write']},
+      admin: {label: 'Admin', scopes: ['event:read', 'event:write', 'event:admin']},
     },
   },
   {
     resource: 'Organization',
     help: 'Manage Organizations, resolve IDs, retrieve Repositories and Commits',
     choices: {
-      'no-access': { label: 'No Access', scopes: [] },
-      read: { label: 'Read', scopes: ['org:read'] },
-      write: { label: 'Read & Write', scopes: ['org:read', 'org:write'] },
-      admin: { label: 'Admin', scopes: ['org:read', 'org:write', 'org:admin'] },
+      'no-access': {label: 'No Access', scopes: []},
+      read: {label: 'Read', scopes: ['org:read']},
+      write: {label: 'Read & Write', scopes: ['org:read', 'org:write']},
+      admin: {label: 'Admin', scopes: ['org:read', 'org:write', 'org:admin']},
     },
   },
   {
     resource: 'Member',
     help: 'Manage Members within Teams',
     choices: {
-      'no-access': { label: 'No Access', scopes: [] },
-      read: { label: 'Read', scopes: ['member:read'] },
-      write: { label: 'Read & Write', scopes: ['member:read', 'member:write'] },
-      admin: { label: 'Admin', scopes: ['member:read', 'member:write', 'member:admin'] },
+      'no-access': {label: 'No Access', scopes: []},
+      read: {label: 'Read', scopes: ['member:read']},
+      write: {label: 'Read & Write', scopes: ['member:read', 'member:write']},
+      admin: {label: 'Admin', scopes: ['member:read', 'member:write', 'member:admin']},
     },
   },
 ];
@@ -306,11 +306,11 @@ export const MAX_QUERY_LENGTH = 400;
 export const DEPLOY_PREVIEW_CONFIG = process.env.DEPLOY_PREVIEW_CONFIG as unknown as
   | undefined
   | {
-    branch: string;
-    commitSha: string;
-    githubOrg: string;
-    githubRepo: string;
-  };
+      branch: string;
+      commitSha: string;
+      githubOrg: string;
+      githubRepo: string;
+    };
 
 // Webpack configures EXPERIMENTAL_SPA.
 export const EXPERIMENTAL_SPA = process.env.EXPERIMENTAL_SPA as unknown as


### PR DESCRIPTION
### Summary
Don't show the invalid_data errors in the UI as to not cause false alarm as this has since been fixed.


### Screenshots

#### Before
![Screenshot 2023-06-14 at 12 08 45 PM](https://github.com/getsentry/sentry/assets/6111995/ccbef4f6-023e-4e1c-80cb-921f7d68ea55)

#### After
![Screenshot 2023-06-14 at 12 04 51 PM](https://github.com/getsentry/sentry/assets/6111995/24582d7a-058e-4b00-9740-9c88f1f513f6)

