### PR TITLE
fix(buffers): Add dates serialization to json serializer

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -1,7 +1,7 @@
 import logging
 import pickle
 import threading
-from datetime import datetime
+from datetime import date, datetime
 from time import time
 
 from django.db import models
@@ -140,6 +140,9 @@ class RedisBuffer(Buffer):
         if isinstance(value, str):
             type_ = "s"
         elif isinstance(value, datetime):
+            type_ = "dt"
+            value = value.strftime("%s.%f")
+        elif isinstance(value, date):
             type_ = "d"
             value = value.strftime("%s.%f")
         elif isinstance(value, int):
@@ -162,8 +165,10 @@ class RedisBuffer(Buffer):
         (type_, value) = payload
         if type_ == "s":
             return force_text(value)
-        elif type_ == "d":
+        elif type_ == "dt":
             return datetime.fromtimestamp(float(value)).replace(tzinfo=timezone.utc)
+        elif type_ == "d":
+            return date.fromtimestamp(float(value))
         elif type_ == "i":
             return int(value)
         elif type_ == "f":

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -1,7 +1,8 @@
+import datetime
 import pickle
-from datetime import datetime
 from unittest import mock
 
+import pytest
 from django.utils import timezone
 from django.utils.encoding import force_text
 from freezegun import freeze_time
@@ -9,6 +10,7 @@ from freezegun import freeze_time
 from sentry.buffer.redis import RedisBuffer
 from sentry.models import Group, Project
 from sentry.testutils import TestCase
+from sentry.utils import json
 
 
 class RedisBufferTest(TestCase):
@@ -54,7 +56,7 @@ class RedisBufferTest(TestCase):
             "foo",
             {
                 "e+foo": '["s","bar"]',
-                "e+datetime": '["d","1493791566.000000"]',
+                "e+datetime": '["dt","1493791566.000000"]',
                 "f": '{"pk": ["i","1"]}',
                 "i+times_seen": "2",
                 "m": "sentry.models.Group",
@@ -62,7 +64,10 @@ class RedisBufferTest(TestCase):
         )
         columns = {"times_seen": 2}
         filters = {"pk": 1}
-        extra = {"foo": "bar", "datetime": datetime(2017, 5, 3, 6, 6, 6, tzinfo=timezone.utc)}
+        extra = {
+            "foo": "bar",
+            "datetime": datetime.datetime(2017, 5, 3, 6, 6, 6, tzinfo=timezone.utc),
+        }
         signal_only = None
         self.buf.process("foo")
         process.assert_called_once_with(Group, columns, filters, extra, signal_only)
@@ -116,7 +121,7 @@ class RedisBufferTest(TestCase):
         assert self.buf.get(model, columns, filters=filters) == {"times_seen": 6}
 
     def test_incr_saves_to_redis(self):
-        now = datetime(2017, 5, 3, 6, 6, 6, tzinfo=timezone.utc)
+        now = datetime.datetime(2017, 5, 3, 6, 6, 6, tzinfo=timezone.utc)
         client = self.buf.cluster.get_routing_client()
         model = mock.Mock()
         model.__name__ = "Mock"
@@ -214,7 +219,7 @@ class RedisBufferTest(TestCase):
 
 #    @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
 #    def test_incr_uses_signal_only(self):
-#        now = datetime(2017, 5, 3, 6, 6, 6, tzinfo=timezone.utc)
+#        now = datetime.datetime(2017, 5, 3, 6, 6, 6, tzinfo=timezone.utc)
 #        client = self.buf.cluster.get_routing_client()
 #        model = mock.Mock()
 #        model.__name__ = "Mock"
@@ -224,9 +229,22 @@ class RedisBufferTest(TestCase):
 #        result = client.hgetall("foo")
 #        assert result == {
 #            "e+foo": '["s","bar"]',
-#            "e+datetime": '["d","1493791566.000000"]',
-#            "f": '{"pk":["i","1"],"datetime":["d","1493791566.000000"]}',
+#            "e+datetime": '["dt","1493791566.000000"]',
+#            "f": '{"pk":["i","1"],"datetime":["dt","1493791566.000000"]}',
 #            "i+times_seen": "1",
 #            "m": "mock.mock.Mock",
 #            "s": "1"
 #        }
+#
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime.datetime.today().replace(tzinfo=timezone.utc),
+        timezone.now(),
+        datetime.date.today(),
+    ],
+)
+def test_dump_value(value):
+    assert RedisBuffer._load_value(json.loads(json.dumps(RedisBuffer._dump_value(value)))) == value


### PR DESCRIPTION
According to our logs we are sometimes passing dates which we also need
to serialize
