### PR TITLE
feat(integrations): Store aggregate error counts in a buffer

### DIFF
--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.integrations import IntegrationProvider
+from sentry.integrations.request_buffer import IntegrationErrorLogBuffer
 from sentry.models import Integration, OrganizationIntegration, User
 from sentry.services.hybrid_cloud.integration import (
     RpcIntegration,
@@ -64,6 +65,10 @@ class IntegrationConfigSerializer(IntegrationSerializer):
         **kwargs: Any,
     ) -> MutableMapping[str, JSONData]:
         data = super().serialize(obj, attrs, user)
+
+        buffer = IntegrationErrorLogBuffer(obj)
+        broken = buffer.is_integration_broken()
+        data.update({"broken": broken})
 
         if not include_config:
             return data

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.integrations import IntegrationProvider
-from sentry.integrations.request_buffer import IntegrationErrorLogBuffer
+from sentry.integrations.request_buffer import IntegrationRequestBuffer
 from sentry.models import Integration, OrganizationIntegration, User
 from sentry.services.hybrid_cloud.integration import (
     RpcIntegration,
@@ -66,7 +66,7 @@ class IntegrationConfigSerializer(IntegrationSerializer):
     ) -> MutableMapping[str, JSONData]:
         data = super().serialize(obj, attrs, user)
 
-        buffer = IntegrationErrorLogBuffer(obj)
+        buffer = IntegrationRequestBuffer(obj)
         broken = buffer.is_integration_broken()
         data.update({"broken": broken})
 

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -66,7 +66,7 @@ class IntegrationConfigSerializer(IntegrationSerializer):
     ) -> MutableMapping[str, JSONData]:
         data = super().serialize(obj, attrs, user)
 
-        buffer = IntegrationRequestBuffer(obj)
+        buffer = IntegrationRequestBuffer(obj.id)
         broken = buffer.is_integration_broken()
         data.update({"broken": broken})
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -122,6 +122,7 @@ SENTRY_RATE_LIMIT_REDIS_CLUSTER = "default"
 SENTRY_RULE_TASK_REDIS_CLUSTER = "default"
 SENTRY_TRANSACTION_NAMES_REDIS_CLUSTER = "default"
 SENTRY_WEBHOOK_LOG_REDIS_CLUSTER = "default"
+SENTRY_INTEGRATION_ERROR_LOG_REDIS_CLUSTER = "default"
 
 # Hosts that are allowed to use system token authentication.
 # http://en.wikipedia.org/wiki/Reserved_IP_addresses

--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -45,9 +45,9 @@ class BitbucketApiClient(ApiClient):
 
     integration_name = "bitbucket"
 
-    def __init__(self, base_url, shared_secret, subject, *args, **kwargs):
+    def __init__(self, base_url, shared_secret, subject, integration_id, *args, **kwargs):
         # subject is probably the clientKey
-        super().__init__(*args, **kwargs)
+        super().__init__(integration_id=integration_id, *args, **kwargs)
         self.base_url = base_url
         self.shared_secret = shared_secret
         self.subject = subject

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -83,6 +83,7 @@ class BitbucketIntegration(IntegrationInstallation, BitbucketIssueBasicMixin, Re
             self.model.metadata["base_url"],
             self.model.metadata["shared_secret"],
             self.model.external_id,
+            self.model.id,
         )
 
     @property

--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -35,7 +35,8 @@ class BitbucketServerSetupClient(ApiClient):
     authorize_url = "{}/plugins/servlet/oauth/authorize?oauth_token={}"
     integration_name = "bitbucket_server_setup"
 
-    def __init__(self, base_url, consumer_key, private_key, verify_ssl=True):
+    def __init__(self, base_url, consumer_key, private_key, verify_ssl=True, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.base_url = base_url
         self.consumer_key = consumer_key
         self.private_key = private_key

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -670,8 +670,10 @@ class GitHubAppsClient(GitHubClientMixin):
         logging_context: Mapping[str, Any] | None = None,
     ) -> None:
         self.integration = integration
+
         super().__init__(
             org_integration_id=org_integration_id,
             verify_ssl=verify_ssl,
             logging_context=logging_context,
+            integration_id=integration.id,
         )

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -211,7 +211,8 @@ class JiraServerSetupClient(ApiClient):
     authorize_url = "{}/plugins/servlet/oauth/authorize?oauth_token={}"
     integration_name = "jira_server_setup"
 
-    def __init__(self, base_url, consumer_key, private_key, verify_ssl=True):
+    def __init__(self, base_url, consumer_key, private_key, verify_ssl=True, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.base_url = base_url
         self.consumer_key = consumer_key
         self.private_key = private_key

--- a/src/sentry/integrations/request_buffer.py
+++ b/src/sentry/integrations/request_buffer.py
@@ -63,6 +63,9 @@ class IntegrationErrorLogBuffer:
             if item.get("count", 0) > 0 and item.get("date")
         ][0:IS_BROKEN_RANGE]
 
+        if not len(data):
+            return False
+
         date_set = {data[0] - timedelta(x) for x in range((data[0] - data[-1]).days)}
         missing = list(date_set - set(data))
         if len(missing):

--- a/src/sentry/integrations/request_buffer.py
+++ b/src/sentry/integrations/request_buffer.py
@@ -58,12 +58,12 @@ class IntegrationErrorLogBuffer:
         pipe = self.client.pipeline()
 
         # get first element from array
-        last_item_array = self.client.lrange(buffer_key, 0, 1)
-        if len(last_item_array):
-            last_item = json.loads(last_item_array[0])
-            if last_item.get("date") == now:
-                last_item["count"] += 1
-                pipe.lset(buffer_key, 0, json.dumps(last_item))
+        recent_item_array = self.client.lrange(buffer_key, 0, 1)
+        if len(recent_item_array):
+            recent_item = json.loads(recent_item_array[0])
+            if recent_item.get("date") == now:
+                recent_item["count"] += 1
+                pipe.lset(buffer_key, 0, json.dumps(recent_item))
             else:
                 data = {
                     "date": now,

--- a/src/sentry/integrations/request_buffer.py
+++ b/src/sentry/integrations/request_buffer.py
@@ -19,16 +19,15 @@ class IntegrationRequestBuffer:
     This should store the aggregate counts of each type for last 30 days for each integration
     """
 
-    def __init__(self, integration):
-        self.integration = integration
+    def __init__(self, integration_id):
+        self.integration_id = integration_id
 
         cluster_id = settings.SENTRY_INTEGRATION_ERROR_LOG_REDIS_CLUSTER
         self.client = redis.redis_clusters.get(cluster_id)
 
     def _get_redis_key(self):
-        integration_id = self.integration.id
 
-        return f"sentry-integration-error:{integration_id}"
+        return f"sentry-integration-error:{self.integration_id}"
 
     def _convert_obj_to_dict(self, redis_object):
         """

--- a/src/sentry/integrations/request_buffer.py
+++ b/src/sentry/integrations/request_buffer.py
@@ -92,5 +92,12 @@ class IntegrationErrorLogBuffer:
                 }
                 pipe.lpush(buffer_key, json.dumps(data))
 
+        else:
+            data = {
+                "date": now,
+                "count": 1,
+            }
+            pipe.lpush(buffer_key, json.dumps(data))
+
         pipe.expire(buffer_key, KEY_EXPIRY)
         pipe.execute()

--- a/src/sentry/integrations/request_buffer.py
+++ b/src/sentry/integrations/request_buffer.py
@@ -1,0 +1,75 @@
+import logging
+from datetime import datetime
+
+from django.conf import settings
+
+from sentry.utils import json, redis
+
+BUFFER_SIZE = 30  # 30 days
+KEY_EXPIRY = 60 * 60 * 24 * 30  # 30 days
+
+logger = logging.getLogger(__name__)
+
+
+class IntegrationErrorLogBuffer:
+    """
+    Create a data structure to store daily error counts for each installed integration in Redis
+    This should store the aggregate counts for last 30 days for each integration
+    """
+
+    def __init__(self, integration):
+        self.integration = integration
+
+        cluster_id = settings.SENTRY_INTEGRATION_ERROR_LOG_REDIS_CLUSTER
+        self.client = redis.redis_clusters.get(cluster_id)
+
+    def _get_redis_key(self):
+        integration_id = self.integration.id
+
+        return f"sentry-integration-error:{integration_id}"
+
+    def _convert_obj_to_dict(self, redis_object):
+        """
+        Convert the request string stored in Redis to a python dict
+        """
+
+        return json.loads(redis_object)
+
+    def _get_all_from_buffer(self, buffer_key):
+        """
+        Get the list at the buffer key.
+        """
+
+        return self.client.lrange(buffer_key, 0, BUFFER_SIZE - 1)
+
+    def get(self):
+        """
+        Returns the list of daily aggregate error counts.
+        """
+        return [
+            self._convert_obj_to_dict(obj)
+            for obj in self._get_all_from_buffer(self._get_redis_key())
+        ]
+
+    def add(self):
+        buffer_key = self._get_redis_key()
+        now = datetime.now().strftime("%Y-%m-%d")
+
+        pipe = self.client.pipeline()
+
+        # get first element from array
+        last_item_array = self.client.lrange(buffer_key, 0, 1)
+        if len(last_item_array):
+            last_item = json.loads(last_item_array[0])
+            if last_item.get("date") == now:
+                last_item["count"] += 1
+                pipe.lset(buffer_key, 0, json.dumps(last_item))
+            else:
+                data = {
+                    "date": now,
+                    "count": 1,
+                }
+                pipe.lpush(buffer_key, json.dumps(data))
+
+        pipe.expire(buffer_key, KEY_EXPIRY)
+        pipe.execute()

--- a/src/sentry/models/integrations/integration.py
+++ b/src/sentry/models/integrations/integration.py
@@ -130,15 +130,3 @@ class Integration(DefaultFieldsModel):
             )
 
             return org_integration
-
-    def record_request_failure(self):
-        from sentry.integrations.request_buffer import IntegrationRequestBuffer
-
-        buffer = IntegrationRequestBuffer(self)
-        buffer.record_error()
-
-    def record_request_success(self):
-        from sentry.integrations.request_buffer import IntegrationRequestBuffer
-
-        buffer = IntegrationRequestBuffer(self)
-        buffer.record_success()

--- a/src/sentry/models/integrations/integration.py
+++ b/src/sentry/models/integrations/integration.py
@@ -130,3 +130,9 @@ class Integration(DefaultFieldsModel):
             )
 
             return org_integration
+
+    def record_failure(self):
+        from sentry.integrations.request_buffer import IntegrationErrorLogBuffer
+
+        buffer = IntegrationErrorLogBuffer(self)
+        buffer.add()

--- a/src/sentry/models/integrations/integration.py
+++ b/src/sentry/models/integrations/integration.py
@@ -131,8 +131,14 @@ class Integration(DefaultFieldsModel):
 
             return org_integration
 
-    def record_failure(self):
-        from sentry.integrations.request_buffer import IntegrationErrorLogBuffer
+    def record_request_failure(self):
+        from sentry.integrations.request_buffer import IntegrationRequestBuffer
 
-        buffer = IntegrationErrorLogBuffer(self)
-        buffer.add()
+        buffer = IntegrationRequestBuffer(self)
+        buffer.record_error()
+
+    def record_request_success(self):
+        from sentry.integrations.request_buffer import IntegrationRequestBuffer
+
+        buffer = IntegrationRequestBuffer(self)
+        buffer.record_success()

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -67,8 +67,11 @@ class IntegrationProxyClient(ApiClient):
         org_integration_id: int | None = None,
         verify_ssl: bool = True,
         logging_context: Mapping[str, Any] | None = None,
+        integration_id: int | None = None,
     ) -> None:
-        super().__init__(verify_ssl=verify_ssl, logging_context=logging_context)
+        super().__init__(
+            verify_ssl=verify_ssl, logging_context=logging_context, integration_id=integration_id
+        )
         self.org_integration_id = org_integration_id
 
         is_region_silo = SiloMode.get_current_mode() == SiloMode.REGION

--- a/tests/sentry/api/endpoints/test_organization_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_integrations.py
@@ -40,7 +40,7 @@ class OrganizationIntegrationsListTest(APITestCase):
         now = datetime.now() - timedelta(hours=1)
         for i in reversed(range(10)):
             with freeze_time(now - timedelta(days=i)):
-                buffer.add()
+                buffer.record_error()
 
         response = self.get_success_response(self.organization.slug, qs_params={"includeConfig": 0})
         assert "broken" in response.data[0]

--- a/tests/sentry/api/endpoints/test_organization_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_integrations.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from freezegun import freeze_time
 
-from sentry.integrations.request_buffer import IntegrationErrorLogBuffer
+from sentry.integrations.request_buffer import IntegrationRequestBuffer
 from sentry.testutils import APITestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -36,7 +36,7 @@ class OrganizationIntegrationsListTest(APITestCase):
         assert "configOrganization" not in response.data[0]
 
     def test_integration_is_broken(self):
-        buffer = IntegrationErrorLogBuffer(self.integration)
+        buffer = IntegrationRequestBuffer(self.integration)
         now = datetime.now() - timedelta(hours=1)
         for i in reversed(range(10)):
             with freeze_time(now - timedelta(days=i)):

--- a/tests/sentry/api/endpoints/test_organization_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_integrations.py
@@ -36,7 +36,7 @@ class OrganizationIntegrationsListTest(APITestCase):
         assert "configOrganization" not in response.data[0]
 
     def test_integration_is_broken(self):
-        buffer = IntegrationRequestBuffer(self.integration)
+        buffer = IntegrationRequestBuffer(self.integration.id)
         now = datetime.now() - timedelta(hours=1)
         for i in reversed(range(10)):
             with freeze_time(now - timedelta(days=i)):


### PR DESCRIPTION
## Objective:

Most of the errors in Sentry wrt integrations are not actionable by us. It requires the user to re-install or update webhook secrets. However, right now users are not aware that their integrations could be broken. And thus, we hammer integrations with incorrect credentials and record a bunch of unactionable errors in Sentry.

This PR creates a new data structure in Redis to store the daily aggregate `error` counts for an integration for 30 days. If an integration consistently fails for 7 days, then we can alert users with an email or in-app.

We can then remove a bunch on unactionable `logger.exception` statements and clear up a bunch of clutter in the Issue Stream.