### PR TITLE
feat(ts): Add LinkButton alias

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
-import {Tooltip} from 'sentry/components/tooltip';
+import {Tooltip, TooltipProps} from 'sentry/components/tooltip';
 import HookStore from 'sentry/stores/hookStore';
 import {space} from 'sentry/styles/space';
 import mergeRefs from 'sentry/utils/mergeRefs';
@@ -18,12 +18,10 @@ import mergeRefs from 'sentry/utils/mergeRefs';
  */
 type ButtonElement = HTMLButtonElement & HTMLAnchorElement & any;
 
-type TooltipProps = React.ComponentProps<typeof Tooltip>;
-
-type ButtonSize = 'zero' | 'xs' | 'sm' | 'md';
-
-interface BaseButtonProps
-  extends Omit<React.ButtonHTMLAttributes<ButtonElement>, 'label' | 'size' | 'title'> {
+/**
+ * Props shared across different types of button components
+ */
+interface CommonButtonProps {
   /**
    * Used when you want to overwrite the default Reload event key for analytics
    */
@@ -55,25 +53,9 @@ interface BaseButtonProps
    */
   disabled?: boolean;
   /**
-   * For use with `href` and `data:` or `blob:` schemes. Tells the browser to
-   * download the contents.
-   *
-   * See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download
-   */
-  download?: HTMLAnchorElement['download'];
-  /**
    * The button is an external link. Similar to the `Link` `external` property.
    */
   external?: boolean;
-  /**
-   * @internal Used in the Button forwardRef
-   */
-  forwardRef?: React.Ref<ButtonElement>;
-  /**
-   * When set the button acts as an anchor link. Use with `external` to have
-   * the link open in a new tab.
-   */
-  href?: string;
   /**
    * The icon to render inside of the button. The size will be set
    * appropriately based on the size of the button.
@@ -92,15 +74,11 @@ interface BaseButtonProps
   /**
    * The size of the button
    */
-  size?: ButtonSize;
+  size?: 'zero' | 'xs' | 'sm' | 'md';
   /**
    * Display a tooltip for the button.
    */
   title?: TooltipProps['title'];
-  /**
-   * Similar to `href`, but for internal links within the app.
-   */
-  to?: string | object;
   /**
    * Additional properites for the Tooltip when `title` is set.
    */
@@ -112,6 +90,45 @@ interface BaseButtonProps
   translucentBorder?: boolean;
 }
 
+/**
+ * Helper type to extraxct the HTML element props for use in button prop
+ * interfaces.
+ *
+ * XXX(epurkhiser): Right now all usages of this use ButtonElement, but in the
+ * future ButtonElement should go away and be replaced with HTMLButtonElement
+ * and HTMLAnchorElement respectively
+ */
+type ElementProps<E> = Omit<React.ButtonHTMLAttributes<E>, 'label' | 'size' | 'title'>;
+
+interface BaseButtonProps extends CommonButtonProps, ElementProps<ButtonElement> {
+  /**
+   * For use with `href` and `data:` or `blob:` schemes. Tells the browser to
+   * download the contents.
+   *
+   * See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download
+   *
+   * @deprecated Use LnikButton instead
+   */
+  download?: HTMLAnchorElement['download'];
+  /**
+   * @internal Used in the Button forwardRef
+   */
+  forwardRef?: React.Ref<ButtonElement>;
+  /**
+   * When set the button acts as an anchor link. Use with `external` to have
+   * the link open in a new tab.
+   *
+   * @deprecated Use LnikButton instead
+   */
+  href?: string;
+  /**
+   * Similar to `href`, but for internal links within the app.
+   *
+   * @deprecated Use LnikButton instead
+   */
+  to?: string | object;
+}
+
 interface ButtonPropsWithoutAriaLabel extends BaseButtonProps {
   children: React.ReactNode;
 }
@@ -121,7 +138,49 @@ interface ButtonPropsWithAriaLabel extends BaseButtonProps {
   children?: never;
 }
 
-export type ButtonProps = ButtonPropsWithoutAriaLabel | ButtonPropsWithAriaLabel;
+type ButtonProps = ButtonPropsWithoutAriaLabel | ButtonPropsWithAriaLabel;
+
+interface BaseLinkButtonProps extends CommonButtonProps, ElementProps<ButtonElement> {
+  /**
+   * @internal Used in the Button forwardRef
+   */
+  forwardRef?: React.Ref<ButtonElement>;
+}
+
+interface ToLinkButtonProps extends BaseLinkButtonProps {
+  /**
+   * Similar to `href`, but for internal links within the app.
+   */
+  to: string | object;
+}
+
+interface HrefLinkButtonProps extends BaseLinkButtonProps {
+  /**
+   * When set the button acts as an anchor link. Use with `external` to have
+   * the link open in a new tab.
+   */
+  href: string;
+  /**
+   * For use with `href` and `data:` or `blob:` schemes. Tells the browser to
+   * download the contents.
+   *
+   * See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download
+   */
+  download?: HTMLAnchorElement['download'];
+}
+
+type EnforcedLinkButtonProps = ToLinkButtonProps | HrefLinkButtonProps;
+
+type LinkButtonPropsWithoutAriaLabel = EnforcedLinkButtonProps & {
+  children: React.ReactNode;
+};
+
+type LinkButtonPropsWithAriaLabel = EnforcedLinkButtonProps & {
+  'aria-label': string;
+  children?: never;
+};
+
+type LinkButtonProps = LinkButtonPropsWithoutAriaLabel | LinkButtonPropsWithAriaLabel;
 
 function BaseButton({
   size = 'md',
@@ -477,12 +536,18 @@ const Icon = styled('span')<IconProps & Omit<StyledButtonProps, 'theme'>>`
   flex-shrink: 0;
 `;
 
-/**
- * Also export these styled components so we can use them as selectors
- */
-export {Button, StyledButton, ButtonLabel};
+const LinkButton = Button as React.ComponentType<LinkButtonProps>;
 
 export {
+  Button,
+  ButtonProps,
+  LinkButton,
+  LinkButtonProps,
+
+  // Also export these styled components so we can use them as selectors
+  StyledButton,
+  ButtonLabel,
+
   /**
    * @deprecated This is only being used in one small component elsewhere. We
    * should probably remove this export


### PR DESCRIPTION
This is the ground work for extracting a LinkButton from Button.

In cases where a Button has a `to` or `href` attribute, these are actually anchor (`a`) elements. We want to differentiate this at the component level to simplify the props, and also fix some improper usages (such as `<Button priority="link" href="..." />`, which should just be a `Link`).

After this change Buttons using `to` and `href` are deprecated. Instead you should use `LinkButton` which in the future will be properly typed as an anchor