### PR TITLE
ref(alerts): Fix Alert Rule Pagination

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -2,7 +2,7 @@ import bisect
 import functools
 import math
 from datetime import datetime
-from urllib.parse import quote, unquote
+from urllib.parse import quote
 
 from django.core.exceptions import EmptyResultSet, ObjectDoesNotExist
 from django.db import connections
@@ -596,19 +596,6 @@ class CombinedQuerysetPaginator:
             )
         else:
             return self._prep_value(item, self.key_from_item(item), for_prev)
-
-    def value_from_cursor(self, cursor):
-        if self.using_dates:
-            return datetime.fromtimestamp(float(cursor.value) / self.multiplier).replace(
-                tzinfo=timezone.utc
-            )
-        else:
-            value = cursor.value
-            if isinstance(value, float):
-                return math.floor(value) if self._is_asc(cursor.is_prev) else math.ceil(value)
-            if isinstance(value, str):
-                return unquote(value)
-            return value
 
     def _is_asc(self, is_prev):
         return (self.desc and is_prev) or not (self.desc or is_prev)

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -642,7 +642,6 @@ class CombinedQuerysetPaginator:
             cursor = Cursor(0, 0, 0)
 
         limit = min(limit, MAX_LIMIT)
-        # extra = 1
 
         combined_querysets = self._build_combined_querysets(cursor.is_prev)
 

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -631,7 +631,6 @@ class CombinedQuerysetPaginator:
                     queryset = queryset.order_by(key)
                 else:
                     queryset = queryset.order_by(f"-{key}")
-
             combined_querysets += list(queryset)
 
         def _sort_combined_querysets(item):
@@ -644,7 +643,7 @@ class CombinedQuerysetPaginator:
 
         combined_querysets.sort(
             key=_sort_combined_querysets,
-            reverse=not asc,
+            reverse=asc if is_prev else not asc,
         )
 
         return combined_querysets

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -613,7 +613,7 @@ class CombinedQuerysetPaginator:
     def _is_asc(self, is_prev):
         return (self.desc and is_prev) or not (self.desc or is_prev)
 
-    def _build_combined_querysets(self, value, is_prev, limit, offset, stop, extra):
+    def _build_combined_querysets(self, value, is_prev, limit, extra):
         asc = self._is_asc(is_prev)
         combined_querysets = list()
         for intermediary in self.intermediaries:
@@ -641,11 +641,7 @@ class CombinedQuerysetPaginator:
                     queryset = queryset.order_by(key)
                 else:
                     queryset = queryset.order_by(f"-{key}")
-            # print(len(list(queryset)))
-            # if offset < 1:
-            #     queryset = queryset[:(limit + extra)]
-            # else:
-            #     queryset = queryset[offset:stop]
+
             combined_querysets += list(queryset)
 
         def _sort_combined_querysets(item):
@@ -680,31 +676,29 @@ class CombinedQuerysetPaginator:
             extra += 1
         stop = offset + limit + extra
         combined_querysets = self._build_combined_querysets(
-            cursor_value, cursor.is_prev, limit, offset, stop, extra
+            cursor_value, cursor.is_prev, limit, extra
         )
 
+        # if cursor.is_prev:
+        #     combined_querysets = combined_querysets[offset:(limit + extra)]
         if offset == 0:
             combined_querysets = combined_querysets[:(limit + extra)]
         else:
             combined_querysets = combined_querysets[offset:stop]
 
         results = list(combined_querysets)
-
         if cursor.is_prev and cursor.value:
             # If the first result is equal to the cursor_value then it's safe to filter
             # it out, since the value hasn't been updated
             if results and self.get_item_key(results[0], for_prev=True) == cursor.value:
-                print("here")
-                # results = results[:-1] # temp
                 results = results[1:]
             # Otherwise we may have fetched an extra row, just drop it off the end if so.
-            # elif len(results) == offset + limit + extra:
-            #     print("no here")
-            #     results = results[:-1]
+            elif len(results) == offset + limit + extra:
+                results = results[:-1]
 
-        # We reversed the results when generating the querysets, so we need to reverse back now.
-        # if cursor.is_prev:
-        #     results.reverse()
+        # # We reversed the results when generating the querysets, so we need to reverse back now.
+        if cursor.is_prev:
+            results.reverse()
 
         return build_cursor(
             results=results,

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -639,7 +639,7 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         Rule.objects.all().delete()
         rule_ids = []
 
-        for i in range(1, 31):
+        for i in range(1, 9):
             rule = Rule.objects.create(id=i, label=f"rule{i}", project=project)
             rule_ids.append(rule.id)
 
@@ -660,21 +660,21 @@ class CombinedQuerysetPaginatorTest(APITestCase):
             desc=True,
         )
 
-        result = paginator.get_result(limit=25, cursor=None)
-        assert len(result) == 25
+        result = paginator.get_result(limit=5, cursor=None)
+        assert len(result) == 5
         page1_results = list(result)
         assert page1_results[0].id == rule_ids[0]
-        assert page1_results[24].id == rule_ids[24]
+        assert page1_results[4].id == rule_ids[4]
 
         next_cursor = result.next
-        result = paginator.get_result(limit=25, cursor=next_cursor)
+        result = paginator.get_result(limit=5, cursor=next_cursor)
         page2_results = list(result)
-        assert len(result) == 5
+        assert len(result) == 3
         assert page2_results[-1].id == rule_ids[-1]
 
         prev_cursor = result.prev
-        result = list(paginator.get_result(limit=25, cursor=prev_cursor))
-        assert len(result) == 25
+        result = list(paginator.get_result(limit=5, cursor=prev_cursor))
+        assert len(result) == 5
         assert result == page1_results
 
     def test_only_metric_alert_rules(self):
@@ -683,7 +683,7 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         Rule.objects.all().delete()
         alert_rule_ids = []
 
-        for i in range(1, 31):
+        for i in range(1, 9):
             alert_rule = self.create_alert_rule(name=f"alertrule{i}", projects=[project])
             alert_rule_ids.append(alert_rule.id)
 
@@ -721,21 +721,21 @@ class CombinedQuerysetPaginatorTest(APITestCase):
             desc=True,
         )
 
-        result = paginator.get_result(limit=25, cursor=None)
-        assert len(result) == 25
+        result = paginator.get_result(limit=5, cursor=None)
+        assert len(result) == 5
         page1_results = list(result)
         assert page1_results[0].id == alert_rule_ids[0]
-        assert page1_results[24].id == alert_rule_ids[24]
+        assert page1_results[4].id == alert_rule_ids[4]
 
         next_cursor = result.next
-        result = paginator.get_result(limit=25, cursor=next_cursor)
+        result = paginator.get_result(limit=5, cursor=next_cursor)
         page2_results = list(result)
-        assert len(result) == 5
+        assert len(result) == 3
         assert page2_results[-1].id == alert_rule_ids[-1]
 
         prev_cursor = result.prev
-        result = list(paginator.get_result(limit=25, cursor=prev_cursor))
-        assert len(result) == 25
+        result = list(paginator.get_result(limit=5, cursor=prev_cursor))
+        assert len(result) == 5
         assert result == page1_results
 
     def test_issue_and_metric_alert_rules(self):
@@ -745,7 +745,7 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         alert_rule_ids = []
         rule_ids = []
 
-        for i in range(1, 16):
+        for i in range(1, 4):
             alert_rule = self.create_alert_rule(name=f"alertrule{i}")
             alert_rule_ids.append(alert_rule.id)
             rule = Rule.objects.create(id=i, label=f"rule{i}", project=project)
@@ -790,21 +790,21 @@ class CombinedQuerysetPaginatorTest(APITestCase):
             desc=True,
         )
 
-        result = paginator.get_result(limit=25, cursor=None)
+        result = paginator.get_result(limit=5, cursor=None)
         page1_results = list(result)
-        assert len(result) == 25
+        assert len(result) == 5
         assert result[0].id == alert_rule_ids[0]
-        assert result[24].id == rule_ids[9]
+        assert result[4].id == rule_ids[1]
 
         next_cursor = result.next
-        result = paginator.get_result(limit=25, cursor=next_cursor)
+        result = paginator.get_result(limit=5, cursor=next_cursor)
         page2_results = list(result)
-        assert len(result) == 5
-        assert page2_results[0].id == 11
+        assert len(result) == 1
+        assert page2_results[0].id == 3
 
         prev_cursor = result.prev
-        result = list(paginator.get_result(limit=25, cursor=prev_cursor))
-        assert len(result) == 25
+        result = list(paginator.get_result(limit=5, cursor=prev_cursor))
+        assert len(result) == 5
         assert result == page1_results
 
 

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -782,7 +782,7 @@ class CombinedQuerysetPaginatorTest(APITestCase):
 
         result = paginator.get_result(limit=25, cursor=None)
         page1_results = list(result)
-        print("page 1 results: ", page1_results)
+        # print("page 1 results: ", page1_results)
         assert len(result) == 25
         assert result[0].id == alert_rule_ids[0]
         assert result[24].id == rule_ids[9]
@@ -795,7 +795,7 @@ class CombinedQuerysetPaginatorTest(APITestCase):
 
         prev_cursor = result.prev
         result = list(paginator.get_result(limit=25, cursor=prev_cursor))
-        print("results: ", result)
+        # print("results: ", result)
         assert len(result) == 25
         assert result == page1_results
 

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -672,6 +672,11 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         assert len(result) == 5
         assert page2_results[-1].id == rule_ids[-1]
 
+        prev_cursor = result.prev
+        result = list(paginator.get_result(limit=25, cursor=prev_cursor))
+        assert len(result) == 25
+        assert result == page1_results
+
     def test_only_metric_alert_rules(self):
         project = self.project
         AlertRule.objects.all().delete()
@@ -727,6 +732,11 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         page2_results = list(result)
         assert len(result) == 5
         assert page2_results[-1].id == alert_rule_ids[-1]
+
+        prev_cursor = result.prev
+        result = list(paginator.get_result(limit=25, cursor=prev_cursor))
+        assert len(result) == 25
+        assert result == page1_results
 
     def test_issue_and_metric_alert_rules(self):
         project = self.project

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -542,15 +542,16 @@ class GenericOffsetPaginatorTest(SimpleTestCase):
 
 class CombinedQuerysetPaginatorTest(APITestCase):
     def test_simple(self):
+        project = self.project
         Rule.objects.all().delete()
 
         alert_rule0 = self.create_alert_rule(name="alertrule0")
         alert_rule1 = self.create_alert_rule(name="alertrule1")
-        rule1 = Rule.objects.create(label="rule1", project=self.project)
+        rule1 = Rule.objects.create(label="rule1", project=project)
         alert_rule2 = self.create_alert_rule(name="alertrule2")
         alert_rule3 = self.create_alert_rule(name="alertrule3")
-        rule2 = Rule.objects.create(label="rule2", project=self.project)
-        rule3 = Rule.objects.create(label="rule3", project=self.project)
+        rule2 = Rule.objects.create(label="rule2", project=project)
+        rule3 = Rule.objects.create(label="rule3", project=project)
 
         alert_rule_intermediary = CombinedQuerysetIntermediary(
             AlertRule.objects.all(), ["date_added"]
@@ -580,7 +581,7 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         prev_cursor = result.prev
         result = paginator.get_result(limit=3, cursor=next_cursor)
         page3_results = list(result)
-        assert len(result) == 2
+        assert len(result) == 1
         assert page3_results[0].id == alert_rule0.id
 
         result = paginator.get_result(limit=3, cursor=prev_cursor)
@@ -593,25 +594,24 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         result = paginator.get_result(limit=3, cursor=None)
         assert len(result) == 3
         page1_results = list(result)
-        assert page1_results[0].id == Rule.objects.all().first().id
-        assert page1_results[1].id == alert_rule0.id
-        assert page1_results[2].id == alert_rule1.id
+        assert page1_results[0].id == alert_rule0.id
+        assert page1_results[1].id == alert_rule1.id
+        assert page1_results[2].id == rule1.id
 
         next_cursor = result.next
         result = paginator.get_result(limit=3, cursor=next_cursor)
         page2_results = list(result)
         assert len(result) == 3
-        assert page2_results[0].id == rule1.id
-        assert page2_results[1].id == alert_rule2.id
-        assert page2_results[2].id == alert_rule3.id
+        assert page2_results[0].id == alert_rule2.id
+        assert page2_results[1].id == alert_rule3.id
+        assert page2_results[2].id == rule2.id
 
         next_cursor = result.next
         prev_cursor = result.prev
         result = paginator.get_result(limit=3, cursor=next_cursor)
         page3_results = list(result)
-        assert len(result) == 2
-        assert page3_results[0].id == rule2.id
-        assert page3_results[1].id == rule3.id
+        assert len(result) == 1
+        assert page3_results[0].id == rule3.id
 
         result = paginator.get_result(limit=3, cursor=prev_cursor)
         assert list(result) == page1_results

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -782,7 +782,6 @@ class CombinedQuerysetPaginatorTest(APITestCase):
 
         result = paginator.get_result(limit=25, cursor=None)
         page1_results = list(result)
-        # print("page 1 results: ", page1_results)
         assert len(result) == 25
         assert result[0].id == alert_rule_ids[0]
         assert result[24].id == rule_ids[9]
@@ -795,7 +794,6 @@ class CombinedQuerysetPaginatorTest(APITestCase):
 
         prev_cursor = result.prev
         result = list(paginator.get_result(limit=25, cursor=prev_cursor))
-        # print("results: ", result)
         assert len(result) == 25
         assert result == page1_results
 

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -670,7 +670,7 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         result = paginator.get_result(limit=25, cursor=next_cursor)
         page2_results = list(result)
         assert len(result) == 5
-        assert page2_results[0].id == rule_ids[-1]
+        assert page2_results[-1].id == rule_ids[-1]
 
     def test_only_metric_alert_rules(self):
         project = self.project
@@ -726,7 +726,7 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         result = paginator.get_result(limit=25, cursor=next_cursor)
         page2_results = list(result)
         assert len(result) == 5
-        assert page2_results[0].id == alert_rule_ids[-1]
+        assert page2_results[-1].id == alert_rule_ids[-1]
 
     def test_issue_and_metric_alert_rules(self):
         project = self.project
@@ -782,9 +782,10 @@ class CombinedQuerysetPaginatorTest(APITestCase):
 
         result = paginator.get_result(limit=25, cursor=None)
         page1_results = list(result)
+        print("page 1 results: ", page1_results)
         assert len(result) == 25
         assert result[0].id == alert_rule_ids[0]
-        assert result[24].id == alert_rule_ids[9]
+        assert result[24].id == rule_ids[9]
 
         next_cursor = result.next
         result = paginator.get_result(limit=25, cursor=next_cursor)
@@ -794,6 +795,7 @@ class CombinedQuerysetPaginatorTest(APITestCase):
 
         prev_cursor = result.prev
         result = list(paginator.get_result(limit=25, cursor=prev_cursor))
+        print("results: ", result)
         assert len(result) == 25
         assert result == page1_results
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -548,8 +548,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             response.get("link").rstrip(">").replace(">,<", ",<")
         )
         next_cursor = links[1]["cursor"]
-        # Cursor should have the title encoded
-        assert next_cursor == "%211%3Fzz:0:0"
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             request_data = {


### PR DESCRIPTION
Fix pagination on the alert rule page. It's currently bonkers, if you click forward once you have to click backwards twice to be on "page 1", and in some cases when you click next you don't see all the alerts you know are there, and sometimes clicking back doesn't show what you just saw. This PR fixes it so pagination functions as expected. It does load all rules / alert rules into memory for the selected projects, but I ran a query to see what the worst case scenario could be, and it should be fine. 

Fixes [WOR-1844](https://getsentry.atlassian.net/browse/WOR-1844)

[WOR-1844]: https://getsentry.atlassian.net/browse/WOR-1844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ