### PR TITLE
ref(sort): Remove a/b test for priority sort

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -27,7 +27,6 @@ from sentry.api.serializers.models.group_stream import StreamGroupSerializerSnub
 from sentry.api.utils import InvalidParams, get_date_range_from_stats_period
 from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.exceptions import InvalidSearchQuery
-from sentry.experiments import manager as expt_manager
 from sentry.models import (
     QUERY_STATUS_LOOKUP,
     Environment,
@@ -166,11 +165,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
     }
 
     @staticmethod
-    def build_better_priority_sort_kwargs(
-        request: Request,
-        choice: str,
-        internal: bool,
-    ) -> Mapping[str, PrioritySortWeights]:
+    def build_better_priority_sort_kwargs(request: Request) -> Mapping[str, PrioritySortWeights]:
         """
         Temporary function to be used while developing the new priority sort. Parses the query params in the request.
 
@@ -190,7 +185,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             return func(val) if val is not None else default
 
         # XXX(CEO): these default values are based on sort E
-        aggregate_kwargs = {
+        return {
             "better_priority": {
                 "log_level": _coerce(
                     request.GET.get("logLevel"), int, DEFAULT_PRIORITY_WEIGHTS["log_level"]
@@ -220,12 +215,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             }
         }
 
-        # XXX(CEO): this is based on sort F
-        if choice == "variant2" and not internal:
-            aggregate_kwargs["better_priority"]["issue_halflife_hours"] = 42
-
-        return aggregate_kwargs
-
     def _search(
         self, request: Request, organization, projects, environments, extra_query_kwargs=None
     ):
@@ -238,31 +227,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                 query_kwargs.update(extra_query_kwargs)
 
             if query_kwargs["sort_by"] == "betterPriority":
-                internal = False
-                choice = None
-                if features.has(
-                    "organizations:better-priority-sort-experiment",
-                    organization,
-                    actor=request.user,
-                ):
-                    choice = expt_manager.get(
-                        "PrioritySortExperiment", org=organization, actor=request.user
-                    )
-                # force into variant1 for internal testing
-                if features.has(
-                    "organizations:issue-list-better-priority-sort",
-                    organization,
-                    actor=request.user,
-                ):
-                    internal = True
-                    choice = "variant1"
-
-                if choice == "baseline":
-                    query_kwargs["sort_by"] = "date"
-                else:
-                    query_kwargs["aggregate_kwargs"] = self.build_better_priority_sort_kwargs(
-                        request, choice, internal
-                    )
+                query_kwargs["aggregate_kwargs"] = self.build_better_priority_sort_kwargs(request)
 
             query_kwargs["environments"] = environments if environments else None
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1460,8 +1460,6 @@ SENTRY_FEATURES = {
     "organizations:issue-list-prefetch-issue-on-hover": False,
     # Enable better priority sort algorithm.
     "organizations:issue-list-better-priority-sort": False,
-    # Enable better priority sort experiment
-    "organizations:better-priority-sort-experiment": False,
     # Adds the ttid & ttfd vitals to the frontend
     "organizations:mobile-vitals": False,
     # Display CPU and memory metrics in transactions with profiles

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -92,7 +92,6 @@ default_manager.add("organizations:issue-details-replay-event", OrganizationFeat
 default_manager.add("organizations:issue-details-tag-improvements", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-list-prefetch-issue-on-hover", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-list-better-priority-sort", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:better-priority-sort-experiment", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-platform", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-use-cdc-primary", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -114,7 +114,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.data[0]["id"] == str(group.id)
 
     @with_feature("organizations:issue-list-better-priority-sort")
-    @with_feature("organizations:better-priority-sort-experiment")
     def test_sort_by_better_priority(self):
         group = self.store_event(
             data={


### PR DESCRIPTION
Remove experiment flag and logic around A/B testing for priority sort.

Front end PR: https://github.com/getsentry/sentry/pull/51481
Related getsentry PR: https://github.com/getsentry/getsentry/pull/10937