### PR TITLE
Revert "perf(generic-metrics): Apply cardinality limits in separate thread"

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/processing.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/processing.py
@@ -1,7 +1,6 @@
 import logging
 import random
-from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, Mapping
 
 import sentry_kafka_schemas
 import sentry_sdk
@@ -20,8 +19,6 @@ from sentry.utils import metrics, sdk
 
 logger = logging.getLogger(__name__)
 
-executor = ThreadPoolExecutor(max_workers=1)
-
 STORAGE_TO_INDEXER: Mapping[IndexerStorage, Callable[[], StringIndexer]] = {
     IndexerStorage.POSTGRES: PostgresIndexer,
     IndexerStorage.MOCK: MockIndexer,
@@ -36,7 +33,6 @@ class MessageProcessor:
     def __init__(self, config: MetricsIngestConfiguration):
         self._indexer = STORAGE_TO_INDEXER[config.db_backend](**config.db_backend_options)
         self._config = config
-        self._prev_future: Optional[Future] = None
 
     # The following two methods are required to work such that the parallel
     # indexer can spawn subprocesses correctly.
@@ -97,12 +93,6 @@ class MessageProcessor:
 
         sdk.set_measurement("indexer_batch.payloads.len", len(batch.parsed_payloads_by_offset))
 
-        with metrics.timer("metrics_consumer.apply_cardinality_limits"), sentry_sdk.start_span(
-            op="apply_cardinality_limits"
-        ):
-            if self._prev_future:
-                self._prev_future.result()
-
         with metrics.timer("metrics_consumer.check_cardinality_limits"), sentry_sdk.start_span(
             op="check_cardinality_limits"
         ):
@@ -110,10 +100,6 @@ class MessageProcessor:
             cardinality_limiter_state = cardinality_limiter.check_cardinality_limits(
                 self._config.use_case_id, batch.parsed_payloads_by_offset
             )
-
-        self._prev_future = executor.submit(
-            cardinality_limiter.apply_cardinality_limits, cardinality_limiter_state
-        )
 
         sdk.set_measurement(
             "cardinality_limiter.keys_to_remove.len", len(cardinality_limiter_state.keys_to_remove)
@@ -133,5 +119,11 @@ class MessageProcessor:
         new_messages = batch.reconstruct_messages(mapping, bulk_record_meta)
 
         sdk.set_measurement("new_messages.len", len(new_messages))
+
+        with metrics.timer("metrics_consumer.apply_cardinality_limits"), sentry_sdk.start_span(
+            op="apply_cardinality_limits"
+        ):
+            # TODO: move to separate thread
+            cardinality_limiter.apply_cardinality_limits(cardinality_limiter_state)
 
         return new_messages


### PR DESCRIPTION
### Reverts getsentry/sentry#50984

No significant performance improvements has been observed