### PR TITLE
ref: Remove unnecessary sleep

### DIFF
--- a/src/sentry/processing/backpressure/arroyo.py
+++ b/src/sentry/processing/backpressure/arroyo.py
@@ -9,10 +9,6 @@ from arroyo.types import FilteredPayload, Message
 from sentry import options
 from sentry.processing.backpressure.health import is_consumer_healthy
 
-# As arroyo would otherwise busy-wait, we will sleep for a short time
-# when a message is rejected.
-SLEEP_MS = 10
-
 
 class HealthChecker:
     def __init__(self, consumer_name: str = "default"):
@@ -51,7 +47,6 @@ def create_backpressure_step(
 
     def ensure_healthy_queue(message: Message[TPayload]) -> TPayload:
         if not health_checker.is_healthy():
-            time.sleep(SLEEP_MS / 1000)
             raise MessageRejected()
 
         return message.payload


### PR DESCRIPTION
We ended up backporting this to Arroyo, sleeping in the consumer isn't needed anymore.
