### PR TITLE
test(js-sdk): Make sure distributed tracing is always configured

### DIFF
--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -121,6 +121,9 @@ jest.mock('@sentry/react', function sentryReact() {
     Scope: SentryReact.Scope,
     Severity: SentryReact.Severity,
     withProfiler: SentryReact.withProfiler,
+    BrowserTracing: jest.fn().mockReturnValue({}),
+    BrowserProfilingIntegration: jest.fn().mockReturnValue({}),
+    addGlobalEventProcessor: jest.fn(),
     BrowserClient: jest.fn().mockReturnValue({
       captureEvent: jest.fn(),
     }),


### PR DESCRIPTION
This is a regression test to confirm that https://github.com/getsentry/sentry/pull/51900 fixed inc-433. See https://getsentry.atlassian.net/browse/INC-433 for more details about the incident.

It's purposefully a bare bones test - there's too many side effects with the sentry lib to unit test properly, so I opted for a very specific test that examines if we are setting `tracePropagationTargets` correctly - as messing this up ruins our backend observability.