### PR TITLE
chore(hybridcloud) Set connection on control silo endpoint transactions

### DIFF
--- a/src/sentry/api/endpoints/api_application_details.py
+++ b/src/sentry/api/endpoints/api_application_details.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -83,7 +83,7 @@ class ApiApplicationDetailsEndpoint(Endpoint):
         except ApiApplication.DoesNotExist:
             raise ResourceDoesNotExist
 
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(ApiApplication)):
             updated = ApiApplication.objects.filter(id=instance.id).update(
                 status=ApiApplicationStatus.pending_deletion
             )

--- a/src/sentry/api/endpoints/api_authorizations.py
+++ b/src/sentry/api/endpoints/api_authorizations.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -37,7 +37,7 @@ class ApiAuthorizationsEndpoint(Endpoint):
         except ApiAuthorization.DoesNotExist:
             return Response(status=404)
 
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(ApiToken)):
             ApiToken.objects.filter(
                 user_id=request.user.id, application=auth.application_id
             ).delete()

--- a/src/sentry/api/endpoints/broadcast_details.py
+++ b/src/sentry/api/endpoints/broadcast_details.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from django.utils import timezone
 from rest_framework.permissions import IsAuthenticated
@@ -74,7 +74,7 @@ class BroadcastDetailsEndpoint(Endpoint):
         if result.get("cta"):
             update_kwargs["cta"] = result["cta"]
         if update_kwargs:
-            with transaction.atomic():
+            with transaction.atomic(using=router.db_for_write(Broadcast)):
                 broadcast.update(**update_kwargs)
                 logger.info(
                     "broadcasts.update",
@@ -88,7 +88,7 @@ class BroadcastDetailsEndpoint(Endpoint):
 
         if result.get("hasSeen"):
             try:
-                with transaction.atomic():
+                with transaction.atomic(using=router.db_for_write(Broadcast)):
                     BroadcastSeen.objects.create(broadcast=broadcast, user_id=request.user.id)
             except IntegrityError:
                 pass

--- a/src/sentry/api/endpoints/integrations/organization_integrations/details.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/details.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.db import transaction
+from django.db import router, transaction
 from django.http import Http404
 from django.views.decorators.cache import never_cache
 from rest_framework import serializers
@@ -91,7 +91,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
             integration=integration, organization_id=organization.id
         ).uninstall()
 
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(OrganizationIntegration)):
             updated = OrganizationIntegration.objects.filter(
                 id=org_integration.id, status=ObjectStatus.ACTIVE
             ).update(status=ObjectStatus.PENDING_DELETION)

--- a/src/sentry/api/endpoints/integrations/sentry_apps/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/details.py
@@ -1,7 +1,7 @@
 import logging
 
 import sentry_sdk
-from django.db import transaction
+from django.db import router, transaction
 from requests import RequestException
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -13,6 +13,8 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import SentryAppSerializer
 from sentry.constants import SentryAppStatus
 from sentry.mediators import InstallationNotifier
+from sentry.models.integrations.sentry_app import SentryApp
+from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.sentry_apps.apps import SentryAppUpdater
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.utils import json
@@ -99,7 +101,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
             if not sentry_app.is_internal:
                 for install in sentry_app.installations.all():
                     try:
-                        with transaction.atomic():
+                        with transaction.atomic(using=router.db_for_write(SentryAppInstallation)):
                             InstallationNotifier.run(
                                 install=install, user=request.user, action="deleted"
                             )
@@ -107,7 +109,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                     except RequestException as exc:
                         sentry_sdk.capture_exception(exc)
 
-            with transaction.atomic():
+            with transaction.atomic(using=router.db_for_write(SentryApp)):
                 deletions.exec_sync(sentry_app)
                 create_audit_entry(
                     request=request,

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/details.py
@@ -1,5 +1,5 @@
 import sentry_sdk
-from django.db import transaction
+from django.db import router, transaction
 from requests import RequestException
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -28,7 +28,7 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
         user = extract_lazy_object(request.user)
         if isinstance(user, RpcUser):
             user = User.objects.get(id=user.id)
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(SentryAppInstallation)):
             try:
                 InstallationNotifier.run(install=installation, user=user, action="deleted")
             # if the error is from a request exception, log the error and continue

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import router, transaction
 from django.http import Http404
 from rest_framework import status
 from rest_framework.request import Request
@@ -36,7 +36,7 @@ class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(SentryAppInstallationToken)):
             try:
                 install_token = SentryAppInstallationToken.objects.get(api_token=api_token)
                 sentry_app_installation = install_token.sentry_app_installation

--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import router, transaction
 from fido2.ctap2 import AuthenticatorData
 from rest_framework import status
 from rest_framework.request import Request
@@ -167,7 +167,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
                     status=status.HTTP_403_FORBIDDEN,
                 )
 
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(Authenticator)):
             authenticator.delete()
 
             # if we delete an actual authenticator and all that

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytz
 from django.conf import settings
 from django.contrib.auth import logout
-from django.db import transaction
+from django.db import router, transaction
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -194,7 +194,7 @@ class UserDetailsEndpoint(UserEndpoint):
                     user=user, key=key_map.get(key, key), value=options_result.get(key)
                 )
 
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(User)):
             user = serializer.save()
 
             if any(k in request.data for k in ("isStaff", "isSuperuser", "isActive")):

--- a/src/sentry/api/endpoints/user_emails.py
+++ b/src/sentry/api/endpoints/user_emails.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from rest_framework import serializers
 
@@ -41,7 +41,7 @@ def add_email(email, user):
         raise DuplicateEmailError
 
     try:
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(UserEmail)):
             new_email = UserEmail.objects.create(user=user, email=email)
     except IntegrityError:
         raise DuplicateEmailError

--- a/src/sentry/api/endpoints/user_identity_config.py
+++ b/src/sentry/api/endpoints/user_identity_config.py
@@ -1,7 +1,7 @@
 import itertools
 from typing import Iterable, Optional
 
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -112,7 +112,7 @@ class UserIdentityConfigDetailsEndpoint(UserEndpoint):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
     def delete(self, request: Request, user, category, identity_id) -> Response:
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(Identity)):
             identity = self._get_identity(user, category, identity_id)
             if not identity:
                 # Returns 404 even if the ID exists but belongs to

--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -155,7 +155,7 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
         if len(emails) != len(emails_to_check):
             return Response({"detail": INVALID_EMAIL_MSG}, status=status.HTTP_400_BAD_REQUEST)
 
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(UserOption)):
             for id, value in data.items():
                 user_option, CREATED = UserOption.objects.get_or_create(
                     user=user,
@@ -168,7 +168,7 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
 
     @staticmethod
     def _handle_put_notification_settings(user, notification_type: FineTuningAPIKey, parents, data):
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(NotificationSetting)):
             for parent in parents:
                 # We fetched every available parent but only care about the ones in `request.data`.
                 if str(parent.id) not in data:

--- a/src/sentry/api/endpoints/user_role_details.py
+++ b/src/sentry/api/endpoints/user_role_details.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -41,7 +41,7 @@ class UserUserRoleDetailsEndpoint(UserEndpoint):
         except UserRole.DoesNotExist:
             return self.respond({"detail": f"'{role_name}' is not a known role."}, status=404)
 
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(UserRoleUser)):
             _, created = UserRoleUser.objects.get_or_create(user=user, role=role)
             if not created:
                 # Already exists.
@@ -68,7 +68,7 @@ class UserUserRoleDetailsEndpoint(UserEndpoint):
         except UserRole.DoesNotExist:
             return self.respond({"detail": f"'{role_name}' is not a known role."}, status=404)
 
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(UserRoleUser)):
             role.users.remove(user)
             audit_logger.info(
                 "user.remove-role",

--- a/src/sentry/api/endpoints/userroles_index.py
+++ b/src/sentry/api/endpoints/userroles_index.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -44,7 +44,7 @@ class UserRolesEndpoint(Endpoint):
 
         result = validator.validated_data
         try:
-            with transaction.atomic():
+            with transaction.atomic(using=router.db_for_write(UserRole)):
                 role = UserRole.objects.create(
                     name=result["name"], permissions=result.get("permissions") or []
                 )


### PR DESCRIPTION
As we move towards a split database in CI and eventually production we need to ensure that our transactions continue to behave correctly. Because control silo tables will be on a non-default connection we need to be explicit about the connection being used.

Refs HC-771