### PR TITLE
feat(github-comments): hit github API to get PR from branch commit

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -218,6 +218,9 @@ class GitHubClientMixin(GithubProxyClient):
         return commit
 
     def get_pullrequest_from_commit(self, repo: str, sha: str) -> JSONData:
+        """
+        https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit
+        """
         pullrequest: JSONData = self.get(f"/repos/{repo}/commits/{sha}/pulls")
         return pullrequest
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -217,6 +217,10 @@ class GitHubClientMixin(GithubProxyClient):
         commit: JSONData = self.get_cached(f"/repos/{repo}/commits/{sha}")
         return commit
 
+    def get_pullrequest_from_commit(self, repo: str, sha: str) -> JSONData:
+        pullrequest: JSONData = self.get(f"/repos/{repo}/commits/{sha}/pulls")
+        return pullrequest
+
     def get_repo(self, repo: str) -> JSONData:
         """
         https://docs.github.com/en/rest/repos/repos#get-a-repository

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -78,7 +78,7 @@ def find_commit_context_for_event(
         install = integration_service.get_installation(
             integration=integration, organization_id=code_mapping.organization_id
         )
-        if installation is None:
+        if installation is None and install is not None:
             installation = install
         try:
             commit_context = install.get_commit_context(

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -25,6 +25,7 @@ def find_commit_context_for_event(
     frame: Event frame
     """
     result = []
+    install = None
     for code_mapping in code_mappings:
         if not code_mapping.organization_integration_id:
             logger.info(
@@ -107,4 +108,4 @@ def find_commit_context_for_event(
         if commit_context:
             result.append((commit_context, code_mapping))
 
-    return result
+    return result, install

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -25,7 +25,7 @@ def find_commit_context_for_event(
     frame: Event frame
     """
     result = []
-    install = None
+    installation = None
     for code_mapping in code_mappings:
         if not code_mapping.organization_integration_id:
             logger.info(
@@ -78,6 +78,8 @@ def find_commit_context_for_event(
         install = integration_service.get_installation(
             integration=integration, organization_id=code_mapping.organization_id
         )
+        if installation is None:
+            installation = install
         try:
             commit_context = install.get_commit_context(
                 code_mapping.repository, src_path, code_mapping.default_branch, frame
@@ -108,4 +110,4 @@ def find_commit_context_for_event(
         if commit_context:
             result.append((commit_context, code_mapping))
 
-    return result, install
+    return result, installation

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -324,9 +324,9 @@ def process_commit_context(
                 )
                 repo = Repository.objects.filter(id=commit.repository_id)
                 if (
-                    repo.exists()
+                    installation is not None
+                    and repo.exists()
                     and repo.get().provider == "integrations:github"
-                    and installation is not None
                 ):
                     queue_comment_task_if_needed(commit, group_owner, repo.get(), installation)
                 else:

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -46,7 +46,8 @@ def queue_comment_task_if_needed(
 
     response = installation.get_client().get_pullrequest_from_commit(repo=repo.name, sha=commit.key)
 
-    if not (response.status_code == 200 and isinstance(response, list)):
+    if not (response.status_code == 200 and isinstance(response, list) and len(response) == 1):
+        # the response should return a single PR, return if multiple
         return
 
     pr_query = PullRequest.objects.filter(


### PR DESCRIPTION
The suspect commits feature identifies the branch commit associated with an issue. The PullRequest table stores pull requests and the merge commit sha.

Previously we were attempting to find the pull request in the table using the branch commit sha, but there is no association between the two so the comment workflow was not being run. Here, we hit the Github API to correctly find the PR associated with a branch commit.

See https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit