### PR TITLE
feat(slack): adds rule id to query parameters of slack alert

### DIFF
--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -64,18 +64,26 @@ def get_title_link(
     issue_details: bool,
     notification: BaseNotification | None,
     provider: ExternalProviders = ExternalProviders.SLACK,
+    rule_id: int | None = None,
 ) -> str:
+    other_params = {}
+    # add in rule id if we have it
+    if rule_id:
+        other_params["rule_id"] = rule_id
+
     if event and link_to_event:
         url = group.get_absolute_url(
-            params={"referrer": EXTERNAL_PROVIDERS[provider]}, event_id=event.event_id
+            params={"referrer": EXTERNAL_PROVIDERS[provider], **other_params},
+            event_id=event.event_id,
         )
 
     elif issue_details and notification:
         referrer = notification.get_referrer(provider)
-        url = group.get_absolute_url(params={"referrer": referrer})
-
+        url = group.get_absolute_url(params={"referrer": referrer, **other_params})
     else:
-        url = group.get_absolute_url(params={"referrer": EXTERNAL_PROVIDERS[provider]})
+        url = group.get_absolute_url(
+            params={"referrer": EXTERNAL_PROVIDERS[provider], **other_params}
+        )
 
     return url
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -303,6 +303,11 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
             )
         else:
             payload_actions = []
+
+        rule_id = None
+        if self.rules:
+            rule_id = self.rules[0].id
+
         return self._build(
             actions=payload_actions,
             callback_id=json.dumps({"issue": self.group.id}),
@@ -319,6 +324,7 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
                 self.issue_details,
                 self.notification,
                 ExternalProviders.SLACK,
+                rule_id,
             ),
             ts=get_timestamp(self.group, self.event) if not self.issue_details else None,
         )


### PR DESCRIPTION
This PR adds the rule ID as a query parameter when clicking on an alert message in Slack so we can track analytics better. We will need to extend to email and MS teams as well.