### PR TITLE
ref(hc): Rename variable in jira webhook

### DIFF
--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -40,7 +40,7 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
 
     def post(self, request: Request, *args, **kwargs) -> Response:
         token = self.get_token(request)
-        integration = get_integration_from_jwt(
+        rpc_integration = get_integration_from_jwt(
             token=token,
             path=request.path,
             provider=self.provider,
@@ -50,10 +50,10 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
 
         data = request.data
         if not data.get("changelog"):
-            logger.info("missing-changelog", extra={"integration_id": integration.id})
+            logger.info("missing-changelog", extra={"integration_id": rpc_integration.id})
             return self.respond()
 
-        handle_assignee_change(integration, data, use_email_scope=settings.JIRA_USE_EMAIL_SCOPE)
-        handle_status_change(integration, data)
+        handle_assignee_change(rpc_integration, data, use_email_scope=settings.JIRA_USE_EMAIL_SCOPE)
+        handle_status_change(rpc_integration, data)
 
         return self.respond()

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -52,12 +52,14 @@ def get_orgs_from_integration(integration_id: int) -> Sequence[Organization]:
 
 def bind_org_context_from_integration(integration_id: int) -> None:
     """
-    Given the id of an Integration, get the associated org(s) and bind that data to the scope.
+    Given the id of an Integration or an RpcIntegration, get the associated org(s) and bind that
+    data to the scope.
 
     Note: An `Integration` is an instance of given provider's integration, tied to a single entity
     on the provider's end (for example, an instance of the GitHub integration tied to a particular
     GitHub org, or an instance of the Slack integration tied to a particular Slack workspace), which
-    can be shared by multiple orgs.
+    can be shared by multiple orgs. Also, it doesn't matter whether the passed id comes from an
+    Integration or an RpcIntegration object, because corresponding ones share the same id.
     """
 
     orgs = get_orgs_from_integration(integration_id)


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/50208/, which changed `get_integration_from_jwt` from returning an `Integration` instance to returning a `RpcIntegration` instance. That PR also renamed the variable pointing to the result of a `get_integration_from_jwt` call in the Jira uninstalled webhook. This PR applies the same renaming to the Jira issue-updated webhook, so the differences in what they're doing (one converts the `RpcIntegration` into an `Integration,` while the other doesn't) are clearer.

It also updates the docstring of `bind_org_context_from_integration` to reflect that fact that it may now be called with the id of an `RpcIntegration` instead of the id of an `Integration`.