### PR TITLE
fix(traces): Return empty array when accessing offender span ids

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -221,7 +221,7 @@ class TraceEvent:
                     span = list(unique_spans)
                     for event_span in self.nodestore_event.data.get("spans", []):
                         for problem in problems:
-                            offender_span_ids = problem.evidence_data.get("offender_span_ids")
+                            offender_span_ids = problem.evidence_data.get("offender_span_ids", [])
                             if event_span.get("span_id") in offender_span_ids:
                                 try:
                                     start_timestamp = float(event_span.get("start_timestamp"))


### PR DESCRIPTION
Currently we don't guard against the case where the evidence data doesn't have this value. We could have added another conditional check against None, but returning an empty array is simpler with this code structure

Fixes SENTRY-1248
