### PR TITLE
chore: Allow postgres container to be customized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all: develop
 
 PIP := python -m pip --disable-pip-version-check
 WEBPACK := yarn build-acceptance
+POSTGRES_CONTAINER := sentry_postgres
 
 freeze-requirements:
 	@python3 -S -m tools.freeze_requirements

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -168,11 +168,12 @@ run-dependent-services() {
 }
 
 create-db() {
+    container_name=${POSTGRES_CONTAINER:-sentry_postgres}
     echo "--> Creating 'sentry' database"
-    docker exec ${POSTGRES_CONTAINER} createdb -h 127.0.0.1 -U postgres -E utf-8 sentry || true
+    docker exec ${container_name} createdb -h 127.0.0.1 -U postgres -E utf-8 sentry || true
     echo "--> Creating 'control' and 'region' database"
-    docker exec ${POSTGRES_CONTAINER} createdb -h 127.0.0.1 -U postgres -E utf-8 control || true
-    docker exec ${POSTGRES_CONTAINER} createdb -h 127.0.0.1 -U postgres -E utf-8 region || true
+    docker exec ${container_name} createdb -h 127.0.0.1 -U postgres -E utf-8 control || true
+    docker exec ${container_name} createdb -h 127.0.0.1 -U postgres -E utf-8 region || true
 }
 
 apply-migrations() {
@@ -222,11 +223,12 @@ clean() {
 }
 
 drop-db() {
+    container_name=${POSTGRES_CONTAINER:-sentry_postgres}
     echo "--> Dropping existing 'sentry' database"
-    docker exec ${POSTGRES_CONTAINER} dropdb --if-exists -h 127.0.0.1 -U postgres sentry
+    docker exec ${container_name} dropdb --if-exists -h 127.0.0.1 -U postgres sentry
     echo "--> Dropping 'control' and 'region' database"
-    docker exec ${POSTGRES_CONTAINER} dropdb --if-exists -h 127.0.0.1 -U postgres control
-    docker exec ${POSTGRES_CONTAINER} dropdb --if-exists -h 127.0.0.1 -U postgres region
+    docker exec ${container_name} dropdb --if-exists -h 127.0.0.1 -U postgres control
+    docker exec ${container_name} dropdb --if-exists -h 127.0.0.1 -U postgres region
 }
 
 reset-db() {

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -169,10 +169,10 @@ run-dependent-services() {
 
 create-db() {
     echo "--> Creating 'sentry' database"
-    docker exec sentry_postgres createdb -h 127.0.0.1 -U postgres -E utf-8 sentry || true
+    docker exec ${POSTGRES_CONTAINER} createdb -h 127.0.0.1 -U postgres -E utf-8 sentry || true
     echo "--> Creating 'control' and 'region' database"
-    docker exec sentry_postgres createdb -h 127.0.0.1 -U postgres -E utf-8 control || true
-    docker exec sentry_postgres createdb -h 127.0.0.1 -U postgres -E utf-8 region || true
+    docker exec ${POSTGRES_CONTAINER} createdb -h 127.0.0.1 -U postgres -E utf-8 control || true
+    docker exec ${POSTGRES_CONTAINER} createdb -h 127.0.0.1 -U postgres -E utf-8 region || true
 }
 
 apply-migrations() {
@@ -223,10 +223,10 @@ clean() {
 
 drop-db() {
     echo "--> Dropping existing 'sentry' database"
-    docker exec sentry_postgres dropdb --if-exists -h 127.0.0.1 -U postgres sentry
+    docker exec ${POSTGRES_CONTAINER} dropdb --if-exists -h 127.0.0.1 -U postgres sentry
     echo "--> Dropping 'control' and 'region' database"
-    docker exec sentry_postgres dropdb --if-exists -h 127.0.0.1 -U postgres control
-    docker exec sentry_postgres dropdb --if-exists -h 127.0.0.1 -U postgres region
+    docker exec ${POSTGRES_CONTAINER} dropdb --if-exists -h 127.0.0.1 -U postgres control
+    docker exec ${POSTGRES_CONTAINER} dropdb --if-exists -h 127.0.0.1 -U postgres region
 }
 
 reset-db() {


### PR DESCRIPTION
When testing a clean run of migrations, using a dedicated set of containers is helpful as you can preserve the data in your day-to-day dev environment.

Refs #50993
