### PR TITLE
fix(pageFilters): Show focus rings

### DIFF
--- a/static/app/components/organizations/pageFilterBar.tsx
+++ b/static/app/components/organizations/pageFilterBar.tsx
@@ -32,9 +32,15 @@ const PageFilterBar = styled('div')<{condensed?: boolean}>`
     height: 100%;
     width: 100%;
     min-height: auto;
-    border-color: transparent !important;
+    border-color: transparent;
     box-shadow: none;
     z-index: 0;
+  }
+
+  & button[aria-haspopup].focus-visible {
+    border-color: ${p => p.theme.focusBorder};
+    box-shadow: 0 0 0 1px ${p => p.theme.focusBorder};
+    z-index: 1;
   }
 
   & > * {


### PR DESCRIPTION
**Before ——**
<img width="395" alt="Screenshot 2023-06-14 at 11 39 22 AM" src="https://github.com/getsentry/sentry/assets/44172267/bfe10303-cfaf-4392-ad53-7e48c74dbbd7">

**After ——**
<img width="395" alt="Screenshot 2023-06-14 at 11 39 33 AM" src="https://github.com/getsentry/sentry/assets/44172267/3c9d866c-39e8-43ed-bbcb-8ea1c156c486">
