### PR TITLE
fix(hc): Query OrganizationMemberMapping for SSO state

### DIFF
--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -89,7 +89,9 @@ def _query_sso_state(
     return RpcMemberSsoState(is_required=requires_sso, is_valid=sso_is_valid)
 
 
-def _can_owner_override_sso(auth_provider, member):
+def _can_owner_override_sso(
+    auth_provider: AuthProvider, member: RpcOrganizationMemberSummary
+) -> bool:
     """If an owner is trying to gain access, allow bypassing SSO if there are no
     other owners with SSO enabled.
     """

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -45,8 +45,6 @@ _SSO_BYPASS = RpcMemberSsoState(is_required=False, is_valid=True)
 _SSO_NONMEMBER = RpcMemberSsoState(is_required=False, is_valid=False)
 
 
-# When OrgMemberMapping table is created for the control silo, org_member_class will use that rather
-# than the OrganizationMember type.
 def _query_sso_state(
     organization_id: int | None, is_super_user: bool, member: RpcOrganizationMemberSummary | None
 ) -> RpcMemberSsoState:

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -15,7 +15,7 @@ from sentry.models import (
     ApiToken,
     AuthIdentity,
     AuthProvider,
-    OrganizationMember,
+    OrganizationMemberMapping,
     SentryAppInstallationToken,
     User,
 )
@@ -47,7 +47,7 @@ _SSO_NONMEMBER = RpcMemberSsoState(is_required=False, is_valid=False)
 
 # When OrgMemberMapping table is created for the control silo, org_member_class will use that rather
 # than the OrganizationMember type.
-def query_sso_state(
+def _query_sso_state(
     organization_id: int | None, is_super_user: bool, member: RpcOrganizationMemberSummary | None
 ) -> RpcMemberSsoState:
     """
@@ -94,22 +94,17 @@ def query_sso_state(
                         organization_id=org_id
                     )
                     return (
-                        OrganizationMember.objects.filter(
+                        OrganizationMemberMapping.objects.filter(
                             Q(id__in=all_top_dogs_from_teams) | Q(role=roles.get_top_dog().id),
                             organization_id=org_id,
-                            user_is_active=True,
-                            user_id__isnull=False,
+                            user__is_active=True,
                         )
                         .exclude(id=mem_id)
                         .values_list("user_id")
                     )
 
                 if SiloMode.get_current_mode() != SiloMode.MONOLITH:
-                    # Giant hack for now until we have control silo org membership table.
-                    with SiloMode.exit_single_process_silo_context(), SiloMode.enter_single_process_silo_context(
-                        SiloMode.MONOLITH
-                    ):
-                        user_ids = get_user_ids(member.organization_id, member.id)
+                    user_ids = get_user_ids(member.organization_id, member.id)
                 else:
                     user_ids = get_user_ids(member.organization_id, member.id)
 
@@ -216,7 +211,7 @@ class DatabaseBackedAuthService(AuthService):
         organization_id: int | None,
         org_member: RpcOrganizationMemberSummary | None,
     ) -> RpcAuthState:
-        sso_state = query_sso_state(
+        sso_state = _query_sso_state(
             organization_id=organization_id, is_super_user=is_superuser, member=org_member
         )
         permissions: List[str] = list()

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -80,26 +80,27 @@ def _query_sso_state(
             )
         except AuthIdentity.DoesNotExist:
             sso_is_valid = False
-            org_roles = organization_service.get_all_org_roles(member_id=member.id)
-            if roles.get_top_dog().id in org_roles:
-                requires_sso = not _can_owner_override_sso(auth_provider, member)
+            requires_sso = not _can_override_sso_as_owner(auth_provider, member)
         else:
             sso_is_valid = auth_identity.is_valid(member)
 
     return RpcMemberSsoState(is_required=requires_sso, is_valid=sso_is_valid)
 
 
-def _can_owner_override_sso(
+def _can_override_sso_as_owner(
     auth_provider: AuthProvider, member: RpcOrganizationMemberSummary
 ) -> bool:
     """If an owner is trying to gain access, allow bypassing SSO if there are no
     other owners with SSO enabled.
     """
 
+    org_roles = organization_service.get_all_org_roles(member_id=member.id)
+    if roles.get_top_dog().id not in org_roles:
+        return False
+
     all_top_dogs_from_teams = organization_service.get_top_dog_team_member_ids(
         organization_id=member.organization_id
     )
-
     user_ids = (
         OrganizationMemberMapping.objects.filter(
             Q(id__in=all_top_dogs_from_teams) | Q(role=roles.get_top_dog().id),
@@ -109,7 +110,6 @@ def _can_owner_override_sso(
         .exclude(id=member.id)
         .values_list("user_id")
     )
-
     return not AuthIdentity.objects.filter(auth_provider=auth_provider, user__in=user_ids).exists()
 
 


### PR DESCRIPTION
Replaces a query to OrganizationMember to obey control silo mode limits. Remove the kludge that was exempting it.