### PR TITLE
feat(hybrid-cloud): Implement proxy client for MsTeams

### DIFF
--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -71,7 +71,7 @@ class MsTeamsClientMixin:
 # MsTeamsPreInstallClient is used with the access token and service url as arguments to the constructor
 # It will not handle token refreshing
 class MsTeamsPreInstallClient(ApiClient, MsTeamsClientMixin):
-    def __init__(self, access_token, service_url):
+    def __init__(self, access_token: str, service_url: str):
         super().__init__()
         self.access_token = access_token
         self.base_url = service_url.rstrip("/")

--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from urllib.parse import urlencode
 
@@ -24,32 +26,32 @@ class MsTeamsClientMixin:
     CONVERSATION_URL = "/v3/conversations"
     MEMBER_URL = "/v3/conversations/%s/pagedmembers"
 
-    def get_team_info(self, team_id):
+    def get_team_info(self, team_id: str):
         return self.get(self.TEAM_URL % team_id)
 
-    def get_channel_list(self, team_id):
+    def get_channel_list(self, team_id: str):
         resp = self.get(self.CHANNEL_URL % team_id)
         return resp.get("conversations")
 
-    def get_member_list(self, team_id, continuation_token=None):
+    def get_member_list(self, team_id: str, continuation_token: str | None = None):
         url = self.MEMBER_URL % team_id
         params = {"pageSize": 500}
         if continuation_token:
             params["continuationToken"] = continuation_token
         return self.get(url, params=params)
 
-    def get_user_conversation_id(self, user_id, tenant_id):
+    def get_user_conversation_id(self, user_id: str, tenant_id: str):
         data = {"members": [{"id": user_id}], "channelData": {"tenant": {"id": tenant_id}}}
         resp = self.post(self.CONVERSATION_URL, data=data)
         return resp.get("id")
 
-    def send_message(self, conversation_id, data):
+    def send_message(self, conversation_id: str, data):
         return self.post(self.ACTIVITY_URL % conversation_id, data=data)
 
-    def update_message(self, conversation_id, activity_id, data):
+    def update_message(self, conversation_id: str, activity_id: str, data):
         return self.put(self.MESSAGE_URL % (conversation_id, activity_id), data=data)
 
-    def send_card(self, conversation_id, card):
+    def send_card(self, conversation_id: str, card):
         payload = {
             "type": "message",
             "attachments": [
@@ -58,7 +60,7 @@ class MsTeamsClientMixin:
         }
         return self.send_message(conversation_id, payload)
 
-    def update_card(self, conversation_id, activity_id, card):
+    def update_card(self, conversation_id: str, activity_id: str, card):
         payload = {
             "type": "message",
             "attachments": [

--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -15,7 +15,7 @@ CLOCK_SKEW = 60 * 5
 
 
 # MsTeamsAbstractClient abstract client does not handle setting the base url or auth token
-class MsTeamsAbstractClient(ApiClient):
+class MsTeamsAbstractClient:
     integration_name = "msteams"
     TEAM_URL = "/v3/teams/%s"
     CHANNEL_URL = "/v3/teams/%s/conversations"
@@ -70,7 +70,7 @@ class MsTeamsAbstractClient(ApiClient):
 
 # MsTeamsPreInstallClient is used with the access token and service url as arguments to the constructor
 # It will not handle token refreshing
-class MsTeamsPreInstallClient(MsTeamsAbstractClient):
+class MsTeamsPreInstallClient(ApiClient, MsTeamsAbstractClient):
     def __init__(self, access_token, service_url):
         super().__init__()
         self.access_token = access_token
@@ -84,9 +84,9 @@ class MsTeamsPreInstallClient(MsTeamsAbstractClient):
 # MsTeamsClient is used with an existing integration object and handles token refreshing
 class MsTeamsClient(IntegrationProxyClient, MsTeamsAbstractClient):
     def __init__(self, integration: Integration):
+        self.integration = integration
         org_integration_id = infer_org_integration(integration_id=integration.id)
         super().__init__(org_integration_id=org_integration_id)
-        self.integration = integration
 
     @property
     def metadata(self):

--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -74,6 +74,8 @@ class MsTeamsClientMixin:
 # MsTeamsPreInstallClient is used with the access token and service url as arguments to the constructor
 # It will not handle token refreshing
 class MsTeamsPreInstallClient(ApiClient, MsTeamsClientMixin):
+    integration_name = "msteams"
+
     def __init__(self, access_token: str, service_url: str):
         super().__init__()
         self.access_token = access_token
@@ -86,6 +88,8 @@ class MsTeamsPreInstallClient(ApiClient, MsTeamsClientMixin):
 
 # MsTeamsClient is used with an existing integration object and handles token refreshing
 class MsTeamsClient(IntegrationProxyClient, MsTeamsClientMixin):
+    integration_name = "msteams"
+
     def __init__(self, integration: Integration):
         self.integration = integration
         org_integration_id = infer_org_integration(integration_id=integration.id)

--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -3,6 +3,7 @@ from urllib.parse import urlencode
 
 from sentry import options
 from sentry.integrations.client import ApiClient
+from sentry.models.integrations import Integration
 from sentry.services.hybrid_cloud.integration import integration_service
 
 # five minutes which is industry standard clock skew tolerance
@@ -78,7 +79,7 @@ class MsTeamsPreInstallClient(MsTeamsAbstractClient):
 
 # MsTeamsClient is used with an existing integration object and handles token refreshing
 class MsTeamsClient(MsTeamsAbstractClient):
-    def __init__(self, integration):
+    def __init__(self, integration: Integration):
         super().__init__()
         self.integration = integration
 

--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -14,8 +14,8 @@ from sentry.shared_integrations.client.proxy import IntegrationProxyClient, infe
 CLOCK_SKEW = 60 * 5
 
 
-# MsTeamsAbstractClient abstract client does not handle setting the base url or auth token
-class MsTeamsAbstractClient:
+# MsTeamsClientMixin abstract client does not handle setting the base url or auth token
+class MsTeamsClientMixin:
     integration_name = "msteams"
     TEAM_URL = "/v3/teams/%s"
     CHANNEL_URL = "/v3/teams/%s/conversations"
@@ -70,7 +70,7 @@ class MsTeamsAbstractClient:
 
 # MsTeamsPreInstallClient is used with the access token and service url as arguments to the constructor
 # It will not handle token refreshing
-class MsTeamsPreInstallClient(ApiClient, MsTeamsAbstractClient):
+class MsTeamsPreInstallClient(ApiClient, MsTeamsClientMixin):
     def __init__(self, access_token, service_url):
         super().__init__()
         self.access_token = access_token
@@ -82,7 +82,7 @@ class MsTeamsPreInstallClient(ApiClient, MsTeamsAbstractClient):
 
 
 # MsTeamsClient is used with an existing integration object and handles token refreshing
-class MsTeamsClient(IntegrationProxyClient, MsTeamsAbstractClient):
+class MsTeamsClient(IntegrationProxyClient, MsTeamsClientMixin):
     def __init__(self, integration: Integration):
         self.integration = integration
         org_integration_id = infer_org_integration(integration_id=integration.id)

--- a/tests/sentry/integrations/msteams/notifications/test_assigned.py
+++ b/tests/sentry/integrations/msteams/notifications/test_assigned.py
@@ -7,10 +7,10 @@ from sentry.types.activity import ActivityType
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsAbstractClient.get_user_conversation_id",
+    "sentry.integrations.msteams.MsTeamsClientMixin.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsAbstractClient.send_card")
+@patch("sentry.integrations.msteams.MsTeamsClientMixin.send_card")
 class MSTeamsAssignedNotificationTest(MSTeamsActivityNotificationTest):
     def test_assigned(self, mock_send_card: MagicMock):
         """

--- a/tests/sentry/integrations/msteams/notifications/test_deploy.py
+++ b/tests/sentry/integrations/msteams/notifications/test_deploy.py
@@ -10,10 +10,10 @@ from sentry.types.activity import ActivityType
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsAbstractClient.get_user_conversation_id",
+    "sentry.integrations.msteams.MsTeamsClientMixin.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsAbstractClient.send_card")
+@patch("sentry.integrations.msteams.MsTeamsClientMixin.send_card")
 class MSTeamsDeployNotificationTest(MSTeamsActivityNotificationTest):
     @skip("Flaky test")
     def test_deploy(self, mock_send_card: MagicMock):

--- a/tests/sentry/integrations/msteams/notifications/test_escalating.py
+++ b/tests/sentry/integrations/msteams/notifications/test_escalating.py
@@ -7,10 +7,10 @@ from sentry.types.activity import ActivityType
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsAbstractClient.get_user_conversation_id",
+    "sentry.integrations.msteams.MsTeamsClientMixin.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsAbstractClient.send_card")
+@patch("sentry.integrations.msteams.MsTeamsClientMixin.send_card")
 class MSTeamsEscalatingNotificationTest(MSTeamsActivityNotificationTest):
     def test_note(self, mock_send_card: MagicMock):
         """

--- a/tests/sentry/integrations/msteams/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/msteams/notifications/test_issue_alert.py
@@ -9,10 +9,10 @@ from sentry.testutils.silo import region_silo_test
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsAbstractClient.get_user_conversation_id",
+    "sentry.integrations.msteams.MsTeamsClientMixin.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsAbstractClient.send_card")
+@patch("sentry.integrations.msteams.MsTeamsClientMixin.send_card")
 @region_silo_test
 class MSTeamsIssueAlertNotificationTest(MSTeamsActivityNotificationTest):
     def test_issue_alert_user(self, mock_send_card: MagicMock):

--- a/tests/sentry/integrations/msteams/notifications/test_note.py
+++ b/tests/sentry/integrations/msteams/notifications/test_note.py
@@ -7,10 +7,10 @@ from sentry.types.activity import ActivityType
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsAbstractClient.get_user_conversation_id",
+    "sentry.integrations.msteams.MsTeamsClientMixin.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsAbstractClient.send_card")
+@patch("sentry.integrations.msteams.MsTeamsClientMixin.send_card")
 class MSTeamsNoteNotificationTest(MSTeamsActivityNotificationTest):
     def test_note(self, mock_send_card: MagicMock):
         """

--- a/tests/sentry/integrations/msteams/notifications/test_regression.py
+++ b/tests/sentry/integrations/msteams/notifications/test_regression.py
@@ -7,10 +7,10 @@ from sentry.types.activity import ActivityType
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsAbstractClient.get_user_conversation_id",
+    "sentry.integrations.msteams.MsTeamsClientMixin.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsAbstractClient.send_card")
+@patch("sentry.integrations.msteams.MsTeamsClientMixin.send_card")
 class MSTeamsRegressionNotificationTest(MSTeamsActivityNotificationTest):
     def test_regression(self, mock_send_card: MagicMock):
         """

--- a/tests/sentry/integrations/msteams/notifications/test_resolved.py
+++ b/tests/sentry/integrations/msteams/notifications/test_resolved.py
@@ -10,10 +10,10 @@ from sentry.types.activity import ActivityType
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsAbstractClient.get_user_conversation_id",
+    "sentry.integrations.msteams.MsTeamsClientMixin.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsAbstractClient.send_card")
+@patch("sentry.integrations.msteams.MsTeamsClientMixin.send_card")
 class MSTeamsResolvedNotificationTest(MSTeamsActivityNotificationTest):
     def test_resolved(self, mock_send_card: MagicMock):
         """

--- a/tests/sentry/integrations/msteams/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/msteams/notifications/test_unassigned.py
@@ -7,10 +7,10 @@ from sentry.types.activity import ActivityType
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsAbstractClient.get_user_conversation_id",
+    "sentry.integrations.msteams.MsTeamsClientMixin.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsAbstractClient.send_card")
+@patch("sentry.integrations.msteams.MsTeamsClientMixin.send_card")
 class MSTeamsUnassignedNotificationTest(MSTeamsActivityNotificationTest):
     def test_unassigned(self, mock_send_card: MagicMock):
         """

--- a/tests/sentry/integrations/msteams/test_client.py
+++ b/tests/sentry/integrations/msteams/test_client.py
@@ -1,11 +1,10 @@
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import call, patch
 from urllib.parse import urlencode
 
 import pytest
 import responses
 from django.test import override_settings
-from mock import call
 
 from sentry.integrations.msteams.client import MsTeamsClient
 from sentry.models import Integration

--- a/tests/sentry/integrations/msteams/test_client.py
+++ b/tests/sentry/integrations/msteams/test_client.py
@@ -16,7 +16,11 @@ class MsTeamsClientTest(TestCase):
         self.integration = Integration.objects.create(
             provider="msteams",
             name="my_team",
-            metadata={"access_token": "my_token", "expires_at": self.expires_at},
+            metadata={
+                "access_token": "my_token",
+                "expires_at": self.expires_at,
+                "service_url": "https://smba.trafficmanager.net/amer/",
+            },
         )
 
         # token mock
@@ -49,6 +53,7 @@ class MsTeamsClientTest(TestCase):
             assert integration.metadata == {
                 "access_token": "my_new_token",
                 "expires_at": self.expires_at + 86399 - 60 * 5,
+                "service_url": "https://smba.trafficmanager.net/amer/",
             }
 
     @responses.activate
@@ -63,4 +68,5 @@ class MsTeamsClientTest(TestCase):
             assert integration.metadata == {
                 "access_token": "my_token",
                 "expires_at": self.expires_at,
+                "service_url": "https://smba.trafficmanager.net/amer/",
             }

--- a/tests/sentry/integrations/msteams/test_notifications.py
+++ b/tests/sentry/integrations/msteams/test_notifications.py
@@ -26,14 +26,14 @@ TEST_CARD = {"type": "test_card"}
     [DummyNotification],
 )
 @patch(
-    "sentry.integrations.msteams.MsTeamsAbstractClient.get_user_conversation_id",
+    "sentry.integrations.msteams.MsTeamsClientMixin.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
 @patch(
-    "sentry.integrations.msteams.MsTeamsAbstractClient.get_member_list",
+    "sentry.integrations.msteams.MsTeamsClientMixin.get_member_list",
     Mock(return_value={"members": [{"user": "some_user", "tenantId": "some_tenant_id"}]}),
 )
-@patch("sentry.integrations.msteams.MsTeamsAbstractClient.send_card")
+@patch("sentry.integrations.msteams.MsTeamsClientMixin.send_card")
 @control_silo_test
 class MSTeamsNotificationTest(TestCase):
     def _install_msteams_personal(self):
@@ -118,7 +118,7 @@ class MSTeamsNotificationTest(TestCase):
         self._install_msteams_team()
 
         with patch(
-            "sentry.integrations.msteams.MsTeamsAbstractClient.get_user_conversation_id",
+            "sentry.integrations.msteams.MsTeamsClientMixin.get_user_conversation_id",
         ) as mock_get_user_conversation_id:
             mock_get_user_conversation_id.return_value = "some_conversation_id"
 

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -1,10 +1,10 @@
 from copy import deepcopy
 from unittest import mock
+from unittest.mock import call
 from urllib.parse import urlencode
 
 import pytest
 import responses
-from mock import call
 
 from sentry.models import Identity, IdentityProvider, Integration
 from sentry.testutils import APITestCase


### PR DESCRIPTION
This was previously reverted in https://github.com/getsentry/sentry/pull/51419. The reason for the revert was due to a datadog alert on the low number of 201 requests. Since the revert, the datadog alert has been flapping; so it seems to be a false positive alert.

In addition, I was able to verify that this changeset works fine locally with a personal MS Teams app that I set up by following the instructions here: https://develop.sentry.dev/integrations/msteams/ I was able to send notifications from the app's bot to channels and to individuals.