### PR TITLE
Turn off labels from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,7 @@ updates:
       time: '15:30'
     reviewers:
       - '@getsentry/owners-js-deps'
-    labels:
-      - 'dependencies'
-      - 'Scope: Frontend'
+    labels: []
     ignore:
       # For all packages, ignore all patch updates
       - dependency-name: '*'


### PR DESCRIPTION
These keep creeping in, they're not in our `labels.yml`, not sure they're providing value so suggesting we disable this feature in Dependabot.

[docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels)