### PR TITLE
fix: register the fly options & disable analytics emit

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -982,15 +982,17 @@ def EnablePartnerSSO(provider_key, org_member, sentry_org, provider_config):
         organization_id=sentry_org.id, provider=provider_key, config=provider_config
     )
 
-    sso_enabled.send_robust(
-        organization=sentry_org,
-        provider=provider_key,
-        sender="EnablePartnerSSO",
-    )
+    # TODO: Analytics requires a user id
+    # At provisioning time, no user is available so we cannot provide any user
+    # sso_enabled.send_robust(
+    #     organization=sentry_org,
+    #     provider=provider_key,
+    #     sender="EnablePartnerSSO",
+    # )
 
     AuditLogEntry.objects.create(
         organization_id=sentry_org.id,
-        actor=org_member,
+        actor_label=f"partner_provisioning_api:{provider_key}",
         target_object=provider_model.id,
         event=audit_log.get_event_id("SSO_ENABLE"),
         data=provider_model.get_audit_log_data(),

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -973,7 +973,7 @@ class AuthHelper(Pipeline):
 
 
 @transaction.atomic
-def EnablePartnerSSO(provider_key, org_member, sentry_org, provider_config):
+def EnablePartnerSSO(provider_key, sentry_org, provider_config):
     """
     Simplified abstraction from AuthHelper for enabling an SSO AuthProvider for a Sentry organization.
     Fires appropriate Audit Log and signal emitter for SSO Enabled

--- a/src/sentry/auth/providers/fly/apps.py
+++ b/src/sentry/auth/providers/fly/apps.py
@@ -5,8 +5,16 @@ class Config(AppConfig):
     name = "sentry.auth.providers.fly"
 
     def ready(self):
-        from sentry import auth
+        from sentry import auth, options
 
         from .provider import FlyOAuth2Provider
 
         auth.register("fly", FlyOAuth2Provider)
+
+        options.register(
+            "auth-fly.client-id", flags=options.FLAG_ALLOW_EMPTY | options.FLAG_PRIORITIZE_DISK
+        )
+        options.register(
+            "auth-fly.client-secret",
+            flags=options.FLAG_ALLOW_EMPTY | options.FLAG_PRIORITIZE_DISK,
+        )

--- a/src/sentry/auth/providers/fly/apps.py
+++ b/src/sentry/auth/providers/fly/apps.py
@@ -12,9 +12,10 @@ class Config(AppConfig):
         auth.register("fly", FlyOAuth2Provider)
 
         options.register(
-            "auth-fly.client-id", flags=options.FLAG_ALLOW_EMPTY | options.FLAG_PRIORITIZE_DISK
+            "auth-fly.client-id",
+            flags=options.FLAG_ALLOW_EMPTY | options.FLAG_PRIORITIZE_DISK,  # type: ignore
         )
         options.register(
             "auth-fly.client-secret",
-            flags=options.FLAG_ALLOW_EMPTY | options.FLAG_PRIORITIZE_DISK,
+            flags=options.FLAG_ALLOW_EMPTY | options.FLAG_PRIORITIZE_DISK,  # type: ignore
         )


### PR DESCRIPTION
We need to actually register the fly options
Analytics event requires a user as well which we do not have at provisioning time.
disable the emitter for now