### PR TITLE
ref(replay): Refactor how we count/track how many backend errors people see

### DIFF
--- a/static/app/utils/replays/hooks/useLogReplayDataLoaded.tsx
+++ b/static/app/utils/replays/hooks/useLogReplayDataLoaded.tsx
@@ -22,17 +22,18 @@ function useLogReplayDataLoaded({fetchError, fetching, projectSlug, replay}: Pro
     if (fetching || fetchError || !replay || !project) {
       return;
     }
-    const feErrorIds = replay.getReplay().error_ids || [];
-    const allErrors = replay.getRawErrors();
-    const beErrorCount = allErrors.filter(error => !feErrorIds.includes(error.id)).length;
+
+    const errorFrames = replay.getErrorFrames();
+    const feErrors = errorFrames.filter(frame => frame.data.projectSlug === projectSlug);
+    const beErrors = errorFrames.filter(frame => frame.data.projectSlug !== projectSlug);
 
     trackAnalytics('replay.details-data-loaded', {
       organization,
-      be_errors: beErrorCount,
-      fe_errors: feErrorIds.length,
+      be_errors: beErrors.length,
+      fe_errors: feErrors.length,
       project_platform: project.platform!,
       replay_errors: 0,
-      total_errors: allErrors.length,
+      total_errors: errorFrames.length,
       started_at_delta: replay.timestampDeltas.startedAtDelta,
       finished_at_delta: replay.timestampDeltas.finishedAtDelta,
       replay_id: replay.getReplay().id,

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -128,7 +128,7 @@ export default class ReplayReader {
     this.replayRecord = replayRecord;
     // Errors don't need to be sorted here, they will be merged with breadcrumbs
     // and spans in the getter and then sorted together.
-    this._errors = hydrateErrors(replayRecord, errors);
+    this._errors = hydrateErrors(replayRecord, errors).sort(sortFrames);
     // RRWeb Events are not sorted here, they are fetched in sorted order.
     this._sortedRRWebEvents = rrwebFrames;
     // Breadcrumbs must be sorted. Crumbs like `slowClick` and `multiClick` will
@@ -213,6 +213,8 @@ export default class ReplayReader {
   };
 
   getRRWebFrames = () => this._sortedRRWebEvents;
+
+  getErrorFrames = () => this._errors;
 
   getConsoleFrames = memoize(() =>
     this._sortedBreadcrumbFrames.filter(frame => frame.category === 'console')


### PR DESCRIPTION
This actually seems like a worse strategy for counting whether or not a user is looking at an replay with backend errors or not.

In the previous code, we look at which errors did the js sdk know about, and compare that to the list of all errors that the replay knows about. 

In the new code we're looking at what errors are related to the same project as the replay, and what errors come from a different project.

The issue with the first case is that the sdk might not know about all errors, an error might be emitted and tagged with the replay_id before the replay is fully setup. So the replay sdk doesn't know about the error.

But the issue with the new strategy is worse. If the org is using one project for both backend and front end (which is common in laravel php setups) then all errors would be in the same project, and we can't figure out if any are backend at all.