### PR TITLE
fix(setup-wizard): Increase org and project limits in SetupWizardView queries

### DIFF
--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -60,7 +60,7 @@ class SetupWizardView(BaseView):
             member_set__role__in=[x.id for x in roles.with_scope("org:read")],
             member_set__user_id=request.user.id,
             status=OrganizationStatus.ACTIVE,
-        ).order_by("-date_added")[:50]
+        ).order_by("-date_added")[:100]
 
         filled_projects = []
 
@@ -68,7 +68,7 @@ class SetupWizardView(BaseView):
             projects = list(
                 Project.objects.filter(organization=org, status=ObjectStatus.ACTIVE).order_by(
                     "-date_added"
-                )[:50]
+                )[:500]
             )
             for project in projects:
                 enriched_project = serialize(project)

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -60,7 +60,7 @@ class SetupWizardView(BaseView):
             member_set__role__in=[x.id for x in roles.with_scope("org:read")],
             member_set__user_id=request.user.id,
             status=OrganizationStatus.ACTIVE,
-        ).order_by("-date_added")[:100]
+        ).order_by("-date_added")[:50]
 
         filled_projects = []
 
@@ -68,7 +68,7 @@ class SetupWizardView(BaseView):
             projects = list(
                 Project.objects.filter(organization=org, status=ObjectStatus.ACTIVE).order_by(
                     "-date_added"
-                )[:500]
+                )[:150]
             )
             for project in projects:
                 enriched_project = serialize(project)


### PR DESCRIPTION
In our `SetupWizardView` we obtain a list of projects that is returned to the Sentry (SDK) setup wizard (`@sentry/wizard`). Users of the wizard then scroll through this list and select the project, they want to connect to. 

Right now, in our `sentry-sdks` org, we have lots of projects and I recently noticed that not all of them show up in the wizard's list. Seems like we (arbitrarily?) limited the number of returned orgs and projects to 50 each when querying for orgs and the projects of the orgs. This PR increases ~these limits by 2x (orgs) and 10x (projects)~ the project limit by 3x.

Happy to completely remove the limits, too. I just have too little context around our backend to know if this has any implications. So if reviewers think this is safe, I can just remove the limits, too. 

Note: Seems like, the nested queries could still use some performance improvements as mentioned in https://github.com/getsentry/sentry/pull/7847#pullrequestreview-108125625 but I'd argue that this is out of scope for this PR. 

sort of ref: https://github.com/getsentry/team-sdks/issues/16