### PR TITLE
fix(starfish): Use generic renderers for span endpoint table

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -68,6 +68,8 @@ export type MetaType = Record<string, ColumnType> & {
   units?: Record<string, string>;
 };
 export type EventsMetaType = {fields: Record<string, ColumnType>} & {
+  units: Record<string, string>;
+} & {
   isMetricsData?: boolean;
 };
 

--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -22,13 +22,13 @@ export type SpanTransactionMetrics = {
 };
 
 export const useSpanTransactionMetrics = (
-  span?: Pick<IndexedSpan, 'group'>,
+  span: Pick<IndexedSpan, 'group'>,
   transactions?: string[],
   _referrer = 'span-transaction-metrics'
 ) => {
   const location = useLocation();
 
-  const eventView = span ? getEventView(span, location, transactions ?? []) : undefined;
+  const eventView = getEventView(span, location, transactions ?? []);
 
   const {isLoading, data, pageLinks} = useSpansQuery<SpanTransactionMetrics[]>({
     eventView,

--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -6,7 +6,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {IndexedSpan} from 'sentry/views/starfish/queries/types';
 import {SpanMetricsFields} from 'sentry/views/starfish/types';
-import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
+import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
 const {SPAN_SELF_TIME} = SpanMetricsFields;
 
@@ -30,13 +30,11 @@ export const useSpanTransactionMetrics = (
 
   const eventView = getEventView(span, location, transactions ?? []);
 
-  const {isLoading, data, pageLinks} = useSpansQuery<SpanTransactionMetrics[]>({
+  return useWrappedDiscoverQuery<SpanTransactionMetrics[]>({
     eventView,
     initialData: [],
     enabled: Boolean(span),
   });
-
-  return {isLoading, data, pageLinks};
 };
 
 function getEventView(span: {group: string}, location: Location, transactions: string[]) {

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -13,20 +13,16 @@ import Link from 'sentry/components/links/link';
 import Pagination from 'sentry/components/pagination';
 import Truncate from 'sentry/components/truncate';
 import {t} from 'sentry/locale';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {useLocation} from 'sentry/utils/useLocation';
-import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
-import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
-import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {IndexedSpan} from 'sentry/views/starfish/queries/types';
 import {
   SpanTransactionMetrics,
   useSpanTransactionMetrics,
 } from 'sentry/views/starfish/queries/useSpanTransactionMetrics';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
-
-const {SPAN_SELF_TIME} = SpanMetricsFields;
 
 type Row = {
   metrics: SpanTransactionMetrics;
@@ -56,9 +52,11 @@ export function SpanTransactionsTable({
   method,
 }: Props) {
   const location = useLocation();
+  const organization = useOrganization();
 
   const {
     data: spanTransactionMetrics,
+    meta,
     isLoading,
     pageLinks,
   } = useSpanTransactionMetrics(span, endpoint ? [endpoint] : undefined);
@@ -75,18 +73,33 @@ export function SpanTransactionsTable({
   };
 
   const renderBodyCell = (column: TableColumnHeader, row: Row) => {
-    return (
-      <BodyCell
-        span={span}
-        column={column}
-        row={row}
-        openSidebar={openSidebar}
-        onClickTransactionName={onClickTransaction}
-        endpoint={endpoint}
-        method={method}
-        location={location}
-      />
-    );
+    if (column.key === 'transaction') {
+      return (
+        <TransactionCell
+          endpoint={endpoint}
+          method={method}
+          span={span}
+          row={row}
+          column={column}
+          openSidebar={openSidebar}
+          onClickTransactionName={onClickTransaction}
+          location={location}
+        />
+      );
+    }
+
+    if (!meta || !meta?.fields) {
+      return row[column.key];
+    }
+
+    const renderer = getFieldRenderer(column.key, meta.fields, false);
+    const rendered = renderer(row, {
+      location,
+      organization,
+      unit: meta.units?.[column.key],
+    });
+
+    return rendered;
   };
 
   return (
@@ -129,61 +142,6 @@ type CellProps = {
   onClickTransactionName?: (row: Row) => void;
   openSidebar?: boolean;
 };
-
-function BodyCell({
-  span,
-  column,
-  row,
-  openSidebar,
-  onClickTransactionName,
-  endpoint,
-  method,
-  location,
-}: CellProps) {
-  if (column.key === 'transaction') {
-    return (
-      <TransactionCell
-        endpoint={endpoint}
-        method={method}
-        span={span}
-        row={row}
-        column={column}
-        openSidebar={openSidebar}
-        onClickTransactionName={onClickTransactionName}
-        location={location}
-      />
-    );
-  }
-
-  if (column.key === 'p95(transaction.duration)') {
-    return (
-      <DurationCell
-        milliseconds={row.metrics?.[`p95(${SPAN_SELF_TIME})`]}
-        delta={row.metrics?.[`percentile_percent_change(${SPAN_SELF_TIME}, 0.95)`]}
-      />
-    );
-  }
-
-  if (column.key === 'sps()') {
-    return (
-      <ThroughputCell
-        throughputPerSecond={row.metrics?.['sps()']}
-        delta={row.metrics?.['sps_percent_change()']}
-      />
-    );
-  }
-
-  if (column.key === 'time_spent_percentage(local)') {
-    return (
-      <TimeSpentCell
-        timeSpentPercentage={row.metrics?.['time_spent_percentage(local)']}
-        totalSpanTime={row.metrics?.[`sum(${SPAN_SELF_TIME})`]}
-      />
-    );
-  }
-
-  return <span>{row[column.key]}</span>;
-}
 
 function TransactionCell({span, column, row, endpoint, method, location}: CellProps) {
   return (

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -21,6 +21,7 @@ import {
   SpanTransactionMetrics,
   useSpanTransactionMetrics,
 } from 'sentry/views/starfish/queries/useSpanTransactionMetrics';
+import {SpanMetricsFields} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 
@@ -37,12 +38,7 @@ type Props = {
   openSidebar?: boolean;
 };
 
-export type Keys =
-  | 'transaction'
-  | 'p95(transaction.duration)'
-  | 'time_spent_percentage(local)'
-  | 'sps()';
-export type TableColumnHeader = GridColumnHeader<Keys>;
+export type TableColumnHeader = GridColumnHeader<keyof Row['metrics']>;
 
 export function SpanTransactionsTable({
   span,
@@ -93,7 +89,7 @@ export function SpanTransactionsTable({
     }
 
     const renderer = getFieldRenderer(column.key, meta.fields, false);
-    const rendered = renderer(row, {
+    const rendered = renderer(row.metrics, {
       location,
       organization,
       unit: meta.units?.[column.key],
@@ -170,12 +166,22 @@ const COLUMN_ORDER: TableColumnHeader[] = [
   {
     key: 'sps()',
     name: DataTitles.throughput,
-    width: 175,
+    width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: 'p95(transaction.duration)',
+    key: 'sps_percent_change()',
+    name: DataTitles.change,
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
+    key: `p95(${SpanMetricsFields.SPAN_SELF_TIME})`,
     name: DataTitles.p95,
-    width: 175,
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
+    key: `percentile_percent_change(${SpanMetricsFields.SPAN_SELF_TIME}, 0.95)`,
+    name: DataTitles.change,
+    width: COL_WIDTH_UNDEFINED,
   },
   {
     key: 'time_spent_percentage(local)',


### PR DESCRIPTION
On our way to consistency! Using generic renderers for the span endpoints table. The table is a little grey (waiting for some backend changes to land) but it'll all resolve itself soon.

**e.g.,**

![Screenshot 2023-06-22 at 2 44 48 PM](https://github.com/getsentry/sentry/assets/989898/899d330d-dda6-4127-b61e-83d2c9b964c7)

## Changes

- Make span mandatory for fetching transaction metrics
- Pass through all response data
- Use generic field rendering
- Fix column titles, width, and types
