### PR TITLE
feat(mute-metric-alerts): Add mute button to metric alert email

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -20,7 +20,6 @@ from sentry.incidents.models import (
     IncidentStatus,
     TriggerStatus,
 )
-from sentry.models import RuleSnooze
 from sentry.models.notificationsetting import NotificationSetting
 from sentry.models.options.user_option import UserOption
 from sentry.models.rulesnooze import RuleSnooze
@@ -287,7 +286,7 @@ def generate_incident_trigger_email_context(
 
     snooze_alert = False
     snooze_alert_url = None
-    if features.has("organizations:mute-alerts", organization):
+    if features.has("organizations:mute-metric-alerts", organization):
         snooze_alert = True
         snooze_alert_url = rule_link + "&" + urlencode({"mute": "1"})
 

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import logging
 from typing import Sequence, Set, Tuple
+from urllib.parse import urlencode
 
 from django.conf import settings
 from django.template.defaultfilters import pluralize
@@ -267,7 +268,7 @@ def generate_incident_trigger_email_context(
     snooze_alert_url = None
     if features.has("organizations:mute-alerts", organization):
         snooze_alert = True
-        snooze_alert_url = rule_link + "&mute=1"
+        snooze_alert_url = rule_link + "&" + urlencode({"mute": "1"})
 
     return {
         "link": alert_link,

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -288,7 +288,7 @@ def generate_incident_trigger_email_context(
     snooze_alert_url = None
     if features.has("organizations:mute-metric-alerts", organization):
         snooze_alert = True
-        snooze_alert_url = rule_link + "&" + urlencode({"mute": "1"})
+        snooze_alert_url = alert_link + "&" + urlencode({"mute": "1"})
 
     return {
         "link": alert_link,

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -239,27 +239,39 @@ def generate_incident_trigger_email_context(
             tz = user_option_tz
 
     organization = incident.organization
+
+    alert_link = organization.absolute_url(
+        reverse(
+            "sentry-metric-alert",
+            kwargs={
+                "organization_slug": organization.slug,
+                "incident_id": incident.identifier,
+            },
+        ),
+        query="referrer=alert_email",
+    )
+
+    rule_link = organization.absolute_url(
+        reverse(
+            "sentry-alert-rule",
+            kwargs={
+                "organization_slug": organization.slug,
+                "project_slug": project.slug,
+                "alert_rule_id": trigger.alert_rule_id,
+            },
+        ),
+        query="referrer=alert_email",
+    )
+
+    snooze_alert = False
+    snooze_alert_url = None
+    if features.has("organizations:mute-alerts", organization):
+        snooze_alert = True
+        snooze_alert_url = rule_link + "&mute=1"
+
     return {
-        "link": organization.absolute_url(
-            reverse(
-                "sentry-metric-alert",
-                kwargs={
-                    "organization_slug": organization.slug,
-                    "incident_id": incident.identifier,
-                },
-            ),
-            query="referrer=alert_email",
-        ),
-        "rule_link": organization.absolute_url(
-            reverse(
-                "sentry-alert-rule",
-                kwargs={
-                    "organization_slug": organization.slug,
-                    "project_slug": project.slug,
-                    "alert_rule_id": trigger.alert_rule_id,
-                },
-            )
-        ),
+        "link": alert_link,
+        "rule_link": rule_link,
         "project_slug": project.slug,
         "incident_name": incident.title,
         "environment": environment_string,
@@ -278,4 +290,6 @@ def generate_incident_trigger_email_context(
         "unsubscribe_link": None,
         "chart_url": chart_url,
         "timezone": tz,
+        "snooze_alert": snooze_alert,
+        "snooze_alert_url": snooze_alert_url,
     }

--- a/src/sentry/templates/sentry/emails/incidents/trigger.html
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.html
@@ -71,6 +71,14 @@
           <td>{{ alert_date_added }}</td>
         </tr>
       </table>
+
+      <p class="info-box">
+        {% if snooze_alert %}
+           <a class='mute' href="{{ snooze_alert_url }}">Mute this alert</a>
+        {% endif %}
+        This email was triggered by
+            <a href="{{ rule_link }}">{{ incident_name }}</a>
+    </p>
     </div>
   {% endif %}
 {% endblock %}

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -242,7 +242,8 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
                         "project_slug": self.project.slug,
                         "alert_rule_id": action.alert_rule_trigger.alert_rule_id,
                     },
-                )
+                ),
+                query="referrer=alert_email",
             ),
             "incident_name": incident.title,
             "aggregate": aggregate,

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -261,6 +261,8 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             "unsubscribe_link": None,
             "chart_url": None,
             "timezone": settings.SENTRY_DEFAULT_TIME_ZONE,
+            "snooze_alert": False,
+            "snooze_alert_url": None,
         }
         assert expected == generate_incident_trigger_email_context(
             self.project,


### PR DESCRIPTION
this pr adds in the mute button to the metric alert email . It attached a query parameter to the email which is used to automatically mute the alert if clicked.
<img width="547" alt="Screenshot 2023-06-15 at 1 05 11 PM" src="https://github.com/getsentry/sentry/assets/46740234/03530c99-9bf2-4f9c-8f69-94b09e1daa6d">
