### PR TITLE
feat(sdk-crash-detection): Remove SDK frame path

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event.py
+++ b/fixtures/sdk_crash_detection/crash_event.py
@@ -1,4 +1,4 @@
-from typing import Any, Collection, Dict, Mapping, Sequence
+from typing import Any, Collection, Dict, Mapping, MutableMapping, Sequence
 
 IN_APP_FRAME = {
     "function": "LoginViewController.viewDidAppear",
@@ -15,7 +15,7 @@ IN_APP_FRAME = {
 }
 
 
-def get_sentry_frame(function: str, in_app: bool = False) -> Mapping[str, Any]:
+def get_sentry_frame(function: str, in_app: bool = False) -> MutableMapping[str, Any]:
     return {
         "function": function,
         "package": "/private/var/containers/Bundle/Application/59E988EF-46DB-4C75-8E08-10C27DC3E90E/iOS-Swift.app/Frameworks/Sentry.framework/Sentry",
@@ -24,7 +24,9 @@ def get_sentry_frame(function: str, in_app: bool = False) -> Mapping[str, Any]:
     }
 
 
-def get_frames(function: str, sentry_frame_in_app: bool = False) -> Sequence[Mapping[str, Any]]:
+def get_frames(
+    function: str, sentry_frame_in_app: bool = False
+) -> Sequence[MutableMapping[str, Any]]:
     frames = [
         get_sentry_frame(function, sentry_frame_in_app),
         {

--- a/src/sentry/utils/sdk_crashes/event_stripper.py
+++ b/src/sentry/utils/sdk_crashes/event_stripper.py
@@ -171,7 +171,7 @@ def _strip_frames(
 
             # The path field usually contains the name of the application, which we can't keep.
             for field in fields_containing_paths:
-                if frame.get(field) is not None:
+                if frame.get(field):
                     frame[field] = "Sentry.framework"
         else:
             frame["in_app"] = False

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -190,7 +190,7 @@ class EventStripperTestMixin(BaseEventStripperMixin):
         cocoa_sdk_frame = stripped_frames[-1]
         assert cocoa_sdk_frame == {
             "function": "SentryCrashMonitor_CPPException.cpp",
-            "package": "/private/var/containers/Bundle/Application/59E988EF-46DB-4C75-8E08-10C27DC3E90E/iOS-Swift.app/Frameworks/Sentry.framework/Sentry",
+            "package": "Sentry.framework",
             "in_app": True,
             "image_addr": "0x100304000",
         }
@@ -208,7 +208,6 @@ class EventStripperTestMixin(BaseEventStripperMixin):
         )
 
         assert first_frame == {
-            "filename": "EventStripperTestFrame.swift",
             "function": "function",
             "raw_function": "raw_function",
             "module": "module",
@@ -262,7 +261,38 @@ class EventStripperTestMixin(BaseEventStripperMixin):
         cocoa_sdk_frame = stripped_frames[-1]
         assert cocoa_sdk_frame == {
             "function": "SentryCrashMonitor_CPPException.cpp",
-            "package": "/private/var/containers/Bundle/Application/59E988EF-46DB-4C75-8E08-10C27DC3E90E/iOS-Swift.app/Frameworks/Sentry.framework/Sentry",
+            "package": "Sentry.framework",
+            "in_app": True,
+            "image_addr": "0x100304000",
+        }
+
+    def test_strip_frames_sdk_frames(self):
+        frames = get_frames("SentryCrashMonitor_CPPException.cpp", sentry_frame_in_app=False)
+        # When statically linked the package or module is usually set to the app name
+        sentry_sdk_frame = frames[-1]
+        sentry_sdk_frame["package"] = "SomeApp"
+        sentry_sdk_frame["module"] = "SomeModule"
+        sentry_sdk_frame["abs_path"] = "SomeApp/SentryDispatchQueueWrapper.m"
+
+        event_data = get_crash_event_with_frames(frames)
+
+        event = self.create_event(
+            data=event_data,
+            project_id=self.project.id,
+        )
+
+        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+
+        stripped_frames = get_path(
+            stripped_event_data, "exception", "values", -1, "stacktrace", "frames"
+        )
+
+        cocoa_sdk_frame = stripped_frames[-1]
+        assert cocoa_sdk_frame == {
+            "function": "SentryCrashMonitor_CPPException.cpp",
+            "package": "Sentry.framework",
+            "abs_path": "Sentry.framework",
+            "module": "Sentry.framework",
             "in_app": True,
             "image_addr": "0x100304000",
         }


### PR DESCRIPTION
Remove the path for SDK frames cause they usually contain the application's name.

Closes #52081