### PR TITLE
ref(issues): Strip relative path prefixes from stack frame title

### DIFF
--- a/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
+++ b/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
@@ -42,6 +42,16 @@ function DefaultTitle({
   const framePlatform = getPlatform(frame.platform, platform);
   const tooltipDelay = isHoverPreviewed ? SLOW_TOOLTIP_DELAY : undefined;
 
+  /**
+   * In some cases (e.g. frame file names from SvelteKit stack frames),`frame.filename` can be
+   * prefixed with parent directory hops (e.g. `../../src/routes/....`).
+   * This function strips these hops so that users can clearly see where this file
+   * is located relative to their project root.
+   */
+  const stripRelativePathPrefix = (filename: string): string => {
+    return filename.replace(/^(..\/)*/, '');
+  };
+
   const handleExternalLink = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.stopPropagation();
   };
@@ -78,7 +88,7 @@ function DefaultTitle({
     if (frame.filename) {
       return {
         key: 'filename',
-        value: frame.filename,
+        value: stripRelativePathPrefix(frame.filename),
         meta: meta?.filename?.[''],
       };
     }

--- a/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
+++ b/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
@@ -49,7 +49,7 @@ function DefaultTitle({
    * is located relative to their project root.
    */
   const stripRelativePathPrefix = (filename: string): string => {
-    return filename.replace(/^(..\/)*/, '');
+    return filename.replace(/^(\.\.\/)*/, '');
   };
 
   const handleExternalLink = (event: React.MouseEvent<HTMLAnchorElement>) => {


### PR DESCRIPTION
As outlined in #50223, stack frame titles of errors from certain JS frameworks (e.g. SvelteKit or other projects built with Vite) can start with multiple `../` parent directory path prefixes.  This is confusing to our users, as they expect to see a filename that's relative to their project root. Therefore, this PR removes these parent directory hops from the frame title.

For more information/why I think this is best fixed in the UI, see #50223 and https://github.com/getsentry/sentry/issues/50223#issuecomment-1601093145

**Before**:
![image](https://github.com/getsentry/sentry/assets/8420481/0bbc8b86-f79a-446d-a4b7-e8b4c26cb129)

**After**:
![image](https://github.com/getsentry/sentry/assets/8420481/2a1a143a-6285-4968-b1f5-da89d7f04349)


  
