### PR TITLE
ref(integrations): Log exception rather than raising in `bind_org_context_from_integration`

### DIFF
--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -7,7 +7,6 @@ from sentry_sdk import configure_scope
 
 from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.sdk import bind_ambiguous_org_context, bind_organization_context
 
 logger = logging.getLogger(__name__)
@@ -63,7 +62,9 @@ def bind_org_context_from_integration(integration_id: int) -> None:
     orgs = get_orgs_from_integration(integration_id)
 
     if len(orgs) == 0:
-        raise IntegrationError(f"No orgs are associated with integration id={integration_id}")
+        logger.exception(
+            f"Can't bind org context - no orgs are associated with integration id={integration_id}."
+        )
     elif len(orgs) == 1:
         bind_organization_context(orgs[0])
     else:

--- a/tests/sentry/integrations/utils/test_scope.py
+++ b/tests/sentry/integrations/utils/test_scope.py
@@ -1,13 +1,10 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from sentry.integrations.utils.scope import (
     bind_org_context_from_integration,
     get_orgs_from_integration,
 )
 from sentry.models.integrations.integration import Integration
-from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import TestCase
 
 
@@ -67,10 +64,20 @@ class BindOrgContextFromIntegrationTest(TestCase):
                 [maisey_org, charlie_org], f"integration (id={integration.id})"
             )
 
-    def test_raises_error_if_no_orgs_found(self):
+    @patch("sentry.integrations.utils.scope.bind_ambiguous_org_context")
+    @patch("sentry.integrations.utils.scope.bind_organization_context")
+    @patch("sentry.integrations.utils.scope.logger.exception")
+    def test_logs_error_if_no_orgs_found(
+        self,
+        mock_logger_exception: MagicMock,
+        mock_bind_org_context: MagicMock,
+        mock_bind_ambiguous_org_context: MagicMock,
+    ):
         integration = Integration.objects.create(name="squirrelChasers")
 
-        with pytest.raises(
-            IntegrationError, match=f"No orgs are associated with integration id={integration.id}"
-        ):
-            bind_org_context_from_integration(integration.id)
+        bind_org_context_from_integration(integration.id)
+        mock_logger_exception.assert_called_with(
+            f"Can't bind org context - no orgs are associated with integration id={integration.id}."
+        )
+        mock_bind_org_context.assert_not_called()
+        mock_bind_ambiguous_org_context.assert_not_called()


### PR DESCRIPTION
This switches `bind_org_context_from_integration` from raising an exception if no organization is found to logging one, so that an attempt to add context data won't ever crash an endpoint.