### PR TITLE
feat(starfish): Add per second unit to y axes of throughput charts

### DIFF
--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -92,6 +92,8 @@ export function axisLabelFormatterUsingAggregateOutputType(
       return axisDuration(value, durationUnit);
     case 'size':
       return formatBytesBase2(value, 0);
+    case 'rate':
+      return `${value}/s`;
     default:
       return value.toString();
   }

--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -9,6 +9,7 @@ import {
   DAY,
   formatAbbreviatedNumber,
   formatPercentage,
+  formatRate,
   getDuration,
   HOUR,
   MINUTE,
@@ -93,7 +94,7 @@ export function axisLabelFormatterUsingAggregateOutputType(
     case 'size':
       return formatBytesBase2(value, 0);
     case 'rate':
-      return `${value}/s`;
+      return formatRate(value);
     default:
       return value.toString();
   }

--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -64,13 +64,15 @@ export function axisLabelFormatter(
   value: number,
   outputType: AggregationOutputType,
   abbreviation: boolean = false,
-  durationUnit?: number
+  durationUnit?: number,
+  rateUnit?: 's' | 'min' | 'hr'
 ): string {
   return axisLabelFormatterUsingAggregateOutputType(
     value,
     outputType,
     abbreviation,
-    durationUnit
+    durationUnit,
+    rateUnit
   );
 }
 
@@ -81,7 +83,8 @@ export function axisLabelFormatterUsingAggregateOutputType(
   value: number,
   type: string,
   abbreviation: boolean = false,
-  durationUnit?: number
+  durationUnit?: number,
+  rateUnit?: 's' | 'min' | 'hr'
 ): string {
   switch (type) {
     case 'integer':
@@ -94,7 +97,7 @@ export function axisLabelFormatterUsingAggregateOutputType(
     case 'size':
       return formatBytesBase2(value, 0);
     case 'rate':
-      return formatRate(value);
+      return formatRate(value, rateUnit);
     default:
       return value.toString();
   }

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -504,7 +504,7 @@ export type AggregationKeyWithAlias = `${AggregationKey}` | keyof typeof ALIASES
 
 export type AggregationOutputType = Extract<
   ColumnType,
-  'number' | 'integer' | 'date' | 'duration' | 'percentage' | 'string' | 'size'
+  'number' | 'integer' | 'date' | 'duration' | 'percentage' | 'string' | 'size' | 'rate'
 >;
 
 export type PlotType = 'bar' | 'line' | 'area';

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -129,6 +129,7 @@ export enum FieldValueType {
   STRING = 'string',
   NEVER = 'never',
   SIZE = 'size',
+  RATE = 'rate',
 }
 
 export enum WebVital {

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -298,3 +298,15 @@ export function formatAbbreviatedNumber(number: number | string) {
 
   return number.toLocaleString();
 }
+
+export function formatRate(value: number) {
+  if (value < 1 && value > 0) {
+    return `${value * 60}/m`;
+  }
+
+  if (value < 0.01 && value > 0) {
+    return `${value * 60 * 60}/hr`;
+  }
+
+  return `${value}/s`;
+}

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -299,14 +299,6 @@ export function formatAbbreviatedNumber(number: number | string) {
   return number.toLocaleString();
 }
 
-export function formatRate(value: number) {
-  if (value < 1 && value > 0) {
-    return `${value * 60}/m`;
-  }
-
-  if (value < 0.01 && value > 0) {
-    return `${value * 60 * 60}/hr`;
-  }
-
-  return `${value}/s`;
+export function formatRate(value: number, rateUnit?: string) {
+  return `${value}/${rateUnit ?? 's'}`;
 }

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -57,7 +57,7 @@ type Props = {
   start: DateString;
   statsPeriod: string | null | undefined;
   utc: boolean;
-  aggregateOutputFormat?: 'number' | 'percentage' | 'duration';
+  aggregateOutputFormat?: AggregationOutputType;
   chartColors?: string[];
   chartGroup?: string;
   definedAxisTicks?: number;

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -135,6 +135,7 @@ function SpanSummaryPage({params, location}: Props) {
                         chartColors={[THROUGHPUT_COLOR]}
                         isLineChart
                         definedAxisTicks={4}
+                        aggregateOutputFormat="rate"
                         tooltipFormatterOptions={{
                           valueFormatter: value => formatThroughput(value),
                         }}

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -151,6 +151,7 @@ function ThroughputChart({moduleName, filters}: ChartProps): JSX.Element {
         bottom: '0',
       }}
       definedAxisTicks={4}
+      aggregateOutputFormat="rate"
       stacked
       isLineChart
       chartColors={[THROUGHPUT_COLOR]}

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -134,6 +134,7 @@ export default function EndpointOverview() {
                 definedAxisTicks={2}
                 disableXAxis
                 chartColors={[THROUGHPUT_COLOR]}
+                aggregateOutputFormat="rate"
                 grid={{
                   left: '8px',
                   right: '0',

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -66,9 +66,14 @@ export function StarfishView(props: BasePerformanceViewProps) {
         dataset={DiscoverDatasets.METRICS}
       >
         {({loading, results}) => {
-          if (!results || !results[1]) {
+          if (!results || !results[0] || !results[1]) {
             return null;
           }
+
+          const throughputData: Series = {
+            seriesName: t('Throughput'),
+            data: results[0].data,
+          };
 
           const errorsData: Series = {
             seriesName: t('Errors (5XXs)'),
@@ -82,7 +87,7 @@ export function StarfishView(props: BasePerformanceViewProps) {
                 <Chart
                   statsPeriod={eventView.statsPeriod}
                   height={80}
-                  data={[results[0]]}
+                  data={[throughputData]}
                   start=""
                   end=""
                   loading={loading}

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -98,6 +98,7 @@ export function StarfishView(props: BasePerformanceViewProps) {
                     top: '8px',
                     bottom: '0',
                   }}
+                  aggregateOutputFormat="rate"
                   definedAxisTicks={2}
                   stacked
                   chartColors={theme.charts.getColorPalette(2)}


### PR DESCRIPTION
Adds `/s` for the throughput charts throughout the app

![image](https://github.com/getsentry/sentry/assets/16740047/3686eea9-849b-4166-8efd-97709015e16e)
