### PR TITLE
feat(function-trends): Add hook to fetch function trends

### DIFF
--- a/static/app/utils/profiling/hooks/types.tsx
+++ b/static/app/utils/profiling/hooks/types.tsx
@@ -21,3 +21,31 @@ export type Sort<F> = {
   key: F;
   order: 'asc' | 'desc';
 };
+
+export type TrendType = 'regression' | 'improvement';
+
+export type FunctionTrend = {
+  aggregate_range_1: number;
+  aggregate_range_2: number;
+  breakpoint: number;
+  change: TrendType;
+  'count()': number;
+  // fingerprint: number; DO NOT use this yet
+  function: string;
+  package: string;
+  project: string;
+  stats: any;
+  trend_difference: number;
+  trend_percentage: number;
+  unweighted_p_value: number;
+};
+
+type EpochTime = number;
+type DataPoint = {count: number};
+type FunctionTrendStatsData = [EpochTime, DataPoint];
+
+export type FunctionTrendStats = {
+  data: FunctionTrendStatsData[];
+  end: number;
+  start: number;
+};

--- a/static/app/utils/profiling/hooks/useProfileFunctionTrends.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctionTrends.spec.tsx
@@ -1,0 +1,77 @@
+import {ReactElement, useMemo} from 'react';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import {useProfileFunctionTrends} from 'sentry/utils/profiling/hooks/useProfileFunctionTrends';
+import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+function TestContext({children}: {children: ReactElement}) {
+  const {organization} = useMemo(() => initializeOrg(), []);
+  // ensure client is rebuilt on each render otherwise caching will interfere with subsequent tests
+  const client = useMemo(() => new QueryClient(), []);
+
+  return (
+    <QueryClientProvider client={client}>
+      <OrganizationContext.Provider value={organization}>
+        {children}
+      </OrganizationContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+describe('useProfileFunctionTrendss', function () {
+  afterEach(function () {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('initializes with the loading state', function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/profiling/function-trends/',
+      body: {data: []},
+    });
+
+    const hook = reactHooks.renderHook(
+      () =>
+        useProfileFunctionTrends({
+          trendFunction: 'p95()',
+          trendType: 'regression',
+        }),
+      {wrapper: TestContext}
+    );
+    expect(hook.result.current).toMatchObject(
+      expect.objectContaining({
+        isInitialLoading: true,
+      })
+    );
+  });
+
+  it('fetches functions', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/profiling/function-trends/',
+      body: {data: []},
+    });
+
+    const hook = reactHooks.renderHook(
+      () =>
+        useProfileFunctionTrends({
+          trendFunction: 'p95()',
+          trendType: 'regression',
+        }),
+      {wrapper: TestContext}
+    );
+    expect(hook.result.current.isLoading).toEqual(true);
+    expect(hook.result.current.isFetched).toEqual(false);
+    await hook.waitForNextUpdate();
+    expect(hook.result.current).toMatchObject(
+      expect.objectContaining({
+        isLoading: false,
+        isFetched: true,
+        data: expect.objectContaining({
+          data: expect.any(Array),
+        }),
+      })
+    );
+  });
+});

--- a/static/app/utils/profiling/hooks/useProfileFunctionTrends.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctionTrends.tsx
@@ -1,0 +1,50 @@
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {PageFilters} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+
+export type TrendType = 'regression' | 'improvement';
+
+interface UseProfileFunctionTrendsOptions<F extends string> {
+  trendFunction: F;
+  trendType: TrendType;
+  datetime?: PageFilters['datetime'];
+  enabled?: boolean;
+  projects?: (number | string)[];
+  query?: string;
+  refetchOnMount?: boolean;
+}
+
+export function useProfileFunctionTrends<F extends string>({
+  datetime,
+  projects,
+  enabled,
+  query,
+  refetchOnMount,
+  trendFunction,
+  trendType,
+}: UseProfileFunctionTrendsOptions<F>) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const path = `/organizations/${organization.slug}/profiling/function-trends/`;
+  const endpointOptions = {
+    query: {
+      project: projects || selection.projects,
+      environment: selection.environments,
+      ...normalizeDateTimeParams(datetime ?? selection.datetime),
+      function: trendFunction,
+      trend: trendType,
+      query,
+    },
+  };
+
+  return useApiQuery([path, endpointOptions], {
+    staleTime: 0,
+    refetchOnWindowFocus: false,
+    refetchOnMount,
+    retry: false,
+    enabled,
+  });
+}

--- a/static/app/utils/profiling/hooks/useProfileFunctionTrends.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctionTrends.tsx
@@ -4,7 +4,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
-export type TrendType = 'regression' | 'improvement';
+import type {FunctionTrend, TrendType} from './types';
 
 interface UseProfileFunctionTrendsOptions<F extends string> {
   trendFunction: F;
@@ -40,7 +40,7 @@ export function useProfileFunctionTrends<F extends string>({
     },
   };
 
-  return useApiQuery([path, endpointOptions], {
+  return useApiQuery<FunctionTrend[]>([path, endpointOptions], {
     staleTime: 0,
     refetchOnWindowFocus: false,
     refetchOnMount,


### PR DESCRIPTION
Adds a hook to allow fetching function trends with support for `regression` and `improvement` as well as trends on any aggregate function.