### PR TITLE
feat(crons): Add mouse-following timeline cursor

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
@@ -70,11 +70,11 @@ export function GridLineOverlay({end, timeWindow, width, showCursor}: Props) {
   const {cursorLabelFormat} = timeWindowData[timeWindow];
 
   const makeCursorText = useCallback(
-    (position: number) => {
+    (percentPosition: number) => {
       const start = getStartFromTimeWindow(end, timeWindow);
-      const timePosition = (end.getTime() - start.getTime()) * position;
+      const timeOffset = (end.getTime() - start.getTime()) * percentPosition;
 
-      return moment(start.getTime() + timePosition).format(cursorLabelFormat);
+      return moment(start.getTime() + timeOffset).format(cursorLabelFormat);
     },
     [cursorLabelFormat, end, timeWindow]
   );

--- a/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
@@ -1,3 +1,4 @@
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment';
 
@@ -9,10 +10,13 @@ import {
   timeWindowData,
 } from 'sentry/views/monitors/components/overviewTimeline/utils';
 
+import {useTimelineCursor} from './timelineCursor';
+
 interface Props {
   end: Date;
   timeWindow: TimeWindow;
   width: number;
+  showCursor?: boolean;
 }
 
 function clampTimeBasedOnResolution(date: moment.Moment, resolution: string) {
@@ -62,9 +66,27 @@ export function GridLineTimeLabels({end, timeWindow, width}: Props) {
   );
 }
 
-export function GridLineOverlay({end, timeWindow, width}: Props) {
+export function GridLineOverlay({end, timeWindow, width, showCursor}: Props) {
+  const {cursorLabelFormat} = timeWindowData[timeWindow];
+
+  const makeCursorText = useCallback(
+    (position: number) => {
+      const start = getStartFromTimeWindow(end, timeWindow);
+      const timePosition = (end.getTime() - start.getTime()) * position;
+
+      return moment(start.getTime() + timePosition).format(cursorLabelFormat);
+    },
+    [cursorLabelFormat, end, timeWindow]
+  );
+
+  const {cursorContainerRef, timelineCursor} = useTimelineCursor<HTMLDivElement>({
+    enabled: showCursor,
+    labelText: makeCursorText,
+  });
+
   return (
-    <Overlay>
+    <Overlay ref={cursorContainerRef}>
+      {timelineCursor}
       <GridLineContainer>
         {getTimeMarkers(end, timeWindow, width).map(({date, position}) => (
           <Gridline key={date.getTime()} left={position} />

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -91,6 +91,7 @@ export function OverviewTimeline({monitorList}: Props) {
         width={timelineWidth}
       />
       <GridLineOverlay
+        showCursor={!isLoading}
         timeWindow={timeWindow}
         end={nowRef.current}
         width={timelineWidth}

--- a/static/app/views/monitors/components/overviewTimeline/timelineCursor.spec.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineCursor.spec.tsx
@@ -1,0 +1,65 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from 'sentry-test/reactTestingLibrary';
+
+import {useTimelineCursor} from './timelineCursor';
+
+function TestComponent() {
+  const {timelineCursor, cursorContainerRef} = useTimelineCursor<HTMLDivElement>({
+    enabled: true,
+    labelText: p => p.toFixed(2),
+  });
+
+  return (
+    <div data-test-id="body">
+      <div data-test-id="container" ref={cursorContainerRef}>
+        {timelineCursor}
+      </div>
+    </div>
+  );
+}
+
+describe('TimelineCursor', function () {
+  it('renders', async function () {
+    render(<TestComponent />);
+
+    const body = screen.getByTestId('body');
+    const container = screen.getByTestId('container');
+
+    container.getBoundingClientRect = jest.fn(() => ({
+      x: 10,
+      y: 10,
+      width: 100,
+      height: 100,
+      left: 10,
+      top: 10,
+      right: 110,
+      bottom: 110,
+      toJSON: jest.fn(),
+    }));
+
+    // Cursor has not appeared
+    expect(screen.queryByRole('presentation')).not.toBeInTheDocument();
+
+    // Move cursor into the container, cursor is visible
+    fireEvent.mouseMove(body, {clientX: 20, clientY: 20});
+
+    const cursor = await screen.findByRole('presentation');
+    expect(cursor).toBeInTheDocument();
+
+    // Cursor is 10px into the container
+    waitFor(() => {
+      expect(container.style.getPropertyValue('--cursorOffset')).toBe('10px');
+      expect(container.style.getPropertyValue('--cursorMax')).toBe('100px');
+    });
+
+    // move cursor outside it is not visible
+    // Move cursor into the container, cursor is visible
+    fireEvent.mouseMove(body, {clientX: 120, clientY: 20});
+    await waitForElementToBeRemoved(() => screen.getByRole('presentation'));
+  });
+});

--- a/static/app/views/monitors/components/overviewTimeline/timelineCursor.spec.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineCursor.spec.tsx
@@ -58,7 +58,6 @@ describe('TimelineCursor', function () {
     });
 
     // move cursor outside it is not visible
-    // Move cursor into the container, cursor is visible
     fireEvent.mouseMove(body, {clientX: 120, clientY: 20});
     await waitForElementToBeRemoved(() => screen.getByRole('presentation'));
   });

--- a/static/app/views/monitors/components/overviewTimeline/timelineCursor.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineCursor.tsx
@@ -1,0 +1,139 @@
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+import {AnimatePresence, motion} from 'framer-motion';
+
+import {Overlay} from 'sentry/components/overlay';
+import {space} from 'sentry/styles/space';
+import testableTransition from 'sentry/utils/testableTransition';
+
+const TOOLTIP_OFFSET = 10;
+
+interface Options {
+  /**
+   * Function used to compute the text of the cursor tooltip. Recieves the %
+   * value the cursor is within the container.
+   */
+  labelText: (percentPosition: number) => string;
+  /**
+   * May be set to false to disable rendering the timeline cursor
+   */
+  enabled?: boolean;
+}
+
+function useTimelineCursor<E extends HTMLElement>({enabled = true, labelText}: Options) {
+  const rafIdRef = useRef<number | null>(null);
+
+  const containerRef = useRef<E>(null);
+  const labelRef = useRef<HTMLDivElement>(null);
+
+  const [isVisible, setIsVisible] = useState(false);
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (rafIdRef.current !== null) {
+        window.cancelAnimationFrame(rafIdRef.current);
+      }
+
+      if (containerRef.current === null) {
+        return;
+      }
+
+      const containerRect = containerRef.current.getBoundingClientRect();
+
+      // Instead of using onMouseEnter / onMouseLeave we check if the mouse is
+      // within the containerRect. This proves to be less glitchy as some
+      // elements within the container may trigger an onMouseLeave even when
+      // the mouse is still "inside" of the container
+      const isInsideContainer =
+        e.clientX > containerRect.left &&
+        e.clientX < containerRect.right &&
+        e.clientY > containerRect.top &&
+        e.clientY < containerRect.bottom;
+
+      if (isInsideContainer !== isVisible) {
+        setIsVisible(isInsideContainer);
+      }
+
+      rafIdRef.current = window.requestAnimationFrame(() => {
+        if (containerRef.current === null || labelRef.current === null) {
+          return;
+        }
+
+        const offset = e.clientX - containerRect.left;
+        const tooltipWidth = labelRef.current.offsetWidth;
+
+        labelRef.current.innerText = labelText(offset / containerRect.width);
+
+        containerRef.current.style.setProperty('--cursorOffset', `${offset}px`);
+        containerRef.current.style.setProperty('--cursorMax', `${containerRect.width}px`);
+        containerRef.current.style.setProperty('--cursorLabelWidth', `${tooltipWidth}px`);
+      });
+    },
+    [isVisible, labelText]
+  );
+
+  useEffect(() => {
+    if (enabled) {
+      window.addEventListener('mousemove', handleMouseMove);
+    } else {
+      setIsVisible(false);
+    }
+
+    return () => window.removeEventListener('mousemove', handleMouseMove);
+  }, [enabled, handleMouseMove]);
+
+  const timelineCursor = (
+    <AnimatePresence>
+      {isVisible && (
+        <Fragment>
+          <Cursor role="presentation" />
+          <CursorLabel ref={labelRef} animated placement="right" />
+        </Fragment>
+      )}
+    </AnimatePresence>
+  );
+
+  return {cursorContainerRef: containerRef, timelineCursor};
+}
+
+const Cursor = styled(motion.div)`
+  pointer-events: none;
+  background: ${p => p.theme.translucentBorder};
+  width: 2px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: clamp(0px, var(--cursorOffset), var(--cursorMax));
+  transform: translateX(-2px);
+  z-index: 3;
+`;
+
+Cursor.defaultProps = {
+  initial: 'initial',
+  animate: 'animate',
+  exit: 'exit',
+  transition: testableTransition({duration: 0.1}),
+  variants: {
+    initial: {opacity: 0},
+    animate: {opacity: 1},
+    exit: {opacity: 0},
+  },
+};
+
+const CursorLabel = styled(Overlay)`
+  font-variant-numeric: tabular-nums;
+  width: max-content;
+  padding: ${space(0.75)} ${space(1)};
+  color: ${p => p.theme.textColor};
+  font-size: ${p => p.theme.fontSizeSmall};
+  line-height: 1.2;
+  position: absolute;
+  top: 12px;
+  left: clamp(
+    0px,
+    calc(var(--cursorOffset) + ${TOOLTIP_OFFSET}px),
+    calc(var(--cursorMax) - var(--cursorLabelWidth) - ${TOOLTIP_OFFSET}px)
+  );
+`;
+
+export {useTimelineCursor};

--- a/static/app/views/monitors/components/overviewTimeline/types.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/types.tsx
@@ -4,6 +4,10 @@ export type TimeWindow = '1h' | '24h' | '7d' | '30d';
 
 export interface TimeWindowOptions {
   /**
+   * The time format used for the cursor label
+   */
+  cursorLabelFormat: string;
+  /**
    * Props to pass to <DateTime> when displaying a time marker
    */
   dateTimeProps: {dateOnly?: boolean; timeOnly?: boolean};

--- a/static/app/views/monitors/components/overviewTimeline/utils.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/utils.tsx
@@ -1,17 +1,31 @@
 import moment from 'moment';
 
+import {getFormat} from 'sentry/utils/dates';
+
 import {TimeWindow, TimeWindowData} from './types';
 
 // Stores options and data which correspond to each selectable time window
 export const timeWindowData: TimeWindowData = {
-  '1h': {elapsedMinutes: 60, timeMarkerInterval: 10, dateTimeProps: {timeOnly: true}},
+  '1h': {
+    cursorLabelFormat: getFormat({timeOnly: true, seconds: true}),
+    elapsedMinutes: 60,
+    timeMarkerInterval: 10,
+    dateTimeProps: {timeOnly: true},
+  },
   '24h': {
+    cursorLabelFormat: getFormat({timeOnly: true}),
     elapsedMinutes: 60 * 24,
     timeMarkerInterval: 60 * 4,
     dateTimeProps: {timeOnly: true},
   },
-  '7d': {elapsedMinutes: 60 * 24 * 7, timeMarkerInterval: 60 * 24, dateTimeProps: {}},
+  '7d': {
+    cursorLabelFormat: getFormat(),
+    elapsedMinutes: 60 * 24 * 7,
+    timeMarkerInterval: 60 * 24,
+    dateTimeProps: {},
+  },
   '30d': {
+    cursorLabelFormat: getFormat({dateOnly: true}),
     elapsedMinutes: 60 * 24 * 30,
     timeMarkerInterval: 60 * 24 * 5,
     dateTimeProps: {dateOnly: true},


### PR DESCRIPTION
Adds a cursor that follows the mouse on the crons timeline

The approach here is to add a mouse listener to the window, and when it enters the container it will render the cusror (animating it in). It updates a few CSS variables that are used to control the position of the cursor and the label.

<img alt="clipboard.png" width="361" src="https://i.imgur.com/mPPsddU.png" />