### PR TITLE
feat(search): Implement my_teams filter for issue search

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -92,7 +92,7 @@ def convert_actor_or_none_value(
     actors_or_none = []
     for actor in value:
         if actor == "my_teams":
-            actors_or_none.extend(get_teams_for_users(projects, user.id))
+            actors_or_none.extend(get_teams_for_users(projects, user))
         else:
             actors_or_none.append(parse_actor_or_none_value(projects, actor, user))
     return actors_or_none

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -25,6 +25,7 @@ from sentry.search.events.constants import EQUALITY_OPERATORS, INEQUALITY_OPERAT
 from sentry.search.events.filter import to_list
 from sentry.search.utils import (
     DEVICE_CLASS,
+    get_teams_for_users,
     parse_actor_or_none_value,
     parse_release,
     parse_status_value,
@@ -81,14 +82,20 @@ ValueConverter = Callable[
 
 
 def convert_actor_or_none_value(
-    value: Iterable[Union[User, Team]],
+    value: Iterable[str],
     projects: Sequence[Project],
     user: User,
     environments: Optional[Sequence[Environment]],
 ) -> List[Optional[Union[User, Team]]]:
     # TODO: This will make N queries. This should be ok, we don't typically have large
     # lists of actors here, but we can look into batching it if needed.
-    return [parse_actor_or_none_value(projects, actor, user) for actor in value]
+    actors_or_none = []
+    for actor in value:
+        if actor == "my_teams":
+            actors_or_none.extend(get_teams_for_users(projects, user.id))
+        else:
+            actors_or_none.append(parse_actor_or_none_value(projects, actor, user))
+    return actors_or_none
 
 
 def convert_user_value(

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -92,7 +92,7 @@ def convert_actor_or_none_value(
     actors_or_none = []
     for actor in value:
         if actor == "my_teams":
-            actors_or_none.extend(get_teams_for_users(projects, user))
+            actors_or_none.extend(get_teams_for_users(projects, [user]))
         else:
             actors_or_none.append(parse_actor_or_none_value(projects, actor, user))
     return actors_or_none

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -10,7 +10,7 @@ from django.db.models import Q, QuerySet
 from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
 
-from sentry import quotas
+from sentry import features, quotas
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import ErrorGroupType, GroupCategory, get_group_types_by_category
@@ -41,13 +41,13 @@ from sentry.search.snuba.executors import (
     PostgresSnubaQueryExecutor,
     PrioritySortWeights,
 )
+from sentry.search.utils import get_teams_for_users
 from sentry.utils.cursors import Cursor, CursorResult
 
 
 def assigned_to_filter(
     actors: Sequence[User | Team | None], projects: Sequence[Project], field_filter: str = "id"
 ) -> Q:
-    from sentry.models import OrganizationMember, OrganizationMemberTeam, Team
 
     include_none = False
     types_to_actors = defaultdict(list)
@@ -79,24 +79,17 @@ def assigned_to_filter(
                 ).values_list("group_id", flat=True)
             }
         )
-        query |= Q(
-            **{
-                f"{field_filter}__in": GroupAssignee.objects.filter(
-                    project_id__in=[p.id for p in projects],
-                    team_id__in=list(
-                        Team.objects.filter(
-                            id__in=OrganizationMemberTeam.objects.filter(
-                                organizationmember__in=OrganizationMember.objects.filter(
-                                    user_id__in=user_ids,
-                                    organization_id=projects[0].organization_id,
-                                ),
-                                is_active=True,
-                            ).values_list("team_id", flat=True)
-                        )
-                    ),
-                ).values_list("group_id", flat=True)
-            }
-        )
+        organization = projects[0].organization
+        # Only add teams to query if assign-to-me flag is off
+        if not features.has("organizations:assign-to-me", organization, actor=None):
+            query |= Q(
+                **{
+                    f"{field_filter}__in": GroupAssignee.objects.filter(
+                        project_id__in=[p.id for p in projects],
+                        team_id__in=[team for team in get_teams_for_users(projects, user_ids)],
+                    ).values_list("group_id", flat=True)
+                }
+            )
 
     if include_none:
         query |= unassigned_filter(True, projects, field_filter=field_filter)
@@ -235,10 +228,15 @@ def assigned_or_suggested_filter(
                 ).values("team")
             ).values_list("id", flat=True)
         )
+        organization = projects[0].organization
+        query_ids = Q(user_id__in=user_ids)
+        # Only add team_ids to query if assign-to-me flag is off
+        if not features.has("organizations:assign-to-me", organization, actor=None):
+            query_ids = query_ids | Q(team_id__in=team_ids)
         owned_by_me = Q(
             **{
                 f"{field_filter}__in": GroupOwner.objects.filter(
-                    Q(user_id__in=user_ids) | Q(team_id__in=team_ids),
+                    query_ids,
                     group__assignee_set__isnull=True,
                     project_id__in=[p.id for p in projects],
                     organization_id=organization_id,

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -228,15 +228,10 @@ def assigned_or_suggested_filter(
                 ).values("team")
             ).values_list("id", flat=True)
         )
-        organization = projects[0].organization
-        query_ids = Q(user_id__in=user_ids)
-        # Only add team_ids to query if assign-to-me flag is off
-        if not features.has("organizations:assign-to-me", organization, actor=None):
-            query_ids = query_ids | Q(team_id__in=team_ids)
         owned_by_me = Q(
             **{
                 f"{field_filter}__in": GroupOwner.objects.filter(
-                    query_ids,
+                    Q(user_id__in=user_ids) | Q(team_id__in=team_ids),
                     group__assignee_set__isnull=True,
                     project_id__in=[p.id for p in projects],
                     organization_id=organization_id,

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -86,7 +86,7 @@ def assigned_to_filter(
                 **{
                     f"{field_filter}__in": GroupAssignee.objects.filter(
                         project_id__in=[p.id for p in projects],
-                        team_id__in=[team for team in get_teams_for_users(projects, user_ids)],
+                        team_id__in=[team for team in get_teams_for_users(projects, users)],
                     ).values_list("group_id", flat=True)
                 }
             )

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -216,7 +216,6 @@ def assigned_or_suggested_filter(
         ) | assigned_to_filter(teams, projects, field_filter=field_filter)
 
     if "User" in types_to_owners:
-        # test change
         users = types_to_owners["User"]
         user_ids: List[int] = [u.id for u in users if u is not None]
         team_ids = list(

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -216,6 +216,7 @@ def assigned_or_suggested_filter(
         ) | assigned_to_filter(teams, projects, field_filter=field_filter)
 
     if "User" in types_to_owners:
+        # test change
         users = types_to_owners["User"]
         user_ids: List[int] = [u.id for u in users if u is not None]
         team_ids = list(

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -318,8 +318,12 @@ def parse_team_value(projects: Sequence[Project], value: Sequence[str], user: Us
     ).first() or Team(id=0)
 
 
-def get_teams_for_users(projects: Sequence[Project], user_ids: Sequence[User]) -> list[Team]:
-    user_ids = [user_ids] if not isinstance(user_ids, list) else user_ids
+def get_teams_for_users(projects: Sequence[Project], users: Sequence[User]) -> list[Team]:
+    user_ids = (
+        [users.id]
+        if not (users is None or isinstance(users, list))
+        else [u.id for u in users if u is not None]
+    )
     teams = Team.objects.filter(
         id__in=OrganizationMemberTeam.objects.filter(
             organizationmember__in=OrganizationMember.objects.filter(

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -319,11 +319,7 @@ def parse_team_value(projects: Sequence[Project], value: Sequence[str], user: Us
 
 
 def get_teams_for_users(projects: Sequence[Project], users: Sequence[User]) -> list[Team]:
-    user_ids = (
-        [users.id]
-        if not (users is None or isinstance(users, list))
-        else [u.id for u in users if u is not None]
-    )
+    user_ids = [u.id for u in users if u is not None]
     teams = Team.objects.filter(
         id__in=OrganizationMemberTeam.objects.filter(
             organizationmember__in=OrganizationMember.objects.filter(

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -27,6 +27,8 @@ from sentry.models import (
     KEYWORD_MAP,
     Environment,
     EventUser,
+    OrganizationMember,
+    OrganizationMemberTeam,
     Project,
     Release,
     Team,
@@ -314,6 +316,19 @@ def parse_team_value(projects: Sequence[Project], value: Sequence[str], user: Us
     return Team.objects.filter(
         slug__iexact=value[1:], projectteam__project__in=projects
     ).first() or Team(id=0)
+
+
+def get_teams_for_users(projects: Sequence[Project], user_ids: Sequence[User]) -> list[Team]:
+    user_ids = [user_ids] if not isinstance(user_ids, list) else user_ids
+    teams = Team.objects.filter(
+        id__in=OrganizationMemberTeam.objects.filter(
+            organizationmember__in=OrganizationMember.objects.filter(
+                user_id__in=user_ids, organization_id=projects[0].organization_id
+            ),
+            is_active=True,
+        ).values("team")
+    )
+    return list(teams)
 
 
 def parse_actor_value(projects: Sequence[Project], value: str, user: User) -> Union[User, Team]:

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -346,7 +346,7 @@ class ConvertActorOrNoneValueTest(TestCase):
     def test_my_team(self):
         assert convert_actor_or_none_value(
             ["my_teams"], [self.project], self.user, None
-        ) == get_teams_for_users([self.project], self.user)
+        ) == get_teams_for_users([self.project], [self.user])
 
     def test_none(self):
         assert convert_actor_or_none_value(["none"], [self.project], self.user, None) == [None]

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -25,7 +25,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES, GroupStatus
 from sentry.testutils import TestCase
-from sentry.testutils.helpers.features import apply_feature_flag_on_cls
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls, with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
 
@@ -180,6 +180,38 @@ class ConvertJavaScriptConsoleTagTest(TestCase):
 
 @region_silo_test(stable=True)
 class ConvertQueryValuesTest(TestCase):
+    @with_feature("organizations:assign-to-me")
+    def test_valid_assign_me_converter(self):
+        filters = [SearchFilter(SearchKey("assigned_to"), "=", SearchValue("me"))]
+        expected = value_converters["assigned_to"](
+            [filters[0].value.raw_value], [self.project], self.user, None
+        )
+        filters = convert_query_values(filters, [self.project], self.user, None)
+        assert filters[0].value.raw_value == expected
+
+    @with_feature("organizations:assign-to-me")
+    def test_valid_assign_me_no_converter(self):
+        search_val = SearchValue("me")
+        filters = [SearchFilter(SearchKey("something"), "=", search_val)]
+        filters = convert_query_values(filters, [self.project], self.user, None)
+        assert filters[0].value.raw_value == search_val.raw_value
+
+    @with_feature("organizations:assign-to-me")
+    def test_valid_assign_my_teams_converter(self):
+        filters = [SearchFilter(SearchKey("assigned_to"), "=", SearchValue("my_teams"))]
+        expected = value_converters["assigned_to"](
+            [filters[0].value.raw_value], [self.project], self.user, None
+        )
+        filters = convert_query_values(filters, [self.project], self.user, None)
+        assert filters[0].value.raw_value == expected
+
+    @with_feature("organizations:assign-to-me")
+    def test_valid_assign_my_teams_no_converter(self):
+        search_val = SearchValue("my_teams")
+        filters = [SearchFilter(SearchKey("something"), "=", search_val)]
+        filters = convert_query_values(filters, [self.project], self.user, None)
+        assert filters[0].value.raw_value == search_val.raw_value
+
     def test_valid_converter(self):
         filters = [SearchFilter(SearchKey("assigned_to"), "=", SearchValue("me"))]
         expected = value_converters["assigned_to"](

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -24,6 +24,7 @@ from sentry.api.issue_search import (
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES, GroupStatus
+from sentry.search.utils import get_teams_for_users
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls, with_feature
 from sentry.testutils.silo import region_silo_test
@@ -340,6 +341,12 @@ class ConvertActorOrNoneValueTest(TestCase):
         assert convert_actor_or_none_value(
             ["me"], [self.project], self.user, None
         ) == convert_user_value(["me"], [self.project], self.user, None)
+
+    @with_feature("organizations:assign-to-me")
+    def test_my_team(self):
+        assert convert_actor_or_none_value(
+            ["my_teams"], [self.project], self.user, None
+        ) == get_teams_for_users([self.project], self.user)
 
     def test_none(self):
         assert convert_actor_or_none_value(["none"], [self.project], self.user, None) == [None]

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1124,7 +1124,7 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         # this should return the groups directly assigned to me as well as groups assigned to teams I belong to
         assert GroupAssignee.objects.get(group=self.group2)
         assert GroupAssignee.objects.get(group=my_team_group)
-        results = self.make_query(search_filter_query="assigned:definitely_me", user=self.user)
+        results = self.make_query(search_filter_query="assigned:me", user=self.user)
         assert set(results) == {self.group2, my_team_group}
 
         # with the feature flag on where we split the behavior so 'me' only checks for groups assigned to me

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1086,6 +1086,7 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         results = self.make_query(search_filter_query="assigned:%s" % other_user.username)
         assert set(results) == set()
 
+        # test comment
         owner = self.create_user()
         self.create_member(
             organization=self.project.organization, user=owner, role="owner", teams=[]

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -58,6 +58,7 @@ class SharedSnubaTest(TestCase, SnubaTestCase):
         self,
         projects=None,
         search_filter_query=None,
+        user=None,
         environments=None,
         sort_by="date",
         limit=None,
@@ -71,7 +72,7 @@ class SharedSnubaTest(TestCase, SnubaTestCase):
         projects = projects if projects is not None else [self.project]
         if search_filter_query is not None:
             search_filters = self.build_search_filter(
-                search_filter_query, projects, environments=environments
+                search_filter_query, projects, user=user, environments=environments
             )
 
         kwargs = {}
@@ -1093,6 +1094,49 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         # test that owners don't see results for all teams
         results = self.make_query(search_filter_query="assigned:%s" % owner.username)
         assert set(results) == set()
+
+    def test_assigned_to_me_my_teams(self):
+        my_team_event = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group-my-teams"],
+                "event_id": "f" * 32,
+                "timestamp": iso_format(self.base_datetime - timedelta(days=20)),
+                "message": "baz",
+                "environment": "staging",
+                "tags": {
+                    "server": "example.com",
+                    "url": "http://example.com",
+                    "sentry:user": "event2@example.com",
+                },
+                "level": "error",
+            },
+            project_id=self.project.id,
+        )
+
+        my_team_group = Group.objects.get(id=my_team_event.group.id)
+        assert my_team_group.id == my_team_event.group.id
+        # assign the issue to my team instead of me
+        GroupAssignee.objects.create(
+            user_id=None, team_id=self.team.id, group=my_team_group, project=my_team_group.project
+        )
+
+        # before the change to me -> (me + my_teams)
+        # this should return the groups directly assigned to me as well as groups assigned to teams I belong to
+        assert GroupAssignee.objects.get(group=self.group2)
+        assert GroupAssignee.objects.get(group=my_team_group)
+        results = self.make_query(search_filter_query="assigned:definitely_me", user=self.user)
+        assert set(results) == {self.group2, my_team_group}
+
+        # with the feature flag on where we split the behavior so 'me' only checks for groups assigned to me
+        with self.feature("organizations:assign-to-me"):
+            results1 = self.make_query(search_filter_query="assigned:me", user=self.user)
+            assert set(results1) == {self.group2}
+
+            results2 = self.make_query(search_filter_query="assigned:my_teams", user=self.user)
+            assert set(results2) == {my_team_group}
+
+            results2 = self.make_query(search_filter_query="assigned:[me,my_teams]", user=self.user)
+            assert set(results2) == {self.group2, my_team_group}
 
     def test_assigned_to_in_syntax(self):
         group_3 = self.store_event(

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1086,7 +1086,6 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         results = self.make_query(search_filter_query="assigned:%s" % other_user.username)
         assert set(results) == set()
 
-        # test comment
         owner = self.create_user()
         self.create_member(
             organization=self.project.organization, user=owner, role="owner", teams=[]


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/50842 and https://github.com/getsentry/sentry/issues/50847

Modifies `assigned_to_filter` query such that when the assign-to-me feature flag is enabled, the `me` filter only returns issues assigned to the user.

Also adds a filter `my_teams` that returns issues assigned to the user's teams and not the individual user.

Finally, adds tests for these changes