### PR TITLE
Split up backpressure.high_watermarks option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1311,18 +1311,28 @@ register("backpressure.status_ttl", default=60, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # The high-watermark levels per-service which will mark a service as unhealthy.
 # This should mirror the `SENTRY_PROCESSING_SERVICES` setting.
-# If this option is being modified downstream, and a new default setting
-# may be added, it has to be updated downstream as well, otherwise the
-# code will throw. This is intentional. We want to throw fast and loud on
-# misconfiguration.
 register(
-    "backpressure.high_watermarks",
-    default={
-        "celery": 0.5,
-        "attachments-store": 0.5,
-        "processing-store": 0.5,
-        "processing-locks": 0.5,
-        "post-process-locks": 0.5,
-    },
+    "backpressure.high_watermarks.celery",
+    default=0.5,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "backpressure.high_watermarks.attachments-store",
+    default=0.5,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "backpressure.high_watermarks.processing-store",
+    default=0.5,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "backpressure.high_watermarks.processing-locks",
+    default=0.5,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "backpressure.high_watermarks.post-process-locks",
+    default=0.5,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/processing/backpressure/monitor.py
+++ b/src/sentry/processing/backpressure/monitor.py
@@ -71,10 +71,9 @@ def assert_all_services_defined(services: Dict[str, Service]) -> None:
 
 def check_service_health(services: Mapping[str, Service]) -> Mapping[str, bool]:
     service_health = {}
-    high_watermarks = options.get("backpressure.high_watermarks")
 
     for name, service in services.items():
-        high_watermark = high_watermarks[name]
+        high_watermark = options.get(f"backpressure.high_watermarks.{name}")
         is_healthy = True
         for memory in check_service_memory(service):
             is_healthy = is_healthy and memory.percentage < high_watermark

--- a/tests/sentry/processing/backpressure/test_monitoring.py
+++ b/tests/sentry/processing/backpressure/test_monitoring.py
@@ -35,7 +35,7 @@ def test_check_redis_health() -> None:
 
     with override_options(
         {
-            "backpressure.high_watermarks": {"redis": 1.0},
+            "backpressure.high_watermarks.redis": 1.0,
         }
     ):
         service_health = check_service_health(services)
@@ -44,7 +44,7 @@ def test_check_redis_health() -> None:
     with override_options(
         {
             # NOTE: the default cluster for local testing will return *some* kind of used and available memory
-            "backpressure.high_watermarks": {"redis": 0.0},
+            "backpressure.high_watermarks.redis": 0.0,
         }
     ):
         service_health = check_service_health(services)


### PR DESCRIPTION
This introduces a separate option for each service.

Fixes https://github.com/getsentry/team-ingest/issues/468