### PR TITLE
fix(events-facets): Increase aggregate tags limit

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -10,7 +10,6 @@ from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.search.utils import DEVICE_CLASS
 from sentry.snuba import discover
-from sentry.snuba.discover import TOP_KEYS_DEFAULT_LIMIT
 
 
 @region_silo_endpoint
@@ -31,8 +30,7 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
                         query=request.GET.get("query"),
                         params=params,
                         referrer="api.organization-events-facets.top-tags",
-                        # TODO(nar): Remove this hardcoded limit and pass in the limit from the paginator
-                        per_page=TOP_KEYS_DEFAULT_LIMIT + 1,
+                        per_page=limit,
                         cursor=offset,
                     )
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -634,7 +634,7 @@ def get_facets(
         if tag == "environment":
             # Add here tags that you want to be individual
             individual_tags.append(tag)
-        elif i >= len(top_tags) - TOP_KEYS_DEFAULT_LIMIT:
+        elif i >= len(top_tags) - per_page:
             aggregate_tags.append(tag)
         else:
             individual_tags.append(tag)
@@ -674,6 +674,8 @@ def get_facets(
                 selected_columns=["count()", "tags_key", "tags_value"],
                 orderby=["tags_key", "-count()"],
                 limitby=("tags_key", TOP_VALUES_DEFAULT_LIMIT),
+                # Increase the limit to ensure we get results for each tag
+                limit=len(aggregate_tags) * TOP_VALUES_DEFAULT_LIMIT,
                 # Ensures Snuba will not apply FINAL
                 turbo=sample_rate is not None,
                 sample_rate=sample_rate,


### PR DESCRIPTION
The default limit by the query builder is 50. We want to have at most 9 top values per tag key, but if there are tag keys with a lot of values then we can hit the query builder limit before we've actually returned values for every key, resulting in behaviour where the pages are missing results.

E.g. imagine the top 6 tag keys have >= 9 values, then we hit the 50 limit while parsing the 6th tag and our query doesn't return results for the next 4 tags.

Set the limit to the number of aggregate tags we're querying for multiplied by the tag limit to ensure we're limiting the correct amount.
