### PR TITLE
fix(scim): disable idp role lockout

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -216,13 +216,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         is_update_org_role = assigned_org_role and assigned_org_role != member.role
 
         if is_update_org_role:
-            if getattr(member.flags, "idp:role-restricted"):
-                return Response(
-                    {
-                        "role": "This user's org-role is managed through your organization's identity provider."
-                    },
-                    status=403,
-                )
+            # TODO(adas): Reenable idp lockout once all scim role bugs are resolved.
 
             allowed_role_ids = {r.id for r in allowed_roles}
 

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -429,25 +429,6 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
         )
         assert member_om.role == "member"
 
-    def test_cannot_update_idp_role_restricted_member_role(self):
-        member = self.create_user("baz@example.com")
-        member_om = self.create_member(
-            organization=self.organization,
-            user=member,
-            role="member",
-            teams=[],
-            flags=OrganizationMember.flags["idp:role-restricted"],
-        )
-
-        self.get_error_response(
-            self.organization.slug, member_om.id, role="manager", status_code=403
-        )
-
-        member_om = OrganizationMember.objects.get(
-            organization=self.organization, user_id=member.id
-        )
-        assert member_om.role == "member"
-
     @with_feature({"organizations:team-roles": False})
     def test_can_update_from_retired_role_without_flag(self):
         member = self.create_user("baz@example.com")


### PR DESCRIPTION
Disabling the lockout until more robust logic preventing incorrect role selection is in place

