### PR TITLE
fix(starfish): add span_id to the spans samples endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -152,12 +152,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
                 span_ids.append(top)
 
         result = spans_indexed.query(
-            selected_columns=[
-                "project",
-                "transaction.id",
-                column,
-                "timestamp",
-            ],
+            selected_columns=["project", "transaction.id", column, "timestamp", "span_id"],
             orderby=["timestamp"],
             params=params,
             query=f"span_id:[{','.join(span_ids)}]",


### PR DESCRIPTION
We need `span_id` for span samples, in order to link to the span in the transaction.
