### PR TITLE
fix(tag-summary): Ignore 400 error codes

### DIFF
--- a/static/app/views/discover/tags.tsx
+++ b/static/app/views/discover/tags.tsx
@@ -115,7 +115,11 @@ class Tags extends Component<Props, State> {
       }
       this.setState({loading: false, hasLoaded: true, tags, hasMore, nextCursor: cursor});
     } catch (err) {
-      if (err.status !== 400) {
+      if (
+        err.status !== 400 &&
+        err.responseJSON.detail !==
+          'Invalid date range. Please try a more recent date range.'
+      ) {
         Sentry.captureException(err);
       }
       this.setState({loading: false, error: err});

--- a/static/app/views/discover/tags.tsx
+++ b/static/app/views/discover/tags.tsx
@@ -115,7 +115,9 @@ class Tags extends Component<Props, State> {
       }
       this.setState({loading: false, hasLoaded: true, tags, hasMore, nextCursor: cursor});
     } catch (err) {
-      Sentry.captureException(err);
+      if (err.status !== 400) {
+        Sentry.captureException(err);
+      }
       this.setState({loading: false, error: err});
     }
   };


### PR DESCRIPTION
Ignores 400 errors due to invalid date ranges. This error is expected for users accessing date ranges out of the retention period or other invalid dates.