### PR TITLE
feat(crons): Add datetime with timezone tooltip to monitors with configured timezone

### DIFF
--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -72,10 +72,6 @@ function MonitorCheckIns({monitor, monitorEnvs, orgId}: Props) {
   const generateDownloadUrl = (checkin: CheckIn) =>
     `/api/0/organizations/${orgId}/monitors/${monitor.slug}/checkins/${checkin.id}/attachment/`;
 
-  const renderDateTime = (date: string, timezone?: string) => (
-    <DateTime date={date} forcedTimezone={timezone} timeZone={!!timezone} timeOnly />
-  );
-
   const emptyCell = <Text>{'\u2014'}</Text>;
 
   return (
@@ -105,12 +101,19 @@ function MonitorCheckIns({monitor, monitorEnvs, orgId}: Props) {
               <div>
                 {monitor.config.timezone ? (
                   <Tooltip
-                    title={renderDateTime(checkIn.dateCreated, monitor.config.timezone)}
+                    title={
+                      <DateTime
+                        date={checkIn.dateCreated}
+                        forcedTimezone={monitor.config.timezone}
+                        timeZone
+                        timeOnly
+                      />
+                    }
                   >
-                    {renderDateTime(checkIn.dateCreated)}
+                    {<DateTime date={checkIn.dateCreated} timeOnly />}
                   </Tooltip>
                 ) : (
-                  renderDateTime(checkIn.dateCreated)
+                  <DateTime date={checkIn.dateCreated} timeOnly />
                 )}
               </div>
             ) : (

--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -11,6 +11,7 @@ import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels';
 import StatusIndicator from 'sentry/components/statusIndicator';
 import Text from 'sentry/components/text';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconDownload} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {defined} from 'sentry/utils';
@@ -71,6 +72,10 @@ function MonitorCheckIns({monitor, monitorEnvs, orgId}: Props) {
   const generateDownloadUrl = (checkin: CheckIn) =>
     `/api/0/organizations/${orgId}/monitors/${monitor.slug}/checkins/${checkin.id}/attachment/`;
 
+  const renderDateTime = (date: string, timezone?: string) => (
+    <DateTime date={date} forcedTimezone={timezone} timeZone={!!timezone} timeOnly />
+  );
+
   const emptyCell = <Text>{'\u2014'}</Text>;
 
   return (
@@ -97,7 +102,17 @@ function MonitorCheckIns({monitor, monitorEnvs, orgId}: Props) {
               <Text>{statusToText[checkIn.status]}</Text>
             </Status>
             {checkIn.status !== CheckInStatus.MISSED ? (
-              <DateTime date={checkIn.dateCreated} timeOnly />
+              <div>
+                {monitor.config.timezone ? (
+                  <Tooltip
+                    title={renderDateTime(checkIn.dateCreated, monitor.config.timezone)}
+                  >
+                    {renderDateTime(checkIn.dateCreated)}
+                  </Tooltip>
+                ) : (
+                  renderDateTime(checkIn.dateCreated)
+                )}
+              </div>
             ) : (
               emptyCell
             )}


### PR DESCRIPTION
In response to customer feedback complaining that monitor check-in times weren't respecting the configured timezone and thus became hard to read.

<img width="916" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/7364db49-e4ed-481f-9e07-ae84ce11a372">
