### PR TITLE
chore(github-comments): add even more loggers

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -36,10 +36,19 @@ logger = logging.getLogger(__name__)
 def queue_comment_task_if_needed(commit: Commit, group_owner: GroupOwner):
     from sentry.tasks.integrations.github.pr_comment import comment_workflow
 
+    logger.info(
+        "github.pr_comment.queue_comment_check",
+        extra={"organization_id": commit.organization_id, "merge_commit_sha": commit.key},
+    )
+
     pr_query = PullRequest.objects.filter(
         organization_id=commit.organization_id, merge_commit_sha=commit.key
     )
     if not pr_query.exists():
+        logger.info(
+            "github.pr_comment.queue_comment_task_missing_pr",
+            extra={"organization_id": commit.organization_id, "merge_commit_sha": commit.key},
+        )
         return
     pr = pr_query.get()
     if pr.date_added >= datetime.now(tz=timezone.utc) - timedelta(days=30) and (
@@ -48,7 +57,7 @@ def queue_comment_task_if_needed(commit: Commit, group_owner: GroupOwner):
     ):
         # TODO: Debouncing Logic
         logger.info(
-            "github.pr_comment.queue_comment_task",
+            "github.pr_comment.queue_comment_workflow",
             extra={"pullrequest_id": pr.id, "project_id": group_owner.project_id},
         )
         comment_workflow.delay(pullrequest_id=pr.id, project_id=group_owner.project_id)
@@ -300,9 +309,18 @@ def process_commit_context(
             )
 
             if features.has("organizations:pr-comment-bot", project.organization):
+                logger.info(
+                    "github.pr_comment",
+                    extra={"organization_id": project.organization_id},
+                )
                 repo = Repository.objects.filter(id=commit.repository_id)
                 if repo.exists() and repo.get().provider == "integrations:github":
                     queue_comment_task_if_needed(commit, group_owner)
+                else:
+                    logger.info(
+                        "github.pr_comment.incorrect_repo_config",
+                        extra={"organization_id": project.organization_id},
+                    )
 
             if created:
                 # If owners exceeds the limit, delete the oldest one.


### PR DESCRIPTION
Add even more loggers. We might not even be hitting the code block in `process_commit_context` to kick off creating a comment.