### PR TITLE
feat(org-token): Keep track of last used date/project

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -23,6 +23,7 @@ from sentry.api.serializers.rest_framework import (
     ReleaseHeadCommitSerializerDeprecated,
     ReleaseWithVersionSerializer,
 )
+from sentry.api.utils import get_auth_api_token_type
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import (
     Activity,
@@ -33,7 +34,7 @@ from sentry.models import (
     ReleaseStatus,
     SemverFilter,
 )
-from sentry.models.apitoken import is_api_token_auth
+from sentry.models.orgauthtoken import is_org_auth_token_auth, update_org_auth_token_last_used
 from sentry.search.events.constants import (
     OPERATOR_TO_DJANGO,
     RELEASE_ALIAS,
@@ -564,8 +565,13 @@ class OrganizationReleasesEndpoint(
                     project_ids=[project.id for project in projects],
                     user_agent=request.META.get("HTTP_USER_AGENT", ""),
                     created_status=status,
-                    auth_type="api_token" if is_api_token_auth(request.auth) else None,
+                    auth_type=get_auth_api_token_type(request.auth),
                 )
+
+                if is_org_auth_token_auth(request.auth):
+                    update_org_auth_token_last_used(
+                        request.auth, [project.id for project in projects]
+                    )
 
                 scope.set_tag("success_status", status)
                 return Response(serialize(release, request.user), status=status)

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -20,7 +20,10 @@ from sentry import options
 # Unfortunately, this function is imported as an export of this module in several places, keep it.
 from sentry.auth.access import get_cached_organization_member  # noqa
 from sentry.auth.superuser import is_active_superuser
+from sentry.models.apikey import is_api_key_auth
+from sentry.models.apitoken import is_api_token_auth
 from sentry.models.organization import Organization
+from sentry.models.orgauthtoken import is_org_auth_token_auth
 from sentry.search.utils import InvalidQuery, parse_datetime_string
 from sentry.services.hybrid_cloud import extract_id_from
 from sentry.services.hybrid_cloud.organization import (
@@ -335,3 +338,13 @@ def print_and_capture_handler_exception(
     event_id: str | None = capture_exception(exception, scope=scope)
 
     return event_id
+
+
+def get_auth_api_token_type(auth: object) -> str | None:
+    if is_api_token_auth(auth):
+        return "api_token"
+    if is_org_auth_token_auth(auth):
+        return "org_auth_token"
+    if is_api_key_auth(auth):
+        return "api_key"
+    return None

--- a/src/sentry/models/orgauthtoken.py
+++ b/src/sentry/models/orgauthtoken.py
@@ -15,6 +15,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
+from sentry.services.hybrid_cloud.orgauthtoken import orgauthtoken_service
 
 
 def validate_scope_list(value):
@@ -80,3 +81,25 @@ def is_org_auth_token_auth(auth: object) -> bool:
     if isinstance(auth, AuthenticatedToken):
         return auth.kind == "org_auth_token"
     return isinstance(auth, OrgAuthToken)
+
+
+def get_org_auth_token_id_from_auth(auth: object) -> int | None:
+    from sentry.services.hybrid_cloud.auth import AuthenticatedToken
+
+    if isinstance(auth, OrgAuthToken):
+        return auth.id
+    if isinstance(auth, AuthenticatedToken):
+        return auth.entity_id
+    return None
+
+
+def update_org_auth_token_last_used(auth: object, project_ids: list[int]):
+    org_auth_token_id = get_org_auth_token_id_from_auth(auth)
+    organization_id = getattr(auth, "organization_id", None)
+    if org_auth_token_id is not None and organization_id is not None:
+        orgauthtoken_service.update_orgauthtoken(
+            organization_id=organization_id,
+            org_auth_token_id=org_auth_token_id,
+            date_last_used=timezone.now(),
+            project_last_used_id=project_ids[0] if len(project_ids) > 0 else None,
+        )

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -79,6 +79,7 @@ class OutboxCategory(IntEnum):
     ORGANIZATION_MEMBER_CREATE = 13  # Unused
     SEND_SIGNAL = 14
     ORGANIZATION_MAPPING_CUSTOMER_ID_UPDATE = 15
+    ORGAUTHTOKEN_UPDATE = 16
 
     @classmethod
     def as_choices(cls):

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -30,6 +30,7 @@ from sentry.services.hybrid_cloud.organizationmember_mapping import (
     RpcOrganizationMemberMappingUpdate,
     organizationmember_mapping_service,
 )
+from sentry.services.hybrid_cloud.orgauthtoken import orgauthtoken_rpc_service
 from sentry.types.region import get_local_region
 
 
@@ -37,6 +38,12 @@ from sentry.types.region import get_local_region
 def process_audit_log_event(payload: Any, **kwds: Any):
     if payload is not None:
         log_rpc_service.record_audit_log(event=AuditLogEvent(**payload))
+
+
+@receiver(process_region_outbox, sender=OutboxCategory.ORGAUTHTOKEN_UPDATE)
+def process_orgauthtoken_update(payload: Any, **kwds: Any):
+    if payload is not None:
+        orgauthtoken_rpc_service.update_orgauthtoken(**payload)
 
 
 @receiver(process_region_outbox, sender=OutboxCategory.USER_IP_EVENT)

--- a/src/sentry/services/hybrid_cloud/orgauthtoken/__init__.py
+++ b/src/sentry/services/hybrid_cloud/orgauthtoken/__init__.py
@@ -1,0 +1,1 @@
+from .service import *  # noqa

--- a/src/sentry/services/hybrid_cloud/orgauthtoken/impl.py
+++ b/src/sentry/services/hybrid_cloud/orgauthtoken/impl.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox
+from sentry.services.hybrid_cloud.orgauthtoken.service import OrgAuthTokenService
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+class DatabaseBackedOrgAuthTokenService(OrgAuthTokenService):
+    def update_orgauthtoken(
+        self,
+        *,
+        organization_id: int,
+        org_auth_token_id: int,
+        date_last_used: Optional[datetime] = None,
+        project_last_used_id: Optional[int] = None,
+    ) -> None:
+        token = OrgAuthToken.objects.filter(id=org_auth_token_id).first()
+
+        if token is None:
+            return
+
+        token.update(date_last_used=date_last_used, project_last_used_id=project_last_used_id)
+
+
+class OutboxBackedOrgAuthTokenService(OrgAuthTokenService):
+    def update_orgauthtoken(
+        self,
+        *,
+        organization_id: int,
+        org_auth_token_id: int,
+        date_last_used: Optional[datetime] = None,
+        project_last_used_id: Optional[int] = None,
+    ) -> None:
+        RegionOutbox(
+            shard_scope=OutboxScope.ORGANIZATION_SCOPE,
+            shard_identifier=organization_id,
+            category=OutboxCategory.ORGAUTHTOKEN_UPDATE,
+            object_identifier=org_auth_token_id,
+            payload={
+                "organization_id": organization_id,
+                "org_auth_token_id": org_auth_token_id,
+                "date_last_used": date_last_used,
+                "project_last_used_id": project_last_used_id,
+            },  # type:ignore
+        ).save()

--- a/src/sentry/services/hybrid_cloud/orgauthtoken/service.py
+++ b/src/sentry/services/hybrid_cloud/orgauthtoken/service.py
@@ -1,0 +1,61 @@
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
+
+from abc import abstractmethod
+from datetime import datetime
+from typing import Optional, cast
+
+from sentry.services.hybrid_cloud import silo_mode_delegation
+from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
+from sentry.silo import SiloMode
+
+
+class OrgAuthTokenService(RpcService):
+    key = "orgauthtoken"
+    local_mode = SiloMode.CONTROL
+
+    @classmethod
+    def get_local_implementation(cls) -> RpcService:
+        return impl_by_db()
+
+    @rpc_method
+    @abstractmethod
+    def update_orgauthtoken(
+        self,
+        *,
+        organization_id: int,
+        org_auth_token_id: int,
+        date_last_used: Optional[datetime] = None,
+        project_last_used_id: Optional[int] = None,
+    ) -> None:
+        pass
+
+
+def impl_by_db() -> OrgAuthTokenService:
+    from .impl import DatabaseBackedOrgAuthTokenService
+
+    return DatabaseBackedOrgAuthTokenService()
+
+
+def impl_by_outbox() -> OrgAuthTokenService:
+    from .impl import OutboxBackedOrgAuthTokenService
+
+    return OutboxBackedOrgAuthTokenService()
+
+
+# An asynchronous service which can delegate to an outbox implementation, essentially enqueueing
+# updates of tokens for future processing.
+orgauthtoken_service: OrgAuthTokenService = silo_mode_delegation(
+    {
+        SiloMode.REGION: impl_by_outbox,
+        SiloMode.CONTROL: impl_by_db,
+        SiloMode.MONOLITH: impl_by_db,
+    }
+)
+
+
+orgauthtoken_rpc_service: OrgAuthTokenService = cast(
+    OrgAuthTokenService, OrgAuthTokenService.create_delegation()
+)

--- a/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
@@ -9,11 +9,12 @@ from sentry.models import ApiToken, FileBlob, FileBlobOwner
 from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.tasks.assemble import ChunkFileState, assemble_artifacts
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class OrganizationArtifactBundleAssembleTest(APITestCase):
     def setUp(self):
         self.organization = self.create_organization(owner=self.user)
@@ -342,15 +343,16 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         )
 
         # right org, wrong permission level
-        bad_token_str = generate_token(self.organization.slug, "")
-        OrgAuthToken.objects.create(
-            organization_id=self.organization.id,
-            name="token 1",
-            token_hashed=hash_token(bad_token_str),
-            token_last_characters="ABCD",
-            scope_list=[],
-            date_last_used=None,
-        )
+        with exempt_from_silo_limits():
+            bad_token_str = generate_token(self.organization.slug, "")
+            OrgAuthToken.objects.create(
+                organization_id=self.organization.id,
+                name="token 1",
+                token_hashed=hash_token(bad_token_str),
+                token_last_characters="ABCD",
+                scope_list=[],
+                date_last_used=None,
+            )
         response = self.client.post(
             self.url,
             data={
@@ -363,15 +365,16 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         assert response.status_code == 403
 
         # wrong org, right permission level
-        bad_org_token_str = generate_token(self.organization.slug, "")
-        OrgAuthToken.objects.create(
-            organization_id=org2.id,
-            name="token 1",
-            token_hashed=hash_token(bad_org_token_str),
-            token_last_characters="ABCD",
-            scope_list=[],
-            date_last_used=None,
-        )
+        with exempt_from_silo_limits():
+            bad_org_token_str = generate_token(self.organization.slug, "")
+            OrgAuthToken.objects.create(
+                organization_id=org2.id,
+                name="token 1",
+                token_hashed=hash_token(bad_org_token_str),
+                token_last_characters="ABCD",
+                scope_list=[],
+                date_last_used=None,
+            )
         response = self.client.post(
             self.url,
             data={
@@ -384,22 +387,31 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         assert response.status_code == 403
 
         # right org, right permission level
-        good_token_str = generate_token(self.organization.slug, "")
-        OrgAuthToken.objects.create(
-            organization_id=self.organization.id,
-            name="token 1",
-            token_hashed=hash_token(good_token_str),
-            token_last_characters="ABCD",
-            scope_list=["org:ci"],
-            date_last_used=None,
-        )
-        response = self.client.post(
-            self.url,
-            data={
-                "checksum": total_checksum,
-                "chunks": [blob1.checksum],
-                "projects": [self.project.slug],
-            },
-            HTTP_AUTHORIZATION=f"Bearer {good_token_str}",
-        )
+        with exempt_from_silo_limits():
+            good_token_str = generate_token(self.organization.slug, "")
+            OrgAuthToken.objects.create(
+                organization_id=self.organization.id,
+                name="token 1",
+                token_hashed=hash_token(good_token_str),
+                token_last_characters="ABCD",
+                scope_list=["org:ci"],
+                date_last_used=None,
+            )
+
+        with outbox_runner():
+            response = self.client.post(
+                self.url,
+                data={
+                    "checksum": total_checksum,
+                    "chunks": [blob1.checksum],
+                    "projects": [self.project.slug],
+                },
+                HTTP_AUTHORIZATION=f"Bearer {good_token_str}",
+            )
         assert response.status_code == 200
+
+        # Make sure org token usage was updated
+        with exempt_from_silo_limits():
+            org_token = OrgAuthToken.objects.get(token_hashed=hash_token(good_token_str))
+        assert org_token.date_last_used is not None
+        assert org_token.project_last_used_id == self.project.id


### PR DESCRIPTION
This updates the key places the org auth token can be used to update the token last used date/project.

We considered making this more generic, e.g. somewhere in the auth layer, but that a) increases complexity of the anyhow already complex auth stuff, b) still does not take care of keeping the last used project, as that will have to be rather custom per endpoint. Also, although we _may_ eventually extend the org tokens to other scopes, when we do so we can revisit this decision and potentially re-think this. But since this is just a possibility at this stage, and not concretely planned, let's just keep it simple with what we _want_ to achieve right now.

I figured this has to be a hybrid cloud service, I hope I set this up correctly - it seems to be working, at least!

Note: Needs https://github.com/getsentry/sentry/pull/52112 so the UI actually looks "correct"