### PR TITLE
fix(gridEditable): Fix overflow issue

### DIFF
--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -51,6 +51,7 @@ export const Body = styled(({children, ...props}) => (
     <PanelBody>{children}</PanelBody>
   </Panel>
 ))`
+  overflow-x: auto;
   z-index: ${Z_INDEX_PANEL};
 `;
 


### PR DESCRIPTION
Fix an overflow issue caused by https://github.com/getsentry/sentry/pull/50515.

**Before ——** right edge overflows without scrolling
<img width="791" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/360f30df-8029-48dd-aca0-0b929fd15b5c">

**After ——**
<img width="791" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/34430e2f-9384-421a-88c1-93663ff7e654">