### PR TITLE
fix(starfish): Checkboxes go back to default when tab loses focus and then regains it

### DIFF
--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 import {Link} from 'react-router';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -24,7 +24,6 @@ import {DataRow} from 'sentry/views/starfish/views/webServiceView/spanGroupBreak
 
 type Props = {
   colorPalette: string[];
-  initialShowSeries: boolean[];
   isCumulativeTimeLoading: boolean;
   isTableLoading: boolean;
   isTimeseriesLoading: boolean;
@@ -44,14 +43,13 @@ export function SpanGroupBreakdown({
   tableData: transformedData,
   totalCumulativeTime: totalValues,
   topSeriesData: data,
-  initialShowSeries,
   transaction,
   isTimeseriesLoading,
   errored,
 }: Props) {
   const {selection} = usePageFilters();
   const theme = useTheme();
-  const [showSeriesArray, setShowSeriesArray] = useState<boolean[]>(initialShowSeries);
+  const [showSeriesArray, setShowSeriesArray] = useState<boolean[]>([]);
   const options: SelectOption<DataDisplayType>[] = [
     {label: 'Total Duration', value: DataDisplayType.CUMULATIVE_DURATION},
     {label: 'Percentages', value: DataDisplayType.PERCENTAGE},
@@ -60,9 +58,9 @@ export function SpanGroupBreakdown({
     DataDisplayType.CUMULATIVE_DURATION
   );
 
-  useEffect(() => {
-    setShowSeriesArray(initialShowSeries);
-  }, [initialShowSeries]);
+  if (showSeriesArray.length === 0 && transformedData.length > 0) {
+    setShowSeriesArray(transformedData.map(() => true));
+  }
 
   const visibleSeries: Series[] = [];
 
@@ -155,7 +153,6 @@ export function SpanGroupBreakdown({
               <ListItemContainer>
                 <Checkbox
                   size="sm"
-                  key={group['span.category']}
                   checkboxColor={colorPalette[index]}
                   inputCss={{backgroundColor: 'red'}}
                   checked={checkedValue}

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -155,6 +155,7 @@ export function SpanGroupBreakdown({
               <ListItemContainer>
                 <Checkbox
                   size="sm"
+                  key={group['span.category']}
                   checkboxColor={colorPalette[index]}
                   inputCss={{backgroundColor: 'red'}}
                   checked={checkedValue}

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -156,8 +156,6 @@ export function SpanGroupBreakdownContainer({transaction, transactionMethod}: Pr
 
   const data = Object.values(seriesByDomain);
 
-  const initialShowSeries = transformedData.map(_ => true);
-
   return (
     <StyledPanel>
       <SpanGroupBreakdown
@@ -166,7 +164,6 @@ export function SpanGroupBreakdownContainer({transaction, transactionMethod}: Pr
         isTableLoading={isSegmentsLoading}
         topSeriesData={data}
         colorPalette={colorPalette}
-        initialShowSeries={initialShowSeries}
         isTimeseriesLoading={isTopDataLoading}
         isCumulativeTimeLoading={isCumulativeDataLoading}
         transaction={transaction}


### PR DESCRIPTION
There's more details in the notion ticket on what the issue, but this PR will fix an issue where checkboxes will reset when you gain then lose focus.

The problem was we can't reliably use `initialShowSeries` inside the useEffect dependency array because it is an array, and arrays are pass by reference.