### PR TITLE
fix(mute-metric-alerts): Fix mute link in email

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -282,7 +282,17 @@ def generate_incident_trigger_email_context(
     snooze_alert_url = None
     if features.has("organizations:mute-metric-alerts", organization):
         snooze_alert = True
-        snooze_alert_url = alert_link + "&" + urlencode({"mute": "1"})
+        alert_rule_link = organization.absolute_url(
+            reverse(
+                "sentry-metric-alert-details",
+                kwargs={
+                    "organization_slug": organization.slug,
+                    "alert_rule_id": alert_rule.id,
+                },
+            ),
+            query="referrer=alert_email",
+        )
+        snooze_alert_url = alert_rule_link + "&" + urlencode({"mute": "1"})
 
     return {
         "link": alert_link,

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -217,6 +217,7 @@ class EmailActionHandlerGetTargetsTest(TestCase):
 
 @freeze_time()
 class EmailActionHandlerGenerateEmailContextTest(TestCase):
+    @with_feature("organizations:mute-metric-alerts")
     def test_simple(self):
         trigger_status = TriggerStatus.ACTIVE
         incident = self.create_incident()
@@ -260,8 +261,18 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             "unsubscribe_link": None,
             "chart_url": None,
             "timezone": settings.SENTRY_DEFAULT_TIME_ZONE,
-            "snooze_alert": False,
-            "snooze_alert_url": None,
+            "snooze_alert": True,
+            "snooze_alert_url": self.organization.absolute_url(
+                reverse(
+                    "sentry-metric-alert-details",
+                    kwargs={
+                        "organization_slug": self.organization.slug,
+                        "alert_rule_id": action.alert_rule_trigger.alert_rule_id,
+                    },
+                ),
+                query="referrer=alert_email",
+            )
+            + "&mute=1",
         }
         assert expected == generate_incident_trigger_email_context(
             self.project,


### PR DESCRIPTION
this pr fixes the link in the email to automatically mute metric alerts. previously, it was linking to the specific incident instead of the overall metric alert which was possibly getting in the way of automatic muting. 

Closes https://github.com/getsentry/sentry/issues/51820