### PR TITLE
ref: Make eventstore.processing use LazyServiceWrapper

### DIFF
--- a/src/sentry/eventstore/processing/__init__.py
+++ b/src/sentry/eventstore/processing/__init__.py
@@ -1,9 +1,12 @@
 from django.conf import settings
 
-from sentry.utils.imports import import_string
+from sentry.eventstore.processing.base import EventProcessingStore
+from sentry.utils.services import LazyServiceWrapper
 
-event_processing_store = import_string(settings.SENTRY_EVENT_PROCESSING_STORE)(
-    **settings.SENTRY_EVENT_PROCESSING_STORE_OPTIONS
+event_processing_store = LazyServiceWrapper(
+    EventProcessingStore,
+    settings.SENTRY_EVENT_PROCESSING_STORE,
+    settings.SENTRY_EVENT_PROCESSING_STORE_OPTIONS,
 )
 
 

--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -5,6 +5,7 @@ import sentry_sdk
 
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.kvstore.abstract import KVStorage
+from sentry.utils.services import Service
 
 DEFAULT_TIMEOUT = 60 * 60 * 24
 
@@ -12,7 +13,7 @@ DEFAULT_TIMEOUT = 60 * 60 * 24
 Event = Any
 
 
-class EventProcessingStore:
+class EventProcessingStore(Service):
     """
     Store for event blobs during processing
 

--- a/src/sentry/eventstore/processing/bigtable.py
+++ b/src/sentry/eventstore/processing/bigtable.py
@@ -5,16 +5,18 @@ from sentry.utils.kvstore.encoding import KVStorageCodecWrapper
 from .base import EventProcessingStore
 
 
-def BigtableEventProcessingStore(**options) -> EventProcessingStore:
+class BigtableEventProcessingStore(EventProcessingStore):
     """
     Creates an instance of the processing store which uses Bigtable as its
     backend.
 
     Keyword argument are forwarded to the ``BigtableKVStorage`` constructor.
     """
-    return EventProcessingStore(
-        KVStorageCodecWrapper(
-            BigtableKVStorage(**options),
-            JSONCodec() | BytesCodec(),  # maintains functional parity with cache backend
+
+    def __init__(self, **options):
+        super().__init__(
+            KVStorageCodecWrapper(
+                BigtableKVStorage(**options),
+                JSONCodec() | BytesCodec(),  # maintains functional parity with cache backend
+            )
         )
-    )

--- a/src/sentry/eventstore/processing/default.py
+++ b/src/sentry/eventstore/processing/default.py
@@ -4,9 +4,10 @@ from sentry.utils.kvstore.cache import CacheKVStorage
 from .base import EventProcessingStore
 
 
-def DefaultEventProcessingStore() -> EventProcessingStore:
-    """
-    Creates an instance of the processing store which uses the
-    ``default_cache`` as its backend.
-    """
-    return EventProcessingStore(CacheKVStorage(default_cache))
+class DefaultEventProcessingStore(EventProcessingStore):
+    def __init__(self) -> None:
+        """
+        Creates an instance of the processing store which uses the
+        ``default_cache`` as its backend.
+        """
+        super().__init__(CacheKVStorage(default_cache))

--- a/src/sentry/eventstore/processing/redis.py
+++ b/src/sentry/eventstore/processing/redis.py
@@ -4,11 +4,13 @@ from sentry.utils.kvstore.cache import CacheKVStorage
 from .base import EventProcessingStore
 
 
-def RedisClusterEventProcessingStore(**options) -> EventProcessingStore:
+class RedisClusterEventProcessingStore(EventProcessingStore):
     """
     Creates an instance of the processing store which uses the Redis Cluster
     cache as its backend.
 
     Keyword argument are forwarded to the ``RedisClusterCache`` constructor.
     """
-    return EventProcessingStore(CacheKVStorage(RedisClusterCache(**options)))
+
+    def __init__(self, **options):
+        super().__init__(CacheKVStorage(RedisClusterCache(**options)))


### PR DESCRIPTION
LazyServiceWrapper is a horrible old beast but it has a few sanity
checks that a simple `import_string` lacks. For starters, whether the
imported string even implements the relevant service baseclass.

Also **LazyServiceWrapper supports typing now** (which is the trigger
for doing this), while import_string would require one additional type
hint. That's easy to add but I don't particularly care for having N
ways to do services in Sentry.
