### PR TITLE
feat(sourcemaps): adds front-end for adding sentry to build step

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
@@ -54,13 +54,6 @@ function getErrorMessage(
     }
     return `${baseSourceMapDocsLink}troubleshooting_js/` + (section ? `#${section}` : '');
   }
-  function getMigrationGuide() {
-    if (docPlatform === 'react-native') {
-      return 'https://docs.sentry.io/platforms/react-native/migration/';
-    }
-    return 'https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#upgrading-from-6x-to-7x';
-  }
-
   const defaultDocsLink = `${baseSourceMapDocsLink}#uploading-source-maps-to-sentry`;
 
   switch (error.type) {
@@ -174,16 +167,14 @@ function getErrorMessage(
           docsLink: getTroubleshootingLink(),
         },
       ];
-    case SourceMapProcessingIssueType.SDK_OUT_OF_DATE:
+    case SourceMapProcessingIssueType.NOT_PART_OF_PIPELINE:
       return [
         {
-          title: t('SDK Out of Date'),
+          title: t('Sentry not part of build pipeline'),
           desc: t(
-            "We're not able to un-minify your application's source code, because your SDK %s is out of date with version %s. Please update it to the latest version.",
-            error.data.sdkName,
-            error.data.sdkVersion
+            'Integrate Sentry into your build pipeline using a tool like Webpack or the CLI.'
           ),
-          docsLink: error.data.showMigrationGuide ? getMigrationGuide() : undefined,
+          docsLink: defaultDocsLink,
         },
       ];
     case SourceMapProcessingIssueType.UNKNOWN_ERROR:

--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.tsx
@@ -50,9 +50,8 @@ interface NoURLMatchDebugError extends BaseSourceMapDebugError {
   type: SourceMapProcessingIssueType.NO_URL_MATCH;
 }
 
-interface SDKOutOfDate extends BaseSourceMapDebugError {
-  data: {sdkName: string; sdkVersion: string; showMigrationGuide: boolean};
-  type: SourceMapProcessingIssueType.SDK_OUT_OF_DATE;
+interface NotPartOfPipelineError extends BaseSourceMapDebugError {
+  type: SourceMapProcessingIssueType.NOT_PART_OF_PIPELINE;
 }
 
 export type SourceMapDebugError =
@@ -65,7 +64,7 @@ export type SourceMapDebugError =
   | DistMismatchDebugError
   | SourcemapNotFoundDebugError
   | NoURLMatchDebugError
-  | SDKOutOfDate;
+  | NotPartOfPipelineError;
 
 export interface SourceMapDebugResponse {
   errors: SourceMapDebugError[];
@@ -81,7 +80,7 @@ export enum SourceMapProcessingIssueType {
   PARTIAL_MATCH = 'partial_match',
   DIST_MISMATCH = 'dist_mismatch',
   SOURCEMAP_NOT_FOUND = 'sourcemap_not_found',
-  SDK_OUT_OF_DATE = 'sdk_out_of_date',
+  NOT_PART_OF_PIPELINE = 'not_part_of_pipeline',
 }
 
 const sourceMapDebugQuery = ({


### PR DESCRIPTION
This PR adds a new step for in-app source map debugging to add Sentry to your build pipeline. We will show this error if the SDK supports debug id but we don't see source maps.

![Screen Shot 2023-06-15 at 9 03 02 AM](https://github.com/getsentry/sentry/assets/8533851/cc6bd869-d755-4b44-a071-3d58c3081735)
