### PR TITLE
feat(debug): Add Metric Alert Trigger

### DIFF
--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -29,6 +29,7 @@
         <option value="mail/performance-alert/transaction-render-blocking-asset">Render Blocking Asset Alert</option>
         <option value="mail/generic-alert/">Generic Alert</option>
         <option value="mail/digest/">Digest</option>
+        <option value="mail/incident-trigger">Metric Alert Trigger</option>
       </optgroup>
       <optgroup label="Account">
         <option value="mail/confirm-email/">Confirm Email</option>


### PR DESCRIPTION
this pr adds the metric alert trigger email to the email debug. The view existed, but it wasn't being included as an option in the dropdown on the preview page.