### PR TITLE
chore(hybridcloud) Update django_db to reset all connections

### DIFF
--- a/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
+++ b/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
@@ -56,7 +56,7 @@ def openai_policy():
         openai_policy_check.disconnect(policy)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_consent(client, default_project, test_event, openai_policy):
     path = reverse(
         "sentry-api-0-event-ai-fix-suggest",

--- a/tests/sentry/api/endpoints/test_event_reprocessable.py
+++ b/tests/sentry/api/endpoints/test_event_reprocessable.py
@@ -16,7 +16,7 @@ def auto_login(settings, client, default_user):
     assert client.login(username=default_user.username, password="admin")
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 def test_simple(client, factories, default_project):
     min_ago = iso_format(before_now(minutes=1))

--- a/tests/sentry/api/endpoints/test_group_hashes_split.py
+++ b/tests/sentry/api/endpoints/test_group_hashes_split.py
@@ -38,7 +38,7 @@ def store_stacktrace(default_project, factories):
     return inner
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 def test_basic(client, default_project, store_stacktrace, reset_snuba):
     def _check_merged(seq):
@@ -130,7 +130,7 @@ def test_basic(client, default_project, store_stacktrace, reset_snuba):
     assert _check_merged(2) == group_id
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 def test_split_everything(client, default_project, store_stacktrace, reset_snuba):
     """
@@ -182,7 +182,7 @@ def test_split_everything(client, default_project, store_stacktrace, reset_snuba
     assert event4.group_id not in (event.group_id, event2.group_id, event3.group_id)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 def test_no_hash_twice(client, default_project, store_stacktrace, reset_snuba):
     """
@@ -211,7 +211,7 @@ def test_no_hash_twice(client, default_project, store_stacktrace, reset_snuba):
     ]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 def test_materialized_hashes_missing(client, default_project, store_stacktrace, reset_snuba):
     """

--- a/tests/sentry/api/endpoints/test_grouping_levels.py
+++ b/tests/sentry/api/endpoints/test_grouping_levels.py
@@ -78,7 +78,7 @@ def _render_all_previews(client):
     return inner
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_error_missing_feature(client, default_project):
     group = Group.objects.create(project=default_project)
 
@@ -88,7 +88,7 @@ def test_error_missing_feature(client, default_project):
         assert response.data["detail"]["code"] == "missing_feature"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_error_no_events(client, default_project):
     group = Group.objects.create(project=default_project)
 
@@ -98,7 +98,7 @@ def test_error_no_events(client, default_project):
 
 
 @region_silo_test(stable=True)
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 def test_error_not_hierarchical(client, default_project, reset_snuba, factories):
     default_project.update_option("sentry:grouping_config", "mobile:2021-02-12")
@@ -120,7 +120,7 @@ def test_error_not_hierarchical(client, default_project, reset_snuba, factories)
     assert response.data["detail"]["code"] == "issue_not_hierarchical"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 def test_error_project_not_hierarchical(client, default_organization, reset_snuba, factories):
 
@@ -164,7 +164,7 @@ def _assert_tree_labels(event, functions):
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 @region_silo_test(stable=True)
 def test_downwards(default_project, store_stacktrace, reset_snuba, _render_all_previews):
@@ -215,7 +215,7 @@ b0505d7461a2e36c4a8235bb6c310a3b: ZeroDivisionError | foo | bar2 | baz2 | bam (1
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 @region_silo_test(stable=True)
 def test_upwards(default_project, store_stacktrace, reset_snuba, _render_all_previews):
@@ -280,7 +280,7 @@ level 2*
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 @region_silo_test(stable=True)
 def test_default_events(default_project, store_stacktrace, reset_snuba, _render_all_previews):

--- a/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
+++ b/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
@@ -121,7 +121,7 @@ class TestAppStoreConnectRefreshEndpoint:
             },
         )
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_ok(
         self,
         client,
@@ -140,7 +140,7 @@ class TestAppStoreConnectRefreshEndpoint:
             project_id=default_project.id, config_id=config_id
         )
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_rate_limited(self, client, default_user, mocked_dsym_download_task, refresh_url):
         client.login(username=default_user.username, password="admin")

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -100,7 +100,7 @@ def no_internal_networks(monkeypatch):
     monkeypatch.setattr("sentry.auth.system.INTERNAL_NETWORKS", ())
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_internal_relays_should_receive_minimal_configs_if_they_do_not_explicitly_ask_for_full_config(
     call_endpoint, default_project
 ):
@@ -117,7 +117,7 @@ def test_internal_relays_should_receive_minimal_configs_if_they_do_not_explicitl
     assert safe.get_path(cfg, "config", "groupingConfig") is None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_internal_relays_should_receive_full_configs(
     call_endpoint, default_project, default_projectkey
 ):
@@ -163,7 +163,7 @@ def test_internal_relays_should_receive_full_configs(
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_relays_dyamic_sampling(client, call_endpoint, default_project, dyn_sampling_data):
     """
     Tests that dynamic sampling configuration set in project details are retrieved in relay configs
@@ -181,7 +181,7 @@ def test_relays_dyamic_sampling(client, call_endpoint, default_project, dyn_samp
         assert dynamic_sampling == {"rules": [], "rulesV2": []}
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_trusted_external_relays_should_not_be_able_to_request_full_configs(
     add_org_key, call_endpoint, no_internal_networks
 ):
@@ -189,7 +189,7 @@ def test_trusted_external_relays_should_not_be_able_to_request_full_configs(
     assert status_code == 403
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_when_not_sending_full_config_info_into_a_internal_relay_a_restricted_config_is_returned(
     call_endpoint, default_project
 ):
@@ -202,7 +202,7 @@ def test_when_not_sending_full_config_info_into_a_internal_relay_a_restricted_co
     assert safe.get_path(cfg, "config", "groupingConfig") is None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_when_not_sending_full_config_info_into_an_external_relay_a_restricted_config_is_returned(
     call_endpoint, add_org_key, relay, default_project
 ):
@@ -218,7 +218,7 @@ def test_when_not_sending_full_config_info_into_an_external_relay_a_restricted_c
     assert safe.get_path(cfg, "config", "groupingConfig") is None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_trusted_external_relays_should_receive_minimal_configs(
     relay, add_org_key, call_endpoint, default_project, default_projectkey
 ):
@@ -256,7 +256,7 @@ def test_trusted_external_relays_should_receive_minimal_configs(
     assert safe.get_path(cfg, "config", "quotas") is None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_untrusted_external_relays_should_not_receive_configs(
     call_endpoint, default_project, no_internal_networks
 ):
@@ -277,7 +277,7 @@ def projectconfig_cache_set(monkeypatch):
     return calls
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_relay_projectconfig_cache_minimal_config(
     call_endpoint, default_project, projectconfig_cache_set, task_runner
 ):
@@ -292,7 +292,7 @@ def test_relay_projectconfig_cache_minimal_config(
     assert not projectconfig_cache_set
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_relay_projectconfig_cache_full_config(
     call_endpoint, default_project, projectconfig_cache_set, task_runner
 ):
@@ -317,7 +317,7 @@ def test_relay_projectconfig_cache_full_config(
     assert redis_cfg == http_cfg
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_relay_nonexistent_project(call_endpoint, projectconfig_cache_set, task_runner):
     wrong_id = max(p.id for p in Project.objects.all()) + 1
 
@@ -331,7 +331,7 @@ def test_relay_nonexistent_project(call_endpoint, projectconfig_cache_set, task_
     assert projectconfig_cache_set == [{str(wrong_id): http_cfg}]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_relay_disabled_project(
     call_endpoint, default_project, projectconfig_cache_set, task_runner
 ):

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -100,7 +100,7 @@ def no_internal_networks(monkeypatch):
     monkeypatch.setattr("sentry.auth.system.INTERNAL_NETWORKS", ())
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_internal_relays_should_receive_minimal_configs_if_they_do_not_explicitly_ask_for_full_config(
     call_endpoint, default_project, default_projectkey
 ):
@@ -117,7 +117,7 @@ def test_internal_relays_should_receive_minimal_configs_if_they_do_not_explicitl
     assert safe.get_path(cfg, "config", "groupingConfig") is None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_internal_relays_should_receive_full_configs(
     call_endpoint, default_project, default_projectkey
 ):
@@ -164,7 +164,7 @@ def test_internal_relays_should_receive_full_configs(
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_relays_dyamic_sampling(
     client, call_endpoint, default_project, default_projectkey, dyn_sampling_data
 ):
@@ -188,7 +188,7 @@ def test_relays_dyamic_sampling(
         assert dynamic_sampling == {"rules": [], "rulesV2": []}
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_trusted_external_relays_should_not_be_able_to_request_full_configs(
     add_org_key, call_endpoint, no_internal_networks
 ):
@@ -196,7 +196,7 @@ def test_trusted_external_relays_should_not_be_able_to_request_full_configs(
     assert status_code == 403
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_when_not_sending_full_config_info_into_a_internal_relay_a_restricted_config_is_returned(
     call_endpoint, default_project, default_projectkey
 ):
@@ -209,7 +209,7 @@ def test_when_not_sending_full_config_info_into_a_internal_relay_a_restricted_co
     assert safe.get_path(cfg, "config", "groupingConfig") is None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_when_not_sending_full_config_info_into_an_external_relay_a_restricted_config_is_returned(
     call_endpoint, add_org_key, relay, default_project, default_projectkey
 ):
@@ -225,7 +225,7 @@ def test_when_not_sending_full_config_info_into_an_external_relay_a_restricted_c
     assert safe.get_path(cfg, "config", "groupingConfig") is None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_trusted_external_relays_should_receive_minimal_configs(
     relay, add_org_key, call_endpoint, default_project, default_projectkey
 ):
@@ -263,7 +263,7 @@ def test_trusted_external_relays_should_receive_minimal_configs(
     assert safe.get_path(cfg, "config", "quotas") is None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_untrusted_external_relays_should_not_receive_configs(
     call_endpoint, default_project, default_projectkey, no_internal_networks
 ):
@@ -283,7 +283,7 @@ def projectconfig_cache_set(monkeypatch):
     return calls
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_relay_projectconfig_cache_minimal_config(
     call_endpoint, default_project, projectconfig_cache_set, task_runner
 ):
@@ -298,7 +298,7 @@ def test_relay_projectconfig_cache_minimal_config(
     assert not projectconfig_cache_set
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_relay_projectconfig_cache_full_config(
     call_endpoint, default_projectkey, projectconfig_cache_set, task_runner
 ):
@@ -323,7 +323,7 @@ def test_relay_projectconfig_cache_full_config(
     assert redis_cfg == http_cfg
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_relay_nonexistent_project(call_endpoint, projectconfig_cache_set, task_runner):
     wrong_public_key = ProjectKey.generate_api_key()
 
@@ -336,7 +336,7 @@ def test_relay_nonexistent_project(call_endpoint, projectconfig_cache_set, task_
     assert projectconfig_cache_set == [{str(wrong_public_key): result["configs"][wrong_public_key]}]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_relay_disabled_project(
     call_endpoint, default_project, projectconfig_cache_set, task_runner
 ):
@@ -353,7 +353,7 @@ def test_relay_disabled_project(
     assert projectconfig_cache_set == [{str(wrong_public_key): result["configs"][wrong_public_key]}]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_relay_disabled_key(
     call_endpoint, default_project, projectconfig_cache_set, task_runner, default_projectkey
 ):
@@ -369,7 +369,7 @@ def test_relay_disabled_key(
     assert projectconfig_cache_set == [{str(default_projectkey.public_key): http_cfg}]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize("drop_sessions", [False, True])
 def test_session_metrics_extraction(call_endpoint, task_runner, drop_sessions):
     with Feature({"organizations:metrics-extraction": True}), Feature(
@@ -384,7 +384,7 @@ def test_session_metrics_extraction(call_endpoint, task_runner, drop_sessions):
             assert config["sessionMetrics"] == {"version": 1, "drop": drop_sessions}
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize("abnormal_mechanism_rollout", [0, 1])
 def test_session_metrics_abnormal_mechanism_tag_extraction(
     call_endpoint, task_runner, set_sentry_option, abnormal_mechanism_rollout

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
@@ -98,7 +98,7 @@ def project_config_get_mock(monkeypatch):
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_return_full_config_if_in_cache(
     call_endpoint, default_projectkey, projectconfig_cache_get_mock_config
 ):
@@ -110,7 +110,7 @@ def test_return_full_config_if_in_cache(
     }
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_return_partial_config_if_in_cache(
     monkeypatch,
     call_endpoint,
@@ -131,7 +131,7 @@ def test_return_partial_config_if_in_cache(
     assert result == expected
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_proj_in_cache_and_another_pending(
     call_endpoint, default_projectkey, single_mock_proj_cached
 ):
@@ -146,7 +146,7 @@ def test_proj_in_cache_and_another_pending(
 
 
 @patch("sentry.tasks.relay.build_project_config.delay")
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_enqueue_task_if_config_not_cached_not_queued(
     schedule_mock,
     call_endpoint,
@@ -159,7 +159,7 @@ def test_enqueue_task_if_config_not_cached_not_queued(
 
 
 @patch("sentry.tasks.relay.build_project_config.delay")
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_debounce_task_if_proj_config_not_cached_already_enqueued(
     task_mock,
     call_endpoint,
@@ -173,7 +173,7 @@ def test_debounce_task_if_proj_config_not_cached_already_enqueued(
 
 
 @patch("sentry.relay.projectconfig_cache.backend.set_many")
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_task_writes_config_into_cache(
     cache_set_many_mock,
     default_projectkey,

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -104,7 +104,7 @@ class TestDSNAuthentication(TestCase):
             self.auth.authenticate(request)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize("internal", [True, False])
 def test_registered_relay(internal):
     sk, pk = generate_key_pair()
@@ -135,7 +135,7 @@ def test_registered_relay(internal):
     assert request.relay_request_data == data
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize("internal", [True, False])
 def test_statically_configured_relay(settings, internal):
     sk, pk = generate_key_pair()

--- a/tests/sentry/dynamic_sampling/rules/biases/test_boost_environments_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_boost_environments_bias.py
@@ -4,7 +4,7 @@ from sentry.dynamic_sampling import ENVIRONMENT_GLOBS
 from sentry.dynamic_sampling.rules.biases.boost_environments_bias import BoostEnvironmentsBias
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_generate_bias_rules_v2(default_project):
     rules = BoostEnvironmentsBias().generate_rules(project=default_project, base_sample_rate=0.1)
     assert rules == [

--- a/tests/sentry/dynamic_sampling/rules/biases/test_boost_latest_releases_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_boost_latest_releases_bias.py
@@ -14,7 +14,7 @@ MOCK_DATETIME = ONE_DAY_AGO.replace(hour=10, minute=0, second=0, microsecond=0)
 
 
 @freeze_time(MOCK_DATETIME)
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch(
     "sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.ProjectBoostedReleases.get_extended_boosted_releases"
 )
@@ -85,7 +85,7 @@ def test_generate_bias_rules_v2(get_boosted_releases, default_project):
     ]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch(
     "sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.ProjectBoostedReleases.get_extended_boosted_releases"
 )

--- a/tests/sentry/dynamic_sampling/rules/biases/test_boost_replay_id_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_boost_replay_id_bias.py
@@ -3,7 +3,7 @@ import pytest
 from sentry.dynamic_sampling.rules.biases.boost_replay_id_bias import BoostReplayIdBias
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_generate_bias_rules_v2(default_project):
     rules = BoostReplayIdBias().generate_rules(project=default_project, base_sample_rate=0.1)
     assert rules == [

--- a/tests/sentry/dynamic_sampling/rules/biases/test_ignore_health_checks_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_ignore_health_checks_bias.py
@@ -6,7 +6,7 @@ from sentry.dynamic_sampling.rules.biases.ignore_health_checks_bias import (
 )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_generate_bias_rules_v2(default_project):
     rules = IgnoreHealthChecksBias().generate_rules(project=default_project, base_sample_rate=1.0)
     assert rules == [

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -98,7 +98,7 @@ def test_generate_rules_capture_exception(get_blended_sample_rate, sentry_sdk):
     _validate_rules(fake_project)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
 def test_generate_rules_return_only_uniform_if_sample_rate_is_100_and_other_rules_are_enabled(
     get_blended_sample_rate, default_old_project
@@ -117,7 +117,7 @@ def test_generate_rules_return_only_uniform_if_sample_rate_is_100_and_other_rule
     _validate_rules(default_old_project)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch("sentry.dynamic_sampling.rules.base.get_enabled_user_biases")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rules_with_rate(
@@ -140,7 +140,7 @@ def test_generate_rules_return_uniform_rules_with_rate(
     _validate_rules(default_old_project)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rules_and_env_rule(
     get_blended_sample_rate, default_old_project
@@ -197,7 +197,7 @@ def test_generate_rules_return_uniform_rules_and_env_rule(
     _validate_rules(default_old_project)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rule_with_100_rate_and_without_env_rule(
     get_blended_sample_rate, default_old_project
@@ -218,7 +218,7 @@ def test_generate_rules_return_uniform_rule_with_100_rate_and_without_env_rule(
 @freeze_time("2022-10-21T18:50:25Z")
 @patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize(
     ["version", "platform", "end"],
     [
@@ -287,7 +287,7 @@ def test_generate_rules_with_different_project_platforms(
     _validate_rules(default_old_project)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @freeze_time("2022-10-21T18:50:25Z")
 @patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
@@ -368,7 +368,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
     _validate_rules(default_old_project)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @freeze_time("2022-10-21T18:50:25Z")
 @patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
@@ -424,7 +424,7 @@ def test_generate_rules_does_not_return_rule_with_deleted_release(
     _validate_rules(default_old_project)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rule_with_100_rate_and_without_latest_release_rule(
     get_blended_sample_rate, default_old_project, latest_release_only
@@ -444,7 +444,7 @@ def test_generate_rules_return_uniform_rule_with_100_rate_and_without_latest_rel
     _validate_rules(default_old_project)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rule_with_non_existent_releases(
     get_blended_sample_rate, default_old_project, latest_release_only
@@ -468,7 +468,7 @@ def test_generate_rules_return_uniform_rule_with_non_existent_releases(
     _validate_rules(default_old_project)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
 def test_generate_rules_with_zero_base_sample_rate(get_blended_sample_rate, default_old_project):
     get_blended_sample_rate.return_value = 0.0
@@ -485,7 +485,7 @@ def test_generate_rules_with_zero_base_sample_rate(get_blended_sample_rate, defa
     _validate_rules(default_old_project)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
 @patch(
     "sentry.dynamic_sampling.rules.biases.boost_low_volume_transactions_bias.get_transactions_resampling_rates"
@@ -558,7 +558,7 @@ def test_generate_rules_return_uniform_rules_and_low_volume_transactions_rules(
     _validate_rules(default_old_project)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
 @patch(
     "sentry.dynamic_sampling.rules.biases.boost_low_volume_transactions_bias.get_transactions_resampling_rates"
@@ -597,7 +597,7 @@ def test_low_volume_transactions_rules_not_returned_when_inactive(
     assert rules[0]["id"] == uniform_id
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @freeze_time("2022-10-21T18:50:25Z")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rules_and_recalibrate_orgs_rule(
@@ -644,7 +644,7 @@ def test_generate_rules_return_uniform_rules_and_recalibrate_orgs_rule(
         _validate_rules(default_project)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
 def test_generate_rules_return_boost_replay_id(get_blended_sample_rate, default_old_project):
     get_blended_sample_rate.return_value = 0.5

--- a/tests/sentry/event_manager/test_hierarchical_hashes.py
+++ b/tests/sentry/event_manager/test_hierarchical_hashes.py
@@ -52,7 +52,7 @@ def _assoc_hash(group, hash):
     gh.save()
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_move_all_events(default_project, fast_save):
     group_info = fast_save("f")
 
@@ -97,7 +97,7 @@ def test_move_all_events(default_project, fast_save):
     assert Group.objects.get(id=new_group_info.group.id).title == "foo"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_partial_move(default_project, fast_save):
     group_info = fast_save("f")
     assert group_info.is_new

--- a/tests/sentry/hybrid_cloud/test_log.py
+++ b/tests/sentry/hybrid_cloud/test_log.py
@@ -6,7 +6,7 @@ from sentry.testutils.factories import Factories
 from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @all_silo_test
 def test_audit_log_event():
     user = Factories.create_user()
@@ -30,7 +30,7 @@ def test_audit_log_event():
     assert AuditLogEntry.objects.count() == 1
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @all_silo_test
 def test_user_ip_event():
     user = Factories.create_user()

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -51,7 +51,7 @@ def preprocess_event(monkeypatch):
     return calls
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_deduplication_works(default_project, task_runner, preprocess_event):
     payload = get_normalized_event({"message": "hello world"}, default_project)
     event_id = payload["event_id"]
@@ -81,7 +81,7 @@ def test_deduplication_works(default_project, task_runner, preprocess_event):
     }
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_transactions_spawn_save_event_transaction(
     default_project,
     task_runner,
@@ -130,7 +130,7 @@ def test_transactions_spawn_save_event_transaction(
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize("missing_chunks", (True, False))
 def test_with_attachments(default_project, task_runner, missing_chunks, monkeypatch, django_cache):
     monkeypatch.setattr("sentry.features.has", lambda *a, **kw: True)
@@ -199,7 +199,7 @@ def test_with_attachments(default_project, task_runner, missing_chunks, monkeypa
         assert not persisted_attachments
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_deobfuscate_view_hierarchy(default_project, task_runner):
     payload = get_normalized_event(
         {
@@ -278,7 +278,7 @@ def test_deobfuscate_view_hierarchy(default_project, task_runner):
     assert file_contents.name == "view_hierarchy.json"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize(
     "event_attachments", [True, False], ids=["with_feature", "without_feature"]
 )
@@ -357,7 +357,7 @@ def test_individual_attachments(
         assert file_contents.name == "foo.txt"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_userreport(django_cache, default_project, monkeypatch):
     """
     Test that user_report-type kafka messages end up in a user report being
@@ -401,7 +401,7 @@ def test_userreport(django_cache, default_project, monkeypatch):
     assert evtuser.name == "Hans Gans"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_userreport_reverse_order(django_cache, default_project, monkeypatch):
     """
     Test that ingesting a userreport before the event works. This is relevant
@@ -442,7 +442,7 @@ def test_userreport_reverse_order(django_cache, default_project, monkeypatch):
     assert evtuser.name is None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_individual_attachments_missing_chunks(default_project, factories, monkeypatch):
     monkeypatch.setattr("sentry.features.has", lambda *a, **kw: True)
 

--- a/tests/sentry/ingest/test_span_desc_clusterer.py
+++ b/tests/sentry/ingest/test_span_desc_clusterer.py
@@ -83,7 +83,7 @@ def test_distribution():
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize(
     "description, description_scrubbed, op, feat_flag_enabled, expected",
     [
@@ -128,7 +128,7 @@ def test_record_span(
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_record_span_desc_url(mocked_record, default_organization):
     with Feature(
         {
@@ -169,7 +169,7 @@ def test_sort_rules():
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.rules.CompositeRuleStore.MERGE_MAX_RULES", 2)
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_max_rule_threshold_merge_composite_store(default_project):
     assert len(get_sorted_rules(ClustererNamespace.SPANS, default_project)) == 0
 
@@ -194,7 +194,7 @@ def test_max_rule_threshold_merge_composite_store(default_project):
     ]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_save_rules(default_project):
     project = default_project
 
@@ -227,7 +227,7 @@ def test_save_rules(default_project):
     "sentry.ingest.transaction_clusterer.tasks.cluster_projects_span_descs.delay",
     wraps=cluster_projects_span_descs,  # call immediately
 )
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @freeze_time("2000-01-01 01:00:00")
 def test_run_clusterer_task(cluster_projects_span_descs, default_organization):
     def _add_mock_data(proj, number):
@@ -307,7 +307,7 @@ def test_run_clusterer_task(cluster_projects_span_descs, default_organization):
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 2)
 @mock.patch("sentry.ingest.transaction_clusterer.tasks.MERGE_THRESHOLD", 2)
 @mock.patch("sentry.ingest.transaction_clusterer.rules.update_rules")
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_clusterer_only_runs_when_enough_data(mock_update_rules, default_project):
     project = default_project
     assert get_rules(ClustererNamespace.SPANS, project) == {}
@@ -329,14 +329,14 @@ def test_clusterer_only_runs_when_enough_data(mock_update_rules, default_project
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_get_deleted_project():
     deleted_project = Project(pk=666, organization=Organization(pk=666))
     _record_sample(ClustererNamespace.SPANS, deleted_project, "foo")
     assert list(get_active_projects(ClustererNamespace.SPANS)) == []
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_span_descs_clusterer_generates_rules(default_project):
     def _get_projconfig_span_desc_rules(project: Project):
         return (
@@ -381,7 +381,7 @@ def test_span_descs_clusterer_generates_rules(default_project):
     "sentry.ingest.transaction_clusterer.tasks.cluster_projects_span_descs.delay",
     wraps=cluster_projects_span_descs,  # call immediately
 )
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_span_descs_clusterer_bumps_rules(_, default_organization):
     with Feature("projects:span-metrics-extraction"), override_options(
         {"span_descs.bump-lifetime-sample-rate": 1.0}
@@ -443,7 +443,7 @@ def test_span_descs_clusterer_bumps_rules(_, default_organization):
     "sentry.ingest.transaction_clusterer.tasks.cluster_projects_span_descs.delay",
     wraps=cluster_projects_span_descs,  # call immediately
 )
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_dont_store_inexisting_rules(_, default_organization):
     with Feature("projects:span-metrics-extraction"), override_options(
         {"span_descs.bump-lifetime-sample-rate": 1.0}
@@ -494,7 +494,7 @@ def test_dont_store_inexisting_rules(_, default_organization):
         assert get_rules(ClustererNamespace.SPANS, project1) == {"**/user/*/**": 1}
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_stale_rules_arent_saved(default_project):
     assert len(get_sorted_rules(ClustererNamespace.SPANS, default_project)) == 0
 

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -146,7 +146,7 @@ def test_distribution():
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize(
     "source, txname, tags, expected",
     [
@@ -182,7 +182,7 @@ def test_sort_rules():
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.rules.CompositeRuleStore.MERGE_MAX_RULES", 2)
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_max_rule_threshold_merge_composite_store(default_project):
     assert len(get_sorted_rules(ClustererNamespace.TRANSACTIONS, default_project)) == 0
 
@@ -207,7 +207,7 @@ def test_max_rule_threshold_merge_composite_store(default_project):
     ]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_save_rules(default_project):
     project = default_project
 
@@ -240,7 +240,7 @@ def test_save_rules(default_project):
     "sentry.ingest.transaction_clusterer.tasks.cluster_projects.delay",
     wraps=cluster_projects,  # call immediately
 )
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @freeze_time("2000-01-01 01:00:00")
 def test_run_clusterer_task(cluster_projects_delay, default_organization):
     def _add_mock_data(proj, number):
@@ -318,7 +318,7 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 2)
 @mock.patch("sentry.ingest.transaction_clusterer.tasks.MERGE_THRESHOLD", 2)
 @mock.patch("sentry.ingest.transaction_clusterer.rules.update_rules")
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default_project):
     project = default_project
     assert get_rules(ClustererNamespace.TRANSACTIONS, project) == {}
@@ -340,14 +340,14 @@ def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_get_deleted_project():
     deleted_project = Project(pk=666, organization=Organization(pk=666))
     _record_sample(ClustererNamespace.TRANSACTIONS, deleted_project, "foo")
     assert list(get_active_projects(ClustererNamespace.TRANSACTIONS)) == []
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_transaction_clusterer_generates_rules(default_project):
     def _get_projconfig_tx_rules(project: Project):
         return (
@@ -389,7 +389,7 @@ def test_transaction_clusterer_generates_rules(default_project):
     "sentry.ingest.transaction_clusterer.tasks.cluster_projects.delay",
     wraps=cluster_projects,  # call immediately
 )
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_transaction_clusterer_bumps_rules(_, default_organization):
     project1 = Project(id=123, name="project1", organization_id=default_organization.id)
     project1.save()
@@ -439,7 +439,7 @@ def test_transaction_clusterer_bumps_rules(_, default_organization):
     "sentry.ingest.transaction_clusterer.tasks.cluster_projects.delay",
     wraps=cluster_projects,  # call immediately
 )
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_dont_store_inexisting_rules(_, default_organization):
     rogue_transaction = {
         "transaction": "/transaction/for/rogue/*/rule",
@@ -476,7 +476,7 @@ def test_dont_store_inexisting_rules(_, default_organization):
         assert get_rules(ClustererNamespace.TRANSACTIONS, project1) == {"/user/*/**": 1}
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_stale_rules_arent_saved(default_project):
     assert len(get_sorted_rules(ClustererNamespace.TRANSACTIONS, default_project)) == 0
 

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -76,7 +76,7 @@ class IssueOccurrenceTestBase(OccurrenceTestMixin, TestCase, SnubaTestCase):
 
 
 class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_occurrence_consumer_with_event(self) -> None:
         message = get_test_message(self.project.id)
         with self.feature("organizations:profile-file-io-main-thread-ingest"):
@@ -96,7 +96,7 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
 
         assert Group.objects.filter(grouphash__hash=occurrence.fingerprint[0]).exists()
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_process_profiling_occurrence(self) -> None:
         event_data = load_data("generic-event-profiling")
         event_data["detection_time"] = datetime.datetime.now(tz=pytz.UTC)
@@ -148,7 +148,7 @@ class IssueOccurrenceLookupEventIdTest(IssueOccurrenceTestBase):
             with self.feature("organizations:profile-file-io-main-thread-ingest"):
                 _process_message(message)
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_transaction_lookup(self) -> None:
         from sentry.event_manager import EventManager
 

--- a/tests/sentry/lang/native/test_appconnect.py
+++ b/tests/sentry/lang/native/test_appconnect.py
@@ -60,7 +60,7 @@ class TestAppStoreConnectConfig:
 
         assert new_data == data
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_from_project_config_empty_sources(
         self, default_project: "Project", data: json.JSONData
     ) -> None:
@@ -83,7 +83,7 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
             bundleId="com.example.app",
         )
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_new_source(
         self, default_project: "Project", config: appconnect.AppStoreConnectConfig
     ) -> None:
@@ -96,7 +96,7 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
         stored_sources = json.loads(raw)
         assert stored_sources == sources
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_new_sources_with_existing(
         self, default_project: "Project", config: appconnect.AppStoreConnectConfig
     ) -> None:
@@ -118,7 +118,7 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
         new_sources.append(cfg.to_json())
         assert stored_sources == new_sources
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_update(
         self, default_project: "Project", config: appconnect.AppStoreConnectConfig
     ) -> None:
@@ -141,7 +141,7 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
         current = appconnect.AppStoreConnectConfig.from_project_config(default_project, config.id)
         assert current.appconnectPrivateKey == "A NEW KEY"
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_update_no_matching_id(
         self, default_project: "Project", config: appconnect.AppStoreConnectConfig
     ) -> None:

--- a/tests/sentry/lang/native/test_ignoredsourcesfiltering.py
+++ b/tests/sentry/lang/native/test_ignoredsourcesfiltering.py
@@ -42,7 +42,7 @@ class TestIgnoredSourcesFiltering:
         return {"sentry:ios-source": "sentry:ios", "sentry:tvos-source": "sentry:ios"}
 
     # Explicitly empty list of sources
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_sources_included_and_ignored_empty(self):
         with override_options({"symbolicator.ignored_sources": []}):
             sources = filter_ignored_sources([])
@@ -50,7 +50,7 @@ class TestIgnoredSourcesFiltering:
             assert sources == []
 
     # Default/unset list of sources
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_sources_ignored_unset(self, sources):
         sources = filter_ignored_sources(sources)
 
@@ -63,7 +63,7 @@ class TestIgnoredSourcesFiltering:
             "custom",
         ]
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_sources_ignored_empty(self, sources):
         with override_options({"symbolicator.ignored_sources": []}):
             sources = filter_ignored_sources(sources)
@@ -77,7 +77,7 @@ class TestIgnoredSourcesFiltering:
                 "custom",
             ]
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_sources_ignored_builtin(self, sources):
         with override_options({"symbolicator.ignored_sources": ["sentry:microsoft"]}):
             sources = filter_ignored_sources(sources)
@@ -90,7 +90,7 @@ class TestIgnoredSourcesFiltering:
                 "custom",
             ]
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_sources_ignored_alias(self, sources, reversed_alias_map):
         with override_options({"symbolicator.ignored_sources": ["sentry:ios"]}):
             sources = filter_ignored_sources(sources, reversed_alias_map)
@@ -98,7 +98,7 @@ class TestIgnoredSourcesFiltering:
             source_ids = list(map(lambda s: s["id"], sources))
             assert source_ids == ["sentry:microsoft", "sentry:electron", "custom"]
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_sources_ignored_bypass_alias(self, sources, reversed_alias_map):
         with override_options({"symbolicator.ignored_sources": ["sentry:ios-source"]}):
             sources = filter_ignored_sources(sources, reversed_alias_map)
@@ -111,7 +111,7 @@ class TestIgnoredSourcesFiltering:
                 "custom",
             ]
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_sources_ignored_custom(self, sources):
         with override_options({"symbolicator.ignored_sources": ["custom"]}):
             sources = filter_ignored_sources(sources)
@@ -124,7 +124,7 @@ class TestIgnoredSourcesFiltering:
                 "sentry:tvos-source",
             ]
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_sources_ignored_unrecognized(self, sources):
         with override_options({"symbolicator.ignored_sources": ["honk"]}):
             sources = filter_ignored_sources(sources)

--- a/tests/sentry/lang/native/test_processing.py
+++ b/tests/sentry/lang/native/test_processing.py
@@ -125,7 +125,7 @@ def test_merge_symbolicator_image_errors(code_file, error):
     }
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @mock.patch("sentry.lang.native.processing.Symbolicator")
 def test_cocoa_function_name(mock_symbolicator, default_project):
 
@@ -226,7 +226,7 @@ def test_instruction_addr_adjustment_none():
     assert not processed_frames[1]["adjust_instruction_addr"]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @mock.patch("sentry.lang.native.processing.Symbolicator")
 def test_il2cpp_symbolication(mock_symbolicator, default_project):
 

--- a/tests/sentry/lang/native/test_symbolicator.py
+++ b/tests/sentry/lang/native/test_symbolicator.py
@@ -19,7 +19,7 @@ CUSTOM_SOURCE_CONFIG = """
 """
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_sources_no_feature(default_project):
     features = {"organizations:symbol-sources": False, "organizations:custom-symbol-sources": False}
 
@@ -31,7 +31,7 @@ def test_sources_no_feature(default_project):
     assert sources[0]["id"] == "sentry:project"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_sources_builtin(default_project):
     features = {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": False}
 
@@ -47,7 +47,7 @@ def test_sources_builtin(default_project):
 
 # Test that a builtin source that is not declared in SENTRY_BUILTIN_SOURCES does
 # not lead to an error. It should simply be ignored.
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_sources_builtin_unknown(default_project):
     features = {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": False}
 
@@ -62,7 +62,7 @@ def test_sources_builtin_unknown(default_project):
 
 # Test that previously saved builtin sources are not returned if the feature for
 # builtin sources is missing at query time.
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_sources_builtin_disabled(default_project):
     features = {"organizations:symbol-sources": False, "organizations:custom-symbol-sources": False}
 
@@ -75,7 +75,7 @@ def test_sources_builtin_disabled(default_project):
     assert source_ids == ["sentry:project"]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_sources_custom(default_project):
     features = {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": True}
 
@@ -93,7 +93,7 @@ def test_sources_custom(default_project):
 
 # Test that previously saved custom sources are not returned if the feature for
 # custom sources is missing at query time.
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_sources_custom_disabled(default_project):
     features = {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": False}
 

--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -5,7 +5,7 @@ from sentry.models import Counter
 from sentry.testutils.silo import region_silo_test
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize("upsert_sample_rate", [0, 1])
 @region_silo_test
 def test_increment(default_project, upsert_sample_rate):

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -584,13 +584,14 @@ class ResolveActorsTestCase(TestCase):
         # Normal team
         owner1 = Owner("team", self.team.slug)
         actor1 = ActorTuple(self.team.id, Team)
+        breakpoint()
 
         # Team that doesn't exist
         owner2 = Owner("team", "nope")
         actor2 = None
 
         # A team that's not ours
-        otherteam = Team.objects.exclude(projectteam__project_id=self.project.id)[0]
+        otherteam = self.create_team()
         owner3 = Owner("team", otherteam.slug)
         actor3 = None
 

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -584,7 +584,6 @@ class ResolveActorsTestCase(TestCase):
         # Normal team
         owner1 = Owner("team", self.team.slug)
         actor1 = ActorTuple(self.team.id, Team)
-        breakpoint()
 
         # Team that doesn't exist
         owner2 = Owner("team", "nope")

--- a/tests/sentry/nodestore/django/test_backend.py
+++ b/tests/sentry/nodestore/django/test_backend.py
@@ -12,7 +12,7 @@ from sentry.testutils.silo import region_silo_test
 from sentry.utils.strings import compress
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 class TestDjangoNodeStorage:
     def setup_method(self):
         self.ns = DjangoNodeStorage()

--- a/tests/sentry/projectoptions/test_basic.py
+++ b/tests/sentry/projectoptions/test_basic.py
@@ -17,7 +17,7 @@ def latest_epoch(value):
         defaults.LATEST_EPOCH = old
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_defaults(default_project):
     default_manager.register(
         key="__sentry_test:test-option",
@@ -33,7 +33,7 @@ def test_defaults(default_project):
     assert default_project.get_option("__sentry_test:test-option") == "latest-value"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def freeze_option(factories, default_team):
     with latest_epoch(42):
         project = factories.create_project(name="Bar", slug="bar", teams=[default_team])

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -92,7 +92,7 @@ def _validate_project_config(config):
     validate_project_config(json.dumps(config), strict=True)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 def test_get_project_config_non_visible(default_project):
     keys = ProjectKey.objects.filter(project=default_project)
@@ -101,7 +101,7 @@ def test_get_project_config_non_visible(default_project):
     assert cfg.to_dict() == {"disabled": True}
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 @pytest.mark.parametrize("full", [False, True], ids=["slim_config", "full_config"])
 def test_get_project_config(default_project, insta_snapshot, django_cache, full):
@@ -131,7 +131,7 @@ def test_get_project_config(default_project, insta_snapshot, django_cache, full)
 SOME_EXCEPTION = RuntimeError("foo")
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 @mock.patch("sentry.relay.config.generate_rules", side_effect=SOME_EXCEPTION)
 @mock.patch("sentry.relay.config.sentry_sdk")
@@ -145,7 +145,7 @@ def test_get_experimental_config_dyn_sampling(mock_sentry_sdk, _, default_projec
     assert mock_sentry_sdk.capture_exception.call_args == mock.call(SOME_EXCEPTION)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 @mock.patch("sentry.relay.config.capture_exception")
 def test_get_experimental_config_transaction_metrics_exception(
@@ -165,7 +165,7 @@ def test_get_experimental_config_transaction_metrics_exception(
     assert mock_capture_exception.call_count == 2
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 @pytest.mark.parametrize("has_custom_filters", [False, True])
 @pytest.mark.parametrize("has_blacklisted_ips", [False, True])
@@ -204,7 +204,7 @@ def test_project_config_uses_filter_features(
         assert cfg_client_ips is None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 @mock.patch("sentry.relay.config.EXPOSABLE_FEATURES", ["organizations:profiling"])
 def test_project_config_exposed_features(default_project):
@@ -217,7 +217,7 @@ def test_project_config_exposed_features(default_project):
     assert cfg_features == ["organizations:profiling"]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 @mock.patch("sentry.relay.config.EXPOSABLE_FEATURES", ["badprefix:custom-inbound-filters"])
 def test_project_config_exposed_features_raise_exc(default_project):
@@ -230,7 +230,7 @@ def test_project_config_exposed_features_raise_exc(default_project):
         )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 @patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
 @freeze_time("2022-10-21 18:50:25.000000+00:00")
@@ -414,7 +414,7 @@ def test_project_config_with_all_biases_enabled(
     }
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize("transaction_metrics", ("with_metrics", "without_metrics"))
 @region_silo_test(stable=True)
 def test_project_config_with_breakdown(default_project, insta_snapshot, transaction_metrics):
@@ -436,7 +436,7 @@ def test_project_config_with_breakdown(default_project, insta_snapshot, transact
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 @pytest.mark.parametrize("has_metrics_extraction", (True, False))
 @pytest.mark.parametrize("abnormal_mechanism_rollout", (0, 1))
@@ -462,7 +462,7 @@ def test_project_config_with_organizations_metrics_extraction(
             assert session_metrics is None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize("has_project_transaction_threshold", (False, True))
 @pytest.mark.parametrize("has_project_transaction_threshold_overrides", (False, True))
 @region_silo_test(stable=True)
@@ -503,7 +503,7 @@ def test_project_config_satisfaction_thresholds(
     insta_snapshot(cfg["config"]["metricConditionalTagging"])
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 def test_project_config_with_span_attributes(default_project, insta_snapshot):
     # The span attributes config is not set with the flag turnd off
@@ -513,7 +513,7 @@ def test_project_config_with_span_attributes(default_project, insta_snapshot):
     insta_snapshot(cfg["config"]["spanAttributes"])
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 @pytest.mark.parametrize("feature_flag", (False, True), ids=("feature_disabled", "feature_enabled"))
 @pytest.mark.parametrize(
@@ -543,7 +543,7 @@ def test_has_metric_extraction(default_project, feature_flag, killswitch):
             assert config["customMeasurements"]["limit"] > 0
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_accept_transaction_names(default_project):
     feature = Feature(
         {
@@ -560,7 +560,7 @@ def test_accept_transaction_names(default_project):
 
 
 @pytest.mark.parametrize("num_clusterer_runs", [9, 10])
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_txnames_ready(default_project, num_clusterer_runs):
     with mock.patch(
         "sentry.relay.config.get_clusterer_meta", return_value={"runs": num_clusterer_runs}
@@ -573,7 +573,7 @@ def test_txnames_ready(default_project, num_clusterer_runs):
         assert config["txNameReady"] is True
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_accept_span_desc_rules(default_project):
     with Feature({"projects:span-metrics-extraction": True}), mock.patch(
         "sentry.relay.config.get_sorted_rules",
@@ -586,7 +586,7 @@ def test_accept_span_desc_rules(default_project):
         assert "spanDescriptionRules" in config
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 def test_project_config_setattr(default_project):
     project_cfg = ProjectConfig(default_project)
@@ -595,14 +595,14 @@ def test_project_config_setattr(default_project):
     assert str(exc_info.value) == "Trying to change read only ProjectConfig object"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 def test_project_config_getattr(default_project):
     project_cfg = ProjectConfig(default_project, foo="bar")
     assert project_cfg.foo == "bar"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 def test_project_config_str(default_project):
     project_cfg = ProjectConfig(default_project, foo="bar")
@@ -614,21 +614,21 @@ def test_project_config_str(default_project):
         assert str(project_cfg1) == "Content Error:bad data"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 def test_project_config_repr(default_project):
     project_cfg = ProjectConfig(default_project, foo="bar")
     assert repr(project_cfg) == '(ProjectConfig){"foo":"bar"}'
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 def test_project_config_to_json_string(default_project):
     project_cfg = ProjectConfig(default_project, foo="bar")
     assert project_cfg.to_json_string() == '{"foo":"bar"}'
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @region_silo_test(stable=True)
 def test_project_config_get_at_path(default_project):
     project_cfg = ProjectConfig(default_project, a=1, b="The b", foo="bar")

--- a/tests/sentry/relay/test_projectconfig_cache.py
+++ b/tests/sentry/relay/test_projectconfig_cache.py
@@ -18,7 +18,7 @@ def test_delete_count(monkeypatch):
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_read_write():
     cache = redis.RedisProjectConfigCache()
     my_key = "fake-dsn-1"

--- a/tests/sentry/replays/unit/test_dead_click_issue.py
+++ b/tests/sentry/replays/unit/test_dead_click_issue.py
@@ -5,7 +5,7 @@ import pytest
 from sentry.replays.usecases.ingest.dead_click import report_dead_click_issue
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_report_dead_click_issue_a_tag():
     event = {
         "data": {
@@ -25,7 +25,7 @@ def test_report_dead_click_issue_a_tag():
     assert reported is True
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_report_dead_click_issue_other_tag():
     event = {
         "data": {
@@ -41,7 +41,7 @@ def test_report_dead_click_issue_other_tag():
     assert reported is False
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_report_dead_click_issue_mutation_reason():
     event = {
         "data": {

--- a/tests/sentry/runner/commands/test_backup.py
+++ b/tests/sentry/runner/commands/test_backup.py
@@ -14,13 +14,13 @@ def backup_json_filename(tmp_path):
     return backup_json
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_import(backup_json_filename):
     rv = CliRunner().invoke(import_, backup_json_filename)
     assert rv.exit_code == 0, rv.output
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_import_duplicate_key(backup_json_filename):
     # Adding an element with the same key as the last item in the backed up file
     # to force a duplicate key violation exception

--- a/tests/sentry/search/events/builder/test_profile_functions.py
+++ b/tests/sentry/search/events/builder/test_profile_functions.py
@@ -61,7 +61,7 @@ def params():
         ),
     ],
 )
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_where(params, search, condition):
     builder = ProfileFunctionsQueryBuilder(
         Dataset.Functions,
@@ -121,7 +121,7 @@ def test_where(params, search, condition):
         ),
     ],
 )
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_having(params, search, condition):
     builder = ProfileFunctionsQueryBuilder(
         Dataset.Functions,

--- a/tests/sentry/services/test_project_key_service.py
+++ b/tests/sentry/services/test_project_key_service.py
@@ -8,7 +8,7 @@ from sentry.testutils.hybrid_cloud import use_real_service
 from sentry.web.client_config import get_client_config
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_project_key_service():
     organization = Factories.create_organization(name="test-org")
     project = Factories.create_project(organization=organization)

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -104,7 +104,7 @@ def get_entity_of_metric_mocked(_, metric_name, use_case_id):
     }[metric_name]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize(
     "query_string,expected",
     [
@@ -723,7 +723,7 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2):
         )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @mock.patch("sentry.snuba.sessions_v2.get_now", return_value=MOCK_NOW)
 @mock.patch("sentry.api.utils.timezone.now", return_value=MOCK_NOW)
 def test_build_snuba_query_orderby(mock_now, mock_now2):
@@ -826,7 +826,7 @@ def test_build_snuba_query_orderby(mock_now, mock_now2):
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @mock.patch("sentry.snuba.sessions_v2.get_now", return_value=MOCK_NOW)
 @mock.patch("sentry.api.utils.timezone.now", return_value=MOCK_NOW)
 def test_build_snuba_query_with_derived_alias(mock_now, mock_now2):

--- a/tests/sentry/snuba/test_profiles.py
+++ b/tests/sentry/snuba/test_profiles.py
@@ -59,7 +59,7 @@ def query_builder_fns(arg_name="query_builder_fn"):
     [pytest.param(column.alias, column.column, id=column.alias) for column in PROFILE_COLUMNS],
 )
 @query_builder_fns()
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_field_resolution(query_builder_fn, params, field, resolved):
     builder = query_builder_fn(
         dataset=Dataset.Profiles,
@@ -163,7 +163,7 @@ def test_field_resolution(query_builder_fn, params, field, resolved):
     ],
 )
 @query_builder_fns()
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_aggregate_resolution(query_builder_fn, params, field, resolved):
     builder = query_builder_fn(
         dataset=Dataset.Profiles,
@@ -228,7 +228,7 @@ def test_aggregate_resolution(query_builder_fn, params, field, resolved):
     ],
 )
 @query_builder_fns()
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_invalid_field_resolution(query_builder_fn, params, field, message):
     with pytest.raises(InvalidSearchQuery, match=message):
         query_builder_fn(
@@ -492,7 +492,7 @@ def is_null(column: str) -> Function:
         ),
     ],
 )
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_where_resolution(params, query, conditions):
     builder = ProfilesQueryBuilder(
         dataset=Dataset.Profiles,
@@ -506,7 +506,7 @@ def test_where_resolution(params, query, conditions):
 
 
 @pytest.mark.parametrize("field", [pytest.param("project"), pytest.param("project.name")])
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_where_resolution_project_slug(params, field):
     project = params["project_objects"][0]
 
@@ -529,7 +529,7 @@ def test_where_resolution_project_slug(params, field):
 
 @pytest.mark.parametrize("field", [pytest.param("project"), pytest.param("project.name")])
 @pytest.mark.parametrize("direction", [pytest.param("", id="asc"), pytest.param("-", id="desc")])
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_order_by_resolution_project_slug(params, field, direction):
     builder = ProfilesQueryBuilder(
         dataset=Dataset.Profiles,
@@ -567,7 +567,7 @@ def test_order_by_resolution_project_slug(params, field, direction):
         for column in PROFILE_COLUMNS
     ],
 )
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_has_resolution(params, field, column):
     builder = ProfilesQueryBuilder(
         dataset=Dataset.Profiles,
@@ -593,7 +593,7 @@ def test_has_resolution(params, field, column):
         for column in PROFILE_COLUMNS
     ],
 )
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_not_has_resolution(params, field, column):
     builder = ProfilesQueryBuilder(
         dataset=Dataset.Profiles,

--- a/tests/sentry/tasks/test_app_store_connect.py
+++ b/tests/sentry/tasks/test_app_store_connect.py
@@ -36,7 +36,7 @@ class TestUpdateDsyms:
             dsym_url="http://iosapps.itunes.apple.com/itunes-assets/Purple116/v4/20/ba/a0/20baa026-2410-b32f-1fde-b227bc2ea7ae/appDsyms.zip?accessKey=very-cool-key",
         )
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_process_no_builds(self, default_project, config):
         before = timezone.now()
         pending = process_builds(project=default_project, config=config, to_process=[])
@@ -46,7 +46,7 @@ class TestUpdateDsyms:
         )
         assert entry.last_checked >= before
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_process_new_build(self, default_project, config, build):
         before = timezone.now()
         pending = process_builds(project=default_project, config=config, to_process=[build])
@@ -60,7 +60,7 @@ class TestUpdateDsyms:
         )
         assert entry.last_checked >= before
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_process_existing_fetched_build(self, default_project, config, build):
         AppConnectBuild.objects.create(
             project=default_project,
@@ -99,7 +99,7 @@ class TestUpdateDsyms:
         )
         assert entry.last_checked >= before
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_process_existing_unfetched_build(self, default_project, config, build):
         AppConnectBuild.objects.create(
             project=default_project,
@@ -126,7 +126,7 @@ class TestUpdateDsyms:
         )
         assert entry.last_checked >= before
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_create_new_persisted_build(self, default_project, config, build):
         returned_build = get_or_create_persisted_build(default_project, config, build)
 
@@ -168,7 +168,7 @@ class TestUpdateDsyms:
         assert saved_build.bundle_version == expected_build.bundle_version
         # assert saved_build.uploaded_to_appstore == expected_build.uploaded_to_appstore
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_get_persisted_build(self, default_project, config, build):
         seen = datetime(2020, 2, 20)
 
@@ -195,7 +195,7 @@ class TestUpdateDsyms:
         assert existing_build.bundle_version == build.build_number
         assert existing_build.uploaded_to_appstore == build.uploaded_date
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_get_persisted_build_preserves_existing_fetched(self, default_project, config, build):
         seen = datetime(2020, 2, 20)
 

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -125,7 +125,7 @@ def invalidation_debounce_cache(monkeypatch):
     return debounce_cache
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_debounce(
     monkeypatch,
     default_projectkey,
@@ -148,7 +148,7 @@ def test_debounce(
     assert tasks[0]["public_key"] == default_projectkey.public_key
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_generate(
     monkeypatch,
     default_project,
@@ -174,7 +174,7 @@ def test_generate(
     ]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_project_update_option(
     default_projectkey, default_project, emulate_transactions, redis_cache, django_cache
 ):
@@ -207,7 +207,7 @@ def test_project_update_option(
         }
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_project_delete_option(
     default_projectkey, default_project, emulate_transactions, redis_cache, django_cache
 ):
@@ -222,7 +222,7 @@ def test_project_delete_option(
     assert redis_cache.get(default_projectkey)["config"]["piiConfig"] == {}
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_project_get_option_does_not_reload(
     default_project, emulate_transactions, monkeypatch, django_cache
 ):
@@ -237,7 +237,7 @@ def test_project_get_option_does_not_reload(
     assert not build_project_config.called
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_invalidation_project_deleted(
     default_project, emulate_transactions, redis_cache, django_cache
 ):
@@ -261,7 +261,7 @@ def test_invalidation_project_deleted(
     assert redis_cache.get(project_key)["disabled"]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_projectkeys(default_project, emulate_transactions, redis_cache, django_cache):
     # When a projectkey is deleted the invalidation task should be triggered and the project
     # should be cached as disabled.
@@ -296,7 +296,7 @@ def test_projectkeys(default_project, emulate_transactions, redis_cache, django_
         assert not redis_cache.get(key.public_key)
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db(databases="__all__", transaction=True)
 def test_db_transaction(
     default_project, default_projectkey, redis_cache, task_runner, django_cache
 ):
@@ -334,7 +334,7 @@ def test_db_transaction(
     }
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db(databases="__all__", transaction=True)
 class TestInvalidationTask:
     def test_debounce(
         self,
@@ -464,7 +464,7 @@ class TestInvalidationTask:
         assert schedule_inner.call_count == 2
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db(databases="__all__", transaction=True)
 def test_invalidate_hierarchy(
     monkeypatch,
     burst_task_runner,

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -100,7 +100,7 @@ def register_event_preprocessor(register_plugin):
     return inner
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 @pytest.mark.parametrize("change_groups", (True, False), ids=("new_group", "same_group"))
 def test_basic(
@@ -209,7 +209,7 @@ def test_basic(
         assert not tombstone_calls
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 def test_concurrent_events_go_into_new_group(
     default_project,
@@ -273,7 +273,7 @@ def test_concurrent_events_go_into_new_group(
     assert activity.ident == str(original_issue_id)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 @pytest.mark.parametrize("remaining_events", ["delete", "keep"])
 @pytest.mark.parametrize("max_events", [2, None])
@@ -350,7 +350,7 @@ def test_max_events(
     assert is_group_finished(group_id)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 def test_attachments_and_userfeedback(
     default_project,
@@ -417,7 +417,7 @@ def test_attachments_and_userfeedback(
     assert is_group_finished(event.group_id)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 @pytest.mark.parametrize("remaining_events", ["keep", "delete"])
 def test_nodestore_missing(
@@ -463,7 +463,7 @@ def test_nodestore_missing(
     assert logs == ["reprocessing2.unprocessed_event.not_found"]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 def test_apply_new_fingerprinting_rules(
     default_project,
@@ -521,7 +521,7 @@ def test_apply_new_fingerprinting_rules(
     assert event2.group.message == "hello world 2"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.snuba
 def test_apply_new_stack_trace_rules(
     default_project,
@@ -613,7 +613,7 @@ def test_apply_new_stack_trace_rules(
     assert event1.data["grouping_config"] != original_grouping_config
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_finish_reprocessing(default_project):
     # Pretend that the old group has more than one activity still connected:
     old_group = Group.objects.create(project=default_project)

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -90,7 +90,7 @@ def mock_metrics_timing():
         yield m
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_move_to_process_event(
     default_project, mock_process_event, mock_save_event, mock_symbolicate_event, register_plugin
 ):
@@ -110,7 +110,7 @@ def test_move_to_process_event(
     assert mock_save_event.delay.call_count == 0
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_move_to_save_event(
     default_project, mock_process_event, mock_save_event, mock_symbolicate_event, register_plugin
 ):
@@ -130,7 +130,7 @@ def test_move_to_save_event(
     assert mock_save_event.delay.call_count == 1
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_process_event_mutate_and_save(
     default_project, mock_event_processing_store, mock_save_event, register_plugin
 ):
@@ -159,7 +159,7 @@ def test_process_event_mutate_and_save(
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_process_event_no_mutate_and_save(
     default_project, mock_event_processing_store, mock_save_event, register_plugin
 ):
@@ -185,7 +185,7 @@ def test_process_event_no_mutate_and_save(
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_process_event_unprocessed(
     default_project, mock_event_processing_store, mock_save_event, register_plugin
 ):
@@ -212,7 +212,7 @@ def test_process_event_unprocessed(
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_hash_discarded_raised(default_project, mock_refund, register_plugin):
     register_plugin(globals(), BasicPreprocessorPlugin)
 
@@ -242,7 +242,7 @@ def options_model(request, default_organization, default_project):
         raise ValueError(request.param)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize("setting_method", ["datascrubbers", "piiconfig"])
 def test_scrubbing_after_processing(
     default_project,

--- a/tests/sentry/tasks/test_symbolication.py
+++ b/tests/sentry/tasks/test_symbolication.py
@@ -93,7 +93,7 @@ def mock_submit_symbolicate():
         yield m
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_move_to_symbolicate_event(
     default_project, mock_process_event, mock_save_event, mock_symbolicate_event, register_plugin
 ):
@@ -113,7 +113,7 @@ def test_move_to_symbolicate_event(
     assert mock_save_event.delay.call_count == 0
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_move_to_symbolicate_event_low_priority(
     default_project,
     mock_process_event,
@@ -140,7 +140,7 @@ def test_move_to_symbolicate_event_low_priority(
         assert mock_save_event.delay.call_count == 0
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_symbolicate_event_doesnt_call_process_inline(
     default_project,
     mock_event_processing_store,
@@ -186,24 +186,24 @@ def options_model(request, default_organization, default_project):
         raise ValueError(request.param)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_should_demote_symbolication_empty(default_project):
     assert not should_demote_symbolication(default_project.id)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_should_demote_symbolication_always(default_project):
     with override_options({"store.symbolicate-event-lpq-always": [default_project.id]}):
         assert should_demote_symbolication(default_project.id)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_should_demote_symbolication_never(default_project):
     with override_options({"store.symbolicate-event-lpq-never": [default_project.id]}):
         assert not should_demote_symbolication(default_project.id)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_should_demote_symbolication_always_and_never(default_project):
     with override_options(
         {
@@ -214,7 +214,7 @@ def test_should_demote_symbolication_always_and_never(default_project):
         assert not should_demote_symbolication(default_project.id)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @patch("sentry.event_manager.EventManager.save", return_value=None)
 def test_submit_symbolicate_queue_switch(
     self,

--- a/tests/sentry/test_datascrubbing.py
+++ b/tests/sentry/test_datascrubbing.py
@@ -16,7 +16,7 @@ def merge_pii_configs(prefixes_and_configs):
     return rv
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 @pytest.mark.parametrize("field", ["ooo", "oöö", "o o", "o\no", "o'o"])
 def test_scrub_data(field, default_project):
     project = default_project

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -78,7 +78,7 @@ class CococaSDKTestMixin(BaseSDKCrashDetectionMixin):
 
 
 class SDKCrashReportTestMixin(BaseSDKCrashDetectionMixin, SnubaTestCase):
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases="__all__")
     def test_sdk_crash_event_stored_to_sdk_crash_project(self):
 
         cocoa_sdk_crashes_project = self.create_project(

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -234,7 +234,7 @@ def _get_query_maker_params(project):
     }
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_filter_proj_slug_in_query(default_project):
     params = _get_query_maker_params(default_project)
     params["project_id"] = [default_project.id]
@@ -246,7 +246,7 @@ def test_filter_proj_slug_in_query(default_project):
     assert query_def.params["project_id"] == [default_project.id]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_filter_proj_slug_in_top_filter(default_project):
     params = _get_query_maker_params(default_project)
     params["project_id"] = [default_project.id]
@@ -258,7 +258,7 @@ def test_filter_proj_slug_in_top_filter(default_project):
     assert query_def.params["project_id"] == [default_project.id]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_filter_proj_slug_in_top_filter_and_query(default_project):
     params = _get_query_maker_params(default_project)
     params["project_id"] = [default_project.id]
@@ -270,7 +270,7 @@ def test_filter_proj_slug_in_top_filter_and_query(default_project):
     assert query_def.params["project_id"] == [default_project.id]
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_proj_neither_in_top_filter_nor_query(default_project):
     params = _get_query_maker_params(default_project)
     query_def = _make_query(
@@ -281,7 +281,7 @@ def test_proj_neither_in_top_filter_nor_query(default_project):
     assert "project_id" not in query_def.params
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_filter_env_in_query(default_project):
     env = "prod"
     params = _get_query_maker_params(default_project)
@@ -292,7 +292,7 @@ def test_filter_env_in_query(default_project):
     assert query_def.query == f"environment:{env}"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_filter_env_in_top_filter(default_project):
     env = "prod"
     params = _get_query_maker_params(default_project)
@@ -304,7 +304,7 @@ def test_filter_env_in_top_filter(default_project):
     assert query_def.query == ""
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_filter_env_in_top_filter_and_query(default_project):
     env = "prod"
     params = _get_query_maker_params(default_project)
@@ -316,7 +316,7 @@ def test_filter_env_in_top_filter_and_query(default_project):
     assert query_def.query == f"environment:{env}"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_env_neither_in_top_filter_nor_query(default_project):
     params = _get_query_maker_params(default_project)
     query_def = _make_query(


### PR DESCRIPTION
Have django manage multiple connections in preparation for the database split that we'll have in siloed application mode.