### PR TITLE
fix(org-tokens): Ensure correct actor is shown in security email

### DIFF
--- a/src/sentry/templates/sentry/emails/org-auth-token-created.html
+++ b/src/sentry/templates/sentry/emails/org-auth-token-created.html
@@ -10,10 +10,10 @@
   <table>
     <tr>
       <td style="width:36px;vertical-align:top;padding-right:15px;">
-        {% avatar_for_email account 36 %}
+        {% avatar_for_email actor 36 %}
       </td>
       <td>
-        <strong>{{ account.email }}</strong><br />
+        <strong>{{ actor.email }}</strong><br />
         {{ ip_address }}<br />
         {{ datetime }} UTC
       </td>

--- a/src/sentry/templates/sentry/emails/org-auth-token-created.txt
+++ b/src/sentry/templates/sentry/emails/org-auth-token-created.txt
@@ -8,7 +8,7 @@ User {{ actor.email }} has created a new Organization Auth Token "{{ token_name 
 Details
 -------
 
-Account: {{ account.email }}
+Account: {{ actor.email }}
 IP: {{ ip_address }}
 When: {{ datetime }} UTC
 {% block security_metadata %}{% endblock %}


### PR DESCRIPTION
@bruno-garcia correctly pointed out that in the security email sent for new org tokens created, we were showing the _owner_ image/name instead of the actor. It should now show the _actor_ in there, making it clear _who_ created an org token.