### PR TITLE
ref(org-tokens): Use new  scope for org tokens

### DIFF
--- a/src/sentry/api/endpoints/org_auth_tokens.py
+++ b/src/sentry/api/endpoints/org_auth_tokens.py
@@ -54,8 +54,7 @@ class OrgAuthTokensEndpoint(OrganizationEndpoint):
         token = OrgAuthToken.objects.create(
             name=name,
             organization_id=organization.id,
-            # TODO FN: This will eventually be org:ci
-            scope_list=["org:read"],
+            scope_list=["org:ci"],
             created_by_id=request.user.id,
             token_last_characters=jwt_token[-4:],
             token_hashed=token_hashed,

--- a/tests/sentry/api/endpoints/test_org_auth_token_details.py
+++ b/tests/sentry/api/endpoints/test_org_auth_token_details.py
@@ -20,7 +20,7 @@ class OrgAuthTokenDetailTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
 
@@ -36,7 +36,7 @@ class OrgAuthTokenDetailTest(APITestCase):
         assert res.get("name") == "token 1"
         assert res.get("token") is None
         assert res.get("tokenLastCharacters") == "xyz1"
-        assert res.get("scopes") == ["project:read", "project:releases"]
+        assert res.get("scopes") == ["org:ci"]
         assert res.get("dateCreated") is not None
         assert res.get("lastUsedDate") is None
         assert res.get("lastUsedProjectId") is None
@@ -47,7 +47,7 @@ class OrgAuthTokenDetailTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=datetime(2023, 1, 1, tzinfo=timezone.utc),
             project_last_used_id=self.project.id,
         )
@@ -68,7 +68,7 @@ class OrgAuthTokenDetailTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
 
@@ -82,7 +82,7 @@ class OrgAuthTokenDetailTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
 
@@ -97,7 +97,7 @@ class OrgAuthTokenDetailTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
 
@@ -116,7 +116,7 @@ class OrgAuthTokenDetailTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
             date_deactivated=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
@@ -137,7 +137,7 @@ class OrgAuthTokenEditTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
         payload = {"name": "new token"}
@@ -159,7 +159,7 @@ class OrgAuthTokenEditTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
         payload: Dict[str, str] = {}
@@ -180,7 +180,7 @@ class OrgAuthTokenEditTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
         payload = {"name": ""}
@@ -201,7 +201,7 @@ class OrgAuthTokenEditTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
         payload: Dict[str, str] = {}
@@ -216,7 +216,7 @@ class OrgAuthTokenEditTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
 
@@ -232,7 +232,7 @@ class OrgAuthTokenEditTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
 
@@ -252,7 +252,7 @@ class OrgAuthTokenEditTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
             date_deactivated=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
@@ -274,7 +274,7 @@ class OrgAuthTokenDeleteTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
 
@@ -297,7 +297,7 @@ class OrgAuthTokenDeleteTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
         response = self.get_error_response(self.organization.slug, token.id)
@@ -310,7 +310,7 @@ class OrgAuthTokenDeleteTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
 
@@ -325,7 +325,7 @@ class OrgAuthTokenDeleteTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
 
@@ -344,7 +344,7 @@ class OrgAuthTokenDeleteTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
             date_deactivated=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
@@ -366,7 +366,7 @@ class OrgAuthTokenDetailsPermissionTest(PermissionTestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
 

--- a/tests/sentry/api/endpoints/test_org_auth_tokens.py
+++ b/tests/sentry/api/endpoints/test_org_auth_tokens.py
@@ -20,7 +20,7 @@ class OrgAuthTokensListTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
         token2 = OrgAuthToken.objects.create(
@@ -28,7 +28,7 @@ class OrgAuthTokensListTest(APITestCase):
             name="token 2",
             token_hashed="ABCDEF2",
             token_last_characters="xyz2",
-            scope_list=["project:read"],
+            scope_list=["org:ci"],
             date_last_used="2023-01-02T00:00:00.000Z",
         )
         token3 = OrgAuthToken.objects.create(
@@ -36,7 +36,7 @@ class OrgAuthTokensListTest(APITestCase):
             name="token 3",
             token_hashed="ABCDEF3",
             token_last_characters="xyz3",
-            scope_list=["project:read"],
+            scope_list=["org:ci"],
             date_last_used="2023-01-01T00:00:00.000Z",
         )
         # Deleted tokens are not returned
@@ -45,7 +45,7 @@ class OrgAuthTokensListTest(APITestCase):
             name="token 4",
             token_hashed="ABCDEF4",
             token_last_characters="xyz3",
-            scope_list=["project:read"],
+            scope_list=["org:ci"],
             date_deactivated="2023-01-01T00:00:00.000Z",
         )
         # tokens from other org are not returned
@@ -54,7 +54,7 @@ class OrgAuthTokensListTest(APITestCase):
             name="token 5",
             token_hashed="ABCDEF5",
             token_last_characters="xyz3",
-            scope_list=["project:read"],
+            scope_list=["org:ci"],
         )
 
         self.login_as(self.user)
@@ -76,7 +76,7 @@ class OrgAuthTokensListTest(APITestCase):
             name="token 1",
             token_hashed="ABCDEF",
             token_last_characters="xyz1",
-            scope_list=["project:read", "project:releases"],
+            scope_list=["org:ci"],
             date_last_used=None,
         )
         OrgAuthToken.objects.create(
@@ -84,7 +84,7 @@ class OrgAuthTokensListTest(APITestCase):
             name="token 2",
             token_hashed="ABCDEF2",
             token_last_characters="xyz2",
-            scope_list=["project:read"],
+            scope_list=["org:ci"],
             date_last_used="2023-01-02T00:00:00.000Z",
         )
 
@@ -124,7 +124,7 @@ class OrgAuthTokenCreateTest(APITestCase):
         assert token.get("dateCreated") is not None
         assert token.get("dateLastUsed") is None
         assert token.get("projectLastUsed") is None
-        assert token.get("scopes") == ["org:read"]
+        assert token.get("scopes") == ["org:ci"]
         assert token.get("name") == "test token"
 
         tokenDb = OrgAuthToken.objects.get(id=token.get("id"))


### PR DESCRIPTION
This updates org token creation to actually use the new scope `org:ci`.