### PR TITLE
perf(indexer): Throttle Sentry logging for dropped cardinality errors

### DIFF
--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -557,8 +557,6 @@ def test_process_messages_cardinality_limited(
 
         compare_message_batches_ignoring_metadata(new_batch, [])
 
-        assert "dropped_message" in caplog.text
-
 
 def test_valid_metric_name() -> None:
     assert valid_metric_name("") is True


### PR DESCRIPTION
We are getting way too many dropped messages due to high cardinality, throttle logging of these to Sentry
