### PR TITLE
fix(org-tokens): Ensure all users can update token names

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -177,7 +177,7 @@ class OrgAuthTokenPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
         "POST": ["org:read", "org:write", "org:admin"],
-        "PUT": ["org:write", "org:admin"],
+        "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:write", "org:admin"],
     }
 

--- a/tests/sentry/api/endpoints/test_org_auth_token_details.py
+++ b/tests/sentry/api/endpoints/test_org_auth_token_details.py
@@ -393,8 +393,8 @@ class OrgAuthTokenDetailsPermissionTest(PermissionTestCase):
             self.path, method="PUT", data=self.putData, content_type="application/json"
         )
 
-    def test_member_cannot_put(self):
-        self.assert_member_cannot_access(
+    def test_member_can_put(self):
+        self.assert_member_can_access(
             self.path, method="PUT", data=self.putData, content_type="application/json"
         )
 


### PR DESCRIPTION
This was actually specced out different than I initially implemented this, which I noticed just now - so fixing this to how it _should_ be. Note that as of now you can only update the token name, which is very low-risk, which is why we allow this for everyone (otherwise, users could not adjust the name of tokens they created). In the future, we _may_ adjust this so that users can only edit tokens they created themselves, but for now this is fine.


ref https://github.com/getsentry/sentry/issues/50932