### PR TITLE
chore(hybridcloud) Update more django_db to manage multiple connections

### DIFF
--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -16,6 +16,7 @@ from sentry.testutils.cases import PerformanceIssueTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.utils import snuba
+from sentry.utils.pytest.fixtures import django_db_all
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
@@ -604,7 +605,7 @@ class GroupEventOccurrenceTest(TestCase, OccurrenceTestMixin):
             assert fetch_mock.call_count == 2
 
 
-@pytest.mark.django_db
+@django_db_all
 def test_renormalization(monkeypatch, factories, task_runner, default_project):
     from sentry_relay.processing import StoreNormalizer
 

--- a/tests/sentry/hybrid_cloud/test_actor.py
+++ b/tests/sentry/hybrid_cloud/test_actor.py
@@ -1,12 +1,11 @@
-import pytest
-
 from sentry.models.actor import ACTOR_TYPES, Actor
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.testutils.factories import Factories
+from sentry.utils.pytest.fixtures import django_db_all
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_many_from_object_users():
     users = [Factories.create_user(), Factories.create_user()]
     actors = RpcActor.many_from_object(users)
@@ -21,7 +20,7 @@ def test_many_from_object_users():
     assert actors[1].actor_type == ActorType.USER
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_many_from_object_rpc_users():
     orm_users = [Factories.create_user(), Factories.create_user()]
     user_ids = [u.id for u in orm_users]
@@ -39,7 +38,7 @@ def test_many_from_object_rpc_users():
     assert actors[1].actor_type == ActorType.USER
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_many_from_object_users_missing_actors():
     users = [Factories.create_user(), Factories.create_user()]
     # Clear all actors
@@ -54,7 +53,7 @@ def test_many_from_object_users_missing_actors():
     assert len(actors) == 2, "Actors should be generated"
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_many_from_object_teams():
     organization = Factories.create_organization()
     teams = [
@@ -76,7 +75,7 @@ def test_many_from_object_teams():
     assert actors[1].slug
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_many_from_object_mixed():
     organization = Factories.create_organization()
     teams = [

--- a/tests/sentry/hybrid_cloud/test_auth.py
+++ b/tests/sentry/hybrid_cloud/test_auth.py
@@ -1,5 +1,3 @@
-import pytest
-
 from sentry.models import ApiKey, AuthProvider
 from sentry.services.hybrid_cloud.auth import (
     RpcAuthProvider,
@@ -10,9 +8,10 @@ from sentry.services.hybrid_cloud.auth import (
 from sentry.testutils.factories import Factories
 from sentry.testutils.hybrid_cloud import use_real_service
 from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits
+from sentry.utils.pytest.fixtures import django_db_all
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 @all_silo_test
 @use_real_service(auth_service, None)
 def test_get_org_auth_config():

--- a/tests/sentry/hybrid_cloud/test_organization.py
+++ b/tests/sentry/hybrid_cloud/test_organization.py
@@ -25,6 +25,7 @@ from sentry.testutils import TestCase
 from sentry.testutils.factories import Factories
 from sentry.testutils.hybrid_cloud import use_real_service
 from sentry.testutils.silo import all_silo_test
+from sentry.utils.pytest.fixtures import django_db_all
 
 
 def basic_filled_out_org() -> Tuple[Organization, Sequence[User]]:
@@ -193,7 +194,7 @@ def assert_get_organization_by_id_works(user_context: Optional[User], orm_org: O
         )
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 @all_silo_test
 @parameterize_with_orgs
 @use_real_service(organization_service, None)
@@ -204,7 +205,7 @@ def test_get_organization_id(org_factory: Callable[[], Tuple[Organization, List[
         assert_get_organization_by_id_works(user_context, orm_org)
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 @all_silo_test
 @parameterize_with_orgs
 @use_real_service(organization_service, None)
@@ -226,7 +227,7 @@ def test_idempotency(org_factory: Callable[[], Tuple[Organization, List[User]]])
         assert_organization_member_equals(OrganizationMember.objects.get(id=member.id), member)
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 @all_silo_test
 @parameterize_with_orgs_with_owner_team
 @use_real_service(organization_service, None)
@@ -241,7 +242,7 @@ def test_get_all_org_roles(org_factory: Callable[[], Tuple[Organization, List[Us
     assert set(all_org_roles) == set(service_org_roles)
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 @all_silo_test
 @parameterize_with_orgs_with_owner_team
 @use_real_service(organization_service, None)

--- a/tests/sentry/hybrid_cloud/test_user.py
+++ b/tests/sentry/hybrid_cloud/test_user.py
@@ -1,11 +1,10 @@
-import pytest
-
 from sentry.models.avatars.user_avatar import UserAvatar
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.testutils.factories import Factories
+from sentry.utils.pytest.fixtures import django_db_all
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_user_serialize_avatar_none():
     user = Factories.create_user()
     rpc_user = user_service.get_user(user_id=user.id)
@@ -13,7 +12,7 @@ def test_user_serialize_avatar_none():
     assert rpc_user.avatar is None
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_user_serialize_avatar():
     user = Factories.create_user()
     avatar = UserAvatar.objects.create(user_id=user.id, avatar_type=2, ident="abc123")
@@ -26,7 +25,7 @@ def test_user_serialize_avatar():
     assert rpc_user.avatar.avatar_type == "gravatar"
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_user_serialize_multiple_emails():
     user = Factories.create_user()
     email = Factories.create_useremail(user=user, email="test@example.com", is_verified=True)

--- a/tests/sentry/hybrid_cloud/test_user_option.py
+++ b/tests/sentry/hybrid_cloud/test_user_option.py
@@ -1,14 +1,13 @@
 import time
 
-import pytest
-
 from sentry.services.hybrid_cloud.user_option import get_option_from_list, user_option_service
 from sentry.testutils.factories import Factories
 from sentry.testutils.hybrid_cloud import use_real_service
 from sentry.testutils.silo import all_silo_test
+from sentry.utils.pytest.fixtures import django_db_all
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 @all_silo_test
 @use_real_service(user_option_service, None)
 def test_user_option_service():

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -14,6 +14,7 @@ from sentry.ingest.consumer_v2.factory import get_ingest_consumer
 from sentry.ingest.types import ConsumerType
 from sentry.utils import json
 from sentry.utils.batching_kafka_consumer import create_topics
+from sentry.utils.pytest.fixtures import django_db_all
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,7 @@ def random_group_id():
     return f"test-consumer-{random.randint(0, 2 ** 16)}"
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
     task_runner,
     kafka_producer,
@@ -142,7 +143,7 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
     assert transaction_message.data["contexts"]["trace"]
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_ingest_topic_can_be_overridden(
     task_runner,
     kafka_admin,

--- a/tests/sentry/snuba/metrics/test_query.py
+++ b/tests/sentry/snuba/metrics/test_query.py
@@ -21,6 +21,7 @@ from sentry.snuba.metrics import (
 )
 from sentry.snuba.metrics.naming_layer import SessionMRI, TransactionMRI
 from sentry.utils.dates import parse_stats_period
+from sentry.utils.pytest.fixtures import django_db_all
 
 
 class MetricsQueryBuilder:
@@ -221,7 +222,7 @@ def test_validate_order_by():
         )
 
 
-@pytest.mark.django_db(True)
+@django_db_all
 def test_validate_order_by_field_in_select():
     create_default_projects()
     metric_field_2 = MetricField(op=None, metric_mri=SessionMRI.ALL.value)
@@ -245,7 +246,7 @@ def test_validate_order_by_field_in_select():
     MetricsQuery(**metrics_query_dict)
 
 
-@pytest.mark.django_db(True)
+@django_db_all
 def test_validate_order_by_field_in_select_with_different_alias():
     create_default_projects()
     ap_dex_with_alias_1 = MetricField(op=None, metric_mri=TransactionMRI.APDEX.value, alias="apdex")
@@ -268,7 +269,7 @@ def test_validate_order_by_field_in_select_with_different_alias():
         )
 
 
-@pytest.mark.django_db(True)
+@django_db_all
 def test_validate_multiple_orderby_columns_not_specified_in_select():
     create_default_projects()
     metric_field_1 = MetricField(op=None, metric_mri=SessionMRI.ABNORMAL.value)
@@ -291,7 +292,7 @@ def test_validate_multiple_orderby_columns_not_specified_in_select():
         MetricsQuery(**metrics_query_dict)
 
 
-@pytest.mark.django_db(True)
+@django_db_all
 def test_validate_multiple_order_by_fields_from_multiple_entities():
     """
     The example should fail because session crash free rate is generated from
@@ -321,7 +322,7 @@ def test_validate_multiple_order_by_fields_from_multiple_entities():
         MetricsQuery(**metrics_query_dict)
 
 
-@pytest.mark.django_db(True)
+@django_db_all
 def test_validate_multiple_orderby_derived_metrics_from_different_entities():
     """
     This example should fail because session crash free rate is generated from
@@ -350,7 +351,7 @@ def test_validate_multiple_orderby_derived_metrics_from_different_entities():
         MetricsQuery(**metrics_query_dict)
 
 
-@pytest.mark.django_db(True)
+@django_db_all
 def test_validate_many_order_by_fields_are_in_select():
     """
     Validate no exception is raised when all orderBy fields are presented the select
@@ -453,7 +454,7 @@ def test_validate_distribution_functions_in_orderby():
     MetricsQuery(**metrics_query_dict)
 
 
-@pytest.mark.django_db(True)
+@django_db_all
 def test_validate_where():
     query = "session.status:crashed"
     where = parse_query(query, [])

--- a/tests/sentry/tasks/deletion/test_hybrid_cloud.py
+++ b/tests/sentry/tasks/deletion/test_hybrid_cloud.py
@@ -18,6 +18,7 @@ from sentry.tasks.deletion.hybrid_cloud import (
 from sentry.testutils.factories import Factories
 from sentry.testutils.silo import exempt_from_silo_limits, no_silo_test, region_silo_test
 from sentry.types.region import find_regions_for_user
+from sentry.utils.pytest.fixtures import django_db_all
 
 
 @pytest.fixture(autouse=True)
@@ -56,7 +57,7 @@ def saved_search_owner_id_field():
     return SavedSearch._meta.get_field("owner_id")
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_no_work_is_no_op(task_runner, saved_search_owner_id_field):
     reset_watermarks()
 
@@ -71,7 +72,7 @@ def test_no_work_is_no_op(task_runner, saved_search_owner_id_field):
     assert get_watermark("tombstone", saved_search_owner_id_field) == (0, tid)
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_watermark_and_transaction_id(task_runner, saved_search_owner_id_field):
     _, tid1 = get_watermark("tombstone", saved_search_owner_id_field)
     # TODO: Add another test to validate the tid is unique per field
@@ -112,7 +113,7 @@ def setup_deletable_objects(
     assert False, "find_regions_for_user could not determine a region for production."
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 @region_silo_test(stable=True)
 def test_region_processing(task_runner):
     reset_watermarks()
@@ -148,7 +149,7 @@ def test_region_processing(task_runner):
 
 
 # No need to run both saas and control tests for this logic, the silo testing is baked in directly.
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 @no_silo_test(stable=True)
 def test_control_processing(task_runner):
     reset_watermarks()

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -15,6 +15,7 @@ from sentry.models import AuthIdentity, AuthProvider
 from sentry.silo import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.utils.auth import login
+from sentry.utils.pytest.fixtures import django_db_all
 from sentry.web.client_config import get_client_config
 
 RequestFactory = Callable[[], Optional[Tuple[HttpRequest, User]]]
@@ -112,7 +113,7 @@ def clear_env_request():
         make_user_request_from_org_with_auth_identities,
     ],
 )
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_client_config_in_silo_modes(request_factory: RequestFactory):
     request = request_factory()
     if request is not None:
@@ -129,7 +130,7 @@ def test_client_config_in_silo_modes(request_factory: RequestFactory):
         assert get_client_config(request) == base_line
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 def test_client_config_deleted_user():
     request, user = make_user_request_from_org()
     request.user = user


### PR DESCRIPTION
Update more tests that were failing with "cannot query 'control' database" errors when tests are run with SENTRY_USE_SPLIT_DBS is enabled.

Refs HC-793
