### PR TITLE
[ignore] Add org info to scope for all jira webhook events

### DIFF
--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -14,6 +14,7 @@ from sentry_sdk import Scope
 
 from sentry.api.base import Endpoint
 from sentry.integrations.utils import AtlassianConnectValidationError
+from sentry.integrations.utils.atlassian_connect import get_integration_from_jwt
 from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,17 @@ class JiraWebhookBase(Endpoint, abc.ABC):
     def convert_args(self, request: Request, *args, **kwargs):
         token = self.get_token(request)
         kwargs["token"] = token
+
+        if self.lookup_integration_from_token:
+            integration = get_integration_from_jwt(
+                token=token,
+                path=request.path,
+                provider=self.provider,
+                query_params=request.GET,
+                method=request.method,
+            )
+            kwargs["integration"] = integration
+
         return super().convert_args(request, *args, **kwargs)
 
     def handle_exception(

--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -15,6 +15,7 @@ from sentry_sdk import Scope
 from sentry.api.base import Endpoint
 from sentry.integrations.utils import AtlassianConnectValidationError
 from sentry.integrations.utils.atlassian_connect import get_integration_from_jwt
+from sentry.integrations.utils.scope import bind_org_context_from_integration
 from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ class JiraWebhookBase(Endpoint, abc.ABC):
                 method=request.method,
             )
             kwargs["integration"] = integration
+            bind_org_context_from_integration(integration.id)
 
         return super().convert_args(request, *args, **kwargs)
 

--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -31,6 +31,7 @@ class JiraWebhookBase(Endpoint, abc.ABC):
     authentication_classes = ()
     permission_classes = ()
     provider = "jira"
+    lookup_integration_from_token = True
 
     @csrf_exempt
     def dispatch(self, request: Request, *args, **kwargs) -> Response:

--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -36,6 +36,11 @@ class JiraWebhookBase(Endpoint, abc.ABC):
     def dispatch(self, request: Request, *args, **kwargs) -> Response:
         return super().dispatch(request, *args, **kwargs)
 
+    def convert_args(self, request: Request, *args, **kwargs):
+        token = self.get_token(request)
+        kwargs["token"] = token
+        return super().convert_args(request, *args, **kwargs)
+
     def handle_exception(
         self,
         request: Request,

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -19,7 +19,7 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
     """
 
     def post(self, request: Request, *args, **kwargs) -> Response:
-        token = self.get_token(request)
+        token = kwargs["token"]
 
         state = request.data
         if not state:

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -18,6 +18,10 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
     Webhook hit by Jira whenever someone installs the Sentry integration in their Jira instance.
     """
 
+    # Prevent the base `dispatch` method from trying to look up the integration based on the auth
+    # headers of the request, given that it doesn't exist yet at that point
+    lookup_integration_from_token = False
+
     def post(self, request: Request, *args, **kwargs) -> Response:
         token = kwargs["token"]
 

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -9,7 +9,6 @@ from rest_framework.response import Response
 from sentry_sdk import Scope
 
 from sentry.api.base import control_silo_endpoint
-from sentry.integrations.utils import get_integration_from_jwt
 from sentry.shared_integrations.exceptions import ApiError
 
 from ..utils import handle_assignee_change, handle_jira_api_error, handle_status_change
@@ -39,14 +38,7 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
         return super().handle_exception(request, exc, handler_context, scope)
 
     def post(self, request: Request, *args, **kwargs) -> Response:
-        token = self.get_token(request)
-        integration = get_integration_from_jwt(
-            token=token,
-            path=request.path,
-            provider=self.provider,
-            query_params=request.GET,
-            method="POST",
-        )
+        integration = kwargs["integration"]
 
         data = request.data
         if not data.get("changelog"):

--- a/src/sentry/integrations/jira/webhooks/uninstalled.py
+++ b/src/sentry/integrations/jira/webhooks/uninstalled.py
@@ -3,7 +3,6 @@ from rest_framework.response import Response
 
 from sentry.api.base import control_silo_endpoint
 from sentry.constants import ObjectStatus
-from sentry.integrations.utils import get_integration_from_jwt
 
 from .base import JiraWebhookBase
 
@@ -15,14 +14,8 @@ class JiraSentryUninstalledWebhook(JiraWebhookBase):
     """
 
     def post(self, request: Request, *args, **kwargs) -> Response:
-        token = self.get_token(request)
-        integration = get_integration_from_jwt(
-            token=token,
-            path=request.path,
-            provider=self.provider,
-            query_params=request.GET,
-            method="POST",
-        )
+        integration = kwargs["integration"]
+
         integration.update(status=ObjectStatus.DISABLED)
 
         return self.respond()

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -38,7 +38,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
     @patch("sentry.integrations.jira.utils.api.sync_group_assignee_inbound")
     def test_simple_assign(self, mock_sync_group_assignee_inbound):
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
@@ -58,7 +58,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
         )
 
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
@@ -77,7 +77,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
         )
 
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
@@ -90,7 +90,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
     @patch("sentry.integrations.jira.utils.api.sync_group_assignee_inbound")
     def test_assign_missing_email(self, mock_sync_group_assignee_inbound):
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
@@ -101,7 +101,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
     @patch("sentry.integrations.jira.utils.api.sync_group_assignee_inbound")
     def test_simple_deassign(self, mock_sync_group_assignee_inbound):
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_no_assignee_payload.json")
@@ -113,7 +113,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
     @patch("sentry.integrations.jira.utils.api.sync_group_assignee_inbound")
     def test_simple_deassign_assignee_missing(self, mock_sync_group_assignee_inbound):
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_missing_payload.json")
@@ -125,7 +125,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
     @patch.object(IssueSyncMixin, "sync_status_inbound")
     def test_simple_status_sync_inbound(self, mock_sync_status_inbound):
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ) as mock_get_integration_from_jwt:
             data = StubService.get_stub_data("jira", "edit_issue_status_payload.json")
@@ -158,7 +158,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
 
     def test_missing_changelog(self):
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "changelog_missing.json")


### PR DESCRIPTION
This is a new version of https://github.com/getsentry/sentry/pull/48412, purely for the purposes of memorializing the approach. (That needs rebasing, but is locked, so can't be updated.) See the PR description there for more details.

In the end I went with the more straightforward solution of calling `bind_org_context_from_integration` in each webhook individually (see https://github.com/getsentry/sentry/pull/51648). I thought it was worth keeping this around for reference anyway, in case we ever decide we want to be a little smarter about things and do something like call `bind_org_context` from our base endpoint class. (Disclaimer: I haven't investigated the feasibility of such an approach, but if we did decide to try to do something along those lines, hopefully the tack taken here can provide inspiration.)