### PR TITLE
fix(sourcemaps): Update placeholder for artifact bundles search

### DIFF
--- a/static/app/views/settings/projectSourceMaps/projectSourceMaps.spec.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMaps.spec.tsx
@@ -227,7 +227,9 @@ describe('ProjectSourceMaps', function () {
       expect(tabs[1]).not.toHaveClass('active');
 
       // Search bar
-      expect(screen.getByPlaceholderText('Filter by Bundle ID')).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText('Filter by Bundle ID, Debug ID or Release')
+      ).toBeInTheDocument();
 
       // Date Uploaded can be sorted
       await userEvent.hover(screen.getByTestId('icon-arrow'));

--- a/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
@@ -274,7 +274,9 @@ export function ProjectSourceMaps({location, router, project}: Props) {
       </NavTabs>
       <SearchBarWithMarginBottom
         placeholder={
-          tabDebugIdBundlesActive ? t('Filter by Bundle ID') : t('Filter by Name')
+          tabDebugIdBundlesActive
+            ? t('Filter by Bundle ID, Debug ID or Release')
+            : t('Filter by Name')
         }
         onSearch={handleSearch}
         query={query}


### PR DESCRIPTION
This PR updates the placeholder text for the artifact bundles search, since we now give users more options.

The PR with updated search is here: https://github.com/getsentry/sentry/pull/51778