### PR TITLE
ref(alerts): Fix indentation counting alerts

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -81,7 +81,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             for condition in rule.data["conditions"]:
                 if is_condition_slow(condition):
                     slow_rules += 1
-                break
+                    break
 
         if slow_rules >= settings.MAX_SLOW_CONDITION_ISSUE_ALERTS:
             return Response(


### PR DESCRIPTION
Fix the indentation so we count slow alerts correctly. 