### PR TITLE
ref(replay): Refactor Replay Breadcrumbs current & hoverTime highlighting

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -24,10 +24,9 @@ type MouseCallback = (crumb: Crumb, e: React.MouseEvent<HTMLElement>) => void;
 
 interface BaseProps {
   crumb: Crumb;
-  isCurrent: boolean;
-  isHovered: boolean;
   onClick: null | MouseCallback;
   startTimestampMs: number;
+  className?: string;
   expandPaths?: string[];
   onMouseEnter?: MouseCallback;
   onMouseLeave?: MouseCallback;
@@ -54,11 +53,10 @@ interface WithDimensionChangeProps extends BaseProps {
 type Props = NoDimensionChangeProps | WithDimensionChangeProps;
 
 function BreadcrumbItem({
+  className,
   crumb,
   expandPaths,
   index,
-  isCurrent,
-  isHovered,
   onClick,
   onDimensionChange,
   onMouseEnter,
@@ -95,14 +93,12 @@ function BreadcrumbItem({
 
   return (
     <CrumbItem
-      aria-current={isCurrent}
       as={onClick ? 'button' : 'span'}
-      isCurrent={isCurrent}
-      isHovered={isHovered}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       style={style}
+      className={className}
     >
       <IconWrapper color={color} hasOccurred>
         <BreadcrumbIcon type={type} />
@@ -197,12 +193,7 @@ const Description = styled(Tooltip)`
   color: ${p => p.theme.subText};
 `;
 
-type CrumbItemProps = {
-  isCurrent: boolean;
-  isHovered: boolean;
-};
-
-const CrumbItem = styled(PanelItem)<CrumbItemProps>`
+const CrumbItem = styled(PanelItem)`
   display: grid;
   grid-template-columns: max-content auto;
   align-items: flex-start;
@@ -215,8 +206,7 @@ const CrumbItem = styled(PanelItem)<CrumbItemProps>`
   text-align: left;
   border: none;
   position: relative;
-  ${p => p.isCurrent && `background-color: ${p.theme.purple100};`}
-  ${p => p.isHovered && `background-color: ${p.theme.surface200};`}
+
   border-radius: ${p => p.theme.borderRadius};
 
   &:hover {

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -80,8 +80,6 @@ function Event({
   const buttons = crumbs.map(crumb => (
     <BreadcrumbItem
       crumb={crumb}
-      isCurrent={false}
-      isHovered={false}
       key={crumb.id}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}

--- a/static/app/components/replays/walker/splitCrumbs.tsx
+++ b/static/app/components/replays/walker/splitCrumbs.tsx
@@ -93,8 +93,6 @@ function SummarySegment({
         <li key={crumb.id || i}>
           <BreadcrumbItem
             crumb={crumb}
-            isCurrent={false}
-            isHovered={false}
             onClick={handleOnClick}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -8,10 +8,8 @@ import {
 import styled from '@emotion/styled';
 
 import Placeholder from 'sentry/components/placeholder';
-import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import type {Crumb} from 'sentry/types/breadcrumbs';
-import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
 import BreadcrumbRow from 'sentry/views/replays/detail/breadcrumbs/breadcrumbRow';
 import useScrollToCurrentItem from 'sentry/views/replays/detail/breadcrumbs/useScrollToCurrentItem';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
@@ -33,8 +31,6 @@ const cellMeasurer = {
 };
 
 function Breadcrumbs({breadcrumbs, startTimestampMs}: Props) {
-  const {currentTime, currentHoverTime} = useReplayContext();
-
   const listRef = useRef<ReactVirtualizedList>(null);
   // Keep a reference of object paths that are expanded (via <ObjectInspector>)
   // by log row, so they they can be restored as the Console pane is scrolling.
@@ -44,39 +40,6 @@ function Breadcrumbs({breadcrumbs, startTimestampMs}: Props) {
   // Note that this is intentionally not in state because we do not want to
   // re-render when items are expanded/collapsed, though it may work in state as well.
   const expandPathsRef = useRef(new Map<number, Set<string>>());
-
-  const itemLookup = useMemo(
-    () =>
-      breadcrumbs &&
-      breadcrumbs
-        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
-        .sort(([a], [b]) => a - b),
-    [breadcrumbs]
-  );
-
-  const current = useMemo(
-    () =>
-      breadcrumbs
-        ? getPrevReplayEvent({
-            itemLookup,
-            items: breadcrumbs,
-            targetTimestampMs: startTimestampMs + currentTime,
-          })
-        : undefined,
-    [itemLookup, breadcrumbs, currentTime, startTimestampMs]
-  );
-
-  const hovered = useMemo(
-    () =>
-      currentHoverTime && breadcrumbs
-        ? getPrevReplayEvent({
-            itemLookup,
-            items: breadcrumbs,
-            targetTimestampMs: startTimestampMs + currentHoverTime,
-          })
-        : undefined,
-    [itemLookup, breadcrumbs, currentHoverTime, startTimestampMs]
-  );
 
   const deps = useMemo(() => [breadcrumbs], [breadcrumbs]);
   const {cache, updateList} = useVirtualizedList({
@@ -109,8 +72,6 @@ function Breadcrumbs({breadcrumbs, startTimestampMs}: Props) {
       >
         <BreadcrumbRow
           index={index}
-          isCurrent={current?.id === item.id}
-          isHovered={hovered?.id === item.id}
           breadcrumb={item}
           startTimestampMs={startTimestampMs}
           style={style}
@@ -158,6 +119,46 @@ const BreadcrumbContainer = styled('div')`
   overflow: hidden;
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
+
+  .beforeHoverTime + .afterHoverTime:before {
+    background-color: ${p => p.theme.surface200};
+    border-top: 1px solid ${p => p.theme.purple200};
+    content: '';
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 999999999%;
+  }
+
+  .beforeHoverTime:last-child:before {
+    background-color: ${p => p.theme.surface200};
+    border-bottom: 1px solid ${p => p.theme.purple200};
+    content: '';
+    right: 0;
+    position: absolute;
+    bottom: 0;
+    width: 999999999%;
+  }
+
+  .beforeCurrentTime + .afterCurrentTime:before {
+    background-color: ${p => p.theme.purple100};
+    border-top: 1px solid ${p => p.theme.purple300};
+    content: '';
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 999999999%;
+  }
+
+  .beforeCurrentTime:last-child:before {
+    background-color: ${p => p.theme.purple100};
+    border-bottom: 1px solid ${p => p.theme.purple300};
+    content: '';
+    right: 0;
+    position: absolute;
+    bottom: 0;
+    width: 999999999%;
+  }
 `;
 
 export default memo(Breadcrumbs);

--- a/static/app/views/replays/detail/breadcrumbs/useScrollToCurrentItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useScrollToCurrentItem.tsx
@@ -34,7 +34,7 @@ function useScrollToCurrentItem({breadcrumbs, ref, startTimestampMs}: Opts) {
   useEffect(() => {
     if (ref.current && current) {
       const index = breadcrumbs?.findIndex(crumb => crumb.id === current.id);
-      ref.current?.scrollToRow(index);
+      ref.current?.scrollToRow(index ? index + 1 : undefined);
     }
   }, [breadcrumbs, current, ref]);
 }


### PR DESCRIPTION
Updates the way we render current/hover breadcrumbs on the replay details page.

Previously we relied only on the background color to indicate the `currentTime` or `hoverTime`, but this wasn't great because sometimes two breadcrumbs have the same timestamp, and so both would have the same background.

So this updates things to use the common 'purple line' pattern as a separator. Other benefits include: fewer dynamic `styled()` components (pass a className instead), fewer props to drill down with (get a className higher in the tree instead of passing down the details), `getPrevReplayEvent` isn't needed on each render (it's kinda slow). 

**Before:**
<img width="682" alt="SCR-20230623-pfaw" src="https://github.com/getsentry/sentry/assets/187460/c79f14ca-130a-4539-8223-49634ce6a7df">


**After:**
<img width="684" alt="SCR-20230623-pexm" src="https://github.com/getsentry/sentry/assets/187460/533cb288-3c81-4a29-9d38-e00284e532f1">
