### PR TITLE
ref: force_text / smart_text => force_str / smart_str

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.utils.crypto import constant_time_compare
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from rest_framework.authentication import BasicAuthentication, get_authorization_header
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
@@ -97,7 +97,7 @@ class StandardAuthentication(QuietBasicAuthentication):
             msg = "Invalid token header. Token string should not contain spaces."
             raise AuthenticationFailed(msg)
 
-        return self.authenticate_credentials(request, force_text(auth[1]))
+        return self.authenticate_credentials(request, force_str(auth[1]))
 
 
 class RelayAuthentication(BasicAuthentication):
@@ -204,7 +204,7 @@ class TokenAuthentication(StandardAuthentication):
         if len(auth) != 2:
             return True
 
-        token_str = force_text(auth[1])
+        token_str = force_str(auth[1])
         return not token_str.startswith(SENTRY_ORG_AUTH_TOKEN_PREFIX)
 
     def authenticate_credentials(self, request: Request, token_str):
@@ -243,7 +243,7 @@ class OrgAuthTokenAuthentication(StandardAuthentication):
         if not super().accepts_auth(auth) or len(auth) != 2:
             return False
 
-        token_str = force_text(auth[1])
+        token_str = force_str(auth[1])
         return token_str.startswith(SENTRY_ORG_AUTH_TOKEN_PREFIX)
 
     def authenticate_credentials(self, request: Request, token_str):

--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -1,7 +1,7 @@
 from typing import List, Union
 from urllib.parse import urlparse
 
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 from drf_spectacular.utils import extend_schema
 from packaging.version import Version
 from rest_framework.exceptions import NotFound, ParseError
@@ -292,7 +292,7 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
                 SourceMapProcessingIssue.SOURCEMAP_NOT_FOUND, {"filename": filename}
             )
 
-        return force_text(sourcemap) if sourcemap is not None else None
+        return force_str(sourcemap) if sourcemap is not None else None
 
     def _unify_url(self, urlparts):
         return "~" + urlparts.path

--- a/src/sentry/auth/provider.py
+++ b/src/sentry/auth/provider.py
@@ -3,7 +3,7 @@ import logging
 from collections import namedtuple
 from typing import Any, Mapping, Sequence
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.views import View
 
 from sentry.models import AuthIdentity, User
@@ -22,7 +22,7 @@ class MigratingIdentityId(namedtuple("MigratingIdentityId", ["id", "legacy_id"])
     __slots__ = ()
 
     def __str__(self) -> str:
-        return force_text(self.id)
+        return force_str(self.id)
 
 
 class Provider(PipelineProvider, abc.ABC):

--- a/src/sentry/auth/providers/saml2/forms.py
+++ b/src/sentry/auth/providers/saml2/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.forms.utils import ErrorList
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from onelogin.saml2.idp_metadata_parser import OneLogin_Saml2_IdPMetadataParser
 from requests.exceptions import SSLError
@@ -87,7 +87,7 @@ def process_metadata(form_cls, request, helper):
     saml_form = SAMLForm(data)
     if not saml_form.is_valid():
         field_errors = [
-            "{}: {}".format(k, ", ".join(force_text(i) for i in v))
+            "{}: {}".format(k, ", ".join(force_str(i) for i in v))
             for k, v in saml_form.errors.items()
         ]
         error_list = ", ".join(field_errors)

--- a/src/sentry/data_export/models.py
+++ b/src/sentry/data_export/models.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.db import models, transaction
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from sentry.db.models import (
     BoundedBigIntegerField,
@@ -66,7 +66,7 @@ class ExportedData(Model):
     @staticmethod
     def format_date(date):
         # Example: 12:21 PM on July 21, 2020 (UTC)
-        return None if date is None else force_text(date.strftime("%-I:%M %p on %B %d, %Y (%Z)"))
+        return None if date is None else force_str(date.strftime("%-I:%M %p on %B %d, %Y (%Z)"))
 
     def delete_file(self):
         file = self._get_file()

--- a/src/sentry/db/models/manager/__init__.py
+++ b/src/sentry/db/models/manager/__init__.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Mapping, TypeVar, Union
 
 from django.db.models import Model
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 from sentry.utils.hashlib import md5_text
 
@@ -29,7 +29,7 @@ def make_key(model: Any, prefix: str, kwargs: Mapping[str, Union[Model, int, str
     kwargs_bits = []
     for k, v in sorted(kwargs.items()):
         k = __prep_key(model, k)
-        v = smart_text(__prep_value(model, k, v))
+        v = smart_str(__prep_value(model, k, v))
         kwargs_bits.append(f"{k}={v}")
     kwargs_bits_str = ":".join(kwargs_bits)
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -32,7 +32,7 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError, OperationalError, connection, transaction
 from django.db.models import Func
 from django.db.models.signals import post_save
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from pytz import UTC
 
 from sentry import (
@@ -773,7 +773,7 @@ def _pull_out_data(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
 
         transaction_name = data.get("transaction")
         if transaction_name:
-            transaction_name = force_text(transaction_name)
+            transaction_name = force_str(transaction_name)
         job["transaction"] = transaction_name
 
         key_id = None if data is None else data.get("key_id")
@@ -1442,7 +1442,7 @@ def materialize_metadata(
 def get_culprit(data: Mapping[str, Any]) -> str:
     """Helper to calculate the default culprit"""
     return str(
-        force_text(data.get("culprit") or data.get("transaction") or generate_culprit(data) or "")
+        force_str(data.get("culprit") or data.get("transaction") or generate_culprit(data) or "")
     )
 
 

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -12,7 +12,7 @@ import pytz
 import sentry_sdk
 from dateutil.parser import parse as parse_date
 from django.conf import settings
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from sentry import eventtypes
 from sentry.db.models import NodeData
@@ -558,12 +558,12 @@ class BaseEvent(metaclass=abc.ABCMeta):
 
         if event_metadata:
             for value in event_metadata.values():
-                value_u = force_text(value, errors="replace")
+                value_u = force_str(value, errors="replace")
                 if value_u not in message:
                     message = f"{message} {value_u}"
 
         if culprit and culprit not in message:
-            culprit_u = force_text(culprit, errors="replace")
+            culprit_u = force_str(culprit, errors="replace")
             message = f"{message} {culprit_u}"
 
         return cast(str, trim(message.strip(), settings.SENTRY_MAX_MESSAGE_LENGTH))
@@ -778,7 +778,7 @@ def augment_message_with_occurrence(message: str, occurrence: IssueOccurrence) -
     for attr in ("issue_title", "subtitle", "culprit"):
         value = getattr(occurrence, attr, "")
         if value and value not in message:
-            value = force_text(value, errors="replace")
+            value = force_str(value, errors="replace")
             message = f"{message} {value}"
     return message
 

--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils import timezone
-from django.utils.encoding import force_bytes, force_text, smart_str
+from django.utils.encoding import force_bytes, force_str, smart_str
 from google.api_core.exceptions import GatewayTimeout, ServiceUnavailable
 from google.auth.exceptions import RefreshError, TransportError
 from google.cloud.exceptions import NotFound
@@ -114,9 +114,9 @@ def safe_join(base, *paths):
     Paths outside the base path indicate a possible security
     sensitive operation.
     """
-    base_path = force_text(base)
+    base_path = force_str(base)
     base_path = base_path.rstrip("/")
-    paths = [force_text(p) for p in paths]
+    paths = [force_str(p) for p in paths]
 
     final_path = base_path + "/"
     for path in paths:

--- a/src/sentry/filestore/s3.py
+++ b/src/sentry/filestore/s3.py
@@ -50,7 +50,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.core.files.base import File
 from django.core.files.storage import Storage
-from django.utils.encoding import filepath_to_uri, force_bytes, force_text, smart_str
+from django.utils.encoding import filepath_to_uri, force_bytes, force_str, smart_str
 from django.utils.timezone import localtime
 
 from sentry.utils import metrics
@@ -83,9 +83,9 @@ def safe_join(base, *paths):
     Paths outside the base path indicate a possible security
     sensitive operation.
     """
-    base_path = force_text(base)
+    base_path = force_str(base)
     base_path = base_path.rstrip("/")
-    paths = [force_text(p) for p in paths]
+    paths = [force_str(p) for p in paths]
 
     final_path = base_path
     for path in paths:
@@ -463,7 +463,7 @@ class S3Boto3Storage(Storage):
         return smart_str(name, encoding=self.file_name_charset)
 
     def _decode_name(self, name):
-        return force_text(name, encoding=self.file_name_charset)
+        return force_str(name, encoding=self.file_name_charset)
 
     def _compress_content(self, content):
         """Gzip a given string content."""

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -1,4 +1,4 @@
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from rest_framework import serializers
 
 from sentry import analytics
@@ -160,7 +160,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                 trigger=self.context["trigger"], **validated_data
             )
         except (ApiRateLimitedError, InvalidTriggerActionError) as e:
-            raise serializers.ValidationError(force_text(e))
+            raise serializers.ValidationError(force_str(e))
 
         analytics.record(
             "metric_alert_with_ui_component.created",
@@ -177,6 +177,6 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
         try:
             action = update_alert_rule_trigger_action(instance, **validated_data)
         except (ApiRateLimitedError, InvalidTriggerActionError) as e:
-            raise serializers.ValidationError(force_text(e))
+            raise serializers.ValidationError(force_str(e))
 
         return action

--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -1,6 +1,6 @@
 import string
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from sentry.interfaces.base import Interface
 from sentry.utils.json import prune_empty_keys
@@ -87,7 +87,7 @@ class ContextType:
             # Even if the value is an empty string,
             # we still want to display the info the UI
             if value is not None:
-                ctx_data[force_text(key)] = value
+                ctx_data[force_str(key)] = value
         self.data = ctx_data
 
     def to_json(self):

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -17,7 +17,7 @@ from urllib.parse import urlsplit
 import sentry_sdk
 from django.conf import settings
 from django.utils import timezone
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 from requests.utils import get_encoding_from_headers
 from symbolic.sourcemap import SourceView
 from symbolic.sourcemapcache import SourceMapCache as SmCache
@@ -190,7 +190,7 @@ def discover_sourcemap(result):
     sourcemap_header = force_bytes(sourcemap_header) if sourcemap_header is not None else None
     sourcemap_url = find_sourcemap(sourcemap_header, result.body)
     sourcemap_url = (
-        force_text(non_standard_url_join(result.url, force_text(sourcemap_url)))
+        force_str(non_standard_url_join(result.url, force_str(sourcemap_url)))
         if sourcemap_url is not None
         else None
     )

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping
 
 import sentry_sdk
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from sentry import options
 from sentry.models import Project, ProjectOption, Team
@@ -41,7 +41,7 @@ def get_headers(notification: BaseNotification) -> Mapping[str, Any]:
 
 
 def build_subject_prefix(project: Project) -> str:
-    return force_text(
+    return force_str(
         ProjectOption.objects.get_value(project, "mail:subject_prefix")
         or options.get("mail.subject-prefix")
     )

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from django.db import models, transaction
 from django.utils import timezone
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from sentry.db.models import (
     BaseManager,
@@ -48,7 +48,7 @@ class ApiToken(Model, HasApiScopes):
     __repr__ = sane_repr("user_id", "token", "application_id")
 
     def __str__(self):
-        return force_text(self.token)
+        return force_str(self.token)
 
     @classmethod
     def from_grant(cls, grant):

--- a/src/sentry/models/orgauthtoken.py
+++ b/src/sentry/models/orgauthtoken.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from sentry.conf.server import SENTRY_SCOPES
 from sentry.db.models import (
@@ -55,7 +55,7 @@ class OrgAuthToken(Model):
     __repr__ = sane_repr("organization_id", "token_hashed")
 
     def __str__(self):
-        return force_text(self.token_hashed)
+        return force_str(self.token_hashed)
 
     def get_audit_log_data(self):
         return {"name": self.name, "scopes": self.get_scopes()}

--- a/src/sentry/net/socket.py
+++ b/src/sentry/net/socket.py
@@ -4,7 +4,7 @@ import socket
 from urllib.parse import urlparse
 
 from django.conf import settings
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from urllib3.exceptions import LocationParseError
 from urllib3.util.connection import _set_socket_options, allowed_gai_family
 
@@ -23,7 +23,7 @@ def is_ipaddress_allowed(ip):
     """
     if not DISALLOWED_IPS:
         return True
-    ip_address = ipaddress.ip_address(force_text(ip, strings_only=True))
+    ip_address = ipaddress.ip_address(force_str(ip, strings_only=True))
     for ip_network in DISALLOWED_IPS:
         if ip_address in ip_network:
             return False
@@ -44,7 +44,7 @@ def ensure_fqdn(hostname):
     if not settings.SENTRY_ENSURE_FQDN:
         return hostname
 
-    hostname = force_text(hostname, strings_only=True)
+    hostname = force_str(hostname, strings_only=True)
 
     # Already fully qualified if it ends in a "."
     if hostname[-1:] == ".":

--- a/src/sentry/notifications/notifications/user_report.py
+++ b/src/sentry/notifications/notifications/user_report.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Mapping, MutableMapping
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from sentry.db.models import Model
 from sentry.models import Group, GroupSubscription
@@ -40,7 +40,7 @@ class UserReportNotification(ProjectNotification):
 
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         message = f"{self.group.qualified_short_id} - New Feedback from {self.report['name']}"
-        message = force_text(message)
+        message = force_str(message)
         return message
 
     def get_notification_title(

--- a/src/sentry/similarity/backends/redis.py
+++ b/src/sentry/similarity/backends/redis.py
@@ -1,7 +1,7 @@
 import itertools
 import time
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from sentry.similarity.backends.abstract import AbstractIndexBackend
 from sentry.utils.iterators import chunked
@@ -56,7 +56,7 @@ class RedisScriptMinHashIndexBackend(AbstractIndexBackend):
         def decode_search_result(result):
             key, scores = result
             return (
-                force_text(key),
+                force_str(key),
                 [score_replacements.get(float(score), float(score)) for score in scores],
             )
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -17,7 +17,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.files.base import ContentFile
 from django.db import transaction
 from django.utils import timezone
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.text import slugify
 
 from sentry.constants import SentryAppInstallationStatus, SentryAppStatus
@@ -449,7 +449,7 @@ class Factories:
         unadopted: Optional[datetime] = None,
     ):
         if version is None:
-            version = force_text(hexlify(os.urandom(20)))
+            version = force_str(hexlify(os.urandom(20)))
 
         if date_added is None:
             date_added = timezone.now()

--- a/src/sentry/utils/avatar.py
+++ b/src/sentry/utils/avatar.py
@@ -10,7 +10,7 @@ from urllib.parse import urlencode
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import escape
 from PIL import Image
 
@@ -58,7 +58,7 @@ COLOR_COUNT = len(LETTER_AVATAR_COLORS)
 
 
 def hash_user_identifier(identifier: str | int) -> int:
-    identifier = force_text(identifier, errors="replace")
+    identifier = force_str(identifier, errors="replace")
     return sum(map(ord, identifier))
 
 

--- a/src/sentry/utils/email/message_builder.py
+++ b/src/sentry/utils/email/message_builder.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
 import lxml.html
 import toronado
 from django.core.mail import EmailMultiAlternatives
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from sentry import options
 from sentry.db.models import Model
@@ -158,7 +158,7 @@ class MessageBuilder:
         message_id = make_msgid(get_from_email_domain())
         headers.setdefault("Message-Id", message_id)
 
-        subject = force_text(self.subject)
+        subject = force_str(self.subject)
 
         reference = self.reference
         if isinstance(reference, Activity):

--- a/src/sentry/utils/email/signer.py
+++ b/src/sentry/utils/email/signer.py
@@ -1,6 +1,6 @@
 from django.core.signing import BadSignature, Signer
 from django.utils.crypto import constant_time_compare
-from django.utils.encoding import force_str, force_text
+from django.utils.encoding import force_str
 
 
 class _CaseInsensitiveSigner(Signer):
@@ -30,4 +30,4 @@ class _CaseInsensitiveSigner(Signer):
         if not constant_time_compare(sig.lower(), self.signature(value)):
             raise BadSignature(f'Signature "{sig}" does not match')
 
-        return force_text(value)
+        return force_str(value)

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -10,7 +10,7 @@ from typing import IO, TYPE_CHECKING, Any, Generator, Mapping, NoReturn, TypeVar
 
 import rapidjson
 import sentry_sdk
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import Promise
 from django.utils.safestring import SafeString, mark_safe
 from django.utils.timezone import is_aware
@@ -67,7 +67,7 @@ def better_default_encoder(o: object) -> object:
         return list(o)
     # serialization for certain Django objects here: https://docs.djangoproject.com/en/1.8/topics/serialization/
     elif isinstance(o, Promise):
-        return force_text(o)
+        return force_str(o)
     raise TypeError(repr(o) + " is not JSON serializable")
 
 

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -4,7 +4,7 @@ from typing import Any, Mapping, Sequence, Union
 import sentry_sdk
 from django.conf import settings
 from django.db import transaction
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.http import urlencode
 
 from sentry.db.postgres.transactions import django_test_transaction_water_mark
@@ -73,11 +73,11 @@ def trim(
     elif isinstance(value, dict):
         result = {}
         _size += 2
-        for k in sorted(value.keys(), key=lambda x: (len(force_text(value[x])), x)):
+        for k in sorted(value.keys(), key=lambda x: (len(force_str(value[x])), x)):
             v = value[k]
             trim_v = trim(v, _size=_size, **options)
             result[k] = trim_v
-            _size += len(force_text(trim_v)) + 1
+            _size += len(force_str(trim_v)) + 1
             if _size >= max_size:
                 break
 
@@ -87,7 +87,7 @@ def trim(
         for v in value:
             trim_v = trim(v, _size=_size, **options)
             result.append(trim_v)
-            _size += len(force_text(trim_v))
+            _size += len(force_str(trim_v))
             if _size >= max_size:
                 break
         if isinstance(value, tuple):

--- a/src/sentry/utils/signing.py
+++ b/src/sentry/utils/signing.py
@@ -5,7 +5,7 @@ Generic way to sign and unsign data for use in urls.
 import base64
 
 from django.core.signing import TimestampSigner
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 
 from sentry.utils.json import dumps, loads
 
@@ -17,7 +17,7 @@ def sign(**kwargs):
     Signs all passed kwargs and produces a base64 string which may be passed to
     unsign which will verify the string has not been tampered with.
     """
-    return force_text(
+    return force_str(
         base64.urlsafe_b64encode(
             TimestampSigner(salt=SALT).sign(dumps(kwargs)).encode("utf-8")
         ).rstrip(b"=")

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -8,7 +8,7 @@ import string
 import zlib
 from typing import Any, Callable, overload
 
-from django.utils.encoding import force_text, smart_text
+from django.utils.encoding import force_str, smart_str
 
 _sprintf_placeholder_re = re.compile(
     r"%(?:\d+\$)?[+-]?(?:[ 0]|\'.{1})?-?\d*(?:\.\d+)?[bcdeEufFgGosxX]"
@@ -84,7 +84,7 @@ def decompress(value: str) -> bytes:
 def strip(value: str | None) -> str:
     if not value:
         return ""
-    return smart_text(value).strip()
+    return smart_str(value).strip()
 
 
 def soft_hyphenate(value: str, length: int, hyphen: str = "\u00ad") -> str:
@@ -117,7 +117,7 @@ def soft_break(value: str, length: int, process: Callable[[str], str] = lambda c
 
 def to_unicode(value: Any) -> str:
     try:
-        value = str(force_text(value))
+        value = str(force_str(value))
     except (UnicodeEncodeError, UnicodeDecodeError):
         value = "(Error decoding value)"
     except Exception:  # in some cases we get a different exception

--- a/src/sentry/utils/validators.py
+++ b/src/sentry/utils/validators.py
@@ -1,7 +1,7 @@
 import re
 import uuid
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 INVALID_ID_DETAILS = "{} must be a valid UUID hex (32-36 characters long, containing only digits, dashes, or a-f characters)"
 
@@ -14,7 +14,7 @@ HEXADECIMAL_16_DIGITS = re.compile("^[0-9a-fA-F]{16}$")
 
 def normalize_event_id(value):
     try:
-        return uuid.UUID(force_text(value)).hex
+        return uuid.UUID(force_str(value)).hex
     except (TypeError, AttributeError, ValueError):
         return None
 
@@ -24,4 +24,4 @@ def is_event_id(value):
 
 
 def is_span_id(value):
-    return bool(HEXADECIMAL_16_DIGITS.search(force_text(value)))
+    return bool(HEXADECIMAL_16_DIGITS.search(force_str(value)))

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -1,4 +1,4 @@
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from sentry.exceptions import InvalidConfiguration
 from sentry.utils import warnings
@@ -6,7 +6,7 @@ from sentry.utils import warnings
 
 class Version(tuple):
     def __str__(self):
-        return ".".join(map(force_text, self))
+        return ".".join(map(force_str, self))
 
 
 def summarize(sequence, max=3):
@@ -21,7 +21,7 @@ def summarize(sequence, max=3):
 
 def make_upgrade_message(service, modality, version, hosts):
     return "{service} {modality} be upgraded to {version} on {hosts}.".format(
-        hosts=",".join(map(force_text, summarize(list(hosts.keys()), 2))),
+        hosts=",".join(map(force_str, summarize(list(hosts.keys()), 2))),
         modality=modality,
         service=service,
         version=version,

--- a/src/sentry_plugins/pivotal/plugin.py
+++ b/src/sentry_plugins/pivotal/plugin.py
@@ -2,7 +2,7 @@ from urllib.parse import urlencode
 
 import requests
 from django.conf.urls import url
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -147,8 +147,8 @@ class PivotalPlugin(CorePluginMixin, IssuePlugin2):
     def create_issue(self, request: Request, group, form_data, **kwargs):
         json_data = {
             "story_type": "bug",
-            "name": force_text(form_data["title"], encoding="utf-8", errors="replace"),
-            "description": force_text(form_data["description"], encoding="utf-8", errors="replace"),
+            "name": force_str(form_data["title"], encoding="utf-8", errors="replace"),
+            "description": force_str(form_data["description"], encoding="utf-8", errors="replace"),
             "labels": ["sentry"],
         }
 

--- a/src/social_auth/fields.py
+++ b/src/social_auth/fields.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db.models import TextField
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 from sentry.db.models.utils import Creator
 from sentry.utils import json
@@ -53,7 +53,7 @@ class JSONField(TextField):
 
     def value_to_string(self, obj):
         """Return value from object converted to string properly"""
-        return smart_text(self.value_from_object(obj))
+        return smart_str(self.value_from_object(obj))
 
     def value_from_object(self, obj):
         """Return value dumped to string."""

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 from django.utils import timezone
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from freezegun import freeze_time
 
 from sentry import options
@@ -142,7 +142,7 @@ class TestRedisBuffer:
         self.buf.incr(model, columns, filters, extra={"foo": "bar", "datetime": now})
         result = client.hgetall(key)
         # Force keys to strings
-        result = {force_text(k): v for k, v in result.items()}
+        result = {force_str(k): v for k, v in result.items()}
 
         f = result.pop("f")
         if self.buf.is_redis_cluster:
@@ -172,7 +172,7 @@ class TestRedisBuffer:
         self.buf.incr(model, columns, filters, extra={"foo": "baz", "datetime": now})
         result = client.hgetall(key)
         # Force keys to strings
-        result = {force_text(k): v for k, v in result.items()}
+        result = {force_str(k): v for k, v in result.items()}
         f = result.pop("f")
         assert load_values(f) == {"pk": 1, "datetime": now}
         assert load_value(result.pop("e+datetime")) == now

--- a/tests/sentry/db/models/fields/test_jsonfield.py
+++ b/tests/sentry/db/models/fields/test_jsonfield.py
@@ -1,7 +1,7 @@
 import pytest
 from django import forms
 from django.db import models
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from sentry.db.models.fields.jsonfield import JSONField
 from sentry.testutils import TestCase
@@ -89,7 +89,7 @@ class JSONFieldTest(TestCase):
         formfield = field.formfield()
         self.assertRaisesMessage(
             forms.ValidationError,
-            force_text(formfield.error_messages["required"]),
+            force_str(formfield.error_messages["required"]),
             formfield.clean,
             value="",
         )
@@ -99,7 +99,7 @@ class JSONFieldTest(TestCase):
         formfield = field.formfield()
         self.assertRaisesMessage(
             forms.ValidationError,
-            force_text(formfield.error_messages["required"]),
+            force_str(formfield.error_messages["required"]),
             formfield.clean,
             value=None,
         )

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -1,4 +1,4 @@
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 
 from sentry.constants import MAX_CULPRIT_LENGTH
 from sentry.testutils import TestCase
@@ -65,9 +65,9 @@ class CursorWrapperTestCase(TestCase):
 
         bad_str = "Hello\ud83dWorld🇦🇹!"
         cursor.execute("SELECT %s", [bad_str])
-        bad_str_from_db = force_text(cursor.fetchone()[0])
+        bad_str_from_db = force_str(cursor.fetchone()[0])
         assert bad_str_from_db == "HelloWorld🇦🇹!"
 
         cursor.execute("SELECT %(bad_str)s", {"bad_str": bad_str})
-        bad_str_from_db = force_text(cursor.fetchone()[0])
+        bad_str_from_db = force_str(cursor.fetchone()[0])
         assert bad_str_from_db == "HelloWorld🇦🇹!"


### PR DESCRIPTION
these aliases are deprecated and removed in django 4

this also blocks upgrading `django-stubs`