### PR TITLE
feat(functions): Add functions meta data to trends response

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -89,7 +89,11 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
             return Response(serializer.errors, status=400)
         data = serializer.validated_data
 
+        top_functions = {}
+
         def get_event_stats(columns, query, params, _rollup, zerofill_results, comparison_delta):
+            nonlocal top_functions
+
             rollup = get_rollup_from_range(params["end"] - params["start"])
 
             top_functions = functions.query(
@@ -147,18 +151,37 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
             return {"data": trending_functions[offset : limit + offset]}
 
         def get_stats_data_for_trending_events(results):
+            functions = {
+                f"{function['project.id']},{function['fingerprint']}": function
+                for function in top_functions.get("data", [])
+            }
             formatted_results = []
             for result in results["data"]:
                 # The endpoint originally was meant for only transactions
                 # hence the name of the key, but it can be adapted to work
                 # for functions as well.
-                stats_key = f"{result['project']},{result['transaction']}"
-                formatted_results.append(
+                key = f"{result['project']},{result['transaction']}"
+                formatted_result = {"stats": stats_data[key]}
+                formatted_result.update(
                     {
-                        **result,
-                        "stats": stats_data[stats_key],
+                        k: result[k]
+                        for k in [
+                            "aggregate_range_1",
+                            "aggregate_range_2",
+                            "breakpoint",
+                            "change",
+                            "project",
+                            "trend_difference",
+                            "trend_percentage",
+                            "unweighted_p_value",
+                            "unweighted_t_value",
+                        ]
                     }
                 )
+                formatted_result.update(
+                    {k: functions[key][k] for k in ["fingerprint", "package", "function", "count"]}
+                )
+                formatted_results.append(formatted_result)
             return formatted_results
 
         with self.handle_query_errors():

--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -48,15 +48,6 @@ class TrendType(Enum):
 
         raise ValueError(f"Unknown TrendType: {self.value}")
 
-    def slope_condition(self):
-        if self is TrendType.REGRESSION:
-            return "slope():>0"
-
-        if self is TrendType.IMPROVEMENT:
-            return "slope():<0"
-
-        raise ValueError(f"Unknown TrendType: {self.value}")
-
 
 class TrendTypeField(serializers.Field):
     def to_representation(self, trend_type: TrendType):
@@ -112,9 +103,8 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
                     "package",
                     "function",
                     "count()",
-                    "slope()",
                 ],
-                query=f"{query} {data['trend'].slope_condition()}",
+                query=query,
                 params=params,
                 orderby=["-count()"],
                 limit=TOP_FUNCTIONS_LIMIT,
@@ -199,7 +189,7 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
                 formatted_result.update(
                     {
                         k: functions[key][k]
-                        for k in ["fingerprint", "package", "function", "count()", "slope()"]
+                        for k in ["fingerprint", "package", "function", "count()"]
                     }
                 )
                 formatted_results.append(formatted_result)

--- a/src/sentry/search/events/datasets/profile_functions.py
+++ b/src/sentry/search/events/datasets/profile_functions.py
@@ -315,24 +315,6 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                     default_result_type="duration",
                     redundant_grouping=True,
                 ),
-                SnQLFunction(
-                    "slope",
-                    snql_aggregate=lambda args, alias: Function(
-                        "tupleElement",
-                        [
-                            Function(
-                                "simpleLinearRegression",
-                                [
-                                    Function("toUInt32", [SnQLColumn("timestamp")]),
-                                    Function("finalizeAggregation", [SnQLColumn("avg")]),
-                                ],
-                            ),
-                            1,
-                        ],
-                        alias,
-                    ),
-                    default_result_type="number",
-                ),
             ]
         }
 

--- a/src/sentry/search/events/datasets/profile_functions.py
+++ b/src/sentry/search/events/datasets/profile_functions.py
@@ -315,6 +315,24 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                     default_result_type="duration",
                     redundant_grouping=True,
                 ),
+                SnQLFunction(
+                    "slope",
+                    snql_aggregate=lambda args, alias: Function(
+                        "tupleElement",
+                        [
+                            Function(
+                                "simpleLinearRegression",
+                                [
+                                    Function("toUInt32", [SnQLColumn("timestamp")]),
+                                    Function("finalizeAggregation", [SnQLColumn("avg")]),
+                                ],
+                            ),
+                            1,
+                        ],
+                        alias,
+                    ),
+                    default_result_type="number",
+                ),
             ]
         }
 

--- a/tests/sentry/api/endpoints/test_organization_profiling_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_functions.py
@@ -134,6 +134,7 @@ class OrganizationProfilingFunctionTrendsEndpointTest(ProfilesSnubaTestCase):
             )
         assert response.status_code == 200
         # TODO: assert response json
+        assert response.json()
 
     @mock.patch("sentry.api.endpoints.organization_profiling_functions.trends_query")
     def test_improvement(self, mock_trends_query):
@@ -207,6 +208,7 @@ class OrganizationProfilingFunctionTrendsEndpointTest(ProfilesSnubaTestCase):
             )
         assert response.status_code == 200
         # TODO: assert response json
+        assert response.json()
 
 
 def test_get_rollup_from_range_max_buckets():


### PR DESCRIPTION
The response previously only contained the function fingerprint under the transaction key. This changes so that we have the function package, name and fingerprint under respective keys.