### PR TITLE
fix(hybridcloud) Drain outbox after transaction completes

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -219,7 +219,10 @@ class DatabaseBackedOrganizationService(OrganizationService):
                     )
                     org_member.set_user(user_id)
                     org_member.save()
-                    org_member.outbox_for_update().drain_shard(max_updates_to_drain=10)
+
+                    transaction.on_commit(
+                        lambda: org_member.outbox_for_update().drain_shard(max_updates_to_drain=10)
+                    )
                 except OrganizationMember.DoesNotExist:
                     return None
         return serialize_member(org_member)

--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
@@ -60,6 +60,8 @@ class DatabaseBackedOrganizationMemberMappingService(OrganizationMemberMappingSe
                 organization_id=organization_id,
                 organizationmember_id=organizationmember_id,
             )
+            assert existing, "Failed to find conflicted org member"
+
             apply_update(existing)
 
         return serialize_org_member_mapping(existing)


### PR DESCRIPTION
We shouldn't drain outbox messages for memberships until after the member has committed, as we'll not be able to find the member.

Fixes SENTRY-12D2