### PR TITLE
ref(dynamic-sampling): Remove unused project options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1258,9 +1258,6 @@ register("dynamic-sampling:enabled-biases", default=True, flags=FLAG_AUTOMATOR_M
 # System-wide options that observes latest releases on transactions and caches these values to be used later in
 # project config computation. This is temporary option to monitor the performance of this feature.
 register("dynamic-sampling:boost-latest-release", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
-register(
-    "dynamic-sampling.prioritise_projects.sample_rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
-)
 # Size of the sliding window used for dynamic sampling. It is defaulted to 24 hours.
 register("dynamic-sampling:sliding_window.size", default=24, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # controls how many orgs will be queried by the prioritise by transaction task

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1252,45 +1252,39 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )  # 1MB
 
-# Dynamic Sampling system wide options
-# Killswitch to disable new dynamic sampling behavior specifically new dynamic sampling biases
+# Dynamic Sampling system-wide options
+# Kill-switch to disable new dynamic sampling behavior specifically new dynamic sampling biases.
 register("dynamic-sampling:enabled-biases", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # System-wide options that observes latest releases on transactions and caches these values to be used later in
 # project config computation. This is temporary option to monitor the performance of this feature.
 register("dynamic-sampling:boost-latest-release", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Size of the sliding window used for dynamic sampling. It is defaulted to 24 hours.
 register("dynamic-sampling:sliding_window.size", default=24, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# controls how many orgs will be queried by the prioritise by transaction task
-# 0-> no orgs , 0.5 -> half of the orgs, 1.0 -> all orgs
-register(
-    "dynamic-sampling.prioritise_transactions.load_rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-# the number of large transactions to retrieve from Snuba for transaction re-balancing
+# Number of large transactions to retrieve from Snuba for transaction re-balancing.
 register(
     "dynamic-sampling.prioritise_transactions.num_explicit_large_transactions",
     30,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# the number of large transactions to retrieve from Snuba for transaction re-balancing
+# Number of large transactions to retrieve from Snuba for transaction re-balancing.
 register(
     "dynamic-sampling.prioritise_transactions.num_explicit_small_transactions",
     0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# controls the intensity of dynamic sampling transaction rebalancing. 0.0 = explict rebalancing
+# Controls the intensity of dynamic sampling transaction rebalancing. 0.0 = explict rebalancing
 # not performed, 1.0= full rebalancing (tries to bring everything to mean). Note that even at 0.0
 # there will still be some rebalancing between the explicit and implicit transactions ( so setting rebalancing
 # to 0.0 is not the same as no rebalancing. To effectively disable rebalancing set the number of explicit
-# transactions to be rebalance (both small and large) to 0
+# transactions to be rebalance (both small and large) to 0.
 register(
     "dynamic-sampling.prioritise_transactions.rebalance_intensity",
     default=0.8,
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
 register("hybrid_cloud.outbox_rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# controls whether we allow people to upload artifact bundles instead of release bundles
+# Controls whether we allow people to upload artifact bundles instead of release bundles.
 register("sourcemaps.enable-artifact-bundles", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Decides whether an incoming transaction triggers an update of the clustering rule applied to it.
 register("txnames.bump-lifetime-sample-rate", default=0.1, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
@@ -32,40 +32,5 @@ class PrioritiseProjectsSnubaQueryTest(BaseMetricsLayerTestCase, TestCase, Snuba
             project_id=p1.id,
             org_id=org1.id,
         )
-        with self.options({"dynamic-sampling.prioritise_projects.sample_rate": 1.0}):
-            results = fetch_projects_with_total_root_transaction_count_and_rates(org_ids=[org1.id])
+        results = fetch_projects_with_total_root_transaction_count_and_rates(org_ids=[org1.id])
         assert results[org1.id] == [(p1.id, 1.0, 0, 0)]
-
-    def test_simple_one_org_one_project_sample_rate_zero(self):
-        org1 = self.create_organization("test-org")
-        p1 = self.create_project(organization=org1)
-
-        self.store_performance_metric(
-            name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
-            tags={"transaction": "foo_transaction"},
-            minutes_before_now=30,
-            value=1,
-            project_id=p1.id,
-            org_id=org1.id,
-        )
-        with self.options({"dynamic-sampling.prioritise_projects.sample_rate": 0.0}):
-            results = fetch_projects_with_total_root_transaction_count_and_rates(org_ids=[org1.id])
-        # No results
-        assert results == {}
-
-    def test_simple_one_org_one_project_but_filtered_by_option(self):
-        org1 = self.create_organization("test-org2")
-        p1 = self.create_project(organization=org1)
-
-        self.store_performance_metric(
-            name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
-            tags={"transaction": "foo_transaction2"},
-            minutes_before_now=30,
-            value=1,
-            project_id=p1.id,
-            org_id=org1.id,
-        )
-        with self.options({"dynamic-sampling.prioritise_projects.sample_rate": 0}):
-            results = fetch_projects_with_total_root_transaction_count_and_rates(org_ids=[org1.id])
-            # No data because rate is too small
-            assert results[org1.id] == []

--- a/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_transactions.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_transactions.py
@@ -79,16 +79,14 @@ class PrioritiseProjectsSnubaQueryTest(BaseMetricsLayerTestCase, TestCase, Snuba
         return 1 + 100 + 1000 + 2000 + 3000 + idx * 5, 5
 
     def test_get_orgs_with_transactions_respects_max_orgs(self):
-        with self.options({"dynamic-sampling.prioritise_transactions.load_rate": 1.0}):
-            actual = list(get_orgs_with_project_counts(2, 20))
+        actual = list(get_orgs_with_project_counts(2, 20))
 
         orgs = self.org_ids
         # we should return groups of 2 orgs at a time
         assert actual == [[orgs[0], orgs[1]], [orgs[2]]]
 
     def test_get_orgs_with_transactions_respects_max_projs(self):
-        with self.options({"dynamic-sampling.prioritise_transactions.load_rate": 1.0}):
-            actual = list(get_orgs_with_project_counts(10, 5))
+        actual = list(get_orgs_with_project_counts(10, 5))
 
         orgs = [org["org_id"] for org in self.orgs_info]
         # since each org has 3 projects and we have a limit of 5 proj

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -463,13 +463,8 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
         BLENDED_RATE = 0.25
         get_blended_sample_rate.return_value = BLENDED_RATE
 
-        with self.options(
-            {
-                "dynamic-sampling.prioritise_transactions.load_rate": 1.0,
-            }
-        ):
-            with self.tasks():
-                boost_low_volume_transactions()
+        with self.tasks():
+            boost_low_volume_transactions()
 
         # now redis should contain rebalancing data for our projects
         for org in self.orgs_info:
@@ -499,14 +494,9 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
             else:
                 self.set_sliding_window_sample_rate_for_all(used_sample_rate)
 
-            with self.options(
-                {
-                    "dynamic-sampling.prioritise_transactions.load_rate": 1.0,
-                }
-            ):
-                with self.feature("organizations:ds-sliding-window"):
-                    with self.tasks():
-                        boost_low_volume_transactions()
+            with self.feature("organizations:ds-sliding-window"):
+                with self.tasks():
+                    boost_low_volume_transactions()
 
             # now redis should contain rebalancing data for our projects
             for org in self.orgs_info:
@@ -544,14 +534,9 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
             elif sliding_window_step == 3:
                 self.set_boost_low_volume_projects_for_all(used_sample_rate)
 
-            with self.options(
-                {
-                    "dynamic-sampling.prioritise_transactions.load_rate": 1.0,
-                }
-            ):
-                with self.feature("organizations:ds-sliding-window-org"):
-                    with self.tasks():
-                        boost_low_volume_transactions()
+            with self.feature("organizations:ds-sliding-window-org"):
+                with self.tasks():
+                    boost_low_volume_transactions()
 
             # now redis should contain rebalancing data for our projects
             for org in self.orgs_info:
@@ -595,7 +580,6 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
 
             with self.options(
                 {
-                    "dynamic-sampling.prioritise_transactions.load_rate": 1.0,
                     "dynamic-sampling.prioritise_transactions.num_explicit_large_transactions": 1,
                     "dynamic-sampling.prioritise_transactions.num_explicit_small_transactions": 1,
                     "dynamic-sampling.prioritise_transactions.rebalance_intensity": 0.7,

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -139,10 +139,9 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         proj_c = self.create_project_and_add_metrics("c", 3, test_org)
         proj_d = self.create_project_and_add_metrics("d", 1, test_org)
 
-        with self.options({"dynamic-sampling.prioritise_projects.sample_rate": 1.0}):
-            with self.tasks():
-                sliding_window_org()
-                boost_low_volume_projects()
+        with self.tasks():
+            sliding_window_org()
+            boost_low_volume_projects()
 
         # we expect only uniform rule
         # also we test here that `generate_rules` can handle trough redis long floats
@@ -176,10 +175,9 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         proj_d = self.create_project_and_add_metrics("d", 1, test_org)
         proj_e = self.create_project_without_metrics("e", test_org)
 
-        with self.options({"dynamic-sampling.prioritise_projects.sample_rate": 1.0}):
-            with self.tasks():
-                sliding_window_org()
-                boost_low_volume_projects()
+        with self.tasks():
+            sliding_window_org()
+            boost_low_volume_projects()
 
         # we expect only uniform rule
         # also we test here that `generate_rules` can handle trough redis long floats
@@ -219,11 +217,10 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         proj_c = self.create_project_and_add_metrics("c", 3, test_org)
         proj_d = self.create_project_and_add_metrics("d", 1, test_org)
 
-        with self.options({"dynamic-sampling.prioritise_projects.sample_rate": 1.0}):
-            with self.feature("organizations:ds-sliding-window-org"):
-                with self.tasks():
-                    sliding_window_org()
-                    boost_low_volume_projects()
+        with self.feature("organizations:ds-sliding-window-org"):
+            with self.tasks():
+                sliding_window_org()
+                boost_low_volume_projects()
 
         # we expect only uniform rule
         # also we test here that `generate_rules` can handle trough redis long floats
@@ -262,12 +259,11 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         proj_c = self.create_project_and_add_metrics("c", 3, test_org)
         proj_d = self.create_project_and_add_metrics("d", 1, test_org)
 
-        with self.options({"dynamic-sampling.prioritise_projects.sample_rate": 1.0}):
-            with self.feature("organizations:ds-sliding-window-org"):
-                with self.tasks():
-                    # We are testing whether the sliding window org sample rate will be synchronously computed
-                    # since the cache value is not there.
-                    boost_low_volume_projects()
+        with self.feature("organizations:ds-sliding-window-org"):
+            with self.tasks():
+                # We are testing whether the sliding window org sample rate will be synchronously computed
+                # since the cache value is not there.
+                boost_low_volume_projects()
 
         # we expect only uniform rule
         # also we test here that `generate_rules` can handle trough redis long floats
@@ -311,10 +307,9 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         self.add_sample_rate_per_project(org_id=test_org.id, project_id=proj_a.id, sample_rate=0.1)
         self.add_sample_rate_per_project(org_id=test_org.id, project_id=proj_b.id, sample_rate=0.2)
 
-        with self.options({"dynamic-sampling.prioritise_projects.sample_rate": 1.0}):
-            with self.feature("organizations:ds-sliding-window-org"):
-                with self.tasks():
-                    boost_low_volume_projects()
+        with self.feature("organizations:ds-sliding-window-org"):
+            with self.tasks():
+                boost_low_volume_projects()
 
         assert schedule_invalidate_project_config.call_count == 2
 
@@ -344,10 +339,9 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         self.add_sample_rate_per_project(org_id=test_org.id, project_id=proj_a.id, sample_rate=1.0)
         self.add_sample_rate_per_project(org_id=test_org.id, project_id=proj_b.id, sample_rate=1.0)
 
-        with self.options({"dynamic-sampling.prioritise_projects.sample_rate": 1.0}):
-            with self.feature("organizations:ds-sliding-window-org"):
-                with self.tasks():
-                    boost_low_volume_projects()
+        with self.feature("organizations:ds-sliding-window-org"):
+            with self.tasks():
+                boost_low_volume_projects()
 
         schedule_invalidate_project_config.assert_not_called()
 


### PR DESCRIPTION
This PR removes some unused projects options that were used in dynamic sampling tasks.

Closes https://github.com/getsentry/sentry/issues/51235