### PR TITLE
fix(dynamic-sampling): Fix ordering of rules

### DIFF
--- a/src/sentry/dynamic_sampling/rules/combine.py
+++ b/src/sentry/dynamic_sampling/rules/combine.py
@@ -21,13 +21,13 @@ def get_relay_biases_combinator(organization: Organization) -> BiasesCombinator:
 
     default_combinator.add(RuleType.IGNORE_HEALTH_CHECKS_RULE, IgnoreHealthChecksBias())
 
+    default_combinator.add(RuleType.BOOST_REPLAY_ID_RULE, BoostReplayIdBias())
+    default_combinator.add(RuleType.BOOST_ENVIRONMENTS_RULE, BoostEnvironmentsBias())
     default_combinator.add_if(
         RuleType.RECALIBRATION_RULE,
         RecalibrationBias(),
         lambda: features.has("organizations:ds-org-recalibration", organization, actor=None),
     )
-    default_combinator.add(RuleType.BOOST_REPLAY_ID_RULE, BoostReplayIdBias())
-    default_combinator.add(RuleType.BOOST_ENVIRONMENTS_RULE, BoostEnvironmentsBias())
     default_combinator.add(RuleType.BOOST_LATEST_RELEASES_RULE, BoostLatestReleasesBias())
     default_combinator.add(
         RuleType.BOOST_LOW_VOLUME_TRANSACTIONS_RULE, BoostLowVolumeTransactionsBias()


### PR DESCRIPTION
This PR fixes the ordering of rules and puts the recalibration rule underneath the sample rate based rules.