### PR TITLE
feat(hybrid-cloud): Rollout avatar migration to 100%

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3507,8 +3507,6 @@ MAX_ENVIRONMENTS_PER_MONITOR = 1000
 # tests)
 SENTRY_METRICS_INDEXER_RAISE_VALIDATION_ERRORS = False
 
-SENTRY_FILE_COPY_ROLLOUT_RATE = 0.5
-
 # The project ID for SDK Crash Monitoring to save the detected SDK crashed to.
 # Currently, this is a single value, as the SDK Crash Detection feature only detects crashes for the Cocoa SDK.
 # Once we start detecting crashes for other SDKs, this will be a mapping of SDK name to project ID or something similar.

--- a/src/sentry/tasks/files.py
+++ b/src/sentry/tasks/files.py
@@ -1,7 +1,4 @@
-import random
-
 from django.apps import apps
-from django.conf import settings
 from django.db import DatabaseError, IntegrityError, router
 
 from sentry.locks import locks
@@ -113,9 +110,6 @@ def copy_file_to_control_and_update_model(
     from sentry.models.files import ControlFile, ControlFileBlob, File
 
     if ControlFileBlob._storage_config() is None:
-        return
-
-    if random.uniform(0, 1) > settings.SENTRY_FILE_COPY_ROLLOUT_RATE:
         return
 
     lock = f"copy-file-lock-{model_name}:{model_id}"

--- a/tests/sentry/api/endpoints/test_user_avatar.py
+++ b/tests/sentry/api/endpoints/test_user_avatar.py
@@ -1,6 +1,5 @@
 from base64 import b64encode
 
-from django.test import override_settings
 from django.urls import reverse
 
 from sentry import options as options_store
@@ -58,7 +57,33 @@ class UserAvatarTest(APITestCase):
         assert avatar.file_id
 
     def test_transition_to_control_before_options_set(self):
-        with override_settings(SENTRY_FILE_COPY_ROLLOUT_RATE=1):
+        with self.tasks():
+            user = self.create_user(email="a@example.com")
+
+            self.login_as(user=user)
+
+            url = reverse("sentry-api-0-user-avatar", kwargs={"user_id": "me"})
+            response = self.client.put(
+                url,
+                data={
+                    "avatar_type": "upload",
+                    "avatar_photo": b64encode(self.load_fixture("avatar.jpg")),
+                },
+                format="json",
+            )
+
+            avatar = UserAvatar.objects.get(user=user)
+            assert response.status_code == 200, response.content
+            assert avatar.file_id
+            assert isinstance(avatar.get_file(), File)
+
+    def test_transition_to_control_after_options_set(self):
+        with self.options(
+            {
+                "filestore.control.backend": options_store.get("filestore.backend"),
+                "filestore.control.options": options_store.get("filestore.options"),
+            }
+        ):
             with self.tasks():
                 user = self.create_user(email="a@example.com")
 
@@ -76,36 +101,8 @@ class UserAvatarTest(APITestCase):
 
                 avatar = UserAvatar.objects.get(user=user)
                 assert response.status_code == 200, response.content
-                assert avatar.file_id
-                assert isinstance(avatar.get_file(), File)
-
-    def test_transition_to_control_after_options_set(self):
-        with override_settings(SENTRY_FILE_COPY_ROLLOUT_RATE=1):
-            with self.options(
-                {
-                    "filestore.control.backend": options_store.get("filestore.backend"),
-                    "filestore.control.options": options_store.get("filestore.options"),
-                }
-            ):
-                with self.tasks():
-                    user = self.create_user(email="a@example.com")
-
-                    self.login_as(user=user)
-
-                    url = reverse("sentry-api-0-user-avatar", kwargs={"user_id": "me"})
-                    response = self.client.put(
-                        url,
-                        data={
-                            "avatar_type": "upload",
-                            "avatar_photo": b64encode(self.load_fixture("avatar.jpg")),
-                        },
-                        format="json",
-                    )
-
-                    avatar = UserAvatar.objects.get(user=user)
-                    assert response.status_code == 200, response.content
-                    assert avatar.control_file_id
-                    assert isinstance(avatar.get_file(), ControlFile)
+                assert avatar.control_file_id
+                assert isinstance(avatar.get_file(), ControlFile)
 
     def test_put_bad(self):
         user = self.create_user(email="a@example.com")

--- a/tests/sentry/models/test_avatar.py
+++ b/tests/sentry/models/test_avatar.py
@@ -1,5 +1,3 @@
-from django.test import override_settings
-
 from sentry import options as options_store
 from sentry.models import File, UserAvatar
 from sentry.models.avatars.organization_avatar import OrganizationAvatar
@@ -37,18 +35,17 @@ class AvatarMigrationTestCase(TestCase):
         avatar = UserAvatar.objects.create(user=user, file_id=afile.id)
 
         assert avatar.control_file_id is None
-        with override_settings(SENTRY_FILE_COPY_ROLLOUT_RATE=1):
-            with self.options(
-                {
-                    "filestore.control.backend": options_store.get("filestore.backend"),
-                    "filestore.control.options": options_store.get("filestore.options"),
-                }
-            ):
-                with self.tasks():
-                    assert isinstance(avatar.get_file(), File)
-                    avatar = UserAvatar.objects.get(id=avatar.id)
-                    assert avatar.control_file_id is not None
-                    assert isinstance(avatar.get_file(), ControlFile)
+        with self.options(
+            {
+                "filestore.control.backend": options_store.get("filestore.backend"),
+                "filestore.control.options": options_store.get("filestore.options"),
+            }
+        ):
+            with self.tasks():
+                assert isinstance(avatar.get_file(), File)
+                avatar = UserAvatar.objects.get(id=avatar.id)
+                assert avatar.control_file_id is not None
+                assert isinstance(avatar.get_file(), ControlFile)
 
 
 @region_silo_test(stable=True)


### PR DESCRIPTION
Remove avatar migration rollout flag. This unblocks the complete backfill script.