### PR TITLE
ref(setup-wizard): Reduce number of queries and remove query limits

### DIFF
--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -60,28 +60,34 @@ class SetupWizardView(BaseView):
             member_set__role__in=[x.id for x in roles.with_scope("org:read")],
             member_set__user_id=request.user.id,
             status=OrganizationStatus.ACTIVE,
-        ).order_by("-date_added")[:50]
+        ).order_by("-date_added")
+
+        projects = Project.objects.filter(organization__in=orgs, status=ObjectStatus.ACTIVE)
+
+        keys = ProjectKey.objects.filter(
+            project__in=projects,
+            roles=F("roles").bitor(ProjectKey.roles.store),
+            status=ProjectKeyStatus.ACTIVE,
+        )
+
+        orgs_map = {}
+        for org in orgs:
+            orgs_map[org.id] = org
+
+        keys_map = {}
+        for key in keys:
+            if key.project_id not in keys_map:
+                keys_map[key.project_id] = [key]
+            else:
+                keys_map[key.project_id].append(key)
 
         filled_projects = []
 
-        for org in orgs:
-            projects = list(
-                Project.objects.filter(organization=org, status=ObjectStatus.ACTIVE).order_by(
-                    "-date_added"
-                )[:50]
-            )
-            for project in projects:
-                enriched_project = serialize(project)
-                enriched_project["organization"] = serialize(org)
-                keys = list(
-                    ProjectKey.objects.filter(
-                        project=project,
-                        roles=F("roles").bitor(ProjectKey.roles.store),
-                        status=ProjectKeyStatus.ACTIVE,
-                    )
-                )
-                enriched_project["keys"] = serialize(keys)
-                filled_projects.append(enriched_project)
+        for project in projects:
+            enriched_project = serialize(project)
+            enriched_project["organization"] = serialize(orgs_map[project.organization_id])
+            enriched_project["keys"] = serialize(keys_map.get(project.id, []))
+            filled_projects.append(enriched_project)
 
         # Fetching or creating a token
         token = None

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -2,7 +2,10 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY
+from sentry.api.serializers import serialize
 from sentry.cache import default_cache
+from sentry.models.apitoken import ApiToken
+from sentry.models.projectkey import ProjectKey
 from sentry.testutils import PermissionTestCase
 from sentry.testutils.silo import control_silo_test
 
@@ -62,6 +65,54 @@ class SetupWizard(PermissionTestCase):
         assert cached.get("projects")[0].get("status") == "active"
         assert cached.get("projects")[0].get("keys")[0].get("isActive")
         assert cached.get("projects")[0].get("organization").get("status").get("id") == "active"
+
+    def test_project_multiple_keys(self):
+        self.org = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.org, name="Mariachi Band")
+        self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
+
+        self.project.key_set.add(ProjectKey.objects.create(project=self.project, label="abc"))
+
+        self.login_as(self.user)
+
+        key = f"{SETUP_WIZARD_CACHE_KEY}abc"
+        default_cache.set(key, "test", 600)
+
+        url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "abc"})
+        resp = self.client.get(url)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/setup-wizard.html")
+        cached = default_cache.get(key)
+
+        assert len(cached.get("projects")[0].get("keys")) == 2
+
+    def test_auth_token(self):
+        user_api_token = ApiToken.objects.create_or_update(
+            user=self.user,
+            scope_list=["project:releases"],
+            refresh_token=None,
+            expires_at=None,
+        )[0]
+        self.org = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.org, name="Mariachi Band")
+        self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
+
+        self.project.key_set.add(ProjectKey.objects.create(project=self.project, label="abc"))
+
+        self.login_as(self.user)
+
+        key = f"{SETUP_WIZARD_CACHE_KEY}abc"
+        default_cache.set(key, "test", 600)
+
+        url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "abc"})
+        resp = self.client.get(url)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/setup-wizard.html")
+        cached = default_cache.get(key)
+
+        assert cached.get("apiKeys") == serialize(user_api_token)
 
     @override_settings(SENTRY_SIGNUP_URL="https://sentry.io/signup/")
     def test_redirect_to_signup(self):


### PR DESCRIPTION
This PR refactors `SetupWizardView` to significantly reduce the number of necessary queries to obtain the enhanced project data. This was done by eliminating a N+1-like query cascade that would:

1. query all orgs of a user (limit to 50)
2. for each org query all projects (limit to 50 per org)
3. for each project of each org query all keys (DSNs). 

As calculated in https://github.com/getsentry/sentry/pull/51784#discussion_r1245279115 this could lead up to 2.5k queries in the worst case. In an initial attempt (https://github.com/getsentry/sentry/pull/51784), I wanted to increase the limit of 50 orgs/projects but this would have [blown up](https://github.com/getsentry/sentry/pull/51784#discussion_r1245273908) the worst case number of queries to over 50k - not a great idea 😅 

Instead, we make use of the IN operator to reduce this to three queries for the whole operation:
1. query all orgs
2. query all projects of all orgs
3. query all keys of all projects of all orgs

Besides obviously reducing the query count, we also can get rid of the limits which means that the Sentry wizard (`@sentry/wizard`) will now finally show _all_ projects of a user. 

h/t @iambriccardo and @beezz for the help! 