### PR TITLE
fix: Wrong default topic on release health last_seen_updater

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -206,7 +206,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
         },
     },
     "metrics-last-seen-updater": {
-        "topic": settings.KAFKA_SNUBA_GENERIC_METRICS,
+        "topic": settings.KAFKA_SNUBA_METRICS,
         "strategy_factory": "sentry.sentry_metrics.consumers.last_seen_updater.LastSeenUpdaterStrategyFactory",
         "click_options": _METRICS_LAST_SEEN_UPDATER_OPTIONS,
         "static_args": {


### PR DESCRIPTION
We rolled this consumer out, and for a short while there were last-seen-updaters consuming from snuba-generic-metrics but writing into the release-health table. This is probably no big deal because it's just last-seen data, but if it was any other consumer we'd be in more trouble 😓 