### PR TITLE
fix(flamegraphs): Ensure filtered stacks are correctly merged

### DIFF
--- a/static/app/utils/profiling/profile/sampledProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.spec.tsx
@@ -374,8 +374,10 @@ describe('SampledProfile', () => {
       trace,
       createFrameIndex('mobile', [{name: 'f0'}, {name: 'f1'}]),
       {
-        type: 'flamechart',
-        frameFilter: frame => frame.name === 'f0',
+        type: 'flamegraph',
+        frameFilter: frame => {
+          return frame.name === 'f0';
+        },
       }
     );
 


### PR DESCRIPTION
We have to filter the stacks before sorting to ensure the merge is correctly executed.