### PR TITLE
feat(python): Add `covdefaults` to dev dependencies

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -28,6 +28,7 @@ cfgv==3.3.1
 charset-normalizer==3.0.1
 click==8.0.4
 confluent-kafka==2.1.1
+covdefaults==2.3.0
 coverage==6.3.3
 croniter==1.3.10
 cryptography==39.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
+covdefaults>=2.3.0
 docker>=3.7.0,<3.8.0
 freezegun>=1.1.0
 honcho>=1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,3 +113,9 @@ python-tag = py38
 omit =
     src/sentry/migrations/*
 plugins = covdefaults
+
+[coverage:report]
+# Setting this to 0 makes it falsy, and it gets ignored, so we set it to
+# a value we'll never fall below. (0 is the default, but it's changed to 100 by
+# covdefaults, so this just changes it back.)
+fail_under = 0.01

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,3 +113,4 @@ python-tag = py38
 omit =
     src/sentry/migrations/*
 source = .
+plugins = covdefaults

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,5 +112,4 @@ python-tag = py38
 [coverage:run]
 omit =
     src/sentry/migrations/*
-source = .
 plugins = covdefaults


### PR DESCRIPTION
This adds `covdefaults` to our Python dev dependencies, in order to pick up the "ignore `if TYPE_CHECKING` blocks when calculating coverage" setting. (This is in lieu of [doing it ourselves](https://github.com/getsentry/sentry/pull/51654#discussion_r1242869671).)