### PR TITLE
fix(mute-metrics-alerts): Fix alert rule id in email

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -268,11 +268,10 @@ def generate_incident_trigger_email_context(
 
     rule_link = organization.absolute_url(
         reverse(
-            "sentry-alert-rule",
+            "sentry-metric-alert-details",
             kwargs={
                 "organization_slug": organization.slug,
-                "project_slug": project.slug,
-                "alert_rule_id": trigger.alert_rule_id,
+                "alert_rule_id": incident.alert_rule.id,
             },
         ),
         query="referrer=alert_email",
@@ -282,17 +281,7 @@ def generate_incident_trigger_email_context(
     snooze_alert_url = None
     if features.has("organizations:mute-metric-alerts", organization):
         snooze_alert = True
-        alert_rule_link = organization.absolute_url(
-            reverse(
-                "sentry-metric-alert-details",
-                kwargs={
-                    "organization_slug": organization.slug,
-                    "alert_rule_id": incident.alert_rule.id,
-                },
-            ),
-            query="referrer=alert_email",
-        )
-        snooze_alert_url = alert_rule_link + "&" + urlencode({"mute": "1"})
+        snooze_alert_url = rule_link + "&" + urlencode({"mute": "1"})
 
     return {
         "link": alert_link,

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -287,7 +287,7 @@ def generate_incident_trigger_email_context(
                 "sentry-metric-alert-details",
                 kwargs={
                     "organization_slug": organization.slug,
-                    "alert_rule_id": alert_rule.id,
+                    "alert_rule_id": incident.alert_rule.id,
                 },
             ),
             query="referrer=alert_email",

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -267,7 +267,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
                     "sentry-metric-alert-details",
                     kwargs={
                         "organization_slug": self.organization.slug,
-                        "alert_rule_id": action.alert_rule_trigger.alert_rule_id,
+                        "alert_rule_id": incident.alert_rule.id,
                     },
                 ),
                 query="referrer=alert_email",

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -223,6 +223,16 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
         incident = self.create_incident()
         action = self.create_alert_rule_trigger_action(triggered_for_incident=incident)
         aggregate = action.alert_rule_trigger.alert_rule.snuba_query.aggregate
+        rule_link = self.organization.absolute_url(
+            reverse(
+                "sentry-metric-alert-details",
+                kwargs={
+                    "organization_slug": self.organization.slug,
+                    "alert_rule_id": incident.alert_rule.id,
+                },
+            ),
+            query="referrer=alert_email",
+        )
         expected = {
             "link": self.organization.absolute_url(
                 reverse(
@@ -234,17 +244,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
                 ),
                 query="referrer=alert_email",
             ),
-            "rule_link": self.organization.absolute_url(
-                reverse(
-                    "sentry-alert-rule",
-                    kwargs={
-                        "organization_slug": incident.organization.slug,
-                        "project_slug": self.project.slug,
-                        "alert_rule_id": action.alert_rule_trigger.alert_rule_id,
-                    },
-                ),
-                query="referrer=alert_email",
-            ),
+            "rule_link": rule_link,
             "incident_name": incident.title,
             "aggregate": aggregate,
             "query": action.alert_rule_trigger.alert_rule.snuba_query.query,
@@ -262,17 +262,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             "chart_url": None,
             "timezone": settings.SENTRY_DEFAULT_TIME_ZONE,
             "snooze_alert": True,
-            "snooze_alert_url": self.organization.absolute_url(
-                reverse(
-                    "sentry-metric-alert-details",
-                    kwargs={
-                        "organization_slug": self.organization.slug,
-                        "alert_rule_id": incident.alert_rule.id,
-                    },
-                ),
-                query="referrer=alert_email",
-            )
-            + "&mute=1",
+            "snooze_alert_url": rule_link + "&mute=1",
         }
         assert expected == generate_incident_trigger_email_context(
             self.project,
@@ -302,16 +292,6 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             },
         )
         assert self.organization.absolute_url(path) in result["link"]
-
-        path = reverse(
-            "sentry-alert-rule",
-            kwargs={
-                "organization_slug": self.organization.slug,
-                "project_slug": self.project.slug,
-                "alert_rule_id": action.alert_rule_trigger.alert_rule_id,
-            },
-        )
-        assert self.organization.absolute_url(path) in result["rule_link"]
 
     def test_resolve(self):
         status = TriggerStatus.RESOLVED


### PR DESCRIPTION
this pr fixes an issue with the alert rule id in the email mute link. The link was working correctly for warning/critical emails, but was giving a non-existent alert rule id for resolved emails. Also replace rule_link to no longer use the project scoped alert rules. 