### PR TITLE
feat(github-comments): populate PullRequestCommit table

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -220,6 +220,8 @@ class GitHubClientMixin(GithubProxyClient):
     def get_pullrequest_from_commit(self, repo: str, sha: str) -> JSONData:
         """
         https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit
+
+        Returns the merged pull request that introduced the commit to the repository. If the commit is not present in the default branch, will only return open pull requests associated with the commit.
         """
         pullrequest: JSONData = self.get(f"/repos/{repo}/commits/{sha}/pulls")
         return pullrequest

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -19,6 +19,7 @@ from sentry.models import (
     RepositoryProjectPathConfig,
 )
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.pullrequest import PullRequestCommit
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.groupowner import process_suspect_commits
@@ -44,19 +45,35 @@ def queue_comment_task_if_needed(
         extra={"organization_id": commit.organization_id, "merge_commit_sha": commit.key},
     )
 
+    # client will raise ApiError if the request is not successful
     response = installation.get_client().get_pullrequest_from_commit(repo=repo.name, sha=commit.key)
 
-    if not (response.status_code == 200 and isinstance(response, list) and len(response) == 1):
+    if not (isinstance(response, list) and len(response) == 1):
         # the response should return a single PR, return if multiple
+        if len(response) > 1:
+            logger.info(
+                "github.pr_comment.queue_comment_check.commit_not_in_default_branch",
+                extra={
+                    "organization_id": commit.organization_id,
+                    "repository_id": repo.id,
+                    "commit_sha": commit.key,
+                },
+            )
         return
 
+    merge_commit_sha = response[0]["merge_commit_sha"]
+
     pr_query = PullRequest.objects.filter(
-        organization_id=commit.organization_id, merge_commit_sha=response[0]["merge_commit_sha"]
+        organization_id=commit.organization_id, merge_commit_sha=merge_commit_sha
     )
     if not pr_query.exists():
         logger.info(
-            "github.pr_comment.queue_comment_task_missing_pr",
-            extra={"organization_id": commit.organization_id, "suspect_commit_sha": commit.key},
+            "github.pr_comment.queue_comment_check.missing_pr",
+            extra={
+                "organization_id": commit.organization_id,
+                "repository_id": repo.id,
+                "commit_sha": commit.key,
+            },
         )
         return
 
@@ -65,6 +82,11 @@ def queue_comment_task_if_needed(
         not pr.pullrequestcomment_set.exists()
         or group_owner.group_id not in pr.pullrequestcomment_set.get().group_ids
     ):
+        # create PR commit row for suspect commit and PR
+        pr_commit_query = PullRequestCommit.objects.filter(commit=commit, pull_request=pr)
+        if not pr_commit_query.exists():
+            PullRequestCommit.objects.create(commit=commit, pull_request=pr)
+
         # TODO: Debouncing Logic
         logger.info(
             "github.pr_comment.queue_comment_workflow",

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -509,7 +509,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
     @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate
     def test_gh_comment_no_pr_from_api(self, get_jwt, mock_comment_workflow):
-        """No comments on suspect commit with no pr"""
+        """No comments on suspect commit with no pr returned from API response"""
         self.pull_request.delete()
 
         responses.add(
@@ -568,7 +568,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
     @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate
     def test_gh_comment_no_pr_from_query(self, get_jwt, mock_comment_workflow):
-        """No comments on suspect commit with no pr"""
+        """No comments on suspect commit with no pr row in table"""
         self.pull_request.delete()
 
         self.add_responses()


### PR DESCRIPTION
The `PullRequestCommit` table is currently empty. We will be using it to associate suspect commits (branch commits) with pull requests. This is so that when we run `pr_to_issue_query`, there is a relationship between the suspect commits attached to issues and pull requests.

For ER-1654