### PR TITLE
fix(muting-metric-alerts): Prevent re-fetch of data when muting

### DIFF
--- a/static/app/views/alerts/rules/metric/details/index.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.tsx
@@ -1,6 +1,8 @@
 import {Component, Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
 import {Location} from 'history';
+import isEqual from 'lodash/isEqual';
+import pick from 'lodash/pick';
 import moment from 'moment';
 
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
@@ -58,9 +60,15 @@ class MetricAlertDetails extends Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
+    const prevQuery = pick(prevProps.location.query, ['start', 'end', 'period', 'alert']);
+    const nextQuery = pick(this.props.location.query, [
+      'start',
+      'end',
+      'period',
+      'alert',
+    ]);
     if (
-      (prevProps.location.search !== this.props.location.search &&
-        prevProps.location.query.mute !== '1') ||
+      !isEqual(prevQuery, nextQuery) ||
       prevProps.organization.slug !== this.props.organization.slug ||
       prevProps.params.ruleId !== this.props.params.ruleId
     ) {

--- a/static/app/views/alerts/rules/metric/details/index.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.tsx
@@ -59,7 +59,8 @@ class MetricAlertDetails extends Component<Props, State> {
 
   componentDidUpdate(prevProps: Props) {
     if (
-      prevProps.location.search !== this.props.location.search ||
+      (prevProps.location.search !== this.props.location.search &&
+        prevProps.location.query.mute !== '1') ||
       prevProps.organization.slug !== this.props.organization.slug ||
       prevProps.params.ruleId !== this.props.params.ruleId
     ) {


### PR DESCRIPTION
to mute metric alerts, we have a query parameter that we want to hide after muting the alert. right now, getting rid of the query parameter re-fetches the data which can potentially not show the most up to date snooze information. this pr fixes the issue by not refetching if the change to the url is because of muting. 