### PR TITLE
styles(functions): Adjust height for profiling landing widgets

### DIFF
--- a/static/app/views/profiling/landing/styles.tsx
+++ b/static/app/views/profiling/landing/styles.tsx
@@ -5,7 +5,7 @@ import {Panel} from 'sentry/components/panels';
 import {space} from 'sentry/styles/space';
 
 export const WidgetContainer = styled(Panel)`
-  height: 325px;
+  height: 340px;
   display: flex;
   flex-direction: column;
   padding-top: ${space(2)};
@@ -61,6 +61,7 @@ export const Accordion = styled('ul')`
 export const AccordionItem = styled('li')`
   line-height: ${p => p.theme.text.lineHeightBody};
   display: flex;
+  align-items: center;
   gap: ${space(1)};
   border-top: 1px solid ${p => p.theme.border};
   padding: ${space(1)} ${space(2)};


### PR DESCRIPTION
Noticed the 3rd row would overflow the widget container by a few pixels.