### PR TITLE
fix(starfish): Rename null breakdown group to custom

### DIFF
--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {getInterval} from 'sentry/components/charts/utils';
 import {Panel} from 'sentry/components/panels';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {PageFilters} from 'sentry/types';
 import {Series, SeriesDataUnit} from 'sentry/types/echarts';
@@ -20,7 +21,7 @@ import {SpanGroupBreakdown} from 'sentry/views/starfish/views/webServiceView/spa
 const {SPAN_SELF_TIME} = SpanMetricsFields;
 
 export const OTHER_SPAN_GROUP_MODULE = 'Other';
-export const NULL_SPAN_CATEGORY = 'custom';
+export const NULL_SPAN_CATEGORY = t('custom');
 
 type Props = {
   transaction?: string;

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -20,7 +20,7 @@ import {SpanGroupBreakdown} from 'sentry/views/starfish/views/webServiceView/spa
 const {SPAN_SELF_TIME} = SpanMetricsFields;
 
 export const OTHER_SPAN_GROUP_MODULE = 'Other';
-export const NULL_SPAN_CATEGORY = '<null>';
+export const NULL_SPAN_CATEGORY = 'custom';
 
 type Props = {
   transaction?: string;


### PR DESCRIPTION
This is a more accurate description of what's going on.

- Rename null to custom
- Use locale translation

**Before:**
![Screenshot 2023-06-27 at 11 13 49 AM](https://github.com/getsentry/sentry/assets/989898/3cdaf220-5f87-43cc-b8df-fec1d067ed9e)

**After:**
![Screenshot 2023-06-27 at 11 25 22 AM](https://github.com/getsentry/sentry/assets/989898/c1bba861-3cbb-4944-ad12-9907d35539bf)
