### PR TITLE
feat(discover-tags): Add page_size and cursor to endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -28,7 +28,7 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
                 cursor = int(request.GET.get("cursor")) if request.GET.get("cursor") else None
                 pagination_data = {}
                 if per_page:
-                    pagination_data["page_size"] = per_page
+                    pagination_data["per_page"] = per_page
                 if cursor:
                     pagination_data["cursor"] = cursor
                 facets = discover.get_facets(

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -24,17 +24,13 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
 
         with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):
             with self.handle_query_errors():
-                page_size = (
-                    int(request.GET.get("page_size")) if request.GET.get("page_size") else None
-                )
-                page_offset = (
-                    int(request.GET.get("page_offset")) if request.GET.get("page_offset") else None
-                )
+                per_page = int(request.GET.get("per_page")) if request.GET.get("per_page") else None
+                cursor = int(request.GET.get("cursor")) if request.GET.get("cursor") else None
                 pagination_data = {}
-                if page_size:
-                    pagination_data["page_size"] = page_size
-                if page_offset:
-                    pagination_data["page_offset"] = page_offset
+                if per_page:
+                    pagination_data["page_size"] = per_page
+                if cursor:
+                    pagination_data["cursor"] = cursor
                 facets = discover.get_facets(
                     query=request.GET.get("query"),
                     params=params,

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -24,10 +24,22 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
 
         with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):
             with self.handle_query_errors():
+                page_size = (
+                    int(request.GET.get("page_size")) if request.GET.get("page_size") else None
+                )
+                page_offset = (
+                    int(request.GET.get("page_offset")) if request.GET.get("page_offset") else None
+                )
+                pagination_data = {}
+                if page_size:
+                    pagination_data["page_size"] = page_size
+                if page_offset:
+                    pagination_data["page_offset"] = page_offset
                 facets = discover.get_facets(
                     query=request.GET.get("query"),
                     params=params,
                     referrer="api.organization-events-facets.top-tags",
+                    **pagination_data,
                 )
 
         with sentry_sdk.start_span(op="discover.endpoint", description="populate_results") as span:

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -563,7 +563,7 @@ def get_facets(
     params (Dict[str, str]) Filtering parameters with start, end, project_id, environment
     referrer (str) A referrer string to help locate the origin of this query.
     per_page (int) The number of records to fetch.
-    cursor (int) The number of records to skip.
+    cursor (int) Multiplied by per_page to determine the number of records to skip.
 
     Returns Sequence[FacetResult]
     """

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -549,7 +549,8 @@ def get_facets(
     query: str,
     params: ParamsType,
     referrer: str,
-    limit: Optional[int] = TOP_KEYS_DEFAULT_LIMIT,
+    page_size: Optional[int] = TOP_KEYS_DEFAULT_LIMIT,
+    page_offset: Optional[int] = 0,
 ):
     """
     High-level API for getting 'facet map' results.
@@ -561,7 +562,8 @@ def get_facets(
     query (str) Filter query string to create conditions from.
     params (Dict[str, str]) Filtering parameters with start, end, project_id, environment
     referrer (str) A referrer string to help locate the origin of this query.
-    limit (int) The number of records to fetch.
+    page_size (int) The number of records to fetch.
+    page_offset (int) The number of records to skip.
 
     Returns Sequence[FacetResult]
     """
@@ -574,7 +576,8 @@ def get_facets(
             query=query,
             selected_columns=["tags_key", "count()"],
             orderby=["-count()", "tags_key"],
-            limit=limit,
+            limit=page_size,
+            offset=page_offset * page_size,
             turbo=sample,
         )
         key_names = key_name_builder.run_query(referrer)
@@ -594,7 +597,7 @@ def get_facets(
 
     fetch_projects = False
     if len(params.get("project_id", [])) > 1:
-        if len(top_tags) == limit:
+        if len(top_tags) == page_size:
             top_tags.pop()
         fetch_projects = True
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -549,8 +549,8 @@ def get_facets(
     query: str,
     params: ParamsType,
     referrer: str,
-    page_size: Optional[int] = TOP_KEYS_DEFAULT_LIMIT,
-    page_offset: Optional[int] = 0,
+    per_page: Optional[int] = TOP_KEYS_DEFAULT_LIMIT,
+    cursor: Optional[int] = 0,
 ):
     """
     High-level API for getting 'facet map' results.
@@ -562,8 +562,8 @@ def get_facets(
     query (str) Filter query string to create conditions from.
     params (Dict[str, str]) Filtering parameters with start, end, project_id, environment
     referrer (str) A referrer string to help locate the origin of this query.
-    page_size (int) The number of records to fetch.
-    page_offset (int) The number of records to skip.
+    per_page (int) The number of records to fetch.
+    cursor (int) The number of records to skip.
 
     Returns Sequence[FacetResult]
     """
@@ -576,8 +576,8 @@ def get_facets(
             query=query,
             selected_columns=["tags_key", "count()"],
             orderby=["-count()", "tags_key"],
-            limit=page_size,
-            offset=page_offset * page_size,
+            limit=per_page,
+            offset=cursor * per_page,
             turbo=sample,
         )
         key_names = key_name_builder.run_query(referrer)
@@ -597,7 +597,7 @@ def get_facets(
 
     fetch_projects = False
     if len(params.get("project_id", [])) > 1:
-        if len(top_tags) == page_size:
+        if len(top_tags) == per_page:
             top_tags.pop()
         fetch_projects = True
 

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -670,7 +670,7 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
         ]
         self.assert_facet(response, "device.class", expected)
 
-    def test_with_page_offset_parameter(self):
+    def test_with_per_page_and_cursor_parameters(self):
         test_project = self.create_project()
         self.store_event(
             data={
@@ -697,7 +697,7 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
             response = self.client.get(
                 self.url,
                 format="json",
-                data={"project": test_project.id, "page_offset": 5, "page_size": 1},
+                data={"project": test_project.id, "cursor": 5, "per_page": 1},
             )
 
         assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -669,3 +669,40 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
             {"count": 1, "name": "low", "value": "low"},
         ]
         self.assert_facet(response, "device.class", expected)
+
+    def test_with_page_offset_parameter(self):
+        test_project = self.create_project()
+        self.store_event(
+            data={
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {
+                    "a": "one",
+                    "b": "two",
+                    "c": "three",
+                    "d": "four",
+                    "e": "five",
+                    "f": "six",
+                    "g": "seven",
+                    "h": "eight",
+                    "i": "nine",
+                    "j": "ten",
+                    "k": "eleven",
+                },
+            },
+            project_id=test_project.id,
+        )
+
+        with self.feature(self.features):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={"project": test_project.id, "page_offset": 5, "page_size": 1},
+            )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        expected = [
+            {"count": 1, "name": "six", "value": "six"},
+        ]
+        self.assert_facet(response, "f", expected)


### PR DESCRIPTION
Update the endpoint to accept page_size and cursor so users can manually load more data in the frontend.

The way that this is going to be used will be to increment the `cursor` parameter each time a "Load more" button is clicked, fetch a new batch of tags, and then append them to what's stored in the frontend to render.