### PR TITLE
fix(ui): Reset tooltip visibility on disabled

### DIFF
--- a/static/app/components/tooltip.spec.tsx
+++ b/static/app/components/tooltip.spec.tsx
@@ -74,6 +74,32 @@ describe('Tooltip', function () {
     await userEvent.unhover(screen.getByText('My Button'));
   });
 
+  it('resets visibility when becoming disabled', async function () {
+    const {rerender} = render(
+      <Tooltip delay={0} title="test" disabled={false}>
+        <span>My Button</span>
+      </Tooltip>
+    );
+
+    await userEvent.hover(screen.getByText('My Button'));
+    expect(screen.getByText('test')).toBeInTheDocument();
+
+    rerender(
+      <Tooltip delay={0} title="test" disabled>
+        <span>My Button</span>
+      </Tooltip>
+    );
+    expect(screen.queryByText('test')).not.toBeInTheDocument();
+
+    // Becomes enabled again
+    rerender(
+      <Tooltip delay={0} title="test" disabled={false}>
+        <span>My Button</span>
+      </Tooltip>
+    );
+    expect(screen.queryByText('test')).not.toBeInTheDocument();
+  });
+
   it('does not render an empty tooltip', async function () {
     render(
       <Tooltip delay={0} title="">

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect} from 'react';
 import {createPortal} from 'react-dom';
 import {SerializedStyles, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -36,8 +36,15 @@ export function DO_NOT_USE_TOOLTIP({
   ...hoverOverlayProps
 }: InternalTooltipProps) {
   const theme = useTheme();
-  const {wrapTrigger, isOpen, overlayProps, placement, arrowData, arrowProps} =
+  const {wrapTrigger, isOpen, overlayProps, placement, arrowData, arrowProps, reset} =
     useHoverOverlay('tooltip', hoverOverlayProps);
+
+  // Reset the visibility when the tooltip becomes disabled
+  useEffect(() => {
+    if (disabled) {
+      reset();
+    }
+  }, [reset, disabled]);
 
   if (disabled || !title) {
     return <Fragment>{children}</Fragment>;

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -266,6 +266,15 @@ function useHoverOverlay(
     ]
   );
 
+  const reset = useCallback(() => {
+    if (isVisible) {
+      setVisible(false);
+    }
+
+    window.clearTimeout(delayOpenTimeoutRef.current);
+    window.clearTimeout(delayHideTimeoutRef.current);
+  }, [isVisible, setVisible, delayOpenTimeoutRef, delayHideTimeoutRef]);
+
   const overlayProps = {
     id: describeById,
     ref: setOverlayElement,
@@ -288,6 +297,7 @@ function useHoverOverlay(
     placement: state?.placement,
     arrowData: state?.modifiersData?.arrow,
     update,
+    reset,
   };
 }
 


### PR DESCRIPTION
Resets the tooltip state when the tooltip becomes disabled. You can see this problem in the issues stream when the button/tooltip becomes disabled and the mouseleave is never recorded. The tooltip is shown again as soon as it becomes enabled.


https://github.com/getsentry/sentry/assets/1400464/636489ed-b4f9-4bef-93e3-3656c3511953


