### PR TITLE
feat(redis): Ability to pass arbitrary client arguments

### DIFF
--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -104,6 +104,8 @@ class _RedisCluster:
         # https://redis.io/docs/reference/cluster-spec/#scaling-reads-using-replica-nodes
         readonly_mode = config.get("readonly_mode", False)
 
+        client_args = config.get("client_args") or {}
+
         # Redis cluster does not wait to attempt to connect. We'd prefer to not
         # make TCP connections on boot. Wrap the client in a lazy proxy object.
         def cluster_factory():
@@ -122,6 +124,7 @@ class _RedisCluster:
                     max_connections=16,
                     max_connections_per_node=True,
                     readonly_mode=readonly_mode,
+                    **client_args,
                 )
             else:
                 host = hosts[0].copy()
@@ -130,7 +133,7 @@ class _RedisCluster:
                     import_string(config["client_class"])
                     if "client_class" in config
                     else FailoverRedis
-                )(**host)
+                )(**host, **client_args)
 
         return SimpleLazyObject(cluster_factory)
 


### PR DESCRIPTION
I don't dare to blindly forward the outer **kwargs because we used to
ignore them, and it's not clear what kind of stuff is in there in all
prod environments.

Also, this only works for redis-cluster, not redis-blaster.

After that, one can:

```
SENTRY_OPTIONS.setdefault("redis.clusters", {}).update(
       ...
        "rc-indexer-ratelimiter": {
            "is_redis_cluster": True,
            "hosts": _generate_redis_cluster_hosts("rc-indexer-ratelimiter", rings=2),
            "client_args": {"socket_timeout": 123456789}
        },
```

see https://github.com/redis/redis-py/blob/d95d8a24ed2af3eae80b7b0f14cbccc9dbe86e96/redis/client.py#L916 for arguments