### PR TITLE
fix(escalating): Add missing escalating statuses to autocomplete

### DIFF
--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -39,10 +39,12 @@ const storeConfig: TagStoreDefinition = {
     const isSuggestions = [
       'resolved',
       'unresolved',
-      org.features.includes('escalating-issues') ? 'archived' : 'ignored',
+      ...(org.features.includes('escalating-issues')
+        ? ['archived', 'escalating', 'new', 'ongoing', 'regressed']
+        : ['ignored']),
       'assigned',
-      'for_review',
       'unassigned',
+      'for_review',
       'linked',
       'unlinked',
     ];


### PR DESCRIPTION
![image](https://github.com/getsentry/sentry/assets/1400464/311a312d-3789-454e-8218-38739938ca28)
