### PR TITLE
fix(crons): Update check-ins with trace_id if sent

### DIFF
--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -202,11 +202,15 @@ class MonitorConsumerTest(TestCase):
 
     def test_check_in_update(self):
         monitor = self._create_monitor(slug="my-monitor")
-        self.send_message(monitor.slug, status="in_progress")
-        self.send_message(monitor.slug, guid=self.guid)
+        self.send_message(monitor.slug, status="in_progress", contexts={})
+        new_trace_id = uuid.uuid4().hex
+        self.send_message(
+            monitor.slug, guid=self.guid, contexts={"trace": {"trace_id": new_trace_id}}
+        )
 
         checkin = MonitorCheckIn.objects.get(guid=self.guid)
         assert checkin.duration is not None
+        assert checkin.trace_id.hex == new_trace_id
 
     def test_check_in_existing_guid(self):
         monitor = self._create_monitor(slug="my-monitor")


### PR DESCRIPTION
Updates the check-in trace_id if it is sent in the payload as python SDK only sends it on closing check-in