### PR TITLE
Provider sso flow

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -688,7 +688,6 @@ class AuthHelper(Pipeline):
         query_params = request.GET
         provider_param = query_params.get("provider")
         config_param = query_params.get("config")
-        provider_query = None
 
         if not (req_state or (config_param and provider_param)):
             return None
@@ -706,12 +705,13 @@ class AuthHelper(Pipeline):
             provider_query = AuthProvider.objects.filter(
                 provider=provider_param, config=config_dict
             )
-
-        if provider_query.exists():
-            flow = cls.FLOW_LOGIN
-            provider_key = provider_param
-            provider_model = provider_query[0]
-            organization = Organization.objects.filter(id=provider_model.organization_id)[0]
+            if provider_query.exists():
+                flow = cls.FLOW_LOGIN
+                provider_key = provider_param
+                provider_model = provider_query[0]
+                organization = Organization.objects.filter(id=provider_model.organization_id)[0]
+            else:
+                return None
 
         if not organization:
             logging.info("Invalid SSO data found")

--- a/src/sentry/auth/providers/fly/provider.py
+++ b/src/sentry/auth/providers/fly/provider.py
@@ -47,35 +47,9 @@ class FlyOAuth2Provider(OAuth2Provider):
     @classmethod
     def build_config(self, state: Any, organization: Optional[Any] = None):
         """
-        On configuration, we determine which provider organization to configure SSO for.
+        On configuration, we determine which provider organization to configure sentry SSO for.
         This configuration is then stored and passed into the pipeline instances during SSO
         to determine whether the Auth'd user has the appropriate access to the provider org
-
-        {
-            'state': '9da4041848844e8088864eaea3c3a705',
-            'data': {
-                'access_token': 'fo1_6xgeCrB8ew8vFQ86vdaakBSFTVDGCzOUvebUbvgPGhI',
-                'token_type': 'Bearer',
-                'expires_in': 7200,
-                'refresh_token': 'PmUkAB75UPLKGZplERMq8WwOHnsTllZ5HveY4RvNUTk',
-                'scope': 'read',
-                'created_at': 1686786353},
-                'user': {
-                    'resource_owner_id': 'k9d01lp82rky6vo2',
-                    'scope': ['read'],
-                    'expires_in': 7200,
-                    'application': {'uid': 'elMJpuhA5bXbR59ZaKdXrxXGFVKTypGHuJ4h6Rfw1Qk'},
-                    'created_at': 1686786353,
-                    'user_id': 'k9d01lp82rky6vo2',
-                    'user_name': 'Nathan',
-                    'email': 'k9d01lp82rky6vo2@customer.fly.io',
-                    'organizations': [
-                        {'id': 'nathans-org', 'role': 'member'},
-                        {'id': '0vogzmzoj1k5xp29', 'role': 'admin'}
-                    ]
-                }
-            }
-        }
         """
         org = organization
         if not organization:
@@ -83,7 +57,7 @@ class FlyOAuth2Provider(OAuth2Provider):
             # TODO: determine which org to configure SSO for
             org = data["user"]["organizations"][0]
 
-        return {"org": org}
+        return {"org": {id: org.id}}
 
     def build_identity(self, state):
         """

--- a/src/sentry/auth/providers/fly/provider.py
+++ b/src/sentry/auth/providers/fly/provider.py
@@ -57,7 +57,7 @@ class FlyOAuth2Provider(OAuth2Provider):
             # TODO: determine which org to configure SSO for
             org = data["user"]["organizations"][0]
 
-        return {"org": {id: cast(Dict, org).get("id")}}
+        return {"org": {"id": cast(Dict, org).get("id")}}
 
     def build_identity(self, state):
         """

--- a/src/sentry/auth/providers/fly/provider.py
+++ b/src/sentry/auth/providers/fly/provider.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Dict, Optional, cast
 
 from sentry import options
 from sentry.auth.partnership_config import SPONSOR_OAUTH_NAME, ChannelName
@@ -45,7 +45,7 @@ class FlyOAuth2Provider(OAuth2Provider):
         return ACCESS_TOKEN_URL
 
     @classmethod
-    def build_config(self, state: Any, organization: Optional[Any] = None):
+    def build_config(self, state: Any, organization: Optional[Dict] = None):
         """
         On configuration, we determine which provider organization to configure sentry SSO for.
         This configuration is then stored and passed into the pipeline instances during SSO
@@ -57,7 +57,7 @@ class FlyOAuth2Provider(OAuth2Provider):
             # TODO: determine which org to configure SSO for
             org = data["user"]["organizations"][0]
 
-        return {"org": {id: org.id}}
+        return {"org": {id: cast(Dict, org).get("id")}}
 
     def build_identity(self, state):
         """

--- a/tests/sentry/auth/providers/fly/test_provider.py
+++ b/tests/sentry/auth/providers/fly/test_provider.py
@@ -53,7 +53,7 @@ class FlyOAuth2ProviderTest(TestCase):
             },
         }
         result = provider.build_config(state)
-        assert result == {"org": {"id": "nathans-org", "role": "member"}}
+        assert result == {"org": {"id": "nathans-org"}}
 
     def test_build_identity(self):
         provider = self.auth_provider.get_provider()


### PR DESCRIPTION
Allow providers to enter in the middle of the SSO OAuth flow by providing the auth config and provider

The SSO redirect_uri will construct an `AuthHelper` on redirect via
`helper = AuthHelper.get_for_request(request)`

Previously, we would have saved state to the redis cache at the start of the OAuth flow - and if that state was not populated, then we would kick the user out of the OAuth flow.
State written to redis included the organization, provider model, and provider key.

We have a challenge now where our partner providers need to send their users through our SSO flow - however our partners have no mapping of their organizations to our Sentry organizations.
They _do_ however know how their SSO configurations were set up, and can pass in their auth configuration so we can query for the data.