### PR TITLE
fix(alerts): Prevent preview request from being cancelled

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -185,11 +185,13 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     return createFromDuplicate && location?.query.duplicateRuleId;
   }
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
+    super.componentDidMount();
     this.fetchPreview();
   }
 
   componentWillUnmount() {
+    super.componentWillUnmount();
     this.isUnmounted = true;
     GroupStore.reset();
     window.clearTimeout(this.pollingTimeout);


### PR DESCRIPTION
The request for the preview is being cancelled by AsyncComponent. It doesn't need to make the request before the component mounts.

fixes a bug with not correctly unmounting async component
