### PR TITLE
test(hc): Add env var to force siloed tests

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3479,6 +3479,9 @@ SLICED_KAFKA_TOPICS: Mapping[Tuple[str, int], Mapping[str, Any]] = {}
 # decorator.
 SINGLE_SERVER_SILO_MODE = False
 
+# Used by silo tests -- activate all silo mode test decorators even if not marked stable
+FORCE_SILOED_TESTS = os.environ.get("SENTRY_FORCE_SILOED_TESTS", False)
+
 # Set the URL for signup page that we redirect to for the setup wizard if signup=1 is in the query params
 SENTRY_SIGNUP_URL = None
 

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Generator, Iterable, Set, Tuple, Type
 from unittest import TestCase
 
 import pytest
+from django.conf import settings
 from django.db import connections, router
 from django.db.models import Model
 from django.db.models.fields.related import RelatedField
@@ -140,7 +141,7 @@ class SiloModeTest:
             raise ValueError("@SiloModeTest must decorate a function or TestCase class")
 
         # Only run non monolith tests when they are marked stable or we are explicitly running for that mode.
-        if not stable:
+        if not (stable or settings.FORCE_SILOED_TESTS):
             # In this case, simply force the current silo mode (monolith)
             return decorated_obj
 


### PR DESCRIPTION
This is a convenience for running tests manually in a local environment. If you want to observe how a test would behave if marked stable, rather than temporarily editing the decorator, you can do `SENTRY_FORCE_SILOED_TESTS=true pytest tests/sentry/test_whatever.py` on the shell.