### PR TITLE
feat(performance-detector-thresholds): Added frontend changes for reset functionality.

### DIFF
--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.jsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.jsx
@@ -269,9 +269,9 @@ describe('projectPerformance', function () {
       },
       statusCode: 200,
     });
-    const endpointMock = MockApiClient.addMockResponse({
+    const delete_request_mock = MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/performance-issues/configure/',
-      method: 'PUT',
+      method: 'DELETE',
     });
 
     render(
@@ -295,23 +295,6 @@ describe('projectPerformance', function () {
 
     await userEvent.click(confirmButton);
 
-    expect(endpointMock).toHaveBeenCalledWith(
-      '/projects/org-slug/project-slug/performance-issues/configure/',
-      expect.objectContaining({
-        data: {
-          n_plus_one_db_duration_threshold: 100,
-        },
-      })
-    );
-
-    // Should not be able to reset thresholds that are disabled by admin
-    expect(endpointMock).toHaveBeenCalledWith(
-      '/projects/org-slug/project-slug/performance-issues/configure/',
-      expect.not.objectContaining({
-        data: {
-          slow_db_query_duration_threshold: 1000,
-        },
-      })
-    );
+    expect(delete_request_mock).toHaveBeenCalled();
   });
 });

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -23,7 +23,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import AsyncView from 'sentry/views/asyncView';
-import {tenSecondInMs} from 'sentry/views/discover/table/quickContext/utils';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 
@@ -42,17 +41,6 @@ export const allowedDurationValues: number[] = [
 
 type ProjectPerformanceSettings = {[key: string]: number | boolean};
 
-type ConfigExtremeType = {
-  default: number | boolean;
-  max: number | boolean;
-  min: number | boolean;
-};
-
-const configExtremes: {[key in DetectorConfigCustomer]?: ConfigExtremeType} = {
-  slow_db_query_duration_threshold: {min: 100, default: 1000, max: tenSecondInMs},
-  n_plus_one_db_duration_threshold: {min: 50, default: 100, max: tenSecondInMs},
-};
-
 enum DetectorConfigAdmin {
   N_PLUS_DB_ENABLED = 'n_plus_one_db_queries_detection_enabled',
   SLOW_DB_ENABLED = 'slow_db_queries_detection_enabled',
@@ -62,13 +50,6 @@ enum DetectorConfigCustomer {
   SLOW_DB_DURATION = 'slow_db_query_duration_threshold',
   N_PLUS_DB_DURATION = 'n_plus_one_db_duration_threshold',
 }
-
-const mapThresholdToDetectionEnabled: {
-  [key in DetectorConfigCustomer]: DetectorConfigAdmin;
-} = {
-  slow_db_query_duration_threshold: DetectorConfigAdmin.SLOW_DB_ENABLED,
-  n_plus_one_db_duration_threshold: DetectorConfigAdmin.N_PLUS_DB_ENABLED,
-};
 
 type RouteParams = {orgId: string; projectId: string};
 
@@ -166,20 +147,10 @@ class ProjectPerformance extends AsyncView<Props, State> {
       loading: true,
     });
 
-    const data = {};
-    Object.values(DetectorConfigCustomer).forEach(threshold => {
-      if (
-        this.state.performance_issue_settings[mapThresholdToDetectionEnabled[threshold]]
-      ) {
-        data[threshold] = configExtremes[threshold]?.default;
-      }
-    });
-
     this.api.request(
       `/projects/${organization.slug}/${projectId}/performance-issues/configure/`,
       {
-        method: 'PUT',
-        data,
+        method: 'DELETE',
         complete: () => this.fetchData(),
       }
     );


### PR DESCRIPTION
- We are introducing new reset functionality in the backend, here's the [PR](https://github.com/getsentry/sentry/pull/51689).
- Reset all button now makes a DELETE request to the /configure/ endpoint.
- Added tests.