### PR TITLE
fix(github-comments): remove extra slash from PATCH url

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -558,7 +558,7 @@ class GitHubClientMixin(GithubProxyClient):
         return self.post(endpoint, data=data)
 
     def update_comment(self, repo: str, comment_id: str, data: Mapping[str, Any]) -> JSONData:
-        endpoint = f"/repos/{repo}/issues/comments/{comment_id}/"
+        endpoint = f"/repos/{repo}/issues/comments/{comment_id}"
         return self.patch(endpoint, data=data)
 
     def get_user(self, gh_username: str) -> JSONData:

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -319,7 +319,7 @@ class GitHubAppsClientTest(TestCase):
 
         responses.add(
             method=responses.PATCH,
-            url=f"https://api.github.com/repos/{self.repo.name}/issues/comments/1/",
+            url=f"https://api.github.com/repos/{self.repo.name}/issues/comments/1",
             json={
                 "id": 1,
                 "node_id": "MDEyOklzc3VlQ29tbWVudDE=",

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -370,7 +370,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         )
         responses.add(
             responses.PATCH,
-            self.base_url + "/repos/getsentry/sentry/issues/comments/1/",
+            self.base_url + "/repos/getsentry/sentry/issues/comments/1",
             json={"id": 1},
         )
 


### PR DESCRIPTION
Fixes https://sentry.sentry.io/issues/4272455224/?project=1

For ER-1669