### PR TITLE
feat: Schema validation in the unified consumer

### DIFF
--- a/src/sentry/conf/types/consumer_definition.py
+++ b/src/sentry/conf/types/consumer_definition.py
@@ -9,6 +9,7 @@ from typing_extensions import Required
 class ConsumerDefinition(TypedDict, total=False):
     # Which logical topic from settings to use.
     topic: Required[str | Callable[[], str]]
+    default_topic: str
 
     strategy_factory: Required[str]
 

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -356,7 +356,7 @@ class ValidateSchemaStrategyFactoryWrapper(ProcessingStrategyFactory):
 
     def __init__(self, topic: str, enforce_schema: bool, inner: ProcessingStrategyFactory) -> None:
         self.topic = topic
-        self.enfoce_schema = enforce_schema
+        self.enforce_schema = enforce_schema
         self.inner = inner
 
     def create_with_partitions(self, commit, partitions) -> ProcessingStrategy:

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -354,13 +354,15 @@ class ValidateSchemaStrategyFactoryWrapper(ProcessingStrategyFactory):
     twice, it should only be run in dev or on a small fraction of prod data.
     """
 
-    def __init__(self, topic: str, inner: ProcessingStrategyFactory) -> None:
+    def __init__(self, topic: str, enforce_schema: bool, inner: ProcessingStrategyFactory) -> None:
+        self.topic = topic
+        self.enfoce_schema = enforce_schema
         self.inner = inner
 
     def create_with_partitions(self, commit, partitions) -> ProcessingStrategy:
         rv = self.inner.create_with_partitions(commit, partitions)
 
-        return ValidateSchema(rv)
+        return ValidateSchema(self.topic, self.enforce_schema, rv)
 
 
 class HealthcheckStrategyFactoryWrapper(ProcessingStrategyFactory):

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -94,6 +94,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
         "strategy_factory": "sentry.monitors.consumers.monitor_consumer.StoreMonitorCheckInStrategyFactory",
     },
     "billing-metrics-consumer": {
+        "topic": settings.KAFKA_SNUBA_GENERIC_METRICS,
         "strategy_factory": "sentry.ingest.billing_metrics_consumer.BillingMetricsConsumerStrategyFactory",
     },
     # Known differences to 'sentry run occurrences-ingest-consumer':

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -7,10 +7,11 @@ import click
 from arroyo.backends.abstract import Consumer
 from arroyo.processing.processor import StreamProcessor
 from arroyo.processing.strategies import Healthcheck
-from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
+from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
 from django.conf import settings
 
 from sentry.conf.types.consumer_definition import ConsumerDefinition
+from sentry.consumers.validate_schema import ValidateSchema
 from sentry.utils.imports import import_string
 
 DEFAULT_BLOCK_SIZE = int(32 * 1e6)
@@ -75,6 +76,10 @@ _POST_PROCESS_FORWARDER_OPTIONS = [
 
 
 # consumer name -> consumer definition
+# XXX: default_topic is needed to lookup the schema even if the actual topic name has been
+# overridden. This is because the current topic override mechanism means the default topic name
+# is no longer available anywhere in code. We should probably fix this later so we don't need both
+#  "topic" and "default_topic" here though.
 KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
     "ingest-profiles": {
         "topic": settings.KAFKA_PROFILES,
@@ -89,7 +94,6 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
         "strategy_factory": "sentry.monitors.consumers.monitor_consumer.StoreMonitorCheckInStrategyFactory",
     },
     "billing-metrics-consumer": {
-        "topic": settings.KAFKA_SNUBA_GENERIC_METRICS,
         "strategy_factory": "sentry.ingest.billing_metrics_consumer.BillingMetricsConsumerStrategyFactory",
     },
     # Known differences to 'sentry run occurrences-ingest-consumer':
@@ -118,6 +122,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
     },
     "generic-metrics-subscription-results": {
         "topic": settings.KAFKA_GENERIC_METRICS_SUBSCRIPTIONS_RESULTS,
+        "default_topic": "generic-metrics-subscription-results",
         "strategy_factory": "sentry.snuba.query_subscriptions.run.QuerySubscriptionStrategyFactory",
         "click_options": multiprocessing_options(default_max_batch_size=100),
         "static_args": {
@@ -227,6 +232,7 @@ def get_stream_processor(
     synchronize_commit_log_topic: Optional[str],
     synchronize_commit_group: Optional[str],
     healthcheck_file_path: Optional[str],
+    validate_schema: bool = False,
 ) -> StreamProcessor:
     try:
         consumer_definition = KAFKA_CONSUMERS[consumer_name]
@@ -319,6 +325,13 @@ def get_stream_processor(
             "--synchronize_commit_group and --synchronize_commit_log_topic are required arguments for this consumer"
         )
 
+    # Validate schema if "default_topic" is set
+    default_topic = consumer_definition.get("default_topic")
+    if default_topic:
+        strategy_factory = ValidateSchemaStrategyFactoryWrapper(
+            default_topic, validate_schema, strategy_factory
+        )
+
     if healthcheck_file_path is not None:
         strategy_factory = HealthcheckStrategyFactoryWrapper(
             healthcheck_file_path, strategy_factory
@@ -331,6 +344,22 @@ def get_stream_processor(
         commit_policy=ONCE_PER_SECOND,
         join_timeout=join_timeout,
     )
+
+
+class ValidateSchemaStrategyFactoryWrapper(ProcessingStrategyFactory):
+    """
+    This wrapper is used to validate the schema of the event before
+    passing to the rest of the pipeline. Since the message is currently decoded
+    twice, it should only be run in dev or on a small fraction of prod data.
+    """
+
+    def __init__(self, topic: str, inner: ProcessingStrategyFactory) -> None:
+        self.inner = inner
+
+    def create_with_partitions(self, commit, partitions) -> ProcessingStrategy:
+        rv = self.inner.create_with_partitions(commit, partitions)
+
+        return ValidateSchema(rv)
 
 
 class HealthcheckStrategyFactoryWrapper(ProcessingStrategyFactory):

--- a/src/sentry/consumers/validate_schema.py
+++ b/src/sentry/consumers/validate_schema.py
@@ -1,0 +1,71 @@
+import logging
+import time
+from typing import Optional
+
+import sentry_kafka_schemas
+import sentry_sdk
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.processing.strategies.abstract import ProcessingStrategy
+from arroyo.types import Message
+
+logger = logging.getLogger(__name__)
+
+
+class ValidateSchema(ProcessingStrategy[KafkaPayload]):
+    """
+    Since ValidateSchema is currently a separate step to the main message
+    processing function, messages that are validated will be decoded twice. As a result,
+    we don't validate a large number of messages outside of dev and test environments.
+
+    If enforce_schema=True is passed, every message that fails validation will
+    raise an error and crash the consumer. This is designed for use in dev and test
+    environments. Otherwise, we rate limit message validation to once per second and log
+    warnings.
+    """
+
+    def __init__(
+        self, topic: str, enforce_schema: bool, next_step: ProcessingStrategy[KafkaPayload]
+    ) -> None:
+        self.__topic = topic
+        self.__enforce_schema = enforce_schema
+        self.__next_step = next_step
+        self.__last_record_time: Optional[int] = None
+
+        try:
+            self.__codec = sentry_kafka_schemas.get_codec(topic)
+        except sentry_kafka_schemas.SchemaNotFound:
+            self.__codec = None
+
+    def submit(self, message: Message[KafkaPayload]) -> None:
+        if self.__enforce_schema:
+            if self.__codec is not None:
+                # This will raise an exception if the message is invalid
+                self.__codec.decode(message.payload.value, validate=True)
+        else:
+            now = time.time()
+            if self.__last_record_time is None or self.__last_record_time + 1.0 < now:
+                with sentry_sdk.push_scope() as scope:
+                    scope.add_attachment(bytes=message.payload.value, filename="message.txt")
+                    scope.set_tag("topic", self.__topic)
+
+                if self.__codec is None:
+                    logger.warning("No validator configured for topic")
+                try:
+                    self.__codec.decode(message.payload.value)
+                except sentry_kafka_schemas.codecs.ValidationError:
+                    logger.warning("Invalid message received")
+                self.__last_record_time = now
+
+        self.__next_step.submit(message)
+
+    def poll(self) -> None:
+        self.__next_step.poll()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        self.__next_step.join(timeout)
+
+    def close(self) -> None:
+        self.__next_step.close()
+
+    def terminate(self) -> None:
+        self.__next_step.terminate()

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -757,6 +757,7 @@ def dev_consumer(consumer_names):
             synchronize_commit_group=None,
             synchronize_commit_log_topic=None,
             healthcheck_file_path=None,
+            validate_schema=True,
         )
         for consumer_name in consumer_names
     ]

--- a/tests/sentry/consumers/test_validate_schema.py
+++ b/tests/sentry/consumers/test_validate_schema.py
@@ -1,0 +1,58 @@
+from unittest.mock import Mock
+
+import pytest
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.types import Message, Value
+
+from sentry.consumers.validate_schema import ValidateSchema
+from sentry.utils import json
+
+
+def make_message(value: object) -> Message[KafkaPayload]:
+    return Message(Value(KafkaPayload(None, json.dumps(value).encode("utf-8"), []), {}))
+
+
+valid = make_message(
+    {
+        "org_id": 420,
+        "project_id": 420,
+        "name": "c:sessions/session@none",
+        "tags": {
+            "sdk": "raven-node/2.6.3",
+            "environment": "production",
+            "release": "sentry-test@1.0.0",
+            "session.status": "init",
+        },
+        "timestamp": 1111111111111111,
+        "retention_days": 90,
+        "type": "c",
+        "value": 1,
+    }
+)
+
+invalid = make_message(
+    {
+        "org_id": 420,
+    }
+)
+
+
+def test_validate_schema_with_enforcement() -> None:
+    next_step = Mock()
+    strategy = ValidateSchema("ingest-metrics", True, next_step)
+    strategy.submit(valid)
+    assert next_step.submit.call_args[0][0] == valid
+
+    with pytest.raises(Exception):
+        strategy.submit(invalid)
+
+
+def test_validate_schema_without_enforcement() -> None:
+    next_step = Mock()
+    strategy = ValidateSchema("ingest-metrics", False, next_step)
+    strategy.submit(valid)
+    assert next_step.submit.call_args[0][0] == valid
+
+    # Does not raise
+    strategy.submit(invalid)
+    assert next_step.submit.call_args[0][0] == invalid


### PR DESCRIPTION
Hard errors in dev-consumer and warns otherwise. Only turned on for generic metrics subscriptions as a first step.

