### PR TITLE
ref(sdk): Improvements to `check_tag` SDK utility function

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -468,7 +468,7 @@ class RavenShim:
             scope.fingerprint = fingerprint
 
 
-def check_tag(tag_key: str, expected_value: str) -> None:
+def check_tag_for_scope_bleed(tag_key: str, expected_value: str) -> None:
     """Detect a tag already set and being different than what we expect.
 
     This function checks if a tag has been already been set and if it differs
@@ -594,7 +594,7 @@ def bind_organization_context(organization):
         op="other", description="bind_organization_context"
     ):
         # This can be used to find errors that may have been mistagged
-        check_tag("organization.slug", organization.slug)
+        check_tag_for_scope_bleed("organization.slug", organization.slug)
 
         scope.set_tag("organization", organization.id)
         scope.set_tag("organization.slug", organization.slug)
@@ -636,7 +636,7 @@ def bind_ambiguous_org_context(orgs: Sequence[Organization], source: str | None 
 
         # It's also possible that the org seems already to be set but it's just a case of scope
         # bleed. In that case, we want to test for that and proceed.
-        check_tag("organization.slug", MULTIPLE_ORGS_TAG)
+        check_tag_for_scope_bleed("organization.slug", MULTIPLE_ORGS_TAG)
 
         scope.set_tag("organization", MULTIPLE_ORGS_TAG)
         scope.set_tag("organization.slug", MULTIPLE_ORGS_TAG)
@@ -681,7 +681,7 @@ __all__ = (
     "capture_exception_with_scope_check",
     "capture_message",
     "check_current_scope_transaction",
-    "check_tag",
+    "check_tag_for_scope_bleed",
     "configure_scope",
     "configure_sdk",
     "get_options",

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -471,10 +471,11 @@ class RavenShim:
 def check_tag_for_scope_bleed(
     tag_key: str, expected_value: str | int, add_to_scope: bool = True
 ) -> None:
-    """Detect a tag already set and being different than what we expect.
-
-    This function checks if a tag has been already been set and if it differs
-    from what we want to set it to.
+    """
+    Detect if the given tag has already been set to a value different than what we expect. If we
+    find a mismatch, log a warning and, if `add_to_scope` is `True`, add scope bleed tags to the
+    scope. (An example of when we don't want to add scope bleed tag is if we're only logging a
+    warning rather than capturing an event.)
     """
     # force the string version to prevent false positives
     expected_value = str(expected_value)

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -468,7 +468,7 @@ class RavenShim:
             scope.fingerprint = fingerprint
 
 
-def check_tag_for_scope_bleed(tag_key: str, expected_value: str) -> None:
+def check_tag_for_scope_bleed(tag_key: str, expected_value: str, add_to_scope: bool = True) -> None:
     """Detect a tag already set and being different than what we expect.
 
     This function checks if a tag has been already been set and if it differs
@@ -500,13 +500,14 @@ def check_tag_for_scope_bleed(tag_key: str, expected_value: str) -> None:
                     return
 
         if current_value != expected_value:
-            scope.set_tag("possible_mistag", True)
-            scope.set_tag(f"scope_bleed.{tag_key}", True)
             extra = {
                 f"previous_{tag_key}_tag": current_value,
                 f"new_{tag_key}_tag": expected_value,
             }
-            merge_context_into_scope("scope_bleed", extra, scope)
+            if add_to_scope:
+                scope.set_tag("possible_mistag", True)
+                scope.set_tag(f"scope_bleed.{tag_key}", True)
+                merge_context_into_scope("scope_bleed", extra, scope)
             logger.warning(f"Tag already set and different ({tag_key}).", extra=extra)
 
 

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -468,17 +468,25 @@ class RavenShim:
             scope.fingerprint = fingerprint
 
 
-def check_tag_for_scope_bleed(tag_key: str, expected_value: str, add_to_scope: bool = True) -> None:
+def check_tag_for_scope_bleed(
+    tag_key: str, expected_value: str | int, add_to_scope: bool = True
+) -> None:
     """Detect a tag already set and being different than what we expect.
 
     This function checks if a tag has been already been set and if it differs
     from what we want to set it to.
     """
+    # force the string version to prevent false positives
+    expected_value = str(expected_value)
+
     with configure_scope() as scope:
         current_value = scope._tags.get(tag_key)
 
         if not current_value:
             return
+
+        # ensure we're comparing apples to apples
+        current_value = str(current_value)
 
         # There are times where we can only narrow down the current org to a list, for example if
         # we've derived it from an integration, since integrations can be shared across multiple orgs.

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -16,7 +16,7 @@ from sentry.utils.sdk import (
     bind_organization_context,
     capture_exception_with_scope_check,
     check_current_scope_transaction,
-    check_tag,
+    check_tag_for_scope_bleed,
     merge_context_into_scope,
 )
 
@@ -60,13 +60,13 @@ class SDKUtilsTest(TestCase):
 
 
 @patch("sentry.utils.sdk.logger.warning")
-class CheckTagTest(TestCase):
+class CheckTagForScopeBleedTest(TestCase):
     def test_no_existing_tag(self, mock_logger_warning: MagicMock):
         mock_scope = Scope()
         mock_scope._tags = {}
 
         with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
-            check_tag("org.slug", "squirrel_chasers")
+            check_tag_for_scope_bleed("org.slug", "squirrel_chasers")
 
         assert "possible_mistag" not in mock_scope._tags
         assert "scope_bleed.tag.org.slug" not in mock_scope._tags
@@ -78,7 +78,7 @@ class CheckTagTest(TestCase):
         mock_scope._tags = {"org.slug": "squirrel_chasers"}
 
         with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
-            check_tag("org.slug", "squirrel_chasers")
+            check_tag_for_scope_bleed("org.slug", "squirrel_chasers")
 
         assert "possible_mistag" not in mock_scope._tags
         assert "scope_bleed.tag.org.slug" not in mock_scope._tags
@@ -91,7 +91,7 @@ class CheckTagTest(TestCase):
         # We don't bother to add the underlying slug list here, since right now it's not checked
 
         with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
-            check_tag("organization.slug", "[multiple orgs]")
+            check_tag_for_scope_bleed("organization.slug", "[multiple orgs]")
 
         assert "possible_mistag" not in mock_scope._tags
         assert "scope_bleed.tag.organization.slug" not in mock_scope._tags
@@ -103,7 +103,7 @@ class CheckTagTest(TestCase):
         mock_scope._tags = {"org.slug": "good_dogs"}
 
         with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
-            check_tag("org.slug", "squirrel_chasers")
+            check_tag_for_scope_bleed("org.slug", "squirrel_chasers")
 
         extra = {
             "previous_org.slug_tag": "good_dogs",
@@ -121,7 +121,7 @@ class CheckTagTest(TestCase):
         mock_scope._tags = {"organization.slug": "good_dogs"}
 
         with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
-            check_tag("organization.slug", "[multiple orgs]")
+            check_tag_for_scope_bleed("organization.slug", "[multiple orgs]")
 
         extra = {
             "previous_organization.slug_tag": "good_dogs",
@@ -142,7 +142,7 @@ class CheckTagTest(TestCase):
         mock_scope.set_context("organization", {"multiple possible": [org.slug for org in orgs]})
 
         with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
-            check_tag("organization.slug", orgs[1].slug)
+            check_tag_for_scope_bleed("organization.slug", orgs[1].slug)
 
         assert "possible_mistag" not in mock_scope._tags
         assert "scope_bleed.tag.organization.slug" not in mock_scope._tags
@@ -159,7 +159,7 @@ class CheckTagTest(TestCase):
         mock_scope.set_context("organization", {"multiple possible": [org.slug for org in orgs]})
 
         with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
-            check_tag("organization.slug", "squirrel_chasers")
+            check_tag_for_scope_bleed("organization.slug", "squirrel_chasers")
 
         extra = {
             "previous_organization.slug_tag": "[multiple orgs]",


### PR DESCRIPTION
This makes a number of small improvements to the `check_tag` function in `utils.sdk`:

- Rename the function to `check_tag_for_scope_bleed`, to make it clearer what it's for.
- Add an option to prevent scope bleed tags from being added to scope when a mismatch is found. (When this is used, the only result of a mismatch is that a warning is logged. This is inspired by a spot where we switched from using `logger.exception` (which sends an event to Sentry) to using `logger.warning` (which doesn't). With no event to add scope data to, it doesn't make sense to set it, lest it pollute other events.)
- Allow the expected value to be passed in as an integer, but then ensure we're comparing strings to strings.
- Update the docstring.