### PR TITLE
ref(useOverlay): Open other overlays on outside click

### DIFF
--- a/static/app/components/compactSelect/index.spec.tsx
+++ b/static/app/components/compactSelect/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {CompactSelect} from 'sentry/components/compactSelect';
@@ -43,6 +45,49 @@ describe('CompactSelect', function () {
     await userEvent.click(screen.getByRole('button'));
 
     expect(screen.getByText('Menu title')).toBeInTheDocument();
+  });
+
+  it('can be dismissed', async function () {
+    render(
+      <Fragment>
+        <CompactSelect
+          value="opt_one"
+          menuTitle="Menu A"
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+        />
+        <CompactSelect
+          value="opt_three"
+          menuTitle="Menu B"
+          options={[
+            {value: 'opt_three', label: 'Option Three'},
+            {value: 'opt_four', label: 'Option Four'},
+          ]}
+        />
+      </Fragment>
+    );
+
+    // Can be dismissed by clicking outside
+    await userEvent.click(screen.getByRole('button', {name: 'Option One'}));
+    expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+    await userEvent.click(document.body);
+    expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
+
+    // Can be dismissed by pressing Escape
+    await userEvent.click(screen.getByRole('button', {name: 'Option One'}));
+    expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+    await userEvent.keyboard('{Escape}');
+    expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
+
+    // When menu A is open, clicking once on menu B's trigger button closes menu A and
+    // then opens menu B
+    await userEvent.click(screen.getByRole('button', {name: 'Option One'}));
+    expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Option Three'}));
+    expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Option Three'})).toBeInTheDocument();
   });
 
   describe('ListBox', function () {

--- a/static/app/components/dropdownMenu/index.spec.tsx
+++ b/static/app/components/dropdownMenu/index.spec.tsx
@@ -1,5 +1,5 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
-
+import {Fragment} from 'react';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 
 describe('DropdownMenu', function () {
@@ -79,6 +79,41 @@ describe('DropdownMenu', function () {
 
     await userEvent.click(menuItem);
     expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('can be dismissed', async function () {
+    render(
+      <Fragment>
+        <DropdownMenu items={[{key: 'item1', label: 'Item One'}]} triggerLabel="Menu A" />
+        <DropdownMenu items={[{key: 'item2', label: 'Item Two'}]} triggerLabel="Menu B" />
+      </Fragment>
+    );
+
+    // Can be dismissed by clicking outside
+    await userEvent.click(screen.getByRole('button', {name: 'Menu A'}));
+    expect(screen.getByRole('menuitemradio', {name: 'Item One'})).toBeInTheDocument();
+    await userEvent.click(document.body);
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'Item One'})
+    ).not.toBeInTheDocument();
+
+    // Can be dismissed by pressing Escape
+    await userEvent.click(screen.getByRole('button', {name: 'Menu A'}));
+    expect(screen.getByRole('menuitemradio', {name: 'Item One'})).toBeInTheDocument();
+    await userEvent.keyboard('{Escape}');
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'Item One'})
+    ).not.toBeInTheDocument();
+
+    // When menu A is open, clicking once on menu B's trigger button closes menu A and
+    // then opens menu B
+    await userEvent.click(screen.getByRole('button', {name: 'Menu A'}));
+    expect(screen.getByRole('menuitemradio', {name: 'Item One'})).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Menu B'}));
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'Item One'})
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', {name: 'Item Two'})).toBeInTheDocument();
   });
 
   it('renders submenus', async function () {

--- a/static/app/components/dropdownMenu/index.spec.tsx
+++ b/static/app/components/dropdownMenu/index.spec.tsx
@@ -1,5 +1,7 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {Fragment} from 'react';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 
 describe('DropdownMenu', function () {

--- a/static/app/utils/useOverlay.tsx
+++ b/static/app/utils/useOverlay.tsx
@@ -228,6 +228,7 @@ function useOverlay({
 
   // Get props for overlay element
   const interactedOutside = useRef(false);
+  const interactOutsideTrigger = useRef<HTMLButtonElement | null>(null);
   const {overlayProps: overlayAriaProps} = useOverlayAria(
     {
       onClose: () => {
@@ -236,6 +237,9 @@ function useOverlay({
         if (interactedOutside.current) {
           onInteractOutside?.();
           interactedOutside.current = false;
+
+          interactOutsideTrigger.current?.click();
+          interactOutsideTrigger.current = null;
         }
 
         openState.close();
@@ -251,6 +255,18 @@ function useOverlay({
           !triggerRef.current?.contains(target) &&
           (shouldCloseOnInteractOutside?.(target) ?? true)
         ) {
+          // Check if the target is inside a different overlay trigger. If yes, then we
+          // should activate that trigger after this overlay has closed (see the onClose
+          // prop above). This allows users to quickly jump between adjacent overlays.
+          const closestOverlayTrigger = target.closest<HTMLButtonElement>(
+            'button[aria-expanded="false"]'
+          );
+          if (closestOverlayTrigger && closestOverlayTrigger !== triggerRef.current) {
+            interactOutsideTrigger.current = closestOverlayTrigger;
+          } else {
+            interactOutsideTrigger.current = null;
+          }
+
           interactedOutside.current = true;
           return true;
         }

--- a/static/app/utils/useOverlay.tsx
+++ b/static/app/utils/useOverlay.tsx
@@ -258,7 +258,7 @@ function useOverlay({
           // Check if the target is inside a different overlay trigger. If yes, then we
           // should activate that trigger after this overlay has closed (see the onClose
           // prop above). This allows users to quickly jump between adjacent overlays.
-          const closestOverlayTrigger = target.closest<HTMLButtonElement>(
+          const closestOverlayTrigger = target.closest?.<HTMLButtonElement>(
             'button[aria-expanded="false"]'
           );
           if (closestOverlayTrigger && closestOverlayTrigger !== triggerRef.current) {


### PR DESCRIPTION
**Before ——** when a menu is open, we need to click twice to switch to a different menu: once to close the current menu, and once more to open the new one

https://github.com/getsentry/sentry/assets/44172267/0c16340a-08c4-4fa8-a456-bf235a762277



**After ——** clicking once on the new menu immediately switches to it

https://github.com/getsentry/sentry/assets/44172267/b94649d4-6dcb-4882-9dfe-9d4fa9ee1228

