### PR TITLE
chore: Enable graph of replays in the weekly email for all customers

### DIFF
--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -975,6 +975,9 @@ def render_template_context(ctx, user):
 
         return heapq.nlargest(3, all_key_performance_issues(), lambda d: d["count"])
 
+    def key_replays():
+        return []
+
     def issue_summary():
         all_issue_count = 0
         existing_issue_count = 0
@@ -1009,7 +1012,6 @@ def render_template_context(ctx, user):
 
     return {
         "has_replay_graph": has_replay_graph,
-        "has_replay_section": has_replay_section,
         "organization": ctx.organization,
         "start": date_format(ctx.start),
         "end": date_format(ctx.end),
@@ -1017,7 +1019,7 @@ def render_template_context(ctx, user):
         "key_errors": key_errors(),
         "key_transactions": key_transactions(),
         "key_performance_issues": key_performance_issues(),
-        "key_replays": [],
+        "key_replays": key_replays() if has_replay_section else [],
         "issue_summary": issue_summary(),
     }
 

--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -724,6 +724,7 @@ def render_template_context(ctx, user):
         user_projects = ctx.projects.values()
 
     has_issue_states = features.has("organizations:escalating-issues", ctx.organization)
+    has_replay_graph = features.has("organizations:session-replay", ctx.organization)
     has_replay_section = features.has(
         "organizations:session-replay", ctx.organization
     ) and features.has("organizations:session-replay-weekly-email", ctx.organization)
@@ -1007,6 +1008,7 @@ def render_template_context(ctx, user):
         }
 
     return {
+        "has_replay_graph": has_replay_graph,
         "has_replay_section": has_replay_section,
         "organization": ctx.organization,
         "start": date_format(ctx.start),

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -534,7 +534,7 @@
   </div>
   {% endif %}
 
-  {% if has_replay_section and key_replays|length > 0 %}
+  {% if key_replays|length > 0 %}
   <div id="key-replays">
     <h4>Most erroneous replays</h4>
     {% for a in key_replays %}

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -229,7 +229,7 @@
     {% with height=110 %}
     <table class="project-breakdown-graph-deck"><tbody><tr>
 
-    <td class="project-breakdown-graph-cell {% if has_replay_section %}errors-wide{% else %}errors{% endif %}" {% if has_replay_section %}colspan="2"{% endif %}>
+    <td class="project-breakdown-graph-cell {% if has_replay_graph %}errors-wide{% else %}errors{% endif %}" {% if has_replay_graph %}colspan="2"{% endif %}>
     <h4 class="total-count-title">Total Project Errors</h4>
     <h1 style="margin: 0;" class="total-count">{{ trends.total_error_count|small_count:1 }}</h1>
     {% url 'sentry-organization-issue-list' organization.slug as issue_list %}
@@ -264,13 +264,13 @@
     </table>
     </td>
 
-{% if has_replay_section %}
+{% if has_replay_graph %}
 </tr>
 <tr>
 {% endif %}
 
     {% if trends.total_transaction_count > 0 %}
-    <td class="project-breakdown-graph-cell {% if has_replay_section %}transactions-below{% else %}transactions{% endif %} {% if has_replay_section and trends.total_replay_count == 0 %}some-empty-below{% endif %}">
+    <td class="project-breakdown-graph-cell {% if has_replay_graph %}transactions-below{% else %}transactions{% endif %} {% if has_replay_graph and trends.total_replay_count == 0 %}some-empty-below{% endif %}">
       <h4 class="total-count-title">Total Project Transactions</h4>
       <h1 style="margin: 0;" class="total-count">{{ trends.total_transaction_count|small_count:1 }}</h1>
       {% url 'sentry-organization-perfomance' organization.slug as performance_landing %}
@@ -304,7 +304,7 @@
       </table>
       </td>
     {% else %}
-      <td class="project-breakdown-graph-cell {% if has_replay_section and trends.total_replay_count > 0 %}transactions-empty-below{% elif has_replay_section %}transactions-empty-below some-empty-below{% else %}transactions-empty{% endif %}">
+      <td class="project-breakdown-graph-cell {% if has_replay_graph and trends.total_replay_count > 0 %}transactions-empty-below{% elif has_replay_graph %}transactions-empty-below some-empty-below{% else %}transactions-empty{% endif %}">
         <div style="border: 1px solid #c4c4cc; border-radius: 4px; padding: 24px 16px; text-align: center; height: 170px;">
           <img src="{% absolute_asset_url 'sentry' 'images/email/icon-circle-lightning.png' %}" width="32px" height="32px" alt="Sentry">
           <h1 style="font-weight: bold; font-size: 17px;">Something slow?</h1>
@@ -316,7 +316,7 @@
       </td>
     {% endif %}
 
-    {% if has_replay_section and trends.total_replay_count > 0 %}
+    {% if has_replay_graph and trends.total_replay_count > 0 %}
       <td class="project-breakdown-graph-cell replays {% if trends.total_transaction_count == 0 %}some-empty-below{% endif %}">
         <h4 class="total-count-title">Total Project Replays</h4>
         <h1 style="margin: 0;" class="total-count">{{ trends.total_replay_count|small_count:1 }}</h1>
@@ -352,7 +352,7 @@
           </tr>
         </table>
       </td>
-    {% elif has_replay_section %}
+    {% elif has_replay_graph %}
       <td class="project-breakdown-graph-cell {% if trends.total_transaction_count > 0 %}replays-empty some-empty-below{% else %}replays-empty{% endif %}">
         <div style="border: 1px solid #c4c4cc; border-radius: 4px; padding: 24px 16px; text-align: center; height: 170px;">
           <img src="{% absolute_asset_url 'sentry' 'images/email/icon-circle-play.png' %}" width="32px" height="32px"


### PR DESCRIPTION
Followup of https://github.com/getsentry/sentry/pull/51388

Make the graph appear at all times. We're still keeping the feature-flag to control the bottom-part of the email, which is a work in progress.

Relates to https://github.com/getsentry/sentry/issues/51369