### PR TITLE
fix(starfish): Fix alignment of span throughput column in spans view

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -68,6 +68,8 @@ export type MetaType = Record<string, ColumnType> & {
   units?: Record<string, string>;
 };
 export type EventsMetaType = {fields: Record<string, ColumnType>} & {
+  units: Record<string, string>;
+} & {
   isMetricsData?: boolean;
 };
 

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -107,6 +107,7 @@ type FieldFormatters = {
   number: FieldFormatter;
   percent_change: FieldFormatter;
   percentage: FieldFormatter;
+  rate: FieldFormatter;
   size: FieldFormatter;
   string: FieldFormatter;
 };
@@ -167,6 +168,12 @@ export const DURATION_UNITS = {
   week: 1000 * 60 * 60 * 24 * 7,
 };
 
+const RATE_UNIT_LABELS = {
+  '1/second': '/s',
+  '1/minute': '/min',
+  '1/hour': '/hr',
+};
+
 export const PERCENTAGE_UNITS = ['ratio', 'percent'];
 
 /**
@@ -220,6 +227,18 @@ export const FIELD_FORMATTERS: FieldFormatters = {
           ) : (
             emptyValue
           )}
+        </NumberContainer>
+      );
+    },
+  },
+  rate: {
+    isSortable: true,
+    renderFunc: (field, data, baggage) => {
+      const {unit} = baggage ?? {};
+
+      return (
+        <NumberContainer>
+          {`${formatFloat(data[field], 2)}${unit ? RATE_UNIT_LABELS[unit] : ''}`}
         </NumberContainer>
       );
     },

--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -151,10 +151,18 @@ export function useWrappedDiscoverQuery<T>({
     },
   });
 
+  const meta = data?.meta as unknown as EventsMetaType;
+  if (meta) {
+    // TODO: Remove this hack when the backend returns `"rate"` as the data
+    // type for `sps()` and other rate fields!
+    meta.fields['sps()'] = 'rate';
+    meta.units['sps()'] = '1/second';
+  }
+
   return {
     isLoading,
     data: isLoading && initialData ? initialData : data?.data,
-    meta: data?.meta as unknown as EventsMetaType, // TODO: useDiscoverQuery incorrectly states that it returns MetaType, but it does not!
+    meta, // TODO: useDiscoverQuery incorrectly states that it returns MetaType, but it does not!
     pageLinks,
   };
 }

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -17,7 +17,6 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import {useSpanList} from 'sentry/views/starfish/queries/useSpanList';
 import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
@@ -167,16 +166,17 @@ function renderBodyCell(
     );
   }
 
-  if (column.key === 'sps()') {
-    return <ThroughputCell throughputPerSecond={row['sps()']} />;
-  }
-
   if (!meta || !meta?.fields) {
     return row[column.key];
   }
 
   const renderer = getFieldRenderer(column.key, meta.fields, false);
-  const rendered = renderer(row, {location, organization});
+
+  const rendered = renderer(row, {
+    location,
+    organization,
+    unit: meta.units?.[column.key],
+  });
 
   return rendered;
 }


### PR DESCRIPTION
The backend for this is still en route, but the gist is that I'm adding a generic `sps()` field formatter, and using it in the spans view right away. This fixes the field to be right-aligned!
