### PR TITLE
ref(hc): Updates org deletion code to queue an org mapping outbox update

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -40,6 +40,9 @@ from sentry.models import (
     UserEmail,
 )
 from sentry.services.hybrid_cloud import IDEMPOTENCY_KEY_LENGTH
+from sentry.services.hybrid_cloud.organization_actions.impl import (
+    mark_organization_as_pending_deletion_with_outbox_message,
+)
 from sentry.utils.cache import memoize
 
 ERR_DEFAULT_ORG = "You cannot remove the default organization."
@@ -564,22 +567,24 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             return self.respond({"detail": ERR_DEFAULT_ORG}, status=400)
 
         with transaction.atomic():
-            updated = Organization.objects.filter(
-                id=organization.id, status=OrganizationStatus.ACTIVE
-            ).update(status=OrganizationStatus.PENDING_DELETION)
-            if updated:
-                organization.status = OrganizationStatus.PENDING_DELETION
+            updated_organization = mark_organization_as_pending_deletion_with_outbox_message(
+                org_id=organization.id
+            )
+
+            if updated_organization is not None:
                 schedule = ScheduledDeletion.schedule(organization, days=1, actor=request.user)
                 entry = self.create_audit_entry(
                     request=request,
-                    organization=organization,
-                    target_object=organization.id,
+                    organization=updated_organization,
+                    target_object=updated_organization.id,
                     event=audit_log.get_event_id("ORG_REMOVE"),
-                    data=organization.get_audit_log_data(),
+                    data=updated_organization.get_audit_log_data(),
                     transaction_id=schedule.guid,
                 )
-                organization.send_delete_confirmation(entry, ONE_DAY)
-                Organization.objects.uncache_object(organization.id)
+                updated_organization.send_delete_confirmation(entry, ONE_DAY)
+                Organization.objects.uncache_object(updated_organization.id)
+
+            organization.status = OrganizationStatus.PENDING_DELETION
         context = serialize(
             organization,
             request.user,

--- a/tests/sentry/services/test_organization_actions.py
+++ b/tests/sentry/services/test_organization_actions.py
@@ -148,14 +148,10 @@ class OrganizationMarkOrganizationAsPendingDeletionWithOutboxMessageTest(TestCas
         updated_org = mark_organization_as_pending_deletion_with_outbox_message(org_id=self.org.id)
 
         assert updated_org
-        assert updated_org.status == OrganizationStatus.PENDING_DELETION
-        assert updated_org.name == org_before_update.name
-        assert updated_org.slug == org_before_update.slug
-
         self.org.refresh_from_db()
-        assert self.org.status == OrganizationStatus.PENDING_DELETION
-        assert self.org.name == org_before_update.name
-        assert self.org.slug == org_before_update.slug
+        assert updated_org.status == self.org.status == OrganizationStatus.PENDING_DELETION
+        assert updated_org.name == self.org.name == org_before_update.name
+        assert updated_org.slug == self.org.slug == org_before_update.slug
 
         assert_outbox_update_message_exists(self.org, 1)
 

--- a/tests/sentry/services/test_organization_actions.py
+++ b/tests/sentry/services/test_organization_actions.py
@@ -9,6 +9,7 @@ from sentry.models import (
 )
 from sentry.services.hybrid_cloud.organization_actions.impl import (
     create_organization_with_outbox_message,
+    mark_organization_as_pending_deletion_with_outbox_message,
     update_organization_with_outbox_message,
     upsert_organization_by_org_id_with_outbox_message,
 )
@@ -130,3 +131,47 @@ class OrganizationUpsertWithOutboxTest(TestCase):
         assert org_before_modification.name == self.org.name
         assert org_before_modification.status == self.org.status
         assert_outbox_update_message_exists(org=db_created_org, expected_count=2)
+
+
+@region_silo_test(stable=True)
+class OrganizationMarkOrganizationAsPendingDeletionWithOutboxMessageTest(TestCase):
+    def setUp(self):
+        self.org: Organization = self.create_organization(
+            slug="sluggy", name="barfoo", status=OrganizationStatus.ACTIVE
+        )
+
+        with outbox_runner():
+            pass
+
+    def test_mark_for_deletion_and_outbox_generation(self):
+        org_before_update = Organization.objects.get(id=self.org.id)
+        updated_org = mark_organization_as_pending_deletion_with_outbox_message(org_id=self.org.id)
+
+        assert updated_org.status == OrganizationStatus.PENDING_DELETION
+        assert updated_org.name == org_before_update.name
+        assert updated_org.slug == org_before_update.slug
+
+        self.org.refresh_from_db()
+        assert self.org.status == OrganizationStatus.PENDING_DELETION
+        assert self.org.name == org_before_update.name
+        assert self.org.slug == org_before_update.slug
+
+        assert_outbox_update_message_exists(self.org, 1)
+
+    def test_mark_for_deletion_on_already_deleted_org(self):
+        self.org.status = OrganizationStatus.PENDING_DELETION
+        with outbox_runner():
+            self.org.save()
+
+        org_before_update = Organization.objects.get(id=self.org.id)
+
+        updated_org = mark_organization_as_pending_deletion_with_outbox_message(org_id=self.org.id)
+
+        assert updated_org is None
+
+        self.org.refresh_from_db()
+        assert self.org.status == org_before_update.status
+        assert self.org.name == org_before_update.name
+        assert self.org.slug == org_before_update.slug
+
+        assert_outbox_update_message_exists(self.org, 0)

--- a/tests/sentry/services/test_organization_actions.py
+++ b/tests/sentry/services/test_organization_actions.py
@@ -147,6 +147,7 @@ class OrganizationMarkOrganizationAsPendingDeletionWithOutboxMessageTest(TestCas
         org_before_update = Organization.objects.get(id=self.org.id)
         updated_org = mark_organization_as_pending_deletion_with_outbox_message(org_id=self.org.id)
 
+        assert updated_org
         assert updated_org.status == OrganizationStatus.PENDING_DELETION
         assert updated_org.name == org_before_update.name
         assert updated_org.slug == org_before_update.slug


### PR DESCRIPTION
Adds a mark for deletion helper for organizations that queues an update outbox message. Updates the organization deletion API to use this new helper to ensure consistency between our org mappings and organizations
