### PR TITLE
feat(org-tokens): Allow to authenticate with OrgAuthTokens

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -199,7 +199,7 @@ class TokenAuthentication(StandardAuthentication):
         if not super().accepts_auth(auth):
             return False
 
-        # Techincally, this will not match if auth length is not 2
+        # Technically, this will not match if auth length is not 2
         # However, we want to run into `authenticate()` in this case, as this throws a more helpful error message
         if len(auth) != 2:
             return True

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -82,7 +82,7 @@ class StandardAuthentication(QuietBasicAuthentication):
     token_name = None
 
     def accepts_auth(self, auth: "list[bytes]") -> bool:
-        return True if auth and auth[0].lower() == self.token_name else False
+        return auth and auth[0].lower() == self.token_name
 
     def authenticate(self, request: Request):
         auth = get_authorization_header(request).split()
@@ -135,7 +135,7 @@ class ApiKeyAuthentication(QuietBasicAuthentication):
     token_name = b"basic"
 
     def accepts_auth(self, auth: "list[bytes]") -> bool:
-        return True if auth and auth[0].lower() == self.token_name else False
+        return auth and auth[0].lower() == self.token_name
 
     def authenticate_credentials(self, userid, password, request=None):
         # We don't use request, but it needs to be passed through to DRF 3.7+.

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -11,9 +11,10 @@ from sentry_relay import UnpackError
 
 from sentry import options
 from sentry.auth.system import SystemToken, is_internal_ip
-from sentry.models import ApiApplication, ApiKey, ApiToken, ProjectKey, Relay
+from sentry.models import ApiApplication, ApiKey, ApiToken, OrgAuthToken, ProjectKey, Relay
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
 from sentry.utils.sdk import configure_scope
+from sentry.utils.security.orgauthtoken_token import SENTRY_ORG_AUTH_TOKEN_PREFIX, hash_token
 
 
 def is_internal_relay(request, public_key):
@@ -80,10 +81,13 @@ class QuietBasicAuthentication(BasicAuthentication):
 class StandardAuthentication(QuietBasicAuthentication):
     token_name = None
 
+    def accepts_auth(self, auth: "list[bytes]") -> bool:
+        return True if auth and auth[0].lower() == self.token_name else False
+
     def authenticate(self, request: Request):
         auth = get_authorization_header(request).split()
 
-        if not auth or auth[0].lower() != self.token_name:
+        if not self.accepts_auth(auth):
             return None
 
         if len(auth) == 1:
@@ -129,6 +133,9 @@ class RelayAuthentication(BasicAuthentication):
 
 class ApiKeyAuthentication(QuietBasicAuthentication):
     token_name = b"basic"
+
+    def accepts_auth(self, auth: "list[bytes]") -> bool:
+        return True if auth and auth[0].lower() == self.token_name else False
 
     def authenticate_credentials(self, userid, password, request=None):
         # We don't use request, but it needs to be passed through to DRF 3.7+.
@@ -188,6 +195,18 @@ class ClientIdSecretAuthentication(QuietBasicAuthentication):
 class TokenAuthentication(StandardAuthentication):
     token_name = b"bearer"
 
+    def accepts_auth(self, auth: "list[bytes]") -> bool:
+        if not super().accepts_auth(auth):
+            return False
+
+        # Techincally, this will not match if auth length is not 2
+        # However, we want to run into `authenticate()` in this case, as this throws a more helpful error message
+        if len(auth) != 2:
+            return True
+
+        token_str = force_text(auth[1])
+        return not token_str.startswith(SENTRY_ORG_AUTH_TOKEN_PREFIX)
+
     def authenticate_credentials(self, request: Request, token_str):
         token = SystemToken.from_request(request, token_str)
         try:
@@ -215,6 +234,35 @@ class TokenAuthentication(StandardAuthentication):
             scope.set_tag("api_token_is_sentry_app", getattr(token.user, "is_sentry_app", False))
 
         return (token.user, token)
+
+
+class OrgAuthTokenAuthentication(StandardAuthentication):
+    token_name = b"bearer"
+
+    def accepts_auth(self, auth: "list[bytes]") -> bool:
+        if not super().accepts_auth(auth) or len(auth) != 2:
+            return False
+
+        token_str = force_text(auth[1])
+        return token_str.startswith(SENTRY_ORG_AUTH_TOKEN_PREFIX)
+
+    def authenticate_credentials(self, request: Request, token_str):
+        token = None
+        token_hashed = hash_token(token_str)
+
+        try:
+            token = OrgAuthToken.objects.filter(
+                token_hashed=token_hashed, date_deactivated__isnull=True
+            ).get()
+        except OrgAuthToken.DoesNotExist:
+            raise AuthenticationFailed("Invalid org token")
+
+        with configure_scope() as scope:
+            scope.set_tag("api_token_type", self.token_name)
+            scope.set_tag("api_token", token.id)
+            scope.set_tag("api_token_is_org_token", True)
+
+        return (AnonymousUser(), token)
 
 
 class DSNAuthentication(StandardAuthentication):

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -35,7 +35,7 @@ from sentry.utils.dates import to_datetime
 from sentry.utils.http import is_valid_origin, origin_from_request
 from sentry.utils.sdk import capture_exception, merge_context_into_scope
 
-from .authentication import ApiKeyAuthentication, TokenAuthentication
+from .authentication import ApiKeyAuthentication, OrgAuthTokenAuthentication, TokenAuthentication
 from .paginator import BadPaginationError, Paginator
 from .permissions import NoPermission
 
@@ -64,7 +64,12 @@ CURSOR_LINK_HEADER = (
     '<{uri}&cursor={cursor}>; rel="{name}"; results="{has_results}"; cursor="{cursor}"'
 )
 
-DEFAULT_AUTHENTICATION = (TokenAuthentication, ApiKeyAuthentication, SessionAuthentication)
+DEFAULT_AUTHENTICATION = (
+    TokenAuthentication,
+    OrgAuthTokenAuthentication,
+    ApiKeyAuthentication,
+    SessionAuthentication,
+)
 
 logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger("sentry.audit.api")

--- a/src/sentry/api/decorators.py
+++ b/src/sentry/api/decorators.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from sentry.api.exceptions import EmailVerificationRequired, SudoRequired
 from sentry.models import ApiKey
 from sentry.models.apitoken import is_api_token_auth
+from sentry.models.orgauthtoken import is_org_auth_token_auth
 
 
 def is_considered_sudo(request):
@@ -16,6 +17,7 @@ def is_considered_sudo(request):
         request.is_sudo()
         or isinstance(request.auth, ApiKey)
         or is_api_token_auth(request.auth)
+        or is_org_auth_token_auth(request.auth)
         or request.user.is_authenticated
         and not request.user.has_usable_password()
     )

--- a/src/sentry/api/endpoints/org_auth_tokens.py
+++ b/src/sentry/api/endpoints/org_auth_tokens.py
@@ -18,8 +18,7 @@ from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.models.user import User
 from sentry.security.utils import capture_security_activity
-from sentry.utils import hashlib
-from sentry.utils.security.orgauthtoken_token import generate_token
+from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 
 @control_silo_endpoint
@@ -43,7 +42,7 @@ class OrgAuthTokensEndpoint(OrganizationEndpoint):
 
     def post(self, request: Request, organization: Organization) -> Response:
         jwt_token = generate_token(organization.slug, generate_region_url())
-        token_hashed = hashlib.sha256_text(jwt_token).hexdigest()
+        token_hashed = hash_token(jwt_token)
 
         name = request.data.get("name")
 

--- a/src/sentry/api/endpoints/org_auth_tokens.py
+++ b/src/sentry/api/endpoints/org_auth_tokens.py
@@ -41,8 +41,8 @@ class OrgAuthTokensEndpoint(OrganizationEndpoint):
         return Response(serialize(token_list, request.user, token=None))
 
     def post(self, request: Request, organization: Organization) -> Response:
-        jwt_token = generate_token(organization.slug, generate_region_url())
-        token_hashed = hash_token(jwt_token)
+        token_str = generate_token(organization.slug, generate_region_url())
+        token_hashed = hash_token(token_str)
 
         name = request.data.get("name")
 
@@ -55,7 +55,7 @@ class OrgAuthTokensEndpoint(OrganizationEndpoint):
             organization_id=organization.id,
             scope_list=["org:ci"],
             created_by_id=request.user.id,
-            token_last_characters=jwt_token[-4:],
+            token_last_characters=token_str[-4:],
             token_hashed=token_hashed,
         )
 
@@ -95,7 +95,7 @@ class OrgAuthTokensEndpoint(OrganizationEndpoint):
         )
 
         # This is THE ONLY TIME that the token is available
-        serialized_token = serialize(token, request.user, token=jwt_token)
+        serialized_token = serialize(token, request.user, token=token_str)
 
         if serialized_token is None:
             return Response({"detail": "Error when serializing token."}, status=400)

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -55,6 +55,7 @@ from sentry.models import (
 )
 from sentry.models.apitoken import is_api_token_auth
 from sentry.models.organizationmember import OrganizationMember
+from sentry.models.orgauthtoken import is_org_auth_token_auth
 from sentry.notifications.helpers import (
     collect_groups_by_project,
     get_groups_for_query,
@@ -725,6 +726,9 @@ class GroupSerializerBase(Serializer, ABC):
                 token=AuthenticatedToken.from_token(request.auth), organization_id=organization_id
             ):
                 return True
+
+        if request and is_org_auth_token_auth(request.auth):
+            return request.auth.organization_id == organization_id
 
         return (
             user.is_authenticated

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -727,7 +727,12 @@ class GroupSerializerBase(Serializer, ABC):
             ):
                 return True
 
-        if request and is_org_auth_token_auth(request.auth):
+        if (
+            request
+            and user.is_anonymous
+            and hasattr(request, "auth")
+            and is_org_auth_token_auth(request.auth)
+        ):
             return request.auth.organization_id == organization_id
 
         return (

--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -95,8 +95,10 @@ class RequestAuthenticationMiddleware(MiddlewareMixin):
                 else:
                     # default to anonymous user and use IP ratelimit
                     request.user = SimpleLazyObject(lambda: get_user(request))
-        else:
-            request.user = SimpleLazyObject(lambda: get_user(request))
+                return
+
+        # default to anonymous user and use IP ratelimit
+        request.user = SimpleLazyObject(lambda: get_user(request))
 
     def process_exception(self, request: Request, exception):
         if isinstance(exception, AuthUserPasswordExpired):

--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -10,7 +10,11 @@ from rest_framework.authentication import get_authorization_header
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 
-from sentry.api.authentication import ApiKeyAuthentication, TokenAuthentication
+from sentry.api.authentication import (
+    ApiKeyAuthentication,
+    OrgAuthTokenAuthentication,
+    TokenAuthentication,
+)
 from sentry.models import UserIP
 from sentry.services.hybrid_cloud.auth import auth_service, authentication_request_from
 from sentry.silo import SiloMode
@@ -73,26 +77,24 @@ class RequestAuthenticationMiddleware(MiddlewareMixin):
         if user is not None:
             request.user = user
             request.user_from_signed_request = True
-        elif auth and auth[0].lower() == TokenAuthentication.token_name:
-            try:
-                result = TokenAuthentication().authenticate(request=request)
-            except AuthenticationFailed:
-                result = None
-            if result:
-                request.user, request.auth = result
-            else:
-                # default to anonymous user and use IP ratelimit
-                request.user = SimpleLazyObject(lambda: get_user(request))
-        elif auth and auth[0].lower() == ApiKeyAuthentication.token_name:
-            try:
-                result = ApiKeyAuthentication().authenticate(request=request)
-            except AuthenticationFailed:
-                result = None
-            if result:
-                request.user, request.auth = result
-            else:
-                # default to anonymous user and use IP ratelimit
-                request.user = SimpleLazyObject(lambda: get_user(request))
+        elif auth:
+            for authenticator_class in [
+                TokenAuthentication,
+                OrgAuthTokenAuthentication,
+                ApiKeyAuthentication,
+            ]:
+                authenticator = authenticator_class()
+                if not authenticator.accepts_auth(auth):
+                    continue
+                try:
+                    result = authenticator.authenticate(request)
+                except AuthenticationFailed:
+                    result = None
+                if result:
+                    request.user, request.auth = result
+                else:
+                    # default to anonymous user and use IP ratelimit
+                    request.user = SimpleLazyObject(lambda: get_user(request))
         else:
             request.user = SimpleLazyObject(lambda: get_user(request))
 

--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -77,7 +77,9 @@ class RequestAuthenticationMiddleware(MiddlewareMixin):
         if user is not None:
             request.user = user
             request.user_from_signed_request = True
-        elif auth:
+            return
+
+        if auth:
             for authenticator_class in [
                 TokenAuthentication,
                 OrgAuthTokenAuthentication,

--- a/src/sentry/models/orgauthtoken.py
+++ b/src/sentry/models/orgauthtoken.py
@@ -60,6 +60,9 @@ class OrgAuthToken(Model):
     def get_audit_log_data(self):
         return {"name": self.name, "scopes": self.get_scopes()}
 
+    def get_allowed_origins(self):
+        return ()
+
     def get_scopes(self):
         return self.scope_list
 
@@ -68,3 +71,12 @@ class OrgAuthToken(Model):
 
     def is_active(self) -> bool:
         return self.date_deactivated is None
+
+
+def is_org_auth_token_auth(auth: object) -> bool:
+    """:returns True when an API token is hitting the API."""
+    from sentry.services.hybrid_cloud.auth import AuthenticatedToken
+
+    if isinstance(auth, AuthenticatedToken):
+        return auth.kind == "org_auth_token"
+    return isinstance(auth, OrgAuthToken)

--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -4,7 +4,12 @@ from uuid import UUID
 
 from rest_framework.request import Request
 
-from sentry.api.authentication import ApiKeyAuthentication, DSNAuthentication, TokenAuthentication
+from sentry.api.authentication import (
+    ApiKeyAuthentication,
+    DSNAuthentication,
+    OrgAuthTokenAuthentication,
+    TokenAuthentication,
+)
 from sentry.api.base import Endpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.bases.project import ProjectPermission
@@ -105,7 +110,12 @@ class MonitorIngestEndpoint(Endpoint):
           - When using DSN auth
     """
 
-    authentication_classes = (DSNAuthentication, TokenAuthentication, ApiKeyAuthentication)
+    authentication_classes = (
+        DSNAuthentication,
+        TokenAuthentication,
+        OrgAuthTokenAuthentication,
+        ApiKeyAuthentication,
+    )
     permission_classes = (ProjectMonitorPermission,)
 
     allow_auto_create_monitors = False

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.models.orgauthtoken import is_org_auth_token_auth
 from sentry.ratelimits.concurrent import ConcurrentRateLimiter
 from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory, RateLimitMeta, RateLimitType
@@ -102,6 +103,11 @@ def get_rate_limit_key(
 
     # ApiKeys will be treated with IP ratelimits
     elif ip_address is not None:
+        category = "ip"
+        id = ip_address
+
+    # OrgAuthTokens will be treated with IP ratelimits
+    elif is_org_auth_token_auth(request_auth):
         category = "ip"
         id = ip_address
 

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -7,7 +7,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
-from sentry.models.orgauthtoken import is_org_auth_token_auth
 from sentry.ratelimits.concurrent import ConcurrentRateLimiter
 from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory, RateLimitMeta, RateLimitType
@@ -101,13 +100,8 @@ def get_rate_limit_key(
         category = "user"
         id = request_user.id
 
-    # ApiKeys will be treated with IP ratelimits
+    # ApiKeys & OrgAuthTokens will be treated with IP ratelimits
     elif ip_address is not None:
-        category = "ip"
-        id = ip_address
-
-    # OrgAuthTokens will be treated with IP ratelimits
-    elif is_org_auth_token_auth(request_auth):
         category = "ip"
         id = ip_address
 

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -16,6 +16,7 @@ from sentry.models import (
     AuthIdentity,
     AuthProvider,
     OrganizationMemberMapping,
+    OrgAuthToken,
     SentryAppInstallationToken,
     User,
 )
@@ -317,6 +318,7 @@ def _unwrap_b64(input: str | None) -> bytes | None:
 
 AuthenticatedToken.register_kind("system", SystemToken)
 AuthenticatedToken.register_kind("api_token", ApiToken)
+AuthenticatedToken.register_kind("org_auth_token", OrgAuthToken)
 AuthenticatedToken.register_kind("api_key", ApiKey)
 
 

--- a/src/sentry/services/hybrid_cloud/auth/model.py
+++ b/src/sentry/services/hybrid_cloud/auth/model.py
@@ -24,26 +24,39 @@ class RpcAuthenticatorType(IntEnum):
     API_KEY_AUTHENTICATION = 0
     TOKEN_AUTHENTICATION = 1
     SESSION_AUTHENTICATION = 2
+    ORG_AUTH_TOKEN_AUTHENTICATION = 3
 
     @classmethod
     def from_authenticator(
         self, auth: Type[BaseAuthentication]
     ) -> Optional["RpcAuthenticatorType"]:
-        from sentry.api.authentication import ApiKeyAuthentication, TokenAuthentication
+        from sentry.api.authentication import (
+            ApiKeyAuthentication,
+            OrgAuthTokenAuthentication,
+            TokenAuthentication,
+        )
 
         if auth == ApiKeyAuthentication:
             return RpcAuthenticatorType.API_KEY_AUTHENTICATION
         if auth == TokenAuthentication:
             return RpcAuthenticatorType.TOKEN_AUTHENTICATION
+        if auth == OrgAuthTokenAuthentication:
+            return RpcAuthenticatorType.ORG_AUTH_TOKEN_AUTHENTICATION
         return None
 
     def as_authenticator(self) -> BaseAuthentication:
-        from sentry.api.authentication import ApiKeyAuthentication, TokenAuthentication
+        from sentry.api.authentication import (
+            ApiKeyAuthentication,
+            OrgAuthTokenAuthentication,
+            TokenAuthentication,
+        )
 
         if self == self.API_KEY_AUTHENTICATION:
             return ApiKeyAuthentication()
         if self == self.TOKEN_AUTHENTICATION:
             return TokenAuthentication()
+        if self == self.ORG_AUTH_TOKEN_AUTHENTICATION:
+            return OrgAuthTokenAuthentication()
         else:
             raise ValueError(f"{self!r} has not authenticator associated with it.")
 

--- a/src/sentry/utils/audit.py
+++ b/src/sentry/utils/audit.py
@@ -34,10 +34,10 @@ def create_audit_entry(
     api_key = get_api_key_for_audit_log(request)
     org_auth_token = get_org_auth_token_for_audit_log(request)
 
-    # We do not keep any user/key ID for this case for now, but only pass the token ID as a label
+    # We do not keep any user/key ID for this case for now, but only pass the token name as a label
     # Without this, the AuditLogEntry fails on save because it cannot find an actor_label
     if org_auth_token:
-        kwargs["actor_label"] = org_auth_token.id
+        kwargs["actor_label"] = org_auth_token.name
 
     return create_audit_entry_from_user(
         user, api_key, request.META["REMOTE_ADDR"], transaction_id, logger, **kwargs

--- a/src/sentry/utils/audit.py
+++ b/src/sentry/utils/audit.py
@@ -18,6 +18,7 @@ from sentry.models import (
     Team,
     User,
 )
+from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.services.hybrid_cloud.log import log_service
 from sentry.services.hybrid_cloud.organization import RpcOrganization
 from sentry.services.hybrid_cloud.user import RpcUser
@@ -31,6 +32,12 @@ def create_audit_entry(
 ) -> AuditLogEntry:
     user = kwargs.pop("actor", request.user if request.user.is_authenticated else None)
     api_key = get_api_key_for_audit_log(request)
+    org_auth_token = get_org_auth_token_for_audit_log(request)
+
+    # We do not keep any user/key ID for this case for now, but only pass the token ID as a label
+    # Without this, the AuditLogEntry fails on save because it cannot find an actor_label
+    if org_auth_token:
+        kwargs["actor_label"] = org_auth_token.id
 
     return create_audit_entry_from_user(
         user, api_key, request.META["REMOTE_ADDR"], transaction_id, logger, **kwargs
@@ -102,6 +109,14 @@ def create_audit_entry_from_user(
 
 def get_api_key_for_audit_log(request: Request) -> ApiKey | None:
     return request.auth if hasattr(request, "auth") and isinstance(request.auth, ApiKey) else None
+
+
+def get_org_auth_token_for_audit_log(request: Request) -> OrgAuthToken | None:
+    return (
+        request.auth
+        if hasattr(request, "auth") and isinstance(request.auth, OrgAuthToken)
+        else None
+    )
 
 
 def _create_org_delete_log(entry: AuditLogEntry) -> None:

--- a/src/sentry/utils/security/orgauthtoken_token.py
+++ b/src/sentry/utils/security/orgauthtoken_token.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from django.conf import settings
 
-from sentry.utils import json
+from sentry.utils import hashlib, json
 
 SENTRY_ORG_AUTH_TOKEN_PREFIX = "sntrys_"
 
@@ -43,3 +43,7 @@ def parse_token(token: str):
 
 def base64_encode_str(str):
     return b64encode(str.encode("ascii")).decode("ascii")
+
+
+def hash_token(token: str):
+    return hashlib.sha256_text(token).hexdigest()

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 
 import pytest
 from django.http import HttpRequest
@@ -9,12 +10,17 @@ from sentry_relay import generate_key_pair
 from sentry.api.authentication import (
     ClientIdSecretAuthentication,
     DSNAuthentication,
+    OrgAuthTokenAuthentication,
     RelayAuthentication,
+    TokenAuthentication,
 )
 from sentry.models import ProjectKeyStatus, Relay
+from sentry.models.apitoken import ApiToken
+from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.testutils import TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.pytest.fixtures import django_db_all
+from sentry.utils.security.orgauthtoken_token import hash_token
 
 
 @control_silo_test(stable=True)
@@ -100,6 +106,81 @@ class TestDSNAuthentication(TestCase):
         self.project_key.update(status=ProjectKeyStatus.INACTIVE)
         request = HttpRequest()
         request.META["HTTP_AUTHORIZATION"] = f"DSN {self.project_key.dsn_public}"
+
+        with pytest.raises(AuthenticationFailed):
+            self.auth.authenticate(request)
+
+
+class TestOrgAuthTokenAuthentication(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.auth = OrgAuthTokenAuthentication()
+        self.org = self.create_organization(owner=self.user)
+        self.token = "sntrys_abc123_xyz"
+        self.org_auth_token = OrgAuthToken.objects.create(
+            name="Test Token 1",
+            token_hashed=hash_token(self.token),
+            organization_id=self.org.id,
+            token_last_characters="xyz",
+            scope_list=[],
+            date_last_used=None,
+        )
+
+    def test_authenticate(self):
+        request = HttpRequest()
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {self.token}"
+
+        result = self.auth.authenticate(request)
+        assert result is not None
+
+        user, auth = result
+        assert user.is_anonymous
+        assert auth == self.org_auth_token
+
+    def test_no_match(self):
+        request = HttpRequest()
+        request.META["HTTP_AUTHORIZATION"] = "Bearer sntrys_abc"
+
+        with pytest.raises(AuthenticationFailed):
+            self.auth.authenticate(request)
+
+    def test_inactive_key(self):
+        self.org_auth_token.update(date_deactivated=datetime.now())
+        request = HttpRequest()
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {self.token}"
+
+        with pytest.raises(AuthenticationFailed):
+            self.auth.authenticate(request)
+
+
+class TestTokenAuthentication(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.auth = TokenAuthentication()
+        self.org = self.create_organization(owner=self.user)
+        self.token = "abc123"
+        self.api_token = ApiToken.objects.create(
+            token=self.token,
+            user=self.user,
+        )
+
+    def test_authenticate(self):
+        request = HttpRequest()
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {self.token}"
+
+        result = self.auth.authenticate(request)
+        assert result is not None
+
+        user, auth = result
+        assert user.is_anonymous is False
+        assert user == self.user
+        assert auth == self.api_token
+
+    def test_no_match(self):
+        request = HttpRequest()
+        request.META["HTTP_AUTHORIZATION"] = "Bearer abc"
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)


### PR DESCRIPTION
This is very much a WIP draft of allowing to authenticate with the new OrgAuthTokens.

Especially in regards to Hybrid Cloud, I honestly don't know exactly how to approach/test/verify this.

I've tried it locally with a "regular" setup, where auth seemed to work fine with the token for API calls - it correctly allowed/rejected access based on the given scopes.

I am very happy about any feedback I can get here - mostly I looked for places where we use `ApiToken` and adjusted them to the best of my knowledge to mirror this for `OrgAuthToken`, but I may or may not have missed something important there.

For anyone interested, you can enable the UI for the org tokens `organizations:org-auth-tokens` and then create new tokens from Org Settings > Auth Tokens. Right now the tokens always have the `org:read` scope only.

Note this will need slight adjustment after https://github.com/getsentry/sentry/pull/51341, but nothing major.