### PR TITLE
feat(js): Track whether frames are symbolicated

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -50,12 +50,14 @@ def _merge_frame(new_frame, symbolicated):
         new_frame["context_line"] = symbolicated["context_line"]
     if symbolicated.get("post_context"):
         new_frame["post_context"] = symbolicated["post_context"]
-    if symbolicated.get("data"):
+    if data := symbolicated.get("data"):
         frame_meta = new_frame.setdefault("data", {})
-        if data_sourcemap := get_path(symbolicated, "data", "sourcemap"):
+        if data_sourcemap := data.get("sourcemap"):
             frame_meta["sourcemap"] = data_sourcemap
-        if data_resolved_with := get_path(symbolicated, "data", "resolved_with"):
+        if data_resolved_with := data.get("resolved_with"):
             frame_meta["resolved_with"] = data_resolved_with
+        if data.get("symbolicated") is not None:
+            frame_meta["symbolicated"] = data["symbolicated"]
     if symbolicated.get("module"):
         new_frame["module"] = symbolicated["module"]
     if symbolicated.get("in_app") is not None:

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -519,6 +519,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[0]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release-old"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
         expected = "\treturn a + b; // fôo"
         assert frame.context_line == expected
@@ -803,6 +804,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[0]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release-old"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
         expected = "\treturn a + b; // fôo"
         assert frame.context_line == expected
@@ -872,6 +874,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[0]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release-old"
+            assert frame.data["symbolicated"]
         assert frame.abs_path == "app:///nofiles.js"
         assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a + b; // fôo"
@@ -945,6 +948,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[0]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release-old"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
 
         expected = "\treturn a + b; // fôo"
@@ -976,6 +980,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[1]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release-old"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function multiply(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a * b;"
         assert frame.post_context == [
@@ -1131,6 +1136,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[0]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release-old"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a + b; // fôo"
         if process_with_symbolicator:
@@ -1141,6 +1147,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[1]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release-old"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function multiply(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a * b;"
         assert frame.post_context == [
@@ -1296,6 +1303,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[0]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release-old"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a + b; // fôo"
         if process_with_symbolicator:
@@ -1306,6 +1314,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[1]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release-old"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function multiply(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a * b;"
         assert frame.post_context == [
@@ -1653,6 +1662,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[0]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release-old"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a + b; // fôo"
         if process_with_symbolicator:
@@ -1663,6 +1673,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[1]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release-old"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function multiply(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a * b;"
         assert frame.post_context == [
@@ -2125,6 +2136,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[0]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "debug-id"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a + b; // fôo"
         if process_with_symbolicator:
@@ -2135,6 +2147,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[1]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "debug-id"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function multiply(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a * b;"
         assert frame.post_context == [
@@ -2148,6 +2161,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[2]
         if process_with_symbolicator:
             assert "resolved_with" not in frame.data
+            assert "symbolicated" not in frame.data
         assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a + b; // fôo"
         if process_with_symbolicator:
@@ -2296,6 +2310,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
             frame = frame_list[0]
             if process_with_symbolicator:
                 assert frame.data["resolved_with"] == "debug-id"
+                assert frame.data["symbolicated"]
             assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
             assert frame.context_line == "\treturn a + b; // fôo"
             if process_with_symbolicator:
@@ -2306,6 +2321,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
             frame = frame_list[1]
             if process_with_symbolicator:
                 assert frame.data["resolved_with"] == "debug-id"
+                assert frame.data["symbolicated"]
             assert frame.pre_context == ["function multiply(a, b) {", '\t"use strict";']
             assert frame.context_line == "\treturn a * b;"
             assert frame.post_context == [
@@ -2731,6 +2747,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[0]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a + b; // fôo"
         if process_with_symbolicator:
@@ -2741,6 +2758,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame = frame_list[1]
         if process_with_symbolicator:
             assert frame.data["resolved_with"] == "release"
+            assert frame.data["symbolicated"]
         assert frame.pre_context == ["function multiply(a, b) {", '\t"use strict";']
         assert frame.context_line == "\treturn a * b;"
         assert frame.post_context == [
@@ -2887,6 +2905,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
             frame = frame_list[0]
             if process_with_symbolicator:
                 assert frame.data["resolved_with"] == "release"
+                assert frame.data["symbolicated"]
             assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
             assert frame.context_line == "\treturn a + b; // fôo"
             if process_with_symbolicator:
@@ -2897,6 +2916,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
             frame = frame_list[1]
             if process_with_symbolicator:
                 assert frame.data["resolved_with"] == "release"
+                assert frame.data["symbolicated"]
             assert frame.pre_context == ["function multiply(a, b) {", '\t"use strict";']
             assert frame.context_line == "\treturn a * b;"
             assert frame.post_context == [


### PR DESCRIPTION
This merges the `symbolicated` flag from the response returned by Symbolicator into the new frame.

The tests are dependent on https://github.com/getsentry/symbolicator/pull/1225.