### PR TITLE
fix(github): Log which event type was missing

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -487,7 +487,7 @@ class GitHubWebhookBase(Endpoint):
         if not handler:
             logger.error(
                 "github.webhook.missing-handler",
-                extra={"event": request.META["HTTP_X_GITHUB_EVENT"]},
+                extra={"event_type": request.META["HTTP_X_GITHUB_EVENT"]},
             )
             return HttpResponse(status=204)
 


### PR DESCRIPTION
We can't use "event" for logging extras because it's already being used for log names.
