### PR TITLE
feat(backend): Use verbose logging when debugging backend tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,20 +41,21 @@
         "--runInBand",
         "--watch",
         "--verbose",
-        "${file}"],
+        "${file}"
+      ],
       // if we don't set this, output goes to the VSCode debug terminal, which
       // only prints the test output if "outputCapture" is also set, and even
       // then won't print in color
       "console": "integratedTerminal",
       // since we're not using it, don't automatically switch to it
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     },
     {
       "name": "pytest - current file",
       "type": "python",
       "request": "launch",
       "module": "pytest",
-      "args": ["${file}"],
+      "args": ["--verbose", "${file}"],
       "django": true,
       "env": {
         "SENTRY_MODEL_MANIFEST_FILE_PATH": "./model-manifest.json"


### PR DESCRIPTION
This changes the VSCode debug profile for debugging backend tests to use verbose logging, since we only run one file's worth of tests at a time, and more information is never a bad thing when you're trying to debug something. It also applies to `launch.json` two small fixes done by the auto-formatter.