### PR TITLE
fix(starfish): duration chart axis sometimes has wrong axis max

### DIFF
--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -119,7 +119,7 @@ function computeAxisMax(data: Series[], stacked?: boolean) {
   }
 
   const step = 10 ** Math.floor(power) * scale;
-  return Math.round(Math.ceil(maxValue / step) * step);
+  return Math.ceil(Math.ceil(maxValue / step) * step);
 }
 
 function Chart({
@@ -419,6 +419,7 @@ function Chart({
       </ChartZoom>
     );
   }
+
   return (
     <TransitionChart
       loading={loading}

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -419,7 +419,6 @@ function Chart({
       </ChartZoom>
     );
   }
-
   return (
     <TransitionChart
       loading={loading}


### PR DESCRIPTION
When we're dealing with super low durations that are a fraction of a ms, sometimes the axis max will round down from say 2.2 to 2 ms causing the line to go off the graph. This PR fixes this bug by always rounding UP to the nearest ms.

Before
<img width="709" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/102e6d89-f6fb-4e61-9bb1-a7f06b4a8f89">

After
<img width="713" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/6b7211bf-a00a-432a-9df7-8fb52833a84d">
