### PR TITLE
metric(save_event): Track number of errors processed by platform

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -443,12 +443,15 @@ class EventManager:
 
             return jobs[0]["event"]
 
+        # Only error events from this point onward
         with metrics.timer("event_manager.save.organization.get_from_cache"):
             project.set_cached_field_value(
                 "organization", Organization.objects.get_from_cache(id=project.organization_id)
             )
 
         jobs = [job]
+        # This metric can be used to track how many error events there are per platform
+        metrics.incr("save_event.error", tags={"platform": job["event"].platform or "unknown"})
 
         is_reprocessed = is_reprocessed_event(job["data"])
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -450,13 +450,14 @@ class EventManager:
             )
 
         jobs = [job]
-        # This metric can be used to track how many error events there are per platform
-        metrics.incr("save_event.error", tags={"platform": job["event"].platform or "unknown"})
 
         is_reprocessed = is_reprocessed_event(job["data"])
 
         with sentry_sdk.start_span(op="event_manager.save.pull_out_data"):
             _pull_out_data(jobs, projects)
+
+        # This metric can be used to track how many error events there are per platform
+        metrics.incr("save_event.error", tags={"platform": job["event"].platform or "unknown"})
 
         with sentry_sdk.start_span(op="event_manager.save.get_or_create_release_many"):
             _get_or_create_release_many(jobs, projects)


### PR DESCRIPTION
This will help with tracking the ratio of group creation to errors processed per platform.

Fixes #51522 