### PR TITLE
fix(slack): change query param for rule id

### DIFF
--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -69,7 +69,9 @@ def get_title_link(
     other_params = {}
     # add in rule id if we have it
     if rule_id:
-        other_params["rule_id"] = rule_id
+        other_params["alert_rule_id"] = rule_id
+        # hard code for issue alerts
+        other_params["alert_type"] = "issue"
 
     if event and link_to_event:
         url = group.get_absolute_url(


### PR DESCRIPTION
Slack should match email for query params: https://github.com/getsentry/sentry/blob/master/src/sentry/notifications/utils/__init__.py#L170-L173

Note that we don't need or use `alert_timestamp` to my knowledge so I omitted it. Really just need the rule id and the rule type so we can build funnels.