### PR TITLE
Allow blank issues after all

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,9 @@
-blank_issues_enabled: false
+# Ideally we could enable this only for Sentry staff. The reason we enable it
+# (vs. linking out to ./new in a contact_link as a hack) is to reduce friction
+# for Sentry staff creating issues from project boards, now that that flow
+# enforces issue templates. The trade-off is worse reports from non-staff. 🤷
+blank_issues_enabled: true
+
 contact_links:
   - name: Access paid support
     url: https://sentry.io/support
@@ -6,6 +11,3 @@ contact_links:
   - name: Discuss self-hosted
     url: https://github.com/getsentry/self-hosted/issues/new
     about: Please use the `self-hosted` repo for questions about self-hosted Sentry.
-  - name: Bypass issue templates
-    url: https://github.com/getsentry/sentry/issues/new
-    about: This is for you, Cramer.


### PR DESCRIPTION
GitHub has started enforcing issue templates in the issue creation workflow that exists on project boards (in addition to the flow from the old issue listing). This adds significant friction for Sentry staff, so we're going to take the tradeoff with low-quality issues from the outside.

(Ideally the blank issue creation UI would be governed by the same permissions that allow some users to bypass templates by navigating to `./new` directly.)