### PR TITLE
feat(escalating-issues): Update MsTeams integration to use Group substates

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1351,6 +1351,8 @@ SENTRY_FEATURES = {
     "organizations:escalating-issues": False,
     # Enable escalating forecast threshold a/b experiment
     "organizations:escalating-issues-experiment-group": False,
+    # Enable archive/escalating issue workflow in MS Teams
+    "organizations:escalating-issues-msteams": False,
     # Enable archive/escalating issue workflow features in v2
     "organizations:escalating-issues-v2": False,
     # Enable the new issue states and substates

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -222,6 +222,7 @@ default_manager.add("organizations:discover-query", OrganizationFeature, Feature
 default_manager.add("organizations:dynamic-sampling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:escalating-issues", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:escalating-issues-experiment-group", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:escalating-issues-msteams", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:escalating-issues-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:issue-states", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:event-attachments", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/integrations/msteams/card_builder/utils.py
+++ b/src/sentry/integrations/msteams/card_builder/utils.py
@@ -110,6 +110,18 @@ class IssueConstants:
 
     STOP_IGNORING = "Stop Ignoring"
 
+    ARCHIVE = "Archive"
+    ARCHIVE_INPUT_TITLE = "Archive until this happens again..."
+    ARCHIVE_INPUT_CHOICES = [
+        ("Archive forever", -1),
+        ("1 time", 1),
+        ("10 times", 10),
+        ("100 times", 100),
+        ("1,000 times", 1000),
+        ("10,000 times", 10000),
+    ]
+    STOP_ARCHIVE = "Unarchive"
+
     ASSIGN = "Assign"
     ASSIGN_INPUT_TITLE = "Assign to..."
     ASSIGN_INPUT_ID = "assignInput"

--- a/tests/sentry/integrations/msteams/test_message_builder.py
+++ b/tests/sentry/integrations/msteams/test_message_builder.py
@@ -36,7 +36,7 @@ from sentry.integrations.msteams.card_builder.notifications import (
     MSTeamsNotificationsMessageBuilder,
 )
 from sentry.models import Integration, Organization, OrganizationIntegration, Rule
-from sentry.models.group import GroupStatus
+from sentry.models.group import GroupStatus, GroupSubStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.notifications import (
@@ -326,6 +326,92 @@ class MSTeamsMessageBuilderTest(TestCase):
         card_json = json.dumps(issue_card)
         assert card_json[0] == "{" and card_json[-1] == "}"
 
+    def test_issue_message_builder_with_escalating_issues(self):
+        with self.feature("organizations:escalating-issues"):
+            self.event1.data["metadata"].update({"value": "some error"})
+            self.group1.data["metadata"].update({"value": "some error"})
+            self.event1.data["type"] = self.group1.data["type"] = "error"
+
+            issue_card = MSTeamsIssueMessageBuilder(
+                group=self.group1, event=self.event1, rules=self.rules, integration=self.integration
+            ).build_group_card()
+
+            body = issue_card["body"]
+            assert 4 == len(body)
+
+            title = body[0]
+            assert "oh no" in title["text"]
+            assert TextSize.LARGE == title["size"]
+            assert TextWeight.BOLDER == title["weight"]
+
+            description = body[1]
+            assert "some error" == description["text"]
+            assert TextWeight.BOLDER == description["weight"]
+
+            footer = body[2]
+            assert "ColumnSet" == footer["type"]
+            assert 3 == len(footer["columns"])
+
+            logo = footer["columns"][0]["items"][0]
+            assert "20px" == logo["height"]
+
+            issue_id_and_rule = footer["columns"][1]["items"][0]
+            assert self.group1.qualified_short_id in issue_id_and_rule["text"]
+            assert "rule1" in issue_id_and_rule["text"]
+            assert "+1 other" in issue_id_and_rule["text"]
+
+            date = footer["columns"][2]["items"][0]
+            assert (
+                re.match(
+                    r"""\{\{                # {{
+                    DATE\(                  # DATE(
+                        [0-9T+:\-]+,\ SHORT #   2022-07-14T19:30:34, SHORT
+                    \)                      # )
+                    \}\}                    # }}
+                    \                       # whitespace
+                    at                      # at
+                    \                       # whitespace
+                    \{\{                    # {{
+                    TIME\([0-9T+:\-]+\)     # TIME(2022-07-14T19:30:34)
+                    \}\}                    # }}""",
+                    date["text"],
+                    re.VERBOSE,
+                )
+                is not None
+            )
+
+            actions_container = body[3]
+            assert "Container" == actions_container["type"]
+
+            action_set = actions_container["items"][0]
+            assert "ActionSet" == action_set["type"]
+
+            actions = action_set["actions"]
+            for action in actions:
+                assert ActionType.SHOW_CARD == action["type"]
+                card_body = action["card"]["body"]
+                assert 2 == len(card_body)
+                assert "Input.ChoiceSet" == card_body[-1]["type"]
+
+            resolve_action, ignore_action, assign_action = actions
+            assert "Resolve" == resolve_action["title"]
+            assert "Archive" == ignore_action["title"]
+            assert "Assign" == assign_action["title"]
+
+            body = ignore_action["card"]["body"]
+            assert 2 == len(body)
+            assert "Archive until this happens again..." == body[0]["text"]
+            assert "Archive" == ignore_action["card"]["actions"][0]["title"]
+
+            body = assign_action["card"]["body"]
+            assert 2 == len(body)
+            assert "Assign to..." == body[0]["text"]
+            assert "Assign" == assign_action["card"]["actions"][0]["title"]
+
+            # Check if card is serializable to json
+            card_json = json.dumps(issue_card)
+            assert card_json[0] == "{" and card_json[-1] == "}"
+
     def test_issue_without_description(self):
         issue_card = MSTeamsIssueMessageBuilder(
             group=self.group1, event=self.event1, rules=self.rules, integration=self.integration
@@ -372,6 +458,21 @@ class MSTeamsMessageBuilderTest(TestCase):
         ignore_action = action_set["actions"][1]
         assert ActionType.SUBMIT == ignore_action["type"]
         assert "Stop Ignoring" == ignore_action["title"]
+
+    def test_archived_issue_message(self):
+        with self.feature("organizations:escalating-issues"):
+            self.group1.status = GroupStatus.IGNORED
+            self.group1.substatus = GroupSubStatus.UNTIL_ESCALATING
+
+            issue_card = MSTeamsIssueMessageBuilder(
+                group=self.group1, event=self.event1, rules=self.rules, integration=self.integration
+            ).build_group_card()
+
+            action_set = issue_card["body"][2]["items"][0]
+
+            ignore_action = action_set["actions"][1]
+            assert ActionType.SUBMIT == ignore_action["type"]
+            assert "Unarchive" == ignore_action["title"]
 
     def test_assigned_issue_message(self):
         GroupAssignee.objects.assign(self.group1, self.user)

--- a/tests/sentry/integrations/msteams/test_message_builder.py
+++ b/tests/sentry/integrations/msteams/test_message_builder.py
@@ -327,7 +327,7 @@ class MSTeamsMessageBuilderTest(TestCase):
         assert card_json[0] == "{" and card_json[-1] == "}"
 
     def test_issue_message_builder_with_escalating_issues(self):
-        with self.feature("organizations:escalating-issues"):
+        with self.feature("organizations:escalating-issues-msteams"):
             self.event1.data["metadata"].update({"value": "some error"})
             self.group1.data["metadata"].update({"value": "some error"})
             self.event1.data["type"] = self.group1.data["type"] = "error"
@@ -460,7 +460,7 @@ class MSTeamsMessageBuilderTest(TestCase):
         assert "Stop Ignoring" == ignore_action["title"]
 
     def test_archived_issue_message(self):
-        with self.feature("organizations:escalating-issues"):
+        with self.feature("organizations:escalating-issues-msteams"):
             self.group1.status = GroupStatus.IGNORED
             self.group1.substatus = GroupSubStatus.UNTIL_ESCALATING
 


### PR DESCRIPTION
## Objective:
 I wasn't able to setup MsTeams locally, so my workaround is to wrap the changes in a new feature flag `escalating-issues-msteams` and test in prod with my prod test-org. Then in a followup PR, I will remove this flag and enable this feature with the `escalating-issues` flag