### PR TITLE
feat(spikes): Setup OrganizationStats for client-side pagination of Spikes

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -12,7 +12,7 @@ import {Platform} from 'sentry/data/platformCategories';
 import {SVGIconProps} from 'sentry/icons/svgIcon';
 import type {Group} from 'sentry/types';
 import {UseExperiment} from 'sentry/utils/useExperiment';
-import {UsageStatsOrganizationProps} from 'sentry/views/organizationStats/usageStatsOrg';
+import {OrganizationStatsProps} from 'sentry/views/organizationStats/index';
 import {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 import type {NavigationItem, NavigationSection} from 'sentry/views/settings/types';
 
@@ -165,7 +165,7 @@ export type ComponentHooks = {
   'component:disabled-custom-symbol-sources': () => React.ComponentType<DisabledCustomSymbolSources>;
   'component:disabled-member': () => React.ComponentType<DisabledMemberViewProps>;
   'component:disabled-member-tooltip': () => React.ComponentType<DisabledMemberTooltipProps>;
-  'component:enhanced-org-stats': () => React.ComponentType<UsageStatsOrganizationProps>;
+  'component:enhanced-org-stats': () => React.ComponentType<OrganizationStatsProps>;
   'component:first-party-integration-additional-cta': () => React.ComponentType<FirstPartyIntegrationAdditionalCTAProps>;
   'component:first-party-integration-alert': () => React.ComponentType<FirstPartyIntegrationAlertProps>;
   'component:header-date-range': () => React.ComponentType<DateRangeProps>;

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -66,17 +66,17 @@ export const PAGE_QUERY_PARAMS = [
   'cursor',
 ];
 
-type Props = {
+export type OrganizationStatsProps = {
   organization: Organization;
   selection: PageFilters;
 } & RouteComponentProps<{}, {}>;
 
-const UsageStatsOrganization = HookOrDefault({
-  hookName: 'component:enhanced-org-stats',
-  defaultComponent: UsageStatsOrg,
-});
+type State = {};
 
-export class OrganizationStats extends Component<Props> {
+export class OrganizationStats<
+  P extends OrganizationStatsProps = OrganizationStatsProps,
+  S extends State = State
+> extends Component<P, S> {
   get dataCategory(): DataCategoryInfo['plural'] {
     const dataCategory = this.props.location?.query?.dataCategory;
 
@@ -181,6 +181,12 @@ export class OrganizationStats extends Component<Props> {
    */
   get hasProjectStats(): boolean {
     return this.props.organization.features.includes('project-stats');
+  }
+
+  get isSingleProject(): boolean {
+    return this.hasProjectStats
+      ? this.projectIds.length === 1 && !this.projectIds.includes(-1)
+      : false;
   }
 
   getNextLocations = (project: Project): Record<string, LocationDescriptorObject> => {
@@ -347,13 +353,28 @@ export class OrganizationStats extends Component<Props> {
     );
   };
 
+  /**
+   * This method is replaced by the hook "component:enhanced-org-stats"
+   */
+  renderUsageStatsOrg() {
+    const {organization} = this.props;
+    return (
+      <UsageStatsOrg
+        isSingleProject={this.isSingleProject}
+        projectIds={this.projectIds}
+        organization={organization}
+        dataCategory={this.dataCategory}
+        dataCategoryName={this.dataCategoryName}
+        dataDatetime={this.dataDatetime}
+        chartTransform={this.chartTransform}
+        handleChangeState={this.setStateOnUrl}
+      />
+    );
+  }
+
   render() {
     const {organization} = this.props;
     const hasTeamInsights = organization.features.includes('team-insights');
-
-    const isSingleProject = this.hasProjectStats
-      ? this.projectIds.length === 1 && !this.projectIds.includes(-1)
-      : false;
 
     return (
       <SentryDocumentTitle title="Usage Stats">
@@ -381,25 +402,14 @@ export class OrganizationStats extends Component<Props> {
               {this.renderProjectPageControl()}
               {this.renderPageControl()}
               <div>
-                <ErrorBoundary mini>
-                  <UsageStatsOrganization
-                    organization={organization}
-                    dataCategory={this.dataCategory}
-                    dataCategoryName={this.dataCategoryName}
-                    dataDatetime={this.dataDatetime}
-                    chartTransform={this.chartTransform}
-                    handleChangeState={this.setStateOnUrl}
-                    projectIds={this.projectIds}
-                    isSingleProject={isSingleProject}
-                  />
-                </ErrorBoundary>
+                <ErrorBoundary mini>{this.renderUsageStatsOrg()}</ErrorBoundary>
               </div>
               <ErrorBoundary mini>
                 <UsageStatsProjects
                   organization={organization}
                   dataCategory={this.dataCategory}
                   dataCategoryName={this.dataCategoryName}
-                  isSingleProject={isSingleProject}
+                  isSingleProject={this.isSingleProject}
                   projectIds={this.projectIds}
                   dataDatetime={this.dataDatetime}
                   tableSort={this.tableSort}
@@ -417,7 +427,12 @@ export class OrganizationStats extends Component<Props> {
   }
 }
 
-export default withPageFilters(withOrganization(OrganizationStats));
+const HookOrgStats = HookOrDefault({
+  hookName: 'component:enhanced-org-stats',
+  defaultComponent: OrganizationStats,
+});
+
+export default withPageFilters(withOrganization(HookOrgStats));
 
 const SelectorGrid = styled('div')`
   display: grid;

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -64,6 +64,7 @@ export const PAGE_QUERY_PARAMS = [
   'sort',
   'query',
   'cursor',
+  'spikeCursor',
 ];
 
 export type OrganizationStatsProps = {
@@ -71,12 +72,7 @@ export type OrganizationStatsProps = {
   selection: PageFilters;
 } & RouteComponentProps<{}, {}>;
 
-type State = {};
-
-export class OrganizationStats<
-  P extends OrganizationStatsProps = OrganizationStatsProps,
-  S extends State = State
-> extends Component<P, S> {
+export class OrganizationStats extends Component<OrganizationStatsProps> {
   get dataCategory(): DataCategoryInfo['plural'] {
     const dataCategory = this.props.location?.query?.dataCategory;
 

--- a/static/app/views/organizationStats/utils.tsx
+++ b/static/app/views/organizationStats/utils.tsx
@@ -105,3 +105,34 @@ export function isDisplayUtc(datetime: DateTimeObject): boolean {
   const hours = parsePeriodToHours(interval);
   return hours >= 24;
 }
+
+/**
+ * HACK(dlee): client-side pagination
+ */
+export function getOffsetFromCursor(cursor?: string) {
+  const offset = Number(cursor?.split(':')[1]);
+  return isNaN(offset) ? 0 : offset;
+}
+
+/**
+ * HACK(dlee): client-side pagination
+ */
+export function getPaginationPageLink({
+  numRows,
+  pageSize,
+  offset,
+}: {
+  numRows: number;
+  offset: number;
+  pageSize: number;
+}) {
+  const prevOffset = offset - pageSize;
+  const nextOffset = offset + pageSize;
+
+  return `<link>; rel="previous"; results="${prevOffset >= 0}"; cursor="0:${Math.max(
+    0,
+    prevOffset
+  )}:1", <link>; rel="next"; results="${
+    nextOffset < numRows
+  }"; cursor="0:${nextOffset}:0"`;
+}


### PR DESCRIPTION
There'll be 2 tables with pagination on this page.

![screencapture-default-dev-getsentry-net-8000-stats-2023-06-28-19_09_20](https://github.com/getsentry/sentry/assets/1748388/b1ae6dcb-b2a7-47bc-a103-1ed08377c762)
