### PR TITLE
fix(api): Filter project get plugins

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -346,7 +346,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
 
         return queryset.count()
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         Retrieve a Project
         ``````````````````
@@ -388,6 +388,8 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         else:
             data["dynamicSamplingBiases"] = None
             data["dynamicSamplingRules"] = None
+
+        data["plugins"] = [plugin for plugin in data["plugins"] if plugin.get("enabled")]
 
         return Response(data)
 

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -389,6 +389,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             data["dynamicSamplingBiases"] = None
             data["dynamicSamplingRules"] = None
 
+        # filter for enabled plugins o/w the response body is gigantic and difficult to read
         data["plugins"] = [plugin for plugin in data["plugins"] if plugin.get("enabled")]
 
         return Response(data)


### PR DESCRIPTION
Project GET is returning a 1200 line response body with ~900 lines of plugins. These plugins are always shown even if they're disabled, so fix will change the response body to only show enabled plugins for a project