### PR TITLE
fix(starfish): Render numbers in span table using field renderers

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -46,6 +46,8 @@ import {
   SpanOperationBreakdownFilter,
   stringToFilter,
 } from 'sentry/views/performance/transactionSummary/filter';
+import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
+import {SpanMetricsFields} from 'sentry/views/starfish/types';
 import {PercentChangeCell} from 'sentry/views/starfish/views/webServiceView/endpointList';
 
 import {decodeScalar} from '../queryString';
@@ -677,6 +679,7 @@ type SpecialFunctions = {
   http_error_count_percent_change: SpecialFunctionFieldRenderer;
   percentile_percent_change: SpecialFunctionFieldRenderer;
   sps_percent_change: SpecialFunctionFieldRenderer;
+  time_spent_percentage: SpecialFunctionFieldRenderer;
   user_misery: SpecialFunctionFieldRenderer;
 };
 
@@ -782,6 +785,14 @@ const SPECIAL_FUNCTIONS: SpecialFunctions = {
       <PercentChangeCell
         trendDirection={trendDirection}
       >{`${sign}${delta}`}</PercentChangeCell>
+    );
+  },
+  time_spent_percentage: fieldName => data => {
+    return (
+      <TimeSpentCell
+        timeSpentPercentage={data[fieldName]}
+        totalSpanTime={data[`sum(${SpanMetricsFields.SPAN_SELF_TIME})`]}
+      />
     );
   },
 };

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -105,6 +105,7 @@ type FieldFormatters = {
   duration: FieldFormatter;
   integer: FieldFormatter;
   number: FieldFormatter;
+  percent_change: FieldFormatter;
   percentage: FieldFormatter;
   size: FieldFormatter;
   string: FieldFormatter;
@@ -291,6 +292,22 @@ export const FIELD_FORMATTERS: FieldFormatters = {
     renderFunc: (field, data) => {
       const value = toArray(data[field]);
       return <ArrayValue value={value} />;
+    },
+  },
+  percent_change: {
+    isSortable: true,
+    renderFunc: (fieldName, data) => {
+      const deltaValue = data[fieldName];
+
+      const sign = deltaValue >= 0 ? '+' : '-';
+      const delta = formatPercentage(Math.abs(deltaValue), 2);
+      const trendDirection = deltaValue < 0 ? 'good' : deltaValue > 0 ? 'bad' : 'neutral';
+
+      return (
+        <PercentChangeCell
+          trendDirection={trendDirection}
+        >{`${sign}${delta}`}</PercentChangeCell>
+      );
     },
   },
 };
@@ -676,8 +693,6 @@ type SpecialFunctionFieldRenderer = (
 ) => (data: EventData, baggage: RenderFunctionBaggage) => React.ReactNode;
 
 type SpecialFunctions = {
-  http_error_count_percent_change: SpecialFunctionFieldRenderer;
-  percentile_percent_change: SpecialFunctionFieldRenderer;
   sps_percent_change: SpecialFunctionFieldRenderer;
   time_spent_percentage: SpecialFunctionFieldRenderer;
   user_misery: SpecialFunctionFieldRenderer;
@@ -747,9 +762,6 @@ const SPECIAL_FUNCTIONS: SpecialFunctions = {
       </BarContainer>
     );
   },
-  // TODO: As soon as events endpoints `meta` give `*_percent_change` fields a
-  // type of `percentage_change` (as opposed to `percentage`, as it currently
-  // is) all this logic can move down into FIELD_RENDERERS and be consolidated
   sps_percent_change: fieldName => data => {
     const deltaValue = data[fieldName];
 
@@ -759,32 +771,6 @@ const SPECIAL_FUNCTIONS: SpecialFunctions = {
     return (
       // N.B. For throughput, the change is neither good nor bad regardless of value! Throughput is just throughput
       <PercentChangeCell trendDirection="neutral">{`${sign}${delta}`}</PercentChangeCell>
-    );
-  },
-  percentile_percent_change: fieldName => data => {
-    const deltaValue = data[fieldName];
-
-    const sign = deltaValue >= 0 ? '+' : '-';
-    const delta = formatPercentage(Math.abs(deltaValue), 2);
-    const trendDirection = deltaValue < 0 ? 'good' : deltaValue > 0 ? 'bad' : 'neutral';
-
-    return (
-      <PercentChangeCell
-        trendDirection={trendDirection}
-      >{`${sign}${delta}`}</PercentChangeCell>
-    );
-  },
-  http_error_count_percent_change: fieldName => data => {
-    const deltaValue = data[fieldName];
-
-    const sign = deltaValue >= 0 ? '+' : '-';
-    const delta = formatPercentage(Math.abs(deltaValue), 2);
-    const trendDirection = deltaValue < 0 ? 'good' : deltaValue > 0 ? 'bad' : 'neutral';
-
-    return (
-      <PercentChangeCell
-        trendDirection={trendDirection}
-      >{`${sign}${delta}`}</PercentChangeCell>
     );
   },
   time_spent_percentage: fieldName => data => {

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -46,9 +46,9 @@ import {
   SpanOperationBreakdownFilter,
   stringToFilter,
 } from 'sentry/views/performance/transactionSummary/filter';
+import {PercentChangeCell} from 'sentry/views/starfish/components/tableCells/percentChangeCell';
 import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {SpanMetricsFields} from 'sentry/views/starfish/types';
-import {PercentChangeCell} from 'sentry/views/starfish/views/webServiceView/endpointList';
 
 import {decodeScalar} from '../queryString';
 

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -132,6 +132,7 @@ export enum FieldValueType {
   NEVER = 'never',
   SIZE = 'size',
   RATE = 'rate',
+  PERCENT_CHANGE = 'percent_change',
 }
 
 export enum WebVital {

--- a/static/app/views/starfish/components/tableCells/percentChangeCell.tsx
+++ b/static/app/views/starfish/components/tableCells/percentChangeCell.tsx
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+export const PercentChangeCell = styled('div')<{
+  trendDirection: 'good' | 'bad' | 'neutral';
+}>`
+  color: ${p =>
+    p.trendDirection === 'good'
+      ? p.theme.successText
+      : p.trendDirection === 'bad'
+      ? p.theme.errorText
+      : p.theme.subText};
+  float: right;
+`;

--- a/static/app/views/starfish/components/tableCells/percentChangeCell.tsx
+++ b/static/app/views/starfish/components/tableCells/percentChangeCell.tsx
@@ -1,13 +1,26 @@
+import React from 'react';
 import styled from '@emotion/styled';
 
-export const PercentChangeCell = styled('div')<{
+import {NumberContainer} from 'sentry/utils/discover/styles';
+
+type Props = {
+  children: React.ReactNode;
   trendDirection: 'good' | 'bad' | 'neutral';
-}>`
+};
+
+export function PercentChangeCell({trendDirection, children}: Props) {
+  return (
+    <NumberContainer>
+      <Colorized trendDirection={trendDirection}>{children}</Colorized>
+    </NumberContainer>
+  );
+}
+
+const Colorized = styled('div')<Props>`
   color: ${p =>
     p.trendDirection === 'good'
       ? p.theme.successText
       : p.trendDirection === 'bad'
       ? p.theme.errorText
       : p.theme.subText};
-  float: right;
 `;

--- a/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
+++ b/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
@@ -1,5 +1,6 @@
 import {Tooltip} from 'sentry/components/tooltip';
 import {formatPercentage} from 'sentry/utils/formatters';
+import {TextAlignRight} from 'sentry/views/starfish/components/textAlign';
 import {getTooltip} from 'sentry/views/starfish/views/spans/types';
 
 export function TimeSpentCell({
@@ -12,10 +13,10 @@ export function TimeSpentCell({
   const toolTip = getTooltip('timeSpent', totalSpanTime);
   const percentage = timeSpentPercentage > 1 ? 1 : timeSpentPercentage;
   return (
-    <span>
+    <TextAlignRight>
       <Tooltip isHoverable title={toolTip}>
         {formatPercentage(percentage)}
       </Tooltip>
-    </span>
+    </TextAlignRight>
   );
 }

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -7,7 +7,7 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
-import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
+import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {NULL_SPAN_CATEGORY} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
 const {SPAN_SELF_TIME} = SpanMetricsFields;
@@ -41,7 +41,7 @@ export const useSpanList = (
 
   const eventView = getEventView(moduleName, location, transaction, spanCategory, sorts);
 
-  const {isLoading, data, meta, pageLinks} = useSpansQuery<SpanMetrics[]>({
+  const {isLoading, data, meta, pageLinks} = useWrappedDiscoverQuery<SpanMetrics[]>({
     eventView,
     initialData: [],
     limit,

--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -34,9 +34,11 @@ export function useSpansQuery<T = any[]>({
   limit?: number;
   referrer?: string;
 }): UseSpansQueryReturnType<T> {
-  const queryFunction = getQueryFunction({
-    isTimeseriesQuery: (eventView?.yAxis?.length ?? 0) > 0,
-  });
+  const isTimeseriesQuery = (eventView?.yAxis?.length ?? 0) > 0;
+  const queryFunction = isTimeseriesQuery
+    ? useWrappedDiscoverTimeseriesQuery
+    : useWrappedDiscoverQuery;
+
   if (eventView) {
     const response = queryFunction({
       eventView,
@@ -142,14 +144,6 @@ export function useWrappedDiscoverQuery({
     meta: data?.meta ?? {},
     pageLinks,
   };
-}
-
-function getQueryFunction({isTimeseriesQuery}: {isTimeseriesQuery?: boolean}) {
-  if (isTimeseriesQuery) {
-    return useWrappedDiscoverTimeseriesQuery;
-  }
-
-  return useWrappedDiscoverQuery;
 }
 
 type Interval = {[key: string]: any; interval: string; group?: string};

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -18,7 +18,6 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import CountCell from 'sentry/views/starfish/components/tableCells/countCell';
-import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
 import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
@@ -181,10 +180,6 @@ function renderBodyCell(
 
   if (column.key === 'sps()') {
     return <ThroughputCell throughputPerSecond={row['sps()']} />;
-  }
-
-  if (column.key === 'p95(span.self_time)') {
-    return <DurationCell milliseconds={row['p95(span.self_time)']} />;
   }
 
   if (column.key === 'http_error_count()') {

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -17,7 +17,6 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import CountCell from 'sentry/views/starfish/components/tableCells/countCell';
 import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
@@ -180,10 +179,6 @@ function renderBodyCell(
 
   if (column.key === 'sps()') {
     return <ThroughputCell throughputPerSecond={row['sps()']} />;
-  }
-
-  if (column.key === 'http_error_count()') {
-    return <CountCell count={row['http_error_count()']} />;
   }
 
   if (!meta || !meta?.fields) {

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -11,7 +11,7 @@ import SortLink from 'sentry/components/gridEditable/sortLink';
 import Link from 'sentry/components/links/link';
 import Pagination, {CursorHandler} from 'sentry/components/pagination';
 import {Organization} from 'sentry/types';
-import {MetaType} from 'sentry/utils/discover/eventView';
+import {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -146,7 +146,7 @@ function renderHeadCell(column: Column, sort: Sort, location: Location) {
 function renderBodyCell(
   column: Column,
   row: Row,
-  meta: MetaType | undefined,
+  meta: EventsMetaType | undefined,
   location: Location,
   organization: Organization,
   endpoint?: string,
@@ -195,7 +195,7 @@ function renderBodyCell(
     return row[column.key];
   }
 
-  const renderer = getFieldRenderer(column.key, meta, false);
+  const renderer = getFieldRenderer(column.key, meta.fields, false);
   const rendered = renderer(row, {location, organization});
 
   return rendered;

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -18,7 +18,6 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
-import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import {useSpanList} from 'sentry/views/starfish/queries/useSpanList';
 import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
@@ -165,15 +164,6 @@ function renderBodyCell(
           row['span.description'] || '<null>'
         )}
       </OverflowEllipsisTextContainer>
-    );
-  }
-
-  if (column.key === 'time_spent_percentage()') {
-    return (
-      <TimeSpentCell
-        timeSpentPercentage={row['time_spent_percentage()']}
-        totalSpanTime={row[`sum(${SPAN_SELF_TIME})`]}
-      />
     );
   }
 

--- a/static/app/views/starfish/views/webServiceView/endpointList.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointList.tsx
@@ -27,6 +27,7 @@ import {getAggregateAlias} from 'sentry/utils/discover/fields';
 import {NumberContainer} from 'sentry/utils/discover/styles';
 import {formatPercentage} from 'sentry/utils/formatters';
 import {TableColumn} from 'sentry/views/discover/table/types';
+import {PercentChangeCell} from 'sentry/views/starfish/components/tableCells/percentChangeCell';
 import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {TIME_SPENT_IN_SERVICE} from 'sentry/views/starfish/utils/generatePerformanceEventView';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
@@ -335,18 +336,6 @@ function EndpointList({eventView, location, organization, setError}: Props) {
 }
 
 export default EndpointList;
-
-export const PercentChangeCell = styled('div')<{
-  trendDirection: 'good' | 'bad' | 'neutral';
-}>`
-  color: ${p =>
-    p.trendDirection === 'good'
-      ? p.theme.successText
-      : p.trendDirection === 'bad'
-      ? p.theme.errorText
-      : p.theme.subText};
-  float: right;
-`;
 
 const StyledSearchBar = styled(BaseSearchBar)`
   margin-bottom: ${space(2)};

--- a/static/app/views/starfish/views/webServiceView/failureDetailPanel/failureDetailTable.tsx
+++ b/static/app/views/starfish/views/webServiceView/failureDetailPanel/failureDetailTable.tsx
@@ -15,7 +15,7 @@ import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {NumberContainer} from 'sentry/utils/discover/styles';
 import {formatPercentage} from 'sentry/utils/formatters';
 import {TableColumn} from 'sentry/views/discover/table/types';
-import {PercentChangeCell} from 'sentry/views/starfish/views/webServiceView/endpointList';
+import {PercentChangeCell} from 'sentry/views/starfish/components/tableCells/percentChangeCell';
 import {FailureSpike} from 'sentry/views/starfish/views/webServiceView/types';
 
 type Props = {


### PR DESCRIPTION
The main motivation here is to fix the alignment of numbers in our tables. Throughput is still wrong, hang tight, but a lot better already:

**Before:**
<img width="565" alt="Screenshot 2023-06-21 at 10 45 44 PM" src="https://github.com/getsentry/sentry/assets/989898/e3f169ca-b340-4335-98d6-5fcc0651858a">

**After:**
<img width="565" alt="Screenshot 2023-06-21 at 10 44 46 PM" src="https://github.com/getsentry/sentry/assets/989898/e76e9366-72b7-4bec-b290-9dd87235956d">


I'll follow this up with more fixes and remove a _lot_ of our custom logic. Soon! We'll be able to use the same renderers for all our tables.

Won't work quite right until https://github.com/getsentry/sentry/pull/51398

## Changes

- Eliminate unnecessary helper function
- Fix incorrect return types for event meta
- Use regular field renderer for p95
- Use regular field renderer for error count
- Add renderer for `time_spent_percentage()`
- Align time spent to the right
- Render percentile values based on field type
- Move out percent change cell component
- Align percent change to the right
