### PR TITLE
fix(hybridcloud) Remove subquery between actor + user

### DIFF
--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -42,7 +42,7 @@ def fetch_actors_by_actor_ids(cls, actor_ids: List[int]) -> Union[List["Team"], 
         user_ids = Actor.objects.filter(type=ACTOR_TYPES["user"], id__in=actor_ids).values_list(
             "user_id", flat=True
         )
-        return user_service.get_many(filter={"user_ids": user_ids})
+        return user_service.get_many(filter={"user_ids": list(user_ids)})
     if cls is Team:
         return Team.objects.filter(actor_id__in=actor_ids).all()
 

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -377,7 +377,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
 
         # Remove alert owners not in new org
         alert_rules = AlertRule.objects.fetch_for_project(self).filter(owner_id__isnull=False)
-        rules = Rule.objects.filter(owner_id__isnull=False, project=self)
+        rules = Rule.objects.filter(owner_id__isnull=False, project=self).select_related("owner")
         for rule in list(chain(alert_rules, rules)):
             actor = rule.owner
             is_member = False


### PR DESCRIPTION
Our annotation restrictions aren't able to catch this kind of query pattern. I was able to catch this problem by working with split databases.