### PR TITLE
ref: remove "Explicit typing" type hacks

### DIFF
--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -239,9 +239,7 @@ def get_release_info(request: Request, group: "Group", version: str) -> Mapping[
     except Release.DoesNotExist:
         release = {"version": version}
 
-    # Explicitly typing to satisfy mypy.
-    release_ifo: Mapping[str, Any] = serialize(release, request.user)
-    return release_ifo
+    return serialize(release, request.user)
 
 
 def get_first_last_release_info(

--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -97,17 +97,13 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
             _local_cache.cache = {}
             _local_cache.generation = gen
 
-        # Explicitly typing to satisfy mypy.
-        cache_: MutableMapping[str, Any] = _local_cache.cache
-        return cache_
+        return _local_cache.cache
 
     def _get_cache(self) -> MutableMapping[str, Any]:
         if not hasattr(self.__local_cache, "value"):
             self.__local_cache.value = weakref.WeakKeyDictionary()
 
-        # Explicitly typing to satisfy mypy.
-        cache_: MutableMapping[str, Any] = self.__local_cache.value
-        return cache_
+        return self.__local_cache.value
 
     def _set_cache(self, value: Any) -> None:
         self.__local_cache.value = value
@@ -255,9 +251,7 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
         class_prepared.connect(self.__class_prepared, sender=model)
 
     def get(self, *args: Any, **kwargs: Any) -> M:
-        # Explicitly typing to satisfy mypy.
-        model: M = super().get(*args, **kwargs)
-        return model
+        return super().get(*args, **kwargs)
 
     def get_from_cache(
         self, use_replica: bool = settings.SENTRY_MODEL_CACHE_USE_REPLICA, **kwargs: Any
@@ -325,9 +319,7 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
             kwargs = {**kwargs, "replica": True} if use_replica else {**kwargs}
             retval._state.db = router.db_for_read(self.model, **kwargs)
 
-            # Explicitly typing to satisfy mypy.
-            r: M = retval
-            return r
+            return retval
         else:
             raise ValueError("We cannot cache this query. Just hit the database.")
 

--- a/src/sentry/db/models/manager/base_query_set.py
+++ b/src/sentry/db/models/manager/base_query_set.py
@@ -16,9 +16,7 @@ class BaseQuerySet(QuerySet, abc.ABC):
         Use read replica for this query. Database router is expected to use the
         `replica=True` hint to make routing decision.
         """
-        # Explicitly typing to satisfy mypy.
-        query_set: "BaseQuerySet" = self.using(router.db_for_read(self.model, replica=True))
-        return query_set
+        return self.using(router.db_for_read(self.model, replica=True))
 
     def defer(self, *args: Any, **kwargs: Any) -> "BaseQuerySet":
         raise NotImplementedError("Use ``values_list`` instead [performance].")

--- a/src/sentry/db/models/manager/option.py
+++ b/src/sentry/db/models/manager/option.py
@@ -13,9 +13,7 @@ class OptionManager(BaseManager[M]):
         if not hasattr(_local_cache, "option_cache"):
             _local_cache.option_cache = {}
 
-        # Explicitly typing to satisfy mypy.
-        option_cache: Dict[str, Dict[str, Any]] = _local_cache.option_cache
-        return option_cache
+        return _local_cache.option_cache
 
     def clear_local_cache(self, **kwargs: Any) -> None:
         self._option_cache.clear()

--- a/src/sentry/digests/__init__.py
+++ b/src/sentry/digests/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import datetime as datetime_mod
 from collections import namedtuple
-from datetime import datetime
 from typing import TYPE_CHECKING, List, MutableMapping
 
 from django.conf import settings
@@ -23,10 +23,8 @@ backend.expose(locals())
 
 class Record(namedtuple("Record", "key value timestamp")):
     @property
-    def datetime(self) -> datetime | None:
-        # Explicitly typing to satisfy mypy.
-        dt: datetime | None = to_datetime(self.timestamp)
-        return dt
+    def datetime(self) -> datetime_mod.datetime | None:
+        return to_datetime(self.timestamp)
 
 
 ScheduleEntry = namedtuple("ScheduleEntry", "key timestamp")

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -142,13 +142,11 @@ class RedisBackend(Backend):
     def __schedule_partition(
         self, host: int, deadline: float, timestamp: float
     ) -> Iterable[Tuple[bytes, float]]:
-        # Explicitly typing to satisfy mypy.
-        partitions: Iterable[Tuple[bytes, float]] = script(
+        return script(
             self.cluster.get_local_client(host),
             ["-"],
             ["SCHEDULE", self.namespace, self.ttl, timestamp, deadline],
         )
-        return partitions
 
     def schedule(
         self, deadline: float, timestamp: Optional[float] = None

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -191,9 +191,7 @@ def sort_rule_groups(rules: Mapping[str, Rule]) -> Mapping[str, Rule]:
 
 
 def check_group_state(record: Record) -> bool:
-    # Explicitly typing to satisfy mypy.
-    is_unresolved: bool = record.value.event.group.get_status() == GroupStatus.UNRESOLVED
-    return is_unresolved
+    return record.value.event.group.get_status() == GroupStatus.UNRESOLVED
 
 
 def build_digest(

--- a/src/sentry/digests/utils.py
+++ b/src/sentry/digests/utils.py
@@ -158,9 +158,7 @@ def sort_records(records: Sequence[Record]) -> Sequence[Record]:
     """Sorts records ordered from newest to oldest."""
 
     def sort_func(record: Record) -> datetime:
-        # Explicitly typing to satisfy mypy.
-        key: datetime = record.value.event.datetime
-        return key
+        return record.value.event.datetime
 
     return sorted(records, key=sort_func, reverse=True)
 

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -343,11 +343,9 @@ class IntegrationInstallation:
         )
 
     def get_config_data(self) -> Mapping[str, str]:
-        # Explicitly typing to satisfy mypy.
         if not self.org_integration:
             return {}
-        config_data: Mapping[str, str] = self.org_integration.config
-        return config_data
+        return self.org_integration.config
 
     def get_dynamic_display_information(self) -> Optional[Mapping[str, Any]]:
         return None
@@ -379,9 +377,7 @@ class IntegrationInstallation:
         if isinstance(exc, ApiUnauthorized):
             return ERR_UNAUTHORIZED
         elif isinstance(exc, ApiHostError):
-            # Explicitly typing to satisfy mypy.
-            message: str = exc.text
-            return message
+            return exc.text
         elif isinstance(exc, UnsupportedResponseType):
             return ERR_UNSUPPORTED_RESPONSE_TYPE.format(content_type=exc.content_type)
         elif isinstance(exc, ApiError):
@@ -413,9 +409,7 @@ class IntegrationInstallation:
 
     @property
     def metadata(self) -> IntegrationMetadata:
-        # Explicitly typing to satisfy mypy.
-        _metadata: IntegrationMetadata = self.model.metadata
-        return _metadata
+        return self.model.metadata
 
     def uninstall(self) -> None:
         """

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -178,44 +178,32 @@ class GitHubClientMixin(GithubProxyClient):
         see https://docs.github.com/en/rest/commits/commits#list-commits-on-a-repository
         using end_sha as parameter.
         """
-        # Explicitly typing to satisfy mypy.
-        commits: Sequence[JSONData] = self.get_cached(
-            f"/repos/{repo}/commits", params={"sha": end_sha}
-        )
-        return commits
+        return self.get_cached(f"/repos/{repo}/commits", params={"sha": end_sha})
 
     def compare_commits(self, repo: str, start_sha: str, end_sha: str) -> JSONData:
         """
         See https://docs.github.com/en/rest/commits/commits#compare-two-commits
         where start sha is oldest and end is most recent.
         """
-        # Explicitly typing to satisfy mypy.
-        diff: JSONData = self.get_cached(f"/repos/{repo}/compare/{start_sha}...{end_sha}")
-        return diff
+        return self.get_cached(f"/repos/{repo}/compare/{start_sha}...{end_sha}")
 
     def repo_hooks(self, repo: str) -> Sequence[JSONData]:
         """
         https://docs.github.com/en/rest/webhooks/repos#list-repository-webhooks
         """
-        # Explicitly typing to satisfy mypy.
-        hooks: Sequence[JSONData] = self.get(f"/repos/{repo}/hooks")
-        return hooks
+        return self.get(f"/repos/{repo}/hooks")
 
     def get_commits(self, repo: str) -> Sequence[JSONData]:
         """
         https://docs.github.com/en/rest/commits/commits#list-commits
         """
-        # Explicitly typing to satisfy mypy.
-        commits: Sequence[JSONData] = self.get(f"/repos/{repo}/commits")
-        return commits
+        return self.get(f"/repos/{repo}/commits")
 
     def get_commit(self, repo: str, sha: str) -> JSONData:
         """
         https://docs.github.com/en/rest/commits/commits#get-a-commit
         """
-        # Explicitly typing to satisfy mypy.
-        commit: JSONData = self.get_cached(f"/repos/{repo}/commits/{sha}")
-        return commit
+        return self.get_cached(f"/repos/{repo}/commits/{sha}")
 
     def get_pullrequest_from_commit(self, repo: str, sha: str) -> JSONData:
         """
@@ -230,9 +218,7 @@ class GitHubClientMixin(GithubProxyClient):
         """
         https://docs.github.com/en/rest/repos/repos#get-a-repository
         """
-        # Explicitly typing to satisfy mypy.
-        repository: JSONData = self.get(f"/repos/{repo}")
-        return repository
+        return self.get(f"/repos/{repo}")
 
     # https://docs.github.com/en/rest/rate-limit?apiVersion=2022-11-28
     def get_rate_limit(self, specific_resource: str = "core") -> GithubRateLimitInfo:
@@ -466,8 +452,7 @@ class GitHubClientMixin(GithubProxyClient):
         """
         # XXX: In order to speed up this function we will need to parallelize this
         # Use ThreadPoolExecutor; see src/sentry/utils/snuba.py#L358
-        # Explicitly typing to satisfy mypy.
-        repos: JSONData = self.get_with_pagination(
+        repos = self.get_with_pagination(
             "/installation/repositories",
             response_key="repositories",
             page_number_limit=self.page_number_limit if fetch_max_pages else 1,
@@ -482,19 +467,13 @@ class GitHubClientMixin(GithubProxyClient):
 
         https://docs.github.com/en/rest/search#search-repositories
         """
-        # Explicitly typing to satisfy mypy.
-        repositories: Mapping[str, Sequence[JSONData]] = self.get(
-            "/search/repositories", params={"q": query}
-        )
-        return repositories
+        return self.get("/search/repositories", params={"q": query})
 
     def get_assignees(self, repo: str) -> Sequence[JSONData]:
         """
         https://docs.github.com/en/rest/issues/assignees#list-assignees
         """
-        # Explicitly typing to satisfy mypy.
-        assignees: Sequence[JSONData] = self.get_with_pagination(f"/repos/{repo}/assignees")
-        return assignees
+        return self.get_with_pagination(f"/repos/{repo}/assignees")
 
     def get_with_pagination(
         self, path: str, response_key: str | None = None, page_number_limit: int | None = None
@@ -556,11 +535,7 @@ class GitHubClientMixin(GithubProxyClient):
         """
         https://docs.github.com/en/rest/search?#search-issues-and-pull-requests
         """
-        # Explicitly typing to satisfy mypy.
-        issues: Mapping[str, Sequence[Mapping[str, Any]]] = self.get(
-            "/search/issues", params={"q": query}
-        )
-        return issues
+        return self.get("/search/issues", params={"q": query})
 
     def get_issue(self, repo: str, number: str) -> JSONData:
         """

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -84,7 +84,6 @@ class GitHubRepositoryProvider(IntegrationRepositoryProvider):
             return eval_commits(client)
         except Exception as e:
             installation.raise_error(e)
-            # Explicitly typing to satisfy mypy.
             return []
 
     def _format_commits(
@@ -142,6 +141,4 @@ class GitHubRepositoryProvider(IntegrationRepositoryProvider):
         return f"{repo.url}/pull/{pull_request.key}"
 
     def repository_external_slug(self, repo: Repository) -> str:
-        # Explicitly typing to satisfy mypy.
-        slug: str = repo.name
-        return slug
+        return repo.name

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -189,14 +189,10 @@ class PushEventWebhook(Webhook):
         return f"github:{username}"
 
     def get_idp_external_id(self, integration: RpcIntegration, host: str | None = None) -> str:
-        # Explicitly typing to satisfy mypy.
-        external_id: str = options.get("github-app.id")
-        return external_id
+        return options.get("github-app.id")
 
     def should_ignore_commit(self, commit: Mapping[str, Any]) -> bool:
-        # Explicitly typing to satisfy mypy.
-        should_ignore: bool = GitHubRepositoryProvider.should_ignore_commit(commit["message"])
-        return should_ignore
+        return GitHubRepositoryProvider.should_ignore_commit(commit["message"])
 
     def _handle(
         self,
@@ -350,9 +346,7 @@ class PullRequestEventWebhook(Webhook):
         return f"github:{username}"
 
     def get_idp_external_id(self, integration: RpcIntegration, host: str | None = None) -> str:
-        # Explicitly typing to satisfy mypy.
-        external_id: str = options.get("github-app.id")
-        return external_id
+        return options.get("github-app.id")
 
     def _handle(
         self,
@@ -454,9 +448,7 @@ class GitHubWebhookBase(Endpoint):
             raise NotImplementedError(f"signature method {method} is not supported")
         expected = hmac.new(key=secret.encode("utf-8"), msg=body, digestmod=mod).hexdigest()
 
-        # Explicitly typing to satisfy mypy.
-        is_valid: bool = constant_time_compare(expected, signature)
-        return is_valid
+        return constant_time_compare(expected, signature)
 
     @method_decorator(csrf_exempt)  # type: ignore
     def dispatch(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
@@ -539,9 +531,7 @@ class GitHubIntegrationsWebhookEndpoint(GitHubWebhookBase):
         return super().dispatch(request, *args, **kwargs)
 
     def get_secret(self) -> str | None:
-        # Explicitly typing to satisfy mypy.
-        secret: str = options.get("github-app.webhook-secret")
-        return secret
+        return options.get("github-app.webhook-secret")
 
     def post(self, request: Request) -> HttpResponse:
         return self.handle(request)

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -54,9 +54,7 @@ def build_attachment_title(obj: Group | GroupEvent) -> str:
             if event is not None and event.occurrence is not None:
                 title = event.occurrence.issue_title
 
-    # Explicitly typing to satisfy mypy.
-    title_str: str = title
-    return title_str
+    return title
 
 
 def get_title_link(
@@ -79,9 +77,7 @@ def get_title_link(
     else:
         url = group.get_absolute_url(params={"referrer": EXTERNAL_PROVIDERS[provider]})
 
-    # Explicitly typing to satisfy mypy.
-    url_str: str = url
-    return url_str
+    return url
 
 
 def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any | None:
@@ -111,9 +107,7 @@ def build_rule_url(rule: Any, group: Group, project: Project) -> str:
     project_slug = project.slug
     rule_url = f"/organizations/{org_slug}/alerts/rules/{project_slug}/{rule.id}/details/"
 
-    # Explicitly typing to satisfy mypy.
-    url: str = absolute_uri(rule_url)
-    return url
+    return absolute_uri(rule_url)
 
 
 def build_footer(

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -176,9 +176,7 @@ class SlackRequest:
         if not (signature and timestamp):
             return False
 
-        # Explicitly typing to satisfy mypy.
-        valid: bool = check_signing_secret(signing_secret, self.request.body, timestamp, signature)
-        return valid
+        return check_signing_secret(signing_secret, self.request.body, timestamp, signature)
 
     def _check_verification_token(self, verification_token: str) -> bool:
         return self.data.get("token") == verification_token

--- a/src/sentry/integrations/slack/utils/rule_status.py
+++ b/src/sentry/integrations/slack/utils/rule_status.py
@@ -63,6 +63,4 @@ class RedisRuleStatus:
         elif status == "failed":
             value["error"] = SLACK_FAILED_MESSAGE
 
-        # Explicitly typing to satisfy mypy.
-        _value: str = json.dumps(value)
-        return _value
+        return json.dumps(value)

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -124,9 +124,7 @@ def _is_message(data: Mapping[str, Any]) -> bool:
     XXX(epurkhiser): Used in coordination with construct_reply.
      Bot posted messages will not have the type at all.
     """
-    # Explicitly typing to satisfy mypy.
-    is_message: bool = data.get("original_message", {}).get("type") == "message"
-    return is_message
+    return data.get("original_message", {}).get("type") == "message"
 
 
 @region_silo_endpoint

--- a/src/sentry/integrations/slack/webhooks/command.py
+++ b/src/sentry/integrations/slack/webhooks/command.py
@@ -34,15 +34,13 @@ INSUFFICIENT_ROLE_MESSAGE = "You must be a Sentry admin, manager, or owner to li
 
 def is_team_linked_to_channel(organization: Organization, slack_request: SlackDMRequest) -> bool:
     """Check if a Slack channel already has a team linked to it"""
-    # Explicitly typing to satisfy mypy.
-    is_linked: bool = ExternalActor.objects.filter(
+    return ExternalActor.objects.filter(
         organization_id=organization.id,
         integration_id=slack_request.integration.id,
         provider=ExternalProviders.SLACK.value,
         external_name=slack_request.channel_name,
         external_id=slack_request.channel_id,
     ).exists()
-    return is_linked
 
 
 @region_silo_endpoint

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -275,9 +275,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             return {"stateFilter": "WellFormed", "$skip": offset, "$top": page_size}
 
         def get_results(resp: Response) -> Sequence[Any]:
-            # Explicitly typing to satisfy mypy.
-            results: Sequence[Any] = resp["value"]
-            return results
+            return resp["value"]
 
         return self.get_with_pagination(
             VstsApiPath.projects.format(instance=instance),

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -320,18 +320,14 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
 
     @property
     def instance(self) -> str:
-        # Explicitly typing to satisfy mypy.
-        instance_: str = self.model.metadata["domain_name"]
-        return instance_
+        return self.model.metadata["domain_name"]
 
     @property
     def default_project(self) -> str | None:
         try:
-            # Explicitly typing to satisfy mypy.
-            default_project_: str = self.model.metadata["default_project"]
+            return self.model.metadata["default_project"]
         except KeyError:
             return None
-        return default_project_
 
 
 class VstsIntegrationProvider(IntegrationProvider):
@@ -499,9 +495,7 @@ class VstsIntegrationProvider(IntegrationProvider):
                 },
             )
         if response.status_code == 200:
-            # Explicitly typing to satisfy mypy.
-            location_url: str | None = response.json()["locationUrl"]
-            return location_url
+            return response.json()["locationUrl"]
 
         logger.info("vsts.get_base_url", extra={"responseCode": response.status_code})
         return None

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -128,6 +128,4 @@ class VstsRepositoryProvider(IntegrationRepositoryProvider):
         ]
 
     def repository_external_slug(self, repo: Repository) -> str:
-        # Explicitly typing to satisfy mypy.
-        external_id: str = repo.external_id
-        return external_id
+        return repo.external_id

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -41,12 +41,10 @@ def get_headers(notification: BaseNotification) -> Mapping[str, Any]:
 
 
 def build_subject_prefix(project: Project) -> str:
-    # Explicitly typing to satisfy mypy.
-    subject_prefix: str = force_text(
+    return force_text(
         ProjectOption.objects.get_value(project, "mail:subject_prefix")
         or options.get("mail.subject-prefix")
     )
-    return subject_prefix
 
 
 def get_subject_with_prefix(

--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -63,9 +63,7 @@ class OrganizationOptionManager(OptionManager["Organization"]):
             else:
                 self._option_cache[cache_key] = result
 
-        # Explicitly typing to satisfy mypy.
-        values: Mapping[str, Value] = self._option_cache.get(cache_key, {})
-        return values
+        return self._option_cache.get(cache_key, {})
 
     def reload_cache(self, organization_id: int, update_reason: str) -> Mapping[str, Value]:
         from sentry.tasks.relay import schedule_invalidate_project_config

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -97,9 +97,7 @@ class ProjectOptionManager(OptionManager["Project"]):
         inst, created = self.create_or_update(project=project, key=key, values={"value": value})
         self.reload_cache(project.id, "projectoption.set_value")
 
-        # Explicitly typing to satisfy mypy.
-        success: bool = created or inst > 0
-        return success
+        return created or inst > 0
 
     def get_all_values(self, project: Project) -> Mapping[str, Value]:
         if isinstance(project, models.Model):
@@ -115,9 +113,7 @@ class ProjectOptionManager(OptionManager["Project"]):
             else:
                 self._option_cache[cache_key] = result
 
-        # Explicitly typing to satisfy mypy.
-        values: Mapping[str, Value] = self._option_cache.get(cache_key, {})
-        return values
+        return self._option_cache.get(cache_key, {})
 
     def reload_cache(self, project_id: int, update_reason: str) -> Mapping[str, Value]:
         from sentry.tasks.relay import schedule_invalidate_project_config

--- a/src/sentry/models/options/user_option.py
+++ b/src/sentry/models/options/user_option.py
@@ -34,9 +34,7 @@ class UserOptionManager(OptionManager["User"]):
         else:
             metakey = f"{uid}:user"
 
-        # Explicitly typing to satisfy mypy.
-        key: str = super()._make_key(metakey)
-        return key
+        return super()._make_key(metakey)
 
     def get_value(
         self, user: User | RpcUser, key: str, default: Value | None = None, **kwargs: Any
@@ -122,9 +120,7 @@ class UserOptionManager(OptionManager["User"]):
             }
             self._option_cache[metakey] = result
 
-        # Explicitly typing to satisfy mypy.
-        values: Mapping[str, Value] = self._option_cache.get(metakey, {})
-        return values
+        return self._option_cache.get(metakey, {})
 
     def post_save(self, instance: UserOption, **kwargs: Any) -> None:
         self.get_all_values(

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -507,7 +507,6 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
 
         assert key_field, "Could not resolve key_field"
 
-        # Explicitly typing to satisfy mypy.
         team_ids: Set[int] = set()
         user_ids: Set[int] = set()
         if isinstance(recipient, RpcActor):
@@ -517,7 +516,7 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
         elif isinstance(recipient, User):
             user_ids.add(recipient.id)
 
-        has_settings: bool = (
+        return (
             self._filter(provider=provider, team_ids=team_ids, user_ids=user_ids)
             .filter(
                 value__in={
@@ -529,7 +528,6 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
             )
             .exists()
         )
-        return has_settings
 
     def enable_settings_for_user(
         self,

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -257,11 +257,8 @@ class ProjectNotification(BaseNotification, abc.ABC):
         super().__init__(project.organization)
 
     def get_project_link(self) -> str:
-        # Explicitly typing to satisfy mypy.
-        return str(
-            self.organization.absolute_url(
-                f"/organizations/{self.organization.slug}/projects/{self.project.slug}/"
-            )
+        return self.organization.absolute_url(
+            f"/organizations/{self.organization.slug}/projects/{self.project.slug}/"
         )
 
     def get_log_params(self, recipient: RpcActor) -> Mapping[str, Any]:

--- a/src/sentry/notifications/notifications/user_report.py
+++ b/src/sentry/notifications/notifications/user_report.py
@@ -39,7 +39,6 @@ class UserReportNotification(ProjectNotification):
         return result
 
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
-        # Explicitly typing to satisfy mypy.
         message = f"{self.group.qualified_short_id} - New Feedback from {self.report['name']}"
         message = force_text(message)
         return message

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -201,11 +201,8 @@ def get_group_settings_link(
 
 
 def get_integration_link(organization: Organization, integration_slug: str) -> str:
-    # Explicitly typing to satisfy mypy.
-    return str(
-        organization.absolute_url(
-            f"/settings/{organization.slug}/integrations/{integration_slug}/?referrer=alert_email"
-        )
+    return organization.absolute_url(
+        f"/settings/{organization.slug}/integrations/{integration_slug}/?referrer=alert_email"
     )
 
 

--- a/src/sentry/notifications/utils/digest.py
+++ b/src/sentry/notifications/utils/digest.py
@@ -32,9 +32,7 @@ def should_send_as_alert_notification(context: Mapping[str, Any]) -> bool:
 
 
 def get_timestamp(record_param: Any) -> float:
-    # Explicitly typing to satisfy mypy.
-    time: float = record_param.timestamp
-    return time
+    return record_param.timestamp
 
 
 def send_as_alert_notification(

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -44,9 +44,7 @@ class IntegrationRepositoryProvider:
             provider=self.repo_provider,
         )
 
-        # Explicitly typing to satisfy mypy.
-        installation: IntegrationInstallation = integration_model.get_installation(organization_id)
-        return installation
+        return integration_model.get_installation(organization_id)
 
     def dispatch(self, request: Request, organization, **kwargs):
         try:

--- a/src/sentry/utils/email/send.py
+++ b/src/sentry/utils/email/send.py
@@ -14,8 +14,7 @@ logger = logging.getLogger("sentry.mail")
 
 def send_messages(messages: Sequence[EmailMultiAlternatives], fail_silently: bool = False) -> int:
     connection = get_connection(fail_silently=fail_silently)
-    # Explicitly typing to satisfy mypy.
-    sent: int = connection.send_messages(messages)
+    sent = connection.send_messages(messages)
     metrics.incr("email.sent", sent, skip_internal=False, tags={"success": True})
     failed = len(messages) - sent
     if failed > 0:
@@ -57,8 +56,7 @@ def send_mail(
     Wrapper that forces sending mail through our connection.
     Uses EmailMessage class which has more options than the simple send_mail
     """
-    # Explicitly typing to satisfy mypy.
-    sent: int = mail.EmailMessage(
+    return mail.EmailMessage(
         subject,
         message,
         from_email,
@@ -66,4 +64,3 @@ def send_mail(
         connection=get_connection(fail_silently=fail_silently),
         **kwargs,
     ).send(fail_silently=fail_silently)
-    return sent

--- a/src/sentry/utils/email/signer.py
+++ b/src/sentry/utils/email/signer.py
@@ -18,9 +18,7 @@ class _CaseInsensitiveSigner(Signer):
     """
 
     def signature(self, value: str) -> str:
-        # Explicitly typing to satisfy mypy.
-        sig: str = super().signature(value)
-        return sig.lower()
+        return super().signature(value).lower()
 
     def unsign(self, signed_value: str) -> str:
         # This `unsign` is identical to subclass except for the lower-casing
@@ -32,6 +30,4 @@ class _CaseInsensitiveSigner(Signer):
         if not constant_time_compare(sig.lower(), self.signature(value)):
             raise BadSignature(f'Signature "{sig}" does not match')
 
-        # Explicitly typing to satisfy mypy.
-        val: str = force_text(value)
-        return val
+        return force_text(value)

--- a/src/sentry/utils/pipeline.py
+++ b/src/sentry/utils/pipeline.py
@@ -32,8 +32,7 @@ class Pipeline:
         self.logs: MutableSequence[str] = []
 
     def __call__(self, sequence: Sequence[Any]) -> tuple[Any, Sequence[str]]:
-        # Explicitly typing to satisfy mypy.
-        func: Callable[[Any, Callable[[Any], Any]], Any] = lambda x, operation: operation(x)
+        func = lambda x, operation: operation(x)
         return reduce(func, self.operations, sequence), self.logs
 
     def _log(self, message: str) -> None:


### PR DESCRIPTION
these were almost entirely incorrect -- this patch doesn't change the unfiltered error count -- just adjust some of the error messages such as:

```diff
-src/sentry/integrations/vsts/repository.py:###: error: Incompatible types in assignment (expression has type "Optional[str]", variable has type "str")  [assignment]
+src/sentry/integrations/vsts/repository.py:###: error: Incompatible return value type (got "Optional[str]", expected "str")  [return-value]
```