### PR TITLE
feat(sdk): Add sampling multiplier config as an intermediate step to 100% sampling

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1768,6 +1768,9 @@ SENTRY_POST_PROCESS_GROUP_APM_SAMPLING = 0
 # sample rate for all reprocessing tasks (except for the per-event ones)
 SENTRY_REPROCESSING_APM_SAMPLING = 0
 
+# upsampling multiplier that we'll increase in steps till we're at 100% throughout
+SENTRY_MULTIPLIER_APM_SAMPLING = 1
+
 # ----
 # end APM config
 # ----

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -269,7 +269,14 @@ def traces_sampler(sampling_context):
             pass
 
     # Default to the sampling rate in settings
-    return float(settings.SENTRY_BACKEND_APM_SAMPLING or 0)
+    rate = float(settings.SENTRY_BACKEND_APM_SAMPLING or 0)
+
+    # multiply everything with the overall multiplier
+    # till we get to 100% client sampling throughout
+    if settings.SENTRY_MULTIPLIER_APM_SAMPLING:
+        rate = min(1, rate * settings.SENTRY_MULTIPLIER_APM_SAMPLING)
+
+    return rate
 
 
 def before_send_transaction(event, _):


### PR DESCRIPTION
We want to eventually end up in a state where we sample at 100% client (sdk) side. 

Not being sure about the impact of just turning this on throughout the system,
we will do it in steps with the new `SENTRY_MULTIPLIER_APM_SAMPLING` config that we will bump in steps,
first on isolated instances and then everywhere till we either

* get to 100% sampling
* find and document problems that we can handle via [backpressure management](https://github.com/getsentry/sentry-python/pull/2189) in SDKs



