### PR TITLE
ref(org-token): Update org-token security email

### DIFF
--- a/src/sentry/templates/sentry/emails/org-auth-token-created.html
+++ b/src/sentry/templates/sentry/emails/org-auth-token-created.html
@@ -1,5 +1,27 @@
-{% extends "sentry/emails/security_base.html" %}
+{% extends "sentry/emails/base.html" %}
 
-{% block security_body %}
+{% load i18n %}
+{% load sentry_avatars %}
+{% load sentry_helpers %}
+
+{% block main %}
+  <h3>Security Notice</h3>
   <p>User {{ actor.email }} has created a new Organization Auth Token "{{ token_name }}" for your Sentry organization {{ organization.name }}.</p>
+  <table>
+    <tr>
+      <td style="width:36px;vertical-align:top;padding-right:15px;">
+        {% avatar_for_email account 36 %}
+      </td>
+      <td>
+        <strong>{{ account.email }}</strong><br />
+        {{ ip_address }}<br />
+        {{ datetime }} UTC
+      </td>
+    </tr>
+    {% block security_metadata %}{% endblock %}
+  </table>
+  <h4>Don't recognize this activity?</h4>
+  <p>We recommend to check with {{ actor.email }} if you are unsure about the purpose of this token. If you determine that this activity is malicious please contact <a href="mailto:{% security_contact %}">{% security_contact %}</a>.</p>
 {% endblock %}
+
+{% block footer %}{% endblock %}

--- a/src/sentry/templates/sentry/emails/org-auth-token-created.txt
+++ b/src/sentry/templates/sentry/emails/org-auth-token-created.txt
@@ -1,5 +1,21 @@
-{% extends "sentry/emails/security_base.txt" %}
-
-{% block security_body %}
+{% spaceless %}
+{% load sentry_helpers %}
+{% autoescape off %}
+Security Notice
+---------------
 User {{ actor.email }} has created a new Organization Auth Token "{{ token_name }}" for your Sentry organization {{ organization.name }}.
-{% endblock %}
+
+Details
+-------
+
+Account: {{ account.email }}
+IP: {{ ip_address }}
+When: {{ datetime }} UTC
+{% block security_metadata %}{% endblock %}
+
+This activity looks suspicious?
+------------------------------
+
+We recommend to check with {{ actor.email }} if you are unsure about the purpose of this token. If you determine that this activity is malicious please contact {% security_contact %}.
+{% endautoescape %}
+{% endspaceless %}


### PR DESCRIPTION
I noticed the content of the security email was slightly off, as the base security template does not fit for this use case perfectly:

![image](https://github.com/getsentry/sentry/assets/2411343/5dca86f2-ff00-48fd-b358-68e05d671f46)

As this email goes to org owners, not the creating user themselves. So I've adjusted this by copy-pasting the base security template and adjusting the text there to make more sense:

> We recommend to check with {{ actor.email }} if you are unsure about the purpose of this token. If you determine that this activity is malicious please contact {% security_contact %}.