### PR TITLE
fix(crons): Filter out alert rule if no targets specified

### DIFF
--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -130,6 +130,11 @@ function transformData(_data: Record<string, any>, model: FormModel) {
     return data;
   }, {});
 
+  // If targets are not specified, don't send alert rule config to backend
+  if (!result.alertRule?.targets) {
+    result.alertRule = undefined;
+  }
+
   return result;
 }
 


### PR DESCRIPTION
Currently if a user makes no selection here 
<img width="761" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/0ada0afc-97d1-465a-a655-ee4ded146202">
we still send an empty `{}` to the backend, which results in a validator error. We should allow users to not have to specify environments or alert rule, so filtering it out in the `transformData` function.