### PR TITLE
feat(ui): Ability to specify timezone display in DateTime component

### DIFF
--- a/static/app/components/dateTime.spec.tsx
+++ b/static/app/components/dateTime.spec.tsx
@@ -60,6 +60,11 @@ describe('DateTime', () => {
     expect(screen.getByText('Oct 17, 2:41 AM UTC')).toBeInTheDocument();
   });
 
+  it('renders date with forced timezone', () => {
+    render(<DateTime date={new Date()} forcedTimezone="America/Toronto" />);
+    expect(screen.getByText('Oct 16, 10:41 PM')).toBeInTheDocument();
+  });
+
   describe('24 Hours', () => {
     beforeAll(() => {
       user.options.clock24Hours = true;
@@ -84,6 +89,11 @@ describe('DateTime', () => {
     it('renders date with forced utc', () => {
       render(<DateTime date={new Date()} utc />);
       expect(screen.getByText('Oct 17, 02:41 UTC')).toBeInTheDocument();
+    });
+
+    it('renders date with forced timezone', () => {
+      render(<DateTime date={new Date()} forcedTimezone="America/Toronto" />);
+      expect(screen.getByText('Oct 16, 22:41')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/dateTime.tsx
+++ b/static/app/components/dateTime.tsx
@@ -14,6 +14,10 @@ interface Props extends React.HTMLAttributes<HTMLTimeElement> {
    */
   dateOnly?: boolean;
   /**
+   * When set, will force the date time display to be in the specified timezone
+   */
+  forcedTimezone?: string;
+  /**
    * Formatting string. If specified, this formatting string will override all
    * other formatting props (dateOnly, timeOnly, year).
    */
@@ -53,6 +57,7 @@ function DateTime({
   year,
   timeZone,
   seconds = false,
+  forcedTimezone,
   ...props
 }: Props) {
   const user = ConfigStore.get('user');
@@ -77,7 +82,9 @@ function DateTime({
     <time {...props}>
       {utc
         ? moment.utc(date as moment.MomentInput).format(formatString)
-        : momentTimezone.tz(date, options?.timezone ?? '').format(formatString)}
+        : momentTimezone
+            .tz(date, forcedTimezone ?? options?.timezone ?? '')
+            .format(formatString)}
     </time>
   );
 }


### PR DESCRIPTION
Adds a `forcedTimezone` prop to the `<DateTime>` component which will allow for a specified timezone to be used when displaying a date to the user.

(does not overwrite `utc` prop)

Adding this because for crons we need to show cron job timestamps in the server/execution timezone. 