### PR TITLE
ref: Remove spammy debug logs

### DIFF
--- a/src/sentry/utils/geo.py
+++ b/src/sentry/utils/geo.py
@@ -58,5 +58,3 @@ def _init_geoip_rust():
 if geoip_path_mmdb:
     _init_geoip()
     _init_geoip_rust()
-else:
-    logger.warning("settings.GEOIP_PATH_MMDB not configured.")

--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -250,8 +250,6 @@ class GitHubPlugin(GitHubMixin, IssuePlugin2):
         bindings.add("repository.provider", GitHubRepositoryProvider, id="github")
         if self.has_apps_configured():
             bindings.add("repository.provider", GitHubAppsRepositoryProvider, id="github_apps")
-        else:
-            self.logger.info("apps-not-configured")
 
 
 class GitHubRepositoryProvider(GitHubMixin, RepositoryProvider):


### PR DESCRIPTION
Those two log lines are absolutely everywhere in devenv, they can't be
that important.
