### PR TITLE
fix(starfish): Omit Redis spans database view

### DIFF
--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -130,6 +130,16 @@ function buildEventViewQuery(
     .map(key => {
       const value = query[key];
       const isArray = Array.isArray(value);
+
+      if (key === '!span.category' && isArray && value.includes('db')) {
+        // When omitting database spans, explicitly allow `db.redis` spans, because
+        // we're not including those spans in the database category
+        const categoriesAsideFromDatabase = value.filter(v => v !== 'db');
+        return `(!span.category:db OR span.op:db.redis) !span.category:[${categoriesAsideFromDatabase.join(
+          ','
+        )}]`;
+      }
+
       return `${key}:${isArray ? `[${value}]` : value}`;
     });
 

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -137,6 +137,10 @@ function buildEventViewQuery(
     result.push(`span.module:${moduleName}`);
   }
 
+  if (moduleName === ModuleName.DB) {
+    result.push('!span.op:db.redis');
+  }
+
   if (defined(spanCategory)) {
     if (spanCategory === NULL_SPAN_CATEGORY) {
       result.push(`!has:span.category`);

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -92,6 +92,11 @@ function getEventView(
   if (moduleName) {
     queryConditions.push('!span.action:""');
   }
+
+  if (moduleName === ModuleName.DB) {
+    queryConditions.push('!span.op:db.redis');
+  }
+
   if (spanCategory) {
     if (spanCategory === NULL_SPAN_CATEGORY) {
       queryConditions.push(`!has:span.category`);

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -79,6 +79,11 @@ function getEventView(
   if (moduleName) {
     queryConditions.push(`span.module:${moduleName}`);
   }
+
+  if (moduleName === ModuleName.DB) {
+    queryConditions.push('!span.op:db.redis');
+  }
+
   if (spanCategory) {
     if (spanCategory === NULL_SPAN_CATEGORY) {
       queryConditions.push(`!has:span.category`);

--- a/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
@@ -69,6 +69,11 @@ function getEventView(
   if (moduleName) {
     queryConditions.push(`span.module:${moduleName}`);
   }
+
+  if (moduleName === ModuleName.DB) {
+    queryConditions.push('!span.op:db.redis');
+  }
+
   if (spanCategory) {
     if (spanCategory === NULL_SPAN_CATEGORY) {
       queryConditions.push(`!has:span.category`);

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -271,6 +271,10 @@ const buildDiscoverQueryConditions = (
     result.push(`span.module:${moduleName}`);
   }
 
+  if (moduleName === ModuleName.DB) {
+    result.push('!span.op:db.redis');
+  }
+
   if (spanCategory) {
     if (spanCategory === NULL_SPAN_CATEGORY) {
       result.push(`!has:span.category`);

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -154,7 +154,6 @@ export function SpanGroupBreakdown({
               : {statsPeriod: period};
 
           if (group['span.category'] === 'Other') {
-            spansLinkQueryParams['!span.module'] = ['db', 'http'];
             spansLinkQueryParams['!span.category'] = transformedData.map(
               r => r.group['span.category']
             );


### PR DESCRIPTION
Temporary solution. Manually omits `db.redis` spans from charts, selectors, and span table in the database module. Manually adds `db.redis` spans to the generic spans view for the "Other" category.

Major Caveats:

- the span category breakdown on the web service view is now incorrect, since it's impossible to omit Redis there
- span operation, action, and domain selectors don't work correctly in the "Other" module due to a pre-existing bug!
