### PR TITLE
feat(org-tokens): Implement endpoints for OrgAuthToken

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -173,6 +173,15 @@ class OrganizationAlertRulePermission(OrganizationPermission):
     }
 
 
+class OrgAuthTokenPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin"],
+        "POST": ["org:read", "org:write", "org:admin"],
+        "PUT": ["org:write", "org:admin"],
+        "DELETE": ["org:write", "org:admin"],
+    }
+
+
 class OrganizationEndpoint(Endpoint):
     permission_classes = (OrganizationPermission,)
 

--- a/src/sentry/api/endpoints/org_auth_token_details.py
+++ b/src/sentry/api/endpoints/org_auth_token_details.py
@@ -1,0 +1,63 @@
+from django.utils import timezone
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import audit_log
+from sentry.api.base import control_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrgAuthTokenPermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.models.organization import Organization
+from sentry.models.orgauthtoken import OrgAuthToken
+
+
+@control_silo_endpoint
+class OrgAuthTokenDetailsEndpoint(OrganizationEndpoint):
+    permission_classes = (OrgAuthTokenPermission,)
+
+    def get(self, request: Request, organization: Organization, token_id) -> Response:
+        try:
+            instance = OrgAuthToken.objects.get(
+                organization_id=organization.id, date_deactivated__isnull=True, id=token_id
+            )
+        except OrgAuthToken.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        return Response(serialize(instance, request.user, token=None))
+
+    def put(self, request: Request, organization, token_id):
+        try:
+            instance = OrgAuthToken.objects.get(
+                organization_id=organization.id, id=token_id, date_deactivated__isnull=True
+            )
+        except OrgAuthToken.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        name = request.data.get("name")
+
+        if not name:
+            return Response({"detail": ["The name cannot be blank."]}, status=400)
+
+        instance.update(name=name)
+
+        return Response(status=204)
+
+    def delete(self, request: Request, organization, token_id):
+        try:
+            instance = OrgAuthToken.objects.get(
+                organization_id=organization.id, id=token_id, date_deactivated__isnull=True
+            )
+        except OrgAuthToken.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        instance.update(date_deactivated=timezone.now())
+
+        self.create_audit_entry(
+            request,
+            organization=organization,
+            target_object=instance.id,
+            event=audit_log.get_event_id("ORGAUTHTOKEN_REMOVE"),
+            data=instance.get_audit_log_data(),
+        )
+
+        return Response(status=204)

--- a/src/sentry/api/endpoints/org_auth_tokens.py
+++ b/src/sentry/api/endpoints/org_auth_tokens.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+
+from django.core.exceptions import ValidationError
+from django.db.models import Value
+from django.db.models.functions import Coalesce
+from django.views.decorators.cache import never_cache
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import audit_log
+from sentry.api.base import control_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrgAuthTokenPermission
+from sentry.api.serializers import serialize
+from sentry.api.utils import generate_region_url
+from sentry.models.organization import Organization
+from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.utils import hashlib
+from sentry.utils.security.orgauthtoken_jwt import generate_token
+
+
+@control_silo_endpoint
+class OrgAuthTokensEndpoint(OrganizationEndpoint):
+    permission_classes = (OrgAuthTokenPermission,)
+
+    @never_cache
+    def get(self, request: Request, organization: Organization) -> Response:
+        # We want to sort by date_last_used, but sort NULLs last
+        the_past = datetime.min
+
+        token_list = list(
+            OrgAuthToken.objects.filter(
+                organization_id=organization.id, date_deactivated__isnull=True
+            )
+            .annotate(last_used_non_null=Coalesce("date_last_used", Value(the_past)))
+            .order_by("-last_used_non_null", "name", "-date_added")
+        )
+
+        return Response(serialize(token_list, request.user, token=None))
+
+    def post(self, request: Request, organization: Organization) -> Response:
+        jwt_token = generate_token(organization.slug, generate_region_url())
+        token_hashed = hashlib.sha256_text(jwt_token).hexdigest()
+
+        name = request.data.get("name")
+
+        # Main validation cases with specific error messages
+        if not name:
+            return Response({"detail": ["The name cannot be blank."]}, status=400)
+
+        token = OrgAuthToken.objects.create(
+            name=name,
+            organization_id=organization.id,
+            # TODO FN: This will eventually be org:ci
+            scope_list=["org:read"],
+            created_by_id=request.user.id,
+            token_last_characters=jwt_token[-4:],
+            token_hashed=token_hashed,
+        )
+
+        try:
+            token.full_clean()
+        except ValidationError as e:
+            return Response({"detail": list(e.messages)}, status=400)
+
+        self.create_audit_entry(
+            request,
+            organization=organization,
+            target_object=token.id,
+            event=audit_log.get_event_id("ORGAUTHTOKEN_ADD"),
+            data=token.get_audit_log_data(),
+        )
+
+        # This is THE ONLY TIME that the token is available
+        serialized_token = serialize(token, request.user, token=jwt_token)
+
+        if serialized_token is None:
+            return Response({"detail": "Error when serializing token."}, status=400)
+
+        return Response(serialized_token, status=status.HTTP_201_CREATED)

--- a/src/sentry/api/serializers/models/__init__.py
+++ b/src/sentry/api/serializers/models/__init__.py
@@ -50,6 +50,7 @@ from .organization_member.response import *  # noqa: F401,F403
 from .organization_member.scim import *  # noqa: F401,F403
 from .organization_member.utils import *  # noqa: F401,F403
 from .organization_plugin import *  # noqa: F401,F403
+from .orgauthtoken import *  # noqa: F401,F403
 from .platformexternalissue import *  # noqa: F401,F403
 from .plugin import *  # noqa: F401,F403
 from .processingissue import *  # noqa: F401,F403

--- a/src/sentry/api/serializers/models/orgauthtoken.py
+++ b/src/sentry/api/serializers/models/orgauthtoken.py
@@ -1,0 +1,23 @@
+from sentry.api.serializers import Serializer, register
+from sentry.models.orgauthtoken import OrgAuthToken
+
+
+@register(OrgAuthToken)
+class OrgAuthTokenSerializer(Serializer):
+    def serialize(self, obj, attrs, user, token):
+        data = {
+            "id": str(obj.id),
+            "name": obj.name,
+            "scopes": obj.get_scopes(),
+            "tokenLastCharacters": obj.token_last_characters,
+            "dateCreated": obj.date_added,
+            "dateLastUsed": obj.date_last_used,
+            "projectLastUsedId": str(obj.project_last_used_id)
+            if obj.project_last_used_id
+            else None,
+        }
+
+        if token:
+            data["token"] = token
+
+        return data

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import include, url
 
 from sentry.api.endpoints.group_event_details import GroupEventDetailsEndpoint
 from sentry.api.endpoints.internal.integration_proxy import InternalIntegrationProxyEndpoint
+from sentry.api.endpoints.org_auth_token_details import OrgAuthTokenDetailsEndpoint
+from sentry.api.endpoints.org_auth_tokens import OrgAuthTokensEndpoint
 from sentry.api.endpoints.organization_events_facets_stats_performance import (
     OrganizationEventsFacetsStatsPerformanceEndpoint,
 )
@@ -1616,6 +1618,16 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_slug>[^\/]+)/sentry-app-components/$",
         OrganizationSentryAppComponentsEndpoint.as_view(),
         name="sentry-api-0-organization-sentry-app-components",
+    ),
+    url(
+        r"^(?P<organization_slug>[^\/]+)/org-auth-tokens/$",
+        OrgAuthTokensEndpoint.as_view(),
+        name="sentry-api-0-org-auth-tokens",
+    ),
+    url(
+        r"^(?P<organization_slug>[^\/]+)/org-auth-tokens/(?P<token_id>[^\/]+)/$",
+        OrgAuthTokenDetailsEndpoint.as_view(),
+        name="sentry-api-0-org-auth-token-details",
     ),
     url(
         r"^(?P<organization_slug>[^\/]+)/stats/$",

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -374,3 +374,19 @@ default_manager.add(
         template="created team {team_slug} and added user as Team Admin while creating project {project_slug}",
     )
 )
+default_manager.add(
+    AuditLogEvent(
+        event_id=176,
+        name="ORGAUTHTOKEN_ADD",
+        api_name="org-auth-token.create",
+        template="added org auth token {name}",
+    )
+)
+default_manager.add(
+    AuditLogEvent(
+        event_id=177,
+        name="ORGAUTHTOKEN_REMOVE",
+        api_name="org-auth-token.remove",
+        template="removed org auth token {name}",
+    )
+)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -797,6 +797,9 @@ class PermissionTestCase(TestCase):
     def assert_member_can_access(self, path, **kwargs):
         return self.assert_role_can_access(path, "member", **kwargs)
 
+    def assert_manager_can_access(self, path, **kwargs):
+        return self.assert_role_can_access(path, "manager", **kwargs)
+
     def assert_teamless_member_can_access(self, path, **kwargs):
         user = self.create_user(is_superuser=False)
         self.create_member(user=user, organization=self.organization, role="member", teams=[])

--- a/src/sentry/utils/hashlib.py
+++ b/src/sentry/utils/hashlib.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 from hashlib import md5 as _md5
 from hashlib import sha1 as _sha1
+from hashlib import sha256 as _sha256
 from typing import Any, Callable, Iterable, Optional
 
 from django.utils.encoding import force_bytes
@@ -18,6 +19,13 @@ def md5_text(*args: Any) -> hashlib._Hash:
 
 def sha1_text(*args: Any) -> hashlib._Hash:
     m = _sha1()
+    for x in args:
+        m.update(force_bytes(x, errors="replace"))
+    return m
+
+
+def sha256_text(*args: Any) -> hashlib._Hash:
+    m = _sha256()
     for x in args:
         m.update(force_bytes(x, errors="replace"))
     return m

--- a/src/sentry/utils/security/orgauthtoken_jwt.py
+++ b/src/sentry/utils/security/orgauthtoken_jwt.py
@@ -9,13 +9,15 @@ SENTRY_JWT_PREFIX = "sntrys_"
 
 
 def generate_token(org_slug: str, region_url: str):
+    sentry_url = settings.SENTRY_OPTIONS.get("system.url-prefix")
+
     jwt_payload = {
         "iss": "sentry.io",
-        "iat": datetime.utcnow(),
-        "nonce": uuid4().hex,
-        "sentry_url": settings.SENTRY_OPTIONS["system.url-prefix"],
+        "iat": datetime.utcnow().timestamp(),
+        "sentry_url": sentry_url,
         "sentry_region_url": region_url,
         "sentry_org": org_slug,
+        "nonce": uuid4().hex,
     }
     jwt_token = jwt.encode(jwt_payload, "", algorithm="none")
     return f"{SENTRY_JWT_PREFIX}{jwt_token}"
@@ -24,11 +26,17 @@ def generate_token(org_slug: str, region_url: str):
 def parse_token(token: str):
     if not token.startswith(SENTRY_JWT_PREFIX):
         return None
-    token = token[7:]
+    jwt_token = token[7:]
+
     try:
-        jwt_payload = jwt.peek_claims(token)
+        jwt_payload = jwt.peek_claims(jwt_token)
         if jwt_payload.get("iss") != "sentry.io":
             return None
         return jwt_payload
     except jwt.DecodeError:
+        # Special case: If the token does not end with `.`, we try again with it added
+        # This is done to help users that do not copy the dot, as it may be unexpected to have a trailing dot
+        # We have trailing dots because we use `None` algorithm
+        if token.endswith(".") is False:
+            return parse_token(token + ".")
         return None

--- a/tests/sentry/api/endpoints/test_org_auth_token_details.py
+++ b/tests/sentry/api/endpoints/test_org_auth_token_details.py
@@ -1,0 +1,408 @@
+from datetime import datetime, timezone
+from typing import Dict
+
+from django.urls import reverse
+from rest_framework import status
+
+from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.testutils import APITestCase
+from sentry.testutils.cases import PermissionTestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test(stable=True)
+class OrgAuthTokenDetailTest(APITestCase):
+    endpoint = "sentry-api-0-org-auth-token-details"
+
+    def test_simple(self):
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+
+        self.login_as(self.user)
+        response = self.get_success_response(
+            self.organization.slug, token.id, status_code=status.HTTP_200_OK
+        )
+        assert response.content
+
+        res = response.data
+
+        assert res.get("id") == str(token.id)
+        assert res.get("name") == "token 1"
+        assert res.get("token") is None
+        assert res.get("tokenLastCharacters") == "xyz1"
+        assert res.get("scopes") == ["project:read", "project:releases"]
+        assert res.get("dateCreated") is not None
+        assert res.get("lastUsedDate") is None
+        assert res.get("lastUsedProjectId") is None
+
+    def test_last_used(self):
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            project_last_used_id=self.project.id,
+        )
+
+        self.login_as(self.user)
+        response = self.get_success_response(
+            self.organization.slug, token.id, status_code=status.HTTP_200_OK
+        )
+        assert response.content
+
+        res = response.data
+        assert res.get("dateLastUsed") == datetime(2023, 1, 1, tzinfo=timezone.utc)
+        assert res.get("projectLastUsedId") == str(self.project.id)
+
+    def test_no_auth(self):
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+
+        response = self.get_error_response(self.organization.slug, token.id)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_other_org_token(self):
+        other_org = self.create_organization()
+        token = OrgAuthToken.objects.create(
+            organization_id=other_org.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+
+        self.login_as(self.user)
+        response = self.get_error_response(other_org.slug, token.id)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_other_org(self):
+        other_org = self.create_organization()
+        token = OrgAuthToken.objects.create(
+            organization_id=other_org.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+
+        self.login_as(self.user)
+        response = self.get_error_response(self.organization.slug, token.id)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_not_exists(self):
+        self.login_as(self.user)
+        response = self.get_error_response(self.organization.slug, 999999)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_get_deleted(self):
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+            date_deactivated=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        )
+
+        self.login_as(self.user)
+        response = self.get_error_response(self.organization.slug, token.id)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@control_silo_test(stable=True)
+class OrgAuthTokenEditTest(APITestCase):
+    endpoint = "sentry-api-0-org-auth-token-details"
+    method = "PUT"
+
+    def test_simple(self):
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+        payload = {"name": "new token"}
+
+        self.login_as(self.user)
+        response = self.get_success_response(
+            self.organization.slug, token.id, status_code=status.HTTP_204_NO_CONTENT, **payload
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        tokenNew = OrgAuthToken.objects.get(id=token.id)
+        assert tokenNew.name == "new token"
+        assert tokenNew.token_hashed == token.token_hashed
+        assert tokenNew.get_scopes() == token.get_scopes()
+
+    def test_no_name(self):
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+        payload: Dict[str, str] = {}
+
+        self.login_as(self.user)
+        response = self.get_error_response(
+            self.organization.slug, token.id, status_code=status.HTTP_400_BAD_REQUEST, **payload
+        )
+        assert response.content
+        assert response.data == {"detail": ["The name cannot be blank."]}
+
+        tokenNew = OrgAuthToken.objects.get(id=token.id)
+        assert tokenNew.name == "token 1"
+
+    def test_blank_name(self):
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+        payload = {"name": ""}
+
+        self.login_as(self.user)
+        response = self.get_error_response(
+            self.organization.slug, token.id, status_code=status.HTTP_400_BAD_REQUEST, **payload
+        )
+        assert response.content
+        assert response.data == {"detail": ["The name cannot be blank."]}
+
+        tokenNew = OrgAuthToken.objects.get(id=token.id)
+        assert tokenNew.name == "token 1"
+
+    def test_no_auth(self):
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+        payload: Dict[str, str] = {}
+        response = self.get_error_response(self.organization.slug, token.id, **payload)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_other_org_token(self):
+        other_org = self.create_organization()
+        payload = {"name": "test token"}
+        token = OrgAuthToken.objects.create(
+            organization_id=other_org.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+
+        self.login_as(self.user)
+        response = self.get_error_response(other_org.slug, token.id, **payload)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_other_org(self):
+        other_org = self.create_organization()
+        payload = {"name": "test token"}
+        token = OrgAuthToken.objects.create(
+            organization_id=other_org.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+
+        self.login_as(self.user)
+        response = self.get_error_response(self.organization.slug, token.id, **payload)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_not_exists(self):
+        payload = {"name": "test token"}
+        self.login_as(self.user)
+        response = self.get_error_response(self.organization.slug, 999999, **payload)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_update_deleted(self):
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+            date_deactivated=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        )
+
+        payload = {"name": "test token"}
+        self.login_as(self.user)
+        response = self.get_error_response(self.organization.slug, token.id, **payload)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@control_silo_test(stable=True)
+class OrgAuthTokenDeleteTest(APITestCase):
+    endpoint = "sentry-api-0-org-auth-token-details"
+    method = "DELETE"
+
+    def test_simple(self):
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+
+        self.login_as(self.user)
+        response = self.get_success_response(
+            self.organization.slug, token.id, status_code=status.HTTP_204_NO_CONTENT
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        tokenNew = OrgAuthToken.objects.get(id=token.id)
+        assert tokenNew.name == "token 1"
+        assert tokenNew.token_hashed == token.token_hashed
+        assert tokenNew.get_scopes() == token.get_scopes()
+        assert tokenNew.is_active() is False
+        assert tokenNew.date_deactivated is not None
+
+    def test_no_auth(self):
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+        response = self.get_error_response(self.organization.slug, token.id)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_other_org_token(self):
+        other_org = self.create_organization()
+        token = OrgAuthToken.objects.create(
+            organization_id=other_org.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+
+        self.login_as(self.user)
+        response = self.get_error_response(other_org.slug, token.id)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_other_org(self):
+        other_org = self.create_organization()
+        token = OrgAuthToken.objects.create(
+            organization_id=other_org.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+
+        self.login_as(self.user)
+        response = self.get_error_response(self.organization.slug, token.id)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_not_exists(self):
+        self.login_as(self.user)
+        response = self.get_error_response(self.organization.slug, 999999)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_delete_deleted(self):
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+            date_deactivated=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        )
+
+        self.login_as(self.user)
+        response = self.get_error_response(self.organization.slug, token.id)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@control_silo_test(stable=True)
+class OrgAuthTokenDetailsPermissionTest(PermissionTestCase):
+    putData = {"name": "token-1"}
+
+    def setUp(self):
+        super().setUp()
+
+        token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+
+        self.path = reverse(
+            "sentry-api-0-org-auth-token-details", args=[self.organization.slug, token.id]
+        )
+
+    def test_owner_can_get(self):
+        self.assert_owner_can_access(self.path)
+
+    def test_manager_can_get(self):
+        self.assert_manager_can_access(self.path)
+
+    def test_member_can_get(self):
+        self.assert_member_can_access(self.path)
+
+    def test_owner_can_put(self):
+        self.assert_owner_can_access(
+            self.path, method="PUT", data=self.putData, content_type="application/json"
+        )
+
+    def test_manager_can_put(self):
+        self.assert_manager_can_access(
+            self.path, method="PUT", data=self.putData, content_type="application/json"
+        )
+
+    def test_member_cannot_put(self):
+        self.assert_member_cannot_access(
+            self.path, method="PUT", data=self.putData, content_type="application/json"
+        )
+
+    def test_owner_can_delete(self):
+        self.assert_owner_can_access(self.path, method="DELETE")
+
+    def test_manager_can_delete(self):
+        self.assert_manager_can_access(self.path, method="DELETE")
+
+    def test_member_cannot_delete(self):
+        self.assert_member_cannot_access(self.path, method="DELETE")

--- a/tests/sentry/api/endpoints/test_org_auth_tokens.py
+++ b/tests/sentry/api/endpoints/test_org_auth_tokens.py
@@ -1,0 +1,194 @@
+from typing import Dict
+
+from django.urls import reverse
+from rest_framework import status
+
+from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.testutils import APITestCase
+from sentry.testutils.cases import PermissionTestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test(stable=True)
+class OrgAuthTokensListTest(APITestCase):
+    endpoint = "sentry-api-0-org-auth-tokens"
+
+    def test_simple(self):
+        other_org = self.create_organization()
+        token1 = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+        token2 = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 2",
+            token_hashed="ABCDEF2",
+            token_last_characters="xyz2",
+            scope_list=["project:read"],
+            date_last_used="2023-01-02T00:00:00.000Z",
+        )
+        token3 = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 3",
+            token_hashed="ABCDEF3",
+            token_last_characters="xyz3",
+            scope_list=["project:read"],
+            date_last_used="2023-01-01T00:00:00.000Z",
+        )
+        # Deleted tokens are not returned
+        OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 4",
+            token_hashed="ABCDEF4",
+            token_last_characters="xyz3",
+            scope_list=["project:read"],
+            date_deactivated="2023-01-01T00:00:00.000Z",
+        )
+        # tokens from other org are not returned
+        OrgAuthToken.objects.create(
+            organization_id=other_org.id,
+            name="token 5",
+            token_hashed="ABCDEF5",
+            token_last_characters="xyz3",
+            scope_list=["project:read"],
+        )
+
+        self.login_as(self.user)
+        response = self.get_success_response(self.organization.slug, status_code=status.HTTP_200_OK)
+        assert response.content
+        assert len(response.data) == 3
+        assert list(map(lambda token: token.get("id"), response.data)) == [
+            str(token2.id),
+            str(token3.id),
+            str(token1.id),
+        ]
+        assert response.data[0].get("token") is None
+        assert response.data[1].get("token") is None
+        assert response.data[2].get("token") is None
+
+    def test_never_cache(self):
+        OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["project:read", "project:releases"],
+            date_last_used=None,
+        )
+        OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 2",
+            token_hashed="ABCDEF2",
+            token_last_characters="xyz2",
+            scope_list=["project:read"],
+            date_last_used="2023-01-02T00:00:00.000Z",
+        )
+
+        self.login_as(self.user)
+        response = self.get_success_response(self.organization.slug, status_code=status.HTTP_200_OK)
+        assert response.content
+        assert response.get("cache-control") == "max-age=0, no-cache, no-store, must-revalidate"
+
+    def test_no_auth(self):
+        response = self.get_error_response(self.organization.slug)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_other_org(self):
+        other_org = self.create_organization()
+        self.login_as(self.user)
+        response = self.get_error_response(other_org.slug)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@control_silo_test(stable=True)
+class OrgAuthTokenCreateTest(APITestCase):
+    endpoint = "sentry-api-0-org-auth-tokens"
+    method = "POST"
+
+    def test_simple(self):
+        payload = {"name": "test token"}
+
+        self.login_as(self.user)
+        response = self.get_success_response(
+            self.organization.slug, status_code=status.HTTP_201_CREATED, **payload
+        )
+        assert response.content
+
+        token = response.data
+        assert token.get("token") is not None
+        assert token.get("tokenLastCharacters") is not None
+        assert token.get("dateCreated") is not None
+        assert token.get("dateLastUsed") is None
+        assert token.get("projectLastUsed") is None
+        assert token.get("scopes") == ["org:read"]
+        assert token.get("name") == "test token"
+
+        tokenDb = OrgAuthToken.objects.get(id=token.get("id"))
+        assert tokenDb.name == "test token"
+        assert tokenDb.token_hashed is not None
+        assert tokenDb.token_hashed != token.get("token")
+        assert tokenDb.get_scopes() == token.get("scopes")
+        assert tokenDb.created_by.id == self.user.id
+
+    def test_no_name(self):
+        payload: Dict[str, str] = {}
+
+        self.login_as(self.user)
+        response = self.get_error_response(
+            self.organization.slug, status_code=status.HTTP_400_BAD_REQUEST, **payload
+        )
+        assert response.content
+        assert response.data == {"detail": ["The name cannot be blank."]}
+
+    def test_blank_name(self):
+        payload = {"name": ""}
+
+        self.login_as(self.user)
+        response = self.get_error_response(
+            self.organization.slug, status_code=status.HTTP_400_BAD_REQUEST, **payload
+        )
+        assert response.content
+        assert response.data == {"detail": ["The name cannot be blank."]}
+
+    def test_no_auth(self):
+        response = self.get_error_response(self.organization.slug)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_other_org(self):
+        other_org = self.create_organization()
+        payload = {"name": "test token"}
+
+        self.login_as(self.user)
+        response = self.get_error_response(other_org.slug, **payload)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@control_silo_test(stable=True)
+class OrgAuthTokensPermissionTest(PermissionTestCase):
+    postData = {"name": "token-1"}
+
+    def setUp(self):
+        super().setUp()
+        self.path = reverse("sentry-api-0-org-auth-tokens", args=[self.organization.slug])
+
+    def test_owner_can_get(self):
+        self.assert_owner_can_access(self.path)
+
+    def test_manager_can_get(self):
+        self.assert_manager_can_access(self.path)
+
+    def test_member_can_get(self):
+        self.assert_member_can_access(self.path)
+
+    def test_owner_can_post(self):
+        self.assert_owner_can_access(self.path, method="POST", data=self.postData)
+
+    def test_manager_can_post(self):
+        self.assert_manager_can_access(self.path, method="POST", data=self.postData)
+
+    def test_member_can_post(self):
+        self.assert_member_can_access(self.path, method="POST", data=self.postData)

--- a/tests/sentry/audit_log/test_register.py
+++ b/tests/sentry/audit_log/test_register.py
@@ -76,6 +76,8 @@ class AuditLogEventRegisterTest(TestCase):
             "notification_action.edit",
             "notification_action.remove",
             "team-and-project.created",
+            "org-auth-token.create",
+            "org-auth-token.remove",
         ]
 
         assert set(audit_log.get_api_names()) == set(audit_log_api_name_list)

--- a/tests/sentry/utils/security/test_orgauthtoken_jwt.py
+++ b/tests/sentry/utils/security/test_orgauthtoken_jwt.py
@@ -21,6 +21,18 @@ class OrgAuthTokenJwtTest(TestCase):
         assert token_payload["sentry_region_url"] == "https://test-region.sentry.io"
         assert token_payload["nonce"]
 
+    def test_parse_token_no_dot(self):
+        token = generate_token("test-org", "https://test-region.sentry.io")
+        # Our JWT tokens end on a dot `.`, which may be confusing, and users _may_ not copy
+        # In order to accomodate this, we special case this and add the missing dot for our users
+        token_payload = parse_token(token[:-1])
+
+        assert token_payload
+        assert token_payload["sentry_org"] == "test-org"
+        assert token_payload["sentry_url"] == "http://testserver"
+        assert token_payload["sentry_region_url"] == "https://test-region.sentry.io"
+        assert token_payload["nonce"]
+
     def test_parse_invalid_token(self):
         assert parse_token("invalid-token") is None
 


### PR DESCRIPTION
This introduces the API endpoints for the new `OrgAuthToken` model.

- [x] Every user can create tokens
- [x] Tokens are only visible right after creation
- [x] Every user can view token entries (*without the actual token itself)
- [x] managers & owners can edit token names
- [x] managers & owners can revoke tokens (=soft delete them)
- [x] tokens are sorted by last used date
- [x] token itself is stored as a sha256 hash in the DB
- [x] we store token creation/deletion in audit log 

Closes https://github.com/getsentry/sentry/issues/50932