### PR TITLE
feat(sourcemaps): adds check if debug id is supported

### DIFF
--- a/src/sentry/models/sourcemapprocessingissue.py
+++ b/src/sentry/models/sourcemapprocessingissue.py
@@ -14,6 +14,7 @@ class SourceMapProcessingIssue:
     PARTIAL_MATCH = "partial_match"
     DIST_MISMATCH = "dist_mismatch"
     SOURCEMAP_NOT_FOUND = "sourcemap_not_found"
+    NOT_PART_OF_PIPELINE = "not_part_of_pipeline"
 
     _messages = {
         UNKNOWN_ERROR: "Unknown error",
@@ -25,6 +26,7 @@ class SourceMapProcessingIssue:
         PARTIAL_MATCH: "The absolute path url is a partial match",
         DIST_MISMATCH: "The dist values do not match",
         SOURCEMAP_NOT_FOUND: "The sourcemap could not be found",
+        NOT_PART_OF_PIPELINE: "Sentry is not part of your build pipeline",
     }
 
     @classmethod


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/51298

This PR adds logic to show the error of incorporating Sentry into your build pipeline if the SDK you're using supports debug ids.