### PR TITLE
fix(starfish): Fixes endpoint overview breakdown chart bad timestamps.

### DIFF
--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -145,7 +145,7 @@ export function SpanGroupBreakdownContainer({transaction, transactionMethod}: Pr
         const label = key === '' ? NULL_SPAN_CATEGORY : key;
         seriesByDomain[label].data =
           seriesData?.data.map(datum => {
-            return {name: datum[0], value: datum[1][0].count} as SeriesDataUnit;
+            return {name: datum[0] * 1000, value: datum[1][0].count} as SeriesDataUnit;
           }) ?? [];
       });
     }


### PR DESCRIPTION
 Fixes endpoint overview breakdown chart bad timestamps. The timestamps should be scaled up by 1000.