### PR TITLE
ref(integrations): Add `endpoints` and `views` folders in module docstring

### DIFF
--- a/src/sentry/integrations/__init__.py
+++ b/src/sentry/integrations/__init__.py
@@ -7,9 +7,14 @@ Notifications, and Stacktrace Linking. No models are defined in this module.
 You should expect each provider to have its own module with the following files:
     - actions/          Alert Rule Action definitions.
     - client.py         Custom APIClient for the provider.
+    - endpoints/        REST API endpoints.
     - integration.py    All of the business logic. Implements the IntegrationInstallation interface.
     - urls.py           Map externally facing URLs to the webhooks defined below.
-    - webhooks/         Endpoints that the providers can hook into to perform actions.
+    - views/            If applicable, HTML views to be displayed either in Sentry or in a Sentry widget
+                        in the provider's UI.
+    - webhooks/         Endpoints that the providers can hook into to perform actions or notify Sentry of
+                        events occurring on the provider's end (like a user uninstalling the Sentry
+                        integration from their instance of the provider).
 
 For more Integrations code, see also:
     - src/sentry/models/integrations/


### PR DESCRIPTION
This updates the docstring for the `integrations` module to mention folders for endpoints and views, separate from the `webhooks` folder.