### PR TITLE
fix(tests): Fix test indentation in integration scope test

### DIFF
--- a/tests/sentry/integrations/utils/test_scope.py
+++ b/tests/sentry/integrations/utils/test_scope.py
@@ -51,21 +51,19 @@ class BindOrgContextFromIntegrationTest(TestCase):
 
         mock_bind_org_context.assert_called_with(org)
 
-        @patch("sentry.integrations.utils.scope.bind_ambiguous_org_context")
-        def test_binds_org_context_with_multiple_orgs(
-            self, mock_bind_ambiguous_org_context: MagicMock
-        ):
-            maisey_org = self.create_organization(slug="themaiseymaiseydog")
-            charlie_org = self.create_organization(slug="charliebear")
-            integration = Integration.objects.create(name="squirrelChasers")
-            integration.add_organization(maisey_org)
-            integration.add_organization(charlie_org)
+    @patch("sentry.integrations.utils.scope.bind_ambiguous_org_context")
+    def test_binds_org_context_with_multiple_orgs(self, mock_bind_ambiguous_org_context: MagicMock):
+        maisey_org = self.create_organization(slug="themaiseymaiseydog")
+        charlie_org = self.create_organization(slug="charliebear")
+        integration = Integration.objects.create(name="squirrelChasers")
+        integration.add_organization(maisey_org)
+        integration.add_organization(charlie_org)
 
-            bind_org_context_from_integration(integration.id)
+        bind_org_context_from_integration(integration.id)
 
-            mock_bind_ambiguous_org_context.assert_called_with(
-                [maisey_org, charlie_org], f"integration (id={integration.id})"
-            )
+        mock_bind_ambiguous_org_context.assert_called_with(
+            [maisey_org, charlie_org], f"integration (id={integration.id})"
+        )
 
     def test_raises_error_if_no_orgs_found(self):
         integration = Integration.objects.create(name="squirrelChasers")


### PR DESCRIPTION
One of the tests in `tests/sentry/integrations/utils/test_scope.py` was accidentally indented too far, unintentionally nesting it inside another test and causing it not to run. This fixes that.