### PR TITLE
ref(auth): Refactor oauth_token.py

### DIFF
--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -87,9 +87,6 @@ class OAuthTokenView(View):
 
         return ApiToken.from_grant(grant)
 
-        # if grant.has_scope("openid"):
-        #     id_token = self._get_open_id_token()
-
     def _get_refresh_token(self, request):
         refresh_token = request.POST.get("refresh_token")
         scope = request.POST.get("scope")
@@ -143,6 +140,3 @@ class OAuthTokenView(View):
             ),
             content_type="application/json",
         )
-
-    def _get_open_id_token(self):
-        pass


### PR DESCRIPTION
UPDATE 07/02/2023 -> this PR is largely obsolete due to the work [here](https://github.com/getsentry/sentry/pull/52065). Feel free to ignore this PR and review that one instead.

-----

Breaks out a few helper functions for the large `POST` handler in our OAuth token endpoint. All this does is make the code more readable and easier to extend. We're adding OIDC and some more functionality to this endpoint soon, so this provides a more extensible base to build that on.

Also adds some nice new tests for edge cases not covered by the previous unit tests.