### PR TITLE
test(ui): Prevent tooltip removed test flake

### DIFF
--- a/static/app/components/tooltip.spec.tsx
+++ b/static/app/components/tooltip.spec.tsx
@@ -1,9 +1,4 @@
-import {
-  render,
-  screen,
-  userEvent,
-  waitForElementToBeRemoved,
-} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {Tooltip} from 'sentry/components/tooltip';
 
@@ -57,7 +52,9 @@ describe('Tooltip', function () {
     expect(screen.getByText('bar')).toBeInTheDocument();
 
     await userEvent.unhover(screen.getByText('My Button'));
-    await waitForElementToBeRemoved(() => screen.queryByText('bar'));
+    await waitFor(() => {
+      expect(screen.queryByText('bar')).not.toBeInTheDocument();
+    });
   });
 
   it('disables and does not render', async function () {


### PR DESCRIPTION
Since we've turned off the animations the element could be removed before react testing library sees the element causing it to flake. https://sentry.sentry.io/issues/3146109922/
