### PR TITLE
feat(dynamic-sampling): Remove recalibration for projects that are sampling at 100%

### DIFF
--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -17,7 +17,8 @@ from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
 from sentry.dynamic_sampling.tasks.helpers.sliding_window import get_sliding_window_sample_rate
 from sentry.models import Organization, Project
 
-ALWAYS_ALLOWED_RULE_TYPES = {RuleType.RECALIBRATION_RULE, RuleType.BOOST_LOW_VOLUME_PROJECTS_RULE}
+# These rules types will always be added to the generated rules, irrespectively of the base sample rate.
+ALWAYS_ALLOWED_RULE_TYPES = {RuleType.BOOST_LOW_VOLUME_PROJECTS_RULE}
 # This threshold should be in sync with the execution time of the cron job responsible for running the sliding window.
 NEW_MODEL_THRESHOLD_IN_MINUTES = 10
 

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -100,21 +100,31 @@ def test_generate_rules_capture_exception(get_blended_sample_rate, sentry_sdk):
 
 @pytest.mark.django_db
 @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
-def test_generate_rules_return_only_uniform_if_sample_rate_is_100_and_other_rules_are_enabled(
+def test_generate_rules_return_only_always_allowed_rules_if_sample_rate_is_100_and_other_rules_are_enabled(
     get_blended_sample_rate, default_old_project
 ):
     get_blended_sample_rate.return_value = 1.0
 
-    assert generate_rules(default_old_project) == [
-        {
-            "condition": {"inner": [], "op": "and"},
-            "id": 1000,
-            "samplingValue": {"type": "sampleRate", "value": 1.0},
-            "type": "trace",
-        },
-    ]
-    get_blended_sample_rate.assert_called_with(organization_id=default_old_project.organization.id)
-    _validate_rules(default_old_project)
+    # We also enable the recalibration to show it's not generated as part of the rules.
+    redis_client = get_redis_client_for_ds()
+    redis_client.set(
+        f"ds::o:{default_old_project.organization.id}:rate_rebalance_factor2",
+        0.5,
+    )
+
+    with Feature("organizations:ds-org-recalibration"):
+        assert generate_rules(default_old_project) == [
+            {
+                "condition": {"inner": [], "op": "and"},
+                "id": 1000,
+                "samplingValue": {"type": "sampleRate", "value": 1.0},
+                "type": "trace",
+            },
+        ]
+        get_blended_sample_rate.assert_called_with(
+            organization_id=default_old_project.organization.id
+        )
+        _validate_rules(default_old_project)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR removes the recalibration for projects that are sampling at 100%, since we noticed that it may cause confusion and unexpected behavior.

The main downside of such implementation is that we are not recalibrating the entire org but only projects that are sampling at < 100%. This is done under the assumption that projects with 100% sample rate have a negligible amount of traffic that should not steer the sampling rate of an org too far away from our target.