### PR TITLE
ref(sdk-crash-detection): Remove context detected

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -38,7 +38,7 @@ class SDKCrashDetection:
             return None
 
         context = get_path(event.data, "contexts", "sdk_crash_detection")
-        if context is not None and context.get("detected", False):
+        if context is not None:
             return None
 
         # Getting the frames and checking if the event is unhandled might different per platform.
@@ -61,7 +61,6 @@ class SDKCrashDetection:
                 "contexts",
                 "sdk_crash_detection",
                 value={
-                    "detected": True,
                     "original_project_id": event.project.id,
                     "original_event_id": event.event_id,
                 },

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -38,7 +38,6 @@ class BaseSDKCrashDetectionMixin(BaseTestCase, metaclass=abc.ABCMeta):
 
             reported_event_data = mock_sdk_crash_reporter.report.call_args.args[0]
             assert reported_event_data["contexts"]["sdk_crash_detection"] == {
-                "detected": True,
                 "original_project_id": event.project_id,
                 "original_event_id": event.event_id,
             }
@@ -84,7 +83,15 @@ class CococaSDKTestMixin(BaseSDKCrashDetectionMixin):
     def test_sdk_crash_detected_event_is_not_reported(self, mock_sdk_crash_reporter):
         event = get_crash_event()
 
-        set_path(event, "contexts", "sdk_crash_detection", value={"detected": True})
+        set_path(
+            event,
+            "contexts",
+            "sdk_crash_detection",
+            value={
+                "original_project_id": 1234,
+                "original_event_id": 1234,
+            },
+        )
 
         self.execute_test(event, False, mock_sdk_crash_reporter)
 


### PR DESCRIPTION
Remove the detected field of sdk-crash-detection context, as we can avoid an infinite processing loop by looking at the project_id and event_id instead.




