### PR TITLE
fix(starfish): tooltip missing units span samples

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -105,7 +105,7 @@ function DurationChart({
       symbol: getSampleSymbol(duration, p95).symbol,
       color: getSampleSymbol(duration, p95).color,
       symbolSize: span_id === highlightedSpanId ? 15 : 10,
-      seriesName: transaction_id,
+      seriesName: transaction_id.substring(0, 8),
     })
   );
 
@@ -154,6 +154,7 @@ function DurationChart({
         height={140}
         onClick={handleChartClick}
         onHighlight={handleChartHighlight}
+        aggregateOutputFormat="duration"
         data={[spanMetricsSeriesData?.[`p95(${SPAN_SELF_TIME})`], baselineP95Series]}
         start=""
         end=""


### PR DESCRIPTION
Add units in span samples duration chart,
format span sample using short eventID
Before
<img width="423" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/ac632cc8-7251-42d1-9800-49c20d501c16">

After
<img width="719" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/48542d79-090e-47e4-8cba-5f32d76931de">
