### PR TITLE
Change filter name from health-check to filtered-transaction

### DIFF
--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -25,7 +25,7 @@ class FilterStatKeys:
     CORS = "cors"
     DISCARDED_HASH = "discarded-hash"  # Not replicated in Relay
     CRASH_REPORT_LIMIT = "crash-report-limit"  # Not replicated in Relay
-    HEALTH_CHECK = "health-check"  # Ignore health-check transactions
+    HEALTH_CHECK = "filtered-transaction"  # Ignore health-check transactions
 
 
 FILTER_STAT_KEYS_TO_VALUES = {

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -92,7 +92,8 @@ register(
     },
 )
 
-register(key="filters:health-check", default="1")
+# NOTE: this is the HealthCheck filter, the name should match Relay reason (which is filtered-transaction)
+register(key="filters:filtered-transaction", default="1")
 
 # Which user-defined tags should be copied from transaction events to the
 # extracted performance metrics.

--- a/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
@@ -39,7 +39,7 @@ const STAT_OPS = {
   localhost: {title: t('Localhost'), color: theme.blue300},
   'release-version': {title: t('Release'), color: theme.purple200},
   'web-crawlers': {title: t('Web Crawler'), color: theme.red300},
-  'health-check': {title: t('Health Check'), color: theme.yellow400},
+  'filtered-transaction': {title: t('Health Check'), color: theme.yellow400},
 };
 
 class ProjectFiltersChart extends Component<Props, State> {

--- a/tests/sentry/api/endpoints/test_project_filter_details.py
+++ b/tests/sentry/api/endpoints/test_project_filter_details.py
@@ -35,7 +35,7 @@ class ProjectFilterDetailsTest(APITestCase):
         project.update_option("filters:filtered-transaction", "0")
         with Feature("organizations:health-check-filter"):
             self.get_success_response(
-                org.slug, project.slug, "health-check", active=True, status_code=204
+                org.slug, project.slug, "filtered-transaction", active=True, status_code=204
             )
         # option was changed by the request
         assert project.get_option("filters:filtered-transaction") == "1"
@@ -60,7 +60,7 @@ class ProjectFilterDetailsTest(APITestCase):
         project.update_option("filters:filtered-transaction", "0")
         with Feature({"organizations:health-check-filter": False}):
             resp = self.get_response(
-                org.slug, project.slug, "health-check", active=True, status_code=204
+                org.slug, project.slug, "filtered-transaction", active=True, status_code=204
             )
         # check we return error
         assert resp.status_code == 404

--- a/tests/sentry/api/endpoints/test_project_filter_details.py
+++ b/tests/sentry/api/endpoints/test_project_filter_details.py
@@ -32,21 +32,21 @@ class ProjectFilterDetailsTest(APITestCase):
         team = self.create_team(organization=org, name="foo", slug="foo")
         project = self.create_project(name="Bar", slug="bar", teams=[team])
 
-        project.update_option("filters:health-check", "0")
+        project.update_option("filters:filtered-transaction", "0")
         with Feature("organizations:health-check-filter"):
             self.get_success_response(
                 org.slug, project.slug, "health-check", active=True, status_code=204
             )
         # option was changed by the request
-        assert project.get_option("filters:health-check") == "1"
+        assert project.get_option("filters:filtered-transaction") == "1"
 
-        project.update_option("filters:health-check", "1")
+        project.update_option("filters:filtered-transaction", "1")
         with Feature("organizations:health-check-filter"):
             self.get_success_response(
-                org.slug, project.slug, "health-check", active=False, status_code=204
+                org.slug, project.slug, "filtered-transaction", active=False, status_code=204
             )
         # option was changed by the request
-        assert project.get_option("filters:health-check") == "0"
+        assert project.get_option("filters:filtered-transaction") == "0"
 
     def test_put_health_check_filter_free_plan(self):
         """
@@ -57,7 +57,7 @@ class ProjectFilterDetailsTest(APITestCase):
         team = self.create_team(organization=org, name="foo", slug="foo")
         project = self.create_project(name="Bar", slug="bar", teams=[team])
 
-        project.update_option("filters:health-check", "0")
+        project.update_option("filters:filtered-transaction", "0")
         with Feature({"organizations:health-check-filter": False}):
             resp = self.get_response(
                 org.slug, project.slug, "health-check", active=True, status_code=204
@@ -65,7 +65,7 @@ class ProjectFilterDetailsTest(APITestCase):
         # check we return error
         assert resp.status_code == 404
         # check we did not touch the option (the request did not change anything)
-        assert project.get_option("filters:health-check") == "0"
+        assert project.get_option("filters:filtered-transaction") == "0"
 
     def test_put_legacy_browsers(self):
         org = self.create_organization(name="baz", slug="1", owner=self.user)

--- a/tests/sentry/api/endpoints/test_project_filters.py
+++ b/tests/sentry/api/endpoints/test_project_filters.py
@@ -42,14 +42,14 @@ class ProjectFiltersTest(APITestCase):
         project.update_option("filters:filtered-transaction", "0")
         with Feature("organizations:health-check-filter"):
             response = self.get_success_response(org.slug, project.slug)
-        health_check = self.get_filter_spec(response.data, "health-check")
+        health_check = self.get_filter_spec(response.data, "filtered-transaction")
         assert health_check is not None
         assert health_check["active"] is False
 
         project.update_option("filters:filtered-transaction", "1")
         with Feature("organizations:health-check-filter"):
             response = self.get_success_response(org.slug, project.slug)
-        health_check = self.get_filter_spec(response.data, "health-check")
+        health_check = self.get_filter_spec(response.data, "filtered-transaction")
         assert health_check is not None
         assert health_check["active"] is True
 
@@ -66,5 +66,5 @@ class ProjectFiltersTest(APITestCase):
         project.update_option("filters:filtered-transaction", "1")
         with Feature({"organizations:health-check-filter": False}):
             response = self.get_success_response(org.slug, project.slug)
-        health_check = self.get_filter_spec(response.data, "health-check")
+        health_check = self.get_filter_spec(response.data, "filtered-transaction")
         assert health_check is None

--- a/tests/sentry/api/endpoints/test_project_filters.py
+++ b/tests/sentry/api/endpoints/test_project_filters.py
@@ -39,14 +39,14 @@ class ProjectFiltersTest(APITestCase):
         team = self.create_team(organization=org, name="foo", slug="foo")
         project = self.create_project(name="Bar", slug="bar", teams=[team])
 
-        project.update_option("filters:health-check", "0")
+        project.update_option("filters:filtered-transaction", "0")
         with Feature("organizations:health-check-filter"):
             response = self.get_success_response(org.slug, project.slug)
         health_check = self.get_filter_spec(response.data, "health-check")
         assert health_check is not None
         assert health_check["active"] is False
 
-        project.update_option("filters:health-check", "1")
+        project.update_option("filters:filtered-transaction", "1")
         with Feature("organizations:health-check-filter"):
             response = self.get_success_response(org.slug, project.slug)
         health_check = self.get_filter_spec(response.data, "health-check")
@@ -55,7 +55,7 @@ class ProjectFiltersTest(APITestCase):
 
     def test_free_plan(self):
         """
-        Tests plans not having "filters:health-check" feature do not return health-check specs
+        Tests plans not having "filters:filtered-transaction" feature do not return health-check specs
         """
         org = self.create_organization(name="baz", slug="1", owner=self.user)
         team = self.create_team(organization=org, name="foo", slug="foo")
@@ -63,7 +63,7 @@ class ProjectFiltersTest(APITestCase):
 
         # we shouldn't return health check information even if the option is set for the project
         # (presumably the user has downgraded from a business plan)
-        project.update_option("filters:health-check", "1")
+        project.update_option("filters:filtered-transaction", "1")
         with Feature({"organizations:health-check-filter": False}):
             response = self.get_success_response(org.slug, project.slug)
         health_check = self.get_filter_spec(response.data, "health-check")

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -358,7 +358,7 @@ def test_health_check_filters(call_endpoint, add_org_key, relay, default_project
     """
     relay.save()
 
-    default_project.update_option("filters:health-check", "1")
+    default_project.update_option("filters:filtered-transaction", "1")
     with Feature({"organizations:health-check-filter": is_business}):
         result, status_code = call_endpoint(full_config=True)
 

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -660,7 +660,7 @@ def test_healthcheck_filter(default_project, has_health_check, health_check_set)
     flag is set for the org and the user has enabled healthcheck filters.
     """
 
-    default_project.update_option("filters:health-check", "1" if health_check_set else "0")
+    default_project.update_option("filters:filtered-transaction", "1" if health_check_set else "0")
     with Feature({"organizations:health-check-filter": has_health_check}):
         config = get_project_config(default_project).to_dict()["config"]
 


### PR DESCRIPTION
This PR changes the name used for the health-check filter to filtered-transaction.

The reason for the change is that Relay's name for the filtered outcome is filtered-transaction.
The filter name is used to derive the option name and is used for query in snuba ( hence the
need for the two to match).