### PR TITLE
ref(hc): organization_integration_added signal in HC

### DIFF
--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -258,8 +258,10 @@ class ApiInviteHelper:
         organization_service.schedule_signal(
             member_joined,
             organization_id=member.organization_id,
-            user_id=member.user_id,
-            organization_member_id=member.id,
+            args=dict(
+                user_id=member.user_id,
+                organization_member_id=member.id,
+            ),
         )
 
         return member

--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -14,6 +14,7 @@ from sentry.services.hybrid_cloud.organization import (
     RpcUserInviteContext,
     organization_service,
 )
+from sentry.signals import member_joined
 from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry
 
@@ -254,6 +255,12 @@ class ApiInviteHelper:
         )
 
         metrics.incr("organization.invite-accepted", sample_rate=1.0)
+        organization_service.schedule_signal(
+            member_joined,
+            organization_id=member.organization_id,
+            user_id=member.user_id,
+            organization_member_id=member.id,
+        )
 
         return member
 

--- a/src/sentry/models/integrations/integration.py
+++ b/src/sentry/models/integrations/integration.py
@@ -115,11 +115,12 @@ class Integration(DefaultFieldsModel):
                 if not created and default_auth_id:
                     org_integration.update(default_auth_id=default_auth_id)
 
-                organization_service.schedule_signal(
-                    integration_added,
-                    organization_id=organization.id,
-                    args=dict(integration_id=self.id, user_id=user.id if user else None),
-                )
+                if created:
+                    organization_service.schedule_signal(
+                        integration_added,
+                        organization_id=organization.id,
+                        args=dict(integration_id=self.id, user_id=user.id if user else None),
+                    )
                 return org_integration
         except IntegrityError:
             logger.info(

--- a/src/sentry/models/integrations/organization_integration.py
+++ b/src/sentry/models/integrations/organization_integration.py
@@ -49,19 +49,6 @@ class OrganizationIntegration(DefaultFieldsModel):
             for region_name in find_regions_for_orgs([self.organization_id])
         ]
 
-    def outboxes_for_add(self, user_id: int | None) -> List[ControlOutbox]:
-        return [
-            ControlOutbox(
-                shard_scope=OutboxScope.ORGANIZATION_SCOPE,
-                shard_identifier=self.organization_id,
-                object_identifier=self.integration_id,
-                category=OutboxCategory.ORGANIZATION_INTEGRATION_ADDED,
-                region_name=region_name,
-                payload=dict(user_id=user_id),
-            )
-            for region_name in find_regions_for_orgs([self.organization_id])
-        ]
-
     def delete(self, *args, **kwds):
         with outbox_context(transaction.atomic(), flush=False):
             for outbox in self.outboxes_for_update():

--- a/src/sentry/models/integrations/organization_integration.py
+++ b/src/sentry/models/integrations/organization_integration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 
 from django.db import models, transaction
@@ -43,6 +45,19 @@ class OrganizationIntegration(DefaultFieldsModel):
                 object_identifier=self.id,
                 category=OutboxCategory.ORGANIZATION_INTEGRATION_UPDATE,
                 region_name=region_name,
+            )
+            for region_name in find_regions_for_orgs([self.organization_id])
+        ]
+
+    def outboxes_for_add(self, user_id: int | None) -> List[ControlOutbox]:
+        return [
+            ControlOutbox(
+                shard_scope=OutboxScope.ORGANIZATION_SCOPE,
+                shard_identifier=self.organization_id,
+                object_identifier=self.integration_id,
+                category=OutboxCategory.ORGANIZATION_INTEGRATION_ADDED,
+                region_name=region_name,
+                payload=dict(user_id=user_id),
             )
             for region_name in find_regions_for_orgs([self.organization_id])
         ]

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -302,6 +302,7 @@ class RegionOutbox(OutboxBase):
             payload=self.payload,
             object_identifier=self.object_identifier,
             shard_identifier=self.shard_identifier,
+            shard_scope=self.shard_scope,
         )
 
     sharding_columns = ("shard_scope", "shard_identifier")
@@ -357,6 +358,7 @@ class ControlOutbox(OutboxBase):
             region_name=self.region_name,
             object_identifier=self.object_identifier,
             shard_identifier=self.shard_identifier,
+            shard_scope=self.shard_scope,
         )
 
     class Meta:

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -74,6 +74,7 @@ class OutboxCategory(IntEnum):
     TEAM_UPDATE = 11
     ORGANIZATION_INTEGRATION_UPDATE = 12
     ORGANIZATION_MEMBER_CREATE = 13  # Unused
+    ORGANIZATION_INTEGRATION_ADDED = 14
 
     @classmethod
     def as_choices(cls):

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -74,7 +74,7 @@ class OutboxCategory(IntEnum):
     TEAM_UPDATE = 11
     ORGANIZATION_INTEGRATION_UPDATE = 12
     ORGANIZATION_MEMBER_CREATE = 13  # Unused
-    ORGANIZATION_INTEGRATION_ADDED = 14
+    SEND_SIGNAL = 14
 
     @classmethod
     def as_choices(cls):

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -159,11 +159,11 @@ def record_project_created(project, user, **kwargs):
 
 
 @member_joined.connect(weak=False)
-def record_member_joined(member, organization_id: int, **kwargs):
+def record_member_joined(organization_id: int, user_id: int, **kwargs):
     FeatureAdoption.objects.record(
-        organization_id=member.organization_id, feature_slug="invite_team", complete=True
+        organization_id=organization_id, feature_slug="invite_team", complete=True
     )
-    analytics.record("organization.joined", user_id=member.user_id, organization_id=organization_id)
+    analytics.record("organization.joined", user_id=user_id, organization_id=organization_id)
 
 
 @issue_assigned.connect(weak=False)

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -297,19 +297,19 @@ def record_member_invited(member, user, **kwargs):
 
 
 @member_joined.connect(weak=False)
-def record_member_joined(member, organization_id: int, **kwargs):
+def record_member_joined(organization_id: int, organization_member_id: int, **kwargs):
     rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
-        organization_id=member.organization_id,
+        organization_id=organization_id,
         task=OnboardingTask.INVITE_MEMBER,
         status=OnboardingTaskStatus.PENDING,
         values={
             "status": OnboardingTaskStatus.COMPLETE,
             "date_completed": timezone.now(),
-            "data": {"invited_member_id": member.id},
+            "data": {"invited_member_id": organization_member_id},
         },
     )
     if created or rows_affected:
-        try_mark_onboarding_complete(member.organization_id)
+        try_mark_onboarding_complete(organization_id)
 
 
 def record_release_received(project, event, **kwargs):

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -23,7 +23,11 @@ from sentry.models import (
     process_control_outbox,
 )
 from sentry.receivers.outbox import maybe_process_tombstone
-from sentry.services.hybrid_cloud.organization import RpcRegionUser, organization_service
+from sentry.services.hybrid_cloud.organization import (
+    RpcOrganizationSignal,
+    RpcRegionUser,
+    organization_service,
+)
 from sentry.silo.base import SiloMode
 
 logger = logging.getLogger(__name__)
@@ -113,5 +117,6 @@ def process_send_signal(
     if shard_scope == OutboxScope.ORGANIZATION_SCOPE:
         organization_service.send_signal(
             organization_id=shard_identifier,
-            args=payload,
+            args=payload["args"],
+            signal=RpcOrganizationSignal(payload["signal"]),
         )

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -103,3 +103,14 @@ def process_async_webhooks(payload: Mapping[str, Any], region_name: str, **kwds:
                 "request_method": webhook_payload.method,
             },
         )
+
+
+@receiver(process_control_outbox, sender=OutboxCategory.ORGANIZATION_INTEGRATION_ADDED)
+def process_organization_added(
+    payload: Mapping[str, Any], object_identifier: int, shard_identifier: int, **kwds: Any
+):
+    organization_service.record_integration_added(
+        organization_id=shard_identifier,
+        integration_id=object_identifier,
+        user_id=payload.get("user_id"),
+    )

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -114,6 +114,7 @@ def maybe_join_org(org_member: OrganizationMember):
             if org_member.role != roles.get_top_dog().id:
                 member_joined.send_robust(
                     sender=None,
-                    member=org_member,
+                    organization_member_id=org_member.id,
                     organization_id=org_member.organization_id,
+                    user_id=org_member.user_id,
                 )

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -41,6 +41,7 @@ from sentry.services.hybrid_cloud.organization.serial import (
 )
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.util import flags_to_bits
+from sentry.signals import integration_added
 
 
 class DatabaseBackedOrganizationService(OrganizationService):
@@ -485,3 +486,10 @@ class DatabaseBackedOrganizationService(OrganizationService):
     def delete_option(self, *, organization_id: int, key: str) -> None:
         orm_organization = Organization.objects.get_from_cache(id=organization_id)
         orm_organization.delete_option(key)
+
+    def record_integration_added(
+        self, *, organization_id: int, integration_id: int, user_id: int | None
+    ) -> None:
+        integration_added.send_robust(
+            None, integration_id=integration_id, organization_id=organization_id, user_id=user_id
+        )

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from typing import Any, Iterable, List, Mapping, Optional, Set, cast
 
 from django.db import IntegrityError, models, transaction
+from django.dispatch import Signal
 
 from sentry import roles
 from sentry.api.serializers import serialize
 from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models import (
     Activity,
+    ControlOutbox,
     GroupAssignee,
     GroupBookmark,
     GroupSeen,
@@ -18,6 +20,8 @@ from sentry.models import (
     OrganizationMember,
     OrganizationMemberTeam,
     OrganizationStatus,
+    OutboxCategory,
+    OutboxScope,
     Team,
     outbox_context,
 )
@@ -25,6 +29,7 @@ from sentry.models.organizationmember import InviteStatus
 from sentry.services.hybrid_cloud import OptionValue, logger
 from sentry.services.hybrid_cloud.organization import (
     OrganizationService,
+    OrganizationSignalService,
     RpcOrganizationFlagsUpdate,
     RpcOrganizationInvite,
     RpcOrganizationMember,
@@ -42,6 +47,7 @@ from sentry.services.hybrid_cloud.organization.serial import (
 )
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.util import flags_to_bits
+from sentry.types.region import find_regions_for_orgs
 
 
 class DatabaseBackedOrganizationService(OrganizationService):
@@ -491,3 +497,37 @@ class DatabaseBackedOrganizationService(OrganizationService):
         self, *, organization_id: int, signal: RpcOrganizationSignal, args: Mapping[str, int | None]
     ) -> None:
         signal.signal.send_robust(None, organization_id=organization_id, **args)
+
+
+class OutboxBackedOrganizationSignalService(OrganizationSignalService):
+    def schedule_signal(
+        self, signal: Signal, organization_id: int, args: Mapping[str, int | str | None]
+    ) -> None:
+        with outbox_context(flush=False):
+            payload: Any = {
+                "args": args,
+                "signal": int(RpcOrganizationSignal.from_signal(signal)),
+            }
+            for region_name in find_regions_for_orgs([organization_id]):
+                ControlOutbox(
+                    shard_scope=OutboxScope.ORGANIZATION_SCOPE,
+                    shard_identifier=organization_id,
+                    region_name=region_name,
+                    category=OutboxCategory.SEND_SIGNAL,
+                    object_identifier=ControlOutbox.next_object_identifier(),
+                    payload=payload,
+                ).save()
+
+
+class OnCommitBackedOrganizationSignalService(OrganizationSignalService):
+    def schedule_signal(
+        self, signal: Signal, organization_id: int, args: Mapping[str, int | str | None]
+    ) -> None:
+        _signal = RpcOrganizationSignal.from_signal(signal)
+        transaction.on_commit(
+            lambda: DatabaseBackedOrganizationService().send_signal(
+                organization_id=organization_id,
+                signal=_signal,
+                args=args,
+            )
+        )

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Iterable, List, Mapping, Optional, Set, cast
+from typing import Any, Iterable, List, Mapping, Optional, Set, Union, cast
 
 from django.db import IntegrityError, models, transaction
 from django.dispatch import Signal
@@ -494,14 +494,18 @@ class DatabaseBackedOrganizationService(OrganizationService):
         orm_organization.delete_option(key)
 
     def send_signal(
-        self, *, organization_id: int, signal: RpcOrganizationSignal, args: Mapping[str, int | None]
+        self,
+        *,
+        organization_id: int,
+        signal: RpcOrganizationSignal,
+        args: Mapping[str, Optional[str, int]],
     ) -> None:
         signal.signal.send_robust(None, organization_id=organization_id, **args)
 
 
 class OutboxBackedOrganizationSignalService(OrganizationSignalService):
     def schedule_signal(
-        self, signal: Signal, organization_id: int, args: Mapping[str, int | str | None]
+        self, signal: Signal, organization_id: int, args: Mapping[str, Optional[Union[str, int]]]
     ) -> None:
         with outbox_context(flush=False):
             payload: Any = {

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -2,9 +2,10 @@
 #     from __future__ import annotations
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
-
+from enum import IntEnum
 from typing import Any, List, Mapping, Optional, TypedDict
 
+from django.dispatch import Signal
 from pydantic import Field
 
 from sentry.db.models import ValidateFunction, Value
@@ -232,3 +233,28 @@ class RpcRegionUser(RpcModel):
     id: int = -1
     is_active: bool = True
     email: Optional[str] = None
+
+
+class RpcOrganizationSignal(IntEnum):
+    INTEGRATION_ADDED = 1
+    MEMBER_JOINED = 2
+
+    @classmethod
+    def from_signal(cls, signal: Signal) -> "RpcOrganizationSignal":
+        for enum, s in cls.signal_map():
+            if s is signal:
+                return enum
+        raise ValueError(f"Signal {signal!r} is not a valid RpcOrganizationSignal")
+
+    @classmethod
+    def signal_map(cls) -> Mapping["RpcOrganizationSignal", Signal]:
+        from sentry.signals import integration_added, member_joined
+
+        return {
+            RpcOrganizationSignal.INTEGRATION_ADDED: integration_added,
+            RpcOrganizationSignal.MEMBER_JOINED: member_joined,
+        }
+
+    @property
+    def signal(self) -> Signal:
+        return self.signal_map()[self]

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -241,7 +241,7 @@ class RpcOrganizationSignal(IntEnum):
 
     @classmethod
     def from_signal(cls, signal: Signal) -> "RpcOrganizationSignal":
-        for enum, s in cls.signal_map():
+        for enum, s in cls.signal_map().items():
             if s is signal:
                 return enum
         raise ValueError(f"Signal {signal!r} is not a valid RpcOrganizationSignal")

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -2,11 +2,9 @@
 #     from __future__ import annotations
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
-from __future__ import annotations
-
 import abc
 from abc import abstractmethod
-from typing import Any, Iterable, List, Mapping, Optional, cast
+from typing import Any, Iterable, List, Mapping, Optional, Union, cast
 
 from django.dispatch import Signal
 
@@ -282,7 +280,11 @@ class OrganizationService(RpcService):
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
     def send_signal(
-        self, *, signal: RpcOrganizationSignal, organization_id: int, args: Mapping[str, int | None]
+        self,
+        *,
+        signal: RpcOrganizationSignal,
+        organization_id: int,
+        args: Mapping[str, Optional[Union[int, str]]],
     ) -> None:
         pass
 
@@ -290,7 +292,7 @@ class OrganizationService(RpcService):
         self,
         signal: Signal,
         organization_id: int,
-        args: Mapping[str, int | str | None],
+        args: Mapping[str, Optional[Union[int, str]]],
     ) -> None:
         _organization_signal_service.schedule_signal(
             signal=signal, organization_id=organization_id, args=args
@@ -303,7 +305,7 @@ class OrganizationSignalService(abc.ABC):
         self,
         signal: Signal,
         organization_id: int,
-        args: Mapping[str, int | str | None],
+        args: Mapping[str, Optional[Union[int, str]]],
     ) -> None:
         pass
 

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -309,7 +309,9 @@ class OrganizationService(RpcService):
                         region_name=region_name,
                         category=OutboxCategory.SEND_SIGNAL,
                         object_identifier=ControlOutbox.next_object_identifier(),
-                        payload=args,
+                        payload=dict(
+                            args=args, signal=int(RpcOrganizationSignal.from_signal(signal))
+                        ),
                     ).save()
 
 

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -2,6 +2,7 @@
 #     from __future__ import annotations
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
+from __future__ import annotations
 
 from abc import abstractmethod
 from typing import Any, Iterable, List, Optional, cast
@@ -272,6 +273,13 @@ class OrganizationService(RpcService):
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
     def delete_option(self, *, organization_id: int, key: str) -> None:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def record_integration_added(
+        self, *, organization_id: int, integration_id: int, user_id: int | None
+    ) -> None:
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -32,7 +32,6 @@ from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.silo import SiloMode
 from sentry.types.region import find_regions_for_orgs
-from sentry.utils import json
 
 
 class OrganizationService(RpcService):
@@ -303,9 +302,10 @@ class OrganizationService(RpcService):
             )
         else:
             with outbox_context(flush=False):
-                payload: str = json.dumps(
-                    {"args": args, "signal": int(RpcOrganizationSignal.from_signal(signal))}
-                )
+                payload: Any = {
+                    "args": args,
+                    "signal": int(RpcOrganizationSignal.from_signal(signal)),
+                }
                 for region_name in find_regions_for_orgs([organization_id]):
                     ControlOutbox(
                         shard_scope=OutboxScope.ORGANIZATION_SCOPE,

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -125,7 +125,9 @@ first_replay_received = BetterSignal(providing_args=["project"])
 first_cron_monitor_created = BetterSignal(providing_args=["project", "user", "from_upsert"])
 first_cron_checkin_received = BetterSignal(providing_args=["project", "monitor_id"])
 member_invited = BetterSignal(providing_args=["member", "user"])
-member_joined = BetterSignal(providing_args=["member", "organization_id"])
+member_joined = BetterSignal(
+    providing_args=["organization_member_id", "organization_id", "user_id"]
+)
 issue_tracker_used = BetterSignal(providing_args=["plugin", "project", "user"])
 plugin_enabled = BetterSignal(providing_args=["plugin", "project", "user"])
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -186,7 +186,7 @@ inbox_out = BetterSignal(
 
 terms_accepted = BetterSignal(providing_args=["organization", "user", "ip_address"])
 team_created = BetterSignal(providing_args=["organization", "user", "team"])
-integration_added = BetterSignal(providing_args=["integration", "organization", "user"])
+integration_added = BetterSignal(providing_args=["integration_id", "organization_id", "user_id"])
 integration_issue_created = BetterSignal(providing_args=["integration", "organization", "user"])
 integration_issue_linked = BetterSignal(providing_args=["integration", "organization", "user"])
 

--- a/tests/sentry/api/test_invite_helper.py
+++ b/tests/sentry/api/test_invite_helper.py
@@ -5,7 +5,9 @@ from django.http import HttpRequest
 from sentry.api.invite_helper import ApiInviteHelper
 from sentry.models import AuthProvider, OrganizationMember
 from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.signals import receivers_raise_on_send
 from sentry.testutils import TestCase
+from sentry.testutils.outbox import outbox_runner
 
 
 class ApiInviteHelperTest(TestCase):
@@ -63,7 +65,9 @@ class ApiInviteHelperTest(TestCase):
             ),
             None,
         )
-        helper.accept_invite()
+
+        with receivers_raise_on_send(), outbox_runner():
+            helper.accept_invite()
 
         om = OrganizationMember.objects.get(id=self.member.id)
         assert om.email is None

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -18,6 +18,7 @@ from sentry.plugins.bases.issue2 import IssuePlugin2
 from sentry.signals import receivers_raise_on_send
 from sentry.silo.base import SiloMode
 from sentry.testutils import IntegrationTestCase
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
 
 
@@ -34,7 +35,7 @@ def naive_build_integration(data):
 
 @pytest.fixture(autouse=True)
 def raise_on_signal_failures():
-    with receivers_raise_on_send():
+    with receivers_raise_on_send(), outbox_runner():
         yield
 
 

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from sentry.api.utils import generate_organization_url
 from sentry.integrations.example import AliasedIntegrationProvider, ExampleIntegrationProvider
 from sentry.integrations.gitlab.integration import GitlabIntegrationProvider
@@ -13,6 +15,7 @@ from sentry.models import (
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.plugins.base import plugins
 from sentry.plugins.bases.issue2 import IssuePlugin2
+from sentry.signals import receivers_raise_on_send
 from sentry.silo.base import SiloMode
 from sentry.testutils import IntegrationTestCase
 from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
@@ -27,6 +30,12 @@ plugins.register(ExamplePlugin)
 
 def naive_build_integration(data):
     return data
+
+
+@pytest.fixture(autouse=True)
+def raise_on_signal_failures():
+    with receivers_raise_on_send():
+        yield
 
 
 @patch(

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -417,6 +417,7 @@ class RegionOutboxTest(TestCase):
                     payload=None,
                     object_identifier=org,
                     shard_identifier=org,
+                    shard_scope=OutboxScope.ORGANIZATION_SCOPE,
                 )
 
             with outbox_context(flush=False):

--- a/tests/sentry/receivers/test_featureadoption.py
+++ b/tests/sentry/receivers/test_featureadoption.py
@@ -452,7 +452,10 @@ class FeatureAdoptionTest(TestCase, SnubaTestCase):
             organization=self.organization, teams=[self.team], user=self.create_user()
         )
         member_joined.send(
-            member=member, organization_id=self.organization.id, sender=type(self.project)
+            organization_member_id=member.id,
+            organization_id=self.organization.id,
+            user_id=member.user_id,
+            sender=type(self.project),
         )
         feature_complete = FeatureAdoption.objects.get_by_slug(
             organization=self.organization, slug="invite_team"

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -14,7 +14,6 @@ from sentry.models import (
     Rule,
 )
 from sentry.plugins.bases import IssueTrackingPlugin
-from sentry.services.hybrid_cloud.organization.serial import serialize_member
 from sentry.signals import (
     alert_rule_created,
     event_processed,
@@ -465,9 +464,10 @@ class OrganizationOnboardingTaskTest(TestCase):
             project=second_project, event=second_event, sender=type(second_project)
         )
         member_joined.send(
-            member=serialize_member(member),
+            organization_member_id=member.id,
             organization_id=self.organization.id,
-            sender=type(member),
+            user_id=member.user_id,
+            sender=None,
         )
         plugin_enabled.send(
             plugin=IssueTrackingPlugin(),

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -344,10 +344,10 @@ class OrganizationOnboardingTaskTest(TestCase):
 
     def test_integration_added(self):
         integration_added.send(
-            integration=self.create_integration("slack", 1234),
-            organization=self.organization,
-            user=self.user,
-            sender=type(self.organization),
+            integration_id=self.create_integration("slack", 1234).id,
+            organization_id=self.organization.id,
+            user_id=self.user.id,
+            sender=None,
         )
         task = OrganizationOnboardingTask.objects.get(
             organization=self.organization,
@@ -359,10 +359,10 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         # Adding a second integration
         integration_added.send(
-            integration=self.create_integration("github", 4567),
-            organization=self.organization,
-            user=self.user,
-            sender=type(self.organization),
+            integration_id=self.create_integration("github", 4567).id,
+            organization_id=self.organization.id,
+            user_id=self.user.id,
+            sender=None,
         )
         task = OrganizationOnboardingTask.objects.get(
             organization=self.organization,
@@ -376,10 +376,10 @@ class OrganizationOnboardingTaskTest(TestCase):
         # Installing an integration a second time doesn't produce
         # duplicated providers in the list
         integration_added.send(
-            integration=self.create_integration("slack", 4747),
-            organization=self.organization,
-            user=self.user,
-            sender=type(self.organization),
+            integration_id=self.create_integration("slack", 4747).id,
+            organization_id=self.organization.id,
+            user_id=self.user.id,
+            sender=None,
         )
         task = OrganizationOnboardingTask.objects.get(
             organization=self.organization,
@@ -482,10 +482,10 @@ class OrganizationOnboardingTaskTest(TestCase):
             sender=type(IssueTrackingPlugin),
         )
         integration_added.send(
-            integration=self.create_integration("slack"),
-            organization=self.organization,
-            user=user,
-            sender=type(project),
+            integration_id=self.create_integration("slack").id,
+            organization_id=self.organization.id,
+            user_id=user.id,
+            sender=None,
         )
         alert_rule_created.send(
             rule=Rule(id=1),


### PR DESCRIPTION
Enable the `organization_integration_added` signal handling in a cross silo world.

Generalizes signal handling for control -> region signals involving an organization.