### PR TITLE
feat(functions): Add dynamic threshold for function trends

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -66,6 +66,7 @@ class FunctionTrendsSerializer(serializers.Serializer):
     function = serializers.CharField(max_length=10)
     trend = TrendTypeField()
     query = serializers.CharField(required=False)
+    threshold = serializers.IntegerField(min_value=0, max_value=1000, required=False)
 
 
 @region_silo_endpoint
@@ -171,11 +172,14 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
         trending_functions = get_trends_data(stats_data)
 
         # Profiling functions have a resolution of ~10ms. To increase the confidence
-        # of the results, ensure there's an minimum difference of 20ms. Otherwise,
-        # the result can easily be contributed to just noise.
-        trending_functions = [
-            data for data in trending_functions if abs(data["trend_difference"]) >= 20 * 1e6
-        ]
+        # of the results, the caller can specify a min threshold for the trend difference.
+        threshold = data.get("threshold")
+        if threshold is not None:
+            trending_functions = [
+                data
+                for data in trending_functions
+                if abs(data["trend_difference"]) >= threshold * 1e6
+            ]
 
         # Make sure to sort the results so that it's in order of largest change
         # to smallest change (ASC/DESC depends on the trend type)


### PR DESCRIPTION
Looking to be a little flexible on this so make the threshold a query parameter that can be user specified.