### PR TITLE
feat(escalating): Add an unarchive button to issues stream

### DIFF
--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -4,6 +4,7 @@ import {useTheme} from '@emotion/react';
 import ActionLink from 'sentry/components/actions/actionLink';
 import ArchiveActions from 'sentry/components/actions/archive';
 import IgnoreActions from 'sentry/components/actions/ignore';
+import {Button} from 'sentry/components/button';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu, MenuItemProps} from 'sentry/components/dropdownMenu';
 import {IconEllipsis} from 'sentry/icons';
@@ -195,6 +196,22 @@ function ActionSet({
 
   return (
     <Fragment>
+      {hasEscalatingIssuesUi && query.includes('is:archived') ? (
+        <Button
+          size="xs"
+          onClick={() => {
+            openConfirmModal({
+              bypass: !onShouldConfirm(ConfirmAction.UNRESOLVE),
+              onConfirm: () => onUpdate({status: ResolutionStatus.UNRESOLVED}),
+              message: confirm({action: ConfirmAction.UNRESOLVE, canBeUndone: true}),
+              confirmText: label('unarchive'),
+            });
+          }}
+          disabled={!anySelected}
+        >
+          {t('Unarchive')}
+        </Button>
+      ) : null}
       {hasEscalatingIssuesUi ? (
         <ArchiveActions
           onUpdate={onUpdate}

--- a/static/app/views/issueList/actions/index.spec.jsx
+++ b/static/app/views/issueList/actions/index.spec.jsx
@@ -282,6 +282,29 @@ describe('IssueListActions', function () {
     );
   });
 
+  it('can unarchive an issue when the query contains is:archived', async () => {
+    const org_escalating = {...organization, features: ['escalating-issues']};
+    const apiMock = MockApiClient.addMockResponse({
+      url: `/organizations/${org_escalating.slug}/issues/`,
+      method: 'PUT',
+    });
+    jest.spyOn(SelectedGroupStore, 'getSelectedIds').mockReturnValue(new Set(['1']));
+
+    render(<WrappedComponent {...defaultProps} query="is:archived" />, {
+      organization: org_escalating,
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Unarchive'}));
+
+    expect(apiMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({id: ['1'], project: [1]}),
+        data: {status: 'unresolved'},
+      })
+    );
+  });
+
   it('can resolve but not merge issues from different projects', function () {
     jest
       .spyOn(SelectedGroupStore, 'getSelectedIds')


### PR DESCRIPTION
Adds an unarchive button when searching for a query containing `is:archived`

fixes #50005

![image](https://github.com/getsentry/sentry/assets/1400464/c118ec18-1303-4b81-b485-6806b4347b14)
