### PR TITLE
fix(ui): Add min/max length types to InputType

### DIFF
--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -110,6 +110,8 @@ export interface CustomType {
 
 type InputType = {type: 'string' | 'secret'} & {
   autoComplete?: string;
+  maxLength?: number;
+  minLength?: number;
 };
 
 type SelectControlType = {type: 'choice' | 'select'} & {


### PR DESCRIPTION
Typescript 5.1 errors on these for whatever reason. Add them to the string type. Used in getsentry in a few places like here https://github.com/getsentry/getsentry/blob/bc48211b1649f0038f0f48c47825e2e9e500510d/static/getsentry/gsAdmin/schemas/policies.tsx#L42
