### PR TITLE
fix(issues): Use get_projects in projects_sent_first_event endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -23,5 +23,5 @@ class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
         :auth: required
         """
         projects = self.get_projects(request, organization)
-        seen_first_event = any(p.first_event is not None for p in projects)
+        seen_first_event = any(p.first_event for p in projects)
         return Response(serialize({"sentFirstEvent": seen_first_event}, request.user))

--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -4,7 +4,6 @@ from rest_framework.response import Response
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import Project
 
 
 @region_silo_endpoint
@@ -20,17 +19,9 @@ class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
         :pparam string organization_slug: the slug of the organization
                                           containing the projects to check
                                           for a first event from.
-        :qparam boolean is_member:        An optional boolean to choose to filter on
-                                          projects which the user is a member of.
         :qparam array[string] project:    An optional list of project ids to filter
         :auth: required
         """
-        is_member = request.GET.get("is_member")
-        project_ids = set(map(int, request.GET.getlist("project")))
-        queryset = Project.objects.filter(organization=organization, first_event__isnull=False)
-        if is_member:
-            queryset = queryset.filter(teams__organizationmember__user_id=request.user.id)
-        if project_ids:
-            queryset = queryset.filter(id__in=project_ids)
-
-        return Response(serialize({"sentFirstEvent": queryset.exists()}, request.user))
+        projects = self.get_projects(request, organization)
+        seen_first_event = any(p.first_event is not None for p in projects)
+        return Response(serialize({"sentFirstEvent": seen_first_event}, request.user))

--- a/static/app/views/issueList/noGroupsHandler/index.tsx
+++ b/static/app/views/issueList/noGroupsHandler/index.tsx
@@ -73,12 +73,12 @@ class NoGroupsHandler extends Component<Props, State> {
 
     // If no projects are selected, then we must check every project the user is a
     // member of and make sure there are no first events for all of the projects
-    let firstEventQuery = {};
+    // Set project to -1 for all projects
+    // Do not pass a project id for "my projects"
+    let firstEventQuery: {project?: number[]} = {};
     const projectsQuery: {per_page: number; query?: string} = {per_page: 1};
 
-    if (!selectedProjectIds || !selectedProjectIds.length) {
-      firstEventQuery = {is_member: true};
-    } else {
+    if (selectedProjectIds?.length) {
       firstEventQuery = {project: selectedProjectIds};
       projectsQuery.query = selectedProjectIds.map(id => `id:${id}`).join(' ');
     }

--- a/tests/sentry/api/endpoints/test_organization_projects_sent_first_event.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_sent_first_event.py
@@ -45,7 +45,7 @@ class OrganizationProjectsSentFirstEventEndpointTest(APITestCase):
 
         self.login_as(user=self.foo)
 
-        response = self.client.get(self.url)
+        response = self.client.get(f"{self.url}?project=-1")
         assert response.status_code == 200
 
         assert response.data["sentFirstEvent"]
@@ -56,7 +56,7 @@ class OrganizationProjectsSentFirstEventEndpointTest(APITestCase):
 
         self.login_as(user=self.foo)
 
-        response = self.client.get(f"{self.url}?is_member=true")
+        response = self.client.get(self.url)
         assert response.status_code == 200
 
         assert not response.data["sentFirstEvent"]


### PR DESCRIPTION
- get_projects correctly uses `project=-1` for all projects and gets the right projects for superusers
- Hides the issues stream error robot for superusers looking at all projects