### PR TITLE
ref(alerts): Remove max offset

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -650,8 +650,6 @@ class CombinedQuerysetPaginator:
         offset = page * cursor_value
         stop = offset + (int(cursor_value) or limit) + 1
 
-        if offset >= 26:
-            raise BadPaginationError("Pagination offset too large")
         if offset < 0:
             raise BadPaginationError("Pagination offset cannot be negative")
 


### PR DESCRIPTION
This is unneeded and causing issues on projects with large numbers of alerts.