### PR TITLE
feat(alerts): add link for docs for over limit errors

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1,4 +1,4 @@
-import {ChangeEvent, ReactNode} from 'react';
+import {ChangeEvent, Fragment, ReactNode} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import {components} from 'react-select';
 import styled from '@emotion/styled';
@@ -1265,6 +1265,16 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                             this.hasError('conditions') && (
                               <StyledAlert type="error">
                                 {detailedError?.conditions[0]}
+                                {(detailedError?.conditions[0] || '').startsWith(
+                                  'You may not exceed'
+                                ) && (
+                                  <Fragment>
+                                    {' '}
+                                    <ExternalLink href="https://docs.sentry.io/product/alerts/create-alerts/#alert-limits">
+                                      {t('View Docs')}
+                                    </ExternalLink>
+                                  </Fragment>
+                                )}
                               </StyledAlert>
                             )
                           }


### PR DESCRIPTION
<img width="1160" alt="Screen Shot 2023-06-26 at 10 50 21 AM" src="https://github.com/getsentry/sentry/assets/8533851/37f0f28c-1936-478f-9d83-ac5f2db4cf4f">

Note the number in reality is different 