### PR TITLE
chore(sdk): Add types to `bind_organization_context`

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -28,6 +28,8 @@ from sentry.utils.rust import RustInfoIntegration
 # Can't import models in utils because utils should be the bottom of the food chain
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
+    from sentry.services.hybrid_cloud.organization import RpcOrganization
+
 
 logger = logging.getLogger(__name__)
 
@@ -595,7 +597,7 @@ def capture_exception_with_scope_check(
     return sentry_sdk.capture_exception(error, scope=extra_scope)
 
 
-def bind_organization_context(organization):
+def bind_organization_context(organization: Organization | RpcOrganization) -> None:
     # Callable to bind additional context for the Sentry SDK
     helper = settings.SENTRY_ORGANIZATION_CONTEXT_HELPER
 
@@ -619,7 +621,9 @@ def bind_organization_context(organization):
                 )
 
 
-def bind_ambiguous_org_context(orgs: Sequence[Organization], source: str | None = None) -> None:
+def bind_ambiguous_org_context(
+    orgs: Sequence[Organization | RpcOrganization], source: str | None = None
+) -> None:
     """
     Add org context information to the scope in the case where the current org might be one of a
     number of known orgs (for example, if we've attempted to derive the current org from an


### PR DESCRIPTION
This adds types to the `bind_organization_context` function, which we use to add org data to the SDK scope. It also changes the type of the `orgs` parameter in `bind_ambiguous_org_context` (which was already typed), to allow for an `RpcOrganization` sequence to be passed.