### PR TITLE
feat(txnames): Include transactions without source in clustering

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/datasource/__init__.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/__init__.py
@@ -1,3 +1,4 @@
+TRANSACTION_SOURCE_UNKNOWN = "unknown"
 TRANSACTION_SOURCE_URL = "url"
 TRANSACTION_SOURCE_SANITIZED = "sanitized"
 HTTP_404_TAG = ["http.status_code", "404"]

--- a/src/sentry/ingest/transaction_clusterer/datasource/__init__.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/__init__.py
@@ -1,4 +1,3 @@
-TRANSACTION_SOURCE_UNKNOWN = "unknown"
 TRANSACTION_SOURCE_URL = "url"
 TRANSACTION_SOURCE_SANITIZED = "sanitized"
 HTTP_404_TAG = ["http.status_code", "404"]

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -137,7 +137,7 @@ def _should_store_transaction_name(event_data: Mapping[str, Any]) -> Optional[st
         # Relay leaves source None if it expects it to be high cardinality, (otherwise it sets it to "unknown")
         # (see https://github.com/getsentry/relay/blob/2d07bef86415cc0ae8af01d16baecde10cdb23a6/relay-general/src/store/transactions/processor.rs#L369-L373).
         #
-        # Our data show that a majority of these `None` source transactions contain slashes, so treat them as URL transactions:
+        # Our data shows that a majority of these `None` source transactions contain slashes, so treat them as URL transactions:
         source is None
         and "/" in transaction_name
     )

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -155,6 +155,8 @@ def test_distribution():
         ("route", "/", [["transaction", "/"]], 0),
         ("url", None, [], 0),
         ("url", "/a/b/c", [["http.status_code", "404"]], 0),
+        (None, "/a/b/c", [], 1),
+        (None, "foo", [], 0),
     ],
 )
 def test_record_transactions(mocked_record, default_organization, source, txname, tags, expected):


### PR DESCRIPTION
When an SDK does not provide a [transaction source](https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations) annotation, Relay does [one of two things](https://github.com/getsentry/relay/blob/ab54df17d285a2210203e3a41dcf0373d7c6a3d2/relay-general/src/store/transactions/processor.rs#L369-L374):

1. When the transaction name is expected to contain identifiers (high-cardinality), leave the source empty.
2. When the transaction name is expected to be low-cardinality, set it to `unknown`.

In the first case, we want to run the [clusterer](https://develop.sentry.dev/transaction-clustering/) to detect high-cardinality patterns. We have to make the simplifying assumption that a transaction name containing `/` is a URL.

Note: This PR includes `source:null` transactions in the clustering input. To also apply the discovered rules in Relay, we need another change in https://github.com/getsentry/relay/.

ref: https://github.com/getsentry/team-ingest/issues/129