### PR TITLE
fix(user-feedback-dialog): Set header on user feedback dialog embed response

### DIFF
--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -227,11 +227,11 @@ class ErrorPageEmbedView(View):
             ),
         }
 
-        response = render_to_response(
+        errorPageEmbedResponse = render_to_response(
             "sentry/error-page-embed.js", context, request, content_type="text/javascript"
         )
 
         # User feedback dialog should be available regardless of cross-origin policy
-        response["Access-Control-Allow-Origin"] = "*"
+        errorPageEmbedResponse["Access-Control-Allow-Origin"] = "*"
 
-        return response
+        return errorPageEmbedResponse

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -227,6 +227,11 @@ class ErrorPageEmbedView(View):
             ),
         }
 
-        return render_to_response(
+        response = render_to_response(
             "sentry/error-page-embed.js", context, request, content_type="text/javascript"
         )
+
+        # User feedback dialog should be available regardless of cross-origin policy
+        response["Access-Control-Allow-Origin"] = "*"
+
+        return response

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -71,6 +71,7 @@ class ErrorPageEmbedTest(TestCase):
             HTTP_ACCEPT="text/html, text/javascript",
         )
         assert resp.status_code == 200, resp.content
+        assert resp["Access-Control-Allow-Origin"] == "*"
         self.assertTemplateUsed(resp, "sentry/error-page-embed.html")
 
     def test_uses_locale_from_header(self):


### PR DESCRIPTION
Apparently some cors policy headers like `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` cause requests to our user report dialog template to fail.

This PR adds a `Access-Control-Allow-Origin: *` header to the response to always allow access to the resource, regardless of the policy. This should be safe since the resource is not behind auth or anything user-specific.

Would love input from some more CORS-savvy people though.

Fixes https://github.com/getsentry/sentry/issues/49535