### PR TITLE
Enable tags: os.name, browser.name, goe.country_code, http.status_code

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -141,8 +141,6 @@ class MetricsQueryBuilder(QueryBuilder):
         if col.startswith("tags["):
             tag_match = constants.TAG_KEY_RE.search(col)
             col = tag_match.group("tag") if tag_match else col
-        if col in constants.METRIC_UNAVAILBLE_COLUMNS:
-            raise IncompatibleMetricsQuery(f"{col} is unavailable")
 
         if self.use_metrics_layer:
             if col in ["project_id", "timestamp"]:

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -281,8 +281,6 @@ METRIC_TOLERATED_TAG_VALUE = "tolerated"
 METRIC_SATISFIED_TAG_VALUE = "satisfied"
 METRIC_FRUSTRATED_TAG_VALUE = "frustrated"
 METRIC_SATISFACTION_TAG_KEY = "satisfaction"
-# These strings will be resolved by the indexer, but aren't available in the dataset
-METRIC_UNAVAILBLE_COLUMNS = {"os.name"}
 
 # Only the metrics that are on the distributions & are in milliseconds
 METRIC_DURATION_COLUMNS = {

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -222,6 +222,8 @@ FILTERABLE_TAGS = {
     "tags[os.name]",
     "tags[release]",
     "tags[histogram_outlier]",
+    "tags[geo.country_code]",
+    "tags[http.status_code]",
 }
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2122,47 +2122,6 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         meta = response.data["meta"]
         assert meta["isMetricsData"]
 
-    def test_os_name_incompatible(self):
-        self.store_transaction_metric(
-            1,
-            tags={"transaction": "foo_transaction", "transaction.status": "foobar"},
-            timestamp=self.min_ago,
-        )
-
-        response = self.do_request(
-            {
-                "field": [
-                    "os.name",
-                    "p90()",
-                ],
-                "query": "transaction:foo_transaction",
-                "dataset": "metrics",
-            }
-        )
-        assert response.status_code == 400, response.content
-        assert response.data["detail"] == "os.name is unavailable"
-
-    def test_os_name_falls_back(self):
-        self.store_transaction_metric(
-            1,
-            tags={"transaction": "foo_transaction", "transaction.status": "foobar"},
-            timestamp=self.min_ago,
-        )
-
-        response = self.do_request(
-            {
-                "field": [
-                    "os.name",
-                    "p75()",
-                ],
-                "query": "transaction:foo_transaction",
-                "dataset": "metricsEnhanced",
-            }
-        )
-        assert response.status_code == 200, response.content
-        meta = response.data["meta"]
-        assert not meta["isMetricsData"]
-
     def test_http_error_rate(self):
         self.store_transaction_metric(
             1,


### PR DESCRIPTION
This PR enables querying in Performance, Dashboards and Alerts using four new tags (new fields):
* `os.name`
* `browser.name`
* `geo.country_code`
*  `http.status_code`