### PR TITLE
fix(starfish): other link doesn't filter properly

### DIFF
--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -11,7 +11,13 @@ import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery
 import {NULL_SPAN_CATEGORY} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
 const {SPAN_SELF_TIME} = SpanMetricsFields;
-const SPAN_FILTER_KEYS = ['span.op', 'span.domain', 'span.action', '!span.module'];
+const SPAN_FILTER_KEYS = [
+  'span.op',
+  'span.domain',
+  'span.action',
+  '!span.module',
+  '!span.category',
+];
 
 export type SpanMetrics = {
   'http_error_count()': number;
@@ -122,7 +128,9 @@ function buildEventViewQuery(
     .filter(key => SPAN_FILTER_KEYS.includes(key))
     .filter(key => Boolean(query[key]))
     .map(key => {
-      return `${key}:${query[key]}`;
+      const value = query[key];
+      const isArray = Array.isArray(value);
+      return `${key}:${isArray ? `[${value}]` : value}`;
     });
 
   if (moduleName !== ModuleName.ALL) {

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -140,15 +140,20 @@ export function SpanGroupBreakdown({
             start && end
               ? {start: getUtcDateString(start), end: getUtcDateString(end), utc}
               : {statsPeriod: period};
-          if (['db', 'http'].includes(group['span.category'])) {
-            spansLinkQueryParams['span.module'] = group['span.category'];
+
+          if (group['span.category'] === 'Other') {
+            spansLinkQueryParams['!span.module'] = ['db', 'http'];
+            spansLinkQueryParams['!span.category'] = transformedData.map(
+              r => r.group['span.category']
+            );
           } else {
-            spansLinkQueryParams['span.module'] = 'Other';
+            if (['db', 'http'].includes(group['span.category'])) {
+              spansLinkQueryParams['span.module'] = group['span.category'];
+            } else {
+              spansLinkQueryParams['span.module'] = 'Other';
+            }
+            spansLinkQueryParams['span.category'] = group['span.category'];
           }
-          spansLinkQueryParams['!span.module'] = transformedData
-            .map(r => r.group['span.category'])
-            .filter(c => !['Other'].includes(c));
-          spansLinkQueryParams['span.category'] = group['span.category'];
 
           const spansLink = `/starfish/spans/?${qs.stringify(spansLinkQueryParams)}`;
           return (


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/51713 didn't solve the issue, we should be filtering by span.category as well, and there was missing square brackets in the query.