### PR TITLE
Add iat header to app store header

### DIFF
--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -100,11 +100,13 @@ def _get_authorization_header(
     """
     if expiry_sec is None:
         expiry_sec = 60 * 10  # default to 10 mins
+    token_creation_time = int(time.time())
     with sentry_sdk.start_span(op="jwt", description="Generating AppStoreConnect JWT token"):
         token = jwt.encode(
             {
                 "iss": credentials.issuer_id,
-                "exp": int(time.time()) + expiry_sec,
+                "iat": token_creation_time,
+                "exp": token_creation_time + expiry_sec,
                 "aud": "appstoreconnect-v1",
             },
             credentials.key,


### PR DESCRIPTION
https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests#3878467

> For every request, App Store Connect calculates the valid time for a token, referred as the token’s lifetime, by subtracting the iat claim from the exp claim

`iat` isn't marked as optional, Apple probably defaults to the current time, but let's set it anyway.