### PR TITLE
ref(crons): Remove sort button temporarily

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -1,12 +1,10 @@
 import {Fragment, useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/button';
 import Link from 'sentry/components/links/link';
 import Panel from 'sentry/components/panels/panel';
 import Placeholder from 'sentry/components/placeholder';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
-import {IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -71,7 +69,6 @@ export function OverviewTimeline({monitorList}: Props) {
   return (
     <MonitorListPanel>
       <ListFilters>
-        <Button size="xs" icon={<IconSort size="xs" />} aria-label={t('Reverse sort')} />
         <SegmentedControl<TimeWindow>
           value={timeWindow}
           onChange={handleResolutionChange}


### PR DESCRIPTION
<img width="323" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/46cc85c5-6940-412c-8d92-7cd69e68ea66">

Button on the left was added in according to mocks and put behind a flag, but we haven't implemented the sort re-ordering functionality and the flag is now turned on. Let's hide this for now until we implement the sort.