### PR TITLE
feat(alerts): Mute metric alerts for integrations

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -48,11 +48,15 @@ class ActionHandler(metaclass=abc.ABCMeta):
 
 class DefaultActionHandler(ActionHandler):
     def fire(self, metric_value: int | float, new_status: IncidentStatus):
-        if not RuleSnooze.objects.filter(alert_rule=self.incident.alert_rule).exists():
+        if not RuleSnooze.objects.filter(
+            alert_rule=self.incident.alert_rule, user_id__isnull=True
+        ).exists():
             self.send_alert(metric_value, new_status)
 
     def resolve(self, metric_value: int | float, new_status: IncidentStatus):
-        if not RuleSnooze.objects.filter(alert_rule=self.incident.alert_rule).exists():
+        if not RuleSnooze.objects.filter(
+            alert_rule=self.incident.alert_rule, user_id__isnull=True
+        ).exists():
             self.send_alert(metric_value, new_status)
 
     @abc.abstractmethod

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -21,6 +21,7 @@ from sentry.incidents.models import (
 )
 from sentry.models.notificationsetting import NotificationSetting
 from sentry.models.options.user_option import UserOption
+from sentry.models.rulesnooze import RuleSnooze
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import ExternalProviders
@@ -47,10 +48,12 @@ class ActionHandler(metaclass=abc.ABCMeta):
 
 class DefaultActionHandler(ActionHandler):
     def fire(self, metric_value: int | float, new_status: IncidentStatus):
-        self.send_alert(metric_value, new_status)
+        if not RuleSnooze.objects.filter(alert_rule=self.incident.alert_rule).exists():
+            self.send_alert(metric_value, new_status)
 
     def resolve(self, metric_value: int | float, new_status: IncidentStatus):
-        self.send_alert(metric_value, new_status)
+        if not RuleSnooze.objects.filter(alert_rule=self.incident.alert_rule).exists():
+            self.send_alert(metric_value, new_status)
 
     @abc.abstractmethod
     def send_alert(self, metric_value: int | float, new_status: IncidentStatus):

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 from sentry.incidents.action_handlers import MsTeamsActionHandler
 from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus
 from sentry.models import Integration
+from sentry.models.rulesnooze import RuleSnooze
 from sentry.testutils import TestCase
 from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 from sentry.utils import json
@@ -17,9 +18,7 @@ from . import FireTest
 @freeze_time()
 class MsTeamsActionHandlerTest(FireTest, TestCase):
     @responses.activate
-    def run_test(self, incident, method):
-        from sentry.integrations.msteams.card_builder import build_incident_attachment
-
+    def setUp(self):
         with exempt_from_silo_limits():
             integration = Integration.objects.create(
                 provider="msteams",
@@ -43,12 +42,16 @@ class MsTeamsActionHandlerTest(FireTest, TestCase):
             json={"conversations": channels},
         )
 
-        action = self.create_alert_rule_trigger_action(
+        self.action = self.create_alert_rule_trigger_action(
             target_identifier=channel_name,
             type=AlertRuleTriggerAction.Type.MSTEAMS,
             target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
             integration=integration,
         )
+
+    @responses.activate
+    def run_test(self, incident, method):
+        from sentry.integrations.msteams.card_builder import build_incident_attachment
 
         responses.add(
             method=responses.POST,
@@ -57,11 +60,11 @@ class MsTeamsActionHandlerTest(FireTest, TestCase):
             json={},
         )
 
-        handler = MsTeamsActionHandler(action, incident, self.project)
+        handler = MsTeamsActionHandler(self.action, incident, self.project)
         metric_value = 1000
         with self.tasks():
             getattr(handler, method)(metric_value, IncidentStatus(incident.status))
-        data = json.loads(responses.calls[1].request.body)
+        data = json.loads(responses.calls[0].request.body)
 
         assert data["attachments"][0]["content"] == build_incident_attachment(
             incident, IncidentStatus(incident.status), metric_value
@@ -69,3 +72,25 @@ class MsTeamsActionHandlerTest(FireTest, TestCase):
 
     def test_fire_metric_alert(self):
         self.run_fire_test()
+
+    def test_resolve_metric_alert(self):
+        self.run_fire_test("resolve")
+
+    @responses.activate
+    def test_rule_snoozed(self):
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
+        RuleSnooze.objects.create(alert_rule=alert_rule)
+        responses.add(
+            method=responses.POST,
+            url="https://smba.trafficmanager.net/amer/v3/conversations/d_s/activities",
+            status=200,
+            json={},
+        )
+
+        handler = MsTeamsActionHandler(self.action, incident, self.project)
+        metric_value = 1000
+        with self.tasks():
+            handler.fire(metric_value, IncidentStatus(incident.status))
+
+        assert len(responses.calls) == 0

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -5,6 +5,7 @@ from sentry.incidents.action_handlers import PagerDutyActionHandler
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus, IncidentStatusMethod
 from sentry.models import Integration, PagerDutyService
+from sentry.models.rulesnooze import RuleSnooze
 from sentry.testutils import TestCase
 from sentry.utils import json
 
@@ -35,6 +36,12 @@ class PagerDutyActionHandlerTest(FireTest, TestCase):
             service_name=service[0]["service_name"],
             integration_key=service[0]["integration_key"],
             organization_integration_id=self.integration.organizationintegration_set.first().id,
+        )
+        self.action = self.create_alert_rule_trigger_action(
+            target_identifier=self.service.id,
+            type=AlertRuleTriggerAction.Type.PAGERDUTY,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            integration=self.integration,
         )
 
     def test_build_incident_attachment(self):
@@ -75,13 +82,6 @@ class PagerDutyActionHandlerTest(FireTest, TestCase):
     def run_test(self, incident, method):
         from sentry.integrations.pagerduty.utils import build_incident_attachment
 
-        action = self.create_alert_rule_trigger_action(
-            target_identifier=self.service.id,
-            type=AlertRuleTriggerAction.Type.PAGERDUTY,
-            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
-            integration=self.integration,
-        )
-
         responses.add(
             method=responses.POST,
             url="https://events.pagerduty.com/v2/enqueue/",
@@ -89,7 +89,7 @@ class PagerDutyActionHandlerTest(FireTest, TestCase):
             status=202,
             content_type="application/json",
         )
-        handler = PagerDutyActionHandler(action, incident, self.project)
+        handler = PagerDutyActionHandler(self.action, incident, self.project)
         metric_value = 1000
         with self.tasks():
             getattr(handler, method)(metric_value, IncidentStatus(incident.status))
@@ -120,3 +120,23 @@ class PagerDutyActionHandlerTest(FireTest, TestCase):
 
     def test_resolve_metric_alert(self):
         self.run_fire_test("resolve")
+
+    @responses.activate
+    def test_rule_snoozed(self):
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
+        RuleSnooze.objects.create(alert_rule=alert_rule)
+
+        responses.add(
+            method=responses.POST,
+            url="https://events.pagerduty.com/v2/enqueue/",
+            json={},
+            status=202,
+            content_type="application/json",
+        )
+        handler = PagerDutyActionHandler(self.action, incident, self.project)
+        metric_value = 1000
+        with self.tasks():
+            handler.fire(metric_value, IncidentStatus(incident.status))
+
+        assert len(responses.calls) == 0

--- a/tests/sentry/incidents/action_handlers/test_sentry_app.py
+++ b/tests/sentry/incidents/action_handlers/test_sentry_app.py
@@ -3,6 +3,7 @@ from freezegun import freeze_time
 
 from sentry.incidents.action_handlers import SentryAppActionHandler
 from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus
+from sentry.models.rulesnooze import RuleSnooze
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
@@ -24,16 +25,16 @@ class SentryAppActionHandlerTest(FireTest, TestCase):
             slug=self.sentry_app.slug, organization=self.organization, user=self.user
         )
 
-    @responses.activate
-    def run_test(self, incident, method):
-        from sentry.rules.actions.notify_event_service import build_incident_attachment
-
-        action = self.create_alert_rule_trigger_action(
+        self.action = self.create_alert_rule_trigger_action(
             target_identifier=self.sentry_app.id,
             type=AlertRuleTriggerAction.Type.SENTRY_APP,
             target_type=AlertRuleTriggerAction.TargetType.SENTRY_APP,
             sentry_app=self.sentry_app,
         )
+
+    @responses.activate
+    def run_test(self, incident, method):
+        from sentry.rules.actions.notify_event_service import build_incident_attachment
 
         responses.add(
             method=responses.POST,
@@ -43,7 +44,7 @@ class SentryAppActionHandlerTest(FireTest, TestCase):
             body=json.dumps({"ok": "true"}),
         )
 
-        handler = SentryAppActionHandler(action, incident, self.project)
+        handler = SentryAppActionHandler(self.action, incident, self.project)
         metric_value = 1000
         with self.tasks():
             getattr(handler, method)(metric_value, IncidentStatus(incident.status))
@@ -54,6 +55,27 @@ class SentryAppActionHandlerTest(FireTest, TestCase):
             )
             in data
         )
+
+    @responses.activate
+    def test_rule_snoozed(self):
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
+        RuleSnooze.objects.create(alert_rule=alert_rule)
+
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/webhook",
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ok": "true"}),
+        )
+
+        handler = SentryAppActionHandler(self.action, incident, self.project)
+        metric_value = 1000
+        with self.tasks():
+            handler.fire(metric_value, IncidentStatus(incident.status))
+
+        assert len(responses.calls) == 0
 
     def test_fire_metric_alert(self):
         self.run_fire_test()

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 from sentry.constants import ObjectStatus
 from sentry.incidents.action_handlers import SlackActionHandler
 from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus
+from sentry.models.rulesnooze import RuleSnooze
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
@@ -17,34 +18,36 @@ from . import FireTest
 @region_silo_test(stable=True)
 class SlackActionHandlerTest(FireTest, TestCase):
     @responses.activate
-    def run_test(self, incident, method, chart_url=None):
-        from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
-
+    def setUp(self):
         token = "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        integration = self.create_integration(
+        self.integration = self.create_integration(
             organization=self.organization,
             external_id="1",
             provider="slack",
             metadata={"access_token": token, "installation_type": "born_as_bot"},
         )
-        channel_id = "some_id"
-        channel_name = "#hello"
+        self.channel_id = "some_id"
+        self.channel_name = "#hello"
         responses.add(
             method=responses.GET,
             url="https://slack.com/api/conversations.list",
             status=200,
             content_type="application/json",
             body=json.dumps(
-                {"ok": "true", "channels": [{"name": channel_name[1:], "id": channel_id}]}
+                {"ok": "true", "channels": [{"name": self.channel_name[1:], "id": self.channel_id}]}
             ),
         )
-
-        action = self.create_alert_rule_trigger_action(
-            target_identifier=channel_name,
+        self.action = self.create_alert_rule_trigger_action(
+            target_identifier=self.channel_name,
             type=AlertRuleTriggerAction.Type.SLACK,
             target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
-            integration=integration,
+            integration=self.integration,
         )
+
+    @responses.activate
+    def run_test(self, incident, method, chart_url=None):
+        from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
+
         responses.add(
             method=responses.POST,
             url="https://slack.com/api/chat.postMessage",
@@ -52,12 +55,12 @@ class SlackActionHandlerTest(FireTest, TestCase):
             content_type="application/json",
             body='{"ok": true}',
         )
-        handler = SlackActionHandler(action, incident, self.project)
+        handler = SlackActionHandler(self.action, incident, self.project)
         metric_value = 1000
         with self.tasks():
             getattr(handler, method)(metric_value, IncidentStatus(incident.status))
-        data = parse_qs(responses.calls[1].request.body)
-        assert data["channel"] == [channel_id]
+        data = parse_qs(responses.calls[0].request.body)
+        assert data["channel"] == [self.channel_id]
         slack_body = SlackIncidentsMessageBuilder(
             incident, IncidentStatus(incident.status), metric_value, chart_url
         ).build()
@@ -80,7 +83,7 @@ class SlackActionHandlerTest(FireTest, TestCase):
         incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
         integration = self.create_integration(
             organization=self.organization,
-            external_id="1",
+            external_id="2",
             provider="slack",
             status=ObjectStatus.DELETION_IN_PROGRESS,
         )
@@ -93,7 +96,28 @@ class SlackActionHandlerTest(FireTest, TestCase):
             integration_id=integration.id,
             sentry_app_id=None,
         )
+
         handler = SlackActionHandler(action, incident, self.project)
         metric_value = 1000
         with self.tasks():
             handler.fire(metric_value, IncidentStatus(incident.status))
+
+    @responses.activate
+    def test_rule_snoozed(self):
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
+        RuleSnooze.objects.create(alert_rule=alert_rule)
+
+        responses.add(
+            method=responses.POST,
+            url="https://slack.com/api/chat.postMessage",
+            status=200,
+            content_type="application/json",
+            body='{"ok": true}',
+        )
+        handler = SlackActionHandler(self.action, incident, self.project)
+        metric_value = 1000
+        with self.tasks():
+            handler.fire(metric_value, IncidentStatus(incident.status))
+
+        assert len(responses.calls) == 0


### PR DESCRIPTION
A follow up to https://github.com/getsentry/sentry/pull/50986 that checks the `RuleSnooze` table before firing notifications to integrations.

Closes #50580 