### PR TITLE
fix(roles): Disable transfer project for team-admins

### DIFF
--- a/src/sentry/api/endpoints/project_transfer.py
+++ b/src/sentry/api/endpoints/project_transfer.py
@@ -20,7 +20,7 @@ delete_logger = logging.getLogger("sentry.deletions.api")
 
 
 class RelaxedProjectPermission(ProjectPermission):
-    scope_map = {"POST": ["project:admin"]}
+    scope_map = {"POST": ["org:admin"]}
 
 
 @region_silo_endpoint

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -178,8 +178,10 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
 
   renderTransferProject() {
     const project = this.state.data;
-    const isProjectAdmin = this.isProjectAdmin();
     const {isInternal} = project;
+    const isOrgOwner = hasEveryAccess(['org:admin'], {
+      organization: this.props.organization,
+    });
 
     return (
       <FieldGroup
@@ -192,7 +194,7 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
           }
         )}
       >
-        {!isProjectAdmin &&
+        {!isOrgOwner &&
           t('You do not have the required permission to transfer this project.')}
 
         {isInternal &&
@@ -200,7 +202,7 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
             'This project cannot be transferred. It is used internally by the Sentry server.'
           )}
 
-        {isProjectAdmin && !isInternal && (
+        {isOrgOwner && !isInternal && (
           <Confirm
             onConfirm={this.handleTransferProject}
             priority="danger"


### PR DESCRIPTION
It is odd that a team-admin can transfer a project and its data outside an organization. That seems riskier than deleting the data, so let's make it only org-owners can do it.

**Before**
<img width="793" alt="Screenshot 2023-06-25 at 8 00 06 PM" src="https://github.com/getsentry/sentry/assets/1748388/c762c0c4-c302-4597-8475-cb39ced50830">

**After**
<img width="1042" alt="Screenshot 2023-06-25 at 8 00 35 PM" src="https://github.com/getsentry/sentry/assets/1748388/eda8b659-8135-4396-9ea3-a6fc5b448149">
