### PR TITLE
ref(Hybrid-Cloud): Patches transaction atomic to choose and assert correct silo for a given silo mode

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -9,6 +9,7 @@ from typing import Any, TypeVar
 import click
 from django.conf import settings
 
+from sentry.silo.patches.silo_aware_transaction_patch import patch_silo_aware_atomic
 from sentry.utils import metrics, warnings
 from sentry.utils.sdk import configure_sdk
 from sentry.utils.warnings import DeprecatedSettingWarning
@@ -373,6 +374,8 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
     validate_regions(settings)
 
     monkeypatch_django_migrations()
+
+    patch_silo_aware_atomic()
 
     apply_legacy_settings(settings)
 

--- a/src/sentry/silo/patches/silo_aware_transaction_patch.py
+++ b/src/sentry/silo/patches/silo_aware_transaction_patch.py
@@ -11,7 +11,7 @@ class MismatchedSiloTransactionError(Exception):
     pass
 
 
-def siloed_atomic(using: Optional[str] = None, savepoint: bool = True) -> Atomic:  # type:ignore
+def siloed_atomic(using: Optional[str] = None, savepoint: bool = True) -> Atomic:
     from sentry.models import ControlOutbox, RegionOutbox
     from sentry.silo import SiloMode
 
@@ -55,4 +55,4 @@ def patch_silo_aware_atomic():
     )
 
     _default_atomic_impl = transaction.atomic
-    transaction.atomic = siloed_atomic
+    transaction.atomic = siloed_atomic  # type:ignore

--- a/src/sentry/silo/patches/silo_aware_transaction_patch.py
+++ b/src/sentry/silo/patches/silo_aware_transaction_patch.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+from django.db import router, transaction
+
+_default_atomic_impl = transaction.atomic
+
+
+def siloed_atomic(using: Optional[str] = None, savepoint: bool = True):
+    from sentry.models import ControlOutbox, RegionOutbox
+    from sentry.silo import SiloMode
+
+    if not using:
+        model_to_route_to = (
+            RegionOutbox if SiloMode.get_current_mode() == SiloMode.REGION else ControlOutbox
+        )
+        using = router.db_for_write(model_to_route_to)
+
+    if using == router.db_for_write(ControlOutbox):
+        assert (
+            SiloMode.get_current_mode() != SiloMode.REGION
+        ), f"Cannot use transaction.atomic({using}) in Region Mode"
+
+    if using == router.db_for_write(RegionOutbox):
+        assert (
+            SiloMode.get_current_mode() != SiloMode.CONTROL
+        ), f"Cannot use transaction.atomic({using}) in Control Mode"
+
+    return _default_atomic_impl(using=using, savepoint=savepoint)
+
+
+def patch_silo_aware_atomic():
+    global _default_atomic_impl
+
+    _default_atomic_impl = transaction.atomic
+    transaction.atomic = siloed_atomic

--- a/src/sentry/silo/patches/silo_aware_transaction_patch.py
+++ b/src/sentry/silo/patches/silo_aware_transaction_patch.py
@@ -13,33 +13,31 @@ def siloed_atomic(using: Optional[str] = None, savepoint: bool = True):
     from sentry.models import ControlOutbox, RegionOutbox
     from sentry.silo import SiloMode
 
+    current_silo_mode = SiloMode.get_current_mode()
     if not using:
-        model_to_route_to = (
-            RegionOutbox if SiloMode.get_current_mode() == SiloMode.REGION else ControlOutbox
-        )
+        model_to_route_to = RegionOutbox if current_silo_mode == SiloMode.REGION else ControlOutbox
         using = router.db_for_write(model_to_route_to)
 
     both_silos_route_to_same_db = router.db_for_write(ControlOutbox) == router.db_for_write(
         RegionOutbox
     )
 
-    current_silo_mode = SiloMode.get_current_mode()
     if both_silos_route_to_same_db or current_silo_mode == SiloMode.MONOLITH:
         pass
     elif (
         using == router.db_for_write(ControlOutbox)
-        and SiloMode.get_current_mode() != SiloMode.REGION
-    ):
-        raise MismatchedSiloTransactionError(
-            f"Cannot use transaction.atomic({using}) in Region Mode"
-        )
-
-    elif (
-        using == router.db_for_write(RegionOutbox)
         and SiloMode.get_current_mode() != SiloMode.CONTROL
     ):
         raise MismatchedSiloTransactionError(
             f"Cannot use transaction.atomic({using}) in Control Mode"
+        )
+
+    elif (
+        using == router.db_for_write(RegionOutbox)
+        and SiloMode.get_current_mode() != SiloMode.REGION
+    ):
+        raise MismatchedSiloTransactionError(
+            f"Cannot use transaction.atomic({using}) in Region Mode"
         )
 
     return _default_atomic_impl(using=using, savepoint=savepoint)

--- a/src/sentry/silo/patches/silo_aware_transaction_patch.py
+++ b/src/sentry/silo/patches/silo_aware_transaction_patch.py
@@ -49,7 +49,7 @@ def patch_silo_aware_atomic():
     global _default_atomic_impl
 
     current_django_version = get_version()
-    assert current_django_version.startswith("2.2"), (
+    assert current_django_version.startswith("2.2."), (
         "Newer versions of Django have an additional 'durable' parameter in atomic,"
         + " verify the signature before updating the version check."
     )

--- a/tests/sentry/deletions/test_sentry_app_installations.py
+++ b/tests/sentry/deletions/test_sentry_app_installations.py
@@ -1,5 +1,6 @@
 import pytest
-from django.db import connection
+from django.db import router
+from django.db.transaction import get_connection
 
 from sentry import deletions
 from sentry.models import (
@@ -84,7 +85,7 @@ class TestSentryAppIntallationDeletionTask(TestCase):
 
         # The QuerySet will automatically NOT include deleted installs, so we
         # use a raw sql query to ensure it still exists.
-        c = connection.cursor()
+        c = get_connection(router.db_for_write(SentryAppInstallation))
         c.execute(
             "SELECT COUNT(1) "
             "FROM sentry_sentryappinstallation "

--- a/tests/sentry/deletions/test_sentry_app_installations.py
+++ b/tests/sentry/deletions/test_sentry_app_installations.py
@@ -85,7 +85,7 @@ class TestSentryAppIntallationDeletionTask(TestCase):
 
         # The QuerySet will automatically NOT include deleted installs, so we
         # use a raw sql query to ensure it still exists.
-        c = get_connection(router.db_for_write(SentryAppInstallation))
+        c = get_connection(router.db_for_write(SentryAppInstallation)).cursor()
         c.execute(
             "SELECT COUNT(1) "
             "FROM sentry_sentryappinstallation "

--- a/tests/sentry/silo/test_silo_aware_transaction_patch.py
+++ b/tests/sentry/silo/test_silo_aware_transaction_patch.py
@@ -1,0 +1,75 @@
+import os
+
+import pytest
+from django.db import router
+from django.test import override_settings
+
+from sentry.models import Organization, OrganizationMapping
+from sentry.silo import SiloMode
+from sentry.silo.patches.silo_aware_transaction_patch import (
+    MismatchedSiloTransactionError,
+    siloed_atomic,
+)
+from sentry.testutils import TestCase
+
+
+def is_running_in_split_db_mode() -> bool:
+    return bool(os.environ.get("SENTRY_USE_SPLIT_DBS"))
+
+
+class TestSiloAwareTransactionPatchInSingleDbMode(TestCase):
+    def test_routes_to_correct_db_in_control_silo(self):
+        if is_running_in_split_db_mode():
+            return
+
+        with override_settings(SILO_MODE=SiloMode.CONTROL):
+            transaction_in_test = siloed_atomic()
+            assert transaction_in_test.using == "default"
+
+    def test_routes_to_correct_db_in_region_silo(self):
+        if is_running_in_split_db_mode():
+            return
+
+        with override_settings(SILO_MODE=SiloMode.REGION):
+            transaction_in_test = siloed_atomic()
+            assert transaction_in_test.using == "default"
+
+    def test_correctly_accepts_using_for_atomic(self):
+        transaction_in_test = siloed_atomic(using="foobar")
+        assert transaction_in_test.using == "foobar"
+
+
+class TestSiloAwareTransactionPatchInSplitDbMode(TestCase):
+    def test_routes_to_correct_db_in_control_silo(self):
+        if not is_running_in_split_db_mode():
+            return
+
+        with override_settings(SILO_MODE=SiloMode.REGION):
+            transaction_in_test = siloed_atomic()
+            assert transaction_in_test.using == "default"
+
+    def test_fails_if_silo_mismatch_with_using_in_region_silo(self):
+        if not is_running_in_split_db_mode():
+            return
+
+        with override_settings(SILO_MODE=SiloMode.REGION), pytest.raises(
+            MismatchedSiloTransactionError
+        ):
+            siloed_atomic(using=router.db_for_write(OrganizationMapping))
+
+    def test_routes_to_correct_db_in_region_silo(self):
+        if not is_running_in_split_db_mode():
+            return
+
+        with override_settings(SILO_MODE=SiloMode.CONTROL):
+            transaction_in_test = siloed_atomic()
+            assert transaction_in_test.using == "control"
+
+    def test_fails_if_silo_mismatch_with_using_in_control_silo(self):
+        if not is_running_in_split_db_mode():
+            return
+
+        with override_settings(SILO_MODE=SiloMode.CONTROL), pytest.raises(
+            MismatchedSiloTransactionError
+        ):
+            siloed_atomic(using=router.db_for_write(Organization))

--- a/tests/sentry/silo/test_silo_aware_transaction_patch.py
+++ b/tests/sentry/silo/test_silo_aware_transaction_patch.py
@@ -18,17 +18,14 @@ def is_running_in_split_db_mode() -> bool:
 
 
 class TestSiloAwareTransactionPatchInSingleDbMode(TestCase):
+    @pytest.mark.skipif(is_running_in_split_db_mode(), reason="only runs in single db mode")
     def test_routes_to_correct_db_in_control_silo(self):
-        if is_running_in_split_db_mode():
-            return
-
         with override_settings(SILO_MODE=SiloMode.CONTROL):
             transaction_in_test = siloed_atomic()
             assert transaction_in_test.using == "default"
 
+    @pytest.mark.skipif(is_running_in_split_db_mode(), reason="only runs in single db mode")
     def test_routes_to_correct_db_in_region_silo(self):
-        if is_running_in_split_db_mode():
-            return
 
         with override_settings(SILO_MODE=SiloMode.REGION):
             transaction_in_test = siloed_atomic()
@@ -40,35 +37,27 @@ class TestSiloAwareTransactionPatchInSingleDbMode(TestCase):
 
 
 class TestSiloAwareTransactionPatchInSplitDbMode(TestCase):
+    @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
     def test_routes_to_correct_db_in_control_silo(self):
-        if not is_running_in_split_db_mode():
-            return
-
         with override_settings(SILO_MODE=SiloMode.REGION):
             transaction_in_test = siloed_atomic()
             assert transaction_in_test.using == "default"
 
+    @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
     def test_fails_if_silo_mismatch_with_using_in_region_silo(self):
-        if not is_running_in_split_db_mode():
-            return
-
         with override_settings(SILO_MODE=SiloMode.REGION), pytest.raises(
             MismatchedSiloTransactionError
         ):
             siloed_atomic(using=router.db_for_write(OrganizationMapping))
 
+    @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
     def test_routes_to_correct_db_in_region_silo(self):
-        if not is_running_in_split_db_mode():
-            return
-
         with override_settings(SILO_MODE=SiloMode.CONTROL):
             transaction_in_test = siloed_atomic()
             assert transaction_in_test.using == "control"
 
+    @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
     def test_fails_if_silo_mismatch_with_using_in_control_silo(self):
-        if not is_running_in_split_db_mode():
-            return
-
         with override_settings(SILO_MODE=SiloMode.CONTROL), pytest.raises(
             MismatchedSiloTransactionError
         ):


### PR DESCRIPTION
We currently don't specify `using` when creating Django transactions, which can lead to hitting the incorrect database for the current silo. In order to remediate this, this PR patches `transaction.atomic` to query the current silo mode and automatically fill in the `using` parameter for the transaction. This PR also adds assertions that operating in a silo mode _requires_ the correct routing within the transaction in order to assist us in catching cross-silo transactions that shouldn't be occurring.

This PR also adds a check before patching atomic to ensure that an upgrade to Django requires a re-verification of our atomic patch, as newer versions of the function contain an additional `durable` parameter which will need to be included.

This also includes a test fix for an app integration that was already broken due to silo mismatches.
