### PR TITLE
feat(alerts): enable transaction.duration filter

### DIFF
--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -244,7 +244,7 @@ export function datasetSupportedTags(
       [Dataset.ERRORS]: undefined,
       [Dataset.TRANSACTIONS]: org.features.includes('alert-allow-indexed')
         ? undefined
-        : TRANSACTION_SUPPORTED_TAGS,
+        : transactionSupportedTags(org),
       [Dataset.METRICS]: SESSION_SUPPORTED_TAGS,
       [Dataset.GENERIC_METRICS]: org.features.includes('alert-allow-indexed')
         ? undefined
@@ -255,6 +255,13 @@ export function datasetSupportedTags(
       return value ? makeTagCollection(value) : undefined;
     }
   )[dataset];
+}
+
+function transactionSupportedTags(org: Organization) {
+  if (org.features.includes('on-demand-metrics-extraction')) {
+    return [...TRANSACTION_SUPPORTED_TAGS, FieldKey.TRANSACTION_DURATION];
+  }
+  return TRANSACTION_SUPPORTED_TAGS;
 }
 
 // Some data sets support all tags except some. For these cases, define the


### PR DESCRIPTION
Closes [Allow transaction.duration filters in alert creation](https://github.com/getsentry/sentry/issues/51589)
Depends on #51683 

<img width="1090" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/782616c8-d82b-4f58-96a6-67aee2e8e8c8">
