### PR TITLE
fix(starfish): update spacing endpoint overview page

### DIFF
--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -311,23 +311,25 @@ export default function EndpointOverview() {
               transaction={transaction}
               method={method}
             />
-            <SegmentedControlContainer>
-              <SegmentedControl
-                size="xs"
-                aria-label={t('Filter events')}
-                value={state.samplesFilter}
-                onChange={key => setState({...state, samplesFilter: key})}
-              >
-                <SegmentedControl.Item key="ALL">
-                  {t('Sample Events')}
-                </SegmentedControl.Item>
-                <SegmentedControl.Item key="500s">{t('5XXs')}</SegmentedControl.Item>
-              </SegmentedControl>
-            </SegmentedControlContainer>
-            <TransactionSamplesTable
-              queryConditions={queryConditions}
-              sampleFilter={state.samplesFilter}
-            />
+            <RowContainer>
+              <SegmentedControlContainer>
+                <SegmentedControl
+                  size="xs"
+                  aria-label={t('Filter events')}
+                  value={state.samplesFilter}
+                  onChange={key => setState({...state, samplesFilter: key})}
+                >
+                  <SegmentedControl.Item key="ALL">
+                    {t('Sample Events')}
+                  </SegmentedControl.Item>
+                  <SegmentedControl.Item key="500s">{t('5XXs')}</SegmentedControl.Item>
+                </SegmentedControl>
+              </SegmentedControlContainer>
+              <TransactionSamplesTable
+                queryConditions={queryConditions}
+                sampleFilter={state.samplesFilter}
+              />
+            </RowContainer>
             <SegmentedControlContainer>
               <SegmentedControl
                 size="xs"
@@ -415,14 +417,20 @@ const SearchContainerWithFilterAndMetrics = styled('div')`
   }
 `;
 
+const RowContainer = styled('div')`
+  padding-bottom: ${space(4)};
+`;
+
 const StyledRow = styled(PerformanceLayoutBodyRow)`
-  margin-bottom: ${space(2)};
+  margin-bottom: ${space(4)};
 `;
 
 const SegmentedControlContainer = styled('div')`
   margin-bottom: ${space(2)};
   display: flex;
   justify-content: space-between;
+  height: 32px;
+  align-items: center;
 `;
 
 const ChartLabel = styled('div')`


### PR DESCRIPTION
Make spacing more consistent in this endpoint overview page.
Adds some space above the issues table so that the view all button does look like it's part of the samples.

**Before**
![image](https://github.com/getsentry/sentry/assets/44422760/4c1af09a-1ea0-47d6-ad88-26df921d362a)

**After**
![image](https://github.com/getsentry/sentry/assets/44422760/3efdde1a-084d-43e5-8a98-370ada9d2a98)
