### PR TITLE
feat(perf-detector-threshold-configuration) Detection now respects system defaults

### DIFF
--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -100,8 +100,6 @@ register(key="sentry:transaction_metrics_custom_tags", epoch_defaults={1: []})
 register(key="sentry:span_attributes", epoch_defaults={1: ["exclusive-time"]})
 
 DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS = {
-    "slow_db_query_duration_threshold": 1000.0,
-    "n_plus_one_db_duration_threshold": 100.0,
     "uncompressed_assets_detection_enabled": True,
     "consecutive_http_spans_detection_enabled": True,
     "large_http_payload_detection_enabled": True,

--- a/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
+++ b/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
@@ -1,9 +1,12 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
 from sentry import projectoptions
 from sentry.api.endpoints.project_performance_issue_settings import SETTINGS_PROJECT_OPTION_KEY
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import region_silo_test
 
 PERFORMANCE_ISSUE_FEATURES = {
@@ -17,7 +20,6 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
 
     def setUp(self) -> None:
         super().setUp()
-
         self.login_as(user=self.user)
         self.project = self.create_project()
 
@@ -30,22 +32,73 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
         )
 
     def test_get_returns_default(self):
-        with self.feature(PERFORMANCE_ISSUE_FEATURES):
-            response = self.client.get(self.url, format="json")
+        with override_options(
+            {
+                "performance.issues.slow_db_query.duration_threshold": 5000,
+                "performance.issues.n_plus_one_db.duration_threshold": 10000,
+            }
+        ):
+            with self.feature(PERFORMANCE_ISSUE_FEATURES):
+                response = self.client.get(self.url, format="json")
 
-        assert response.status_code == 200, response.content
-        assert response.data["slow_db_query_duration_threshold"] == 1000
-        assert response.data["n_plus_one_db_duration_threshold"] == 100
-        assert response.data["uncompressed_assets_detection_enabled"]
-        assert response.data["consecutive_http_spans_detection_enabled"]
-        assert response.data["large_http_payload_detection_enabled"]
-        assert response.data["n_plus_one_db_queries_detection_enabled"]
-        assert response.data["n_plus_one_api_calls_detection_enabled"]
-        assert response.data["db_on_main_thread_detection_enabled"]
-        assert response.data["file_io_on_main_thread_detection_enabled"]
-        assert response.data["consecutive_db_queries_detection_enabled"]
-        assert response.data["large_render_blocking_asset_detection_enabled"]
-        assert response.data["slow_db_queries_detection_enabled"]
+            assert response.status_code == 200, response.content
+
+            # Respects system defaults
+            assert response.data["slow_db_query_duration_threshold"] == 5000
+            assert response.data["n_plus_one_db_duration_threshold"] == 10000
+
+            assert response.data["uncompressed_assets_detection_enabled"]
+            assert response.data["consecutive_http_spans_detection_enabled"]
+            assert response.data["large_http_payload_detection_enabled"]
+            assert response.data["n_plus_one_db_queries_detection_enabled"]
+            assert response.data["n_plus_one_api_calls_detection_enabled"]
+            assert response.data["db_on_main_thread_detection_enabled"]
+            assert response.data["file_io_on_main_thread_detection_enabled"]
+            assert response.data["consecutive_db_queries_detection_enabled"]
+            assert response.data["large_render_blocking_asset_detection_enabled"]
+            assert response.data["slow_db_queries_detection_enabled"]
+
+    def test_get_project_options_overrides_defaults(self):
+        with override_options(
+            {
+                "performance.issues.slow_db_query.duration_threshold": 1000,
+                "performance.issues.n_plus_one_db.duration_threshold": 100,
+            }
+        ):
+            with self.feature(PERFORMANCE_ISSUE_FEATURES):
+                response = self.client.get(self.url, format="json")
+
+            assert response.status_code == 200, response.content
+
+            # System and project defaults
+            assert response.data["slow_db_query_duration_threshold"] == 1000
+            assert response.data["n_plus_one_db_duration_threshold"] == 100
+            assert response.data["n_plus_one_db_queries_detection_enabled"]
+            assert response.data["slow_db_queries_detection_enabled"]
+
+            patch_project_option_get = patch("sentry.models.ProjectOption.objects.get_value")
+            self.project_option_mock = patch_project_option_get.start()
+            self.project_option_mock.return_value = {}
+
+            self.project_option_mock.return_value = {
+                "n_plus_one_db_duration_threshold": 10000,
+                "n_plus_one_db_queries_detection_enabled": False,
+                "slow_db_query_duration_threshold": 5000,
+                "slow_db_queries_detection_enabled": False,
+            }
+
+            with self.feature(PERFORMANCE_ISSUE_FEATURES):
+                response = self.client.get(self.url, format="json")
+
+            assert response.status_code == 200, response.content
+
+            self.addCleanup(patch_project_option_get.stop)
+
+            # System and project defaults
+            assert response.data["slow_db_query_duration_threshold"] == 5000
+            assert response.data["n_plus_one_db_duration_threshold"] == 10000
+            assert not response.data["n_plus_one_db_queries_detection_enabled"]
+            assert not response.data["slow_db_queries_detection_enabled"]
 
     def test_get_returns_error_without_feature_enabled(self):
         with self.feature({}):

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -312,8 +312,7 @@ class PerformanceDetectionTest(TestCase):
         )
         with override_options(
             {
-                "performance.issues.n_plus_one_db.count_threshold": 20,
-                "performance.issues.n_plus_one_db.duration_threshold": 100,
+                "performance.issues.n_plus_one_db.duration_threshold": 100000,
             }
         ):
             perf_problems = _detect_performance_problems(
@@ -323,7 +322,6 @@ class PerformanceDetectionTest(TestCase):
 
         with override_options(
             {
-                "performance.issues.n_plus_one_db.count_threshold": 5,
                 "performance.issues.n_plus_one_db.duration_threshold": 100,
             }
         ):


### PR DESCRIPTION
 - Performance detection should use system defaults for configurable thresholds when there are no project specific settings.
 - Removed configurable thresholds from default project options, so that system defaults are not overridden by them for this case.  
 - Updated get view, to return system default values for the same case. 
 - Updated tests. 