### PR TITLE
ref(crons): Remove references to crons-issue-platform flag

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -518,7 +518,7 @@ class MonitorEnvironment(Model):
             organization = Organization.objects.get(id=self.monitor.organization_id)
             use_issue_platform = features.has(
                 "organizations:issue-platform", organization=organization
-            ) and features.has("organizations:crons-issue-platform", organization=organization)
+            )
         except Organization.DoesNotExist:
             pass
 

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -159,7 +159,7 @@ class MonitorTestCase(TestCase):
 
 @region_silo_test(stable=True)
 class MonitorEnvironmentTestCase(TestCase):
-    @with_feature({"organizations:crons-issue-platform": False})
+    @with_feature({"organizations:issue-platform": False})
     @patch("sentry.coreapi.insert_data_to_database_legacy")
     def test_mark_failed_default_params_legacy(self, mock_insert_data_to_database_legacy):
         monitor = Monitor.objects.create(
@@ -204,7 +204,7 @@ class MonitorEnvironmentTestCase(TestCase):
             },
         ) == dict(event)
 
-    @with_feature({"organizations:crons-issue-platform": False})
+    @with_feature({"organizations:issue-platform": False})
     @patch("sentry.coreapi.insert_data_to_database_legacy")
     def test_mark_failed_with_reason_legacy(self, mock_insert_data_to_database_legacy):
         monitor = Monitor.objects.create(
@@ -249,7 +249,7 @@ class MonitorEnvironmentTestCase(TestCase):
             },
         ) == dict(event)
 
-    @with_feature({"organizations:crons-issue-platform": False})
+    @with_feature({"organizations:issue-platform": False})
     @patch("sentry.coreapi.insert_data_to_database_legacy")
     def test_mark_failed_with_missed_reason_legacy(self, mock_insert_data_to_database_legacy):
         monitor = Monitor.objects.create(
@@ -298,7 +298,7 @@ class MonitorEnvironmentTestCase(TestCase):
             },
         ) == dict(event)
 
-    @with_feature(["organizations:issue-platform", "organizations:crons-issue-platform"])
+    @with_feature("organizations:issue-platform")
     @patch("sentry.issues.producer.produce_occurrence_to_kafka")
     def test_mark_failed_default_params_issue_platform(self, mock_produce_occurrence_to_kafka):
         monitor = Monitor.objects.create(
@@ -376,7 +376,7 @@ class MonitorEnvironmentTestCase(TestCase):
             },
         ) == dict(event)
 
-    @with_feature(["organizations:issue-platform", "organizations:crons-issue-platform"])
+    @with_feature("organizations:issue-platform")
     @patch("sentry.issues.producer.produce_occurrence_to_kafka")
     def test_mark_failed_with_reason_issue_platform(self, mock_produce_occurrence_to_kafka):
         monitor = Monitor.objects.create(
@@ -455,7 +455,7 @@ class MonitorEnvironmentTestCase(TestCase):
             },
         ) == dict(event)
 
-    @with_feature(["organizations:issue-platform", "organizations:crons-issue-platform"])
+    @with_feature("organizations:issue-platform")
     @patch("sentry.issues.producer.produce_occurrence_to_kafka")
     def test_mark_failed_with_missed_reason_issue_platform(self, mock_produce_occurrence_to_kafka):
         monitor = Monitor.objects.create(


### PR DESCRIPTION
Removes logical references to `crons-issue-platform` flag.

Rework of https://github.com/getsentry/sentry/pull/51291
Initial work for https://github.com/getsentry/getsentry/pull/10888
Final PR will remove the flag in settings