### PR TITLE
ref(sort): Hard code a/b test values

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -189,7 +189,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
             return func(val) if val is not None else default
 
-        # XXX(CEO): these default values are based on the current sort C and are subject to change
+        # XXX(CEO): these default values are based on sort E
         aggregate_kwargs = {
             "better_priority": {
                 "log_level": _coerce(
@@ -220,11 +220,9 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             }
         }
 
-        # XXX(CEO): these are based on the current sort D and E and are subject to change
-        if choice and not internal:
-            aggregate_kwargs["better_priority"]["issue_halflife_hours"] = 12
-        if choice == "variant1" and not internal:
-            aggregate_kwargs["better_priority"]["relative_volume"] = 0
+        # XXX(CEO): this is based on sort F
+        if choice == "variant2" and not internal:
+            aggregate_kwargs["better_priority"]["issue_halflife_hours"] = 42
 
         return aggregate_kwargs
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -68,7 +68,7 @@ DEFAULT_PRIORITY_WEIGHTS: PrioritySortWeights = {
     "has_stacktrace": 0,
     "relative_volume": 1,
     "event_halflife_hours": 4,
-    "issue_halflife_hours": 72,
+    "issue_halflife_hours": 12,
     "v2": True,
     "norm": False,
 }


### PR DESCRIPTION
Hard code the sort E and F values for `variant1` and `variant2` to prep for EA.