### PR TITLE
fix(sdk-crash-detection): Ignore test crash

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event.py
+++ b/fixtures/sdk_crash_detection/crash_event.py
@@ -37,6 +37,9 @@ def get_frames(
             "filename": "LoginViewController.swift",
             "image_addr": "0x100260000",
         },
+        get_sentry_frame(
+            "__49-[SentrySwizzleWrapper swizzleSendAction:forKey:]_block_invoke_2", False
+        ),
         IN_APP_FRAME,
         {
             "function": "-[UIViewController _setViewAppearState:isAnimating:]",

--- a/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
@@ -13,6 +13,12 @@ class CocoaSDKCrashDetector(SDKCrashDetector):
         # The last frame is the one creating the exception.
         # Therefore, we must iterate in reverse order.
         for frame in reversed(frames):
+            # [SentrySDK crash] is a testing function causing a crash.
+            # Therefore, we don't want to mark it a as a SDK crash.
+            function = frame.get("function")
+            if function and "SentrySDK crash" in function:
+                return False
+
             if self.is_sdk_frame(frame):
                 return True
 
@@ -25,11 +31,6 @@ class CocoaSDKCrashDetector(SDKCrashDetector):
 
         function = frame.get("function")
         if function:
-            # [SentrySDK crash] is a testing function causing a crash.
-            # Therefore, we don't want to mark it a as a SDK crash.
-            if "SentrySDK crash" in function:
-                return False
-
             function_matchers = ["*sentrycrash*", "**[[]Sentry*"]
             for matcher in function_matchers:
                 if glob_match(function, matcher, ignorecase=True):

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -256,15 +256,23 @@ class EventStripperTestMixin(BaseEventStripperMixin):
             stripped_event_data, "exception", "values", -1, "stacktrace", "frames"
         )
 
-        assert len(stripped_frames) == 9
+        assert len(stripped_frames) == 10
 
-        cocoa_sdk_frame = stripped_frames[-1]
-        assert cocoa_sdk_frame == {
-            "function": "SentryCrashMonitor_CPPException.cpp",
-            "package": "Sentry.framework",
-            "in_app": True,
-            "image_addr": "0x100304000",
-        }
+        cocoa_sdk_frames = stripped_frames[-2:]
+        assert cocoa_sdk_frames == [
+            {
+                "function": "__49-[SentrySwizzleWrapper swizzleSendAction:forKey:]_block_invoke_2",
+                "package": "Sentry.framework",
+                "in_app": True,
+                "image_addr": "0x100304000",
+            },
+            {
+                "function": "SentryCrashMonitor_CPPException.cpp",
+                "package": "Sentry.framework",
+                "in_app": True,
+                "image_addr": "0x100304000",
+            },
+        ]
 
     def test_strip_frames_sdk_frames(self):
         frames = get_frames("SentryCrashMonitor_CPPException.cpp", sentry_frame_in_app=False)


### PR DESCRIPTION
Fix ignoring crashes stemming from a crash testing function in the Cocoa SDK. The code checked for that function in the is_sdk_frame function, which doesn't make sense. The logic wrongly reported crashes stemming from the testing function as an SDK crash and then stripped the crash testing function from the stacktrace. Instead, the code should ignore such crashes, and the is_sdk_frame function shouldn't bother about the crash testing function.