### PR TITLE
Query the bundle index in the artifact-lookup

### DIFF
--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -1,45 +1,32 @@
 import logging
-from datetime import datetime, timedelta
-from typing import List, Mapping, Optional, Sequence, Set, Tuple
+from typing import Dict, List, Optional, Sequence, Set, Tuple
 
-import pytz
-from django.db import router
 from django.http import Http404, HttpResponse, StreamingHttpResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
 from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import SymbolicError
 
-from sentry import options, ratelimits
+from sentry import ratelimits
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.endpoints.debug_files import has_download_permission
 from sentry.api.serializers import serialize
 from sentry.auth.system import is_system_auth
-from sentry.lang.native.sources import get_internal_artifact_lookup_source_url
-from sentry.models import (
-    ArtifactBundle,
-    DebugIdArtifactBundle,
-    Distribution,
-    Project,
-    ProjectArtifactBundle,
-    Release,
-    ReleaseArtifactBundle,
-    ReleaseFile,
+from sentry.debug_files.artifact_bundles import (
+    MAX_BUNDLES_QUERY,
+    query_artifact_bundles_containing_file,
 )
-from sentry.utils import metrics
-from sentry.utils.db import atomic_transaction
+from sentry.lang.native.sources import get_internal_artifact_lookup_source_url
+from sentry.models import ArtifactBundle, Distribution, Project, Release, ReleaseFile
+from sentry.models.artifactbundle import NULL_STRING
 
 logger = logging.getLogger("sentry.api")
 
 # The marker for "release" bundles
 RELEASE_BUNDLE_TYPE = "release.bundle"
-# The number of bundles ("artifact" or "release") that we query
-MAX_BUNDLES_QUERY = 5
 # The number of files returned by the `get_releasefiles` query
 MAX_RELEASEFILES_QUERY = 10
-# Number of days that determine whether an artifact bundle is ready for being renewed.
-AVAILABLE_FOR_RENEWAL_DAYS = 30
 
 
 @region_silo_endpoint
@@ -128,48 +115,34 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
             debug_id = normalize_debug_id(debug_id)
         except SymbolicError:
             pass
-        url = request.GET.get("url")
-        release_name = request.GET.get("release")
-        dist_name = request.GET.get("dist")
+        url = request.GET.get("url") or NULL_STRING
+        release_name = request.GET.get("release") or NULL_STRING
+        dist_name = request.GET.get("dist") or NULL_STRING
 
-        used_artifact_bundles = dict()
-        bundle_file_ids = set()
+        # First query all the files:
+        # We first do that using the `ArtifactBundle` infrastructure.
+        artifact_bundles = query_artifact_bundles_containing_file(
+            project, release_name, dist_name, url, debug_id
+        )
+        all_bundles: Dict[str, str] = {
+            f"artifact_bundle/{bundle_id}": resolved for bundle_id, resolved in artifact_bundles
+        }
 
-        def update_bundles(inner_bundles: Set[Tuple[int, datetime]], resolved: str):
-            for (bundle_id, date_added) in inner_bundles:
-                used_artifact_bundles[bundle_id] = date_added
-                bundle_file_ids.add((f"artifact_bundle/{bundle_id}", resolved))
-
-        if debug_id:
-            bundles = get_artifact_bundles_containing_debug_id(debug_id, project)
-            update_bundles(bundles, "debug-id")
-
-        individual_files = set()
-        if url and release_name and not bundle_file_ids:
-            # Get both the newest X release artifact bundles,
-            # and also query the legacy artifact bundles. One of those should have the
-            # file we are looking for. We want to return more here, even bundles that
-            # do *not* contain the file, rather than opening up each bundle. We want to
-            # avoid opening up bundles at all cost.
-            bundles = get_release_artifacts(project, release_name, dist_name)
-            update_bundles(bundles, "release")
-
+        # If no `ArtifactBundle`s were found matching the file, we fall back to
+        # looking up the file using the legacy `ReleaseFile` infrastructure.
+        individual_files = []
+        if not artifact_bundles:
             release, dist = try_resolve_release_dist(project, release_name, dist_name)
             if release:
                 for releasefile_id in get_legacy_release_bundles(release, dist):
-                    bundle_file_ids.add((f"release_file/{releasefile_id}", "release-old"))
+                    all_bundles[f"release_file/{releasefile_id}"] = "release-old"
                 individual_files = get_legacy_releasefile_by_file_url(release, dist, url)
-
-        if options.get("sourcemaps.artifact-bundles.enable-renewal") == 1.0:
-            with metrics.timer("artifact_lookup.get.renew_artifact_bundles"):
-                # Before constructing the response, we want to update the artifact bundles renewal date.
-                renew_artifact_bundles(used_artifact_bundles)
 
         # Then: Construct our response
         url_constructor = UrlConstructor(request, project)
 
         found_artifacts = []
-        for (download_id, resolved_with) in bundle_file_ids:
+        for (download_id, resolved_with) in all_bundles.items():
             found_artifacts.append(
                 {
                     "id": download_id,
@@ -210,84 +183,8 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
         return Response(serialize(found_artifacts, request.user))
 
 
-def renew_artifact_bundles(used_artifact_bundles: Mapping[int, datetime]):
-    # We take a snapshot in time that MUST be consistent across all updates.
-    now = datetime.now(tz=pytz.UTC)
-    # We compute the threshold used to determine whether we want to renew the specific bundle.
-    threshold_date = now - timedelta(days=AVAILABLE_FOR_RENEWAL_DAYS)
-
-    for (artifact_bundle_id, date_added) in used_artifact_bundles.items():
-        metrics.incr("artifact_lookup.get.renew_artifact_bundles.should_be_renewed")
-        # We perform the condition check also before running the query, in order to reduce the amount of queries to the
-        # database.
-        if date_added <= threshold_date:
-            # We want to use a transaction, in order to keep the `date_added` consistent across multiple tables.
-            with atomic_transaction(
-                using=(
-                    router.db_for_write(ArtifactBundle),
-                    router.db_for_write(ProjectArtifactBundle),
-                    router.db_for_write(ReleaseArtifactBundle),
-                    router.db_for_write(DebugIdArtifactBundle),
-                )
-            ):
-                # We check again for the date_added condition in order to achieve consistency, this is done because
-                # the `can_be_renewed` call is using a time which differs from the one of the actual update in the db.
-                updated_rows_count = ArtifactBundle.objects.filter(
-                    id=artifact_bundle_id, date_added__lte=threshold_date
-                ).update(date_added=now)
-                # We want to make cascading queries only if there were actual changes in the db.
-                if updated_rows_count > 0:
-                    ProjectArtifactBundle.objects.filter(
-                        artifact_bundle_id=artifact_bundle_id, date_added__lte=threshold_date
-                    ).update(date_added=now)
-                    ReleaseArtifactBundle.objects.filter(
-                        artifact_bundle_id=artifact_bundle_id, date_added__lte=threshold_date
-                    ).update(date_added=now)
-                    DebugIdArtifactBundle.objects.filter(
-                        artifact_bundle_id=artifact_bundle_id, date_added__lte=threshold_date
-                    ).update(date_added=now)
-
-            # If the transaction succeeded, and we did actually modify some rows, we want to track the metric.
-            if updated_rows_count > 0:
-                metrics.incr("artifact_lookup.get.renew_artifact_bundles.renewed")
-
-
-def get_artifact_bundles_containing_debug_id(
-    debug_id: str, project: Project
-) -> Set[Tuple[int, datetime]]:
-    # We want to have the newest `File` for each `debug_id`.
-    return set(
-        ArtifactBundle.objects.filter(
-            organization_id=project.organization.id,
-            projectartifactbundle__project_id=project.id,
-            debugidartifactbundle__debug_id=debug_id,
-        )
-        .values_list("id", "date_added")
-        .order_by("-date_uploaded")[:1]
-    )
-
-
-def get_release_artifacts(
-    project: Project,
-    release_name: str,
-    dist_name: Optional[str],
-) -> Set[Tuple[int, datetime]]:
-    return set(
-        ArtifactBundle.objects.filter(
-            organization_id=project.organization.id,
-            projectartifactbundle__project_id=project.id,
-            releaseartifactbundle__release_name=release_name,
-            # In case no dist is provided, we will fall back to "" which is the NULL equivalent for our tables.
-            # See `_create_artifact_bundle` in `src/sentry/tasks/assemble.py` for the reference.
-            releaseartifactbundle__dist_name=dist_name or "",
-        )
-        .values_list("id", "date_added")
-        .order_by("-date_uploaded")[:MAX_BUNDLES_QUERY]
-    )
-
-
 def try_resolve_release_dist(
-    project: Project, release_name: str, dist_name: Optional[str]
+    project: Project, release_name: str, dist_name: str
 ) -> Tuple[Optional[Release], Optional[Distribution]]:
     release = None
     dist = None

--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -1,21 +1,41 @@
-from typing import List
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict, List, Set, Tuple
 
 import sentry_sdk
 from django.conf import settings
 from django.db import router
+from django.db.models import Count
+from django.utils import timezone
 
+from sentry import options
 from sentry.models.artifactbundle import (
+    INDEXING_THRESHOLD,
     ArtifactBundle,
     ArtifactBundleArchive,
     ArtifactBundleIndex,
     ArtifactBundleIndexingState,
+    DebugIdArtifactBundle,
+    ProjectArtifactBundle,
+    ReleaseArtifactBundle,
 )
+from sentry.models.project import Project
 from sentry.utils import metrics, redis
 from sentry.utils.db import atomic_transaction
+
+# The number of Artifact Bundles that we return in case of incomplete indexes.
+MAX_BUNDLES_QUERY = 5
+
+# Number of days that determine whether an artifact bundle is ready for being renewed.
+AVAILABLE_FOR_RENEWAL_DAYS = 30
 
 # We want to keep the bundle as being indexed for 600 seconds = 10 minutes. We might need to revise this number and
 # optimize it based on the time taken to perform the indexing (on average).
 INDEXING_CACHE_TIMEOUT = 600
+
+
+# ===== Indexing of Artifact Bundles =====
 
 
 def get_redis_cluster_for_artifact_bundles():
@@ -139,3 +159,220 @@ def _index_urls_in_bundle(
 
         metrics.incr("artifact_bundle_indexing.bundles_indexed")
         metrics.incr("artifact_bundle_indexing.urls_indexed", len(urls_to_index))
+
+
+# ===== Renewal of Artifact Bundles =====
+
+
+def maybe_renew_artifact_bundles(used_artifact_bundles: Dict[int, datetime]):
+    if options.get("sourcemaps.artifact-bundles.enable-renewal") == 1.0:
+        with metrics.timer("artifact_bundle_renewal"):
+            renew_artifact_bundles(used_artifact_bundles)
+
+
+def renew_artifact_bundles(used_artifact_bundles: Dict[int, datetime]):
+    # We take a snapshot in time that MUST be consistent across all updates.
+    now = timezone.now()
+    # We compute the threshold used to determine whether we want to renew the specific bundle.
+    threshold_date = now - timedelta(days=AVAILABLE_FOR_RENEWAL_DAYS)
+
+    for (artifact_bundle_id, date_added) in used_artifact_bundles.items():
+        # We perform the condition check also before running the query, in order to reduce the amount of queries to the database.
+        if date_added <= threshold_date:
+            metrics.incr("artifact_bundle_renewal.need_renewal")
+            # We want to use a transaction, in order to keep the `date_added` consistent across multiple tables.
+            with atomic_transaction(
+                using=(
+                    router.db_for_write(ArtifactBundle),
+                    router.db_for_write(ProjectArtifactBundle),
+                    router.db_for_write(ReleaseArtifactBundle),
+                    router.db_for_write(DebugIdArtifactBundle),
+                    router.db_for_write(ArtifactBundleIndex),
+                )
+            ):
+                # We check again for the date_added condition in order to achieve consistency, this is done because
+                # the `can_be_renewed` call is using a time which differs from the one of the actual update in the db.
+                updated_rows_count = ArtifactBundle.objects.filter(
+                    id=artifact_bundle_id, date_added__lte=threshold_date
+                ).update(date_added=now)
+                # We want to make cascading queries only if there were actual changes in the db.
+                if updated_rows_count > 0:
+                    ProjectArtifactBundle.objects.filter(
+                        artifact_bundle_id=artifact_bundle_id, date_added__lte=threshold_date
+                    ).update(date_added=now)
+                    ReleaseArtifactBundle.objects.filter(
+                        artifact_bundle_id=artifact_bundle_id, date_added__lte=threshold_date
+                    ).update(date_added=now)
+                    DebugIdArtifactBundle.objects.filter(
+                        artifact_bundle_id=artifact_bundle_id, date_added__lte=threshold_date
+                    ).update(date_added=now)
+                    ArtifactBundleIndex.objects.filter(
+                        artifact_bundle_id=artifact_bundle_id, date_added__lte=threshold_date
+                    ).update(date_added=now)
+
+            # If the transaction succeeded, and we did actually modify some rows, we want to track the metric.
+            if updated_rows_count > 0:
+                metrics.incr("artifact_bundle_renewal.were_renewed")
+
+
+# ===== Querying of Artifact Bundles =====
+
+
+def _maybe_renew_and_return_bundles(
+    bundles: Dict[int, Tuple[datetime, str]]
+) -> List[Tuple[int, str]]:
+    maybe_renew_artifact_bundles(
+        {id: date_added for id, (date_added, _resolved) in bundles.items()}
+    )
+
+    return [(id, resolved) for id, (_date_added, resolved) in bundles.items()]
+
+
+def query_artifact_bundles_containing_file(
+    project: Project,
+    release: str,
+    dist: str,
+    url: str,
+    debug_id: str | None,
+) -> List[Tuple[int, str]]:
+    """
+    This looks up the artifact bundles that satisfy the query consisting of
+    `release`, `dist`, `url` and `debug_id`.
+
+    This function should ideally return a single bundle containing the file matching
+    the query. However it can also return more than a single bundle in case no
+    complete index is available, in which case the N most recent bundles will be
+    returned under the assumption that one of those may contain the file.
+
+    Along the bundles `id`, it also returns the most-precise method the bundles
+    was resolved with.
+    """
+
+    if debug_id:
+        bundles = get_artifact_bundles_containing_debug_id(project, debug_id)
+        if bundles:
+            return _maybe_renew_and_return_bundles(
+                {id: (date_added, "debug-id") for id, date_added in bundles}
+            )
+
+    total_release_bundles, not_indexed = get_release_indexing_state(project, release, dist)
+
+    if not total_release_bundles:
+        return []
+
+    # If all the bundles for this release are full indexed, we will only query
+    # the url index.
+    # Otherwise, if we are below the threshold, or only partially indexed, we
+    # want to return the N most recent bundles associated with the release,
+    # under the assumption that one of those should ideally contain the file we
+    # are looking for.
+    partially_indexed = total_release_bundles <= INDEXING_THRESHOLD
+
+    if total_release_bundles > INDEXING_THRESHOLD and not_indexed:
+        partially_indexed = True
+        metrics.incr("artifact_bundle_indexing.query_partial_index")
+        # TODO: spawn an async task to backfill non-indexed bundles
+        # lets do this in a different PR though :-)
+
+    # We keep track of all the discovered artifact bundles, by the various means of lookup.
+    # We are intentionally overwriting the `resolved` flag, as we want to rank these from
+    # coarse-grained to fine-grained.
+    artifact_bundles: Dict[int, Tuple[datetime, str]] = dict()
+
+    def update_bundles(bundles: Set[Tuple[int, datetime]], resolved: str):
+        for (bundle_id, date_added) in bundles:
+            artifact_bundles[bundle_id] = (date_added, resolved)
+
+    # First, get the N most recently uploaded bundles for the release,
+    # but only if the index is only partial:
+    if partially_indexed:
+        bundles = get_artifact_bundles_by_release(project, release, dist)
+        update_bundles(bundles, "release")
+
+    # Then, we are matching by `url`:
+    if url:
+        bundles = get_artifact_bundles_containing_url(project, release, dist, url)
+        update_bundles(bundles, "index")
+
+    return _maybe_renew_and_return_bundles(artifact_bundles)
+
+
+def get_release_indexing_state(project: Project, release_name: str, dist_name: str):
+    """
+    Returns the number of total bundles, and the number of not-yet-indexed bundles
+    associated with the given `release` / `dist`.
+    """
+    not_indexed = 0
+    total_bundles = 0
+
+    for state, count in (
+        ArtifactBundle.objects.filter(
+            organization_id=project.organization.id,
+            projectartifactbundle__project_id=project.id,
+            releaseartifactbundle__release_name=release_name,
+            releaseartifactbundle__dist_name=dist_name,
+        )
+        .values_list("indexing_state")
+        .annotate(count=Count("*"))
+    ):
+        if state == ArtifactBundleIndexingState.NOT_INDEXED.value:
+            not_indexed = count
+        total_bundles += count
+
+    return (total_bundles, not_indexed)
+
+
+def get_artifact_bundles_containing_debug_id(
+    project: Project, debug_id: str
+) -> Set[Tuple[int, datetime]]:
+    """
+    Returns the most recently uploaded artifact bundle containing the given `debug_id`.
+    """
+    return set(
+        ArtifactBundle.objects.filter(
+            organization_id=project.organization.id,
+            projectartifactbundle__project_id=project.id,
+            debugidartifactbundle__debug_id=debug_id,
+        )
+        .values_list("id", "date_added")
+        .order_by("-date_uploaded")[:1]
+    )
+
+
+def get_artifact_bundles_containing_url(
+    project: Project, release_name: str, dist_name: str, url: str
+) -> Set[Tuple[int, datetime]]:
+    """
+    Returns the most recently uploaded bundle containing a file matching the `release`, `dist` and `url`.
+    """
+    return set(
+        ArtifactBundleIndex.objects.filter(
+            organization_id=project.organization.id,
+            release_name=release_name,
+            dist_name=dist_name,
+            url=url,
+            artifact_bundle__projectartifactbundle__project_id=project.id,
+        ).values_list("artifact_bundle_id", "date_added")
+        # we want to always return the most recent bundle matching the file
+        .order_by("-date_last_modified", "-artifact_bundle_id")[:1]
+    )
+
+
+def get_artifact_bundles_by_release(
+    project: Project,
+    release_name: str,
+    dist_name: str,
+) -> Set[Tuple[int, datetime]]:
+    """
+    Returns up to N most recently uploaded bundles for the given `release` and `dist`.
+    """
+    return set(
+        ArtifactBundle.objects.filter(
+            organization_id=project.organization.id,
+            projectartifactbundle__project_id=project.id,
+            releaseartifactbundle__release_name=release_name,
+            releaseartifactbundle__dist_name=dist_name,
+        )
+        .values_list("id", "date_added")
+        .order_by("-date_uploaded")[:MAX_BUNDLES_QUERY]
+    )


### PR DESCRIPTION
This moves all the code related to querying `ArtifactBundle`s into a more appropriate location, and hooks that up to the `artifact-lookup` API.
Also adds a place where a re-index could be triggered in case not all the necessary bundles are properly indexed.