### PR TITLE
feat(perf-detector-threshold-configuration) Added backend changes for n+1 db and slow db queries

### DIFF
--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -8,6 +8,7 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.permissions import SuperuserPermission
 
 MAX_VALUE = 2147483647
+TEN_SECONDS = 10000  # ten seconds in milliseconds
 SETTINGS_PROJECT_OPTION_KEY = "sentry:performance_issue_settings"
 
 
@@ -19,6 +20,12 @@ class ProjectOwnerOrSuperUserPermissions(ProjectSettingPermission):
 
 
 class ProjectPerformanceIssueSettingsSerializer(serializers.Serializer):
+    n_plus_one_db_duration_threshold = serializers.FloatField(
+        required=False, min_value=50, max_value=TEN_SECONDS
+    )
+    slow_db_query_duration_threshold = serializers.FloatField(
+        required=False, min_value=100, max_value=TEN_SECONDS
+    )
     uncompressed_assets_detection_enabled = serializers.BooleanField(required=False)
     consecutive_http_spans_detection_enabled = serializers.BooleanField(required=False)
     large_http_payload_detection_enabled = serializers.BooleanField(required=False)

--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -20,10 +20,10 @@ class ProjectOwnerOrSuperUserPermissions(ProjectSettingPermission):
 
 
 class ProjectPerformanceIssueSettingsSerializer(serializers.Serializer):
-    n_plus_one_db_duration_threshold = serializers.FloatField(
+    n_plus_one_db_duration_threshold = serializers.IntegerField(
         required=False, min_value=50, max_value=TEN_SECONDS
     )
-    slow_db_query_duration_threshold = serializers.FloatField(
+    slow_db_query_duration_threshold = serializers.IntegerField(
         required=False, min_value=100, max_value=TEN_SECONDS
     )
     uncompressed_assets_detection_enabled = serializers.BooleanField(required=False)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1212,6 +1212,11 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "performance.issues.slow_db_query.duration_threshold",
+    default=1000.0,  # ms
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "performance.issues.render_blocking_assets.fcp_minimum_threshold",
     default=2000.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -98,6 +98,8 @@ register(key="sentry:transaction_metrics_custom_tags", epoch_defaults={1: []})
 register(key="sentry:span_attributes", epoch_defaults={1: ["exclusive-time"]})
 
 DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS = {
+    "slow_db_query_duration_threshold": 1000.0,
+    "n_plus_one_db_duration_threshold": 100.0,
     "uncompressed_assets_detection_enabled": True,
     "consecutive_http_spans_detection_enabled": True,
     "large_http_payload_detection_enabled": True,

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -133,6 +133,9 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
         "n_plus_one_db_duration_threshold": options.get(
             "performance.issues.n_plus_one_db.duration_threshold"
         ),
+        "slow_db_query_duration_threshold": options.get(
+            "performance.issues.slow_db_query.duration_threshold"
+        ),
         "render_blocking_fcp_min": options.get(
             "performance.issues.render_blocking_assets.fcp_minimum_threshold"
         ),
@@ -186,7 +189,7 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
     return {
         DetectorType.SLOW_DB_QUERY: [
             {
-                "duration_threshold": 1000.0,  # ms
+                "duration_threshold": settings["slow_db_query_duration_threshold"],  # ms
                 "allowed_span_ops": ["db"],
                 "detection_enabled": settings["slow_db_queries_detection_enabled"],
             },

--- a/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
+++ b/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
@@ -34,6 +34,8 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
             response = self.client.get(self.url, format="json")
 
         assert response.status_code == 200, response.content
+        assert response.data["slow_db_query_duration_threshold"] == 1000
+        assert response.data["n_plus_one_db_duration_threshold"] == 100
         assert response.data["uncompressed_assets_detection_enabled"]
         assert response.data["consecutive_http_spans_detection_enabled"]
         assert response.data["large_http_payload_detection_enabled"]

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -24,6 +24,7 @@ from sentry.utils.performance_issues.performance_detection import (
     NPlusOneDBSpanDetector,
     _detect_performance_problems,
     detect_performance_problems,
+    get_detection_settings,
 )
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
 
@@ -115,7 +116,7 @@ class PerformanceDetectionTest(TestCase):
         assert mock.call_count == 1
 
     @override_options(BASE_DETECTOR_OPTIONS)
-    def test_project_option_overrides_default(self):
+    def test_detector_respects_project_option_settings(self):
         n_plus_one_event = get_event("n-plus-one-in-django-index-view")
         sdk_span_mock = Mock()
 
@@ -128,6 +129,61 @@ class PerformanceDetectionTest(TestCase):
 
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock, self.project)
         assert perf_problems == []
+
+    def test_project_options_overrides_default_settings(self):
+
+        default_settings = get_detection_settings(self.project)
+
+        assert default_settings[DetectorType.N_PLUS_ONE_DB_QUERIES]["duration_threshold"] == 100
+        assert default_settings[DetectorType.N_PLUS_ONE_DB_QUERIES]["detection_enabled"]
+        assert default_settings[DetectorType.SLOW_DB_QUERY][0]["duration_threshold"] == 1000
+        assert default_settings[DetectorType.SLOW_DB_QUERY][0]["detection_enabled"]
+        assert default_settings[DetectorType.CONSECUTIVE_DB_OP]["detection_enabled"]
+        assert default_settings[DetectorType.CONSECUTIVE_HTTP_OP]["detection_enabled"]
+        assert default_settings[DetectorType.DB_MAIN_THREAD][0]["detection_enabled"]
+        assert default_settings[DetectorType.FILE_IO_MAIN_THREAD][0]["detection_enabled"]
+        assert default_settings[DetectorType.M_N_PLUS_ONE_DB]["detection_enabled"]
+        assert default_settings[DetectorType.N_PLUS_ONE_API_CALLS]["detection_enabled"]
+        assert default_settings[DetectorType.CONSECUTIVE_HTTP_OP]["detection_enabled"]
+        assert default_settings[DetectorType.LARGE_HTTP_PAYLOAD]["detection_enabled"]
+        assert default_settings[DetectorType.RENDER_BLOCKING_ASSET_SPAN]["detection_enabled"]
+        assert default_settings[DetectorType.UNCOMPRESSED_ASSETS]["detection_enabled"]
+
+        self.project_option_mock.return_value = {
+            "n_plus_one_db_duration_threshold": 100000,
+            "n_plus_one_db_queries_detection_enabled": False,
+            "slow_db_query_duration_threshold": 5000,
+            "slow_db_queries_detection_enabled": False,
+            "uncompressed_assets_detection_enabled": False,
+            "consecutive_http_spans_detection_enabled": False,
+            "large_http_payload_detection_enabled": False,
+            "n_plus_one_api_calls_detection_enabled": False,
+            "db_on_main_thread_detection_enabled": False,
+            "file_io_on_main_thread_detection_enabled": False,
+            "consecutive_db_queries_detection_enabled": False,
+            "large_render_blocking_asset_detection_enabled": False,
+        }
+
+        configured_settings = get_detection_settings(self.project)
+
+        assert (
+            configured_settings[DetectorType.N_PLUS_ONE_DB_QUERIES]["duration_threshold"] == 100000
+        )
+        assert not configured_settings[DetectorType.N_PLUS_ONE_DB_QUERIES]["detection_enabled"]
+        assert configured_settings[DetectorType.SLOW_DB_QUERY][0]["duration_threshold"] == 5000
+        assert not configured_settings[DetectorType.SLOW_DB_QUERY][0]["detection_enabled"]
+        assert not configured_settings[DetectorType.CONSECUTIVE_DB_OP]["detection_enabled"]
+        assert not configured_settings[DetectorType.CONSECUTIVE_HTTP_OP]["detection_enabled"]
+        assert not configured_settings[DetectorType.DB_MAIN_THREAD][0]["detection_enabled"]
+        assert not (configured_settings[DetectorType.FILE_IO_MAIN_THREAD][0]["detection_enabled"])
+        assert not configured_settings[DetectorType.M_N_PLUS_ONE_DB]["detection_enabled"]
+        assert not configured_settings[DetectorType.N_PLUS_ONE_API_CALLS]["detection_enabled"]
+        assert not configured_settings[DetectorType.CONSECUTIVE_HTTP_OP]["detection_enabled"]
+        assert not configured_settings[DetectorType.LARGE_HTTP_PAYLOAD]["detection_enabled"]
+        assert not (
+            configured_settings[DetectorType.RENDER_BLOCKING_ASSET_SPAN]["detection_enabled"]
+        )
+        assert not configured_settings[DetectorType.UNCOMPRESSED_ASSETS]["detection_enabled"]
 
     @override_options(BASE_DETECTOR_OPTIONS)
     def test_n_plus_one_extended_detection_no_parent_span(self):


### PR DESCRIPTION
New thresholds: [notion block](https://www.notion.so/sentry/Detector-Threshold-Configuration-f8cb07e7cceb42388cedb09ea05fc116?pvs=4#bdb59b6b94cf47af9447264582c08936)

- Backend changes required for making n+1 db queries and slow db queries configurable by the customer.
- Added test that ensures all of the new project setting options override the defaults.
