### PR TITLE
fix(hc): Fixing sentry app installation creation

### DIFF
--- a/src/sentry/sentry_apps/installations.py
+++ b/src/sentry/sentry_apps/installations.py
@@ -121,19 +121,17 @@ class SentryAppInstallationCreator:
         if not self.sentry_app.verify_install:
             status = SentryAppInstallationStatus.INSTALLED
 
-        return SentryAppInstallation.objects.update_or_create(
+        return SentryAppInstallation.objects.create(
             organization_id=self.organization_id,
             sentry_app_id=self.sentry_app.id,
-            defaults=dict(
-                api_grant_id=api_grant.id,
-                status=status,
-            ),
-        )[0]
+            api_grant_id=api_grant.id,
+            status=status,
+        )
 
     def _create_api_grant(self) -> ApiGrant:
-        return ApiGrant.objects.get_or_create(
+        return ApiGrant.objects.create(
             user_id=self.sentry_app.proxy_user.id, application_id=self.api_application.id
-        )[0]
+        )
 
     def _create_service_hooks(self, install: SentryAppInstallation) -> None:
         # only make the service hook if there is a webhook url

--- a/tests/sentry/sentry_apps/test_sentry_app_installation_creator.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_installation_creator.py
@@ -41,6 +41,15 @@ class TestCreator(TestCase):
         assert install.pk
 
     @responses.activate
+    def test_creates_installation__multiple_runs(self):
+        responses.add(responses.POST, "https://example.com/webhook")
+        install = self.run_creator()
+        assert install.pk
+
+        install2 = self.run_creator()
+        assert install2.pk != install.pk
+
+    @responses.activate
     def test_creates_api_grant(self):
         responses.add(responses.POST, "https://example.com/webhook")
         install = self.run_creator()


### PR DESCRIPTION
I made a really careless mistake, thinking that this logic needed to be more idempotent, but in reality this installation creator should always create new objects and not recycle.  This is a dumb bug on my part.