### PR TITLE
feat(priority-sort): allow saving last seen as a default search

### DIFF
--- a/static/app/views/issueList/issueListSetAsDefault.tsx
+++ b/static/app/views/issueList/issueListSetAsDefault.tsx
@@ -93,8 +93,8 @@ function IssueListSetAsDefault({organization, sort, query}: IssueListSetAsDefaul
   // Hide if we are already on the default search,
   // except when the user has a different search pinned.
   if (
-    isDefaultIssueStreamSearch({query, sort}) &&
-    (!pinnedSearch || isDefaultIssueStreamSearch(pinnedSearch))
+    isDefaultIssueStreamSearch({query, sort, organization}) &&
+    (!pinnedSearch || isDefaultIssueStreamSearch({organization, ...pinnedSearch}))
   ) {
     return null;
   }

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -176,8 +176,19 @@ export enum IssueSortOptions {
 
 export const DEFAULT_ISSUE_STREAM_SORT = IssueSortOptions.DATE;
 
-export function isDefaultIssueStreamSearch({query, sort}: {query: string; sort: string}) {
-  return query === DEFAULT_QUERY && sort === DEFAULT_ISSUE_STREAM_SORT;
+export function isDefaultIssueStreamSearch({
+  query,
+  sort,
+  organization,
+}: {
+  organization: Organization;
+  query: string;
+  sort: string;
+}) {
+  const defaultSort = organization.features.includes('issue-list-better-priority-sort')
+    ? IssueSortOptions.BETTER_PRIORITY
+    : DEFAULT_ISSUE_STREAM_SORT;
+  return query === DEFAULT_QUERY && sort === defaultSort;
 }
 
 export function getSortLabel(key: string) {


### PR DESCRIPTION
If you have the better priority sort as the default via feature flag, we should allow saving `last seen` as a your saved search

<img width="1190" alt="Screen Shot 2023-06-29 at 3 31 54 PM" src="https://github.com/getsentry/sentry/assets/8533851/4909b471-6f03-4620-a370-f6f11f348f9c">
