### PR TITLE
feat(hybrid-cloud): Implement `get_region_for_organization`

### DIFF
--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -12,7 +12,7 @@ def _request_should_be_proxied(request: Request, view_func, view_kwargs) -> bool
         return False
     view_class = getattr(view_func, "view_class", None)
     current_silo_mode = SiloMode.get_current_mode()
-    if current_silo_mode != SiloMode.MONOLITH and view_class is not None:
+    if current_silo_mode == SiloMode.CONTROL and view_class is not None:
         endpoint_silo_limit = getattr(view_class, "silo_limit", None)
         if endpoint_silo_limit is not None:
             endpoint_silo_set = endpoint_silo_limit.modes

--- a/src/sentry/api_gateway/proxy.py
+++ b/src/sentry/api_gateway/proxy.py
@@ -1,6 +1,7 @@
 """
 Utilities related to proxying a request to a region silo
 """
+import logging
 from wsgiref.util import is_hop_by_hop
 
 from django.conf import settings
@@ -8,6 +9,7 @@ from django.http import StreamingHttpResponse
 from requests import Response as ExternalResponse
 from requests import request as external_request
 from requests.exceptions import Timeout
+from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 
 from sentry.api.exceptions import RequestTimeout
@@ -16,6 +18,9 @@ from sentry.silo.util import (
     clean_outbound_headers,
     clean_proxy_headers,
 )
+from sentry.types.region import RegionResolutionError
+
+logger = logging.getLogger(__name__)
 
 # stream 0.5 MB at a time
 PROXY_CHUNK_SIZE = 512 * 1024
@@ -47,7 +52,13 @@ def proxy_request(request: Request, org_slug: str) -> StreamingHttpResponse:
     """Take a django request object and proxy it to a remote location given an org_slug"""
     from sentry.types.region import get_region_for_organization
 
-    target_url = get_region_for_organization(org_slug).to_url(request.path)
+    try:
+        region = get_region_for_organization(org_slug)
+    except RegionResolutionError:
+        logger.info("region_resolution_error", extra={"org_slug": org_slug})
+        raise NotFound
+
+    target_url = region.to_url(request.path)
     header_dict = clean_proxy_headers(request.headers)
     # TODO: use requests session for connection pooling capabilities
     query_params = getattr(request, request.method, None)

--- a/src/sentry/api_gateway/proxy.py
+++ b/src/sentry/api_gateway/proxy.py
@@ -47,7 +47,7 @@ def proxy_request(request: Request, org_slug: str) -> StreamingHttpResponse:
     """Take a django request object and proxy it to a remote location given an org_slug"""
     from sentry.types.region import get_region_for_organization
 
-    target_url = get_region_for_organization(None).to_url(request.path)
+    target_url = get_region_for_organization(org_slug).to_url(request.path)
     header_dict = clean_proxy_headers(request.headers)
     # TODO: use requests session for connection pooling capabilities
     query_params = getattr(request, request.method, None)

--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -172,4 +172,4 @@ class BaseRequestParser(abc.ABC):
             logger.error("no_organizations", extra={"path": self.request.path})
             return []
 
-        return [get_region_for_organization(organization) for organization in organizations]
+        return [get_region_for_organization(organization.slug) for organization in organizations]

--- a/src/sentry/testutils/helpers/api_gateway.py
+++ b/src/sentry/testutils/helpers/api_gateway.py
@@ -9,8 +9,9 @@ from rest_framework.response import Response
 
 from sentry.api.base import control_silo_endpoint, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.testutils import APITestCase
-from sentry.types.region import Region, RegionCategory
+from sentry.types.region import Region, RegionCategory, clear_global_regions
 from sentry.utils import json
 
 SENTRY_REGION_CONFIG = [
@@ -116,6 +117,7 @@ def provision_middleware():
 class ApiGatewayTestCase(APITestCase):
     def setUp(self):
         super().setUp()
+        clear_global_regions()
         responses.add(
             responses.GET,
             "http://region1.testserver/get",
@@ -130,6 +132,9 @@ class ApiGatewayTestCase(APITestCase):
             status=400,
             content_type="application/json",
             adding_headers={"test": "header"},
+        )
+        OrganizationMapping.objects.get(organization_id=self.organization.id).update(
+            region_name="region1"
         )
 
         # Echos the request body and header back for verification

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -152,17 +152,8 @@ def get_region_by_name(name: str) -> Region:
 
 @control_silo_function
 def get_region_for_organization(organization_slug: str) -> Region:
+    """Resolve an organization to the region where its data is stored."""
     from sentry.models.organizationmapping import OrganizationMapping
-
-    """Resolve an organization to the region where its data is stored.
-
-    Raises RegionContextError if this Sentry platform instance is configured to
-    run only in monolith mode.
-    """
-    directory = load_global_regions()
-
-    if not directory.regions:
-        raise RegionContextError("No regions are configured")
 
     mapping = OrganizationMapping.objects.filter(slug=organization_slug).first()
     if not mapping:

--- a/tests/sentry/api_gateway/test_proxy.py
+++ b/tests/sentry/api_gateway/test_proxy.py
@@ -1,4 +1,3 @@
-from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytest
@@ -10,7 +9,6 @@ from rest_framework.exceptions import NotFound
 from sentry.api_gateway.proxy import proxy_request
 from sentry.silo.util import INVALID_OUTBOUND_HEADERS, PROXY_DIRECT_LOCATION_HEADER
 from sentry.testutils.helpers.api_gateway import (
-    SENTRY_REGION_CONFIG,
     ApiGatewayTestCase,
     verify_file_body,
     verify_request_body,
@@ -19,10 +17,9 @@ from sentry.testutils.helpers.api_gateway import (
 from sentry.utils import json
 
 
-@patch("sentry.types.region.get_region_for_organization", return_value=SENTRY_REGION_CONFIG[0])
 class ProxyTestCase(ApiGatewayTestCase):
     @responses.activate
-    def test_simple(self, _):
+    def test_simple(self):
         request = RequestFactory().get("http://sentry.io/get")
         resp = proxy_request(request, self.organization.slug)
         resp_json = json.loads(b"".join(resp.streaming_content))
@@ -44,7 +41,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region1.testserver/error"
 
     @responses.activate
-    def test_query_params(self, _):
+    def test_query_params(self):
 
         query_param_dict = dict(foo="bar", numlist=["1", "2", "3"])
         query_param_str = urlencode(query_param_dict, doseq=True)
@@ -58,15 +55,14 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert query_param_dict["foo"] == resp_json["foo"][0]
         assert query_param_dict["numlist"] == resp_json["numlist"]
 
-    @pytest.mark.xfail(reason="Uncommitted to Organization Table Location")
     @responses.activate
-    def test_bad_org(self, _):
+    def test_bad_org(self):
         request = RequestFactory().get("http://sentry.io/get")
         with pytest.raises(NotFound):
             proxy_request(request, "doesnotexist")
 
     @responses.activate
-    def test_post(self, _):
+    def test_post(self):
         request_body = {"foo": "bar", "nested": {"int_list": [1, 2, 3]}}
         responses.add_callback(
             responses.POST,
@@ -86,7 +82,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region1.testserver/post"
 
     @responses.activate
-    def test_put(self, _):
+    def test_put(self):
         request_body = {"foo": "bar", "nested": {"int_list": [1, 2, 3]}}
         responses.add_callback(
             responses.PUT,
@@ -106,7 +102,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region1.testserver/put"
 
     @responses.activate
-    def test_patch(self, _):
+    def test_patch(self):
         request_body = {"foo": "bar", "nested": {"int_list": [1, 2, 3]}}
         responses.add_callback(
             responses.PATCH,
@@ -126,7 +122,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region1.testserver/patch"
 
     @responses.activate
-    def test_head(self, _):
+    def test_head(self):
         request_body = {"foo": "bar", "nested": {"int_list": [1, 2, 3]}}
         responses.add_callback(
             responses.HEAD,
@@ -146,7 +142,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region1.testserver/head"
 
     @responses.activate
-    def test_delete(self, _):
+    def test_delete(self):
         request_body = {"foo": "bar", "nested": {"int_list": [1, 2, 3]}}
         responses.add_callback(
             responses.DELETE,
@@ -166,7 +162,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region1.testserver/delete"
 
     @responses.activate
-    def test_file_upload(self, _):
+    def test_file_upload(self):
         foo = dict(test="a", file="b", what="c")
         contents = json.dumps(foo).encode()
         request_body = {
@@ -189,7 +185,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp_json["proxy"]
 
     @responses.activate
-    def test_alternate_content_type(self, _):
+    def test_alternate_content_type(self):
         # Check form encoded files also work
         foo = dict(test="a", file="b", what="c")
         contents = urlencode(foo, doseq=True).encode("utf-8")
@@ -211,7 +207,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp_json["proxy"]
 
     @responses.activate
-    def test_strip_request_headers(self, _):
+    def test_strip_request_headers(self):
         request_body = {"foo": "bar", "nested": {"int_list": [1, 2, 3]}}
         responses.add_callback(
             responses.POST,


### PR DESCRIPTION
This PR implements the `get_region_for_organization` method using the `OrganizationMapping` table. It depends on the `slug` and updates the callsites to reflect this.