### PR TITLE
fix(ui): Remove xAxis splitNumber for category xAxis

### DIFF
--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -134,7 +134,7 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
             period="7d"
             legend={{right: 0, top: 0}}
             yAxis={{minInterval: 1}}
-            xAxis={barAxisLabel(seriesData.length)}
+            xAxis={barAxisLabel()}
             series={[
               {
                 seriesName: t('Alerts Triggered'),

--- a/static/app/views/organizationStats/teamInsights/teamIssuesAge.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesAge.tsx
@@ -113,7 +113,6 @@ class TeamIssuesAge extends AsyncComponent<Props, State> {
               legend={{right: 3, top: 0}}
               yAxis={{minInterval: 1}}
               xAxis={{
-                splitNumber: seriesData.length,
                 type: 'category',
                 min: 0,
                 axisLabel: {

--- a/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
@@ -163,7 +163,7 @@ class TeamIssuesBreakdown extends AsyncComponent<Props, State> {
               isGroupedByDate
               useShortDate
               legend={{right: 0, top: 0}}
-              xAxis={barAxisLabel(allSeries[0]?.data.length ?? 0)}
+              xAxis={barAxisLabel()}
               yAxis={{minInterval: 1}}
               series={allSeries}
             />

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -206,7 +206,7 @@ class TeamReleases extends AsyncComponent<Props, State> {
             period="7d"
             legend={{right: 3, top: 0}}
             yAxis={{minInterval: 1}}
-            xAxis={barAxisLabel(seriesData.length)}
+            xAxis={barAxisLabel()}
             series={[
               {
                 seriesName: t('This Period'),

--- a/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
@@ -107,7 +107,7 @@ class TeamResolutionTime extends AsyncComponent<Props, State> {
             },
           }}
           legend={{right: 0, top: 0}}
-          xAxis={barAxisLabel(seriesData.length)}
+          xAxis={barAxisLabel()}
           series={[
             {
               seriesName: t('Time to Resolution'),

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
@@ -124,7 +124,7 @@ export function TeamUnresolvedIssues({
             useShortDate
             legend={{right: 3, top: 0}}
             yAxis={{minInterval: 1}}
-            xAxis={barAxisLabel(seriesData.length)}
+            xAxis={barAxisLabel()}
             series={[
               {
                 seriesName: t('Unresolved Issues'),

--- a/static/app/views/organizationStats/teamInsights/utils.tsx
+++ b/static/app/views/organizationStats/teamInsights/utils.tsx
@@ -34,11 +34,8 @@ export function groupByTrend<T extends {trend: number}>(data: T[]): T[] {
   return [...worseItems, ...betterItems, ...zeroItems];
 }
 
-export const barAxisLabel = (
-  dataEntries: number
-): React.ComponentProps<typeof BaseChart>['xAxis'] => {
+export const barAxisLabel = (): React.ComponentProps<typeof BaseChart>['xAxis'] => {
   return {
-    splitNumber: Math.max(Math.round(dataEntries / 7), 4),
     type: 'category',
     axisTick: {
       alignWithLabel: true,


### PR DESCRIPTION
Switching to category removed the need for the splitNumber. These charts are all in the team stats pages

more typescript 5.1 prep

