### PR TITLE
feat(sdk-crash-detection): Project and event ID

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -57,7 +57,14 @@ class SDKCrashDetection:
             sdk_crash_event_data = strip_event_data(event.data, self.cocoa_sdk_crash_detector)
 
             set_path(
-                sdk_crash_event_data, "contexts", "sdk_crash_detection", value={"detected": True}
+                sdk_crash_event_data,
+                "contexts",
+                "sdk_crash_detection",
+                value={
+                    "detected": True,
+                    "original_project_id": event.project.id,
+                    "original_event_id": event.event_id,
+                },
             )
 
             return self.sdk_crash_reporter.report(sdk_crash_event_data, event_project_id)

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -37,7 +37,11 @@ class BaseSDKCrashDetectionMixin(BaseTestCase, metaclass=abc.ABCMeta):
             assert mock_sdk_crash_reporter.report.call_count == 1
 
             reported_event_data = mock_sdk_crash_reporter.report.call_args.args[0]
-            assert reported_event_data["contexts"]["sdk_crash_detection"]["detected"] is True
+            assert reported_event_data["contexts"]["sdk_crash_detection"] == {
+                "detected": True,
+                "original_project_id": event.project_id,
+                "original_event_id": event.event_id,
+            }
         else:
             assert mock_sdk_crash_reporter.report.call_count == 0
 


### PR DESCRIPTION
Set project and event ID to the sdk_crash_detection context to be able to find the original SDK crash event.

Closes #52094