### PR TITLE
feat(github-comments): comment reactions task

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1095,7 +1095,7 @@ CELERYBEAT_SCHEDULE_REGION = {
     },
     "github_comment_reactions": {
         "task": "sentry.tasks.integrations.github_comment_reactions",
-        "schedule": crontab(hour=14),  # 9:00 PDT, 12:00 EDT, 16:00 UTC
+        "schedule": crontab(hour=16),  # 9:00 PDT, 12:00 EDT, 16:00 UTC
     },
 }
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1093,6 +1093,10 @@ CELERYBEAT_SCHEDULE_REGION = {
         "schedule": crontab(minute=0, hour="*/6"),
         "options": {"expires": 3600},
     },
+    "github_comment_reactions": {
+        "task": "sentry.tasks.integrations.github_comment_reactions",
+        "schedule": crontab(hour=14),  # 9:00 PDT, 12:00 EDT, 16:00 UTC
+    },
 }
 
 # Assign the configuration keys celery uses based on our silo mode.

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -561,6 +561,13 @@ class GitHubClientMixin(GithubProxyClient):
         endpoint = f"/repos/{repo}/issues/comments/{comment_id}"
         return self.patch(endpoint, data=data)
 
+    def get_comment_reactions(self, repo: str, comment_id: str) -> JSONData:
+        endpoint = f"/repos/{repo}/issues/comments/{comment_id}"
+        response = self.get(endpoint)
+        reactions = response["reactions"]
+        del reactions["url"]
+        return reactions
+
     def get_user(self, gh_username: str) -> JSONData:
         """
         https://docs.github.com/en/rest/users/users#get-a-user

--- a/src/sentry/tasks/integrations/github/__init__.py
+++ b/src/sentry/tasks/integrations/github/__init__.py
@@ -1,3 +1,6 @@
-from .pr_comment import github_comment_workflow
+from .pr_comment import github_comment_reactions, github_comment_workflow
 
-__all__ = ("github_comment_workflow",)
+__all__ = (
+    "github_comment_workflow",
+    "github_comment_reactions",
+)

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -244,6 +244,8 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
 
 @instrumented_task(name="sentry.tasks.integrations.github_comment_reactions")
 def github_comment_reactions():
+    logger.info("github.pr_comment.reactions_task")
+
     comments = PullRequestComment.objects.filter(
         created_at__gte=datetime.now(tz=timezone.utc) - timedelta(days=30)
     )

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from itertools import groupby
 from typing import List
 
 import sentry_sdk
@@ -24,6 +23,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.tasks.commit_context import DEBOUNCE_PR_COMMENT_CACHE_KEY
 from sentry.utils import metrics
 from sentry.utils.cache import cache
+from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.snuba import Dataset, raw_snql_query
 
 logger = logging.getLogger(__name__)
@@ -249,12 +249,11 @@ def github_comment_reactions():
     comments = PullRequestComment.objects.filter(
         created_at__gte=datetime.now(tz=timezone.utc) - timedelta(days=30)
     )
-    sorted_comments = sorted(comments, key=lambda c: c.pull_request.repository_id)
-    grouped_comments = groupby(sorted_comments, key=lambda c: c.pull_request.repository_id)
 
-    for repository_id, comments in grouped_comments:
+    for comment in RangeQuerySetWrapper(comments):
+        pr = comment.pull_request
         try:
-            repo = Repository.objects.get(id=repository_id)
+            repo = Repository.objects.get(id=pr.repository_id)
         except Repository.DoesNotExist:
             metrics.incr("github_pr_comment.comment_reactions.missing_repo")
             continue
@@ -263,27 +262,25 @@ def github_comment_reactions():
         if not integration:
             logger.error(
                 "github.pr_comment.comment_reactions.integration_missing",
-                extra={"organization_id": repo.organization_id},
+                extra={"organization_id": pr.organization_id},
             )
             metrics.incr("github_pr_comment.comment_reactions.missing_integration")
             return
 
         installation = integration_service.get_installation(
-            integration=integration, organization_id=repo.organization_id
+            integration=integration, organization_id=pr.organization_id
         )
 
         # GitHubAppsClient (GithubClientMixin)
+        # TODO(cathy): create helper function to fetch client for repo
         client = installation.get_client()
 
-        for comment in comments:
-            try:
-                reactions = client.get_comment_reactions(
-                    repo=repo.name, comment_id=comment.external_id
-                )
+        try:
+            reactions = client.get_comment_reactions(repo=repo.name, comment_id=comment.external_id)
 
-                comment.reactions = reactions
-                comment.save()
-            except ApiError as e:
-                metrics.incr("github_pr_comment.comment_reactions.api_error")
-                sentry_sdk.capture_exception(e)
-                continue
+            comment.reactions = reactions
+            comment.save()
+        except ApiError as e:
+            metrics.incr("github_pr_comment.comment_reactions.api_error")
+            sentry_sdk.capture_exception(e)
+            continue

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -337,6 +337,26 @@ class GitHubAppsClientTest(TestCase):
         assert responses.calls[2].response.status_code == 200
         assert responses.calls[2].request.body == b'{"body": "world"}'
 
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @responses.activate
+    def test_get_comment_reactions(self, get_jwt):
+        comment_reactions = {
+            "reactions": {
+                "url": "abcdef",
+                "hooray": 1,
+                "+1": 2,
+                "-1": 0,
+            }
+        }
+        responses.add(
+            responses.GET,
+            f"https://api.github.com/repos/{self.repo.name}/issues/comments/2",
+            json=comment_reactions,
+        )
+
+        reactions = self.client.get_comment_reactions(repo=self.repo.name, comment_id="2")
+        assert reactions == comment_reactions["reactions"]
+
 
 control_address = "http://controlserver"
 secret = "hush-hush-im-invisible"

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -355,7 +355,9 @@ class GitHubAppsClientTest(TestCase):
         )
 
         reactions = self.client.get_comment_reactions(repo=self.repo.name, comment_id="2")
-        assert reactions == comment_reactions["reactions"]
+        stored_reactions = comment_reactions["reactions"]
+        del stored_reactions["url"]
+        assert reactions == stored_reactions
 
 
 control_address = "http://controlserver"

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -256,7 +256,7 @@ class TestTop5IssuesByCount(TestCase, SnubaTestCase):
         assert len(res) == 5
 
 
-@region_silo_test()
+@region_silo_test(stable=True)
 class TestCommentBuilderQueries(GithubCommentTestCase):
     def test_simple(self):
         ev1 = self.store_event(
@@ -274,7 +274,7 @@ class TestCommentBuilderQueries(GithubCommentTestCase):
         comment_contents = get_comment_contents([ev1.group.id, ev2.group.id, ev3.group.id])
         assert (
             PullRequestIssue(
-                title="issue1",
+                title="issue 1",
                 subtitle="issue1",
                 url=f"http://testserver/organizations/{self.organization.slug}/issues/{ev1.group.id}/",
             )
@@ -282,7 +282,7 @@ class TestCommentBuilderQueries(GithubCommentTestCase):
         )
         assert (
             PullRequestIssue(
-                title="issue2",
+                title="issue 2",
                 subtitle="issue2",
                 url=f"http://testserver/organizations/{self.organization.slug}/issues/{ev2.group.id}/",
             )
@@ -290,7 +290,7 @@ class TestCommentBuilderQueries(GithubCommentTestCase):
         )
         assert (
             PullRequestIssue(
-                title="issue3",
+                title="issue 3",
                 subtitle="issue3",
                 url=f"http://testserver/organizations/{self.organization.slug}/issues/{ev3.group.id}/",
             )

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -256,7 +256,7 @@ class TestTop5IssuesByCount(TestCase, SnubaTestCase):
         assert len(res) == 5
 
 
-@region_silo_test(stable=True)
+@region_silo_test()
 class TestCommentBuilderQueries(GithubCommentTestCase):
     def test_simple(self):
         ev1 = self.store_event(
@@ -272,20 +272,29 @@ class TestCommentBuilderQueries(GithubCommentTestCase):
             project_id=self.project.id,
         )
         comment_contents = get_comment_contents([ev1.group.id, ev2.group.id, ev3.group.id])
-        assert comment_contents[0] == PullRequestIssue(
-            title="issue 1",
-            subtitle="issue1",
-            url=f"http://testserver/organizations/{self.organization.slug}/issues/{ev1.group.id}/",
+        assert (
+            PullRequestIssue(
+                title="issue1",
+                subtitle="issue1",
+                url=f"http://testserver/organizations/{self.organization.slug}/issues/{ev1.group.id}/",
+            )
+            in comment_contents
         )
-        assert comment_contents[1] == PullRequestIssue(
-            title="issue 2",
-            subtitle="issue2",
-            url=f"http://testserver/organizations/{self.organization.slug}/issues/{ev2.group.id}/",
+        assert (
+            PullRequestIssue(
+                title="issue2",
+                subtitle="issue2",
+                url=f"http://testserver/organizations/{self.organization.slug}/issues/{ev2.group.id}/",
+            )
+            in comment_contents
         )
-        assert comment_contents[2] == PullRequestIssue(
-            title="issue 3",
-            subtitle="issue3",
-            url=f"http://testserver/organizations/{self.organization.slug}/issues/{ev3.group.id}/",
+        assert (
+            PullRequestIssue(
+                title="issue3",
+                subtitle="issue3",
+                url=f"http://testserver/organizations/{self.organization.slug}/issues/{ev3.group.id}/",
+            )
+            in comment_contents
         )
 
 
@@ -310,7 +319,7 @@ class TestFormatComment(TestCase):
         assert formatted_comment == expected_comment
 
 
-@region_silo_test(stable=True)
+@region_silo_test()
 class TestCommentWorkflow(GithubCommentTestCase):
     base_url = "https://api.github.com"
 
@@ -564,7 +573,7 @@ class TestCommentReactionsTask(GithubCommentTestCase):
 
     @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate
-    def test_comment_reactions_task(self, get_jwt, mock_issues):
+    def test_comment_reactions_task(self, get_jwt):
         old_comment = PullRequestComment.objects.create(
             external_id="1",
             pull_request=self.expired_pr,

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -579,26 +579,14 @@ class TestCommentReactionsTask(GithubCommentTestCase):
         self.expired_pr.save()
 
     @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
-    @patch("sentry.models.Repository.objects.get")
     @responses.activate
-    def test_comment_reactions_task(self, mock_get_repo, get_jwt):
-        mock_get_repo.return_value = self.gh_repo
-
+    def test_comment_reactions_task(self, get_jwt):
         old_comment = PullRequestComment.objects.create(
             external_id="1",
             pull_request=self.expired_pr,
             created_at=timezone.now() - timedelta(days=35),
             updated_at=timezone.now() - timedelta(days=35),
             group_ids=[1, 2, 3],
-        )
-
-        pr = self.create_pr_issues()
-        PullRequestComment.objects.create(
-            external_id="3",
-            pull_request=pr,
-            created_at=timezone.now(),
-            updated_at=timezone.now(),
-            group_ids=[6],
         )
 
         responses.add(
@@ -618,17 +606,6 @@ class TestCommentReactionsTask(GithubCommentTestCase):
             responses.GET,
             self.base_url + "/repos/getsentry/sentry/issues/comments/2",
             json=comment_reactions,
-        )
-        responses.add(
-            responses.GET,
-            self.base_url + "/repos/getsentry/sentry/issues/comments/3",
-            json={
-                "reactions": {
-                    "url": "abcdef",
-                    "+1": 0,
-                    "-1": 0,
-                }
-            },
         )
 
         github_comment_reactions()


### PR DESCRIPTION
A daily celery task that iterates through all comments created <= 30 days ago, hits the Github API to get a JSON blob of the reactions for each comment, and then stores them in the `reactions` column in the model.

For ER-1592