### PR TITLE
test: Run event manager tests in Snuba CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ test-snuba:
 		tests/sentry/post_process_forwarder \
 		tests/sentry/snuba \
 		tests/sentry/search/events \
+		tests/sentry/event_manager \
 		-vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
 	@echo ""
 


### PR DESCRIPTION
There was a Kafka schema change made in Snuba that could have been picked up with this test
