### PR TITLE
feat(starfish): Allow sorting the span table

### DIFF
--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -44,7 +44,6 @@ export const useSpanList = (
     orderBy
   );
 
-  // TODO: Add referrer
   const {isLoading, data, pageLinks} = useSpansQuery<SpanMetrics[]>({
     eventView,
     initialData: [],

--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -124,6 +124,7 @@ export function useWrappedDiscoverQuery({
   return {
     isLoading,
     data: isLoading && initialData ? initialData : data?.data,
+    meta: data?.meta ?? {},
     pageLinks,
   };
 }

--- a/static/app/views/starfish/views/queryParameters.tsx
+++ b/static/app/views/starfish/views/queryParameters.tsx
@@ -1,0 +1,4 @@
+export enum QueryParameterNames {
+  CURSOR = 'spansCursor',
+  SORT = 'spansSort',
+}

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -20,9 +20,8 @@ import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpe
 import {useSpanList} from 'sentry/views/starfish/queries/useSpanList';
 import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
+import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
-
-const SPANS_CURSOR_NAME = 'spansCursor';
 
 type Props = {
   moduleName: ModuleName;
@@ -71,7 +70,7 @@ export default function SpansTable({
   limit = 25,
 }: Props) {
   const location = useLocation();
-  const spansCursor = decodeScalar(location.query?.[SPANS_CURSOR_NAME]);
+  const spansCursor = decodeScalar(location.query?.[QueryParameterNames.CURSOR]);
   const {isLoading, data, pageLinks} = useSpanList(
     moduleName ?? ModuleName.ALL,
     undefined,
@@ -85,7 +84,7 @@ export default function SpansTable({
   const handleCursor: CursorHandler = (cursor, pathname, query) => {
     browserHistory.push({
       pathname,
-      query: {...query, [SPANS_CURSOR_NAME]: cursor},
+      query: {...query, [QueryParameterNames.CURSOR]: cursor},
     });
   };
 

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -99,7 +99,7 @@ export default function SpansTable({
           orderBy ? [] : [{key: orderBy, order: 'desc'} as TableColumnSort<Keys>]
         }
         grid={{
-          renderHeadCell: getRenderHeadCell(orderBy, onSetOrderBy),
+          renderHeadCell: column => renderHeadCell(orderBy, onSetOrderBy, column),
           renderBodyCell: (column, row) =>
             renderBodyCell(column, row, location, endpoint, method),
         }}
@@ -110,27 +110,27 @@ export default function SpansTable({
   );
 }
 
-function getRenderHeadCell(orderBy: string, onSetOrderBy: (orderBy: string) => void) {
-  function renderHeadCell(column: TableColumnHeader): React.ReactNode {
-    return (
-      <SortLink
-        align="left"
-        canSort
-        direction={orderBy === column.key ? 'desc' : undefined}
-        onClick={() => {
-          onSetOrderBy(`${column.key}`);
-        }}
-        title={column.name}
-        generateSortLink={() => {
-          return {
-            ...location,
-          };
-        }}
-      />
-    );
-  }
-
-  return renderHeadCell;
+function renderHeadCell(
+  orderBy: string,
+  onSetOrderBy: (orderBy: string) => void,
+  column: TableColumnHeader
+) {
+  return (
+    <SortLink
+      align="left"
+      canSort
+      direction={orderBy === column.key ? 'desc' : undefined}
+      onClick={() => {
+        onSetOrderBy(`${column.key}`);
+      }}
+      title={column.name}
+      generateSortLink={() => {
+        return {
+          ...location,
+        };
+      }}
+    />
+  );
 }
 
 function renderBodyCell(

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -54,8 +54,8 @@ type Props = {
 const {SPAN_SELF_TIME} = SpanMetricsFields;
 
 export const SORTABLE_FIELDS = new Set([
-  'p95(span.self_time)',
-  'percentile_percent_change(span.self_time, 0.95)',
+  `p95(${SPAN_SELF_TIME})`,
+  `percentile_percent_change(${SPAN_SELF_TIME}, 0.95)`,
   'sps()',
   'sps_percent_change()',
   'time_spent_percentage()',

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 import {browserHistory} from 'react-router';
-import styled from '@emotion/styled';
 import {urlEncode} from '@sentry/utils';
 import {Location} from 'history';
 
@@ -17,6 +16,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
 import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
+import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import {useSpanList} from 'sentry/views/starfish/queries/useSpanList';
 import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
@@ -257,9 +257,3 @@ function getColumns(moduleName: ModuleName): Column[] {
 export function isAValidSort(sort: Sort): sort is ValidSort {
   return SORTABLE_FIELDS.has(sort.field);
 }
-
-export const OverflowEllipsisTextContainer = styled('span')`
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-`;

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -5,6 +5,7 @@ import pick from 'lodash/pick';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import {space} from 'sentry/styles/space';
 import {fromSorts} from 'sentry/utils/discover/eventView';
+import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {ModuleName} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
@@ -13,11 +14,11 @@ import {DomainSelector} from 'sentry/views/starfish/views/spans/selectors/domain
 import {SpanOperationSelector} from 'sentry/views/starfish/views/spans/selectors/spanOperationSelector';
 import {SpanTimeCharts} from 'sentry/views/starfish/views/spans/spanTimeCharts';
 
-import SpansTable from './spansTable';
+import SpansTable, {isAValidSort} from './spansTable';
 
 const DEFAULT_SORT: Sort = {
   kind: 'desc',
-  field: 'time_spent_percentage()',
+  field: 'sps()',
 };
 const LIMIT: number = 25;
 
@@ -44,7 +45,8 @@ export default function SpansView(props: Props) {
   ]);
 
   const sort =
-    fromSorts(location.query[QueryParameterNames.SORT] ?? '')[0] ?? DEFAULT_SORT; // We only allow one sort on this table
+    fromSorts(location.query[QueryParameterNames.SORT]).filter(isAValidSort)[0] ??
+    DEFAULT_SORT; // We only allow one sort on this table in this view
 
   return (
     <Fragment>

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -75,7 +75,6 @@ export default function SpansView(props: Props) {
           moduleName={props.moduleName || ModuleName.ALL}
           orderBy={orderBy}
           spanCategory={props.spanCategory}
-          onSetOrderBy={newOrderBy => setState({orderBy: newOrderBy})}
           limit={LIMIT}
         />
       </PaddedContainer>

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -1,10 +1,13 @@
-import {Fragment, useState} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import pick from 'lodash/pick';
 
 import DatePageFilter from 'sentry/components/datePageFilter';
 import {space} from 'sentry/styles/space';
+import {fromSorts} from 'sentry/utils/discover/eventView';
 import {useLocation} from 'sentry/utils/useLocation';
 import {ModuleName} from 'sentry/views/starfish/types';
+import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {ActionSelector} from 'sentry/views/starfish/views/spans/selectors/actionSelector';
 import {DomainSelector} from 'sentry/views/starfish/views/spans/selectors/domainSelector';
 import {SpanOperationSelector} from 'sentry/views/starfish/views/spans/selectors/spanOperationSelector';
@@ -12,6 +15,10 @@ import {SpanTimeCharts} from 'sentry/views/starfish/views/spans/spanTimeCharts';
 
 import SpansTable from './spansTable';
 
+const DEFAULT_SORT: Sort = {
+  kind: 'desc',
+  field: 'time_spent_percentage()',
+};
 const LIMIT: number = 25;
 
 type Props = {
@@ -19,23 +26,25 @@ type Props = {
   spanCategory?: string;
 };
 
-type State = {
-  orderBy: string;
-};
-
 type Query = {
   'span.action': string;
   'span.domain': string;
   'span.group': string;
   'span.op': string;
+  [QueryParameterNames.SORT]: string;
 };
 
 export default function SpansView(props: Props) {
   const location = useLocation<Query>();
-  const appliedFilters = location.query;
-  const [state, setState] = useState<State>({orderBy: '-time_spent_percentage'});
+  const appliedFilters = pick(location.query, [
+    'span.action',
+    'span.domain',
+    'span.op',
+    'span.group',
+  ]);
 
-  const {orderBy} = state;
+  const sort =
+    fromSorts(location.query[QueryParameterNames.SORT] ?? '')[0] ?? DEFAULT_SORT; // We only allow one sort on this table
 
   return (
     <Fragment>
@@ -73,8 +82,8 @@ export default function SpansView(props: Props) {
       <PaddedContainer>
         <SpansTable
           moduleName={props.moduleName || ModuleName.ALL}
-          orderBy={orderBy}
           spanCategory={props.spanCategory}
+          sort={sort}
           limit={LIMIT}
         />
       </PaddedContainer>

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -348,7 +348,10 @@ function SpanMetricsTable({
   return (
     <SpansTable
       moduleName={filter ?? ModuleName.ALL}
-      orderBy="-time_spent_percentage"
+      sort={{
+        field: 'time_spent_percentage()',
+        kind: 'desc',
+      }}
       endpoint={transaction}
       method={method}
       limit={SPANS_TABLE_LIMIT}

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -349,7 +349,6 @@ function SpanMetricsTable({
     <SpansTable
       moduleName={filter ?? ModuleName.ALL}
       orderBy="-time_spent_percentage"
-      onSetOrderBy={() => undefined}
       endpoint={transaction}
       method={method}
       limit={SPANS_TABLE_LIMIT}


### PR DESCRIPTION
I had to make surprisingly a lot of changes to make this one work. `SpansTable` used to _think_ it can do sorting, but it could not. It was all busted. Here's what I had to do:

- `useSpanList` now accepts a `sorts` prop instead of `orderby`. I'm not 100% sold on this, but it's kind of nice, that way a `Sort` object is used everywhere, which makes it possible to have great typing. Try giving `SpansTable` a sort on a field it doesn't support and watch it warn you! Pretty good
- fix it so `SpansTable` doesn't maintain any weird sorting state, instead using the URL query parameter `spansSort`. I think that's kind of gross, but it's what we're doing with the cursors for now, so I did the same thing with sorts
- improve the typing in `SpansTable`. Much less duplication, and now it'll throw errors when you try to feed it data it doesn't have, and so on

I'm pretty pleased with the `isAValidSort` predicate, too. Exporting it makes it possible to correctly type everything.

**e.g.,**

![Screenshot 2023-06-20 at 3 19 00 PM](https://github.com/getsentry/sentry/assets/989898/54ab77d0-5423-47c1-860b-5cea72b6b34b)
