### PR TITLE
fix(hybridcloud) Handle deleted users getting client config

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -240,8 +240,11 @@ def get_client_config(request=None):
             "sentryUrl": options.get("system.url-prefix"),
         },
     }
+
+    user_details = None
     if user and user.is_authenticated:
-        (serialized_user,) = user_service.serialize_many(
+        # Fetch the user, this could be an empty result as the user could be deleted.
+        user_details = user_service.serialize_many(
             filter={"user_ids": [user.id]},
             serializer=UserSerializeType.SELF_DETAILED,
             auth_context=AuthenticationContext(
@@ -249,12 +252,10 @@ def get_client_config(request=None):
                 user=request.user,
             ),
         )
-        context.update(
-            {
-                "isAuthenticated": True,
-                "user": serialized_user,
-            }
-        )
+
+    if user and user.is_authenticated and user_details:
+        context["isAuthenticated"] = True
+        context["user"] = user_details[0]
 
         if request.user.is_superuser:
             # Note: This intentionally does not use the "active" superuser flag as

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -127,3 +127,15 @@ def test_client_config_in_silo_modes(request_factory: RequestFactory):
 
     with override_settings(SILO_MODE=SiloMode.CONTROL):
         assert get_client_config(request) == base_line
+
+
+@pytest.mark.django_db(transaction=True)
+def test_client_config_deleted_user():
+    request, user = make_user_request_from_org()
+    request.user = user
+
+    user.delete()
+
+    result = get_client_config(request)
+    assert result["isAuthenticated"] is False
+    assert result["user"] is None


### PR DESCRIPTION
We've had a few different users who no longer exist trigger during their initial page load, that then trigger more errors as we fail to render a 500 page as well.

Fixes SENTRY-122H