### PR TITLE
feat(starfish): update all components to use starfish date picker

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -4,7 +4,6 @@ import {Location} from 'history';
 import * as qs from 'query-string';
 
 import Breadcrumbs, {Crumb} from 'sentry/components/breadcrumbs';
-import DatePageFilter from 'sentry/components/datePageFilter';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {Panel, PanelBody} from 'sentry/components/panels';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -21,6 +20,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {P95_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
 import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
+import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
 import StarfishPageFilterContainer from 'sentry/views/starfish/components/pageFilterContainer';
 import {SpanDescription} from 'sentry/views/starfish/components/spanDescription';
 import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
@@ -151,7 +151,7 @@ function SpanSummaryPage({params, location}: Props) {
               <PageErrorAlert />
               <BlockContainer>
                 <FilterOptionsContainer>
-                  <DatePageFilter alignDropdown="left" />
+                  <StarfishDatePicker />
                 </FilterOptionsContainer>
                 <BlockContainer>
                   <Block title={t('Operation')}>{span?.['span.op']}</Block>

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -7,7 +7,6 @@ import Breadcrumbs from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/button';
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {getInterval} from 'sentry/components/charts/utils';
-import DatePageFilter from 'sentry/components/datePageFilter';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {PerformanceLayoutBodyRow} from 'sentry/components/performance/layouts';
@@ -30,6 +29,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {SidebarSpacer} from 'sentry/views/performance/transactionSummary/utils';
 import {ERRORS_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
 import Chart from 'sentry/views/starfish/components/chart';
+import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
 import StarfishPageFilterContainer from 'sentry/views/starfish/components/pageFilterContainer';
 import {TransactionSamplesTable} from 'sentry/views/starfish/components/samplesTable/transactionSamplesTable';
 import {ModuleName} from 'sentry/views/starfish/types';
@@ -248,7 +248,7 @@ export default function EndpointOverview() {
         <Layout.Body>
           <SearchContainerWithFilterAndMetrics>
             <PageFilterBar condensed>
-              <DatePageFilter alignDropdown="left" />
+              <StarfishDatePicker />
             </PageFilterBar>
           </SearchContainerWithFilterAndMetrics>
 


### PR DESCRIPTION
Couple of components needed to be updated to use the starfish date picker.
The starfish date picker allows us to limit the date range that is selectable to 7d, it had to be added in a couple more places.