### PR TITLE
fix(escalating-issues): Add substatus when archiving with condition

### DIFF
--- a/static/app/components/actions/archive.spec.tsx
+++ b/static/app/components/actions/archive.spec.tsx
@@ -74,6 +74,7 @@ describe('ArchiveActions', () => {
     expect(onUpdate).toHaveBeenCalledWith({
       status: 'ignored',
       statusDetails: {ignoreDuration: 30},
+      substatus: 'archived_until_condition_met',
     });
   });
 });

--- a/static/app/components/actions/archive.tsx
+++ b/static/app/components/actions/archive.tsx
@@ -99,7 +99,13 @@ function ArchiveActions({
         priority="primary"
         size="xs"
         title={t('Change status to unresolved')}
-        onClick={() => onUpdate({status: ResolutionStatus.UNRESOLVED, statusDetails: {}})}
+        onClick={() =>
+          onUpdate({
+            status: ResolutionStatus.UNRESOLVED,
+            statusDetails: {},
+            substatus: GroupSubstatus.ONGOING,
+          })
+        }
         aria-label={t('Unarchive')}
       />
     );

--- a/static/app/components/actions/ignore.spec.tsx
+++ b/static/app/components/actions/ignore.spec.tsx
@@ -43,7 +43,11 @@ describe('IgnoreActions', function () {
       const button = screen.getByRole('button', {name: 'Ignore'});
       await userEvent.click(button);
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith({status: 'ignored', statusDetails: {}});
+      expect(spy).toHaveBeenCalledWith({
+        status: 'ignored',
+        statusDetails: {},
+        substatus: 'archived_until_condition_met',
+      });
     });
   });
 
@@ -87,6 +91,7 @@ describe('IgnoreActions', function () {
         statusDetails: {
           ignoreDuration: expect.any(Number),
         },
+        substatus: 'archived_until_condition_met',
       });
     });
   });

--- a/static/app/components/actions/ignore.spec.tsx
+++ b/static/app/components/actions/ignore.spec.tsx
@@ -33,7 +33,11 @@ describe('IgnoreActions', function () {
       expect(button).toHaveTextContent('');
 
       await userEvent.click(button);
-      expect(spy).toHaveBeenCalledWith({status: 'unresolved', statusDetails: {}});
+      expect(spy).toHaveBeenCalledWith({
+        status: 'unresolved',
+        statusDetails: {},
+        substatus: 'ongoing',
+      });
     });
   });
 

--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -230,7 +230,11 @@ function IgnoreActions({
           priority="primary"
           size="xs"
           onClick={() =>
-            onUpdate({status: ResolutionStatus.UNRESOLVED, statusDetails: {}})
+            onUpdate({
+              status: ResolutionStatus.UNRESOLVED,
+              statusDetails: {},
+              substatus: GroupSubstatus.ONGOING,
+            })
           }
           aria-label={t('Unignore')}
         />

--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -12,6 +12,7 @@ import {IconChevron} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {
   GroupStatusResolution,
+  GroupSubstatus,
   ResolutionStatus,
   ResolutionStatusDetails,
   SelectValue,
@@ -61,6 +62,7 @@ export function getIgnoreActions({
         onUpdate({
           status: ResolutionStatus.IGNORED,
           statusDetails,
+          substatus: GroupSubstatus.ARCHIVED_UNTIL_CONDITION_MET,
         }),
       message: confirmMessage?.() ?? null,
       confirmText: confirmLabel,

--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -71,7 +71,11 @@ describe('ResolveActions', function () {
       expect(button).toHaveTextContent('');
 
       await userEvent.click(button);
-      expect(spy).toHaveBeenCalledWith({status: 'unresolved', statusDetails: {}});
+      expect(spy).toHaveBeenCalledWith({
+        status: 'unresolved',
+        statusDetails: {},
+        substatus: 'ongoing',
+      });
     });
   });
 
@@ -98,7 +102,11 @@ describe('ResolveActions', function () {
       render(<ResolveActions onUpdate={spy} hasRelease={false} projectSlug="proj-1" />);
       await userEvent.click(screen.getByRole('button', {name: 'Resolve'}));
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith({status: 'resolved', statusDetails: {}});
+      expect(spy).toHaveBeenCalledWith({
+        status: 'resolved',
+        statusDetails: {},
+        substatus: null,
+      });
     });
   });
 
@@ -151,6 +159,7 @@ describe('ResolveActions', function () {
       statusDetails: {
         inRelease: 'sentry-android-shop@1.2.0',
       },
+      substatus: null,
     });
   });
 

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -13,8 +13,8 @@ import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {
   GroupStatusResolution,
-  Project,
   GroupSubstatus,
+  Project,
   ResolutionStatus,
   ResolutionStatusDetails,
 } from 'sentry/types';

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -14,6 +14,7 @@ import {t} from 'sentry/locale';
 import {
   GroupStatusResolution,
   Project,
+  GroupSubstatus,
   ResolutionStatus,
   ResolutionStatusDetails,
 } from 'sentry/types';
@@ -60,6 +61,7 @@ function ResolveActions({
     onUpdate({
       status: ResolutionStatus.RESOLVED,
       statusDetails,
+      substatus: null,
     });
   }
 
@@ -69,6 +71,7 @@ function ResolveActions({
     onUpdate({
       status: ResolutionStatus.RESOLVED,
       statusDetails,
+      substatus: null,
     });
     trackAnalytics('resolve_issue', {
       organization,
@@ -83,6 +86,7 @@ function ResolveActions({
         statusDetails: {
           inRelease: latestRelease ? latestRelease.version : 'latest',
         },
+        substatus: null,
       });
     }
 
@@ -99,6 +103,7 @@ function ResolveActions({
         statusDetails: {
           inNextRelease: true,
         },
+        substatus: null,
       });
     }
 
@@ -125,7 +130,11 @@ function ResolveActions({
           aria-label={t('Unresolve')}
           disabled={isAutoResolved}
           onClick={() =>
-            onUpdate({status: ResolutionStatus.UNRESOLVED, statusDetails: {}})
+            onUpdate({
+              status: ResolutionStatus.UNRESOLVED,
+              statusDetails: {},
+              substatus: GroupSubstatus.ONGOING,
+            })
           }
         />
       </Tooltip>
@@ -254,7 +263,11 @@ function ResolveActions({
             openConfirmModal({
               bypass: !shouldConfirm,
               onConfirm: () =>
-                onUpdate({status: ResolutionStatus.RESOLVED, statusDetails: {}}),
+                onUpdate({
+                  status: ResolutionStatus.RESOLVED,
+                  statusDetails: {},
+                  substatus: null,
+                }),
               message: confirmMessage,
               confirmText: confirmLabel,
             })

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -549,7 +549,7 @@ export type ResolutionStatusDetails = {
 export type GroupStatusResolution = {
   status: ResolutionStatus;
   statusDetails: ResolutionStatusDetails;
-  substatus?: GroupSubstatus;
+  substatus: GroupSubstatus;
 };
 
 // TODO(ts): incomplete

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -549,7 +549,7 @@ export type ResolutionStatusDetails = {
 export type GroupStatusResolution = {
   status: ResolutionStatus;
   statusDetails: ResolutionStatusDetails;
-  substatus: GroupSubstatus;
+  substatus: GroupSubstatus | null;
 };
 
 // TODO(ts): incomplete
@@ -605,7 +605,7 @@ export interface GroupResolution
   // A proper fix for this would be to make the status field an enum or string and correctly extend it.
   extends Omit<BaseGroup, 'status'>,
     GroupStats,
-    GroupStatusResolution {}
+    Omit<GroupStatusResolution, 'substatus'> {}
 
 export type Group = GroupResolution | GroupReprocessing;
 

--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -273,7 +273,9 @@ describe('GroupActions', function () {
 
     expect(issuesApi).toHaveBeenCalledWith(
       `/projects/${organization.slug}/project/issues/`,
-      expect.objectContaining({data: {status: 'resolved', statusDetails: {}}})
+      expect.objectContaining({
+        data: {status: 'resolved', statusDetails: {}, substatus: null},
+      })
     );
     expect(analyticsSpy).toHaveBeenCalledWith(
       'issue_details.action_clicked',
@@ -295,7 +297,9 @@ describe('GroupActions', function () {
 
     expect(issuesApi).toHaveBeenCalledWith(
       `/projects/${organization.slug}/project/issues/`,
-      expect.objectContaining({data: {status: 'unresolved', statusDetails: {}}})
+      expect.objectContaining({
+        data: {status: 'unresolved', statusDetails: {}, substatus: 'ongoing'},
+      })
     );
   });
 

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -34,6 +34,7 @@ import {space} from 'sentry/styles/space';
 import {
   Group,
   GroupStatusResolution,
+  GroupSubstatus,
   IssueCategory,
   Organization,
   Project,
@@ -134,7 +135,7 @@ export function Actions(props: Props) {
       | 'discarded'
       | 'open_in_discover'
       | ResolutionStatus,
-    substatus?: string,
+    substatus?: GroupSubstatus | null,
     statusDetailsKey?: string
   ) => {
     const {alert_date, alert_rule_id, alert_type} = query;
@@ -142,7 +143,7 @@ export function Actions(props: Props) {
       organization,
       project_id: parseInt(project.id, 10),
       action_type: action,
-      action_substatus: substatus,
+      action_substatus: substatus ?? undefined,
       action_status_details: statusDetailsKey,
       // Alert properties track if the user came from email/slack alerts
       alert_date:
@@ -502,6 +503,7 @@ export function Actions(props: Props) {
             onUpdate({
               status: ResolutionStatus.UNRESOLVED,
               statusDetails: {},
+              substatus: GroupSubstatus.ONGOING,
             })
           }
         >

--- a/static/app/views/issueList/actions/index.spec.tsx
+++ b/static/app/views/issueList/actions/index.spec.tsx
@@ -105,7 +105,7 @@ describe('IssueListActions', function () {
             query: {
               project: [1],
             },
-            data: {status: 'resolved', statusDetails: {}},
+            data: {status: 'resolved', statusDetails: {}, substatus: null},
           })
         );
       });
@@ -158,7 +158,7 @@ describe('IssueListActions', function () {
             query: {
               project: [1],
             },
-            data: {status: 'resolved', statusDetails: {}},
+            data: {status: 'resolved', statusDetails: {}, substatus: null},
           })
         );
       });
@@ -186,7 +186,7 @@ describe('IssueListActions', function () {
               id: ['1'],
               project: [1],
             },
-            data: {status: 'resolved', statusDetails: {}},
+            data: {status: 'resolved', statusDetails: {}, substatus: null},
           })
         );
       });

--- a/static/app/views/issueList/actions/index.spec.tsx
+++ b/static/app/views/issueList/actions/index.spec.tsx
@@ -234,6 +234,7 @@ describe('IssueListActions', function () {
                 ignoreUserCount: 300,
                 ignoreUserWindow: 10080,
               },
+              substatus: 'archived_until_condition_met',
             },
           })
         );


### PR DESCRIPTION
## Objective:
We are defaulting to recording the GroupHistory change as IGNORED bc we are missing the substatus in the payload. We need a followup PR for the backend to do some validation on the API and prevent this type of error.