### PR TITLE
ref(email): Add unsubscribe link to metric alert emails

### DIFF
--- a/src/sentry/web/frontend/debug/debug_incident_trigger_email.py
+++ b/src/sentry/web/frontend/debug/debug_incident_trigger_email.py
@@ -27,8 +27,8 @@ class DebugIncidentTriggerEmailView(MailPreviewView):
     @mock.patch("sentry.models.UserOption.objects.get_value", return_value="US/Pacific")
     def get_context(self, request, incident_trigger_mock, user_option_mock):
         organization = Organization(slug="myorg")
-        project = Project(slug="myproject", organization=organization)
-        user = User()
+        project = Project(id=1, slug="myproject", organization=organization)
+        user = User(id=1)
 
         query = SnubaQuery(
             time_window=60, query="transaction:/some/transaction", aggregate="count()"


### PR DESCRIPTION
Adds an unsubscribe button to metric alert emails in the same way we have them for issue alerts and digests.

<img width="727" alt="Screenshot 2023-06-21 at 3 52 54 PM" src="https://github.com/getsentry/sentry/assets/29959063/2cdd86cd-d557-4a9c-985e-ece350ee4cf8">
