### PR TITLE
fix(workflow): Remove unused `rule-page` flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1386,8 +1386,6 @@ SENTRY_FEATURES = {
     "organizations:grouping-title-ui": False,
     # Lets organizations manage grouping configs
     "organizations:set-grouping-config": False,
-    # Enable rule page.
-    "organizations:rule-page": False,
     # Enable incidents feature
     "organizations:incidents": False,
     # Enable issue platform

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -162,7 +162,6 @@ default_manager.add("organizations:release-comparison-performance", Organization
 default_manager.add("organizations:release-health-drop-sessions", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:reprocessing-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:required-email-verification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:rule-page", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:sandbox-kill-switch", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:scim-team-roles", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:org-roles-for-teams", OrganizationFeature, FeatureHandlerStrategy.REMOTE)


### PR DESCRIPTION
No longer used. seems to be from this project a long time ago https://www.notion.so/Rule-Page-previously-Audit-Page-Design-Doc-81108939d0f847938385942a16d1305d

