### PR TITLE
ref(replay): Refactor Replay Details>Memory chart to use *Frame types

### DIFF
--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -26,6 +26,7 @@ import splitAttachmentsByType from 'sentry/utils/replays/splitAttachmentsByType'
 import type {
   BreadcrumbFrame,
   ErrorFrame,
+  MemoryFrame,
   OptionFrame,
   RecordingFrame,
   SpanFrame,
@@ -229,7 +230,7 @@ export default class ReplayReader {
   );
 
   getMemoryFrames = memoize(() =>
-    this._sortedSpanFrames.filter(frame => frame.op === 'memory')
+    this._sortedSpanFrames.filter((frame): frame is MemoryFrame => frame.op === 'memory')
   );
 
   getChapterFrames = memoize(() =>

--- a/static/app/views/replays/detail/layout/focusArea.tsx
+++ b/static/app/views/replays/detail/layout/focusArea.tsx
@@ -59,7 +59,7 @@ function FocusArea({}: Props) {
         <MemoryChart
           currentTime={currentTime}
           currentHoverTime={currentHoverTime}
-          memorySpans={replay?.getMemorySpans()}
+          memoryFrames={replay?.getMemoryFrames()}
           setCurrentTime={setCurrentTime}
           setCurrentHoverTime={setCurrentHoverTime}
           startTimestampMs={replay?.getReplay()?.started_at?.getTime()}

--- a/static/app/views/replays/detail/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryChart.tsx
@@ -16,11 +16,11 @@ import {space} from 'sentry/styles/space';
 import {ReactEchartsRef, Series} from 'sentry/types/echarts';
 import {formatBytesBase2} from 'sentry/utils';
 import {getFormattedDate} from 'sentry/utils/dates';
+import type {MemoryFrame} from 'sentry/utils/replays/types';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
-import type {MemorySpan} from 'sentry/views/replays/types';
 
 interface Props {
-  memorySpans: undefined | MemorySpan[];
+  memoryFrames: undefined | MemoryFrame[];
   setCurrentHoverTime: (time: undefined | number) => void;
   setCurrentTime: (time: number) => void;
   startTimestampMs: undefined | number;
@@ -31,18 +31,18 @@ interface MemoryChartProps extends Props {
 }
 
 const formatTimestamp = timestamp =>
-  getFormattedDate(timestamp * 1000, 'MMM D, YYYY hh:mm:ss A z', {local: false});
+  getFormattedDate(timestamp, 'MMM D, YYYY hh:mm:ss A z', {local: false});
 
 function MemoryChart({
   forwardedRef,
-  memorySpans,
+  memoryFrames,
   startTimestampMs = 0,
   setCurrentTime,
   setCurrentHoverTime,
 }: MemoryChartProps) {
   const theme = useTheme();
 
-  if (!memorySpans) {
+  if (!memoryFrames) {
     return (
       <MemoryChartWrapper>
         <Placeholder height="100%" />
@@ -50,7 +50,7 @@ function MemoryChart({
     );
   }
 
-  if (memorySpans.length <= 0) {
+  if (!memoryFrames.length) {
     return (
       <EmptyMessage
         title={t('No memory metrics found')}
@@ -96,9 +96,7 @@ function MemoryChart({
           </div>`,
           `<div class="tooltip-footer" style="border: none;">${'Relative Time'}:
             ${showPlayerTime(
-              moment(values[0].axisValue * 1000)
-                .toDate()
-                .toUTCString(),
+              moment(values[0].axisValue).toDate().toUTCString(),
               startTimestampMs
             )}
           </div>`,
@@ -140,7 +138,7 @@ function MemoryChart({
     // with the "area" under the line.
     onMouseOver: ({data}) => {
       if (data[0]) {
-        setCurrentHoverTime(data[0] * 1000 - startTimestampMs);
+        setCurrentHoverTime(data[0] - startTimestampMs);
       }
     },
     onMouseOut: () => {
@@ -148,7 +146,7 @@ function MemoryChart({
     },
     onClick: ({data}) => {
       if (data.value) {
-        setCurrentTime(data.value * 1000 - startTimestampMs);
+        setCurrentTime(data.value - startTimestampMs);
       }
     },
   };
@@ -156,9 +154,9 @@ function MemoryChart({
   const series: Series[] = [
     {
       seriesName: t('Used Heap Memory'),
-      data: memorySpans.map(span => ({
-        value: span.data.memory.usedJSHeapSize,
-        name: span.endTimestamp,
+      data: memoryFrames.map(frame => ({
+        value: frame.data.memory.usedJSHeapSize,
+        name: frame.endTimestampMs,
       })),
       stack: 'heap-memory',
       lineStyle: {
@@ -168,9 +166,9 @@ function MemoryChart({
     },
     {
       seriesName: t('Free Heap Memory'),
-      data: memorySpans.map(span => ({
-        value: span.data.memory.totalJSHeapSize - span.data.memory.usedJSHeapSize,
-        name: span.endTimestamp,
+      data: memoryFrames.map(frame => ({
+        value: frame.data.memory.totalJSHeapSize - frame.data.memory.usedJSHeapSize,
+        name: frame.endTimestampMs,
       })),
       stack: 'heap-memory',
       lineStyle: {


### PR DESCRIPTION
Quick refactor to let the memory chart use the new *Frame types.

This also fixes an issue with the memory chart where the `currentTime` and `currentHoverTime` lines were not rendering.

Before:
![SCR-20230622-jwec](https://github.com/getsentry/sentry/assets/187460/15eebece-f171-427f-8fde-e790fd3fdfc2)

After:
![SCR-20230622-kbsq](https://github.com/getsentry/sentry/assets/187460/f46493fe-570a-4e17-854b-504c09284e28)


