### PR TITLE
feat(helpful-event): Pass contextual issue stream query into helpful event endpoint

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -86,6 +86,7 @@ function EventOrGroupHeader({
             hasSeen={hasSeen === undefined ? true : hasSeen}
             withStackTracePreview
             grouping={grouping}
+            query={query}
           />
         </ErrorBoundary>
       </Fragment>

--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -15,6 +15,7 @@ interface EventOrGroupTitleProps {
   className?: string;
   /* is issue breakdown? */
   grouping?: boolean;
+  query?: string;
   withStackTracePreview?: boolean;
 }
 
@@ -24,6 +25,7 @@ function EventOrGroupTitle({
   withStackTracePreview,
   grouping = false,
   className,
+  query,
 }: EventOrGroupTitleProps) {
   const {id, groupID} = data as Event;
 
@@ -41,6 +43,7 @@ function EventOrGroupTitle({
           groupId={groupID ? groupID : id}
           issueCategory={data.issueCategory}
           groupingCurrentLevel={data.metadata?.current_level}
+          query={query}
         >
           {titleLabel}
         </GroupPreviewTooltip>

--- a/static/app/components/groupPreviewTooltip/evidencePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/evidencePreview.tsx
@@ -14,6 +14,7 @@ import {space} from 'sentry/styles/space';
 type SpanEvidencePreviewProps = {
   children: ReactChild;
   groupId: string;
+  query?: string;
 };
 
 type SpanEvidencePreviewBodyProps = {
@@ -21,6 +22,7 @@ type SpanEvidencePreviewBodyProps = {
   onRequestBegin: () => void;
   onRequestEnd: () => void;
   onUnmount: () => void;
+  query?: string;
 };
 
 function SpanEvidencePreviewBody({
@@ -28,8 +30,9 @@ function SpanEvidencePreviewBody({
   onRequestEnd,
   onUnmount,
   groupId,
+  query,
 }: SpanEvidencePreviewBodyProps) {
-  const {data, isLoading, isError} = usePreviewEvent({groupId});
+  const {data, isLoading, isError} = usePreviewEvent({groupId, query});
 
   useEffect(() => {
     if (isLoading) {
@@ -75,7 +78,7 @@ function SpanEvidencePreviewBody({
   );
 }
 
-export function EvidencePreview({children, groupId}: SpanEvidencePreviewProps) {
+export function EvidencePreview({children, groupId, query}: SpanEvidencePreviewProps) {
   const {shouldShowLoadingState, onRequestBegin, onRequestEnd, reset} =
     useDelayedLoadingState();
 
@@ -88,6 +91,7 @@ export function EvidencePreview({children, groupId}: SpanEvidencePreviewProps) {
           onRequestEnd={onRequestEnd}
           onUnmount={reset}
           groupId={groupId}
+          query={query}
         />
       }
     >

--- a/static/app/components/groupPreviewTooltip/index.tsx
+++ b/static/app/components/groupPreviewTooltip/index.tsx
@@ -12,6 +12,7 @@ type GroupPreviewTooltipProps = {
   groupingCurrentLevel?: number;
   issueCategory?: IssueCategory;
   projectId?: string;
+  query?: string;
 };
 
 function GroupPreviewTooltip({
@@ -19,6 +20,7 @@ function GroupPreviewTooltip({
   groupId,
   groupingCurrentLevel,
   issueCategory,
+  query,
 }: GroupPreviewTooltipProps) {
   if (!issueCategory) {
     return null;
@@ -27,14 +29,26 @@ function GroupPreviewTooltip({
   switch (issueCategory) {
     case IssueCategory.ERROR:
       return (
-        <StackTracePreview groupId={groupId} groupingCurrentLevel={groupingCurrentLevel}>
+        <StackTracePreview
+          groupId={groupId}
+          groupingCurrentLevel={groupingCurrentLevel}
+          query={query}
+        >
           {children}
         </StackTracePreview>
       );
     case IssueCategory.PERFORMANCE:
-      return <SpanEvidencePreview groupId={groupId}>{children}</SpanEvidencePreview>;
+      return (
+        <SpanEvidencePreview groupId={groupId} query={query}>
+          {children}
+        </SpanEvidencePreview>
+      );
     default:
-      return <EvidencePreview groupId={groupId}>{children}</EvidencePreview>;
+      return (
+        <EvidencePreview groupId={groupId} query={query}>
+          {children}
+        </EvidencePreview>
+      );
   }
 }
 

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
@@ -15,6 +15,7 @@ import {EventTransaction} from 'sentry/types';
 type SpanEvidencePreviewProps = {
   children: ReactChild;
   groupId: string;
+  query?: string;
 };
 
 type SpanEvidencePreviewBodyProps = {
@@ -22,6 +23,7 @@ type SpanEvidencePreviewBodyProps = {
   onRequestBegin: () => void;
   onRequestEnd: () => void;
   onUnmount: () => void;
+  query?: string;
 };
 
 function SpanEvidencePreviewBody({
@@ -29,9 +31,11 @@ function SpanEvidencePreviewBody({
   onRequestBegin,
   onRequestEnd,
   onUnmount,
+  query,
 }: SpanEvidencePreviewBodyProps) {
   const {data, isLoading, isError} = usePreviewEvent<EventTransaction>({
     groupId,
+    query,
   });
 
   useEffect(() => {
@@ -71,7 +75,11 @@ function SpanEvidencePreviewBody({
   );
 }
 
-export function SpanEvidencePreview({children, groupId}: SpanEvidencePreviewProps) {
+export function SpanEvidencePreview({
+  children,
+  groupId,
+  query,
+}: SpanEvidencePreviewProps) {
   const {shouldShowLoadingState, onRequestBegin, onRequestEnd, reset} =
     useDelayedLoadingState();
 
@@ -84,6 +92,7 @@ export function SpanEvidencePreview({children, groupId}: SpanEvidencePreviewProp
           onRequestEnd={onRequestEnd}
           onUnmount={reset}
           groupId={groupId}
+          query={query}
         />
       }
     >

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
@@ -105,12 +105,13 @@ type StackTracePreviewProps = {
   eventId?: string;
   groupingCurrentLevel?: number;
   projectSlug?: string;
+  query?: string;
 };
 
 interface StackTracePreviewBodyProps
   extends Pick<
     StackTracePreviewProps,
-    'groupId' | 'eventId' | 'groupingCurrentLevel' | 'projectSlug'
+    'groupId' | 'eventId' | 'groupingCurrentLevel' | 'projectSlug' | 'query'
   > {
   onRequestBegin: () => void;
   onRequestEnd: () => void;
@@ -123,10 +124,11 @@ function StackTracePreviewBody({
   onRequestBegin,
   onRequestEnd,
   onUnmount,
+  query,
 }: StackTracePreviewBodyProps) {
   const organization = useOrganization();
 
-  const {data, isLoading, isError} = usePreviewEvent({groupId});
+  const {data, isLoading, isError} = usePreviewEvent({groupId, query});
 
   useEffect(() => {
     if (isLoading) {

--- a/static/app/components/groupPreviewTooltip/utils.tsx
+++ b/static/app/components/groupPreviewTooltip/utils.tsx
@@ -37,18 +37,33 @@ export function useDelayedLoadingState() {
   };
 }
 
-export function usePreviewEvent<T = Event>({groupId}: {groupId: string}) {
+export function usePreviewEvent<T = Event>({
+  groupId,
+  query,
+}: {
+  groupId: string;
+  query?: string;
+}) {
   const organization = useOrganization();
   const hasPrefetchIssueFeature = organization.features.includes(
     'issue-list-prefetch-issue-on-hover'
   );
+  const hasMostHelpfulEventFeature = organization.features.includes(
+    'issue-details-most-helpful-event'
+  );
+  const eventType = hasMostHelpfulEventFeature ? 'helpful' : 'latest';
 
   // This query should match the one on group details so that the event will
   // be fully loaded already if you preview then click.
   const eventQuery = useApiQuery<T>(
     [
-      `/issues/${groupId}/events/latest/`,
-      {query: getGroupEventDetailsQueryData({stacktraceOnly: !hasPrefetchIssueFeature})},
+      `/issues/${groupId}/events/${eventType}/`,
+      {
+        query: getGroupEventDetailsQueryData({
+          stacktraceOnly: !hasPrefetchIssueFeature,
+          query: hasMostHelpfulEventFeature ? query : undefined,
+        }),
+      },
     ],
     {staleTime: 30000, cacheTime: 30000}
   );

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -241,6 +241,7 @@ function useEventApiQuery({
   eventId?: string;
 }) {
   const organization = useOrganization();
+  const location = useLocation<{query?: string}>();
   const hasMostHelpfulEventFeature = organization.features.includes(
     'issue-details-most-helpful-event'
   );
@@ -248,7 +249,12 @@ function useEventApiQuery({
 
   const queryKey: ApiQueryKey = [
     `/issues/${groupId}/events/${eventIdUrl}/`,
-    {query: getGroupEventDetailsQueryData({environments})},
+    {
+      query: getGroupEventDetailsQueryData({
+        environments,
+        query: hasMostHelpfulEventFeature ? location.query.query : undefined,
+      }),
+    },
   ];
 
   const isLatestOrHelpfulEvent = eventIdUrl === 'latest' || eventIdUrl === 'helpful';

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -186,12 +186,17 @@ export function getGroupDetailsQueryData({
 
 export function getGroupEventDetailsQueryData({
   environments,
+  query,
   stacktraceOnly,
 }: {
   environments?: string[];
+  query?: string;
   stacktraceOnly?: boolean;
 } = {}): Record<string, string | string[]> {
-  const defaultParams = {collapse: stacktraceOnly ? ['stacktraceOnly'] : ['fullRelease']};
+  const defaultParams = {
+    collapse: stacktraceOnly ? ['stacktraceOnly'] : ['fullRelease'],
+    ...(query ? {query} : {}),
+  };
 
   if (!environments || isEmpty(environments)) {
     return defaultParams;


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/51770

Utilizes the work done here: https://github.com/getsentry/sentry/pull/51124

When coming from an issue stream search, events will be filtered down by the query they used to find the issue.