### PR TITLE
ref(HC): Revokes org and org mapping write permissions, adds outbox handling to org model

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -266,6 +266,9 @@ class Organization(Model, OptionMixin, OrganizationAbsoluteUrlMixin, SnowflakeId
             with outbox_context(transaction.atomic()):
                 self.save_with_update_outbox(*args, **kwargs)
 
+    # Override for the default update method to ensure that most atomic updates
+    #  generate an outbox alongside any mutations to ensure data is replicated
+    #  properly to the control silo.
     @override
     def update(self, *args, **kwargs):
         with outbox_context(transaction.atomic()):

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -29,8 +29,8 @@ from sentry.models.organizationmember import InviteStatus
 from sentry.services.hybrid_cloud import OptionValue, logger
 from sentry.services.hybrid_cloud.organization import (
     OrganizationService,
-    RpcOrganization,
     OrganizationSignalService,
+    RpcOrganization,
     RpcOrganizationFlagsUpdate,
     RpcOrganizationInvite,
     RpcOrganizationMember,

--- a/src/sentry/services/hybrid_cloud/organization_actions/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_actions/impl.py
@@ -3,7 +3,7 @@ from typing import Optional, TypedDict
 from django.db import transaction
 from django.db.models.expressions import CombinedExpression
 
-from sentry.models import Organization, OrganizationStatus
+from sentry.models import Organization, OrganizationStatus, outbox_context
 
 
 class OrganizationCreateAndUpdateOptions(TypedDict, total=False):
@@ -17,37 +17,33 @@ class OrganizationCreateAndUpdateOptions(TypedDict, total=False):
 def create_organization_with_outbox_message(
     *, create_options: OrganizationCreateAndUpdateOptions
 ) -> Organization:
-    with transaction.atomic():
-        org: Organization = Organization.objects.create(**create_options)
-        Organization.outbox_for_update(org_id=org.id).save()
+    org: Organization = Organization.objects.create(**create_options)
     return org
 
 
 def update_organization_with_outbox_message(
     *, org_id: int, update_data: OrganizationCreateAndUpdateOptions
 ) -> Organization:
-    with transaction.atomic():
+    with outbox_context(transaction.atomic()):
         org: Organization = Organization.objects.get(id=org_id)
         org.update(**update_data)
-        Organization.outbox_for_update(org_id=org.id).save()
 
-    org.refresh_from_db()
-    return org
+        org.refresh_from_db()
+        return org
 
 
 def upsert_organization_by_org_id_with_outbox_message(
     *, org_id: int, upsert_data: OrganizationCreateAndUpdateOptions
 ) -> Organization:
-    with transaction.atomic():
+    with outbox_context(transaction.atomic()):
         org, created = Organization.objects.update_or_create(id=org_id, defaults=upsert_data)
-        Organization.outbox_for_update(org_id=org_id).save()
         return org
 
 
 def mark_organization_as_pending_deletion_with_outbox_message(
     *, org_id: int
 ) -> Optional[Organization]:
-    with transaction.atomic():
+    with outbox_context(transaction.atomic()):
         query_result = Organization.objects.filter(
             id=org_id, status=OrganizationStatus.ACTIVE
         ).update(status=OrganizationStatus.PENDING_DELETION)
@@ -56,6 +52,5 @@ def mark_organization_as_pending_deletion_with_outbox_message(
             return None
 
         Organization.outbox_for_update(org_id=org_id).save()
-
         org = Organization.objects.get(id=org_id)
         return org

--- a/src/sentry/services/hybrid_cloud/organization_actions/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_actions/impl.py
@@ -44,13 +44,35 @@ def mark_organization_as_pending_deletion_with_outbox_message(
     *, org_id: int
 ) -> Optional[Organization]:
     with outbox_context(transaction.atomic()):
-        query_result = Organization.objects.filter(
+        update_count = Organization.objects.filter(
             id=org_id, status=OrganizationStatus.ACTIVE
         ).update(status=OrganizationStatus.PENDING_DELETION)
 
-        if not query_result:
+        if not update_count:
             return None
 
         Organization.outbox_for_update(org_id=org_id).save()
+
+        org = Organization.objects.get(id=org_id)
+        return org
+
+
+def unmark_organization_as_pending_deletion_with_outbox_message(
+    *, org_id: int
+) -> Optional[Organization]:
+    with outbox_context(transaction.atomic()):
+        update_count = Organization.objects.filter(
+            id=org_id,
+            status__in=[
+                OrganizationStatus.PENDING_DELETION,
+                OrganizationStatus.DELETION_IN_PROGRESS,
+            ],
+        ).update(status=OrganizationStatus.ACTIVE)
+
+        if not update_count:
+            return None
+
+        Organization.outbox_for_update(org_id=org_id).save()
+
         org = Organization.objects.get(id=org_id)
         return org

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.organization_mapping import (
     OrganizationMappingService,
@@ -68,11 +69,12 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
     def upsert(
         self, organization_id: int, update: RpcOrganizationMappingUpdate
     ) -> RpcOrganizationMapping:
-        org_mapping, _created = OrganizationMapping.objects.update_or_create(
-            organization_id=organization_id, defaults=update
-        )
+        with in_test_psql_role_override("postgres"):
+            org_mapping, _created = OrganizationMapping.objects.update_or_create(
+                organization_id=organization_id, defaults=update
+            )
 
-        return serialize_organization_mapping(org_mapping)
+            return serialize_organization_mapping(org_mapping)
 
     def verify_mappings(self, organization_id: int, slug: str) -> None:
         try:

--- a/src/sentry/testutils/helpers/api_gateway.py
+++ b/src/sentry/testutils/helpers/api_gateway.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 
 from sentry.api.base import control_silo_endpoint, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.testutils import APITestCase
 from sentry.types.region import Region, RegionCategory, clear_global_regions
@@ -133,9 +134,11 @@ class ApiGatewayTestCase(APITestCase):
             content_type="application/json",
             adding_headers={"test": "header"},
         )
-        OrganizationMapping.objects.get(organization_id=self.organization.id).update(
-            region_name="region1"
-        )
+
+        with in_test_psql_role_override("postgres"):
+            OrganizationMapping.objects.get(organization_id=self.organization.id).update(
+                region_name="region1"
+            )
 
         # Echos the request body and header back for verification
         def return_request_body(request):

--- a/src/sentry/utils/migrations.py
+++ b/src/sentry/utils/migrations.py
@@ -1,5 +1,6 @@
 from django.db.models import F
 
+from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
 
 
@@ -14,4 +15,5 @@ def clear_flag(Model, flag_name, flag_attr_name="flags"):
             update_kwargs = {
                 flag_attr_name: F(flag_attr_name).bitand(~getattr(Model, flag_attr_name)[flag_name])
             }
-            Model.objects.filter(id=item.id).update(**update_kwargs)
+            with in_test_psql_role_override("postgres"):
+                Model.objects.filter(id=item.id).update(**update_kwargs)

--- a/src/sentry/web/frontend/restore_organization.py
+++ b/src/sentry/web/frontend/restore_organization.py
@@ -8,6 +8,9 @@ from sentry import audit_log
 from sentry.api import client
 from sentry.models import Organization, OrganizationStatus
 from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.services.hybrid_cloud.organization_actions.impl import (
+    unmark_organization_as_pending_deletion_with_outbox_message,
+)
 from sentry.web.frontend.base import OrganizationView
 from sentry.web.helpers import render_to_response
 
@@ -65,9 +68,10 @@ class RestoreOrganizationView(OrganizationView):
             messages.add_message(request, messages.ERROR, ERR_MESSAGES[organization.status])
             return self.redirect(reverse("sentry"))
 
-        updated = Organization.objects.filter(
-            id=organization.id, status__in=deletion_statuses
-        ).update(status=OrganizationStatus.ACTIVE)
+        updated = unmark_organization_as_pending_deletion_with_outbox_message(
+            org_id=organization.id
+        )
+
         if updated:
             client.put(
                 f"/organizations/{organization.slug}/",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,7 +172,12 @@ def protect_hybrid_cloud_writes_and_deletes(request):
     create Outbox objects in the same transaction that matches what you delete.
     """
     from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
-    from sentry.models import OrganizationMember, OrganizationMemberMapping
+    from sentry.models import (
+        Organization,
+        OrganizationMapping,
+        OrganizationMember,
+        OrganizationMemberMapping,
+    )
     from sentry.testutils.silo import iter_models, reset_test_role, restrict_role
 
     try:
@@ -205,6 +210,10 @@ def protect_hybrid_cloud_writes_and_deletes(request):
     # outboxes in a transaction, and cover that transaction with `in_test_psql_role_override`
     restrict_role(role="postgres_unprivileged", model=OrganizationMember, revocation_type="INSERT")
     restrict_role(role="postgres_unprivileged", model=OrganizationMember, revocation_type="UPDATE")
+    restrict_role(role="postgres_unprivileged", model=Organization, revocation_type="INSERT")
+    restrict_role(role="postgres_unprivileged", model=Organization, revocation_type="UPDATE")
+    restrict_role(role="postgres_unprivileged", model=OrganizationMapping, revocation_type="INSERT")
+    restrict_role(role="postgres_unprivileged", model=OrganizationMapping, revocation_type="UPDATE")
     # OrganizationMember objects need to cascade, but they can't use the standard hybrid cloud foreign key because the
     # identifiers are not snowflake ids.
     restrict_role(role="postgres_unprivileged", model=OrganizationMember, revocation_type="DELETE")

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -156,13 +156,14 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
                 ),
             ]
         ):
-            self.create_organization_mapping(
-                organization_id=101010,
-                slug="abcslug",
-                name="The Thing",
-                idempotency_key="",
-                region_name="some-region",
-            )
+            with in_test_psql_role_override("postgres"):
+                self.create_organization_mapping(
+                    organization_id=101010,
+                    slug="abcslug",
+                    name="The Thing",
+                    idempotency_key="",
+                    region_name="some-region",
+                )
             self._require_2fa_for_organization()
             assert not self.user.has_2fa()
 

--- a/tests/sentry/hybrid_cloud/test_organizationmapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmapping.py
@@ -1,7 +1,7 @@
 import pytest
 from django.db import IntegrityError
 
-from sentry.models import Organization, outbox_context
+from sentry.models import outbox_context
 from sentry.models.organization import OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.organization_mapping import (
@@ -9,7 +9,6 @@ from sentry.services.hybrid_cloud.organization_mapping import (
     organization_mapping_service,
 )
 from sentry.testutils import TransactionTestCase
-from sentry.testutils.factories import Factories
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
 
@@ -18,10 +17,9 @@ from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
 class OrganizationMappingTest(TransactionTestCase):
     def test_create_on_organization_save(self):
         with outbox_context(flush=False), exempt_from_silo_limits():
-            organization = Organization(
+            organization = self.create_organization(
                 name="test name",
             )
-            organization.save()
 
         # Validate that organization mapping has not been created
         with pytest.raises(OrganizationMapping.DoesNotExist):
@@ -64,15 +62,10 @@ class OrganizationMappingTest(TransactionTestCase):
 
     def test_upsert__update_if_found(self):
         with exempt_from_silo_limits():
-            self.organization = Organization(
+            self.organization = self.create_organization(
                 name="test name",
                 slug="foobar",
             )
-
-            self.organization.save()
-
-        with outbox_runner():
-            pass
 
         fixture_org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
 
@@ -89,7 +82,7 @@ class OrganizationMappingTest(TransactionTestCase):
         assert fixture_org_mapping.status == OrganizationStatus.PENDING_DELETION
 
     def test_upsert__duplicate_slug(self):
-        self.organization = Factories.create_organization(slug="alreadytaken")
+        self.organization = self.create_organization(slug="alreadytaken")
 
         with pytest.raises(IntegrityError):
             organization_mapping_service.upsert(

--- a/tests/sentry/hybrid_cloud/test_region.py
+++ b/tests/sentry/hybrid_cloud/test_region.py
@@ -1,5 +1,6 @@
 import pytest
 
+from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import OrganizationMember
 from sentry.services.hybrid_cloud.region import (
@@ -26,8 +27,9 @@ class RegionResolutionTest(TestCase):
         self.target_region = self.regions[0]
         self.organization = self.create_organization()
         org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
-        org_mapping.region_name = self.target_region.name
-        org_mapping.save()
+        with in_test_psql_role_override("postgres"):
+            org_mapping.region_name = self.target_region.name
+            org_mapping.save()
 
     def test_by_organization_object(self):
         with override_regions(self.regions):

--- a/tests/sentry/hybrid_cloud/test_rpc.py
+++ b/tests/sentry/hybrid_cloud/test_rpc.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 from django.test import override_settings
 
+from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models import OrganizationMapping
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.services.hybrid_cloud.auth import AuthService
@@ -45,14 +46,15 @@ class RpcServiceTest(TestCase):
 
         user = self.create_user()
         organization = self.create_organization()
-        OrganizationMapping.objects.update_or_create(
-            organization_id=organization.id,
-            defaults={
-                "slug": organization.slug,
-                "name": organization.name,
-                "region_name": target_region.name,
-            },
-        )
+        with in_test_psql_role_override("postgres"):
+            OrganizationMapping.objects.update_or_create(
+                organization_id=organization.id,
+                defaults={
+                    "slug": organization.slug,
+                    "name": organization.name,
+                    "region_name": target_region.name,
+                },
+            )
 
         serial_user = RpcUser(id=user.id)
         serial_org = serialize_rpc_organization(organization)

--- a/tests/sentry/runner/commands/test_backup.py
+++ b/tests/sentry/runner/commands/test_backup.py
@@ -2,6 +2,7 @@ import pytest
 from click.testing import CliRunner
 from django.db import IntegrityError
 
+from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.runner.commands.backup import export, import_
 from sentry.utils import json
 
@@ -16,7 +17,8 @@ def backup_json_filename(tmp_path):
 
 @pytest.mark.django_db
 def test_import(backup_json_filename):
-    rv = CliRunner().invoke(import_, backup_json_filename)
+    with in_test_psql_role_override("postgres"):
+        rv = CliRunner().invoke(import_, backup_json_filename)
     assert rv.exit_code == 0, rv.output
 
 
@@ -31,7 +33,9 @@ def test_import_duplicate_key(backup_json_filename):
         contents.append(duplicate_key_item)
     with open(backup_json_filename, "w") as backup_file:
         backup_file.write(json.dumps(contents))
-    rv = CliRunner().invoke(import_, backup_json_filename)
+
+    with in_test_psql_role_override("postgres"):
+        rv = CliRunner().invoke(import_, backup_json_filename)
     assert (
         rv.output
         == ">> Are you restoring from a backup of the same version of Sentry?\n>> Are you restoring onto a clean database?\n>> If so then this IntegrityError might be our fault, you can open an issue here:\n>> https://github.com/getsentry/sentry/issues/new/choose\n"

--- a/tests/sentry/services/test_organization_actions.py
+++ b/tests/sentry/services/test_organization_actions.py
@@ -11,6 +11,7 @@ from sentry.models import (
 from sentry.services.hybrid_cloud.organization_actions.impl import (
     create_organization_with_outbox_message,
     mark_organization_as_pending_deletion_with_outbox_message,
+    unmark_organization_as_pending_deletion_with_outbox_message,
     update_organization_with_outbox_message,
     upsert_organization_by_org_id_with_outbox_message,
 )
@@ -177,4 +178,66 @@ class OrganizationMarkOrganizationAsPendingDeletionWithOutboxMessageTest(TestCas
         assert self.org.name == org_before_update.name
         assert self.org.slug == org_before_update.slug
 
+        assert_outbox_update_message_exists(self.org, 0)
+
+
+@region_silo_test(stable=True)
+class UnmarkOrganizationForDeletionWithOutboxMessageTest(TestCase):
+    def setUp(self):
+        self.org: Organization = self.create_organization(
+            slug="sluggy", name="barfoo", status=OrganizationStatus.PENDING_DELETION
+        )
+
+    def test_unmark_for_pending_deletion_and_outbox_generation(self):
+        with outbox_context(flush=False):
+            updated_org = unmark_organization_as_pending_deletion_with_outbox_message(
+                org_id=self.org.id
+            )
+
+        assert updated_org
+        self.org.refresh_from_db()
+
+        assert updated_org.status == self.org.status == OrganizationStatus.ACTIVE
+        assert updated_org.name == self.org.name
+        assert updated_org.slug == self.org.slug
+
+        assert_outbox_update_message_exists(self.org, 1)
+
+    def test_unmark_for_deletion_in_progress_and_outbox_generation(self):
+        update_organization_with_outbox_message(
+            org_id=self.org.id, update_data={"status": OrganizationStatus.DELETION_IN_PROGRESS}
+        )
+
+        with outbox_context(flush=False):
+            updated_org = unmark_organization_as_pending_deletion_with_outbox_message(
+                org_id=self.org.id
+            )
+
+        assert updated_org
+        self.org.refresh_from_db()
+
+        assert updated_org.status == self.org.status == OrganizationStatus.ACTIVE
+        assert updated_org.name == self.org.name
+        assert updated_org.slug == self.org.slug
+
+        assert_outbox_update_message_exists(self.org, 1)
+
+    def test_unmark_org_when_already_active(self):
+        update_organization_with_outbox_message(
+            org_id=self.org.id, update_data={"status": OrganizationStatus.ACTIVE}
+        )
+
+        org_before_update = Organization.objects.get(id=self.org.id)
+
+        with outbox_context(flush=False):
+            updated_org = unmark_organization_as_pending_deletion_with_outbox_message(
+                org_id=self.org.id
+            )
+
+        assert not updated_org
+
+        self.org.refresh_from_db()
+        assert self.org.status == org_before_update.status
+        assert self.org.name == org_before_update.name
+        assert self.org.slug == org_before_update.slug
         assert_outbox_update_message_exists(self.org, 0)

--- a/tests/sentry/tasks/test_organization_mapping.py
+++ b/tests/sentry/tasks/test_organization_mapping.py
@@ -2,11 +2,18 @@ from datetime import datetime
 
 import pytest
 
+from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.tasks.organization_mapping import ORGANIZATION_MAPPING_EXPIRY, repair_mappings
 from sentry.testutils import TestCase
 from sentry.testutils.factories import Factories
+
+
+@pytest.fixture(autouse=True)
+def role_override():
+    with in_test_psql_role_override("postgres"):
+        yield
 
 
 class OrganizationMappingRepairTest(TestCase):
@@ -17,6 +24,7 @@ class OrganizationMappingRepairTest(TestCase):
         mapping.verified = False
         mapping.date_created = expired_time
         mapping.save()
+
         phantom_mapping = self.create_organization_mapping(
             Organization(id=123, slug="fake-slug"), date_created=expired_time, verified=False
         )

--- a/tests/sentry/types/test_region.py
+++ b/tests/sentry/types/test_region.py
@@ -2,6 +2,7 @@ import pytest
 from django.conf import settings
 from django.test import override_settings
 
+from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models import OrganizationMapping
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.silo import SiloMode
@@ -56,7 +57,7 @@ class RegionMappingTest(TestCase):
             Region("eu", 2, "http://eu.testserver", RegionCategory.MULTI_TENANT),
         ]
         mapping = OrganizationMapping.objects.get(slug=self.organization.slug)
-        with override_regions(regions):
+        with override_regions(regions), in_test_psql_role_override("postgres"):
             mapping.update(region_name="az")
             with pytest.raises(RegionResolutionError):
                 # Region does not exist
@@ -104,7 +105,9 @@ class RegionMappingTest(TestCase):
         organization_mapping.name = "test name"
         organization_mapping.region_name = "na"
         organization_mapping.idempotency_key = "test"
-        organization_mapping.save()
+
+        with in_test_psql_role_override("postgres"):
+            organization_mapping.save()
 
         region_config = [
             {

--- a/tests/sentry/utils/test_audit.py
+++ b/tests/sentry/utils/test_audit.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import AnonymousUser
 
 from sentry import audit_log
+from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models import (
     AuditLogEntry,
     DeletedOrganization,
@@ -90,7 +91,7 @@ class CreateAuditEntryTest(TestCase):
         self.assert_valid_deleted_log(deleted_org, self.org)
 
     def test_audit_entry_org_restore_log(self):
-        with exempt_from_silo_limits():
+        with exempt_from_silo_limits(), in_test_psql_role_override("postgres"):
             Organization.objects.filter(id=self.organization.id).update(
                 status=OrganizationStatus.PENDING_DELETION
             )

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -11,7 +11,6 @@ from sentry.auth.authenticators.totp import TotpInterface
 from sentry.models import (
     AuthIdentity,
     AuthProvider,
-    Organization,
     OrganizationMember,
     OrganizationOption,
     OrganizationStatus,
@@ -1055,9 +1054,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.status_code == 200
 
     def test_org_not_visible(self):
-        Organization.objects.filter(id=self.organization.id).update(
-            status=OrganizationStatus.DELETION_IN_PROGRESS
-        )
+        self.organization.update(status=OrganizationStatus.DELETION_IN_PROGRESS)
 
         resp = self.client.get(self.path, follow=True)
         assert resp.status_code == 200

--- a/tests/sentry/web/frontend/test_restore_organization.py
+++ b/tests/sentry/web/frontend/test_restore_organization.py
@@ -48,9 +48,7 @@ class RemoveOrganizationTest(TestCase):
         assert resp.context["deleting_organization"] == self.organization
         assert resp.context["pending_deletion"] is True
 
-        Organization.objects.filter(id=self.organization.id).update(
-            status=OrganizationStatus.DELETION_IN_PROGRESS
-        )
+        self.organization.update(status=OrganizationStatus.DELETION_IN_PROGRESS)
 
         resp = self.client.get(self.path)
 
@@ -73,9 +71,7 @@ class RemoveOrganizationTest(TestCase):
         assert resp.context["deleting_organization"] == self.organization
         assert resp.context["pending_deletion"] is True
 
-        Organization.objects.filter(id=self.organization.id).update(
-            status=OrganizationStatus.DELETION_IN_PROGRESS
-        )
+        self.organization.update(status=OrganizationStatus.DELETION_IN_PROGRESS)
 
         resp = self.client.get(path, SERVER_NAME=f"{self.organization.slug}.testserver")
 
@@ -96,9 +92,7 @@ class RemoveOrganizationTest(TestCase):
         assert org.status == OrganizationStatus.ACTIVE
 
     def test_too_late_still_restores(self):
-        Organization.objects.filter(id=self.organization.id).update(
-            status=OrganizationStatus.DELETION_IN_PROGRESS
-        )
+        self.organization.update(status=OrganizationStatus.DELETION_IN_PROGRESS)
 
         resp = self.client.post(self.path)
 
@@ -112,7 +106,7 @@ class RemoveOrganizationTest(TestCase):
         assert ScheduledDeletion.objects.count() == 0
 
         org_id = self.organization.id
-        Organization.objects.filter(id=org_id).update(status=OrganizationStatus.PENDING_DELETION)
+        self.organization.update(status=OrganizationStatus.PENDING_DELETION)
         deletion = ScheduledDeletion.schedule(self.organization, days=0)
         deletion.update(in_progress=True)
 


### PR DESCRIPTION
In lieu of changing over everything to use org domain actions for updates which ended up being a herculean task (See #51377), this PR adds an update override to the org model. In order to ensure that all organization writes generate an outbox message when required, this PR also adds both organization and org mapping to the growing list of postgres role write restrictions.
