### PR TITLE
fix(starfish): other link doesn't filter properly

### DIFF
--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -11,7 +11,7 @@ import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery
 import {NULL_SPAN_CATEGORY} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
 const {SPAN_SELF_TIME} = SpanMetricsFields;
-const SPAN_FILTER_KEYS = ['span.op', 'span.domain', 'span.action'];
+const SPAN_FILTER_KEYS = ['span.op', 'span.domain', 'span.action', '!span.module'];
 
 export type SpanMetrics = {
   'http_error_count()': number;

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -147,6 +147,9 @@ export function SpanGroupBreakdown({
           } else {
             spansLinkQueryParams['span.module'] = 'Other';
           }
+          spansLinkQueryParams['!span.module'] = transformedData
+            .map(r => r.group['span.category'])
+            .filter(c => !['Other'].includes(c));
           spansLinkQueryParams['span.category'] = group['span.category'];
 
           const spansLink = `/starfish/spans/?${qs.stringify(spansLinkQueryParams)}`;


### PR DESCRIPTION
Clicking on the 'other' link in the WSV will not filter out other modules from the result.
<img width="831" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/a301a4eb-5c97-44d3-810e-dcae11abdcd6">
