### PR TITLE
fix(ui): Remove xAxis data release charts

### DIFF
--- a/static/app/components/charts/percentageAreaChart.tsx
+++ b/static/app/components/charts/percentageAreaChart.tsx
@@ -102,7 +102,6 @@ export default class PercentageAreaChart extends Component<Props> {
           type: 'value',
           interval: 25,
           splitNumber: 4,
-          data: [0, 25, 50, 100],
           axisLabel: {
             formatter: '{value}%',
           },

--- a/static/app/views/releases/list/releasesAdoptionChart.tsx
+++ b/static/app/views/releases/list/releasesAdoptionChart.tsx
@@ -209,7 +209,6 @@ class ReleasesAdoptionChart extends Component<Props> {
                           type: 'value',
                           interval: 10,
                           splitNumber: 10,
-                          data: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
                           axisLabel: {
                             formatter: '{value}%',
                           },
@@ -219,7 +218,6 @@ class ReleasesAdoptionChart extends Component<Props> {
                           min: xAxisData[0],
                           max: xAxisData[numDataPoints - 1],
                           type: 'time',
-                          data: xAxisData,
                         }}
                         tooltip={{
                           formatter: seriesParams => {


### PR DESCRIPTION
I didn't notice any difference with these charts without the data. Typescript 5.1 says they don't exist