### PR TITLE
fix(starfish): Fix missing feature flag crashing the app

### DIFF
--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -49,19 +49,15 @@ export function SpanGroupBreakdown({
     visibleSeries.push(series);
   }
 
-  // Skip these calculations if the feature flag is not enabled
-  let dataAsPercentages;
-  if (hasDropdownFeatureFlag) {
-    dataAsPercentages = cloneDeep(visibleSeries);
-    const numDataPoints = data[0]?.data?.length ?? 0;
-    for (let i = 0; i < numDataPoints; i++) {
-      const totalTimeAtIndex = data.reduce((acc, datum) => acc + datum.data[i].value, 0);
-      dataAsPercentages.forEach(segment => {
-        const clone = {...segment.data[i]};
-        clone.value = clone.value / totalTimeAtIndex;
-        segment.data[i] = clone;
-      });
-    }
+  const dataAsPercentages = cloneDeep(visibleSeries);
+  const numDataPoints = data[0]?.data?.length ?? 0;
+  for (let i = 0; i < numDataPoints; i++) {
+    const totalTimeAtIndex = data.reduce((acc, datum) => acc + datum.data[i].value, 0);
+    dataAsPercentages.forEach(segment => {
+      const clone = {...segment.data[i]};
+      clone.value = clone.value / totalTimeAtIndex;
+      segment.data[i] = clone;
+    });
   }
 
   const handleChange = (option: SelectOption<DataDisplayType>) =>


### PR DESCRIPTION
If the dropdown feature flag was not available, it would cause Starfish to crash. This was happening because we switched the default WSV chart to percentages, but the calculations for the percentage view were still gated behind the feature flag.