### PR TITLE
feat(org-tokens): Track creation/deletion of tokens

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -2,6 +2,8 @@ from .advanced_search_feature_gated import *  # noqa: F401,F403
 from .alert_created import *  # noqa: F401,F403
 from .alert_edited import *  # noqa: F401,F403
 from .alert_rule_ui_component_webhook_sent import *  # noqa: F401,F403
+from .api_token_created import *  # noqa: F401,F403
+from .api_token_deleted import *  # noqa: F401,F403
 from .codeowners_assignment import *  # noqa: F401,F403
 from .codeowners_created import *  # noqa: F401,F403
 from .codeowners_updated import *  # noqa: F401,F403
@@ -43,6 +45,8 @@ from .metric_alert_with_ui_component_created import *  # noqa: F401,F403
 from .monitor_mark_failed import *  # noqa: F401,F403
 from .notifications_settings_updated import *  # noqa: F401,F403
 from .onboarding_continuation_sent import *  # noqa: F401,F403
+from .org_auth_token_created import *  # noqa: F401,F403
+from .org_auth_token_deleted import *  # noqa: F401,F403
 from .organization_created import *  # noqa: F401,F403
 from .organization_joined import *  # noqa: F401,F403
 from .plugin_enabled import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/api_token_created.py
+++ b/src/sentry/analytics/events/api_token_created.py
@@ -1,0 +1,10 @@
+from sentry import analytics
+
+
+class ApiTokenCreated(analytics.Event):
+    type = "api_token.created"
+
+    attributes = (analytics.Attribute("user_id"),)
+
+
+analytics.register(ApiTokenCreated)

--- a/src/sentry/analytics/events/api_token_deleted.py
+++ b/src/sentry/analytics/events/api_token_deleted.py
@@ -1,0 +1,10 @@
+from sentry import analytics
+
+
+class ApiTokenDeleted(analytics.Event):
+    type = "api_token.deleted"
+
+    attributes = (analytics.Attribute("user_id"),)
+
+
+analytics.register(ApiTokenDeleted)

--- a/src/sentry/analytics/events/org_auth_token_created.py
+++ b/src/sentry/analytics/events/org_auth_token_created.py
@@ -1,0 +1,13 @@
+from sentry import analytics
+
+
+class OrgAuthTokenCreated(analytics.Event):
+    type = "org_auth_token.created"
+
+    attributes = (
+        analytics.Attribute("user_id"),
+        analytics.Attribute("organization_id"),
+    )
+
+
+analytics.register(OrgAuthTokenCreated)

--- a/src/sentry/analytics/events/org_auth_token_deleted.py
+++ b/src/sentry/analytics/events/org_auth_token_deleted.py
@@ -1,0 +1,13 @@
+from sentry import analytics
+
+
+class OrgAuthTokenDeleted(analytics.Event):
+    type = "org_auth_token.deleted"
+
+    attributes = (
+        analytics.Attribute("user_id"),
+        analytics.Attribute("organization_id"),
+    )
+
+
+analytics.register(OrgAuthTokenDeleted)

--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -5,6 +5,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import analytics
 from sentry.api.base import Endpoint, SessionAuthentication, control_silo_endpoint
 from sentry.api.fields import MultipleChoiceField
 from sentry.api.serializers import serialize
@@ -59,6 +60,8 @@ class ApiTokensEndpoint(Endpoint):
                 send_email=True,
             )
 
+            analytics.record("api_token.created", user_id=request.user.id)
+
             return Response(serialize(token, request.user), status=201)
         return Response(serializer.errors, status=400)
 
@@ -72,5 +75,7 @@ class ApiTokensEndpoint(Endpoint):
             return Response({"token": ""}, status=400)
 
         ApiToken.objects.filter(user_id=user_id, token=token, application__isnull=True).delete()
+
+        analytics.record("api_token.deleted", user_id=request.user.id)
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/org_auth_token_details.py
+++ b/src/sentry/api/endpoints/org_auth_token_details.py
@@ -2,7 +2,7 @@ from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import audit_log
+from sentry import analytics, audit_log
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrgAuthTokenPermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -58,6 +58,12 @@ class OrgAuthTokenDetailsEndpoint(OrganizationEndpoint):
             target_object=instance.id,
             event=audit_log.get_event_id("ORGAUTHTOKEN_REMOVE"),
             data=instance.get_audit_log_data(),
+        )
+
+        analytics.record(
+            "org_auth_token.deleted",
+            user_id=request.user.id,
+            organization_id=organization.id,
         )
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/org_auth_tokens.py
+++ b/src/sentry/api/endpoints/org_auth_tokens.py
@@ -8,7 +8,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import audit_log
+from sentry import analytics, audit_log
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrgAuthTokenPermission
 from sentry.api.serializers import serialize
@@ -69,6 +69,12 @@ class OrgAuthTokensEndpoint(OrganizationEndpoint):
             target_object=token.id,
             event=audit_log.get_event_id("ORGAUTHTOKEN_ADD"),
             data=token.get_audit_log_data(),
+        )
+
+        analytics.record(
+            "org_auth_token.created",
+            user_id=request.user.id,
+            organization_id=organization.id,
         )
 
         # This is THE ONLY TIME that the token is available


### PR DESCRIPTION
This adds analytics for when tokens are created/deleted:

Custom integrations are already tracked:

* `sentry_app_installation_token.created`
* `sentry_app_installation_token.deleted`

New tracking added:

* `api_token.created`
* `api_token.deleted`
* `org_auth_token.created`
* `org_auth_token.deleted`

ref https://github.com/getsentry/team-webplatform-meta/issues/91