### PR TITLE
feat(github-comments): use org option

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -19,6 +19,7 @@ from sentry.models import (
     RepositoryProjectPathConfig,
 )
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import PullRequestCommit
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.base import instrumented_task
@@ -352,7 +353,13 @@ def process_commit_context(
                 },  # Updates date of an existing owner, since we just matched them with this new event
             )
 
-            if features.has("organizations:pr-comment-bot", project.organization):
+            if features.has(
+                "organizations:pr-comment-bot", project.organization
+            ) and OrganizationOption.objects.get_value(
+                organization=project.organization,
+                key="sentry:github_pr_bot",
+                default=True,
+            ):
                 logger.info(
                     "github.pr_comment",
                     extra={"organization_id": project.organization_id},

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -10,6 +10,7 @@ from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.models import PullRequest, PullRequestComment, Repository
 from sentry.models.commit import Commit
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import PullRequestCommit
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.snuba.sessions_v2 import isoformat_z
@@ -494,6 +495,24 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
 
     def test_gh_comment_feature_flag(self, mock_comment_workflow):
         """No comments on org with feature flag disabled"""
+        with self.tasks():
+            event_frames = get_frame_paths(self.event)
+            process_commit_context(
+                event_id=self.event.event_id,
+                event_platform=self.event.platform,
+                event_frames=event_frames,
+                group_id=self.event.group_id,
+                project_id=self.event.project_id,
+            )
+            assert not mock_comment_workflow.called
+
+    @with_feature("organizations:pr-comment-bot")
+    def test_gh_comment_org_option(self, mock_comment_workflow):
+        """No comments on org with organization option disabled"""
+        OrganizationOption.objects.set_value(
+            organization=self.project.organization, key="sentry:github_pr_bot", value=False
+        )
+
         with self.tasks():
             event_frames = get_frame_paths(self.event)
             process_commit_context(


### PR DESCRIPTION
Use the OrganizationOption `sentry:github_pr_bot` in addition to the feature flag to determine if we should comment on the pull request tied to a suspect commit.

For ER-1587