### PR TITLE
feat(api): Document inbound filters except hydration + custom filters

### DIFF
--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -37,7 +37,7 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
             name="FilterPutSerializer",
             fields={
                 "active": serializers.CharField(required=False),
-                "subfilters": serializers.ListField(child=serializers.CharField()),
+                "subfilters": serializers.ListField(child=serializers.CharField(), required=False),
             },
         ),
         responses={

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -50,7 +50,7 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
     )
     def put(self, request: Request, project, filter_id) -> Response:
         """
-        Update various inbound data filters for a project. Note that updating the hydration error filter or custom filters must be done through the `Update a Project` endpoint.
+        Update various inbound data filters for a project.
         """
         current_filter = None
         for flt in inbound_filters.get_all_filter_specs():

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -1,5 +1,7 @@
 from collections.abc import Iterable
 
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -7,19 +9,48 @@ from sentry import audit_log
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NO_CONTENT,
+    RESPONSE_NOTFOUND,
+)
+from sentry.apidocs.parameters import GlobalParams, ProjectParams
 from sentry.ingest import inbound_filters
 
 
+@extend_schema(tags=["Projects"])
 @region_silo_endpoint
 class ProjectFilterDetailsEndpoint(ProjectEndpoint):
+    public = {"PUT"}
+
+    @extend_schema(
+        operation_id="Update an Inbound Data Filter",
+        parameters=[
+            GlobalParams.ORG_SLUG,
+            GlobalParams.PROJECT_SLUG,
+            ProjectParams.FILTER_ID,
+            ProjectParams.ACTIVE,
+            ProjectParams.SUB_FILTERS,
+        ],
+        request=inline_serializer(
+            name="FilterPutSerializer",
+            fields={
+                "active": serializers.CharField(required=False),
+                "subfilters": serializers.ListField(serializers.CharField(), required=False),
+            },
+        ),
+        responses={
+            201: RESPONSE_NO_CONTENT,
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOTFOUND,
+        },
+        examples=None,
+    )
     def put(self, request: Request, project, filter_id) -> Response:
         """
-        Update a filter
-
-        Update a project's filter.
-
-            {method} {path}
-
+        Update various inbound data filters for a project. Note that updating the hydration error filter or custom filters must be done through the `Update a Project` endpoint.
         """
         current_filter = None
         for flt in inbound_filters.get_all_filter_specs():

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -37,7 +37,7 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
             name="FilterPutSerializer",
             fields={
                 "active": serializers.CharField(required=False),
-                "subfilters": serializers.ListField(serializers.CharField),
+                "subfilters": serializers.ListField(child=serializers.CharField()),
             },
         ),
         responses={

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -37,7 +37,7 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
             name="FilterPutSerializer",
             fields={
                 "active": serializers.CharField(required=False),
-                "subfilters": serializers.ListField(serializers.CharField(), required=False),
+                "subfilters": serializers.ListField(serializers.CharField()),
             },
         ),
         responses={

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -37,7 +37,7 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
             name="FilterPutSerializer",
             fields={
                 "active": serializers.CharField(required=False),
-                "subfilters": serializers.ListField(child=serializers.CharField(), required=False),
+                "subfilters": serializers.ListField(child=serializers.CharField(required=False)),
             },
         ),
         responses={

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -37,7 +37,7 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
             name="FilterPutSerializer",
             fields={
                 "active": serializers.CharField(required=False),
-                "subfilters": serializers.ListField(serializers.CharField()),
+                "subfilters": serializers.ListField(serializers.CharField),
             },
         ),
         responses={

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -2,6 +2,8 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
 from rest_framework import serializers
 
+# NOTE: Please add new params by path vs query, then in alphabetical order
+
 
 class GlobalParams:
     ORG_SLUG = OpenApiParameter(
@@ -214,12 +216,55 @@ class EventParams:
 
 
 class ProjectParams:
+    FILTER_ID = OpenApiParameter(
+        name="filter_id",
+        location="path",
+        required=True,
+        type=str,
+        description="""The type of filter toggle to update. The options are:
+- `browser-extensions`: Filter out errors known to be caused by browser extensions
+- `localhost`: Filter out events coming from localhost. This applies to both IPv4 (``127.0.0.1``)
+and IPv6 (``::1``) addresses.
+- `web-crawlers`: Filter out known web crawlers. Some crawlers may execute pages in incompatible
+ways which then cause errors that are unlikely to be seen by a normal user.
+- `legacy-browser`: Filter out known errors from legacy browsers. Older browsers often give less
+accurate information, and while they may report valid issues, the context to understand them is
+incorrect or missing.
+""",
+    )
+
+    ACTIVE = OpenApiParameter(
+        name="active",
+        location="query",
+        required=False,
+        type=bool,
+        description="Toggle the browser-extensions, localhost, or web-crawlers filter on or off",
+    )
+
     DEFAULT_RULES = OpenApiParameter(
         name="default_rules",
         location="query",
         required=False,
         type=bool,
         description="Defaults to true where the behavior is to alert the user on every new issue. Setting this to false will turn this off and the user must create their own alerts to be notified of new issues.",
+    )
+
+    SUB_FILTERS = OpenApiParameter(
+        name="subfilters",
+        location="query",
+        required=False,
+        type={"type": "array", "items": {"type": "string"}},
+        description="""A list of which legacy browsers filters should be active. Anything excluded from
+                    the list will be turned off. The options are:
+- `ie_pre_9`: Internet Explorer Version 8 and lower
+- `ie9`: Internet Explorer Version 9
+- `ie10`: Internet Explorer Version 10
+- `ie11`: Internet Explorer Version 11
+- `safari_pre_6`: Safari Version 5 and lower
+- `opera_pre_15`: Opera Version 14 and lower
+- `opera_mini_pre_8`: Opera Mini Version 8 and lower
+- `android_pre_4`: Android Version 3 and lower
+""",
     )
 
     @staticmethod

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1,8 +1,15 @@
+from drf_spectacular.plumbing import build_array_type, build_basic_type
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
 from rest_framework import serializers
 
 # NOTE: Please add new params by path vs query, then in alphabetical order
+
+
+# drf-spectacular doesn't support a list type in it's OpenApiTypes, so we manually build
+# a typed list using this workaround
+def build_typed_list(type: OpenApiTypes):
+    return build_array_type(build_basic_type(type))
 
 
 class GlobalParams:
@@ -253,7 +260,7 @@ incorrect or missing.
         name="subfilters",
         location="query",
         required=False,
-        type={"type": "array", "items": {"type": "string"}},
+        type=build_typed_list(OpenApiTypes.STR),
         description="""A list of which legacy browsers filters should be active. Anything excluded from
                     the list will be turned off. The options are:
 - `ie_pre_9`: Internet Explorer Version 8 and lower

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -261,7 +261,7 @@ incorrect or missing.
         location="query",
         required=False,
         type=build_typed_list(OpenApiTypes.STR),
-        description="""A list of which legacy browsers filters should be active. Anything excluded from
+        description="""A list specifying which legacy browser filters should be active. Anything excluded from
                     the list will be turned off. The options are:
 - `ie_pre_9`: Internet Explorer Version 8 and lower
 - `ie9`: Internet Explorer Version 9

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -200,8 +200,7 @@ _browser_extensions_filter = _FilterSpec(
 )
 
 
-class _LegacyBrowserFilterSerializer(serializers.Serializer):
-    active = serializers.BooleanField()
+class _LegacyBrowserFilterSerializer(_FilterSerializer):
     subfilters = MultipleChoiceField(
         choices=[
             "ie_pre_9",


### PR DESCRIPTION
Previously undocumented Inbound filters toggle. Note that hydration errors filter and custom filters are attached to the [Update a Project](https://docs.sentry.io/api/projects/update-a-project/). I will add this to the description once I've updated the other endpoint with documentation for hydration + custom errs.

New Doc (split in two images):
<img width="1071" alt="Screenshot 2023-06-26 at 11 01 13 AM" src="https://github.com/getsentry/sentry/assets/67301797/cbf9714f-8977-4814-8bf6-242a824267fb">
<img width="1072" alt="Screenshot 2023-06-26 at 11 01 21 AM" src="https://github.com/getsentry/sentry/assets/67301797/8636853e-8c8e-49c2-bbcb-b4d574cb2c11">