### PR TITLE
feat(analytics): Add analytics for source map upload

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -5,7 +5,7 @@ from .alert_rule_ui_component_webhook_sent import *  # noqa: F401,F403
 from .api_token_created import *  # noqa: F401,F403
 from .api_token_deleted import *  # noqa: F401,F403
 from .artifactbundle_assemble import *  # noqa: F401,F403
-from .artifactbundle_assemble_complete import *  # noqa: F401,F403
+from .artifactbundle_manifest_extracted import *  # noqa: F401,F403
 from .codeowners_assignment import *  # noqa: F401,F403
 from .codeowners_created import *  # noqa: F401,F403
 from .codeowners_updated import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -4,6 +4,8 @@ from .alert_edited import *  # noqa: F401,F403
 from .alert_rule_ui_component_webhook_sent import *  # noqa: F401,F403
 from .api_token_created import *  # noqa: F401,F403
 from .api_token_deleted import *  # noqa: F401,F403
+from .artifactbundle_assemble import *  # noqa: F401,F403
+from .artifactbundle_assemble_complete import *  # noqa: F401,F403
 from .codeowners_assignment import *  # noqa: F401,F403
 from .codeowners_created import *  # noqa: F401,F403
 from .codeowners_updated import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/artifactbundle_assemble.py
+++ b/src/sentry/analytics/events/artifactbundle_assemble.py
@@ -1,8 +1,8 @@
 from sentry import analytics
 
 
-class ReleaseCreatedEvent(analytics.Event):
-    type = "release.created"
+class ArtifactBundleAssemble(analytics.Event):
+    type = "artifactbundle.assemble"
 
     attributes = (
         analytics.Attribute("user_id", required=False),
@@ -10,8 +10,7 @@ class ReleaseCreatedEvent(analytics.Event):
         analytics.Attribute("project_ids"),
         analytics.Attribute("user_agent", required=False),
         analytics.Attribute("auth_type", required=False),
-        analytics.Attribute("created_status"),
     )
 
 
-analytics.register(ReleaseCreatedEvent)
+analytics.register(ArtifactBundleAssemble)

--- a/src/sentry/analytics/events/artifactbundle_assemble_complete.py
+++ b/src/sentry/analytics/events/artifactbundle_assemble_complete.py
@@ -1,0 +1,14 @@
+from sentry import analytics
+
+
+class ArtifactBundleAssembleComplete(analytics.Event):
+    type = "artifactbundle.assemble_complete"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_ids"),
+        analytics.Attribute("has_debug_ids"),
+    )
+
+
+analytics.register(ArtifactBundleAssembleComplete)

--- a/src/sentry/analytics/events/artifactbundle_manifest_extracted.py
+++ b/src/sentry/analytics/events/artifactbundle_manifest_extracted.py
@@ -1,8 +1,8 @@
 from sentry import analytics
 
 
-class ArtifactBundleAssembleComplete(analytics.Event):
-    type = "artifactbundle.assemble_complete"
+class ArtifactBundleManifestExtracted(analytics.Event):
+    type = "artifactbundle.manifest_extracted"
 
     attributes = (
         analytics.Attribute("organization_id"),
@@ -11,4 +11,4 @@ class ArtifactBundleAssembleComplete(analytics.Event):
     )
 
 
-analytics.register(ArtifactBundleAssembleComplete)
+analytics.register(ArtifactBundleManifestExtracted)

--- a/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
+++ b/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
@@ -2,12 +2,13 @@ import jsonschema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import options
+from sentry import analytics, options
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.constants import ObjectStatus
 from sentry.models import FileBlobOwner, Project
+from sentry.models.apitoken import is_api_token_auth
 from sentry.tasks.assemble import (
     AssembleTask,
     ChunkFileState,
@@ -138,6 +139,15 @@ class OrganizationArtifactBundleAssembleEndpoint(
                 "chunks": chunks,
                 "upload_as_artifact_bundle": True,
             }
+        )
+
+        analytics.record(
+            "artifactbundle.assemble",
+            user_id=request.user.id if request.user and request.user.id else None,
+            organization_id=organization.id,
+            project_ids=project_ids,
+            user_agent=request.META.get("HTTP_USER_AGENT", ""),
+            auth_type="api_token" if is_api_token_auth(request.auth) else None,
         )
 
         return Response({"state": ChunkFileState.CREATED, "missingChunks": []}, status=200)

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -33,6 +33,7 @@ from sentry.models import (
     ReleaseStatus,
     SemverFilter,
 )
+from sentry.models.apitoken import is_api_token_auth
 from sentry.search.events.constants import (
     OPERATOR_TO_DJANGO,
     RELEASE_ALIAS,
@@ -563,6 +564,7 @@ class OrganizationReleasesEndpoint(
                     project_ids=[project.id for project in projects],
                     user_agent=request.META.get("HTTP_USER_AGENT", ""),
                     created_status=status,
+                    auth_type="api_token" if is_api_token_auth(request.auth) else None,
                 )
 
                 scope.set_tag("success_status", status)

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -12,6 +12,7 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import ReleaseWithVersionSerializer
 from sentry.models import Activity, Environment, Release, ReleaseStatus
+from sentry.models.apitoken import is_api_token_auth
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.ratelimits.config import SENTRY_RATELIMITER_GROUP_DEFAULTS, RateLimitConfig
 from sentry.signals import release_created
@@ -186,6 +187,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
                     project_ids=[project.id],
                     user_agent=request.META.get("HTTP_USER_AGENT", "")[:256],
                     created_status=status,
+                    auth_type="api_token" if is_api_token_auth(request.auth) else None,
                 )
                 scope.set_tag("success_status", status)
 

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -373,7 +373,7 @@ def _create_artifact_bundle(
         bundle_id, debug_ids_with_types = _extract_debug_ids_from_manifest(archive.manifest)
 
         analytics.record(
-            "artifactbundle.assemble_complete",
+            "artifactbundle.manifest_extracted",
             organization_id=org_id,
             project_ids=project_ids,
             has_debug_ids=len(debug_ids_with_types) > 0,

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import SymbolicError
 
-from sentry import options
+from sentry import analytics, options
 from sentry.api.serializers import serialize
 from sentry.cache import default_cache
 from sentry.models import File, Organization, Release, ReleaseFile
@@ -371,6 +371,13 @@ def _create_artifact_bundle(
 ) -> None:
     with ReleaseArchive(archive_file.getfile()) as archive:
         bundle_id, debug_ids_with_types = _extract_debug_ids_from_manifest(archive.manifest)
+
+        analytics.record(
+            "artifactbundle.assemble_complete",
+            organization_id=org_id,
+            project_ids=project_ids,
+            has_debug_ids=len(debug_ids_with_types) > 0,
+        )
 
         # We want to save an artifact bundle only if we have found debug ids in the manifest or if the user specified
         # a release for the upload.


### PR DESCRIPTION
This PR adds two amplitude event when uploading source maps.

One, is in the upload endpoint, where we can track the user agent & auth type that's used for uploading.
Another is when the source maps are processed, where we can track if debug ids are used.

I also add an `auth_type` to the existing release creation analytics, in preparation for the org tokens.