### PR TITLE
feat(api): Truncate Project GET LatestRelease value

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -704,11 +704,8 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
                 project_env["environment__name"]
             )
 
-        # We just return the version key here so that we cut down on response size
-        latest_release_versions = {
-            release.actual_project_id: {"version": release.version}
-            for release in bulk_fetch_project_latest_releases(item_list)
-        }
+        # Only return the version key for the latest release to cut down on response size
+        latest_release_versions = _get_project_to_release_version_mapping(item_list)
 
         deploys_by_project = None
         if not self._collapse(LATEST_DEPLOYS_KEY):
@@ -766,7 +763,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
         return context
 
 
-def bulk_fetch_project_latest_releases(projects):
+def bulk_fetch_project_latest_releases(projects: Sequence[Project]):
     """
     Fetches the latest release for each of the passed projects
     :param projects:
@@ -816,6 +813,18 @@ def bulk_fetch_project_latest_releases(projects):
     )
 
 
+def _get_project_to_release_version_mapping(
+    item_list: Sequence[Project],
+) -> Dict[str, Dict[str, str]]:
+    """
+    Return mapping of project_ID -> release version for the latest release in each project
+    """
+    return {
+        release.actual_project_id: {"version": release.version}
+        for release in bulk_fetch_project_latest_releases(item_list)
+    }
+
+
 class DetailedProjectSerializer(ProjectWithTeamSerializer):
     def get_attrs(
         self, item_list: Sequence[Project], user: User, **kwargs: Any
@@ -841,16 +850,13 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
 
         orgs = {d["id"]: d for d in serialize(list({i.organization for i in item_list}), user)}
 
-        latest_release_list = bulk_fetch_project_latest_releases(item_list)
-        latest_releases = {
-            r.actual_project_id: d
-            for r, d in zip(latest_release_list, serialize(latest_release_list, user))
-        }
+        # Only return the version key for the latest release to cut down on response size
+        latest_release_versions = _get_project_to_release_version_mapping(item_list)
 
         for item in item_list:
             attrs[item].update(
                 {
-                    "latest_release": latest_releases.get(item.id),
+                    "latest_release": latest_release_versions.get(item.id),
                     "org": orgs[str(item.organization_id)],
                     "options": options_by_project[item.id],
                     "processing_issues": processing_issues_by_project.get(item.id, 0),

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from sentry import features
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import (
+    DetailedProjectSerializer,
     ProjectSummarySerializer,
     ProjectWithOrganizationSerializer,
     ProjectWithTeamSerializer,
@@ -657,6 +658,32 @@ class ProjectWithOrganizationSerializerTest(TestCase):
         assert result["name"] == project.name
         assert result["id"] == str(project.id)
         assert result["organization"] == serialize(organization, user)
+
+
+@region_silo_test
+class DetailedProjectSerializerTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.date = datetime.datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc)
+        self.user = self.create_user(username="foo")
+        self.organization = self.create_organization(owner=self.user)
+        team = self.create_team(organization=self.organization)
+        self.project = self.create_project(teams=[team], organization=self.organization, name="foo")
+        self.project.flags.has_releases = True
+        self.project.save()
+
+        self.release = self.create_release(self.project)
+
+    def test_truncated_latest_release(self):
+        result = serialize(self.project, self.user, DetailedProjectSerializer())
+
+        assert result["id"] == str(self.project.id)
+        assert result["name"] == self.project.name
+        assert result["slug"] == self.project.slug
+        assert result["firstEvent"] == self.project.first_event
+        assert "releases" in result["features"]
+        assert result["platform"] == self.project.platform
+        assert result["latestRelease"] == {"version": self.release.version}
 
 
 @region_silo_test


### PR DESCRIPTION
Hitting the proj GET returns a huge response body, where `latestRelease` is 235 lines. This will cut it down to just the release key and greatly shorten the body