### PR TITLE
feat(sdk): Add scope context in jira webhooks

### DIFF
--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -32,6 +33,11 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
 
         data = JiraIntegrationProvider().build_integration(state)
         integration = ensure_integration(self.provider, data)
+
+        # Note: Unlike in all other Jira webhooks, we don't call `bind_org_context_from_integration`
+        # here, because at this point the integration hasn't yet been bound to an organization. The
+        # best we can do at this point is to record the integration's id.
+        sentry_sdk.set_tag("integration_id", integration.id)
 
         # Sync integration metadata from Jira. This must be executed *after*
         # the integration has been installed on Jira as the access tokens will

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Mapping
 
+import sentry_sdk
 from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,6 +11,7 @@ from sentry_sdk import Scope
 
 from sentry.api.base import region_silo_endpoint
 from sentry.integrations.utils import get_integration_from_jwt
+from sentry.integrations.utils.scope import bind_org_context_from_integration
 from sentry.shared_integrations.exceptions import ApiError
 
 from ..utils import handle_assignee_change, handle_jira_api_error, handle_status_change
@@ -47,6 +49,10 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
             query_params=request.GET,
             method="POST",
         )
+        # Integrations and their corresponding RpcIntegrations share the same id,
+        # so we don't need to first convert this to a full Integration object
+        bind_org_context_from_integration(rpc_integration.id)
+        sentry_sdk.set_tag("integration_id", rpc_integration.id)
 
         data = request.data
         if not data.get("changelog"):

--- a/src/sentry/integrations/jira/webhooks/uninstalled.py
+++ b/src/sentry/integrations/jira/webhooks/uninstalled.py
@@ -1,9 +1,11 @@
+import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.base import control_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.utils import get_integration_from_jwt
+from sentry.integrations.utils.scope import bind_org_context_from_integration
 from sentry.models.integrations.integration import Integration
 
 from .base import JiraWebhookBase
@@ -25,6 +27,9 @@ class JiraSentryUninstalledWebhook(JiraWebhookBase):
             method="POST",
         )
         integration = Integration.objects.get(id=rpc_integration.id)
+        bind_org_context_from_integration(integration.id)
+        sentry_sdk.set_tag("integration_id", integration.id)
+
         integration.update(status=ObjectStatus.DISABLED)
 
         return self.respond()

--- a/tests/sentry/integrations/jira/test_uninstalled.py
+++ b/tests/sentry/integrations/jira/test_uninstalled.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import jwt
 import responses
 
@@ -43,7 +45,9 @@ class JiraUninstalledTest(APITestCase):
             headers={"kid": self.kid, "alg": jira_signing_algorithm},
         )
 
-    def test_with_shared_secret(self):
+    @patch("sentry_sdk.set_tag")
+    @patch("sentry.integrations.utils.scope.bind_organization_context")
+    def test_with_shared_secret(self, mock_bind_org_context: MagicMock, mock_set_tag: MagicMock):
         org = self.organization
 
         integration = Integration.objects.create(
@@ -57,12 +61,18 @@ class JiraUninstalledTest(APITestCase):
         resp = self.client.post(
             self.path, data={}, HTTP_AUTHORIZATION="JWT " + self.jwt_token_secret()
         )
+        # We have to pull this from the DB again to see the updated status
         integration = Integration.objects.get(id=integration.id)
+
+        mock_set_tag.assert_called_with("integration_id", integration.id)
+        mock_bind_org_context.assert_called_with(org)
         assert integration.status == ObjectStatus.DISABLED
         assert resp.status_code == 200
 
+    @patch("sentry_sdk.set_tag")
+    @patch("sentry.integrations.utils.scope.bind_organization_context")
     @responses.activate
-    def test_with_key_id(self):
+    def test_with_key_id(self, mock_bind_org_context: MagicMock, mock_set_tag: MagicMock):
         org = self.organization
 
         integration = Integration.objects.create(
@@ -79,6 +89,10 @@ class JiraUninstalledTest(APITestCase):
         resp = self.client.post(
             self.path, data={}, HTTP_AUTHORIZATION="JWT " + self.jwt_token_cdn()
         )
+        # We have to pull this from the DB again to see the updated status
         integration = Integration.objects.get(id=integration.id)
+
+        mock_set_tag.assert_called_with("integration_id", integration.id)
+        mock_bind_org_context.assert_called_with(org)
         assert integration.status == ObjectStatus.DISABLED
         assert resp.status_code == 200


### PR DESCRIPTION
This adds both org data and the integration id to the SDK scope when running Jira webhooks. (The one exception is the `installed` webhook, which only gets the integration id, because at the point the webhook runs, the integration has not yet been associated with an org.)