### PR TITLE
ref(crons): Move timeline component into overviewTimeline/

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/checkInTimeline.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/checkInTimeline.tsx
@@ -2,15 +2,13 @@ import styled from '@emotion/styled';
 
 import {Resizeable} from 'sentry/components/replays/resizeable';
 import {space} from 'sentry/styles/space';
-import {JobTickTooltip} from 'sentry/views/monitors/components/overviewTimeline/jobTickTooltip';
-import {
-  MonitorBucketData,
-  TimeWindow,
-} from 'sentry/views/monitors/components/overviewTimeline/types';
 import {CheckInStatus} from 'sentry/views/monitors/types';
 import {getColorsFromStatus} from 'sentry/views/monitors/utils';
 import {getAggregateStatus} from 'sentry/views/monitors/utils/getAggregateStatus';
 import {mergeBuckets} from 'sentry/views/monitors/utils/mergeBuckets';
+
+import {JobTickTooltip} from './jobTickTooltip';
+import {MonitorBucketData, TimeWindow} from './types';
 
 interface Props {
   bucketedData: MonitorBucketData;

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -11,7 +11,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
-import {CheckInTimeline} from 'sentry/views/monitors/components/checkInTimeline';
+import {CheckInTimeline} from 'sentry/views/monitors/components/overviewTimeline/checkInTimeline';
 import {
   GridLineOverlay,
   GridLineTimeLabels,


### PR DESCRIPTION
Makes sense for this component to reside here, along with its dependent components.