### PR TITLE
fix(config): Use boolean in `codecov.yml`

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -72,5 +72,5 @@ comment:
   # already exists, and a newer commit results in no coverage change for the
   # entire pull, the comment will be deleted.
   require_changes: true
-  require_base: yes # must have a base report to post
-  require_head: yes # must have a head report to post
+  require_base: true # must have a base report to post
+  require_head: true # must have a head report to post


### PR DESCRIPTION
This switches from using `yes` to using `true` in `codecov.yml`, as specified in the [schema for the file](https://json.schemastore.org/codecov.json), so our linter will stop yelling at us. (This also matches the example in the [codecov docs](https://docs.codecov.com/docs/pull-request-comments#configuration).)