### PR TITLE
ref(inbound-filters) Remove unused inbound filter health-check feature

### DIFF
--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -54,7 +54,7 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
         Update various inbound data filters for a project.
         """
 
-        for flt in inbound_filters.get_all_filter_specs(project):
+        for flt in inbound_filters.get_all_filter_specs():
             if flt.id == filter_id:
                 current_filter = flt
                 break

--- a/src/sentry/api/endpoints/project_filters.py
+++ b/src/sentry/api/endpoints/project_filters.py
@@ -18,7 +18,7 @@ class ProjectFiltersEndpoint(ProjectEndpoint):
 
         """
         results = []
-        for flt in inbound_filters.get_all_filter_specs(project):
+        for flt in inbound_filters.get_all_filter_specs():
             results.append(
                 {
                     "id": flt.id,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1647,8 +1647,6 @@ SENTRY_FEATURES = {
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.
     "projects:custom-inbound-filters": False,
-    # Enable specifying inbound filter for health check calls.
-    "organizations:health-check-filter": False,
     # Enable data forwarding functionality for projects.
     "projects:data-forwarding": True,
     # Enable functionality to discard groups.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -255,7 +255,6 @@ default_manager.add("organizations:codecov-integration", OrganizationFeature, Fe
 default_manager.add("organizations:codecov-commit-sha-from-git-blame", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:ds-sliding-window", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:ds-sliding-window-org", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:health-check-filter", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:pr-comment-bot", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:ds-org-recalibration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 
-from sentry import features
 from sentry.api.fields.multiplechoice import MultipleChoiceField
 from sentry.models import ProjectOption
 from sentry.relay.utils import to_camel_case_name
@@ -52,7 +51,7 @@ def get_filter_key(flt):
     return to_camel_case_name(flt.config_name.replace("-", "_"))
 
 
-def get_all_filter_specs(project):
+def get_all_filter_specs():
     """
     Return metadata about the filters known by Sentry.
 
@@ -66,16 +65,14 @@ def get_all_filter_specs(project):
         _browser_extensions_filter,
         _legacy_browsers_filter,
         _web_crawlers_filter,
+        _healthcheck_filter,
     ]
-
-    if features.has("organizations:health-check-filter", project.organization):
-        filters.append(_healthcheck_filter)
 
     return tuple(filters)  # returning tuple for backwards compatibility
 
 
 def set_filter_state(filter_id, project, state):
-    flt = _filter_from_filter_id(filter_id, project)
+    flt = _filter_from_filter_id(filter_id)
     if flt is None:
         raise FilterNotRegistered(filter_id)
 
@@ -124,7 +121,7 @@ def get_filter_state(filter_id, project):
     :return: True if the filter is enabled False otherwise
     :raises: ValueError if filter id not registered
     """
-    flt = _filter_from_filter_id(filter_id, project)
+    flt = _filter_from_filter_id(filter_id)
     if flt is None:
         raise FilterNotRegistered(filter_id)
 
@@ -153,11 +150,11 @@ class FilterNotRegistered(Exception):
     pass
 
 
-def _filter_from_filter_id(filter_id, project):
+def _filter_from_filter_id(filter_id):
     """
     Returns the corresponding filter for a filter id or None if no filter with the given id found
     """
-    for flt in get_all_filter_specs(project):
+    for flt in get_all_filter_specs():
         if flt.id == filter_id:
             return flt
     return None

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -119,7 +119,7 @@ def get_public_key_configs(
 def get_filter_settings(project: Project) -> Mapping[str, Any]:
     filter_settings = {}
 
-    for flt in get_all_filter_specs(project):
+    for flt in get_all_filter_specs():
         filter_id = get_filter_key(flt)
         settings = _load_filter_settings(flt, project)
 

--- a/tests/sentry/api/endpoints/snapshots/ProjectFiltersTest/test_get.pysnap
+++ b/tests/sentry/api/endpoints/snapshots/ProjectFiltersTest/test_get.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-09T11:33:30.140674Z'
+created: '2023-07-04T12:49:12.065585Z'
 creator: sentry
 source: tests/sentry/api/endpoints/test_project_filters.py
 ---
@@ -14,6 +14,12 @@ source: tests/sentry/api/endpoints/test_project_filters.py
   hello: localhost - Filter out events coming from localhost
   id: localhost
   name: Filter out events coming from localhost
+- active: true
+  description: Filter transactions that match most common naming patterns for health
+    checks.
+  hello: filtered-transaction - Filter out health check transactions
+  id: filtered-transaction
+  name: Filter out health check transactions
 - active: false
   description: Older browsers often give less accurate information, and while they
     may report valid issues, the context to understand them is incorrect or missing.

--- a/tests/sentry/api/endpoints/test_project_filter_details.py
+++ b/tests/sentry/api/endpoints/test_project_filter_details.py
@@ -23,7 +23,7 @@ class ProjectFilterDetailsTest(APITestCase):
 
         assert project.get_option("filters:browser-extensions") == "1"
 
-    def test_put_health_check_filter_business(self):
+    def test_put_health_check_filter(self):
         """
         Tests that it accepts to set the health-check filter when the feature flag is enabled
         """
@@ -43,24 +43,6 @@ class ProjectFilterDetailsTest(APITestCase):
             org.slug, project.slug, "filtered-transaction", active=False, status_code=204
         )
         # option was changed by the request
-        assert project.get_option("filters:filtered-transaction") == "0"
-
-    def test_put_health_check_filter_free_plan(self):
-        """
-        Tests that it does not accept to set the health-check filter on plans that
-        do not allow it ( free plans)
-        """
-        org = self.create_organization(name="baz", slug="1", owner=self.user)
-        team = self.create_team(organization=org, name="foo", slug="foo")
-        project = self.create_project(name="Bar", slug="bar", teams=[team])
-
-        project.update_option("filters:filtered-transaction", "0")
-        resp = self.get_response(
-            org.slug, project.slug, "filtered-transaction", active=True, status_code=204
-        )
-        # check we return error
-        assert resp.status_code == 404
-        # check we did not touch the option (the request did not change anything)
         assert project.get_option("filters:filtered-transaction") == "0"
 
     def test_put_legacy_browsers(self):

--- a/tests/sentry/api/endpoints/test_project_filter_details.py
+++ b/tests/sentry/api/endpoints/test_project_filter_details.py
@@ -1,5 +1,4 @@
 from sentry.testutils import APITestCase
-from sentry.testutils.helpers import Feature
 from sentry.testutils.silo import region_silo_test
 
 
@@ -33,18 +32,16 @@ class ProjectFilterDetailsTest(APITestCase):
         project = self.create_project(name="Bar", slug="bar", teams=[team])
 
         project.update_option("filters:filtered-transaction", "0")
-        with Feature("organizations:health-check-filter"):
-            self.get_success_response(
-                org.slug, project.slug, "filtered-transaction", active=True, status_code=204
-            )
+        self.get_success_response(
+            org.slug, project.slug, "filtered-transaction", active=True, status_code=204
+        )
         # option was changed by the request
         assert project.get_option("filters:filtered-transaction") == "1"
 
         project.update_option("filters:filtered-transaction", "1")
-        with Feature("organizations:health-check-filter"):
-            self.get_success_response(
-                org.slug, project.slug, "filtered-transaction", active=False, status_code=204
-            )
+        self.get_success_response(
+            org.slug, project.slug, "filtered-transaction", active=False, status_code=204
+        )
         # option was changed by the request
         assert project.get_option("filters:filtered-transaction") == "0"
 
@@ -58,10 +55,9 @@ class ProjectFilterDetailsTest(APITestCase):
         project = self.create_project(name="Bar", slug="bar", teams=[team])
 
         project.update_option("filters:filtered-transaction", "0")
-        with Feature({"organizations:health-check-filter": False}):
-            resp = self.get_response(
-                org.slug, project.slug, "filtered-transaction", active=True, status_code=204
-            )
+        resp = self.get_response(
+            org.slug, project.slug, "filtered-transaction", active=True, status_code=204
+        )
         # check we return error
         assert resp.status_code == 404
         # check we did not touch the option (the request did not change anything)

--- a/tests/sentry/api/endpoints/test_project_filters.py
+++ b/tests/sentry/api/endpoints/test_project_filters.py
@@ -1,5 +1,4 @@
 from sentry.testutils import APITestCase
-from sentry.testutils.helpers import Feature
 from sentry.testutils.silo import region_silo_test
 
 
@@ -30,41 +29,22 @@ class ProjectFiltersTest(APITestCase):
 
         self.insta_snapshot(response.data)
 
-    def test_get_business(self):
+    def test_health_check_filter(self):
         """
-        Test business plans return health-check-filter
-        :return:
+        Tests setting health check filters ( aka filtered-transactions)
         """
         org = self.create_organization(name="baz", slug="1", owner=self.user)
         team = self.create_team(organization=org, name="foo", slug="foo")
         project = self.create_project(name="Bar", slug="bar", teams=[team])
 
         project.update_option("filters:filtered-transaction", "0")
-        with Feature("organizations:health-check-filter"):
-            response = self.get_success_response(org.slug, project.slug)
+        response = self.get_success_response(org.slug, project.slug)
         health_check = self.get_filter_spec(response.data, "filtered-transaction")
         assert health_check is not None
         assert health_check["active"] is False
 
         project.update_option("filters:filtered-transaction", "1")
-        with Feature("organizations:health-check-filter"):
-            response = self.get_success_response(org.slug, project.slug)
+        response = self.get_success_response(org.slug, project.slug)
         health_check = self.get_filter_spec(response.data, "filtered-transaction")
         assert health_check is not None
         assert health_check["active"] is True
-
-    def test_free_plan(self):
-        """
-        Tests plans not having "filters:filtered-transaction" feature do not return health-check specs
-        """
-        org = self.create_organization(name="baz", slug="1", owner=self.user)
-        team = self.create_team(organization=org, name="foo", slug="foo")
-        project = self.create_project(name="Bar", slug="bar", teams=[team])
-
-        # we shouldn't return health check information even if the option is set for the project
-        # (presumably the user has downgraded from a business plan)
-        project.update_option("filters:filtered-transaction", "1")
-        with Feature({"organizations:health-check-filter": False}):
-            response = self.get_success_response(org.slug, project.slug)
-        health_check = self.get_filter_spec(response.data, "filtered-transaction")
-        assert health_check is None

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -351,16 +351,14 @@ def test_relay_disabled_project(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("is_business", [True, False], ids=["business_plan", "free_plan"])
-def test_health_check_filters(call_endpoint, add_org_key, relay, default_project, is_business):
+def test_health_check_filters(call_endpoint, add_org_key, relay, default_project):
     """
-    Test that only business plans contain healthcheck filters
+    Test health check filter (aka ignoreTransactions)
     """
     relay.save()
 
     default_project.update_option("filters:filtered-transaction", "1")
-    with Feature({"organizations:health-check-filter": is_business}):
-        result, status_code = call_endpoint(full_config=True)
+    result, status_code = call_endpoint(full_config=True)
 
     assert status_code < 400
 
@@ -368,7 +366,4 @@ def test_health_check_filters(call_endpoint, add_org_key, relay, default_project
         result, "configs", str(default_project.id), "config", "filterSettings"
     )
     assert filter_settings is not None
-
-    has_health_check = "ignoreTransactions" in filter_settings
-
-    assert has_health_check == is_business
+    assert "ignoreTransactions" in filter_settings

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-06-16T19:42:12.350023Z'
+created: '2023-07-04T12:45:26.399540Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -83,6 +83,17 @@ config:
     errorMessages:
       patterns:
       - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
+    ignoreTransactions:
+      isEnabled: true
+      patterns:
+      - '*healthcheck*'
+      - '*healthy*'
+      - '*live*'
+      - '*ready*'
+      - '*heartbeat*'
+      - '*/health'
+      - '*/healthz'
+      - '*/ping'
   groupingConfig:
     enhancements: eJybzDRxc15qeXFJZU6qlZGBkbGugaGuoeEEAHJMCAM
     id: newstyle:2023-01-11

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-06-16T19:42:12.909565Z'
+created: '2023-07-04T12:45:26.525117Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -83,6 +83,17 @@ config:
     errorMessages:
       patterns:
       - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
+    ignoreTransactions:
+      isEnabled: true
+      patterns:
+      - '*healthcheck*'
+      - '*healthy*'
+      - '*live*'
+      - '*ready*'
+      - '*heartbeat*'
+      - '*/health'
+      - '*/healthz'
+      - '*/ping'
   groupingConfig:
     enhancements: eJybzDRxc15qeXFJZU6qlZGBkbGugaGuoeEEAHJMCAM
     id: newstyle:2023-01-11

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -662,8 +662,7 @@ def test_healthcheck_filter(default_project, has_health_check, health_check_set)
     """
 
     default_project.update_option("filters:filtered-transaction", "1" if health_check_set else "0")
-    with Feature({"organizations:health-check-filter": has_health_check}):
-        config = get_project_config(default_project).to_dict()["config"]
+    config = get_project_config(default_project).to_dict()["config"]
 
     _validate_project_config(config)
     filter_settings = get_path(config, "filterSettings")

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -641,24 +641,14 @@ def test_project_config_get_at_path(default_project):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "has_health_check, health_check_set",
-    [
-        (True, True),
-        (False, True),
-        (True, False),
-        (False, False),
-    ],
-    ids=[
-        "with_healthcheck, option set",
-        "without_healthcheck, option set",
-        "with_healthcheck, option not set",
-        "without_healthcheck, option not set",
-    ],
+    "health_check_set",
+    [True, False],
+    ids=["healthcheck set", "healthcheck not set"],
 )
-def test_healthcheck_filter(default_project, has_health_check, health_check_set):
+def test_healthcheck_filter(default_project, health_check_set):
     """
     Tests that the project config properly returns healthcheck filters when the
-    flag is set for the org and the user has enabled healthcheck filters.
+    user has enabled healthcheck filters.
     """
 
     default_project.update_option("filters:filtered-transaction", "1" if health_check_set else "0")
@@ -667,8 +657,13 @@ def test_healthcheck_filter(default_project, has_health_check, health_check_set)
     _validate_project_config(config)
     filter_settings = get_path(config, "filterSettings")
     config_has_health_check = "ignoreTransactions" in filter_settings
-    should_have_health_check_config = has_health_check and health_check_set
-    assert config_has_health_check == should_have_health_check_config
+    assert config_has_health_check == health_check_set
+    if health_check_set:
+        health_check_config = filter_settings["ignoreTransactions"]
+        # healthcheck is enabled
+        assert health_check_config["isEnabled"]
+        # we have some patterns
+        assert len(health_check_config["patterns"]) > 1
 
 
 @django_db_all


### PR DESCRIPTION
This PR removes the health-check feature for inbound filters since it is no longer used

fixes: https://github.com/getsentry/sentry/issues/51698