### PR TITLE
fix(usageTable): mark project as selected

### DIFF
--- a/static/app/components/asyncComponent.tsx
+++ b/static/app/components/asyncComponent.tsx
@@ -16,7 +16,7 @@ import RouteError from 'sentry/views/routeError';
 
 export type AsyncComponentProps = Partial<RouteComponentProps<{}, {}>>;
 
-type AsyncComponentState = {
+export type AsyncComponentState = {
   [key: string]: any;
   error: boolean;
   errors: Record<string, ResponseMeta>;

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -4,7 +4,10 @@ import * as Sentry from '@sentry/react';
 import {LocationDescriptorObject} from 'history';
 import isEqual from 'lodash/isEqual';
 
-import AsyncComponent from 'sentry/components/asyncComponent';
+import AsyncComponent, {
+  AsyncComponentProps,
+  AsyncComponentState,
+} from 'sentry/components/asyncComponent';
 import {DateTimeObject, getSeriesApiInterval} from 'sentry/components/charts/utils';
 import SortLink, {Alignments, Directions} from 'sentry/components/gridEditable/sortLink';
 import Pagination from 'sentry/components/pagination';
@@ -19,7 +22,7 @@ import withProjects from 'sentry/utils/withProjects';
 import {UsageSeries} from './types';
 import UsageTable, {CellProject, CellStat, TableStat} from './usageTable';
 
-type Props = {
+interface Props extends AsyncComponentProps {
   dataCategory: DataCategoryInfo['plural'];
   dataCategoryName: string;
   dataDatetime: DateTimeObject;
@@ -40,11 +43,11 @@ type Props = {
   tableCursor?: string;
   tableQuery?: string;
   tableSort?: string;
-} & AsyncComponent['props'];
+}
 
-type State = {
+interface State extends AsyncComponentState {
   projectStats: UsageSeries | undefined;
-} & AsyncComponent['state'];
+}
 
 export enum SortBy {
   PROJECT = 'project',
@@ -444,6 +447,7 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
         )}
         <Container data-test-id="usage-stats-table">
           <UsageTable
+            selectedProjects={this.props.projectIds}
             isLoading={loading || loadingProjects}
             isError={error}
             errors={errors as any} // TODO(ts)


### PR DESCRIPTION
Show button indicating a project is selected (previously just a noop button)

<img width="1036" alt="CleanShot 2023-06-28 at 11 05 59@2x" src="https://github.com/getsentry/sentry/assets/9317857/d03a0fa9-7e08-4585-b2c1-b541b3ffc042">

Not ready to merge yet as it is unclear on how to distinguish between my projects and all projects selection (filter value is set to -1 in both cases)


