### PR TITLE
fix(style): Align form action spacing with panel item

### DIFF
--- a/static/app/components/forms/form.tsx
+++ b/static/app/components/forms/form.tsx
@@ -273,7 +273,7 @@ const StyledFooter = styled('div')<{saveOnBlur?: boolean}>`
     `
   ${Panel} & {
     margin-top: 0;
-    padding-right: 36px;
+    padding-right: ${space(2)}
   }
 
   /* Better padding with form inside of a modal */


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry/pull/51267, @priscilawebdev noticed that the padding is off for the form inside of a panel. There is a dedicated style for this but it does not match the padding for PanelItem. This PR adjusts this so this is correct.

I tried to find occurrences in the app that use this combination (Form inside of a Panel) but couldn't really find one. I tried it in the org token PR where it looks correct to me - the buttons are aligned with the rest of the panel items.