### PR TITLE
feat(replays): add electron platform to onboarding

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -304,6 +304,7 @@ export const releaseHealth: PlatformKey[] = [
 ];
 
 export const replayPlatforms: readonly PlatformKey[] = [
+  'electron',
   'javascript-angular',
   // 'javascript-angularjs', // Unsupported, angularjs requires the v6.x core SDK
   'javascript-backbone',
@@ -325,6 +326,7 @@ export const replayPlatforms: readonly PlatformKey[] = [
  * See: https://github.com/getsentry/sentry-docs/tree/master/src/wizard/javascript/replay-onboarding
  */
 export const replayOnboardingPlatforms: readonly PlatformKey[] = [
+  'electron',
   'javascript-angular',
   // 'javascript-angularjs', // Unsupported, angularjs requires the v6.x core SDK
   // 'javascript-backbone', // No docs yet

--- a/static/app/utils/replays/projectSupportsReplay.spec.tsx
+++ b/static/app/utils/replays/projectSupportsReplay.spec.tsx
@@ -47,7 +47,6 @@ describe('projectSupportsReplay & projectCanLinkToReplay', () => {
 
   it.each([
     'apple-macos' as PlatformKey,
-    'electron' as PlatformKey,
     'flutter' as PlatformKey,
     'unity' as PlatformKey,
   ])('should FAIL for Desktop framework %s', platform => {


### PR DESCRIPTION
## Summary
Adds electron to platform onboarding.

Note: requires onboarding docs before this can be shipped.

relates to https://github.com/getsentry/sentry/issues/49595