### PR TITLE
ref(alerts): Update alert limit error message

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -85,12 +85,20 @@ class ProjectRulesEndpoint(ProjectEndpoint):
 
         if slow_rules >= settings.MAX_SLOW_CONDITION_ISSUE_ALERTS:
             return Response(
-                f"You may not exceed {settings.MAX_SLOW_CONDITION_ISSUE_ALERTS} 'slow' rules per project.",
+                {
+                    "conditions": [
+                        f"You may not exceed {settings.MAX_SLOW_CONDITION_ISSUE_ALERTS} rules with this type of condition per project.",
+                    ]
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
         if (len(rules) - slow_rules) >= settings.MAX_FAST_CONDITION_ISSUE_ALERTS:
             return Response(
-                f"You may not exceed {settings.MAX_FAST_CONDITION_ISSUE_ALERTS} 'fast' rules per project.",
+                {
+                    "conditions": [
+                        f"You may not exceed {settings.MAX_FAST_CONDITION_ISSUE_ALERTS} rules with this type of condition per project.",
+                    ]
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -207,7 +207,10 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             conditions=conditions,
             status_code=status.HTTP_400_BAD_REQUEST,
         )
-        assert resp.data == "You may not exceed 1 'fast' rules per project."
+        assert (
+            resp.data["conditions"][0]
+            == "You may not exceed 1 rules with this type of condition per project."
+        )
         # Make sure pending deletions don't affect the process
         Rule.objects.filter(project=self.project).update(status=RuleStatus.PENDING_DELETION)
         self.run_test(conditions=conditions, actions=actions)
@@ -237,7 +240,10 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             conditions=conditions,
             status_code=status.HTTP_400_BAD_REQUEST,
         )
-        assert resp.data == "You may not exceed 1 'slow' rules per project."
+        assert (
+            resp.data["conditions"][0]
+            == "You may not exceed 1 rules with this type of condition per project."
+        )
         # Make sure pending deletions don't affect the process
         Rule.objects.filter(project=self.project).update(status=RuleStatus.PENDING_DELETION)
         self.run_test(conditions=conditions, actions=actions)


### PR DESCRIPTION
Update the copy and set it to `conditions` so the front end can display the error message w/ a link to the [docs](https://github.com/getsentry/sentry-docs/pull/7259/) that explain in more depth. 