### PR TITLE
ref: fix some of the errors when snuba_sdk types are followed

### DIFF
--- a/src/sentry/search/events/builder/profile_functions.py
+++ b/src/sentry/search/events/builder/profile_functions.py
@@ -115,6 +115,7 @@ class ProfileTopFunctionsTimeseriesQueryBuilder(ProfileFunctionsTimeseriesQueryB
             if groupby == self.time_column:
                 continue
             if isinstance(groupby, (CurriedFunction, AliasedExpression)):
+                assert groupby.alias is not None
                 translated.append(groupby.alias)
             else:
                 translated.append(groupby.name)

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -356,7 +356,9 @@ class QueryDefinition:
 
 
 def run_outcomes_query_totals(
-    query: QueryDefinition, tenant_ids: dict[str, Any] | None = None
+    query: QueryDefinition,
+    *,
+    tenant_ids: dict[str, int | str],
 ) -> ResultSet:
     snql_query = Query(
         match=Entity(query.match),
@@ -376,8 +378,9 @@ def run_outcomes_query_totals(
 
 def run_outcomes_query_timeseries(
     query: QueryDefinition,
+    *,
+    tenant_ids: dict[str, int | str],
     referrer: str = "outcomes.timeseries",
-    tenant_ids: dict[str, Any] | None = None,
 ) -> ResultSet:
     """
     Runs an outcomes query. By default the referrer is `outcomes.timeseries` and this should not change

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -970,7 +970,11 @@ def _bulk_snuba_query(
 RawResult = Tuple[urllib3.response.HTTPResponse, Callable[[Any], Any], Callable[[Any], Any]]
 
 
-def _snql_query(params: Tuple[SnubaQuery, Hub, Mapping[str, str], str]) -> RawResult:
+def _snql_query(
+    params: tuple[
+        tuple[SnubaQuery, Callable[[Any], Any], Callable[[Any], Any]], Hub, Mapping[str, str], str
+    ]
+) -> RawResult:
     # Eventually we can get rid of this wrapper, but for now it's cleaner to unwrap
     # the params here than in the calling function.
     query_data, thread_hub, headers, parent_api = params

--- a/tests/sentry/issues/test_search_issues_dataset.py
+++ b/tests/sentry/issues/test_search_issues_dataset.py
@@ -30,7 +30,8 @@ class DatasetTest(SnubaTestCase, TestCase):
         }
         request = json_to_snql(json_body, "search_issues")
         request.validate()
-        resp = _snql_query(((request, None, None), Hub(Hub.current), {}, "test_api"))
+        identity = lambda x: x
+        resp = _snql_query(((request, identity, identity), Hub(Hub.current), {}, "test_api"))
         assert resp[0].status == 200
         stuff = json.loads(resp[0].data)
 


### PR DESCRIPTION
currently `snuba_sdk.*` is skipped in `pyproject.toml` -- this fixes some of the errors when that is un-skipped




<!-- Describe your PR here. -->