### PR TITLE
fix(HC): Adds the postgres role override to org mapping updates

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -61,10 +61,11 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
 
     def update(self, organization_id: int, update: RpcOrganizationMappingUpdate) -> None:
         # TODO: REMOVE FROM GETSENTRY!
-        try:
-            OrganizationMapping.objects.get(organization_id=organization_id).update(**update)
-        except OrganizationMapping.DoesNotExist:
-            pass
+        with in_test_psql_role_override("postgres"):
+            try:
+                OrganizationMapping.objects.get(organization_id=organization_id).update(**update)
+            except OrganizationMapping.DoesNotExist:
+                pass
 
     def upsert(
         self, organization_id: int, update: RpcOrganizationMappingUpdate


### PR DESCRIPTION
Temporarily enabling this as an allowed method of updating organization mappings while I prep to replace these calls with an outbox for customer IDs in the future.