### PR TITLE
fix(hc): Have runner use normal parsing functions for region config

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3424,7 +3424,7 @@ if USE_SILOS:
             "name": "us",
             "snowflake_id": 1,
             "category": "MULTI_TENANT",
-            "address": "http://localhost:8000",
+            "address": "http://us.localhost:8000",
             "api_token": "dev-region-silo-token",
         }
     ]

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -453,24 +453,13 @@ def validate_options(settings: Any) -> None:
 
 
 def validate_regions(settings: Any) -> None:
-    from sentry.types.region import Region, RegionCategory
-    from sentry.utils import json
+    from sentry.types.region import load_from_config
 
     region_config = getattr(settings, "SENTRY_REGION_CONFIG", None)
     if not region_config:
         return
 
-    if isinstance(region_config, str):
-        parsed = []
-        config_values = json.loads(region_config)
-        for config_value in config_values:
-            config_value["category"] = RegionCategory[config_value["category"]]
-            parsed.append(Region(**config_value))
-
-        settings.SENTRY_REGION_CONFIG = parsed
-    else:
-        for region in region_config:
-            region.validate()
+    load_from_config(region_config).validate_all()
 
 
 import django.db.models.base


### PR DESCRIPTION
This allows the region config to be a dict of primitive values, as in `sentry.conf.server` in the "if USE_SILOS" block.

Tweak the default config's address so that it passes validation. Omit the default "monolith region" from address validation.