### PR TITLE
fix(github-comments): don't raise ApiError if issue is locked

### DIFF
--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -233,7 +233,7 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
     except ApiError as e:
         cache.delete(cache_key)
 
-        if ISSUE_LOCKED_ERROR_MESSAGE in e.json["message"]:
+        if ISSUE_LOCKED_ERROR_MESSAGE in e.json.get("message", ""):
             return
 
         metrics.incr("github_pr_comment.api_error")

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -233,7 +233,7 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
     except ApiError as e:
         cache.delete(cache_key)
 
-        if ISSUE_LOCKED_ERROR_MESSAGE in e.text:
+        if ISSUE_LOCKED_ERROR_MESSAGE in e.json["message"]:
             return
 
         metrics.incr("github_pr_comment.api_error")

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -45,6 +45,8 @@ Have questions? Reach out to us in the #proj-github-pr-comments channel.
 
 SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url})"
 
+ISSUE_LOCKED_ERROR_MESSAGE = "Unable to create comment because issue is locked."
+
 
 def format_comment(issues: List[PullRequestIssue]):
     def format_subtitle(subtitle):
@@ -230,5 +232,9 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
         )
     except ApiError as e:
         cache.delete(cache_key)
+
+        if ISSUE_LOCKED_ERROR_MESSAGE in e.text:
+            return
+
         metrics.incr("github_pr_comment.api_error")
         raise e

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -389,7 +389,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @with_feature("organizations:pr-comment-bot")
     @responses.activate
-    def test_comment_workflow_raises_error(self, mock_metrics, get_jwt, mock_issues):
+    def test_comment_workflow_api_error(self, mock_metrics, get_jwt, mock_issues):
         cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
         mock_issues.return_value = [
             {"group_id": g.id, "event_count": 10} for g in Group.objects.all()
@@ -411,6 +411,36 @@ class TestCommentWorkflow(GithubCommentTestCase):
             github_comment_workflow(self.pr.id, self.project.id)
             assert cache.get(self.cache_key) is None
             mock_metrics.incr.assert_called_with("github_pr_comment.api_error")
+
+    @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
+    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.tasks.integrations.github.pr_comment.metrics")
+    @with_feature("organizations:pr-comment-bot")
+    @responses.activate
+    def test_comment_workflow_api_error_locked_issue(self, mock_metrics, get_jwt, mock_issues):
+        cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
+        mock_issues.return_value = [
+            {"group_id": g.id, "event_count": 10} for g in Group.objects.all()
+        ]
+
+        responses.add(
+            responses.POST,
+            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
+            json={"token": self.access_token, "expires_at": self.expires_at},
+        )
+        responses.add(
+            responses.POST,
+            self.base_url + "/repos/getsentry/sentry/issues/1/comments",
+            status=400,
+            json={
+                "message": "Unable to create comment because issue is locked.",
+                "documentation_url": "https://docs.github.com/articles/locking-conversations/",
+            },
+        )
+
+        github_comment_workflow(self.pr.id, self.project.id)
+        assert cache.get(self.cache_key) is None
+        assert not mock_metrics.incr.called
 
     @patch(
         "sentry.tasks.integrations.github.pr_comment.pr_to_issue_query",


### PR DESCRIPTION
Fixes https://sentry.sentry.io/issues/4274474265/?project=1

The comment workflow errors out with `ApiError` when the integration client attempts to comment on a locked PR. We should just early return and not raise an error at all.