### PR TITLE
fix: Make remove_unneeded_type_ignores work under MacOS, and add it to CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -479,6 +479,7 @@ jobs:
 
       # only if `backend-typing` succeeds should we try and trim the blocklist
       - run: |
+          python3 -m tools.mypy_helpers.remove_unneeded_type_ignores
           python3 -m tools.mypy_helpers.make_module_ignores
           git diff --exit-code
 

--- a/tools/mypy_helpers/remove_unneeded_type_ignores.py
+++ b/tools/mypy_helpers/remove_unneeded_type_ignores.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 
@@ -14,12 +15,14 @@ def main() -> int:
             subprocess.check_call(
                 (
                     "sed",
-                    "-i",
+                    # https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
+                    "-i/tmp/bogus.bak",
                     "-r",
                     rf"{n}s/# type: ?ignore[^#]*(#|$)/\1/g",
                     fname,
                 )
             )
+            os.remove("/tmp/bogus.bak")
     return 0
 
 


### PR DESCRIPTION
If we run remove_unneeded_type_ignores before make_module_ignores, we
can potentially remove even more files from pyproject.toml

Currently if nobody runs remove_unneeded_type_ignores, files might stay
in pyproject.toml even though the only errors are about unneeded
type:ignore
