### PR TITLE
feat(search): Update default filter on For Review tab

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -133,7 +133,8 @@ function BaseGroupRow({
   }, [organization, group.id, group.owners, query]);
 
   const trackClick = useCallback(() => {
-    if (query === Query.FOR_REVIEW) {
+    const forReviewQueries: string[] = [Query.FOR_REVIEW, Query.FOR_REVIEW_OLD];
+    if (forReviewQueries.includes(query || '')) {
       trackAnalytics('inbox_tab.issue_clicked', {
         organization,
         group_id: group.id,

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -35,10 +35,11 @@ function IssueListSortOptions({onSelect, sort, query}: Props) {
   const hasBetterPrioritySort = organization.features.includes(
     'issue-list-better-priority-sort'
   );
+  const forReviewQueries: string[] = [Query.FOR_REVIEW, Query.FOR_REVIEW_OLD];
   const sortKey = sort || IssueSortOptions.DATE;
   const sortKeys = [
     ...(hasBetterPrioritySort ? [IssueSortOptions.BETTER_PRIORITY] : []), // show better priority for EA orgs
-    ...(query === Query.FOR_REVIEW ? [IssueSortOptions.INBOX] : []),
+    ...(forReviewQueries.includes(query || '') ? [IssueSortOptions.INBOX] : []),
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
     ...(hasBetterPrioritySort ? [] : [IssueSortOptions.PRIORITY]), // hide regular priority for EA orgs

--- a/static/app/views/issueList/header.tsx
+++ b/static/app/views/issueList/header.tsx
@@ -92,7 +92,7 @@ function IssueListHeader({
   const selectedProjects = projects.filter(({id}) =>
     selectedProjectIds.includes(Number(id))
   );
-
+  const forReviewQueries: string[] = [Query.FOR_REVIEW, Query.FOR_REVIEW_OLD];
   const realtimeTitle = realtimeActive
     ? t('Pause real-time updates')
     : t('Enable real-time updates');
@@ -133,8 +133,9 @@ function IssueListHeader({
                   query: {
                     ...queryParms,
                     query: tabQuery,
-                    sort:
-                      tabQuery === Query.FOR_REVIEW ? IssueSortOptions.INBOX : sortParam,
+                    sort: forReviewQueries.includes(tabQuery || '')
+                      ? IssueSortOptions.INBOX
+                      : sortParam,
                   },
                   pathname: `/organizations/${organization.slug}/issues/`,
                 });

--- a/static/app/views/issueList/noGroupsHandler/index.tsx
+++ b/static/app/views/issueList/noGroupsHandler/index.tsx
@@ -138,6 +138,7 @@ class NoGroupsHandler extends Component<Props, State> {
   render() {
     const {fetchingSentFirstEvent, sentFirstEvent, firstEventProjects} = this.state;
     const {query} = this.props;
+    const forReviewQueries: string[] = [Query.FOR_REVIEW, Query.FOR_REVIEW_OLD];
 
     if (fetchingSentFirstEvent) {
       return this.renderLoading();
@@ -154,7 +155,7 @@ class NoGroupsHandler extends Component<Props, State> {
       );
     }
 
-    if (query === Query.FOR_REVIEW) {
+    if (forReviewQueries.includes(query || '')) {
       return (
         <NoUnresolvedIssues
           title={t('Well, would you look at that.')}

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -921,8 +921,11 @@ class IssueListOverview extends Component<Props, State> {
       path = `/organizations/${organization.slug}/issues/`;
     }
 
-    // Remove inbox tab specific sort
-    if (query.sort === IssueSortOptions.INBOX && query.query !== Query.FOR_REVIEW) {
+    const forReviewQueries: string[] = [Query.FOR_REVIEW, Query.FOR_REVIEW_OLD];
+    if (
+      query.sort === IssueSortOptions.INBOX &&
+      !forReviewQueries.includes(query.query || '')
+    ) {
       delete query.sort;
     }
 

--- a/static/app/views/issueList/utils.spec.tsx
+++ b/static/app/views/issueList/utils.spec.tsx
@@ -12,4 +12,14 @@ describe('getTabs', () => {
       getTabs(TestStubs.Organization({features: []})).map(tab => tab[1].name)
     ).toEqual(['All Unresolved', 'For Review', 'Ignored']);
   });
+
+  it('should enable/disable my_teams filter in For Review tab', () => {
+    expect(
+      getTabs(TestStubs.Organization({features: ['assign-to-me']})).map(tab => tab[1][0])
+    ).toEqual('is:unresolved is:for_review assigned_or_suggested:[me, my_teams, none]');
+
+    expect(getTabs(TestStubs.Organization({features: []})).map(tab => tab[1][0])).toEqual(
+      'is:unresolved is:for_review assigned_or_suggested:[me, none]'
+    );
+  });
 });

--- a/static/app/views/issueList/utils.spec.tsx
+++ b/static/app/views/issueList/utils.spec.tsx
@@ -15,10 +15,10 @@ describe('getTabs', () => {
 
   it('should enable/disable my_teams filter in For Review tab', () => {
     expect(
-      getTabs(TestStubs.Organization({features: ['assign-to-me']})).map(tab => tab[1][0])
+      getTabs(TestStubs.Organization({features: ['assign-to-me']})).map(tab => tab[0])
     ).toEqual('is:unresolved is:for_review assigned_or_suggested:[me, my_teams, none]');
 
-    expect(getTabs(TestStubs.Organization({features: []})).map(tab => tab[1][0])).toEqual(
+    expect(getTabs(TestStubs.Organization({features: []})).map(tab => tab[0])).toEqual(
       'is:unresolved is:for_review assigned_or_suggested:[me, none]'
     );
   });

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -55,22 +55,6 @@ export function getTabs(organization: Organization) {
       },
     ],
     [
-      Query.FOR_REVIEW_OLD,
-      {
-        name: t('For Review'),
-        analyticsName: 'needs_review',
-        count: true,
-        enabled: true,
-        tooltipTitle: hasEscalatingIssuesUi
-          ? t(
-              'Issues are marked for review if they are new or escalating, and have not been resolved or archived. Issues are automatically marked reviewed in 7 days.'
-            )
-          : t(`Issues are marked for review when they are created, unresolved, or unignored.
-          Mark an issue reviewed to move it out of this list.
-          Issues are automatically marked reviewed in 7 days.`),
-      },
-    ],
-    [
       Query.FOR_REVIEW,
       {
         name: t('For Review'),

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -44,6 +44,7 @@ type OverviewTab = {
  */
 export function getTabs(organization: Organization) {
   const hasEscalatingIssuesUi = organization.features.includes('escalating-issues');
+  const hasAssignToMe = organization.features.includes('assign-to-me');
   const tabs: Array<[string, OverviewTab]> = [
     [
       Query.UNRESOLVED,
@@ -55,7 +56,7 @@ export function getTabs(organization: Organization) {
       },
     ],
     [
-      Query.FOR_REVIEW,
+      hasAssignToMe ? Query.FOR_REVIEW : Query.FOR_REVIEW_OLD,
       {
         name: t('For Review'),
         analyticsName: 'needs_review',

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -4,7 +4,8 @@ import {t, tct} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 
 export enum Query {
-  FOR_REVIEW = 'is:unresolved is:for_review assigned_or_suggested:[me, none]',
+  FOR_REVIEW_OLD = 'is:unresolved is:for_review assigned_or_suggested:[me, none]',
+  FOR_REVIEW = 'is:unresolved is:for_review assigned_or_suggested:[me, my_teams, none]',
   UNRESOLVED = 'is:unresolved',
   IGNORED = 'is:ignored',
   NEW = 'is:new',
@@ -51,6 +52,22 @@ export function getTabs(organization: Organization) {
         analyticsName: 'unresolved',
         count: true,
         enabled: true,
+      },
+    ],
+    [
+      Query.FOR_REVIEW_OLD,
+      {
+        name: t('For Review'),
+        analyticsName: 'needs_review',
+        count: true,
+        enabled: true,
+        tooltipTitle: hasEscalatingIssuesUi
+          ? t(
+              'Issues are marked for review if they are new or escalating, and have not been resolved or archived. Issues are automatically marked reviewed in 7 days.'
+            )
+          : t(`Issues are marked for review when they are created, unresolved, or unignored.
+          Mark an issue reviewed to move it out of this list.
+          Issues are automatically marked reviewed in 7 days.`),
       },
     ],
     [


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/50845

Update For Review tab's pre-populated default filter from `is:unresolved is:for_review assigned_or_suggested:[me, none]` to `is:unresolved is: for_review assigned_or_suggested:[me, my_teams, none]` 