### PR TITLE
ref(auth): change id from client_id in serializer (ER-1447)

### DIFF
--- a/src/sentry/api/serializers/models/apiapplication.py
+++ b/src/sentry/api/serializers/models/apiapplication.py
@@ -11,7 +11,7 @@ class ApiApplicationSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         has_secret = obj.date_added > timezone.now() - timedelta(days=1)
         return {
-            "id": obj.client_id,
+            "id": obj.id,
             "clientID": obj.client_id,
             "clientSecret": obj.client_secret if has_secret else None,
             "name": obj.name,


### PR DESCRIPTION
Changes the ApiApplication serializer to return the actual ID of the object, rather than the Client ID.