### PR TITLE
feat(issue-platform): Write occurrence details to group message and event search_message

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -763,6 +763,25 @@ class GroupEvent(BaseEvent):
             return cast(str, self._snuba_data[column])
         return None
 
+    @memoize
+    def search_message(self) -> str:
+        message = super().search_message
+        # Include values from the occurrence in our search message as well, so that occurrences work
+        # correctly in search.
+        if self.occurrence is not None:
+            message = augment_message_with_occurrence(message, self.occurrence)
+
+        return message
+
+
+def augment_message_with_occurrence(message: str, occurrence: IssueOccurrence) -> str:
+    for attr in ("issue_title", "subtitle", "culprit"):
+        value = getattr(occurrence, attr, "")
+        if value and value not in message:
+            value = force_text(value, errors="replace")
+            message = f"{message} {value}"
+    return message
+
 
 class EventSubjectTemplate(string.Template):
     idpattern = r"(tag:)?[_a-z][_a-z0-9]*"

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -20,7 +20,7 @@ from sentry.event_manager import (
     _save_grouphash_and_group,
     get_event_type,
 )
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import Event, GroupEvent, augment_message_with_occurrence
 from sentry.issues.grouptype import should_create_group
 from sentry.issues.issue_occurrence import IssueOccurrence, IssueOccurrenceData
 from sentry.models import GroupHash, Release
@@ -144,6 +144,9 @@ def save_issue_from_occurrence(
 ) -> Optional[GroupInfo]:
     project = event.project
     issue_kwargs = _create_issue_kwargs(occurrence, event, release)
+    # We need to augment the message with occurrence data here since we can't build a `GroupEvent`
+    # until after we have created a `Group`.
+    issue_kwargs["message"] = augment_message_with_occurrence(issue_kwargs["message"], occurrence)
 
     # TODO: For now we will assume a single fingerprint. We can expand later if necessary.
     # Note that additional fingerprints won't be used to generated additional issues, they'll be
@@ -206,9 +209,9 @@ def save_issue_from_occurrence(
         is_new = False
         is_regression = False
 
-        # Note: This updates the message of the issue based on the event. Not sure what we want to
-        # store there yet, so we may need to revisit that.
-        is_regression = _process_existing_aggregate(group, event, issue_kwargs, release)
+        group_event = GroupEvent.from_event(event, group)
+        group_event.occurrence = occurrence
+        is_regression = _process_existing_aggregate(group, group_event, issue_kwargs, release)
         group_info = GroupInfo(group=group, is_new=is_new, is_regression=is_regression)
 
     return group_info

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -206,13 +206,10 @@ def save_issue_from_occurrence(
             )
             return None
 
-        is_new = False
-        is_regression = False
-
         group_event = GroupEvent.from_event(event, group)
         group_event.occurrence = occurrence
         is_regression = _process_existing_aggregate(group, group_event, issue_kwargs, release)
-        group_info = GroupInfo(group=group, is_new=is_new, is_regression=is_regression)
+        group_info = GroupInfo(group=group, is_new=False, is_regression=is_regression)
 
     return group_info
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2357,7 +2357,10 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             assert event.group
             group = event.group
             assert group.title == "N+1 Query"
-            assert group.message == "/books/"
+            assert (
+                group.message
+                == "/books/ N+1 Query SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+            )
             assert group.culprit == "/books/"
             assert group.get_event_type() == "transaction"
             description = "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
@@ -2366,7 +2369,10 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
                 "title": "N+1 Query",
                 "value": description,
             }
-            assert event.search_message == "/books/"
+            assert (
+                event.search_message
+                == "/books/ N+1 Query SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+            )
             assert group.location() == "/books/"
             assert group.level == 40
             assert group.issue_category == GroupCategory.PERFORMANCE

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -141,6 +141,7 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
         assert group.title == occurrence.issue_title
         assert group.data["metadata"]["value"] == occurrence.subtitle
         assert group.culprit == occurrence.culprit
+        assert group.message == "<unlabeled event> something bad happened it was bad api/123"
         assert group.location() == event.location
 
     def test_existing_group(self) -> None:
@@ -165,6 +166,7 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
         assert updated_group.culprit == new_occurrence.culprit
         assert updated_group.location() == event.location
         assert updated_group.times_seen == 2
+        assert updated_group.message == "<unlabeled event> new title new subtitle api/123"
 
     def test_existing_group_different_category(self) -> None:
         event = self.store_event(data={}, project_id=self.project.id)


### PR DESCRIPTION
We want occurrence information like title, subtitle and culprit to be searchable in clickhouse. For this to happen, we need to make sure this information is included in:
 - `search_message`, which is passed on to snuba to be written to the message columns
 - `Group.message`, which is used in the postgres side of search.

Related to https://github.com/getsentry/sentry/issues/50345

