### PR TITLE
fix(perf-issues): Require space in N+1 ext span description

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_db_span_detector.py
@@ -286,9 +286,11 @@ class NPlusOneDBSpanDetectorExtended(NPlusOneDBSpanDetector):
 
     def _contains_valid_repeating_query(self, span: Span) -> bool:
         # Remove the regular expression check for parameterization, relying on
-        # the parameterization in span hashing to handle it.
+        # the parameterization in span hashing to handle it.  Make sure we at
+        # least have a space though, to exclude e.g. MongoDB and Prisma's
+        # `rawQuery`.
         query = span.get("description", None)
-        return bool(query)
+        return bool(query) and " " in query
 
 
 def contains_complete_query(span: Span, is_source: Optional[bool] = False) -> bool:


### PR DESCRIPTION
Continuing the experiment to remove the query parameterization check from the N+1 DB Query detector, I noticed that as a side effect we started detecting issues for Mongo N+1s, which isn't appropriate. The simplest thing we could do: check for a space in the query. (Everything we care about will definitely have at least one space in it.)

This change is for experimentation (only affects metrics collected and doesn't affect any actual issue creation yet).

Will add a test if this change graduates to the real N+1 DB detector.