### PR TITLE
ref(alerts): Fix bug when hit max slow alerts

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -98,7 +98,10 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        if (len(rules) - slow_rules) >= settings.MAX_FAST_CONDITION_ISSUE_ALERTS:
+        if (
+            not new_rule_is_slow
+            and (len(rules) - slow_rules) >= settings.MAX_FAST_CONDITION_ISSUE_ALERTS
+        ):
             return Response(
                 {
                     "conditions": [

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -75,6 +75,12 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         if "filters" in data:
             conditions.extend(data["filters"])
 
+        new_rule_is_slow = False
+        for condition in conditions:
+            if is_condition_slow(condition):
+                new_rule_is_slow = True
+                break
+
         rules = Rule.objects.filter(project=project, status=RuleStatus.ACTIVE)
         slow_rules = 0
         for rule in rules:
@@ -83,7 +89,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                     slow_rules += 1
                     break
 
-        if slow_rules >= settings.MAX_SLOW_CONDITION_ISSUE_ALERTS:
+        if new_rule_is_slow and slow_rules >= settings.MAX_SLOW_CONDITION_ISSUE_ALERTS:
             return Response(
                 {
                     "conditions": [


### PR DESCRIPTION
Fix a bug where if you've already maxed out the "slow" alerts you can't create more "fast" alerts. This checks whether the new rule is slow or fast and only throws the error about exceeding the slow limit if the new rule conditions are slow.