### PR TITLE
ref(HC): Updates outbox scheduling to favor newer message schedule, clamp backoff delay

### DIFF
--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -8,7 +8,7 @@ from enum import IntEnum
 from typing import Any, Generator, Iterable, List, Mapping, Type, TypeVar
 
 from django.db import connections, models, router, transaction
-from django.db.models import Max
+from django.db.models import Max, Min
 from django.dispatch import Signal
 from django.http import HttpRequest
 from django.utils import timezone
@@ -113,7 +113,7 @@ class OutboxBase(Model):
         return (
             cls.objects.values(*cls.sharding_columns)
             .annotate(
-                scheduled_for=Max("scheduled_for"),
+                scheduled_for=Min("scheduled_for"),
                 id=Max("id"),
             )
             .filter(scheduled_for__lte=timezone.now())
@@ -174,7 +174,10 @@ class OutboxBase(Model):
     scheduled_for = models.DateTimeField(null=False, default=THE_PAST)
 
     def last_delay(self) -> datetime.timedelta:
-        return max(self.scheduled_for - self.scheduled_from, datetime.timedelta(seconds=1))
+        return min(
+            max(self.scheduled_for - self.scheduled_from, datetime.timedelta(seconds=1)),
+            datetime.timedelta(hours=1),
+        )
 
     def next_schedule(self, now: datetime.datetime) -> datetime.datetime:
         return now + (self.last_delay() * 2)

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -4,6 +4,7 @@ from typing import ContextManager
 from unittest.mock import call, patch
 
 import pytest
+import pytz
 import responses
 from django.conf import settings
 from django.test import RequestFactory
@@ -339,8 +340,10 @@ class RegionOutboxTest(TestCase):
                 assert_called_for_org(10001)
                 ensure_converged()
 
-                # Concurrently added items still follow the largest retry schedule
+                # Concurrently added items will favor a newer scheduling time,
+                # but eventually converges.
                 Organization.outbox_for_update(10002).save()
+                run_with_error()
                 ensure_converged()
 
     def test_outbox_converges(self):
@@ -379,3 +382,48 @@ class RegionOutboxTest(TestCase):
             (OutboxScope.ORGANIZATION_SCOPE.value, org1.id),
             (OutboxScope.ORGANIZATION_SCOPE.value, org2.id),
         }
+
+    def test_scheduling_with_future_outbox_time(self):
+        with outbox_runner():
+            pass
+
+        start_time = datetime(year=2022, month=10, day=1, second=0, tzinfo=pytz.UTC)
+        with freeze_time(start_time):
+            future_scheduled_outbox = Organization.outbox_for_update(org_id=10001)
+            future_scheduled_outbox.scheduled_for = start_time + timedelta(hours=1)
+            future_scheduled_outbox.save()
+            assert future_scheduled_outbox.scheduled_for > start_time
+
+            assert RegionOutbox.find_scheduled_shards().count() == 0  # type: ignore
+
+            with outbox_runner():
+                pass
+
+            # We expect the shard to be drained if at *least* one scheduled
+            # message is in the past.
+            assert RegionOutbox.objects.count() == 1
+
+    def test_scheduling_with_past_and_future_outbox_times(self):
+        with outbox_runner():
+            pass
+
+        start_time = datetime(year=2022, month=10, day=1, second=0, tzinfo=pytz.UTC)
+        with freeze_time(start_time):
+            future_scheduled_outbox = Organization.outbox_for_update(org_id=10001)
+            future_scheduled_outbox.scheduled_for = start_time + timedelta(hours=1)
+            future_scheduled_outbox.save()
+            assert future_scheduled_outbox.scheduled_for > start_time
+
+            past_scheduled_outbox = Organization.outbox_for_update(org_id=10001)
+            past_scheduled_outbox.save()
+            assert past_scheduled_outbox.scheduled_for < start_time
+            assert RegionOutbox.objects.count() == 2
+
+            assert RegionOutbox.find_scheduled_shards().count() == 1  # type: ignore
+
+            with outbox_runner():
+                pass
+
+            # We expect the shard to be drained if at *least* one scheduled
+            # message is in the past.
+            assert RegionOutbox.objects.count() == 0

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -393,14 +393,15 @@ class RegionOutboxTest(TestCase):
             future_scheduled_outbox.scheduled_for = start_time + timedelta(hours=1)
             future_scheduled_outbox.save()
             assert future_scheduled_outbox.scheduled_for > start_time
+            assert RegionOutbox.objects.count() == 1
 
             assert RegionOutbox.find_scheduled_shards().count() == 0  # type: ignore
 
             with outbox_runner():
                 pass
 
-            # We expect the shard to be drained if at *least* one scheduled
-            # message is in the past.
+            # Since the event is sometime in the future, we expect the single
+            #  outbox message not to be processed
             assert RegionOutbox.objects.count() == 1
 
     def test_scheduling_with_past_and_future_outbox_times(self):


### PR DESCRIPTION
We ran into a couple issues surrounding failed outbox message queueing:
1. Failure backoffs have no maximum, allowing them to become increasingly long.
2. Correcting a failed outbox condition will not allow a newer message to be scheduled for an extended period of time if multiple previous failures have occurred.

This PR:
1. Changes the outbox maximum backoff to an hour per shard which seems reasonable without creating too much churn.
2. Favors a newly scheduled outbox message for more optimistic scheduling which may create allow for more churn to do failures, but will ensure that backfills or correcting outboxes are processed immediately.


