### PR TITLE
feat(sdk): Add org context when instantiating `Pipeline` class

### DIFF
--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -13,6 +13,7 @@ from sentry import analytics
 from sentry.db.models import Model
 from sentry.services.hybrid_cloud.organization import RpcOrganization, organization_service
 from sentry.utils.hashlib import md5_text
+from sentry.utils.sdk import bind_organization_context
 from sentry.web.helpers import render_to_response
 
 from ..models import Organization
@@ -102,6 +103,9 @@ class Pipeline(abc.ABC):
         provider_model: Model | None = None,
         config: Mapping[str, Any] | None = None,
     ) -> None:
+        if organization:
+            bind_organization_context(organization)
+
         self.request = request
         self.organization: RpcOrganization | None = (
             serialize_rpc_organization(organization)

--- a/tests/sentry/pipeline/test_pipeline.py
+++ b/tests/sentry/pipeline/test_pipeline.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 from django.http import HttpRequest
 
 from sentry.pipeline import Pipeline, PipelineProvider, PipelineView
@@ -32,7 +34,8 @@ class DummyPipeline(Pipeline):
 
 @control_silo_test
 class PipelineTestCase(TestCase):
-    def test_simple_pipeline(self):
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_simple_pipeline(self, mock_bind_org_context: MagicMock):
         org = self.create_organization()
         request = HttpRequest()
         request.session = {}
@@ -42,8 +45,8 @@ class PipelineTestCase(TestCase):
         pipeline.initialize()
 
         assert pipeline.is_valid()
-
         assert "some_config" in pipeline.provider.config
+        mock_bind_org_context.assert_called_with(org)
 
         # Test state
         pipeline.finished = False


### PR DESCRIPTION
This adds org context data to the SDK scope when creating `Pipeline` instances.  (A pipeline is used when walking a user through a multi-view flow, with state persisting between views, such as when signing in using GH or Google or when installing an integration.)

(This was inspired by work adding org context to integration endpoints. That works fine, except with an integration's `installed` webhook, since the integration isn't yet attached to an org at that point. While this doesn't solve that problem directly (the best we can do there is tag with the integration id), it does ensure that other code that runs during integration installation will have the correct data.)