### PR TITLE
fix(hc): Fix hybrid cloud ApiKey authentication

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -158,7 +158,7 @@ class Endpoint(APIView):
         result: List[BaseAuthentication] = []
         for authenticator_cls in self.authentication_classes:
             auth_type = RpcAuthenticatorType.from_authenticator(authenticator_cls)
-            if auth_type:
+            if auth_type is not None:
                 last_api_authenticator.types.append(auth_type)
             else:
                 if last_api_authenticator.types:

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -19,7 +19,8 @@ from sentry.api.utils import (
 )
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import ALL_ACCESS_PROJECTS, ALL_ACCESS_PROJECTS_SLUG, ObjectStatus
-from sentry.models import ApiKey, Organization, Project, ReleaseProject
+from sentry.models import Organization, Project, ReleaseProject
+from sentry.models.apikey import is_api_key_auth
 from sentry.models.environment import Environment
 from sentry.models.release import Release
 from sentry.services.hybrid_cloud.organization import RpcOrganization, RpcUserOrganizationContext
@@ -434,7 +435,7 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         detail in the parent class's method of the same name.
         """
         has_valid_api_key = False
-        if isinstance(request.auth, ApiKey):
+        if is_api_key_auth(request.auth):
             if request.auth.organization_id != organization.id:
                 return []
             has_valid_api_key = request.auth.has_scope(

--- a/src/sentry/api/decorators.py
+++ b/src/sentry/api/decorators.py
@@ -4,7 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.exceptions import EmailVerificationRequired, SudoRequired
-from sentry.models import ApiKey
+from sentry.models.apikey import is_api_key_auth
 from sentry.models.apitoken import is_api_token_auth
 from sentry.models.orgauthtoken import is_org_auth_token_auth
 
@@ -15,7 +15,7 @@ def is_considered_sudo(request):
     # then we shouldn't prompt them for the password they don't have.
     return (
         request.is_sudo()
-        or isinstance(request.auth, ApiKey)
+        or is_api_key_auth(request.auth)
         or is_api_token_auth(request.auth)
         or is_org_auth_token_auth(request.auth)
         or request.user.is_authenticated

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -106,3 +106,12 @@ class ApiKey(Model):
 
     def has_scope(self, scope):
         return scope in self.get_scopes()
+
+
+def is_api_key_auth(auth: object) -> bool:
+    """:returns True when an API Key is hitting the API."""
+    from sentry.services.hybrid_cloud.auth import AuthenticatedToken
+
+    if isinstance(auth, AuthenticatedToken):
+        return auth.kind == "api_key"
+    return isinstance(auth, ApiKey)

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -578,13 +578,11 @@ class Organization(Model, OptionMixin, OrganizationAbsoluteUrlMixin, SnowflakeId
         ).send_async([o.email for o in owners])
 
     def _handle_requirement_change(self, request, task):
-        from sentry.models import ApiKey
+        from sentry.models.apikey import is_api_key_auth
 
         actor_id = request.user.id if request.user and request.user.is_authenticated else None
         api_key_id = (
-            request.auth.id
-            if hasattr(request, "auth") and isinstance(request.auth, ApiKey)
-            else None
+            request.auth.id if hasattr(request, "auth") and is_api_key_auth(request.auth) else None
         )
         ip_address = request.META["REMOTE_ADDR"]
 

--- a/src/sentry/services/hybrid_cloud/auth/model.py
+++ b/src/sentry/services/hybrid_cloud/auth/model.py
@@ -77,6 +77,9 @@ class RpcAuthentication(BaseAuthentication):
         self.types = types
 
     def authenticate(self, request: Request) -> Optional[Tuple[Any, Any]]:
+        from django.contrib.auth.models import AnonymousUser
+
+        from sentry.models.apikey import is_api_key_auth
         from sentry.services.hybrid_cloud.auth.service import auth_service
 
         response = auth_service.authenticate_with(
@@ -85,6 +88,9 @@ class RpcAuthentication(BaseAuthentication):
 
         if response.user is not None:
             return response.user, response.auth
+
+        if response.auth is not None and is_api_key_auth(response.auth):
+            return AnonymousUser(), response.auth
 
         return None
 


### PR DESCRIPTION
While working on some org auth token stuff, I noticed that a hybrid cloud check for ApiKey authentication seemed off, because we were checking `if auth_type` in a place where `auth_type` could be `0` for `ApiKey` (see: https://github.com/getsentry/sentry/blob/fn/fix-api-key-auth-hc/src/sentry/services/hybrid_cloud/auth/model.py#L24).

So I updated this to check for `None` instead, and adjusted stuff around it to match how we do this for `ApiToken`. I think that is actually correct this way?