### PR TITLE
feat(graphql): Add alert below request when there were errors

### DIFF
--- a/static/app/components/events/interfaces/request/graphQlRequestBody.tsx
+++ b/static/app/components/events/interfaces/request/graphQlRequestBody.tsx
@@ -1,9 +1,15 @@
 import {useEffect, useRef} from 'react';
+import styled from '@emotion/styled';
+import isEmpty from 'lodash/isEmpty';
 import omit from 'lodash/omit';
 import uniq from 'lodash/uniq';
 import Prism from 'prismjs';
 
+import Alert from 'sentry/components/alert';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
+import List from 'sentry/components/list';
+import {tn} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {EntryRequestDataGraphQl, Event} from 'sentry/types';
 import {loadPrismLanguage} from 'sentry/utils/loadPrismLanguage';
 
@@ -41,6 +47,32 @@ function getErrorLineNumbers(errors: GraphQlErrors): number[] {
   );
 }
 
+function ErrorsAlert({errors}: {errors: GraphQlErrors}) {
+  if (isEmpty(errors)) {
+    return null;
+  }
+
+  return (
+    <StyledAlert
+      type="error"
+      showIcon
+      expand={
+        <List symbol="bullet">
+          {errors.map((error, i) => (
+            <li key={i}>{error.message}</li>
+          ))}
+        </List>
+      }
+    >
+      {tn(
+        'There was %s GraphQL error raised during this request.',
+        'There were %s errors raised during this request.',
+        errors.length
+      )}
+    </StyledAlert>
+  );
+}
+
 export function GraphQlRequestBody({data, event}: GraphQlBodyProps) {
   const ref = useRef<HTMLElement | null>(null);
 
@@ -73,6 +105,7 @@ export function GraphQlRequestBody({data, event}: GraphQlBodyProps) {
           {data.query}
         </code>
       </pre>
+      <ErrorsAlert errors={errors} />
       <KeyValueList
         data={Object.entries(omit(data, 'query')).map(([key, value]) => ({
           key,
@@ -84,3 +117,7 @@ export function GraphQlRequestBody({data, event}: GraphQlBodyProps) {
     </div>
   );
 }
+
+const StyledAlert = styled(Alert)`
+  margin-top: -${space(1)};
+`;

--- a/static/app/components/events/interfaces/request/index.spec.tsx
+++ b/static/app/components/events/interfaces/request/index.spec.tsx
@@ -386,7 +386,7 @@ describe('Request entry', function () {
         ).toBeInTheDocument();
       });
 
-      it('highlights graphql query lines with errors', function () {
+      it('highlights graphql query lines with errors', async function () {
         const data: EntryRequest['data'] = {
           apiTarget: 'graphql',
           method: 'POST',
@@ -406,7 +406,11 @@ describe('Request entry', function () {
               data,
             },
           ],
-          contexts: {response: {data: {errors: [{locations: [{line: 1}]}]}}},
+          contexts: {
+            response: {
+              data: {errors: [{message: 'Very bad error', locations: [{line: 1}]}]},
+            },
+          },
         };
 
         const {container} = render(
@@ -417,6 +421,13 @@ describe('Request entry', function () {
         expect(
           container.querySelector('.line-highlight')?.getAttribute('data-start')
         ).toBe('1');
+        expect(
+          screen.getByText('There was 1 GraphQL error raised during this request.')
+        ).toBeInTheDocument();
+
+        await userEvent.click(screen.getByText(/There was 1 GraphQL error/i));
+
+        expect(screen.getByText('Very bad error')).toBeInTheDocument();
       });
     });
   });

--- a/static/app/components/events/interfaces/request/index.spec.tsx
+++ b/static/app/components/events/interfaces/request/index.spec.tsx
@@ -408,7 +408,9 @@ describe('Request entry', function () {
           ],
           contexts: {
             response: {
-              data: {errors: [{message: 'Very bad error', locations: [{line: 1}]}]},
+              data: {
+                errors: [{message: 'Very bad error', locations: [{line: 1, column: 2}]}],
+              },
             },
           },
         };
@@ -427,7 +429,7 @@ describe('Request entry', function () {
 
         await userEvent.click(screen.getByText(/There was 1 GraphQL error/i));
 
-        expect(screen.getByText('Very bad error')).toBeInTheDocument();
+        expect(screen.getByText('Line 1 Column 2: Very bad error')).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
This adds context as to why a line has been highlighted and summarizes errors in the response.

![CleanShot 2023-06-29 at 15 20 19](https://github.com/getsentry/sentry/assets/10888943/04e7c8a9-0223-4b82-bc37-bf6d30f84fa8)