### PR TITLE
feat(org-token): Ensure you can upload source maps & create releases with org token

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -51,9 +51,9 @@ class StrictProjectPermission(ProjectPermission):
 
 class ProjectReleasePermission(ProjectPermission):
     scope_map = {
-        "GET": ["project:read", "project:write", "project:admin", "project:releases"],
-        "POST": ["project:write", "project:admin", "project:releases"],
-        "PUT": ["project:write", "project:admin", "project:releases"],
+        "GET": ["project:read", "project:write", "project:admin", "project:releases", "org:ci"],
+        "POST": ["project:write", "project:admin", "project:releases", "org:ci"],
+        "PUT": ["project:write", "project:admin", "project:releases", "org:ci"],
         "DELETE": ["project:admin", "project:releases"],
     }
 

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -469,7 +469,7 @@ class OrganizationReleaseDetailsEndpoint(
 
             scope.set_tag("has_refs", bool(refs))
             if refs:
-                if not request.user.is_authenticated:
+                if not request.user.is_authenticated and not request.auth:
                     scope.set_tag("failure_reason", "user_not_authenticated")
                     return Response(
                         {"refs": ["You must use an authenticated API token to fetch refs"]},

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -535,7 +535,7 @@ class OrganizationReleasesEndpoint(
                     ]
                 scope.set_tag("has_refs", bool(refs))
                 if refs:
-                    if not request.user.is_authenticated:
+                    if not request.user.is_authenticated and not request.auth:
                         scope.set_tag("failure_reason", "user_not_authenticated")
                         return Response(
                             {"refs": ["You must use an authenticated API token to fetch refs"]},

--- a/src/sentry/services/hybrid_cloud/auth/model.py
+++ b/src/sentry/services/hybrid_cloud/auth/model.py
@@ -80,6 +80,7 @@ class RpcAuthentication(BaseAuthentication):
         from django.contrib.auth.models import AnonymousUser
 
         from sentry.models.apikey import is_api_key_auth
+        from sentry.models.orgauthtoken import is_org_auth_token_auth
         from sentry.services.hybrid_cloud.auth.service import auth_service
 
         response = auth_service.authenticate_with(
@@ -89,7 +90,9 @@ class RpcAuthentication(BaseAuthentication):
         if response.user is not None:
             return response.user, response.auth
 
-        if response.auth is not None and is_api_key_auth(response.auth):
+        if response.auth is not None and (
+            is_api_key_auth(response.auth) or is_org_auth_token_auth(response.auth)
+        ):
             return AnonymousUser(), response.auth
 
         return None

--- a/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
@@ -6,9 +6,11 @@ from django.urls import reverse
 
 from sentry.constants import ObjectStatus
 from sentry.models import ApiToken, FileBlob, FileBlobOwner
+from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.tasks.assemble import ChunkFileState, assemble_artifacts
 from sentry.testutils import APITestCase
 from sentry.testutils.silo import region_silo_test
+from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 
 @region_silo_test
@@ -320,3 +322,84 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.CREATED
+
+    def test_assemble_org_auth_token(self):
+        org2 = self.create_organization(owner=self.user)
+
+        bundle_file = self.create_artifact_bundle_zip(
+            org=self.organization.slug, release=self.release.version
+        )
+        total_checksum = sha1(bundle_file).hexdigest()
+        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        FileBlobOwner.objects.get_or_create(organization_id=self.organization.id, blob=blob1)
+
+        assemble_artifacts(
+            org_id=self.organization.id,
+            version=self.release.version,
+            checksum=total_checksum,
+            chunks=[blob1.checksum],
+            upload_as_artifact_bundle=False,
+        )
+
+        # right org, wrong permission level
+        bad_token_str = generate_token(self.organization.slug, "")
+        OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed=hash_token(bad_token_str),
+            token_last_characters="ABCD",
+            scope_list=[],
+            date_last_used=None,
+        )
+        response = self.client.post(
+            self.url,
+            data={
+                "checksum": total_checksum,
+                "chunks": [blob1.checksum],
+                "projects": [self.project.slug],
+            },
+            HTTP_AUTHORIZATION=f"Bearer {bad_token_str}",
+        )
+        assert response.status_code == 403
+
+        # wrong org, right permission level
+        bad_org_token_str = generate_token(self.organization.slug, "")
+        OrgAuthToken.objects.create(
+            organization_id=org2.id,
+            name="token 1",
+            token_hashed=hash_token(bad_org_token_str),
+            token_last_characters="ABCD",
+            scope_list=[],
+            date_last_used=None,
+        )
+        response = self.client.post(
+            self.url,
+            data={
+                "checksum": total_checksum,
+                "chunks": [blob1.checksum],
+                "projects": [self.project.slug],
+            },
+            HTTP_AUTHORIZATION=f"Bearer {bad_org_token_str}",
+        )
+        assert response.status_code == 403
+
+        # right org, right permission level
+        good_token_str = generate_token(self.organization.slug, "")
+        OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed=hash_token(good_token_str),
+            token_last_characters="ABCD",
+            scope_list=["org:ci"],
+            date_last_used=None,
+        )
+        response = self.client.post(
+            self.url,
+            data={
+                "checksum": total_checksum,
+                "chunks": [blob1.checksum],
+                "projects": [self.project.slug],
+            },
+            HTTP_AUTHORIZATION=f"Bearer {good_token_str}",
+        )
+        assert response.status_code == 200

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -20,9 +20,11 @@ from sentry.models import (
     ReleaseStatus,
     Repository,
 )
+from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 from sentry.types.activity import ActivityType
+from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 
 @region_silo_test(stable=True)
@@ -1028,6 +1030,69 @@ class UpdateReleaseDetailsTest(APITestCase):
             type=ActivityType.RELEASE.value, project=project, ident=release.version[:64]
         )
         assert activity.exists()
+
+    def test_org_auth_token(self):
+        org = self.organization
+
+        with exempt_from_silo_limits():
+            good_token_str = generate_token(org.slug, "")
+            OrgAuthToken.objects.create(
+                organization_id=org.id,
+                name="token 1",
+                token_hashed=hash_token(good_token_str),
+                token_last_characters="ABCD",
+                scope_list=["org:ci"],
+                date_last_used=None,
+            )
+
+        repo = Repository.objects.create(
+            organization_id=org.id, name="example/example", provider="dummy"
+        )
+
+        team1 = self.create_team(organization=org)
+
+        project = self.create_project(teams=[team1], organization=org)
+
+        base_release = Release.objects.create(organization_id=org.id, version="000000000")
+        base_release.add_project(project)
+        release = Release.objects.create(organization_id=org.id, version="abcabcabc")
+        release.add_project(project)
+
+        url = reverse(
+            "sentry-api-0-organization-release-details",
+            kwargs={"organization_slug": org.slug, "version": base_release.version},
+        )
+        self.client.put(
+            url,
+            data={
+                "ref": "master",
+                "headCommits": [
+                    {"currentId": "0" * 40, "repository": repo.name},
+                ],
+            },
+            HTTP_AUTHORIZATION=f"Bearer {good_token_str}",
+        )
+
+        url = reverse(
+            "sentry-api-0-organization-release-details",
+            kwargs={"organization_slug": org.slug, "version": release.version},
+        )
+        response = self.client.put(
+            url,
+            data={
+                "ref": "master",
+                "refs": [
+                    {"commit": "a" * 40, "repository": repo.name},
+                ],
+            },
+            HTTP_AUTHORIZATION=f"Bearer {good_token_str}",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["version"] == release.version
+
+        release = Release.objects.get(id=release.id)
+        assert release.ref == "master"
 
 
 @region_silo_test(stable=True)

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -31,6 +31,7 @@ from sentry.models import (
     ReleaseStages,
     Repository,
 )
+from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.plugins.providers.dummy.repository import DummyRepositoryProvider
 from sentry.search.events.constants import (
     RELEASE_ALIAS,
@@ -48,6 +49,7 @@ from sentry.testutils import (
 )
 from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 from sentry.types.activity import ActivityType
+from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 
 @region_silo_test(stable=True)
@@ -1656,6 +1658,76 @@ class OrganizationReleaseCreateTest(APITestCase):
             url,
             data={"version": "1.2.1", "projects": [project1.slug]},
             HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{good_api_key.key}:".encode()),
+        )
+        assert response.status_code == 201, response.content
+
+    def test_org_auth_token(self):
+        org = self.create_organization()
+        org.flags.allow_joinleave = False
+        org.save()
+
+        org2 = self.create_organization()
+
+        team1 = self.create_team(organization=org)
+        project1 = self.create_project(teams=[team1], organization=org)
+        release1 = Release.objects.create(
+            organization_id=org.id, version="1", date_added=datetime(2013, 8, 13, 3, 8, 24, 880386)
+        )
+        release1.add_project(project1)
+
+        url = reverse("sentry-api-0-organization-releases", kwargs={"organization_slug": org.slug})
+
+        # test right org, wrong permissions level
+        with exempt_from_silo_limits():
+            bad_token_str = generate_token(org.slug, "")
+            OrgAuthToken.objects.create(
+                organization_id=org.id,
+                name="token 1",
+                token_hashed=hash_token(bad_token_str),
+                token_last_characters="ABCD",
+                scope_list=[],
+                date_last_used=None,
+            )
+        response = self.client.post(
+            url,
+            data={"version": "1.2.1", "projects": [project1.slug]},
+            HTTP_AUTHORIZATION=f"Bearer {bad_token_str}",
+        )
+        assert response.status_code == 403
+
+        # test wrong org, right permissions level
+        with exempt_from_silo_limits():
+            wrong_org_token_str = generate_token(org2.slug, "")
+            OrgAuthToken.objects.create(
+                organization_id=org2.id,
+                name="token 1",
+                token_hashed=hash_token(wrong_org_token_str),
+                token_last_characters="ABCD",
+                scope_list=["org:ci"],
+                date_last_used=None,
+            )
+        response = self.client.post(
+            url,
+            data={"version": "1.2.1", "projects": [project1.slug]},
+            HTTP_AUTHORIZATION=f"Bearer {wrong_org_token_str}",
+        )
+        assert response.status_code == 403
+
+        # test right org, right permissions level
+        with exempt_from_silo_limits():
+            good_token_str = generate_token(org.slug, "")
+            OrgAuthToken.objects.create(
+                organization_id=org.id,
+                name="token 1",
+                token_hashed=hash_token(good_token_str),
+                token_last_characters="ABCD",
+                scope_list=["org:ci"],
+                date_last_used=None,
+            )
+        response = self.client.post(
+            url,
+            data={"version": "1.2.1", "projects": [project1.slug]},
+            HTTP_AUTHORIZATION=f"Bearer {good_token_str}",
         )
         assert response.status_code == 201, response.content
 

--- a/tests/sentry/api/endpoints/test_project_release_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_details.py
@@ -7,8 +7,10 @@ from django.urls import reverse
 from sentry.api.endpoints.project_release_details import ReleaseSerializer
 from sentry.constants import MAX_VERSION_LENGTH
 from sentry.models import Activity, File, Release, ReleaseCommit, ReleaseFile, ReleaseProject
+from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.testutils import APITestCase
 from sentry.types.activity import ActivityType
+from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 
 class ReleaseDetailsTest(APITestCase):
@@ -156,6 +158,44 @@ class UpdateReleaseDetailsTest(APITestCase):
             type=ActivityType.RELEASE.value, project=project, ident=release.version[:64]
         )
         assert activity.exists()
+
+    def test_org_auth_token(self):
+        project = self.create_project(name="foo")
+        project2 = self.create_project(name="bar", organization=project.organization)
+
+        good_token_str = generate_token(project.organization.slug, "")
+        OrgAuthToken.objects.create(
+            organization_id=project.organization.id,
+            name="token 1",
+            token_hashed=hash_token(good_token_str),
+            token_last_characters="ABCD",
+            scope_list=["org:ci"],
+            date_last_used=None,
+        )
+
+        release = Release.objects.create(organization_id=project.organization_id, version="1")
+        release.add_project(project)
+        release.add_project(project2)
+
+        url = reverse(
+            "sentry-api-0-project-release-details",
+            kwargs={
+                "organization_slug": project.organization.slug,
+                "project_slug": project.slug,
+                "version": release.version,
+            },
+        )
+        response = self.client.put(
+            url,
+            data={"ref": "master"},
+            HTTP_AUTHORIZATION=f"Bearer {good_token_str}",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["version"] == release.version
+
+        release = Release.objects.get(id=release.id)
+        assert release.ref == "master"
 
 
 class ReleaseDeleteTest(APITestCase):


### PR DESCRIPTION
This PR actually wires up the `org:ci` scope & the org tokens with release creation.

This adds tests for authentication with org tokens for source map upload & release creation.

I tried it locally with sentry-cli, where it worked fine as far as I can tell.

Note that the scope needs to work for GET, POST and PUT for both project/org releases, as all of these are used by sentry-cli. 