### PR TITLE
ref(starfish): Go back to the old wsv chart

### DIFF
--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -84,9 +84,8 @@ export function SpanGroupBreakdown({
         </Header>
         <Chart
           statsPeriod="24h"
-          height={210}
+          height={190}
           showLegend
-          isLineChart
           data={
             dataDisplayType === DataDisplayType.PERCENTAGE
               ? dataAsPercentages

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -58,13 +58,13 @@ export function SpanGroupBreakdownContainer({transaction, transactionMethod}: Pr
   const theme = useTheme();
 
   const options: SelectOption<DataDisplayType>[] = [
+    {label: 'Percentages', value: DataDisplayType.PERCENTAGE},
     {label: 'Duration (p95)', value: DataDisplayType.DURATION_P95},
     {label: 'Total Duration', value: DataDisplayType.CUMULATIVE_DURATION},
-    {label: 'Percentages', value: DataDisplayType.PERCENTAGE},
   ];
 
   const [dataDisplayType, setDataDisplayType] = useState<DataDisplayType>(
-    DataDisplayType.DURATION_P95
+    DataDisplayType.PERCENTAGE
   );
 
   const {data: segments, isLoading: isSegmentsLoading} = useDiscoverQuery({

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -26,8 +26,7 @@ import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/char
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 import formatThroughput from 'sentry/views/starfish/utils/chartValueFormatters/formatThroughput';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
-import {ServiceDurationChartContainer} from 'sentry/views/starfish/views/webServiceView/serviceDurationChartContainer';
-import {ServiceTimeSpentBreakdown} from 'sentry/views/starfish/views/webServiceView/serviceTimeSpentBreakdown';
+import {SpanGroupBreakdownContainer} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
 import EndpointList from './endpointList';
 
@@ -146,12 +145,9 @@ export function StarfishView(props: BasePerformanceViewProps) {
       <StyledRow minSize={200}>
         <ChartsContainer>
           <ChartsContainerItem>
-            <ServiceDurationChartContainer />
+            <SpanGroupBreakdownContainer />
           </ChartsContainerItem>
           <ChartsContainerItem2>{renderCharts()}</ChartsContainerItem2>
-          <ChartsContainerItem3>
-            <ServiceTimeSpentBreakdown />
-          </ChartsContainerItem3>
         </ChartsContainer>
       </StyledRow>
 
@@ -177,8 +173,4 @@ const ChartsContainerItem = styled('div')`
 
 const ChartsContainerItem2 = styled('div')`
   flex: 1;
-`;
-
-const ChartsContainerItem3 = styled('div')`
-  flex: 0.75;
 `;


### PR DESCRIPTION
Go back to the last chart, default to the percentage breakdown, remove the new service breakdown component on the right

![image](https://github.com/getsentry/sentry/assets/16740047/afbb6b5c-6877-4525-89ff-4ca1c7f36b28)
