### PR TITLE
feat(strings): Add exclusive time light metric

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -158,6 +158,7 @@ SPAN_METRICS_NAMES = {
     "s:spans/user@none": PREFIX + 403,
     "d:spans/duration@millisecond": PREFIX + 404,
     "d:spans/exclusive_time@millisecond": PREFIX + 405,
+    "d:spans/exclusive_time_light@millisecond": PREFIX + 406,
 }
 
 SHARED_STRINGS = {


### PR DESCRIPTION
Adds the string for the new metric extracted in https://github.com/getsentry/relay/pull/2265.