### PR TITLE
feat(starfish): Show only endpoint transactions in span summary

### DIFF
--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -2,6 +2,7 @@ import {Location} from 'history';
 
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {IndexedSpan} from 'sentry/views/starfish/queries/types';
 import {SpanMetricsFields} from 'sentry/views/starfish/types';
@@ -41,12 +42,18 @@ export const useSpanTransactionMetrics = (
 function getEventView(span: {group: string}, location: Location, transactions: string[]) {
   const cleanGroupId = span.group.replaceAll('-', '').slice(-16);
 
+  const search = new MutableSearch('');
+  search.addFilterValues('span.group', [cleanGroupId]);
+  search.addFilterValues('transaction.op', ['http.server']);
+
+  if (transactions.length > 0) {
+    search.addFilterValues('transaction', transactions);
+  }
+
   return EventView.fromNewQueryWithLocation(
     {
       name: '',
-      query: `span.group:${cleanGroupId}${
-        transactions.length > 0 ? ` transaction:[${transactions.join(',')}]` : ''
-      }`,
+      query: search.formatString(),
       fields: [
         'transaction',
         'sps()',
@@ -55,6 +62,7 @@ function getEventView(span: {group: string}, location: Location, transactions: s
         `p95(${SPAN_SELF_TIME})`,
         `percentile_percent_change(${SPAN_SELF_TIME}, 0.95)`,
         'time_spent_percentage(local)',
+        'transaction.op',
       ],
       orderby: '-time_spent_percentage_local',
       dataset: DiscoverDatasets.SPANS_METRICS,


### PR DESCRIPTION
On the span summary page, the `Found In Endpoints` column was including transactions that are from tasks/jobs. This PR filters out these transactions by considering only transactions that have `http.server` as the transaction operation.