### PR TITLE
ref(deletions): Update error message copy

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -52,7 +52,7 @@ ERR_NO_USER = "This request requires an authenticated user."
 ERR_NO_2FA = "Cannot require two-factor authentication without personal two-factor enabled."
 ERR_SSO_ENABLED = "Cannot require two-factor authentication with SSO enabled"
 ERR_EMAIL_VERIFICATION = "Cannot require email verification before verifying your email address."
-ERR_3RD_PARTY_PUBLISHED_APP = "Cannot delete an organization that owns a published integration."
+ERR_3RD_PARTY_PUBLISHED_APP = "Cannot delete an organization that owns a published integration. Contact support if you need assistance."
 
 ORG_OPTIONS = (
     # serializer field name, option key name, type, default value


### PR DESCRIPTION
Update error message copy to prompt the org to contact support if they really need to delete their org that owns a publishe 3rd party integration (maybe the company went under, etc. but we need to know so we can unpublish first). 