### PR TITLE
chore: Prevent committing to master

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,3 +76,4 @@ repos:
     - id: debug-statements
     - id: name-tests-test
       args: [--pytest-test-first]
+    - id: no-commit-to-branch


### PR DESCRIPTION
Prevent committing to master via pre-commit hook.

There is no proper reason to commit to master, as we don't allow pushing to master. Sometimes you may commit to master by accident. Then you, anyways, have to create a new branch and then reset master again.


