### PR TITLE
docs(api): Italicize string in docs

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -376,5 +376,7 @@ class TeamParams:
         location="query",
         required=False,
         type=str,
-        description='Specify "0" to return team details that do not include projects.',
+        description="""
+Specify `"0"` to return team details that do not include projects.
+""",
     )


### PR DESCRIPTION
Makes the `"0"` look better in docs

Before:
<img width="443" alt="Screenshot 2023-06-30 at 2 46 04 PM" src="https://github.com/getsentry/sentry/assets/67301797/7b4a9d36-b21d-4427-b99f-5364d8d4cf46">

After:
<img width="496" alt="Screenshot 2023-06-30 at 2 46 00 PM" src="https://github.com/getsentry/sentry/assets/67301797/308a6b08-fb81-4822-be29-a3ed92f2ab24">
