### PR TITLE
fix(release-filter): Apply dashboard saved filters to widget viewer

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -51,11 +51,15 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
 import withPageFilters from 'sentry/utils/withPageFilters';
-import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboards/types';
+import {
+  DashboardFilters,
+  DisplayType,
+  Widget,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
 import {
   dashboardFiltersToString,
   eventViewFromWidget,
-  getDashboardFiltersFromURL,
   getFieldsFromEquations,
   getNumEquations,
   getWidgetDiscoverUrl,
@@ -95,6 +99,7 @@ import {
 export interface WidgetViewerModalOptions {
   organization: Organization;
   widget: Widget;
+  dashboardFilters?: DashboardFilters;
   onEdit?: () => void;
   pageLinks?: string;
   seriesData?: Series[];
@@ -175,6 +180,7 @@ function WidgetViewerModal(props: Props) {
     totalIssuesCount,
     pageLinks: defaultPageLinks,
     seriesResultsType,
+    dashboardFilters,
   } = props;
   const location = useLocation();
   const {projects} = useProjects();
@@ -396,13 +402,12 @@ function WidgetViewerModal(props: Props) {
 
   const queryOptions = sortedQueries.map(({name, conditions}, index) => {
     // Creates the highlighted query elements to be used in the Query Select
-    const dashboardFilters = dashboardFiltersToString(
-      getDashboardFiltersFromURL(location)
-    );
+    const dashboardFiltersString = dashboardFiltersToString(dashboardFilters);
     const parsedQuery =
       !name && !!conditions
         ? parseSearch(
-            conditions + (dashboardFilters === '' ? '' : ` ${dashboardFilters}`)
+            conditions +
+              (dashboardFiltersString === '' ? '' : ` ${dashboardFiltersString}`)
           )
         : null;
     const getHighlightedQuery = (
@@ -749,7 +754,7 @@ function WidgetViewerModal(props: Props) {
                 : HALF_TABLE_ITEM_LIMIT
             }
             cursor={cursor}
-            dashboardFilters={getDashboardFiltersFromURL(location) ?? undefined}
+            dashboardFilters={dashboardFilters}
           >
             {renderIssuesTable}
           </IssueWidgetQueries>
@@ -774,7 +779,7 @@ function WidgetViewerModal(props: Props) {
                 : HALF_TABLE_ITEM_LIMIT
             }
             cursor={cursor}
-            dashboardFilters={getDashboardFiltersFromURL(location) ?? undefined}
+            dashboardFilters={dashboardFilters}
           >
             {renderReleaseTable}
           </ReleaseWidgetQueries>
@@ -802,7 +807,7 @@ function WidgetViewerModal(props: Props) {
                 : HALF_TABLE_ITEM_LIMIT
             }
             cursor={cursor}
-            dashboardFilters={getDashboardFiltersFromURL(location) ?? undefined}
+            dashboardFilters={dashboardFilters}
           >
             {({tableResults, loading, pageLinks}) => {
               // TODO(Tele-Team): Re-enable this when we have a better way to determine if the data is transaction only
@@ -868,7 +873,7 @@ function WidgetViewerModal(props: Props) {
                 api={api}
                 organization={organization}
                 selection={modalChartSelection.current}
-                dashboardFilters={getDashboardFiltersFromURL(location) ?? undefined}
+                dashboardFilters={dashboardFilters}
                 // Top N charts rely on the orderby of the table
                 widget={primaryWidget}
                 onZoom={onZoom}

--- a/static/app/views/dashboards/detail.spec.jsx
+++ b/static/app/views/dashboards/detail.spec.jsx
@@ -890,6 +890,66 @@ describe('Dashboards > Detail', function () {
       expect(screen.queryByText('Save')).not.toBeInTheDocument();
     });
 
+    it('opens the widget viewer with saved dashboard filters', async () => {
+      const openWidgetViewerModal = jest.spyOn(modals, 'openWidgetViewerModal');
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/dashboards/1/',
+        body: TestStubs.Dashboard(widgets, {
+          id: '1',
+          filters: {release: ['sentry-android-shop@1.2.0']},
+        }),
+      });
+      render(
+        <ViewEditDashboard
+          organization={initialData.organization}
+          params={{orgId: 'org-slug', dashboardId: '1', widgetId: '1'}}
+          router={initialData.router}
+          location={{...initialData.router.location, pathname: '/widget/1/'}}
+        />,
+        {context: initialData.routerContext, organization: initialData.organization}
+      );
+
+      await waitFor(() => {
+        expect(openWidgetViewerModal).toHaveBeenCalledWith(
+          expect.objectContaining({
+            dashboardFilters: {release: ['sentry-android-shop@1.2.0']},
+          })
+        );
+      });
+    });
+
+    it('opens the widget viewer with unsaved dashboard filters', async () => {
+      const openWidgetViewerModal = jest.spyOn(modals, 'openWidgetViewerModal');
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/dashboards/1/',
+        body: TestStubs.Dashboard(widgets, {
+          id: '1',
+          filters: {release: ['sentry-android-shop@1.2.0']},
+        }),
+      });
+      render(
+        <ViewEditDashboard
+          organization={initialData.organization}
+          params={{orgId: 'org-slug', dashboardId: '1', widgetId: '1'}}
+          router={initialData.router}
+          location={{
+            ...initialData.router.location,
+            pathname: '/widget/1/',
+            query: {release: ['unsaved-release-filter@1.2.0']},
+          }}
+        />,
+        {context: initialData.routerContext, organization: initialData.organization}
+      );
+
+      await waitFor(() => {
+        expect(openWidgetViewerModal).toHaveBeenCalledWith(
+          expect.objectContaining({
+            dashboardFilters: {release: ['unsaved-release-filter@1.2.0']},
+          })
+        );
+      });
+    });
+
     it('can save dashboard filters in existing dashboard', async () => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/releases/',

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -165,6 +165,7 @@ class DashboardDetail extends Component<Props, State> {
           tableData,
           pageLinks,
           totalIssuesCount,
+          dashboardFilters: getDashboardFiltersFromURL(location) ?? dashboard.filters,
           onClose: () => {
             // Filter out Widget Viewer Modal query params when exiting the Modal
             const query = omit(location.query, Object.values(WidgetViewerQueryField));


### PR DESCRIPTION
When the dashboard is saved, the unsaved filters get saved to state and removed from the URL. We weren't taking into account the saved state so filters weren't always applied. Instead, the dashboard should be responsible for fetching the filters from the URL or state to pass down to the widget viewer.

Closes #51129