### PR TITLE
fix(codecov): Wait for extra job before making codecov PR comment

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -78,7 +78,8 @@ jobs:
         pg-version: ['14']
 
     env:
-      # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
+      # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.
+      # If this increases, make sure to also increase `flags.backend.after_n_builds` in `codecov.yml`.
       MATRIX_INSTANCE_TOTAL: 6
 
     steps:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -169,7 +169,8 @@ jobs:
           GITHUB_PR_REF: ${{ github.event.pull_request.head.ref || github.ref }}
           # XXX: CI_NODE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
           #      Otherwise, if there are other things in the matrix, using strategy.job-total
-          #      wouldn't be correct.
+          #      wouldn't be correct. Also, if this increases, make sure to also increase
+          #      `flags.frontend.after_n_builds` in `codecov.yml`.
           CI_NODE_TOTAL: 4
           CI_NODE_INDEX: ${{ matrix.instance }}
           # Disable testing-library from printing out any of of the DOM to

--- a/codecov.yml
+++ b/codecov.yml
@@ -58,7 +58,7 @@ flags:
     - "src/sentry/**/*.py"
     carryforward: true
     # Do not send any status checks until N coverage reports are uploaded
-    after_n_builds: 16
+    after_n_builds: 17
 
 # Read more here: https://docs.codecov.com/docs/pull-request-comments
 comment:


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/51558, which increased the number of shards into which the backend test suite is broken in GHA. The extra shard means that codecov should now wait for an extra coverage report to be uploaded before it adds its comment to PRs. This fixes the codecov config and adds a note to both the backend and frontend GHA configs to future folks to make this change.