### PR TITLE
feat(event-details): Move response context to be below the request

### DIFF
--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -15,7 +15,7 @@ type Props = {
 export function EventContexts({event, group}: Props) {
   const {user, contexts, sdk} = event;
 
-  const {feedback, ...otherContexts} = contexts ?? {};
+  const {feedback, response, ...otherContexts} = contexts ?? {};
 
   const usingOtel = useCallback(
     () => otherContexts.otel !== undefined,
@@ -33,6 +33,16 @@ export function EventContexts({event, group}: Props) {
 
   return (
     <Fragment>
+      {!objectIsEmpty(response) && (
+        <Chunk
+          key="response"
+          type="response"
+          alias="response"
+          group={group}
+          event={event}
+          value={response}
+        />
+      )}
       {!objectIsEmpty(feedback) && (
         <Chunk
           key="feedback"


### PR DESCRIPTION
Moves the `response` context to the top of the `EventContexts` component so that it is closer to the request info. 

We might want to better incorporate responses into the request interface in the future, but this is a quick fix for now.

Before:

![CleanShot 2023-06-14 at 13 02 49](https://github.com/getsentry/sentry/assets/10888943/5ac906f8-0180-4a06-a8cc-cd8d7fcdb3da)

After:

![CleanShot 2023-06-14 at 13 02 56](https://github.com/getsentry/sentry/assets/10888943/76acdb79-d76b-4e2d-9e42-40feb81d592d)

