### PR TITLE
Try to micro-optimize Enhancement matchers

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -270,7 +270,7 @@ class Enhancements:
             raise InvalidEnhancerConfig(
                 f'Invalid syntax near "{context}" (line {e.line()}, column {e.column()})'
             )
-        return EnhancmentsVisitor(bases, id).visit(tree)
+        return EnhancementsVisitor(bases, id).visit(tree)
 
 
 class Rule:
@@ -351,7 +351,7 @@ class Rule:
         )
 
 
-class EnhancmentsVisitor(NodeVisitor):
+class EnhancementsVisitor(NodeVisitor):
     visit_comment = visit_empty = lambda *a: None
     unwrapped_exceptions = (InvalidEnhancerConfig,)
 

--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -242,19 +242,20 @@ class InAppMatch(FrameMatch):
         return ref_val is not None and ref_val == match_frame["in_app"]
 
 
-class FunctionMatch(FrameMatch):
-    def _positive_frame_match(self, match_frame, platform, exception_data, cache):
-
-        return cached(cache, glob_match, match_frame["function"], self._encoded_pattern)
-
-
 class FrameFieldMatch(FrameMatch):
     def _positive_frame_match(self, match_frame, platform, exception_data, cache):
         field = match_frame[self.field]
         if field is None:
             return False
+        if field == self._encoded_pattern:
+            return True
 
         return cached(cache, glob_match, field, self._encoded_pattern)
+
+
+class FunctionMatch(FrameFieldMatch):
+
+    field = "function"
 
 
 class ModuleMatch(FrameFieldMatch):


### PR DESCRIPTION
- Turn the `FunctionMatch` into a normal `FrameFieldMatch` which short-circuits on `None`.
- Do a fast-path for exact matches.