### PR TITLE
fix(tests): Ignore type-checking imports in coverage reports

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -113,3 +113,13 @@ python-tag = py38
 omit =
     src/sentry/migrations/*
 source = .
+
+[coverage:report]
+exclude_lines =
+    # Once we upgrade to coverage >= 7.2, we can switch to using `exclude_also` and
+    # remove `"pragma: no cover"`. See https://coverage.readthedocs.io/en/latest/config.html#report-exclude-also.
+    "pragma: no cover",
+
+    # This may at some point get added to the defaults, in which case we can remove it
+    # from our config. See https://github.com/nedbat/coveragepy/issues/831.
+    "if TYPE_CHECKING:",


### PR DESCRIPTION
Currently, any line in an `if TYPE_CHECKING:` block is counted as a miss by codecov, since it's not executed during tests. This leads to PRs failing the codecov check when they really shouldn't. (For example, https://github.com/getsentry/sentry/pull/51644 only adds types, but because one of the three lines modified is in an `if TYPE_CHECKING:` block, it counts as a miss, making the patch coverage 66%, below our 90% threshold for passing.)

This PR adds configuration to ignore such lines when calculating coverage. (This is the solution [suggested by the `coverage` maintainer](https://github.com/nedbat/coveragepy/issues/831#issuecomment-517778185). While he seems to have [changed his mind](https://github.com/nedbat/coveragepy/issues/831#issuecomment-1020479593) about whether or not this should be the default, as of the time of this writing the issue is still open, so for now we still have to do it ourselves.)