### PR TITLE
fix(starfish): Checkboxes go back to default when tab loses focus and then regains it

### DIFF
--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -155,6 +155,7 @@ export function SpanGroupBreakdown({
               <ListItemContainer>
                 <Checkbox
                   size="sm"
+                  key={group['span.category']}
                   checkboxColor={colorPalette[index]}
                   inputCss={{backgroundColor: 'red'}}
                   checked={checkedValue}


### PR DESCRIPTION
There's more details in the notion ticket, but this PR will fix an issue where checkboxes will reset when you gain then lose focus.