### PR TITLE
feat(github-comments): debounce comment task

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -32,6 +32,9 @@ from sentry.utils.sdk import set_current_event_project
 PREFERRED_GROUP_OWNERS = 1
 PREFERRED_GROUP_OWNER_AGE = timedelta(days=7)
 DEBOUNCE_CACHE_KEY = lambda group_id: f"process-commit-context-{group_id}"
+DEBOUNCE_PR_COMMENT_CACHE_KEY = lambda pullrequest_id: f"process-commit-context-{pullrequest_id}"
+PR_COMMENT_TASK_TTL = timedelta(minutes=5).total_seconds()
+
 logger = logging.getLogger(__name__)
 
 
@@ -82,7 +85,9 @@ def queue_comment_task_if_needed(
         not pr.pullrequestcomment_set.exists()
         or group_owner.group_id not in pr.pullrequestcomment_set.get().group_ids
     ):
-        # TODO: Debouncing Logic
+        cache_key = DEBOUNCE_PR_COMMENT_CACHE_KEY(pullrequest_id=pr.id)
+        if cache.get(cache_key) is not None:
+            return
 
         # create PR commit row for suspect commit and PR
         PullRequestCommit.objects.get_or_create(commit=commit, pull_request=pr)
@@ -91,6 +96,9 @@ def queue_comment_task_if_needed(
             "github.pr_comment.queue_comment_workflow",
             extra={"pullrequest_id": pr.id, "project_id": group_owner.project_id},
         )
+
+        cache.set(cache_key, True, PR_COMMENT_TASK_TTL)
+
         comment_workflow.delay(pullrequest_id=pr.id, project_id=group_owner.project_id)
 
 

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -91,17 +91,17 @@ def queue_comment_task_if_needed(
             if cache.get(cache_key) is not None:
                 return
 
-        # create PR commit row for suspect commit and PR
-        PullRequestCommit.objects.get_or_create(commit=commit, pull_request=pr)
+            # create PR commit row for suspect commit and PR
+            PullRequestCommit.objects.get_or_create(commit=commit, pull_request=pr)
 
-        logger.info(
-            "github.pr_comment.queue_comment_workflow",
-            extra={"pullrequest_id": pr.id, "project_id": group_owner.project_id},
-        )
+            logger.info(
+                "github.pr_comment.queue_comment_workflow",
+                extra={"pullrequest_id": pr.id, "project_id": group_owner.project_id},
+            )
 
-        cache.set(cache_key, True, PR_COMMENT_TASK_TTL)
+            cache.set(cache_key, True, PR_COMMENT_TASK_TTL)
 
-        comment_workflow.delay(pullrequest_id=pr.id, project_id=group_owner.project_id)
+            comment_workflow.delay(pullrequest_id=pr.id, project_id=group_owner.project_id)
 
 
 @instrumented_task(

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -17,7 +17,10 @@ from sentry.models.organization import Organization
 from sentry.models.pullrequest import PullRequestComment
 from sentry.models.repository import Repository
 from sentry.services.hybrid_cloud.integration import integration_service
+from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.tasks.base import instrumented_task
+from sentry.tasks.commit_context import DEBOUNCE_PR_COMMENT_CACHE_KEY
+from sentry.utils.cache import cache
 from sentry.utils.snuba import Dataset, raw_snql_query
 
 logger = logging.getLogger(__name__)
@@ -150,12 +153,14 @@ def create_or_update_comment(
 
 @instrumented_task(name="sentry.tasks.integrations.github_pr_comments")
 def comment_workflow(pullrequest_id: int, project_id: int):
+    cache_key = DEBOUNCE_PR_COMMENT_CACHE_KEY(pullrequest_id)
+
     gh_repo_id, pr_key, org_id, issue_list = pr_to_issue_query(pullrequest_id)[0]
 
     try:
         organization = Organization.objects.get_from_cache(id=org_id)
     except Organization.DoesNotExist:
-        # TODO(cathy): release the cache key even after exceptions
+        cache.delete(cache_key)
         logger.error("github.pr_comment.org_missing")
         return
 
@@ -172,6 +177,7 @@ def comment_workflow(pullrequest_id: int, project_id: int):
     try:
         project = Project.objects.get_from_cache(id=project_id)
     except Project.DoesNotExist:
+        cache.delete(cache_key)
         logger.error("github.pr_comment.project_missing", extra={"organization_id": org_id})
         return
 
@@ -182,11 +188,13 @@ def comment_workflow(pullrequest_id: int, project_id: int):
     try:
         repo = Repository.objects.get(id=gh_repo_id)
     except Repository.DoesNotExist:
+        cache.delete(cache_key)
         logger.error("github.pr_comment.repo_missing", extra={"organization_id": org_id})
         return
 
     integration = integration_service.get_integration(integration_id=repo.integration_id)
     if not integration:
+        cache.delete(cache_key)
         logger.error("github.pr_comment.integration_missing", extra={"organization_id": org_id})
         return
 
@@ -201,12 +209,17 @@ def comment_workflow(pullrequest_id: int, project_id: int):
     comment_body = format_comment(issue_comment_contents)
 
     top_24_issues = issue_list[:24]  # 24 is the P99 for issues-per-PR
-    create_or_update_comment(
-        pr_comment=pr_comment,
-        client=client,
-        repo=repo,
-        pr_key=pr_key,
-        comment_body=comment_body,
-        pullrequest_id=pullrequest_id,
-        issue_list=top_24_issues,
-    )
+
+    try:
+        create_or_update_comment(
+            pr_comment=pr_comment,
+            client=client,
+            repo=repo,
+            pr_key=pr_key,
+            comment_body=comment_body,
+            pullrequest_id=pullrequest_id,
+            issue_list=top_24_issues,
+        )
+    except ApiError as e:
+        cache.delete(cache_key)
+        raise e

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -13,6 +13,7 @@ from sentry.models.pullrequest import PullRequestComment
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.snuba.sessions_v2 import isoformat_z
+from sentry.tasks.commit_context import DEBOUNCE_PR_COMMENT_CACHE_KEY
 from sentry.tasks.integrations.github import pr_comment
 from sentry.tasks.integrations.github.pr_comment import (
     PullRequestIssue,
@@ -22,6 +23,7 @@ from sentry.tasks.integrations.github.pr_comment import (
 from sentry.testutils import IntegrationTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.utils.cache import cache
 
 
 class GithubCommentTestCase(IntegrationTestCase):
@@ -277,6 +279,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         self.access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
         self.expires_at = isoformat_z(timezone.now() + timedelta(days=365))
         self.pr = self.create_pr_issues()
+        self.cache_key = DEBOUNCE_PR_COMMENT_CACHE_KEY(self.pr.id)
 
     def create_pr_issues(self):
         commit_1 = self.add_commit_to_repo(self.gh_repo, self.user, self.project)
@@ -357,6 +360,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
     @with_feature("organizations:pr-comment-bot")
     @responses.activate
     def test_comment_workflow_raises_error(self, get_jwt, mock_issues):
+        cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
         mock_issues.return_value = [
             {"group_id": g.id, "event_count": 10} for g in Group.objects.all()
         ]
@@ -375,6 +379,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
 
         with pytest.raises(ApiError):
             pr_comment.comment_workflow(self.pr.id, self.project.id)
+            assert cache.get(self.cache_key) is None
 
     @patch(
         "sentry.tasks.integrations.github.pr_comment.pr_to_issue_query",
@@ -382,9 +387,12 @@ class TestCommentWorkflow(GithubCommentTestCase):
     )
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
     def test_comment_workflow_missing_org(self, mock_issues, mock_issue_query):
+        # Organization.DoesNotExist should trigger the cache to release the key
+        cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
         pr_comment.comment_workflow(self.pr.id, self.project.id)
 
         assert not mock_issues.called
+        assert cache.get(self.cache_key) is None
 
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
     def test_comment_workflow_missing_feature_flag(self, mock_issues):
@@ -396,11 +404,15 @@ class TestCommentWorkflow(GithubCommentTestCase):
     @patch("sentry.models.Project.objects.get_from_cache")
     @with_feature("organizations:pr-comment-bot")
     def test_comment_workflow_missing_project(self, mock_project, mock_issues):
+        # Project.DoesNotExist should trigger the cache to release the key
+        cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
+
         mock_project.side_effect = Project.DoesNotExist
 
         pr_comment.comment_workflow(self.pr.id, self.project.id)
 
         assert not mock_issues.called
+        assert cache.get(self.cache_key) is None
 
     @patch(
         "sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count",
@@ -409,6 +421,9 @@ class TestCommentWorkflow(GithubCommentTestCase):
     @patch("sentry.tasks.integrations.github.pr_comment.format_comment")
     @with_feature("organizations:pr-comment-bot")
     def test_comment_workflow_missing_repo(self, mock_format_comment, mock_repository, mock_issues):
+        # Repository.DoesNotExist should trigger the cache to release the key
+        cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
+
         mock_repository.get.side_effect = Repository.DoesNotExist
         pr_comment.comment_workflow(self.pr.id, self.project.id)
 
@@ -418,6 +433,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
 
         assert mock_issues.called
         assert not mock_format_comment.called
+        assert cache.get(self.cache_key) is None
 
     @patch(
         "sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count",
@@ -425,6 +441,9 @@ class TestCommentWorkflow(GithubCommentTestCase):
     @patch("sentry.tasks.integrations.github.pr_comment.format_comment")
     @with_feature("organizations:pr-comment-bot")
     def test_comment_workflow_missing_integration(self, mock_format_comment, mock_issues):
+        # missing integration should trigger the cache to release the key
+        cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
+
         # invalid integration id
         self.gh_repo.integration_id = 0
         self.gh_repo.save()
@@ -437,3 +456,4 @@ class TestCommentWorkflow(GithubCommentTestCase):
 
         assert mock_issues.called
         assert not mock_format_comment.called
+        assert cache.get(self.cache_key) is None


### PR DESCRIPTION
Before the comment task is queued, look for a cache key with `pullrequest_id`. If the cache key already exists, then a comment task for the same PR has already been queued and we shouldn't queue another one.

Otherwise, set the cache key and queue the task. If the task exits at any point due to a db lookup or API call failing, we delete the cache key so that another task can be queued.

For ER-1627