### PR TITLE
feat(sourcemaps): Implement missing chunks functionality for artifact bundles

### DIFF
--- a/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
+++ b/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
@@ -86,7 +86,7 @@ class OrganizationArtifactBundleAssembleEndpoint(
         if options.get("sourcemaps.artifact_bundles.assemble_with_missing_chunks"):
             # We check if all requested chunks have been uploaded.
             missing_chunks = self.find_missing_chunks(organization, chunks)
-            # In case there are some missing chunks, we will tell the client the number of chunks that we require.
+            # In case there are some missing chunks, we will tell the client which chunks we require.
             if missing_chunks:
                 return Response(
                     {

--- a/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
+++ b/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
@@ -6,7 +6,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.constants import ObjectStatus
-from sentry.models import Project
+from sentry.models import FileBlobOwner, Project
 from sentry.tasks.assemble import (
     AssembleTask,
     ChunkFileState,
@@ -16,8 +16,25 @@ from sentry.tasks.assemble import (
 from sentry.utils import json
 
 
+class OrganizationArtifactBundleAssembleMixin:
+    @classmethod
+    def find_missing_chunks(cls, organization, chunks):
+        """
+        Returns a list of chunks which are missing for an org.
+        """
+        owned = set(
+            FileBlobOwner.objects.filter(
+                blob__checksum__in=chunks, organization_id=organization.id
+            ).values_list("blob__checksum", flat=True)
+        )
+
+        return list(set(chunks) - owned)
+
+
 @region_silo_endpoint
-class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoint):
+class OrganizationArtifactBundleAssembleEndpoint(
+    OrganizationReleasesBaseEndpoint, OrganizationArtifactBundleAssembleMixin
+):
     def post(self, request: Request, organization) -> Response:
         """
         Assembles an artifact bundle and stores the debug ids in the database.
@@ -63,10 +80,26 @@ class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoin
         checksum = data.get("checksum")
         chunks = data.get("chunks", [])
 
-        state, detail = get_assemble_status(AssembleTask.ARTIFACTS, organization.id, checksum)
+        # We check if all requested chunks have been uploaded.
+        missing_chunks = self.find_missing_chunks(organization, chunks)
+        # In case there are some missing chunks, we will tell the client the number of chunks that we require.
+        if missing_chunks:
+            return Response(
+                {
+                    "state": ChunkFileState.NOT_FOUND,
+                    "missingChunks": missing_chunks,
+                }
+            )
+
+        # We want to check the current state of the assemble status.
+        state, detail = get_assemble_status(AssembleTask.ARTIFACT_BUNDLE, organization.id, checksum)
         if state == ChunkFileState.OK:
             return Response({"state": state, "detail": None, "missingChunks": []}, status=200)
         elif state is not None:
+            # In case we have some state into the cache, we will not perform any assembly task again and rather we will
+            # return. This might cause issues with CLI because it might have uploaded the same bundle chunks two times
+            # in a row but only the first call the assemble started the assembly task, all subsequent calls will get
+            # an assemble status.
             return Response({"state": state, "detail": detail, "missingChunks": []})
 
         # There is neither a known file nor a cached state, so we will
@@ -76,7 +109,7 @@ class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoin
             return Response({"state": ChunkFileState.NOT_FOUND, "missingChunks": []}, status=200)
 
         set_assemble_status(
-            AssembleTask.ARTIFACTS, organization.id, checksum, ChunkFileState.CREATED
+            AssembleTask.ARTIFACT_BUNDLE, organization.id, checksum, ChunkFileState.CREATED
         )
 
         from sentry.tasks.assemble import assemble_artifacts

--- a/src/sentry/api/endpoints/organization_release_assemble.py
+++ b/src/sentry/api/endpoints/organization_release_assemble.py
@@ -57,7 +57,7 @@ class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
         checksum = data.get("checksum", None)
         chunks = data.get("chunks", [])
 
-        state, detail = get_assemble_status(AssembleTask.ARTIFACTS, organization.id, checksum)
+        state, detail = get_assemble_status(AssembleTask.RELEASE_BUNDLE, organization.id, checksum)
         if state == ChunkFileState.OK:
             return Response({"state": state, "detail": None, "missingChunks": []}, status=200)
         elif state is not None:
@@ -70,7 +70,7 @@ class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
             return Response({"state": ChunkFileState.NOT_FOUND, "missingChunks": []}, status=200)
 
         set_assemble_status(
-            AssembleTask.ARTIFACTS, organization.id, checksum, ChunkFileState.CREATED
+            AssembleTask.RELEASE_BUNDLE, organization.id, checksum, ChunkFileState.CREATED
         )
 
         from sentry.tasks.assemble import assemble_artifacts

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1346,3 +1346,11 @@ register(
     default=0.5,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Control whether the artifact bundles assemble endpoint support the missing chunks check the enables the CLI to only
+# upload missing chunks instead of the entire bundle again.
+register(
+    "sourcemaps.artifact_bundles.assemble_with_missing_chunks",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -43,7 +43,8 @@ class ChunkFileState:
 
 class AssembleTask:
     DIF = "project.dsym"  # Debug file upload
-    ARTIFACTS = "organization.artifacts"  # Release file upload
+    RELEASE_BUNDLE = "organization.artifacts"  # Release file upload
+    ARTIFACT_BUNDLE = "organization.artifact_bundle"  # Artifact bundle upload
 
 
 def _get_cache_key(task, scope, checksum):
@@ -491,11 +492,16 @@ def assemble_artifacts(
     if project_ids is None:
         project_ids = []
 
+    # We want to evaluate the type of assemble task given the input parameters.
+    assemble_task = (
+        AssembleTask.ARTIFACT_BUNDLE if upload_as_artifact_bundle else AssembleTask.RELEASE_BUNDLE
+    )
+
     try:
         organization = Organization.objects.get_from_cache(pk=org_id)
         bind_organization_context(organization)
 
-        set_assemble_status(AssembleTask.ARTIFACTS, org_id, checksum, ChunkFileState.ASSEMBLING)
+        set_assemble_status(assemble_task, org_id, checksum, ChunkFileState.ASSEMBLING)
 
         archive_name = "bundle-artifacts" if upload_as_artifact_bundle else "release-artifacts"
         archive_filename = f"{archive_name}-{uuid.uuid4().hex}.zip"
@@ -503,7 +509,7 @@ def assemble_artifacts(
 
         # Assemble the chunks into a temporary file
         rv = assemble_file(
-            AssembleTask.ARTIFACTS,
+            assemble_task,
             organization,
             archive_filename,
             checksum,
@@ -520,8 +526,6 @@ def assemble_artifacts(
         bundle, temp_file = rv
 
         try:
-            # TODO(iambriccardo): Once the new lookup PR is merged it would be better if we generalize the archive
-            #  handling class.
             archive = ReleaseArchive(temp_file)
         except Exception:
             raise AssembleArtifactsError("failed to open release manifest")
@@ -537,20 +541,18 @@ def assemble_artifacts(
             # Count files extracted, to compare them to release files endpoint
             metrics.incr("tasks.assemble.extracted_files", amount=archive.artifact_count)
     except AssembleArtifactsError as e:
-        set_assemble_status(
-            AssembleTask.ARTIFACTS, org_id, checksum, ChunkFileState.ERROR, detail=str(e)
-        )
+        set_assemble_status(assemble_task, org_id, checksum, ChunkFileState.ERROR, detail=str(e))
     except Exception:
         logger.error("failed to assemble release bundle", exc_info=True)
         set_assemble_status(
-            AssembleTask.ARTIFACTS,
+            assemble_task,
             org_id,
             checksum,
             ChunkFileState.ERROR,
             detail="internal server error",
         )
     else:
-        set_assemble_status(AssembleTask.ARTIFACTS, org_id, checksum, ChunkFileState.OK)
+        set_assemble_status(assemble_task, org_id, checksum, ChunkFileState.OK)
 
 
 def assemble_file(task, org_or_project, name, checksum, chunks, file_type):

--- a/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
@@ -269,7 +269,7 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.NOT_FOUND
-        assert set(response.data["missingChunks"]) == set(total_checksum)
+        assert set(response.data["missingChunks"]) == {total_checksum}
 
         # We store the blobs into the database.
         blob1 = FileBlob.from_file(ContentFile(bundle_file))

--- a/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
@@ -248,48 +248,49 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         )
 
     def test_assemble_with_missing_chunks(self):
-        dist = "android"
-        bundle_file = self.create_artifact_bundle_zip(
-            org=self.organization.slug, release=self.release.version
-        )
-        total_checksum = sha1(bundle_file).hexdigest()
+        with self.options({"sourcemaps.artifact_bundles.assemble_with_missing_chunks": True}):
+            dist = "android"
+            bundle_file = self.create_artifact_bundle_zip(
+                org=self.organization.slug, release=self.release.version
+            )
+            total_checksum = sha1(bundle_file).hexdigest()
 
-        # We try to upload with all the checksums missing.
-        response = self.client.post(
-            self.url,
-            data={
-                "checksum": total_checksum,
-                "chunks": [total_checksum],
-                "projects": [self.project.slug],
-                "version": self.release.version,
-                "dist": dist,
-            },
-            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
-        )
+            # We try to upload with all the checksums missing.
+            response = self.client.post(
+                self.url,
+                data={
+                    "checksum": total_checksum,
+                    "chunks": [total_checksum],
+                    "projects": [self.project.slug],
+                    "version": self.release.version,
+                    "dist": dist,
+                },
+                HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            )
 
-        assert response.status_code == 200, response.content
-        assert response.data["state"] == ChunkFileState.NOT_FOUND
-        assert set(response.data["missingChunks"]) == {total_checksum}
+            assert response.status_code == 200, response.content
+            assert response.data["state"] == ChunkFileState.NOT_FOUND
+            assert set(response.data["missingChunks"]) == {total_checksum}
 
-        # We store the blobs into the database.
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
-        FileBlobOwner.objects.get_or_create(organization_id=self.organization.id, blob=blob1)
+            # We store the blobs into the database.
+            blob1 = FileBlob.from_file(ContentFile(bundle_file))
+            FileBlobOwner.objects.get_or_create(organization_id=self.organization.id, blob=blob1)
 
-        # We make the request again after the file have been uploaded.
-        response = self.client.post(
-            self.url,
-            data={
-                "checksum": total_checksum,
-                "chunks": [total_checksum],
-                "projects": [self.project.slug],
-                "version": self.release.version,
-                "dist": dist,
-            },
-            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
-        )
+            # We make the request again after the file have been uploaded.
+            response = self.client.post(
+                self.url,
+                data={
+                    "checksum": total_checksum,
+                    "chunks": [total_checksum],
+                    "projects": [self.project.slug],
+                    "version": self.release.version,
+                    "dist": dist,
+                },
+                HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            )
 
-        assert response.status_code == 200, response.content
-        assert response.data["state"] == ChunkFileState.CREATED
+            assert response.status_code == 200, response.content
+            assert response.data["state"] == ChunkFileState.CREATED
 
     def test_assemble_response(self):
         bundle_file = self.create_artifact_bundle_zip(

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -229,7 +229,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
             assert self.release.count_artifacts() == 0
 
             status, details = get_assemble_status(
-                AssembleTask.RELEASE_BUNDLE, self.organization.id, total_checksum
+                AssembleTask.ARTIFACT_BUNDLE, self.organization.id, total_checksum
             )
             assert status == ChunkFileState.OK
             assert details is None

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -229,7 +229,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
             assert self.release.count_artifacts() == 0
 
             status, details = get_assemble_status(
-                AssembleTask.ARTIFACTS, self.organization.id, total_checksum
+                AssembleTask.RELEASE_BUNDLE, self.organization.id, total_checksum
             )
             assert status == ChunkFileState.OK
             assert details is None
@@ -567,7 +567,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
                 assert self.release.count_artifacts() == 2
 
                 status, details = get_assemble_status(
-                    AssembleTask.ARTIFACTS, self.organization.id, total_checksum
+                    AssembleTask.RELEASE_BUNDLE, self.organization.id, total_checksum
                 )
                 assert status == ChunkFileState.OK
                 assert details is None
@@ -605,7 +605,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         )
 
         status, details = get_assemble_status(
-            AssembleTask.ARTIFACTS, self.organization.id, total_checksum
+            AssembleTask.RELEASE_BUNDLE, self.organization.id, total_checksum
         )
         assert status == ChunkFileState.ERROR
 
@@ -623,7 +623,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         )
 
         status, details = get_assemble_status(
-            AssembleTask.ARTIFACTS, self.organization.id, total_checksum
+            AssembleTask.RELEASE_BUNDLE, self.organization.id, total_checksum
         )
         assert status == ChunkFileState.ERROR
 
@@ -641,7 +641,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         )
 
         status, details = get_assemble_status(
-            AssembleTask.ARTIFACTS, self.organization.id, total_checksum
+            AssembleTask.RELEASE_BUNDLE, self.organization.id, total_checksum
         )
         assert status == ChunkFileState.ERROR
 
@@ -669,6 +669,6 @@ class AssembleArtifactsTest(BaseAssembleTest):
 
             # Status is still OK:
             status, details = get_assemble_status(
-                AssembleTask.ARTIFACTS, self.organization.id, total_checksum
+                AssembleTask.RELEASE_BUNDLE, self.organization.id, total_checksum
             )
             assert status == ChunkFileState.OK


### PR DESCRIPTION
This PR adds the `missingChunks` support for the artifact bundles upload endpoint, which will improve performance of the uploads with very similar chunks.

In order to avoid complex reverts due to possible regressions, we put the missing chunk functionality behind the `sourcemaps.artifact_bundles.assemble_with_missing_chunks` option.

Closes https://github.com/getsentry/sentry/issues/51224