### PR TITLE
fix(ui): Remove xAxis boundaryGap from profilingMeasurements

### DIFF
--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -98,7 +98,6 @@ function Chart({data, type, transactionDuration}: ChartProps) {
           type: 'none',
           triggerOn: 'mousemove',
         },
-        boundaryGap: false,
         type: 'value',
         alignTicks: false,
         max: parseFloat(transactionDuration.toFixed(2)),

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -98,6 +98,7 @@ function Chart({data, type, transactionDuration}: ChartProps) {
           type: 'none',
           triggerOn: 'mousemove',
         },
+        boundaryGap: [0, 0],
         type: 'value',
         alignTicks: false,
         max: parseFloat(transactionDuration.toFixed(2)),


### PR DESCRIPTION
False only works when the type is category. https://echarts.apache.org/en/option.html#xAxis.boundaryGap

last thing for typescript 5.1 \

its this chart
![image](https://github.com/getsentry/sentry/assets/1400464/6254923f-2384-4de5-8ee9-61fb050b8fcd)
