### PR TITLE
feat(crons): Set trace_id on consumer check-ins

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -298,6 +298,8 @@ def _process_message(wrapper: Dict) -> None:
                         minutes=(monitor_config or {}).get("max_runtime") or TIMEOUT
                     )
 
+                trace_id = validated_params.get("contexts", {}).get("trace", {}).get("trace_id")
+
                 # If the UUID is unset (zero value) generate a new UUID
                 if check_in_id.int == 0:
                     guid = uuid.uuid4()
@@ -316,6 +318,7 @@ def _process_message(wrapper: Dict) -> None:
                                 "expected_time": expected_time,
                                 "timeout_at": timeout_at,
                                 "monitor_config": monitor_config,
+                                "trace_id": trace_id,
                             },
                             project_id=project_id,
                             monitor=monitor,

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -225,6 +225,14 @@ class MonitorValidator(CamelSnakeSerializer):
         return validated_data
 
 
+class TraceContextValidator(serializers.Serializer):
+    trace_id = serializers.CharField(max_length=32)
+
+
+class ContextsValidator(serializers.Serializer):
+    trace = TraceContextValidator(required=False)
+
+
 class MonitorCheckInValidator(serializers.Serializer):
     status = serializers.ChoiceField(
         choices=(
@@ -241,7 +249,7 @@ class MonitorCheckInValidator(serializers.Serializer):
     )
     environment = serializers.CharField(required=False, allow_null=True)
     monitor_config = ConfigValidator(required=False)
-    trace_id = serializers.CharField(required=False, allow_null=True, max_length=32)
+    contexts = ContextsValidator(required=False, allow_null=True)
 
     def validate(self, attrs):
         attrs = super().validate(attrs)

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -60,6 +60,7 @@ class MonitorConsumerTest(TestCase):
             "duration": None,
             "check_in_id": self.guid,
             "environment": "production",
+            "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
         }
         payload.update(overrides)
 
@@ -105,6 +106,7 @@ class MonitorConsumerTest(TestCase):
         checkin = MonitorCheckIn.objects.get(guid=self.guid)
         # the expected time should not include the margin of 5 minutes
         assert checkin.expected_time == expected_time - timedelta(minutes=5)
+        assert checkin.trace_id is not None
 
     def test_passing(self) -> None:
         monitor = self._create_monitor(slug="my-monitor")

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -53,6 +53,7 @@ class MonitorConsumerTest(TestCase):
     ) -> None:
         now = datetime.now()
         self.guid = uuid.uuid4().hex if not guid else guid
+        self.trace_id = uuid.uuid4().hex
 
         payload = {
             "monitor_slug": monitor_slug,
@@ -60,7 +61,7 @@ class MonitorConsumerTest(TestCase):
             "duration": None,
             "check_in_id": self.guid,
             "environment": "production",
-            "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+            "contexts": {"trace": {"trace_id": self.trace_id}},
         }
         payload.update(overrides)
 
@@ -106,7 +107,7 @@ class MonitorConsumerTest(TestCase):
         checkin = MonitorCheckIn.objects.get(guid=self.guid)
         # the expected time should not include the margin of 5 minutes
         assert checkin.expected_time == expected_time - timedelta(minutes=5)
-        assert checkin.trace_id is not None
+        assert checkin.trace_id.hex == self.trace_id
 
     def test_passing(self) -> None:
         monitor = self._create_monitor(slug="my-monitor")


### PR DESCRIPTION
Stores `trace_id` in the `CheckIn` object

Closes https://github.com/getsentry/sentry/issues/51385