### PR TITLE
feat(github-comments): use internal feature flag

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -254,7 +254,7 @@ default_manager.add("organizations:codecov-integration", OrganizationFeature, Fe
 default_manager.add("organizations:codecov-commit-sha-from-git-blame", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:ds-sliding-window", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:ds-sliding-window-org", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:pr-comment-bot", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:pr-comment-bot", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:ds-org-recalibration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:sourcemaps-bundle-indexing", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -184,7 +184,6 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
         metrics.incr("github_pr_comment.error", tags={"type": "missing_org"})
         return
 
-    # TODO(cathy): add check for OrganizationOption for comment bot
     if not (
         features.has("organizations:pr-comment-bot", organization)
         and OrganizationOption.objects.get_value(


### PR DESCRIPTION
Use Sentry internal feature flag as opposed to Flagr for the Github PR Comment Bot.