### PR TITLE
ref: django 4+: get_random_string requires a length

### DIFF
--- a/src/sudo/utils.py
+++ b/src/sudo/utils.py
@@ -27,7 +27,7 @@ def grant_sudo_privileges(request, max_age=COOKIE_AGE):
 
     # Token doesn't need to be unique,
     # just needs to be unpredictable and match the cookie and the session
-    token = get_random_string()
+    token = get_random_string(12)
     request.session[COOKIE_NAME] = token
     request._sudo = True
     request._sudo_token = token


### PR DESCRIPTION
I used the default value in django 2.x