### PR TITLE
feat(escalating): Use resolved badge instead of strikethrough

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -95,10 +95,14 @@ function EventOrGroupHeader({
   function getTitle() {
     const {id, status} = data as Group;
     const {eventID, groupID} = data as Event;
+    const hasEscalatingIssues = organization.features.includes('escalating-issues');
 
     const commonEleProps = {
       'data-test-id': status === 'resolved' ? 'resolved-issue' : null,
-      style: status === 'resolved' ? {textDecoration: 'line-through'} : undefined,
+      style:
+        status === 'resolved' && !hasEscalatingIssues
+          ? {textDecoration: 'line-through'}
+          : undefined,
     };
 
     if (isTombstone(data)) {

--- a/static/app/components/group/inboxBadges/statusBadge.spec.tsx
+++ b/static/app/components/group/inboxBadges/statusBadge.spec.tsx
@@ -41,4 +41,8 @@ describe('GroupStatusBadge', () => {
     );
     expect(screen.getByText('Regressed')).toBeInTheDocument();
   });
+  it('should display resolved', () => {
+    render(<GroupStatusBadge status={ResolutionStatus.UNRESOLVED} />);
+    expect(screen.getByText('Regressed')).toBeInTheDocument();
+  });
 });

--- a/static/app/components/group/inboxBadges/statusBadge.spec.tsx
+++ b/static/app/components/group/inboxBadges/statusBadge.spec.tsx
@@ -42,7 +42,7 @@ describe('GroupStatusBadge', () => {
     expect(screen.getByText('Regressed')).toBeInTheDocument();
   });
   it('should display resolved', () => {
-    render(<GroupStatusBadge status={ResolutionStatus.UNRESOLVED} />);
-    expect(screen.getByText('Regressed')).toBeInTheDocument();
+    render(<GroupStatusBadge status={ResolutionStatus.RESOLVED} />);
+    expect(screen.getByText('Resolved')).toBeInTheDocument();
   });
 });

--- a/static/app/components/group/inboxBadges/statusBadge.tsx
+++ b/static/app/components/group/inboxBadges/statusBadge.tsx
@@ -16,7 +16,7 @@ function getBadgeProperties(
 ): {status: string; tagType: keyof Theme['tag']; tooltip?: string} | undefined {
   if (status === 'resolved') {
     return {
-      tagType: 'default',
+      tagType: 'highlight',
       status: t('Resolved'),
     };
   }

--- a/static/app/components/group/inboxBadges/statusBadge.tsx
+++ b/static/app/components/group/inboxBadges/statusBadge.tsx
@@ -6,14 +6,20 @@ import {Group, GroupSubstatus} from 'sentry/types';
 
 interface SubstatusBadgeProps {
   status: Group['status'];
-  substatus: Group['substatus'];
   fontSize?: 'sm' | 'md';
+  substatus?: Group['substatus'];
 }
 
 function getBadgeProperties(
   status: Group['status'],
   substatus: Group['substatus']
 ): {status: string; tagType: keyof Theme['tag']; tooltip?: string} | undefined {
+  if (status === 'resolved') {
+    return {
+      tagType: 'default',
+      status: t('Resolved'),
+    };
+  }
   if (status === 'unresolved') {
     if (substatus === GroupSubstatus.REGRESSED) {
       return {


### PR DESCRIPTION
![image](https://github.com/getsentry/sentry/assets/1400464/96a29a7d-19da-4db2-a33f-220f7489db7d)

fixes #49657