### PR TITLE
feat(alerts): custom metric alerts

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -4,7 +4,7 @@ import logging
 from copy import deepcopy
 from dataclasses import replace
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 from django.db import transaction
 from django.db.models.signals import post_save
@@ -59,6 +59,7 @@ from sentry.snuba.subscriptions import (
     update_snuba_query,
 )
 from sentry.snuba.tasks import build_query_builder
+from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry_from_user
 from sentry.utils.snuba import is_measurement
@@ -560,6 +561,8 @@ def create_alert_rule(
             type=AlertRuleActivityType.CREATED.value,
         )
 
+    schedule_update_project_config(alert_rule, projects)
+
     return alert_rule
 
 
@@ -794,6 +797,8 @@ def update_alert_rule(
             data=alert_rule.get_audit_log_data(),
             event=audit_log.get_event_id("ALERT_RULE_EDIT"),
         )
+
+    schedule_update_project_config(alert_rule, projects)
 
     return alert_rule
 
@@ -1491,3 +1496,16 @@ def get_filtered_actions(
         for action in trigger.get("actions", [])
         if STRING_TO_ACTION_TYPE.get(action.get("type")) == action_type
     ]
+
+
+def schedule_update_project_config(alert_rule: AlertRule, projects: Sequence[Project]):
+    if not projects or not features.has(
+        "organizations:on-demand-metrics-extraction", alert_rule.organization
+    ):
+        return
+
+    if alert_rule.is_custom_metric:
+        for project in projects:
+            schedule_invalidate_project_config(
+                trigger="alerts:create-on-demand-metric", project_id=project.id
+            )

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -408,6 +408,12 @@ class AlertRule(Model):
             pass
         return None
 
+    @property
+    def is_custom_metric(self):
+        # TODO(ogi): Remove this once we decide on a better way to determine if an alert rule is
+        # based on a a custom metric or not.
+        return "transaction.duration" in self.snuba_query.query
+
     def get_audit_log_data(self):
         return {"label": self.name}
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -639,6 +639,24 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert alert_rule.snuba_query.type == SnubaQuery.Type.PERFORMANCE.value
         assert alert_rule.snuba_query.dataset == Dataset.PerformanceMetrics.value
 
+    @patch("sentry.incidents.logic.schedule_update_project_config")
+    def test_custom_metric_alert(self, mocked_schedule_update_project_config):
+        alert_rule = create_alert_rule(
+            self.organization,
+            [self.project],
+            "custom metric alert",
+            "transaction.duration:>=1000",
+            "count()",
+            1,
+            AlertRuleThresholdType.ABOVE,
+            1,
+            query_type=SnubaQuery.Type.PERFORMANCE,
+            dataset=Dataset.Metrics,
+        )
+        assert alert_rule.is_custom_metric
+
+        mocked_schedule_update_project_config.assert_called_once_with(alert_rule, [self.project])
+
 
 class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
     @cached_property
@@ -944,6 +962,32 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         )
         assert alert_rule.snuba_query.type == SnubaQuery.Type.PERFORMANCE.value
         assert alert_rule.snuba_query.dataset == Dataset.PerformanceMetrics.value
+
+    @patch("sentry.incidents.logic.schedule_update_project_config")
+    def test_custom_metric_alert(self, mocked_schedule_update_project_config):
+        alert_rule = create_alert_rule(
+            self.organization,
+            [self.project],
+            "custom metric alert",
+            "",
+            "count()",
+            1,
+            AlertRuleThresholdType.ABOVE,
+            1,
+            query_type=SnubaQuery.Type.PERFORMANCE,
+            dataset=Dataset.Metrics,
+        )
+
+        assert not alert_rule.is_custom_metric
+        mocked_schedule_update_project_config.assert_called_with(alert_rule, [self.project])
+
+        alert_rule = update_alert_rule(
+            alert_rule, name="updated alert", query="transaction.duration:>=100"
+        )
+
+        assert alert_rule.is_custom_metric
+
+        mocked_schedule_update_project_config.assert_called_with(alert_rule, None)
 
 
 class DeleteAlertRuleTest(TestCase, BaseIncidentsTest):
@@ -1877,3 +1921,38 @@ class TestDeduplicateTriggerActions(TestCase):
         )
         # now this should win over the new critical
         self.run_test([trigger_w, trigger_c], [action_w, other_action_w])
+
+
+class TestCustomMetricAlertRule(TestCase):
+    @patch("sentry.incidents.logic.features.has", return_value=True)
+    @patch("sentry.incidents.logic.schedule_invalidate_project_config")
+    def test_create_alert_rule(self, mocked_schedule_invalidate_project_config, mocked_feature_has):
+        self.create_alert_rule()
+
+        mocked_schedule_invalidate_project_config.assert_not_called()
+
+    @patch("sentry.incidents.logic.features.has", return_value=True)
+    @patch("sentry.incidents.logic.schedule_invalidate_project_config")
+    def test_create_custom_metric_alert_rule(
+        self, mocked_schedule_invalidate_project_config, mocked_feature_has
+    ):
+        self.create_alert_rule(
+            projects=[self.project],
+            query="transaction.duration:>=100",
+        )
+
+        mocked_schedule_invalidate_project_config.assert_called_once_with(
+            trigger="alerts:create-on-demand-metric", project_id=self.project.id
+        )
+
+    @patch("sentry.incidents.logic.features.has", return_value=False)
+    @patch("sentry.incidents.logic.schedule_invalidate_project_config")
+    def test_create_custom_metric_turned_off(
+        self, mocked_schedule_invalidate_project_config, mocked_feature_has
+    ):
+        self.create_alert_rule(
+            projects=[self.project],
+            query="transaction.duration:>=100",
+        )
+
+        mocked_schedule_invalidate_project_config.assert_not_called()

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -554,3 +554,13 @@ class AlertRuleActivityTest(TestCase):
         assert AlertRuleActivity.objects.filter(
             alert_rule=self.alert_rule, type=AlertRuleActivityType.UPDATED.value
         ).exists()
+
+
+class AlertRuleCustomMetricTest(TestCase):
+    def test_simple(self):
+        standard_alert_rule = self.create_alert_rule(query="event.type:error")
+        custom_alert_rule = self.create_alert_rule(query="transaction.duration:>=1000")
+
+        assert not standard_alert_rule.is_custom_metric
+
+        assert custom_alert_rule.is_custom_metric


### PR DESCRIPTION
Part of [Allow transaction.duration filters in alert creation](https://github.com/getsentry/sentry/issues/51589)
Related to https://github.com/getsentry/sentry/pull/51679

Adds `is_custom_metric` field to `AlertRule` model. Adds project config invalidation trigger on custom alert creation/update