### PR TITLE
feat(most-helpful-event): add support for querying the most helpful event for a group

### DIFF
--- a/src/sentry/api/endpoints/group_event_details.py
+++ b/src/sentry/api/endpoints/group_event_details.py
@@ -30,20 +30,21 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
 
     def get(self, request: Request, group: Group, event_id: str) -> Response:
         """
-        Retrieve the Latest Event for an Issue
+        Retrieve the latest(most recent), oldest, or most helpful Event for an Issue
         ``````````````````````````````````````
 
-        Retrieves the details of the latest event for an issue.
+        Retrieves the details of the latest/oldest/most-helpful event for an issue.
 
         :pparam string group_id: the ID of the issue
         """
         environments = [e.name for e in get_environments(request, group.project.organization)]
-        event = None
 
         if event_id == "latest":
             event = group.get_latest_event_for_environments(environments)
         elif event_id == "oldest":
             event = group.get_oldest_event_for_environments(environments)
+        elif event_id == "helpful":
+            event = group.get_helpful_event_for_environments(environments)
         else:
             event = eventstore.backend.get_event_by_id(
                 group.project.id, event_id, group_id=group.id

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List
+from typing import Any, List, Union
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -8,12 +8,12 @@ from sentry import eventstore
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import IssueEventSerializer, serialize
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import Event, GroupEvent
 
 
 def wrap_event_response(
     request_user: Any,
-    event: Event,
+    event: Union[Event, GroupEvent],
     environments: List[str],
     include_full_release_data: bool = False,
 ):

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -564,7 +564,7 @@ GROUP_URLS = [
         GroupEventsEndpoint.as_view(),
     ),
     url(
-        r"^(?P<issue_id>[^\/]+)/events/(?P<event_id>(?:latest|oldest|\d+|[A-Fa-f0-9-]{32,36}))/$",
+        r"^(?P<issue_id>[^\/]+)/events/(?P<event_id>(?:latest|oldest|helpful|\d+|[A-Fa-f0-9-]{32,36}))/$",
         GroupEventDetailsEndpoint.as_view(),
     ),
     url(

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1474,6 +1474,8 @@ SENTRY_FEATURES = {
     "organizations:sql-format": False,
     # Enable experimental replay-issue rendering on Issue Details page
     "organizations:issue-details-replay-event": False,
+    # Enable sorting Issue detail events by 'most helpful'
+    "organizations:issue-details-most-helpful-event": False,
     # Enable prefetching of issues from the issue list when hovered
     "organizations:issue-list-prefetch-issue-on-hover": False,
     # Enable better priority sort algorithm.

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -1,6 +1,9 @@
 from copy import deepcopy
+from datetime import datetime
+from typing import Optional, Sequence
 
 import sentry_sdk
+from snuba_sdk import Condition
 
 from sentry import nodestore
 from sentry.eventstore.models import Event
@@ -121,6 +124,7 @@ class EventStorage(Service):
         "create_event",
         "get_event_by_id",
         "get_events",
+        "get_events_snql",
         "get_unfetched_events",
         "get_adjacent_event_ids",
         "bind_nodes",
@@ -170,6 +174,22 @@ class EventStorage(Service):
         offset (int): Query offset - default 0
         referrer (string): Referrer - default "eventstore.get_events"
         """
+        raise NotImplementedError
+
+    def get_events_snql(
+        self,
+        organization_id: int,
+        group_id: int,
+        start: Optional[datetime],
+        end: Optional[datetime],
+        conditions: Sequence[Condition],
+        orderby: Optional[Sequence[str]] = None,
+        limit=100,
+        offset=0,
+        referrer="eventstore.get_events_snql",
+        dataset=Dataset.Events,
+        tenant_ids=None,
+    ):
         raise NotImplementedError
 
     def get_unfetched_events(

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -183,7 +183,7 @@ class EventStorage(Service):
         start: Optional[datetime],
         end: Optional[datetime],
         conditions: Sequence[Condition],
-        orderby: Optional[Sequence[str]] = None,
+        orderby: Sequence[str],
         limit=100,
         offset=0,
         referrer="eventstore.get_events_snql",

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -86,7 +86,7 @@ class SnubaEventStorage(EventStorage):
         else:
             resolved_order_by = []
             for order_field_alias in orderby:
-                if order_field_alias.startswith("_"):
+                if order_field_alias.startswith("-"):
                     direction = Direction.DESC
                     order_field_alias = order_field_alias[1:]
                 else:

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -89,6 +89,7 @@ default_manager.add("organizations:integrations-discord", OrganizationFeature, F
 default_manager.add("organizations:issue-alert-fallback-targeting", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sql-format", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-details-replay-event", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:issue-details-most-helpful-event", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-details-tag-improvements", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-list-prefetch-issue-on-hover", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-list-better-priority-sort", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -18,6 +18,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
+from snuba_sdk import Column, Condition, Op
 
 from sentry import eventstore, eventtypes, tagstore
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS, MAX_CULPRIT_LENGTH
@@ -197,6 +198,13 @@ STATUS_UPDATE_CHOICES = {
 class EventOrdering(Enum):
     LATEST = ["-timestamp", "-event_id"]
     OLDEST = ["timestamp", "event_id"]
+    MOST_HELPFUL = [
+        "-replayId",
+        "-profile.id",
+        "num_processing_errors",
+        "-trace.sampled",
+        "-timestamp",
+    ]
 
 
 def get_oldest_or_latest_event_for_environments(
@@ -215,12 +223,44 @@ def get_oldest_or_latest_event_for_environments(
     _filter = eventstore.Filter(
         conditions=conditions, project_ids=[group.project_id], group_ids=[group.id]
     )
-
     events = eventstore.backend.get_events(
         filter=_filter,
         limit=1,
         orderby=ordering.value,
         referrer="Group.get_latest",
+        dataset=dataset,
+        tenant_ids={"organization_id": group.project.organization_id},
+    )
+
+    if events:
+        return events[0].for_group(group)
+
+    return None
+
+
+def get_helpful_event_for_environments(
+    environments: Sequence[str], group: Group
+) -> GroupEvent | None:
+    if group.issue_category == GroupCategory.ERROR:
+        dataset = Dataset.Events
+    else:
+        dataset = Dataset.IssuePlatform
+
+    conditions = []
+    if len(environments) > 0:
+        conditions.append(Condition(Column("environment"), Op.IN, environments))
+    conditions.append(Condition(Column("project_id"), Op.IN, [group.project.id]))
+    conditions.append(Condition(Column("group_id"), Op.IN, [group.id]))
+
+    events = eventstore.get_events_snql(
+        organization_id=group.project.organization_id,
+        group_id=group.id,
+        start=None,
+        end=None,
+        conditions=conditions,
+        limit=1,
+        orderby=EventOrdering.MOST_HELPFUL.value,
+        referrer="Group.get_helpful",
         dataset=dataset,
         tenant_ids={"organization_id": group.project.organization_id},
     )
@@ -591,6 +631,14 @@ class Group(Model):
     ) -> GroupEvent | None:
         return get_oldest_or_latest_event_for_environments(
             EventOrdering.OLDEST,
+            environments,
+            self,
+        )
+
+    def get_helpful_event_for_environments(
+        self, environments: Sequence[str] = ()
+    ) -> GroupEvent | None:
+        return get_helpful_event_for_environments(
             environments,
             self,
         )

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -731,9 +731,27 @@ class Columns(Enum):
 
     REPLAY_ID = Column(
         group_name=None,
-        event_name=None,
+        event_name="replay_id",
         transaction_name=None,
         discover_name=None,
         issue_platform_name="replay_id",
         alias="replayId",
+    )
+
+    TRACE_SAMPLED = Column(
+        group_name=None,
+        event_name="trace_sampled",
+        transaction_name=None,
+        discover_name=None,
+        issue_platform_name=None,
+        alias="trace.sampled",
+    )
+
+    NUM_PROCESSING_ERRORS = Column(
+        group_name=None,
+        event_name="num_processing_errors",
+        transaction_name=None,
+        discover_name=None,
+        issue_platform_name=None,
+        alias="num_processing_errors",
     )

--- a/tests/sentry/api/endpoints/test_group_event_details.py
+++ b/tests/sentry/api/endpoints/test_group_event_details.py
@@ -1,7 +1,9 @@
+import uuid
 from uuid import uuid4
 
 from sentry.models.release import Release
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 
@@ -12,13 +14,13 @@ class GroupEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         super().setUp()
 
         self.login_as(user=self.user)
-        project = self.create_project()
+        self.project_1 = self.create_project()
 
         release_version = uuid4().hex
         release = Release.objects.create(
-            organization_id=self.project.organization_id, version=release_version
+            organization_id=self.project_1.organization_id, version=release_version
         )
-        release.add_project(self.project)
+        release.add_project(self.project_1)
 
         self.event_a = self.store_event(
             data={
@@ -28,7 +30,7 @@ class GroupEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group-1"],
                 "release": release_version,
             },
-            project_id=project.id,
+            project_id=self.project_1.id,
         )
         self.event_b = self.store_event(
             data={
@@ -38,7 +40,7 @@ class GroupEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group-1"],
                 "release": release_version,
             },
-            project_id=project.id,
+            project_id=self.project_1.id,
         )
         self.event_c = self.store_event(
             data={
@@ -48,7 +50,7 @@ class GroupEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group-1"],
                 "release": release_version,
             },
-            project_id=project.id,
+            project_id=self.project_1.id,
         )
 
     def test_get_simple_latest(self):
@@ -129,3 +131,37 @@ class GroupEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         assert not {"firstEvent", "lastEvent", "newGroups"} <= set(
             response_with_collapse.data["release"]
         )
+
+    def test_get_helpful_feature_off(self):
+        url = f"/api/0/issues/{self.event_a.group.id}/events/helpful/"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 404, response.content
+
+    @with_feature("organizations:issue-details-most-helpful-event")
+    def test_get_simple_helpful(self):
+        self.event_d = self.store_event(
+            data={
+                "event_id": "d" * 32,
+                "environment": "staging",
+                "timestamp": iso_format(before_now(minutes=1)),
+                "fingerprint": ["group-1"],
+                "contexts": {
+                    "replay": {"replay_id": uuid.uuid4().hex},
+                    "trace": {
+                        "sampled": True,
+                        "span_id": "babaae0d4b7512d9",
+                        "trace_id": "a7d67cf796774551a95be6543cacd459",
+                    },
+                },
+                "errors": [],
+            },
+            project_id=self.project_1.id,
+        )
+        url = f"/api/0/issues/{self.event_a.group.id}/events/helpful/"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == str(self.event_d.event_id)
+        assert response.data["previousEventID"] == self.event_c.event_id
+        assert response.data["nextEventID"] is None

--- a/tests/snuba/models/test_group.py
+++ b/tests/snuba/models/test_group.py
@@ -1,16 +1,18 @@
 import uuid
 
-from sentry.issues.grouptype import PerformanceNPlusOneGroupType
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType, ProfileFileIOGroupType
+from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.models import Group
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.cases import PerformanceIssueTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.samples import load_data
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
 @region_silo_test
-class GroupTestSnuba(TestCase, SnubaTestCase, PerformanceIssueTestCase):
+class GroupTestSnuba(TestCase, SnubaTestCase, PerformanceIssueTestCase, OccurrenceTestMixin):
     def test_get_oldest_latest_for_environments(self):
         project = self.create_project()
 
@@ -50,93 +52,6 @@ class GroupTestSnuba(TestCase, SnubaTestCase, PerformanceIssueTestCase):
         )
         assert group.get_oldest_event_for_environments(["staging"]) is None
 
-    def test_get_helpful_for_environments(self):
-        project = self.create_project()
-
-        min_ago = iso_format(before_now(minutes=1))
-        replay_id = uuid.uuid4().hex
-
-        event_all_helpful_params = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "timestamp": min_ago,
-                "fingerprint": ["group-1"],
-                "contexts": {
-                    "replay": {"replay_id": replay_id},
-                    "trace": {
-                        "sampled": True,
-                        "span_id": "babaae0d4b7512d9",
-                        "trace_id": "a7d67cf796774551a95be6543cacd459",
-                    },
-                },
-                "errors": None,
-            },
-            project_id=project.id,
-        )
-        event_partial_helpful_params = self.store_event(
-            data={
-                "event_id": "b" * 32,
-                "timestamp": min_ago,
-                "fingerprint": ["group-1"],
-                "contexts": {
-                    "replay": {"replay_id": replay_id},
-                },
-            },
-            project_id=project.id,
-        )
-        event_none_helpful_params = self.store_event(
-            data={"event_id": "c" * 32, "timestamp": min_ago, "fingerprint": ["group-1"]},
-            project_id=project.id,
-        )
-
-        group = Group.objects.first()
-        assert event_partial_helpful_params
-        assert event_none_helpful_params
-        assert (
-            group.get_helpful_event_for_environments().event_id == event_all_helpful_params.event_id
-        )
-
-    def test_get_helpful_for_environments_partial(self):
-        project = self.create_project()
-
-        min_ago = iso_format(before_now(minutes=1))
-        replay_id = uuid.uuid4().hex
-
-        event_all_helpful_params = self.store_event(
-            data={
-                "event_id": "b" * 32,
-                "timestamp": min_ago,
-                "fingerprint": ["group-1"],
-                "contexts": {
-                    "replay": {"replay_id": replay_id},
-                    "trace": {
-                        "sampled": True,
-                        "span_id": "babaae0d4b7512d9",
-                        "trace_id": "a7d67cf796774551a95be6543cacd459",
-                    },
-                },
-                "errors": None,
-            },
-            project_id=project.id,
-        )
-        event_partial_helpful_params = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "timestamp": min_ago,
-                "fingerprint": ["group-1"],
-                "contexts": {
-                    "replay": {"replay_id": replay_id},
-                },
-            },
-            project_id=project.id,
-        )
-
-        group = Group.objects.first()
-        assert event_partial_helpful_params
-        assert (
-            group.get_helpful_event_for_environments().event_id == event_all_helpful_params.event_id
-        )
-
     def test_perf_issue(self):
         group_fingerprint = f"{PerformanceNPlusOneGroupType.type_id}-group1"
 
@@ -163,3 +78,146 @@ class GroupTestSnuba(TestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         assert perf_group.get_latest_event_for_environments().event_id == "d" * 32
         assert perf_group.get_oldest_event_for_environments().event_id == "f" * 32
+
+    def test_error_issue_get_helpful_for_environments(self):
+        project = self.create_project()
+        min_ago = iso_format(before_now(minutes=1))
+        replay_id = uuid.uuid4().hex
+
+        event_all_helpful_params = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "timestamp": min_ago,
+                "fingerprint": ["group-1"],
+                "contexts": {
+                    "replay": {"replay_id": replay_id},
+                    "trace": {
+                        "sampled": True,
+                        "span_id": "babaae0d4b7512d9",
+                        "trace_id": "a7d67cf796774551a95be6543cacd459",
+                    },
+                },
+                "errors": [],
+            },
+            project_id=project.id,
+            assert_no_errors=False,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "timestamp": min_ago,
+                "fingerprint": ["group-1"],
+                "contexts": {
+                    "replay": {"replay_id": replay_id},
+                },
+                "errors": [{"type": "one"}, {"type": "two"}],
+            },
+            project_id=project.id,
+            assert_no_errors=False,
+        )
+        event_none_helpful_params = self.store_event(
+            data={"event_id": "c" * 32, "timestamp": min_ago, "fingerprint": ["group-1"]},
+            project_id=project.id,
+        )
+
+        group = Group.objects.first()
+        assert (
+            group.get_helpful_event_for_environments().event_id == event_all_helpful_params.event_id
+        )
+        assert (
+            group.get_latest_event_for_environments().event_id == event_none_helpful_params.event_id
+        )
+        assert (
+            group.get_oldest_event_for_environments().event_id == event_all_helpful_params.event_id
+        )
+
+    def test_perf_issue_helpful(self):
+        group_fingerprint = f"{PerformanceNPlusOneGroupType.type_id}-group1"
+
+        transaction_event_data_with_all_helpful = load_data(
+            "transaction-n-plus-one", fingerprint=[group_fingerprint]
+        )
+        transaction_event_data_with_all_helpful["timestamp"] = iso_format(before_now(seconds=10))
+        transaction_event_data_with_all_helpful["start_timestamp"] = iso_format(
+            before_now(seconds=11)
+        )
+        transaction_event_data_with_all_helpful["event_id"] = "d" * 32
+        transaction_event_data_with_all_helpful["contexts"].update(
+            {"profile": {"profile_id": uuid.uuid4().hex}}
+        )
+        transaction_event_data_with_all_helpful["contexts"].update(
+            {"replay": {"replay_id": uuid.uuid4().hex}}
+        )
+        transaction_event_data_with_all_helpful["contexts"]["trace"]["sampled"] = True
+        transaction_event_data_with_all_helpful["errors"] = []
+
+        transaction_event_data_with_none_helpful = load_data(
+            "transaction-n-plus-one", fingerprint=[group_fingerprint]
+        )
+        transaction_event_data_with_none_helpful["timestamp"] = iso_format(before_now(seconds=20))
+        transaction_event_data_with_none_helpful["start_timestamp"] = iso_format(
+            before_now(seconds=21)
+        )
+        transaction_event_data_with_none_helpful["event_id"] = "f" * 32
+
+        transaction_event_1 = self.create_performance_issue(
+            event_data=transaction_event_data_with_all_helpful, fingerprint=group_fingerprint
+        )
+        transaction_event_2 = self.create_performance_issue(
+            event_data=transaction_event_data_with_none_helpful, fingerprint=group_fingerprint
+        )
+
+        perf_group = transaction_event_1.group
+
+        assert (
+            perf_group.get_helpful_event_for_environments().event_id == transaction_event_1.event_id
+        )
+        assert (
+            perf_group.get_latest_event_for_environments().event_id == transaction_event_1.event_id
+        )
+        assert (
+            perf_group.get_oldest_event_for_environments().event_id == transaction_event_2.event_id
+        )
+
+    def test_profile_issue_helpful(self):
+        event_id_1 = uuid.uuid4().hex
+        occurrence = process_event_and_issue_occurrence(
+            self.build_occurrence_data(event_id=event_id_1, project_id=self.project.id),
+            {
+                "event_id": event_id_1,
+                "fingerprint": ["group-1"],
+                "project_id": self.project.id,
+                "timestamp": before_now(minutes=2).isoformat(),
+                "contexts": {
+                    "profile": {"profile_id": uuid.uuid4().hex},
+                    "replay": {"replay_id": uuid.uuid4().hex},
+                    "trace": {
+                        "sampled": True,
+                        "span_id": "babaae0d4b7512d9",
+                        "trace_id": "a7d67cf796774551a95be6543cacd459",
+                    },
+                },
+                "errors": [],
+            },
+        )[0]
+
+        event_id_2 = uuid.uuid4().hex
+        occurrence_2 = process_event_and_issue_occurrence(
+            self.build_occurrence_data(event_id=event_id_2, project_id=self.project.id),
+            {
+                "event_id": event_id_2,
+                "fingerprint": ["group-1"],
+                "project_id": self.project.id,
+                "timestamp": before_now(minutes=1).isoformat(),
+            },
+        )[0]
+
+        group = Group.objects.first()
+        group.update(type=ProfileFileIOGroupType.type_id)
+
+        group_event = group.get_helpful_event_for_environments()
+        assert group_event.event_id == occurrence.event_id
+        self.assert_occurrences_identical(group_event.occurrence, occurrence)
+
+        assert group.get_latest_event_for_environments().event_id == occurrence_2.event_id
+        assert group.get_oldest_event_for_environments().event_id == occurrence.event_id


### PR DESCRIPTION
Currently, the `GroupEventDetailsEndpoint` supports retrieving the latest or oldest event associated with the Group. 

This PR adds a third option, retrieving the 'most helpful' event associated with the Group. In practical terms, this new sort method prioritizes events with:
- `replay_id`, events with a replay have a higher sort order than events without a replay
- `profile_id`, events with a profile have a higher sort order than events without a profile
- `num_processing_errors`, events with fewer processing errors are prioritized over events with processing errrors
- `trace.sampled`, error events with full trace will be prioritized over events without full trace

This feature is behind a feature flag.

Resolves https://github.com/getsentry/sentry/issues/50890, https://github.com/getsentry/sentry/issues/51070

