### PR TITLE
fix: Use the correct name for the weekly email preview selection

### DIFF
--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -51,7 +51,7 @@
         <option value="mail/join-request/">Join Request</option>
       </optgroup>
       <optgroup label="Reports">
-        <option value="mail/report/">Weekly Report</option>
+        <option value="mail/weekly-reports/">Weekly Report</option>
       </optgroup>
       <optgroup label="Repository">
         <option value="mail/unable-to-delete-repo/">Unable to Delete Repo</option>


### PR DESCRIPTION
Before this open wasn't working, it would take me to a "CSRF failed" page:

<img width="994" alt="SCR-20230626-mjvs" src="https://github.com/getsentry/sentry/assets/187460/22eb47c1-0554-4b10-bc98-0fae40988b1f">

Now i properly endup at the weekly-report debug view.