### PR TITLE
feat(hybrid-cloud): Update and mark Vercel's webhook endpoints as control silo only

### DIFF
--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -20,6 +20,7 @@ from sentry.models import (
     SentryAppInstallationToken,
 )
 from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.services.hybrid_cloud.project import project_service
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.http import absolute_uri
@@ -92,7 +93,9 @@ def get_payload_and_token(
     meta = payload["deployment"]["meta"]
 
     # look up the project so we can get the slug
-    project = Project.objects.get(id=sentry_project_id)
+    project = project_service.get_by_id(organization_id=organization_id, id=sentry_project_id)
+    if project is None:
+        raise Project.DoesNotExist
 
     # find the connected sentry app installation
     installation_for_provider = SentryAppInstallationForProvider.objects.select_related(

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -14,7 +14,6 @@ from sentry import VERSION, audit_log, http, options
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.models import (
     Integration,
-    Organization,
     OrganizationIntegration,
     Project,
     SentryAppInstallationForProvider,
@@ -275,10 +274,9 @@ class VercelWebhookEndpoint(Endpoint):
                 organization_id=configuration["organization_id"], integration_id=integration.id
             ).delete()
 
-            organization = Organization.objects.get(id=configuration["organization_id"])
             create_audit_entry(
                 request=request,
-                organization=organization,
+                organization_id=configuration["organization_id"],
                 target_object=integration.id,
                 event=audit_log.get_event_id("INTEGRATION_REMOVE"),
                 actor_label="Vercel User",

--- a/src/sentry/services/hybrid_cloud/project/service.py
+++ b/src/sentry/services/hybrid_cloud/project/service.py
@@ -4,7 +4,7 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
-from typing import cast
+from typing import Optional, cast
 
 from sentry.services.hybrid_cloud import OptionValue
 from sentry.services.hybrid_cloud.project import RpcProject, RpcProjectOptionValue
@@ -40,7 +40,7 @@ class ProjectService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
-    def get_by_id(self, *, organization_id: int, id: int) -> RpcProject:
+    def get_by_id(self, *, organization_id: int, id: int) -> Optional[RpcProject]:
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/project/service.py
+++ b/src/sentry/services/hybrid_cloud/project/service.py
@@ -8,7 +8,7 @@ from typing import cast
 
 from sentry.services.hybrid_cloud import OptionValue
 from sentry.services.hybrid_cloud.project import RpcProject, RpcProjectOptionValue
-from sentry.services.hybrid_cloud.region import ByOrganizationIdAttribute
+from sentry.services.hybrid_cloud.region import ByOrganizationId, ByOrganizationIdAttribute
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method
 from sentry.silo import SiloMode
 
@@ -36,6 +36,11 @@ class ProjectService(RpcService):
     @regional_rpc_method(resolve=ByOrganizationIdAttribute("project"))
     @abstractmethod
     def delete_option(self, *, project: RpcProject, key: str) -> None:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def get_by_id(self, *, organization_id: int, id: int) -> RpcProject:
         pass
 
 

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -24,11 +24,12 @@ from sentry.models import (
 )
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import override_options
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
 
+@control_silo_test(stable=True)
 class SignatureVercelTest(APITestCase):
     webhook_url = "/extensions/vercel/webhook/"
 
@@ -48,7 +49,7 @@ class SignatureVercelTest(APITestCase):
             assert response.status_code == 401
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class VercelReleasesTest(APITestCase):
     webhook_url = "/extensions/vercel/webhook/"
     header = "VERCEL"
@@ -210,7 +211,8 @@ class VercelReleasesTest(APITestCase):
             absolute_uri("/api/0/organizations/%s/releases/" % self.organization.slug),
             json={},
         )
-        self.project.delete()
+        with exempt_from_silo_limits():
+            self.project.delete()
 
         with override_options({"vercel.client-secret": SECRET}):
             response = self._get_response(EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE_OLD, SIGNATURE)
@@ -308,6 +310,7 @@ class VercelReleasesTest(APITestCase):
         assert "Could not determine repository" == response.data["detail"]
 
 
+@control_silo_test(stable=True)
 class VercelReleasesNewTest(VercelReleasesTest):
     webhook_url = "/extensions/vercel/delete/"
     header = "VERCEL"


### PR DESCRIPTION
We will not be needing a request parser for Vercel's webhook endpoints; and instead, update them to be control-silo only.