### PR TITLE
docs(api): Update openapi-examples-validator

### DIFF
--- a/api-docs/components/schemas/event.json
+++ b/api-docs/components/schemas/event.json
@@ -124,7 +124,18 @@
               "type": "string"
             },
             "data": {
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "column": {
+                  "type": "integer"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "row": {
+                  "type": "integer"
+                }
+              }
             }
           }
         }
@@ -259,18 +270,14 @@
           }
         }
       },
-      "contexts": {
-        "type": "object"
-      },
+      "contexts": { "$ref": "#/contexts" },
       "fingerprints": {
         "type": "array",
         "items": {
           "type": "string"
         }
       },
-      "context": {
-        "type": "object"
-      },
+      "context": { "$ref": "#/context" },
       "release": {
         "type": "object",
         "nullable": true,
@@ -346,7 +353,18 @@
               "type": "string"
             },
             "data": {
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "column": {
+                  "type": "integer"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "row": {
+                  "type": "integer"
+                }
+              }
             }
           }
         }
@@ -477,18 +495,14 @@
           }
         }
       },
-      "contexts": {
-        "type": "object"
-      },
+      "contexts": { "$ref": "#/contexts" },
       "fingerprints": {
         "type": "array",
         "items": {
           "type": "string"
         }
       },
-      "context": {
-        "type": "object"
-      },
+      "context": { "$ref": "#/context" },
       "groupID": {
         "type": "string"
       },
@@ -587,9 +601,7 @@
           }
         }
       },
-      "contexts": {
-        "type": "object"
-      },
+      "contexts": { "$ref": "#/contexts" },
       "dateCreated": {
         "type": "string"
       },
@@ -705,6 +717,139 @@
         "$ref": "users.json#/EventUser"
       },
       "title": {
+        "type": "string"
+      }
+    }
+  },
+  "contexts": {
+    "type": "object",
+    "properties": {
+      "ForbiddenError": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "integer"
+          },
+          "statusText": {
+            "type": "string"
+          },
+          "responseJSON": {
+            "type": "object",
+            "properties": {
+              "detail": {
+                "type": "string"
+              }
+            }
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "browser": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "os": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "trace": {
+        "type": "object",
+        "properties": {
+          "span_id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "trace_id": {
+            "type": "string"
+          },
+          "op": {
+            "type": "string"
+          }
+        }
+      },
+      "organization": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "context": {
+    "type": "object",
+    "properties": {
+      "resp": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "integer"
+          },
+          "responseJSON": {
+            "type": "object",
+            "properties": {
+              "detail": {
+                "type": "string"
+              }
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "statusText": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "stack": {
+            "type": "string"
+          }
+        }
+      },
+      "session": {
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "string"
+          }
+        }
+      },
+      "unauthorized": {
+        "type": "boolean"
+      },
+      "url": {
         "type": "string"
       }
     }

--- a/api-docs/components/schemas/event.json
+++ b/api-docs/components/schemas/event.json
@@ -281,12 +281,9 @@
       "release": {
         "type": "object",
         "nullable": true,
-        "oneOf": [
+        "allOf": [
           {
             "$ref": "releases/organization-release.json#/OrganizationRelease"
-          },
-          {
-            "$ref": "null.json#/NullValue"
           }
         ]
       },

--- a/api-docs/components/schemas/null.json
+++ b/api-docs/components/schemas/null.json
@@ -1,5 +1,7 @@
 {
   "NullValue": {
+    "type": "string",
+    "nullable": true,
     "not": {
       "anyOf": [
         { "type": "string" },

--- a/api-docs/components/schemas/null.json
+++ b/api-docs/components/schemas/null.json
@@ -1,6 +1,5 @@
 {
   "NullValue": {
-    "nullable": true,
     "not": {
       "anyOf": [
         { "type": "string" },

--- a/api-docs/components/schemas/organization-details.json
+++ b/api-docs/components/schemas/organization-details.json
@@ -140,16 +140,21 @@
         "type": "object",
         "properties": {
           "accountLimit": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           "maxRate": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
           },
           "maxRateInterval": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           "projectLimit": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           }
         }
       },

--- a/api-docs/components/schemas/organization-details.json
+++ b/api-docs/components/schemas/organization-details.json
@@ -103,8 +103,7 @@
           "type": "object",
           "properties": {
             "data": {
-              "type": "object",
-              "nullable": true
+              "type": "object"
             },
             "dateCompleted": {
               "type": "string",
@@ -117,8 +116,7 @@
               "type": "integer"
             },
             "user": {
-              "type": "string",
-              "nullable": true
+              "type": "string"
             }
           }
         }

--- a/api-docs/components/schemas/organization-details.json
+++ b/api-docs/components/schemas/organization-details.json
@@ -100,7 +100,27 @@
       "onboardingTasks": {
         "type": "array",
         "items": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object",
+              "nullable": true
+            },
+            "dateCompleted": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "status": {
+              "type": "string"
+            },
+            "task": {
+              "type": "integer"
+            },
+            "user": {
+              "type": "string",
+              "nullable": true
+            }
+          }
         }
       },
       "openMembership": {
@@ -117,7 +137,21 @@
         }
       },
       "quota": {
-        "type": "object"
+        "type": "object",
+        "properties": {
+          "accountLimit": {
+            "type": "integer"
+          },
+          "maxRate": {
+            "type": "integer"
+          },
+          "maxRateInterval": {
+            "type": "integer"
+          },
+          "projectLimit": {
+            "type": "integer"
+          }
+        }
       },
       "require2FA": {
         "type": "boolean"

--- a/api-docs/components/schemas/organization-details.json
+++ b/api-docs/components/schemas/organization-details.json
@@ -103,7 +103,8 @@
           "type": "object",
           "properties": {
             "data": {
-              "type": "object"
+              "type": "object",
+              "nullable": true
             },
             "dateCompleted": {
               "type": "string",
@@ -116,7 +117,8 @@
               "type": "integer"
             },
             "user": {
-              "type": "string"
+              "type": "string",
+              "nullable": true
             }
           }
         }

--- a/api-docs/components/schemas/project.json
+++ b/api-docs/components/schemas/project.json
@@ -207,12 +207,9 @@
       "team": {
           "type": "object",
           "nullable": true,
-          "oneOf": [
+          "allOf": [
             {
               "$ref": "team.json#/TeamMinimal"
-            },
-            {
-              "$ref": "null.json#/NullValue"
             }
           ]
       },

--- a/api-docs/components/schemas/releases/organization-release.json
+++ b/api-docs/components/schemas/releases/organization-release.json
@@ -21,6 +21,9 @@
       "url"
     ],
     "properties": {
+      "id": {
+        "type": "integer"
+      },
       "authors": {
         "type": "array",
         "items": {

--- a/api-docs/components/schemas/releases/release-file.json
+++ b/api-docs/components/schemas/releases/release-file.json
@@ -18,7 +18,12 @@
         "format": "date-time"
       },
       "headers": {
-        "type": "object"
+        "type": "object",
+        "properties": {
+          "Content-Type": {
+            "type": "string"
+          }
+        }
       },
       "id": {
         "type": "string"

--- a/api-docs/components/schemas/sessions.json
+++ b/api-docs/components/schemas/sessions.json
@@ -36,11 +36,23 @@
     "properties": {
       "by": {
         "type": "object",
-        "description": "These are key/value pairs, the key being the requested `groupBy` property with its corresponding value."
+        "description": "These are key/value pairs, the key being the requested `groupBy` property with its corresponding value.",
+        "properties": {
+          "session.status": {
+            "type": "string",
+            "description": "Example `groupBy` property"
+          }
+        }
       },
       "totals": {
         "type": "object",
-        "description": "These are key/value pairs, the key being the requested `field`, and the value the corresponding total over the requested time frame."
+        "description": "These are key/value pairs, the key being the requested `field`, and the value the corresponding total over the requested time frame.",
+        "properties": {
+          "sum(session)": {
+            "type": "integer",
+            "description": "Example `field` value"
+          }
+        }
       },
       "series": {
         "type": "object",

--- a/api-docs/package.json
+++ b/api-docs/package.json
@@ -13,7 +13,7 @@
     "js-yaml": "^3.14.0",
     "json-diff": "^0.7.1",
     "json-refs": "^3.0.15",
-    "openapi-examples-validator": "^4.1.1",
+    "openapi-examples-validator": "^5.0.0",
     "sane": "^5.0.1"
   },
   "devDependencies": {

--- a/api-docs/paths/releases/organization-releases.json
+++ b/api-docs/paths/releases/organization-releases.json
@@ -31,7 +31,8 @@
               "type": "array",
               "items": {
                 "$ref": "../../components/schemas/releases/organization-release.json#/OrganizationRelease"
-              }
+              },
+              "minItems": 2
             },
             "example": [
               {

--- a/api-docs/paths/releases/organization-releases.json
+++ b/api-docs/paths/releases/organization-releases.json
@@ -31,8 +31,7 @@
               "type": "array",
               "items": {
                 "$ref": "../../components/schemas/releases/organization-release.json#/OrganizationRelease"
-              },
-              "minItems": 2
+              }
             },
             "example": [
               {

--- a/api-docs/yarn.lock
+++ b/api-docs/yarn.lock
@@ -40,21 +40,26 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
-ajv-oai@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ajv-oai/-/ajv-oai-1.2.1.tgz#6d253fde782cf809ace2d9d0b1b07a53905dcdaa"
-  integrity sha512-gj7dnSdLyjWKid3uQI16u5wQNpkyqivjtCuvI4BWezeOzYTj5YHt4otH9GOBCaXY3FEbzQeWsp6C2qc18+BXDA==
-  dependencies:
-    decimal.js "^10.2.0"
+ajv-draft-04@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz#3b64761b268ba0b9e668f0b41ba53fce0ad77fc8"
+  integrity sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==
 
-ajv@^6.12.6:
-  version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
+ajv@^8.0.0, ajv@^8.12.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
   dependencies:
     fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 anymatch@^3.1.1:
@@ -87,13 +92,12 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
   dependencies:
     balanced-match "^1.0.0"
-    concat-map "0.0.1"
 
 braces@^3.0.2:
   version "3.0.2"
@@ -162,11 +166,6 @@ component-emitter@^1.2.0:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
-
 cookiejar@^2.1.0:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.3.tgz#fc7a6216e408e74414b90230050842dacda75acc"
@@ -200,11 +199,6 @@ debug@^3.1.0:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-decimal.js@^10.2.0:
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
-  integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -325,11 +319,6 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-json-stable-stringify@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
-  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
-
 fb-watchman@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.2.tgz#e9524ee6b5c77e9e5001af0f85f3adbb8623255c"
@@ -389,17 +378,16 @@ get-stream@^5.0.0:
   dependencies:
     pump "^3.0.0"
 
-glob@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
-  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+glob@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.4"
+    minimatch "^5.0.1"
     once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 graphlib@^2.1.8:
   version "2.1.8"
@@ -492,10 +480,10 @@ json-diff@^0.7.1:
     difflib "~0.2.1"
     dreamopt "~0.8.0"
 
-json-pointer@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/json-pointer/-/json-pointer-0.6.1.tgz#3c6caa6ac139e2599f5a1659d39852154015054d"
-  integrity sha512-3OvjqKdCBvH41DLpV4iSt6v2XhZXV1bPB4OROuknvUXI7ZQNofieCPkmE26stEJ9zdQuvIxDHCuYhfgxFAAs+Q==
+json-pointer@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/json-pointer/-/json-pointer-0.6.2.tgz#f97bd7550be5e9ea901f8c9264c9d436a22a93cd"
+  integrity sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==
   dependencies:
     foreach "^2.0.4"
 
@@ -520,15 +508,15 @@ json-schema-ref-parser@^9.0.9:
   dependencies:
     "@apidevtools/json-schema-ref-parser" "9.0.9"
 
-json-schema-traverse@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
-  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-jsonpath-plus@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz#9a3e16cedadfab07a3d8dc4e8cd5df4ed8f49c4d"
-  integrity sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==
+jsonpath-plus@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz#7ad94e147b3ed42f7939c315d2b9ce490c5a3899"
+  integrity sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==
 
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
@@ -623,12 +611,12 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@^3.0.4:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
   dependencies:
-    brace-expansion "^1.1.7"
+    brace-expansion "^2.0.1"
 
 minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.8"
@@ -686,29 +674,25 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-openapi-examples-validator@^4.1.1:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/openapi-examples-validator/-/openapi-examples-validator-4.6.0.tgz#c61adfd378b2a4435dcf95276a639cfac09d5f7e"
-  integrity sha512-3E8VwRrNVk8xGaAbPK3pkdQgsQfsHtp9qZ1rSTgOoQP6S2F339UfldTDFOKNjV9YywGrrS/A1FM4qbslLf2LUQ==
+openapi-examples-validator@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/openapi-examples-validator/-/openapi-examples-validator-5.0.0.tgz#d35cbffc5f0669961f8ce514c413d0b44a153b62"
+  integrity sha512-UbyFT66im7n8yJWBMHup2VBKzWjIX0v9y+RroExPHqArUx/1kCdb39BfDra+cPiiZIwU9YYGtxwBwYyCCJAVgg==
   dependencies:
-    ajv "^6.12.6"
-    ajv-oai "1.2.1"
+    ajv "^8.12.0"
+    ajv-draft-04 "^1.0.0"
+    ajv-formats "^2.1.1"
     commander "^6.2.1"
     errno "^1.0.0"
-    glob "^7.2.0"
-    json-pointer "0.6.1"
+    glob "^8.1.0"
+    json-pointer "^0.6.2"
     json-schema-ref-parser "^9.0.9"
-    jsonpath-plus "^6.0.1"
+    jsonpath-plus "^7.2.0"
     lodash.clonedeep "^4.5.0"
     lodash.flatmap "^4.5.0"
     lodash.flatten "^4.4.0"
     lodash.merge "^4.6.2"
-    yaml "^1.10.2"
-
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+    yaml "^2.2.2"
 
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
@@ -770,6 +754,11 @@ readable-stream@^2.3.5:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -926,7 +915,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-yaml@^1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+yaml@^2.2.2:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.1.tgz#02fe0975d23cd441242aa7204e09fc28ac2ac33b"
+  integrity sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==


### PR DESCRIPTION
Update Openapi-examples-validator to version 5.0.0

The previous version 4.1.1 had a bug that was only fixed in 4.7.0 that incorrectly validated schema with additional Properties when the `--no-additional-properties` flag was set https://github.com/codekie/openapi-examples-validator/issues/178. Shoutout to @mdtro for discovering this in an earlier [PR](https://github.com/getsentry/sentry/pull/43216#issuecomment-1396261406)

Upgrading also forces the `nullable` property to explicitly be used with a type, so we include one fix for that. 