### PR TITLE
fix(org-tokens): Ensure tokens are correctly reloaded

### DIFF
--- a/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
@@ -129,9 +129,7 @@ function AuthTokenDetailsForm({
         );
       }
 
-      // Without this, it complains that we are updating state while unmounting, as we are also updating the query cache
-      // which triggers a re-fetch of the query, which then tries to update the state of the component that is unmounting
-      window.setTimeout(handleGoBack, 1);
+      handleGoBack();
     },
     onError: error => {
       const message = t('Failed to update the auth token.');


### PR DESCRIPTION
As found by @oioki, when editing a token, but there is no list cached yet, the list is not correctly refreshed.
This happens because we need to guard if the cache is not set at all yet.

While looking at this, I also noticed a react warning about mutation state while unmounting. I was able to 'fix' it by delaying going back to the next tick, not super pretty but I guess it's fine?