### PR TITLE
ref(replay): Refactor useReplayData and create a new wrapper useReplayReader

### DIFF
--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -15,7 +15,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Event} from 'sentry/types/event';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
-import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
+import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 
@@ -27,15 +27,14 @@ type Props = {
 
 function ReplayPreview({orgSlug, replaySlug, event}: Props) {
   const routes = useRoutes();
-  const {fetching, replay, fetchError, replayId} = useReplayData({
+  const {fetching, replay, replayRecord, fetchError, replayId} = useReplayReader({
     orgSlug,
     replaySlug,
   });
+
   const eventTimestamp = event.dateCreated
     ? Math.floor(new Date(event.dateCreated).getTime() / 1000) * 1000
     : 0;
-
-  const replayRecord = replay?.getReplay();
 
   const startTimestampMs = replayRecord?.started_at.getTime() ?? 0;
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -9,17 +9,13 @@ import {
   useHasOrganizationSentAnyReplayEvents,
   useReplayOnboardingSidebarPanel,
 } from 'sentry/utils/replays/hooks/useReplayOnboarding';
+import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import useProjects from 'sentry/utils/useProjects';
 
-const mockReplay = ReplayReader.factory({
-  replayRecord: TestStubs.ReplayRecord({}),
-  errors: [],
-  attachments: TestStubs.ReplaySegmentInit({}),
-});
-
-jest.mock('sentry/utils/useProjects');
 jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
+jest.mock('sentry/utils/replays/hooks/useReplayReader');
+jest.mock('sentry/utils/useProjects');
 
 jest.mock('screenfull', () => ({
   enabled: true,
@@ -30,15 +26,27 @@ jest.mock('screenfull', () => ({
   off: jest.fn(),
 }));
 
-jest.mock('sentry/utils/replays/hooks/useReplayData', () => {
+const mockReplay = ReplayReader.factory({
+  replayRecord: TestStubs.ReplayRecord({}),
+  errors: [],
+  attachments: TestStubs.ReplaySegmentInit({}),
+});
+
+const mockUseReplayReader = useReplayReader as jest.MockedFunction<
+  typeof useReplayReader
+>;
+
+mockUseReplayReader.mockImplementation(() => {
   return {
-    __esModule: true,
-    default: jest.fn(() => {
-      return {
-        replay: mockReplay,
-        fetching: false,
-      };
-    }),
+    attachments: [],
+    errors: [],
+    fetchError: undefined,
+    fetching: false,
+    onRetry: jest.fn(),
+    projectSlug: TestStubs.Project().slug,
+    replay: mockReplay,
+    replayId: TestStubs.ReplayRecord({}).id,
+    replayRecord: TestStubs.ReplayRecord(),
   };
 });
 

--- a/static/app/utils/replays/hooks/useLogReplayDataLoaded.tsx
+++ b/static/app/utils/replays/hooks/useLogReplayDataLoaded.tsx
@@ -1,13 +1,13 @@
 import {useEffect} from 'react';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type useReplayData from 'sentry/utils/replays/hooks/useReplayData';
+import type useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
 
 interface Props
   extends Pick<
-    ReturnType<typeof useReplayData>,
+    ReturnType<typeof useReplayReader>,
     'fetchError' | 'fetching' | 'projectSlug' | 'replay'
   > {}
 

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -4,12 +4,10 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
 import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
-import ReplayReader from 'sentry/utils/replays/replayReader';
 import useProjects from 'sentry/utils/useProjects';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 jest.useFakeTimers();
-jest.spyOn(ReplayReader, 'factory');
 jest.mock('sentry/utils/useProjects');
 
 const {organization, project} = initializeOrg();
@@ -24,10 +22,6 @@ mockUseProjects.mockReturnValue({
   onSearch: () => Promise.resolve(),
   placeholders: [],
 });
-
-const MockedReplayReaderFactory = ReplayReader.factory as jest.MockedFunction<
-  typeof ReplayReader.factory
->;
 
 function getMockReplayRecord(replayRecord?: Partial<ReplayRecord>) {
   const HYDRATED_REPLAY = TestStubs.ReplayRecord({
@@ -49,7 +43,6 @@ function getMockReplayRecord(replayRecord?: Partial<ReplayRecord>) {
 
 describe('useReplayData', () => {
   beforeEach(() => {
-    MockedReplayReaderFactory.mockClear();
     MockApiClient.clearMockResponses();
   });
 
@@ -79,7 +72,7 @@ describe('useReplayData', () => {
 
     const {result, waitForNextUpdate} = reactHooks.renderHook(useReplayData, {
       initialProps: {
-        replaySlug: `${project.slug}:${mockReplayResponse.id}`,
+        replayId: mockReplayResponse.id,
         orgSlug: organization.slug,
       },
     });
@@ -87,14 +80,13 @@ describe('useReplayData', () => {
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
+      attachments: expect.any(Array),
+      errors: expect.any(Array),
       fetchError: undefined,
       fetching: false,
       onRetry: expect.any(Function),
-      replay: expect.any(ReplayReader),
-      replayErrors: expect.any(Array),
-      replayRecord: expectedReplay,
       projectSlug: project.slug,
-      replayId: expectedReplay.id,
+      replayRecord: expectedReplay,
     });
   });
 
@@ -145,9 +137,9 @@ describe('useReplayData', () => {
       match: [(_url, options) => options.query?.cursor === '0:1:0'],
     });
 
-    const {waitForNextUpdate} = reactHooks.renderHook(useReplayData, {
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplayData, {
       initialProps: {
-        replaySlug: `${project.slug}:${mockReplayResponse.id}`,
+        replayId: mockReplayResponse.id,
         orgSlug: organization.slug,
         segmentsPerPage: 1,
       },
@@ -159,11 +151,13 @@ describe('useReplayData', () => {
     expect(mockedSegmentsCall1).toHaveBeenCalledTimes(1);
     expect(mockedSegmentsCall2).toHaveBeenCalledTimes(1);
 
-    expect(MockedReplayReaderFactory).toHaveBeenLastCalledWith({
-      attachments: [...mockSegmentResponse1, ...mockSegmentResponse2],
-      replayRecord: expectedReplay,
-      errors: [],
-    });
+    expect(result.current).toStrictEqual(
+      expect.objectContaining({
+        attachments: [...mockSegmentResponse1, ...mockSegmentResponse2],
+        errors: [],
+        replayRecord: expectedReplay,
+      })
+    );
   });
 
   it('should concat N error responses and pass them through to Replay Reader', async () => {
@@ -231,9 +225,9 @@ describe('useReplayData', () => {
       ],
     });
 
-    const {waitForNextUpdate} = reactHooks.renderHook(useReplayData, {
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplayData, {
       initialProps: {
-        replaySlug: `${project.slug}:${mockReplayResponse.id}`,
+        replayId: mockReplayResponse.id,
         orgSlug: organization.slug,
         errorsPerPage: 1,
       },
@@ -245,11 +239,13 @@ describe('useReplayData', () => {
     expect(mockedErrorsCall1).toHaveBeenCalledTimes(1);
     expect(mockedErrorsCall2).toHaveBeenCalledTimes(1);
 
-    expect(MockedReplayReaderFactory).toHaveBeenLastCalledWith({
-      attachments: [],
-      replayRecord: expectedReplay,
-      errors: [...mockErrorResponse1, ...mockErrorResponse2],
-    });
+    expect(result.current).toStrictEqual(
+      expect.objectContaining({
+        attachments: [],
+        errors: [...mockErrorResponse1, ...mockErrorResponse2],
+        replayRecord: expectedReplay,
+      })
+    );
   });
 
   it('should incrementally load attachments and errors', async () => {
@@ -294,31 +290,25 @@ describe('useReplayData', () => {
 
     const {result, waitForNextUpdate} = reactHooks.renderHook(useReplayData, {
       initialProps: {
-        replaySlug: `${project.slug}:${mockReplayResponse.id}`,
+        replayId: mockReplayResponse.id,
         orgSlug: organization.slug,
       },
     });
 
     const expectedReplayData = {
+      attachments: [],
+      errors: [],
       fetchError: undefined,
       fetching: true,
       onRetry: expect.any(Function),
-      replayErrors: expect.any(Array),
-      replay: null,
-      replayRecord: undefined,
       projectSlug: null,
-      replayId: expectedReplay.id,
+      replayRecord: undefined,
     } as Record<string, unknown>;
 
     // Immediately we will see the replay call is made
     expect(mockedReplayCall).toHaveBeenCalledTimes(1);
     expect(mockedEventsMetaCall).not.toHaveBeenCalledTimes(1);
     expect(mockedSegmentsCall).not.toHaveBeenCalledTimes(1);
-    expect(MockedReplayReaderFactory).toHaveBeenLastCalledWith({
-      attachments: [],
-      replayRecord: undefined,
-      errors: [],
-    });
     expect(result.current).toEqual(expectedReplayData);
 
     jest.advanceTimersByTime(10);
@@ -328,80 +318,37 @@ describe('useReplayData', () => {
     expect(mockedReplayCall).toHaveBeenCalledTimes(1);
     expect(mockedEventsMetaCall).toHaveBeenCalledTimes(1);
     expect(mockedSegmentsCall).toHaveBeenCalledTimes(1);
-    expect(MockedReplayReaderFactory).toHaveBeenLastCalledWith({
-      attachments: [],
-      replayRecord: expectedReplay,
-      errors: [],
-    });
-    expectedReplayData.replayRecord = expectedReplay;
-    expectedReplayData.projectSlug = project.slug;
-    expectedReplayData.replay = expect.any(ReplayReader);
-    expect(result.current).toEqual(expectedReplayData);
+    expect(result.current).toStrictEqual(
+      expect.objectContaining({
+        attachments: [],
+        errors: [],
+        projectSlug: project.slug,
+        replayRecord: expectedReplay,
+      })
+    );
 
     jest.advanceTimersByTime(100);
     await waitForNextUpdate();
 
     // Next we see that some rrweb data has arrived
-    expect(MockedReplayReaderFactory).toHaveBeenLastCalledWith({
-      attachments: mockSegmentResponse,
-      replayRecord: expectedReplay,
-      errors: [],
-    });
+    expect(result.current).toStrictEqual(
+      expect.objectContaining({
+        attachments: mockSegmentResponse,
+        errors: [],
+        replayRecord: expectedReplay,
+      })
+    );
 
     jest.advanceTimersByTime(250);
     await waitForNextUpdate();
 
     // Finally we see fetching is complete, errors are here too
-    expect(MockedReplayReaderFactory).toHaveBeenLastCalledWith({
-      attachments: mockSegmentResponse,
-      replayRecord: expectedReplay,
-      errors: mockErrorResponse,
-    });
-  });
-
-  it('should handle a replaySlug without projectSlug', async () => {
-    const {mockReplayResponse, expectedReplay} = getMockReplayRecord({
-      count_errors: 0,
-      count_segments: 0,
-      error_ids: [],
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/replays-events-meta/`,
-      body: {
-        data: [],
-      },
-      headers: {
-        Link: [
-          '<http://localhost/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:1:0"',
-          '<http://localhost/?cursor=0:2:0>; rel="next"; results="false"; cursor="0:1:0"',
-        ].join(','),
-      },
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/replays/${mockReplayResponse.id}/`,
-      body: {data: mockReplayResponse},
-    });
-
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplayData, {
-      initialProps: {
-        replaySlug: mockReplayResponse.id,
-        orgSlug: organization.slug,
-      },
-    });
-
-    await waitForNextUpdate();
-
-    expect(result.current).toEqual({
-      fetchError: undefined,
-      fetching: false,
-      onRetry: expect.any(Function),
-      replay: expect.any(ReplayReader),
-      replayRecord: expectedReplay,
-      projectSlug: project.slug,
-      replayErrors: expect.any(Array),
-      replayId: expectedReplay.id,
-    });
+    expect(result.current).toStrictEqual(
+      expect.objectContaining({
+        attachments: mockSegmentResponse,
+        errors: mockErrorResponse,
+        replayRecord: expectedReplay,
+      })
+    );
   });
 });

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -4,7 +4,6 @@ import * as Sentry from '@sentry/react';
 import {Client} from 'sentry/api';
 import parseLinkHeader, {ParsedHeader} from 'sentry/utils/parseLinkHeader';
 import {mapResponseToReplayRecord} from 'sentry/utils/replays/replayDataUtils';
-import ReplayReader from 'sentry/utils/replays/replayReader';
 import RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import useProjects from 'sentry/utils/useProjects';
@@ -32,9 +31,9 @@ type Options = {
   orgSlug: string;
 
   /**
-   * The projectSlug and replayId concatenated together
+   * The replayId
    */
-  replaySlug: string;
+  replayId: string;
 
   /**
    * Default: 50
@@ -50,13 +49,12 @@ type Options = {
 };
 
 interface Result {
+  attachments: unknown[];
+  errors: ReplayError[];
   fetchError: undefined | RequestError;
   fetching: boolean;
   onRetry: () => void;
   projectSlug: string | null;
-  replay: ReplayReader | null;
-  replayErrors: ReplayError[];
-  replayId: string;
   replayRecord: ReplayRecord | undefined;
 }
 
@@ -88,16 +86,15 @@ const INITIAL_STATE: State = Object.freeze({
  * Front-end processing, filtering and re-mixing of the different data streams
  * must be delegated to the `ReplayReader` class.
  *
- * @param {orgSlug, replaySlug} Where to find the root replay event
+ * @param {orgSlug, replayId} Where to find the root replay event
  * @returns An object representing a unified result of the network requests. Either a single `ReplayReader` data object or fetch errors.
  */
 function useReplayData({
-  replaySlug,
+  replayId,
   orgSlug,
   errorsPerPage = 50,
   segmentsPerPage = 100,
 }: Options): Result {
-  const replayId = parseReplayId(replaySlug);
   const projects = useProjects();
 
   const api = useApi();
@@ -215,40 +212,15 @@ function useReplayData({
     fetchAttachments().catch(onError);
   }, [state.fetchError, fetchAttachments, onError]);
 
-  const replay = useMemo(() => {
-    return ReplayReader.factory({
-      attachments,
-      errors,
-      replayRecord,
-    });
-  }, [attachments, errors, replayRecord]);
-
   return {
-    replayErrors: errors,
+    attachments,
+    errors,
     fetchError: state.fetchError,
     fetching: state.fetchingAttachments || state.fetchingErrors || state.fetchingReplay,
     onRetry: loadData,
-    replay,
-    replayRecord,
     projectSlug,
-    replayId,
+    replayRecord,
   };
-}
-
-// see https://github.com/getsentry/sentry/pull/47859
-// replays can apply to many projects when incorporating backend errors
-// this makes having project in the `replaySlug` obsolete
-// we must keep this url schema for now for backward compat but we should remove it at some point
-// TODO: remove support for projectSlug in replay url?
-function parseReplayId(replaySlug: string) {
-  const maybeProjectSlugAndReplayId = replaySlug.split(':');
-  if (maybeProjectSlugAndReplayId.length === 2) {
-    return maybeProjectSlugAndReplayId[1];
-  }
-
-  // if there is no projectSlug then we assume we just have the replayId
-  // all other cases would be a malformed url
-  return maybeProjectSlugAndReplayId[0];
 }
 
 function makeFetchReplayApiUrl(orgSlug: string, replayId: string) {

--- a/static/app/utils/replays/hooks/useReplayReader.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayReader.spec.tsx
@@ -1,0 +1,47 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+
+jest.mock('sentry/utils/replays/hooks/useReplayData', () => ({
+  __esModule: true,
+  default: () => jest.fn().mockReturnValue({}),
+}));
+
+const {organization, project} = initializeOrg();
+
+describe('useReplayReader', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('should accept a replaySlug with project and id parts', () => {
+    const {result} = reactHooks.renderHook(useReplayReader, {
+      initialProps: {
+        orgSlug: organization.slug,
+        replaySlug: `${project.slug}:123`,
+      },
+    });
+
+    expect(result.current).toStrictEqual(
+      expect.objectContaining({
+        replayId: '123',
+      })
+    );
+  });
+
+  it('should accept a replaySlug with only the replay-id', () => {
+    const {result} = reactHooks.renderHook(useReplayReader, {
+      initialProps: {
+        orgSlug: organization.slug,
+        replaySlug: `123`,
+      },
+    });
+
+    expect(result.current).toStrictEqual(
+      expect.objectContaining({
+        replayId: '123',
+      })
+    );
+  });
+});

--- a/static/app/utils/replays/hooks/useReplayReader.tsx
+++ b/static/app/utils/replays/hooks/useReplayReader.tsx
@@ -1,0 +1,48 @@
+import {useMemo} from 'react';
+
+import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
+import ReplayReader from 'sentry/utils/replays/replayReader';
+
+type Props = {
+  orgSlug: string;
+  replaySlug: string;
+};
+
+export default function useReplayReader({orgSlug, replaySlug}: Props) {
+  const replayId = parseReplayId(replaySlug);
+
+  const {attachments, errors, replayRecord, ...replayData} = useReplayData({
+    orgSlug,
+    replayId,
+  });
+
+  const replay = useMemo(
+    () => ReplayReader.factory({attachments, errors, replayRecord}),
+    [attachments, errors, replayRecord]
+  );
+
+  return {
+    ...replayData,
+    attachments,
+    errors,
+    replay,
+    replayId,
+    replayRecord,
+  };
+}
+
+// see https://github.com/getsentry/sentry/pull/47859
+// replays can apply to many projects when incorporating backend errors
+// this makes having project in the `replaySlug` obsolete
+// we must keep this url schema for now for backward compat but we should remove it at some point
+// TODO: remove support for projectSlug in replay url?
+function parseReplayId(replaySlug: string) {
+  const maybeProjectSlugAndReplayId = replaySlug.split(':');
+  if (maybeProjectSlugAndReplayId.length === 2) {
+    return maybeProjectSlugAndReplayId[1];
+  }
+
+  // if there is no projectSlug then we assume we just have the replayId
+  // all other cases would be a malformed url
+  return maybeProjectSlugAndReplayId[0];
+}

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -128,7 +128,7 @@ export default class ReplayReader {
     this.replayRecord = replayRecord;
     // Errors don't need to be sorted here, they will be merged with breadcrumbs
     // and spans in the getter and then sorted together.
-    this._errors = hydrateErrors(replayRecord, errors);
+    this._errors = hydrateErrors(replayRecord, errors).sort(sortFrames);
     // RRWeb Events are not sorted here, they are fetched in sorted order.
     this._sortedRRWebEvents = rrwebFrames;
     // Breadcrumbs must be sorted. Crumbs like `slowClick` and `multiClick` will
@@ -213,6 +213,8 @@ export default class ReplayReader {
   };
 
   getRRWebFrames = () => this._sortedRRWebEvents;
+
+  getErrorFrames = () => this._errors;
 
   getConsoleFrames = memoize(() =>
     this._sortedBreadcrumbFrames.filter(frame => frame.category === 'console')

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -15,9 +15,9 @@ import useInitialTimeOffsetMs, {
   TimeOffsetLocationQueryParams,
 } from 'sentry/utils/replays/hooks/useInitialTimeOffsetMs';
 import useLogReplayDataLoaded from 'sentry/utils/replays/hooks/useLogReplayDataLoaded';
-import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
 import useReplayLayout from 'sentry/utils/replays/hooks/useReplayLayout';
 import useReplayPageview from 'sentry/utils/replays/hooks/useReplayPageview';
+import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import useOrganization from 'sentry/utils/useOrganization';
 import ReplaysLayout from 'sentry/views/replays/detail/layout';
 import Page from 'sentry/views/replays/detail/page';
@@ -39,20 +39,20 @@ function ReplayDetails({params: {replaySlug}}: Props) {
   // TODO: replayId is known ahead of time and useReplayData is parsing it from the replaySlug
   // once we fix the route params and links we should fix this to accept replayId and stop returning it
   const {
+    errors: replayErrors,
+    fetchError,
     fetching,
     onRetry,
-    replay,
-    replayRecord,
-    fetchError,
     projectSlug,
+    replay,
     replayId,
-    replayErrors,
-  } = useReplayData({
+    replayRecord,
+  } = useReplayReader({
     replaySlug,
     orgSlug,
   });
 
-  useLogReplayDataLoaded({fetching, fetchError, replay, projectSlug});
+  useLogReplayDataLoaded({fetchError, fetching, projectSlug, replay});
 
   const initialTimeOffsetMs = useInitialTimeOffsetMs({
     orgSlug,


### PR DESCRIPTION
The return type of `useReplayData` always bugged me a bit. It was returning almost all the raw data (errors and replayRecord, but not attachments) and also all the hydrated data (a ReplayReader instance).

It should be doing one thing only!

So this introduces a little wrapper, `useReplayReader` which takes all the raw data from `useReplayData` and gets a Reader instance back out.

It's also a good place to parse the `replaySlug` into `[projectSlug, replayId]` parts. We'll need to keep this parsing for a while, until all links in the app are fixed to use pass replayId, and then all old data has expired.

Tests are also be simplified because the old file has fewer dependencies, and the replaySlug stuff can be tested in isolation.