### PR TITLE
ref(generic-metrics): Remove `cardinality_limit_legacy` tag

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -173,13 +173,6 @@ class IndexerBatch:
 
     @metrics.wraps("process_messages.filter_messages")
     def filter_messages(self, keys_to_remove: Sequence[PartitionIdxOffset]) -> None:
-        metrics.incr(
-            "sentry_metrics.indexer.process_messages.dropped_message",
-            amount=len(keys_to_remove),
-            tags={
-                "reason": "cardinality_limit_legacy",
-            },
-        )
 
         # XXX: it is useful to be able to get a sample of organization ids that are affected by rate limits, but this is really slow.
         for offset in keys_to_remove:

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -173,7 +173,6 @@ class IndexerBatch:
 
     @metrics.wraps("process_messages.filter_messages")
     def filter_messages(self, keys_to_remove: Sequence[PartitionIdxOffset]) -> None:
-
         # XXX: it is useful to be able to get a sample of organization ids that are affected by rate limits, but this is really slow.
         for offset in keys_to_remove:
             # Log once per second at most since we are getting too many dropped messages because


### PR DESCRIPTION
### Overview

The `cardinality_limit_legacy` tag was used to gage if the new cardinality limit metrics is being counted correctly. Now that we have verified it, it can be safely removed.