### PR TITLE
fix(starfish): span samples with empty result

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -150,6 +150,8 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
                 span_ids.append(middle)
             if top:
                 span_ids.append(top)
+        if len(span_ids) == 0:
+            return Response({"data": []})
 
         result = spans_indexed.query(
             selected_columns=["project", "transaction.id", column, "timestamp", "span_id"],


### PR DESCRIPTION
- Fixes SENTRY-12GN
- This fixes a bug where we'd error in the third query when there wasn't any span ids to filter on