### PR TITLE
ref(hc): Restructure RPC response body with "value" and "meta" fields

### DIFF
--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -428,7 +428,10 @@ def dispatch_to_local_service(
 
         return value
 
-    return result_to_dict(result)
+    return {
+        "meta": {},  # reserved for future use
+        "value": result_to_dict(result),
+    }
 
 
 _RPC_CONTENT_CHARSET = "utf-8"
@@ -475,11 +478,14 @@ def dispatch_remote_call(
         charset = response.headers.get_content_charset() or _RPC_CONTENT_CHARSET
         metrics.incr("hybrid_cloud.dispatch_rpc.response_code", tags={"status": response.status})
         response_body = response.read().decode(charset)
-    if response_body:
-        serial_response = json.loads(response_body)
-        return service.deserialize_rpc_response(method_name, serial_response)
-    else:
-        return None
+
+    serial_response = json.loads(response_body)
+    return_value = serial_response["value"]
+    return (
+        None
+        if return_value is None
+        else service.deserialize_rpc_response(method_name, return_value)
+    )
 
 
 def _fire_request(url: str, body: Any, api_token: str) -> urllib.response.addinfourl:

--- a/tests/sentry/api/endpoints/test_rpc.py
+++ b/tests/sentry/api/endpoints/test_rpc.py
@@ -74,7 +74,8 @@ class RpcServiceEndpointTest(APITestCase):
         path = self._get_path("organization", "get_organization_by_id")
         response = self.client.post(path, {"args": {"id": 0}})
         assert response.status_code == 200
-        assert response.data is None
+        assert "meta" in response.data
+        assert response.data["value"] is None
 
     @override_settings(DEV_HYBRID_CLOUD_RPC_SENDER={"is_allowed": True})
     def test_with_object_response(self):
@@ -84,8 +85,9 @@ class RpcServiceEndpointTest(APITestCase):
         response = self.client.post(path, {"args": {"id": organization.id}})
         assert response.status_code == 200
         assert response.data
+        assert "meta" in response.data
 
-        response_obj = RpcUserOrganizationContext.parse_obj(response.data)
+        response_obj = RpcUserOrganizationContext.parse_obj(response.data["value"])
         assert response_obj.organization.id == organization.id
         assert response_obj.organization.slug == organization.slug
         assert response_obj.organization.name == organization.name
@@ -123,11 +125,12 @@ class RpcServiceEndpointTest(APITestCase):
             },
         )
         assert response.status_code == 200
-        assert response.json() == [
+        response_body = response.json()
+        assert response_body["value"] == [
             {
                 "scope_type": NotificationScopeType.USER.value,
                 "scope_identifier": self.user.id,
-                "target_id": response.data[0]["target_id"],
+                "target_id": response_body["value"][0]["target_id"],
                 "team_id": None,
                 "user_id": self.user.id,
                 "provider": ExternalProviders.EMAIL.value,

--- a/tests/sentry/hybrid_cloud/test_rpc.py
+++ b/tests/sentry/hybrid_cloud/test_rpc.py
@@ -130,7 +130,8 @@ class RpcServiceTest(TestCase):
         args = {"organization_ids": [organization.id]}
         with override_settings(SILO_MODE=SiloMode.CONTROL):
             service = AuthService.create_delegation()
-            result = dispatch_to_local_service(service.key, "get_org_auth_config", args)
+            response = dispatch_to_local_service(service.key, "get_org_auth_config", args)
+            result = response["value"]
             assert len(result) == 1
             assert result[0]["organization_id"] == organization.id
 
@@ -149,11 +150,12 @@ class DispatchRemoteCallTest(TestCase):
     @staticmethod
     def _set_up_mock_response(mock_urlopen, response_value):
         charset = "utf-8"
-        response_body = json.dumps(response_value).encode(charset)
+        response_body = {"meta": {}, "value": response_value}
+        serial_response = json.dumps(response_body).encode(charset)
 
         mock_response = MagicMock()
         mock_response.headers.get_content_charset.return_value = charset
-        mock_response.read.return_value = response_body
+        mock_response.read.return_value = serial_response
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
     @override_settings(SILO_MODE=SiloMode.REGION, DEV_HYBRID_CLOUD_RPC_SENDER=_REGION_SILO_CREDS)


### PR DESCRIPTION
This makes responses symmetric to the request body (which has "args" and "meta"), and prevents the awkwardness of having an empty response body to represent a logical null return value.

As with requests, the "meta" field is currently empty but available for future use. It also gives us the opportunity to add other fields to the root-level object, rather than being stuck with the raw return value at the root level.