### PR TITLE
feat(sdk): Check for scope bleed in `bind_org_context_from_integration`

### DIFF
--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -7,7 +7,11 @@ from sentry_sdk import configure_scope
 
 from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.utils.sdk import bind_ambiguous_org_context, bind_organization_context
+from sentry.utils.sdk import (
+    bind_ambiguous_org_context,
+    bind_organization_context,
+    check_tag_for_scope_bleed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +74,14 @@ def bind_org_context_from_integration(
             f"Can't bind org context - no orgs are associated with integration id={integration_id}.",
             extra=extra,
         )
+
+        # When the `logger.warning` call above was `logger.error`, we saw that the `integration_id`
+        # tag on the resulting event didn't match the `integration_id` value logged in the event's
+        # message. Even though we've switched to `logger.warning` (and therefore no longer have a
+        # sentry event to which to tie the data), we still want to be able track when this happens.
+        # (With `add_to_scope=False`, we still log a warning - separate from the one above - on data
+        # mismatch.)
+        check_tag_for_scope_bleed("integration_id", integration_id, add_to_scope=False)
     elif len(orgs) == 1:
         bind_organization_context(orgs[0])
     else:

--- a/tests/sentry/integrations/utils/test_scope.py
+++ b/tests/sentry/integrations/utils/test_scope.py
@@ -64,10 +64,12 @@ class BindOrgContextFromIntegrationTest(TestCase):
 
     @patch("sentry.integrations.utils.scope.bind_ambiguous_org_context")
     @patch("sentry.integrations.utils.scope.bind_organization_context")
+    @patch("sentry.integrations.utils.scope.check_tag_for_scope_bleed")
     @patch("sentry.integrations.utils.scope.logger.warning")
     def test_logs_warning_if_no_orgs_found(
         self,
         mock_logger_warning: MagicMock,
+        mock_check_tag_for_scope_bleed: MagicMock,
         mock_bind_org_context: MagicMock,
         mock_bind_ambiguous_org_context: MagicMock,
     ):
@@ -77,6 +79,9 @@ class BindOrgContextFromIntegrationTest(TestCase):
         mock_logger_warning.assert_called_with(
             f"Can't bind org context - no orgs are associated with integration id={integration.id}.",
             extra={"webhook": "issue_updated"},
+        )
+        mock_check_tag_for_scope_bleed.assert_called_with(
+            "integration_id", integration.id, add_to_scope=False
         )
         mock_bind_org_context.assert_not_called()
         mock_bind_ambiguous_org_context.assert_not_called()


### PR DESCRIPTION
Before https://github.com/getsentry/sentry/pull/51718, we were capturing a Sentry event when a Jira webhook got triggered by an integration with no orgs attached to it. In that event, we were capturing the integration id both as scope data and in the text of the error message. Only problem was, the data didn't match. Scope bleed rears its ugly head again!

Now that we're no longer capturing an event, that evidence of scope bleed has been lost. This restores that evidence by explicitly checking for `integration_id` mismatch and logging a warning when it's found.