### PR TITLE
feat(search): Add feature logic for assigned_or_suggested

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -25,6 +25,7 @@ from sentry.search.events.constants import EQUALITY_OPERATORS, INEQUALITY_OPERAT
 from sentry.search.events.filter import to_list
 from sentry.search.utils import (
     DEVICE_CLASS,
+    get_teams_for_user,
     parse_actor_or_none_value,
     parse_release,
     parse_status_value,
@@ -81,14 +82,22 @@ ValueConverter = Callable[
 
 
 def convert_actor_or_none_value(
-    value: Iterable[Union[User, Team]],
+    value: Iterable[str],
     projects: Sequence[Project],
     user: User,
     environments: Optional[Sequence[Environment]],
 ) -> List[Optional[Union[User, Team]]]:
     # TODO: This will make N queries. This should be ok, we don't typically have large
     # lists of actors here, but we can look into batching it if needed.
-    return [parse_actor_or_none_value(projects, actor, user) for actor in value]
+    actors_or_none = []
+    for actor in value:
+        if actor == "my_teams":
+            # get teams
+            actors_or_none.extend(get_teams_for_user(projects, user))
+        else:
+            # normal behavior
+            actors_or_none.append(parse_actor_or_none_value(projects, actor, user))
+    return actors_or_none
 
 
 def convert_user_value(

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -92,10 +92,8 @@ def convert_actor_or_none_value(
     actors_or_none = []
     for actor in value:
         if actor == "my_teams":
-            # get teams
             actors_or_none.extend(get_teams_for_user(projects, user))
         else:
-            # normal behavior
             actors_or_none.append(parse_actor_or_none_value(projects, actor, user))
     return actors_or_none
 

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -25,7 +25,7 @@ from sentry.search.events.constants import EQUALITY_OPERATORS, INEQUALITY_OPERAT
 from sentry.search.events.filter import to_list
 from sentry.search.utils import (
     DEVICE_CLASS,
-    get_teams_for_user,
+    get_teams_for_users,
     parse_actor_or_none_value,
     parse_release,
     parse_status_value,
@@ -92,7 +92,7 @@ def convert_actor_or_none_value(
     actors_or_none = []
     for actor in value:
         if actor == "my_teams":
-            actors_or_none.extend(get_teams_for_user(projects, user))
+            actors_or_none.extend(get_teams_for_users(projects, [user]))
         else:
             actors_or_none.append(parse_actor_or_none_value(projects, actor, user))
     return actors_or_none

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -228,15 +228,10 @@ def assigned_or_suggested_filter(
                 ).values("team")
             ).values_list("id", flat=True)
         )
-        organization = projects[0].organization
-        query_ids = Q(user_id__in=user_ids)
-        # Only add team_ids to query if assign-to-me flag is off
-        if not features.has("organizations:assign-to-me", organization, actor=None):
-            query_ids = query_ids | Q(team_id__in=team_ids)
         owned_by_me = Q(
             **{
                 f"{field_filter}__in": GroupOwner.objects.filter(
-                    query_ids,
+                    Q(user_id__in=user_ids) | Q(team_id__in=team_ids),
                     group__assignee_set__isnull=True,
                     project_id__in=[p.id for p in projects],
                     organization_id=organization_id,

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -228,10 +228,15 @@ def assigned_or_suggested_filter(
                 ).values("team")
             ).values_list("id", flat=True)
         )
+        organization = projects[0].organization
+        query_ids = Q(user_id__in=user_ids)
+        # Only add team_ids to query if assign-to-me flag is off
+        if not features.has("organizations:assign-to-me", organization, actor=None):
+            query_ids = query_ids | Q(team_id__in=team_ids)
         owned_by_me = Q(
             **{
                 f"{field_filter}__in": GroupOwner.objects.filter(
-                    Q(user_id__in=user_ids) | Q(team_id__in=team_ids),
+                    query_ids,
                     group__assignee_set__isnull=True,
                     project_id__in=[p.id for p in projects],
                     organization_id=organization_id,

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -238,10 +238,15 @@ def assigned_or_suggested_filter(
                 ).values("team")
             ).values_list("id", flat=True)
         )
+        organization = projects[0].organization
+        query_ids = Q(user_id__in=user_ids)
+        # Only add team_ids to query if assign-to-me flag is off
+        if not features.has("organizations:assign-to-me", organization, actor=None):
+            query_ids = query_ids | Q(team_id__in=team_ids)
         owned_by_me = Q(
             **{
                 f"{field_filter}__in": GroupOwner.objects.filter(
-                    Q(user_id__in=user_ids) | Q(team_id__in=team_ids),
+                    query_ids,
                     group__assignee_set__isnull=True,
                     project_id__in=[p.id for p in projects],
                     organization_id=organization_id,

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -87,7 +87,7 @@ def assigned_to_filter(
                     f"{field_filter}__in": GroupAssignee.objects.filter(
                         project_id__in=[p.id for p in projects],
                         team_id__in=[team.id for team in get_teams_for_user()],
-                    ).values_list("group_id", flat=True)
+                    )
                 }
             )
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -25,8 +25,6 @@ from sentry.models import (
     GroupOwner,
     GroupStatus,
     GroupSubscription,
-    OrganizationMember,
-    OrganizationMemberTeam,
     PlatformExternalIssue,
     Project,
     Release,
@@ -228,20 +226,10 @@ def assigned_or_suggested_filter(
     if "User" in types_to_owners:
         users = types_to_owners["User"]
         user_ids: List[int] = [u.id for u in users if u is not None]
-        team_ids = list(
-            Team.objects.filter(
-                id__in=OrganizationMemberTeam.objects.filter(
-                    organizationmember__in=OrganizationMember.objects.filter(
-                        user_id__in=user_ids, organization_id=organization_id
-                    ),
-                    is_active=True,
-                ).values("team")
-            ).values_list("id", flat=True)
-        )
         owned_by_me = Q(
             **{
                 f"{field_filter}__in": GroupOwner.objects.filter(
-                    Q(user_id__in=user_ids) | Q(team_id__in=team_ids),
+                    Q(user_id__in=user_ids),
                     group__assignee_set__isnull=True,
                     project_id__in=[p.id for p in projects],
                     organization_id=organization_id,

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -10,7 +10,7 @@ from django.db.models import Q, QuerySet
 from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
 
-from sentry import quotas
+from sentry import features, quotas
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import ErrorGroupType, GroupCategory, get_group_types_by_category
@@ -79,24 +79,27 @@ def assigned_to_filter(
                 ).values_list("group_id", flat=True)
             }
         )
-        query |= Q(
-            **{
-                f"{field_filter}__in": GroupAssignee.objects.filter(
-                    project_id__in=[p.id for p in projects],
-                    team_id__in=list(
-                        Team.objects.filter(
-                            id__in=OrganizationMemberTeam.objects.filter(
-                                organizationmember__in=OrganizationMember.objects.filter(
-                                    user_id__in=user_ids,
-                                    organization_id=projects[0].organization_id,
-                                ),
-                                is_active=True,
-                            ).values_list("team_id", flat=True)
-                        )
-                    ),
-                ).values_list("group_id", flat=True)
-            }
-        )
+        organization = projects[0].organization
+        # Only add teams to query if assign-to-me flag is off
+        if not features.has("organizations:assign-to-me", organization, actor=None):
+            query |= Q(
+                **{
+                    f"{field_filter}__in": GroupAssignee.objects.filter(
+                        project_id__in=[p.id for p in projects],
+                        team_id__in=list(
+                            Team.objects.filter(
+                                id__in=OrganizationMemberTeam.objects.filter(
+                                    organizationmember__in=OrganizationMember.objects.filter(
+                                        user_id__in=user_ids,
+                                        organization_id=projects[0].organization_id,
+                                    ),
+                                    is_active=True,
+                                ).values_list("team_id", flat=True)
+                            )
+                        ),
+                    ).values_list("group_id", flat=True)
+                }
+            )
 
     if include_none:
         query |= unassigned_filter(True, projects, field_filter=field_filter)

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -41,7 +41,7 @@ from sentry.search.snuba.executors import (
     PostgresSnubaQueryExecutor,
     PrioritySortWeights,
 )
-from sentry.search.utils import get_teams_for_user
+from sentry.search.utils import get_teams_for_users
 from sentry.utils.cursors import Cursor, CursorResult
 
 
@@ -86,8 +86,8 @@ def assigned_to_filter(
                 **{
                     f"{field_filter}__in": GroupAssignee.objects.filter(
                         project_id__in=[p.id for p in projects],
-                        team_id__in=[team.id for team in get_teams_for_user()],
-                    )
+                        team_id__in=[team for team in get_teams_for_users(projects, users)],
+                    ).values_list("group_id", flat=True)
                 }
             )
 

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -319,7 +319,7 @@ def parse_team_value(projects: Sequence[Project], value: Sequence[str], user: Us
 
 
 def get_teams_for_user(projects: Sequence[Project], user: User) -> list[Team]:
-    team_ids = Team.objects.filter(
+    teams = Team.objects.filter(
         id__in=OrganizationMemberTeam.objects.filter(
             organizationmember__in=OrganizationMember.objects.filter(
                 user_id__in=[user.id], organization_id=projects[0].organization_id
@@ -328,7 +328,7 @@ def get_teams_for_user(projects: Sequence[Project], user: User) -> list[Team]:
         ).values("team")
     )
 
-    return list(team_ids)
+    return list(teams)
 
 
 def parse_actor_value(projects: Sequence[Project], value: str, user: User) -> Union[User, Team]:

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -318,16 +318,16 @@ def parse_team_value(projects: Sequence[Project], value: Sequence[str], user: Us
     ).first() or Team(id=0)
 
 
-def get_teams_for_user(projects: Sequence[Project], user: User) -> list[Team]:
+def get_teams_for_users(projects: Sequence[Project], users: Sequence[User]) -> list[Team]:
+    user_ids = [u.id for u in users if u is not None]
     teams = Team.objects.filter(
         id__in=OrganizationMemberTeam.objects.filter(
             organizationmember__in=OrganizationMember.objects.filter(
-                user_id__in=[user.id], organization_id=projects[0].organization_id
+                user_id__in=user_ids, organization_id=projects[0].organization_id
             ),
             is_active=True,
         ).values("team")
     )
-
     return list(teams)
 
 

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -319,12 +319,10 @@ def parse_team_value(projects: Sequence[Project], value: Sequence[str], user: Us
 
 
 def get_teams_for_user(projects: Sequence[Project], user: User) -> list[Team]:
-    user_ids = [user.id]
-
     team_ids = Team.objects.filter(
         id__in=OrganizationMemberTeam.objects.filter(
             organizationmember__in=OrganizationMember.objects.filter(
-                user_id__in=user_ids, organization_id=projects[0].organization_id
+                user_id__in=[user.id], organization_id=projects[0].organization_id
             ),
             is_active=True,
         ).values("team")

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -24,8 +24,9 @@ from sentry.api.issue_search import (
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES, GroupStatus
+from sentry.search.utils import get_teams_for_user
 from sentry.testutils import TestCase
-from sentry.testutils.helpers.features import apply_feature_flag_on_cls
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls, with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
 
@@ -180,6 +181,38 @@ class ConvertJavaScriptConsoleTagTest(TestCase):
 
 @region_silo_test(stable=True)
 class ConvertQueryValuesTest(TestCase):
+    @with_feature("organizations:assign-to-me")
+    def test_valid_assign_me_converter(self):
+        filters = [SearchFilter(SearchKey("assigned_to"), "=", SearchValue("me"))]
+        expected = value_converters["assigned_to"](
+            [filters[0].value.raw_value], [self.project], self.user, None
+        )
+        filters = convert_query_values(filters, [self.project], self.user, None)
+        assert filters[0].value.raw_value == expected
+
+    @with_feature("organizations:assign-to-me")
+    def test_valid_assign_me_no_converter(self):
+        search_val = SearchValue("me")
+        filters = [SearchFilter(SearchKey("something"), "=", search_val)]
+        filters = convert_query_values(filters, [self.project], self.user, None)
+        assert filters[0].value.raw_value == search_val.raw_value
+
+    @with_feature("organizations:assign-to-me")
+    def test_valid_assign_my_teams_converter(self):
+        filters = [SearchFilter(SearchKey("assigned_to"), "=", SearchValue("my_teams"))]
+        expected = value_converters["assigned_to"](
+            [filters[0].value.raw_value], [self.project], self.user, None
+        )
+        filters = convert_query_values(filters, [self.project], self.user, None)
+        assert filters[0].value.raw_value == expected
+
+    @with_feature("organizations:assign-to-me")
+    def test_valid_assign_my_teams_no_converter(self):
+        search_val = SearchValue("my_teams")
+        filters = [SearchFilter(SearchKey("something"), "=", search_val)]
+        filters = convert_query_values(filters, [self.project], self.user, None)
+        assert filters[0].value.raw_value == search_val.raw_value
+
     def test_valid_converter(self):
         filters = [SearchFilter(SearchKey("assigned_to"), "=", SearchValue("me"))]
         expected = value_converters["assigned_to"](
@@ -308,6 +341,12 @@ class ConvertActorOrNoneValueTest(TestCase):
         assert convert_actor_or_none_value(
             ["me"], [self.project], self.user, None
         ) == convert_user_value(["me"], [self.project], self.user, None)
+
+    @with_feature("organizations:assign-to-me")
+    def test_my_team(self):
+        assert convert_actor_or_none_value(
+            ["my_teams"], [self.project], self.user, None
+        ) == get_teams_for_user([self.project], self.user)
 
     def test_none(self):
         assert convert_actor_or_none_value(["none"], [self.project], self.user, None) == [None]

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -24,7 +24,7 @@ from sentry.api.issue_search import (
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES, GroupStatus
-from sentry.search.utils import get_teams_for_user
+from sentry.search.utils import get_teams_for_users
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls, with_feature
 from sentry.testutils.silo import region_silo_test
@@ -346,7 +346,7 @@ class ConvertActorOrNoneValueTest(TestCase):
     def test_my_team(self):
         assert convert_actor_or_none_value(
             ["my_teams"], [self.project], self.user, None
-        ) == get_teams_for_user([self.project], self.user)
+        ) == get_teams_for_users([self.project], self.user)
 
     def test_none(self):
         assert convert_actor_or_none_value(["none"], [self.project], self.user, None) == [None]


### PR DESCRIPTION
Adds a feature flag (assign-to-me) to toggle whether to include a user's teams when querying for suggested issues with #me filter

This line was separated from https://github.com/getsentry/sentry/pull/51082 to reduce scope