### PR TITLE
ref(auth): Update ApiApplication serializer (ER-1448)

### DIFF
--- a/src/sentry/api/serializers/models/apiapplication.py
+++ b/src/sentry/api/serializers/models/apiapplication.py
@@ -19,5 +19,5 @@ class ApiApplicationSerializer(Serializer):
             "privacyUrl": obj.privacy_url,
             "termsUrl": obj.terms_url,
             "allowedOrigins": obj.get_allowed_origins(),
-            "redirectUris": [o for o in obj.redirect_uris.splitlines() if o],
+            "redirectUris": obj.get_redirect_uris(),
         }

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -109,12 +109,17 @@ class ApiApplication(Model):
         return False
 
     def get_default_redirect_uri(self):
-        return self.redirect_uris.split("\n", 1)[0]
+        return self.redirect_uris.split()[0]
 
     def get_allowed_origins(self):
         if not self.allowed_origins:
             return []
-        return [a for a in self.allowed_origins.split("\n") if a]
+        return [origin for origin in self.allowed_origins.split()]
+
+    def get_redirect_uris(self):
+        if not self.redirect_uris:
+            return []
+        return [redirect_uri for redirect_uri in self.redirect_uris.split()]
 
     def get_audit_log_data(self):
         return {

--- a/tests/sentry/models/test_apiapplication.py
+++ b/tests/sentry/models/test_apiapplication.py
@@ -63,6 +63,11 @@ class ApiApplicationTest(TestCase):
 
         assert app.get_allowed_origins() == []
 
+    def test_get_allowed_origins_empty_string(self):
+        app = ApiApplication.objects.create(name="origins_test", redirect_uris="")
+
+        assert app.get_allowed_origins() == []
+
     def test_get_redirect_uris_space_separated(self):
         app = ApiApplication.objects.create(
             name="origins_test",

--- a/tests/sentry/models/test_apiapplication.py
+++ b/tests/sentry/models/test_apiapplication.py
@@ -55,6 +55,14 @@ class ApiApplicationTest(TestCase):
             "http://example.io",
         ]
 
+    def test_get_allowed_origins_none(self):
+        app = ApiApplication.objects.create(
+            name="origins_test",
+            redirect_uris="http://example.com",
+        )
+
+        assert app.get_allowed_origins() == []
+
     def test_get_redirect_uris_space_separated(self):
         app = ApiApplication.objects.create(
             name="origins_test",

--- a/tests/sentry/models/test_apiapplication.py
+++ b/tests/sentry/models/test_apiapplication.py
@@ -28,3 +28,53 @@ class ApiApplicationTest(TestCase):
         )
 
         assert app.get_default_redirect_uri() == "http://example.com"
+
+    def test_get_allowed_origins_space_separated(self):
+        app = ApiApplication.objects.create(
+            name="origins_test",
+            redirect_uris="http://example.com",
+            allowed_origins="http://example.com http://example2.com http://example.io",
+        )
+
+        assert app.get_allowed_origins() == [
+            "http://example.com",
+            "http://example2.com",
+            "http://example.io",
+        ]
+
+    def test_get_allowed_origins_newline_separated(self):
+        app = ApiApplication.objects.create(
+            name="origins_test",
+            redirect_uris="http://example.com",
+            allowed_origins="http://example.com\nhttp://example2.com\nhttp://example.io",
+        )
+
+        assert app.get_allowed_origins() == [
+            "http://example.com",
+            "http://example2.com",
+            "http://example.io",
+        ]
+
+    def test_get_redirect_uris_space_separated(self):
+        app = ApiApplication.objects.create(
+            name="origins_test",
+            redirect_uris="http://example.com http://example2.com http://example.io",
+        )
+
+        assert app.get_redirect_uris() == [
+            "http://example.com",
+            "http://example2.com",
+            "http://example.io",
+        ]
+
+    def test_get_redirect_uris_newline_separated(self):
+        app = ApiApplication.objects.create(
+            name="origins_test",
+            redirect_uris="http://example.com\nhttp://example2.com\nhttp://example.io",
+        )
+
+        assert app.get_redirect_uris() == [
+            "http://example.com",
+            "http://example2.com",
+            "http://example.io",
+        ]


### PR DESCRIPTION
`allowed_origins` and `redirect_uris` are stored as character fields in our DB. I _think_ we accept both space separated and newline separated lists. This PR updates our outbound serializers to have consistent returns for these fields. 

Note that we're using this model for a new endpoint for instance level OAuth clients (i.e. to eventually allow users to sign in  to CodeCov with Sentry), but it's [also used for creating API Applications ](https://sentry.io/settings/account/api/applications/). The code for this was written 6-8 years ago, and there might be subtle side effects of this change somewhere. 

Although this passes all tests and shouldn't be breaking, I'd feel better if someone familiar with that part of our codebase/product could take a look, if anyone knows who that may be please let me know!