### PR TITLE
ref(integrations): Switch to warning when no org integration found

### DIFF
--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -51,7 +51,7 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
         )
         # Integrations and their corresponding RpcIntegrations share the same id,
         # so we don't need to first convert this to a full Integration object
-        bind_org_context_from_integration(rpc_integration.id)
+        bind_org_context_from_integration(rpc_integration.id, {"webhook": "issue_updated"})
         sentry_sdk.set_tag("integration_id", rpc_integration.id)
 
         data = request.data

--- a/src/sentry/integrations/jira/webhooks/uninstalled.py
+++ b/src/sentry/integrations/jira/webhooks/uninstalled.py
@@ -27,7 +27,7 @@ class JiraSentryUninstalledWebhook(JiraWebhookBase):
             method="POST",
         )
         integration = Integration.objects.get(id=rpc_integration.id)
-        bind_org_context_from_integration(integration.id)
+        bind_org_context_from_integration(integration.id, {"webhook": "uninstalled"})
         sentry_sdk.set_tag("integration_id", integration.id)
 
         integration.update(status=ObjectStatus.DISABLED)

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -64,8 +64,9 @@ def bind_org_context_from_integration(integration_id: int) -> None:
     orgs = get_orgs_from_integration(integration_id)
 
     if len(orgs) == 0:
-        logger.exception(
-            f"Can't bind org context - no orgs are associated with integration id={integration_id}."
+        logger.warning(
+            f"Can't bind org context - no orgs are associated with integration id={integration_id}.",
+            extra=extra,
         )
     elif len(orgs) == 1:
         bind_organization_context(orgs[0])

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Sequence
+from typing import Any, Mapping, Sequence
 
 from sentry_sdk import configure_scope
 
@@ -49,7 +49,9 @@ def get_orgs_from_integration(integration_id: int) -> Sequence[Organization]:
     return orgs
 
 
-def bind_org_context_from_integration(integration_id: int) -> None:
+def bind_org_context_from_integration(
+    integration_id: int, extra: Mapping[str, Any] | None = None
+) -> None:
     """
     Given the id of an Integration or an RpcIntegration, get the associated org(s) and bind that
     data to the scope.

--- a/tests/sentry/integrations/utils/test_scope.py
+++ b/tests/sentry/integrations/utils/test_scope.py
@@ -64,18 +64,19 @@ class BindOrgContextFromIntegrationTest(TestCase):
 
     @patch("sentry.integrations.utils.scope.bind_ambiguous_org_context")
     @patch("sentry.integrations.utils.scope.bind_organization_context")
-    @patch("sentry.integrations.utils.scope.logger.exception")
-    def test_logs_error_if_no_orgs_found(
+    @patch("sentry.integrations.utils.scope.logger.warning")
+    def test_logs_warning_if_no_orgs_found(
         self,
-        mock_logger_exception: MagicMock,
+        mock_logger_warning: MagicMock,
         mock_bind_org_context: MagicMock,
         mock_bind_ambiguous_org_context: MagicMock,
     ):
         integration = Integration.objects.create(name="squirrelChasers")
 
-        bind_org_context_from_integration(integration.id)
-        mock_logger_exception.assert_called_with(
-            f"Can't bind org context - no orgs are associated with integration id={integration.id}."
+        bind_org_context_from_integration(integration.id, {"webhook": "issue_updated"})
+        mock_logger_warning.assert_called_with(
+            f"Can't bind org context - no orgs are associated with integration id={integration.id}.",
+            extra={"webhook": "issue_updated"},
         )
         mock_bind_org_context.assert_not_called()
         mock_bind_ambiguous_org_context.assert_not_called()


### PR DESCRIPTION
Currently, when `bind_org_context_from_integration` doesn't find any orgs associated with the given integration id, it logs an exception to Sentry. This turns out to be a _much_ more frequent occurrence than I was counting on - we've gotten ~400K events just in the 8 hours since I merged that change. So, to avoid spam in our backend project, this PR switches to calling `logger.warning`. 

(One hypothesis is that this is happening because old integrations are still hanging around, tied to orgs that no longer exist. If so, we should do some cleanup there. If and when we do, it'll be helpful to see the if the frequency of "no orgs found" decreases, which is why I'm continuing to log it rather than just ignoring it.)

In order for the new log messages to have (at least some of) the same data as one would find in a Sentry event, this PR also allows extra data to be passed directly to `bind_org_context_from_integration`.