### PR TITLE
fix: Remove span duration as the default column

### DIFF
--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -101,7 +101,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                                 "equals",
                                 [
                                     Column("metric_id"),
-                                    self.resolve_metric("span.duration"),
+                                    self.resolve_metric("span.self_time"),
                                 ],
                             ),
                         ],
@@ -113,7 +113,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     "sum",
                     optional_args=[
                         fields.with_default(
-                            "span.duration",
+                            "span.self_time",
                             fields.MetricArg(
                                 "column",
                                 allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS,
@@ -136,7 +136,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     "percentile",
                     required_args=[
                         fields.with_default(
-                            "span.duration",
+                            "span.self_time",
                             fields.MetricArg(
                                 "column", allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS
                             ),
@@ -152,7 +152,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     "p50",
                     optional_args=[
                         fields.with_default(
-                            "span.duration",
+                            "span.self_time",
                             fields.MetricArg(
                                 "column",
                                 allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS,
@@ -170,7 +170,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     "p75",
                     optional_args=[
                         fields.with_default(
-                            "span.duration",
+                            "span.self_time",
                             fields.MetricArg(
                                 "column",
                                 allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS,
@@ -188,7 +188,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     "p95",
                     optional_args=[
                         fields.with_default(
-                            "span.duration",
+                            "span.self_time",
                             fields.MetricArg(
                                 "column",
                                 allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS,
@@ -216,7 +216,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     "p99",
                     optional_args=[
                         fields.with_default(
-                            "span.duration",
+                            "span.self_time",
                             fields.MetricArg(
                                 "column",
                                 allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS,
@@ -234,7 +234,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     "p100",
                     optional_args=[
                         fields.with_default(
-                            "span.duration",
+                            "span.self_time",
                             fields.MetricArg(
                                 "column",
                                 allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS,
@@ -262,7 +262,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                                         "equals",
                                         [
                                             Column("metric_id"),
-                                            self.resolve_metric("span.duration"),
+                                            self.resolve_metric("span.self_time"),
                                         ],
                                     ),
                                 ],
@@ -381,7 +381,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
             dataset=self.builder.dataset,
             params={},
             snuba_params=self.builder.params,
-            selected_columns=["sum(span.duration)"],
+            selected_columns=["sum(span.self_time)"],
         )
 
         total_query.columns += self.builder.resolve_groupby()
@@ -397,7 +397,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         if len(results["data"]) != 1:
             self.total_span_duration = 0
             return Function("toFloat64", [0], alias)
-        self.total_span_duration = results["data"][0]["sum_span_duration"]
+        self.total_span_duration = results["data"][0]["sum_span_self_time"]
         return Function("toFloat64", [self.total_span_duration], alias)
 
     def _resolve_time_spent_percentage(
@@ -406,7 +406,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         total_time = self._resolve_total_span_duration(
             constants.TOTAL_SPAN_DURATION_ALIAS, args["scope"]
         )
-        metric_id = self.resolve_metric("span.duration")
+        metric_id = self.resolve_metric("span.self_time")
 
         return Function(
             "divide",
@@ -455,7 +455,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                 "equals",
                 [
                     Column("metric_id"),
-                    self.resolve_metric("span.duration"),
+                    self.resolve_metric("span.self_time"),
                 ],
             ),
             condition,
@@ -489,7 +489,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
             "equals",
             [
                 Column("metric_id"),
-                self.resolve_metric("span.duration"),
+                self.resolve_metric("span.self_time"),
             ],
         )
         if extra_condition:

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1625,6 +1625,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
     ENTITY_MAP = {
         "transaction.duration": "metrics_distributions",
         "span.duration": "metrics_distributions",
+        "span.self_time": "metrics_distributions",
         "measurements.lcp": "metrics_distributions",
         "measurements.fp": "metrics_distributions",
         "measurements.fcp": "metrics_distributions",
@@ -1702,7 +1703,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
     def store_span_metric(
         self,
         value: List[int] | int,
-        metric: str = "span.duration",
+        metric: str = "span.self_time",
         internal_metric: Optional[str] = None,
         entity: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -111,7 +111,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         )
         response = self.do_request(
             {
-                "field": ["sum(span.duration)"],
+                "field": ["sum(span.self_time)"],
                 "query": "",
                 "project": self.project.id,
                 "dataset": "spansMetrics",
@@ -121,7 +121,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 1
-        assert data[0]["sum(span.duration)"] == 420
+        assert data[0]["sum(span.self_time)"] == 420
         assert meta["dataset"] == "spansMetrics"
 
     def test_percentile(self):
@@ -131,7 +131,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         )
         response = self.do_request(
             {
-                "field": ["percentile(span.duration, 0.95)"],
+                "field": ["percentile(span.self_time, 0.95)"],
                 "query": "",
                 "project": self.project.id,
                 "dataset": "spansMetrics",
@@ -141,7 +141,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 1
-        assert data[0]["percentile(span.duration, 0.95)"] == 1
+        assert data[0]["percentile(span.self_time, 0.95)"] == 1
         assert meta["dataset"] == "spansMetrics"
 
     def test_p50(self):
@@ -284,9 +284,9 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         )
         response = self.do_request(
             {
-                "field": ["percentile_percent_change(span.duration, 0.95)"],
+                "field": ["percentile_percent_change(span.self_time, 0.95)"],
                 "query": "",
-                "orderby": ["-percentile_percent_change(span.duration, 0.95)"],
+                "orderby": ["-percentile_percent_change(span.self_time, 0.95)"],
                 "project": self.project.id,
                 "dataset": "spansMetrics",
                 "statsPeriod": "10m",
@@ -296,9 +296,9 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 1
-        assert data[0]["percentile_percent_change(span.duration, 0.95)"] == 1
+        assert data[0]["percentile_percent_change(span.self_time, 0.95)"] == 1
         assert meta["dataset"] == "spansMetrics"
-        assert meta["fields"]["percentile_percent_change(span.duration, 0.95)"] == "percent_change"
+        assert meta["fields"]["percentile_percent_change(span.self_time, 0.95)"] == "percent_change"
 
     def test_http_error_count_percent_change(self):
         for _ in range(4):


### PR DESCRIPTION
- This makes span self time as the default column everywhere
- This should help with performance slightly since we're only querying one metric in a lot of places