### PR TITLE
feat(hybridcloud) Add a label to trigger hybrid cloud builds

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -18,6 +18,9 @@
 - name: 'Trigger: Visual Snapshot'
   color: 'A0CABD'
   description: 'add to a PR to run a visual snapshot diff'
+- name: 'Trigger: Silo db'
+  color: 'A0CABD'
+  description: 'Trigger tests with split databases that simulate hybrid cloud data separation in postgres'
 
 # Unito - notion.so/52d10dbfad474328850319e48b057a5b
 - name: 'Sync: Jira'


### PR DESCRIPTION
As we work towards having split databases be the norm for CI, we need a way to incrementally improve our code compatibility without disrupting master.

To achieve this, I've put together a pull request (#51252) to update our CI automation to read this label and change the CI configuration for as long as the label is applied. My plan is to use this to get incremental progress reports as we fix errors in the current state. Once we have all the tests passing, I'll add this to the CI configuration until it is no longer 'feature flagged'.
