### PR TITLE
fix(hybridcloud) Fix startup warnings

### DIFF
--- a/src/sentry/services/hybrid_cloud/log/service.py
+++ b/src/sentry/services/hybrid_cloud/log/service.py
@@ -1,7 +1,10 @@
-from __future__ import annotations
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 import abc
-from typing import cast
+from typing import Optional, cast
 
 from sentry.services.hybrid_cloud import silo_mode_delegation
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
@@ -31,8 +34,12 @@ class LogService(RpcService):
     @rpc_method
     @abc.abstractmethod
     def find_last_log(
-        self, *, organization_id: int | None, target_object_id: int | None, event: int | None
-    ) -> AuditLogEvent | None:
+        self,
+        *,
+        organization_id: Optional[int],
+        target_object_id: Optional[int],
+        event: Optional[int],
+    ) -> Optional[AuditLogEvent]:
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -3,10 +3,11 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 from enum import IntEnum
-from typing import Any, List, Mapping, Optional, TypedDict
+from typing import Any, List, Mapping, Optional
 
 from django.dispatch import Signal
 from pydantic import Field
+from typing_extensions import TypedDict
 
 from sentry.db.models import ValidateFunction, Value
 from sentry.models.options.option import HasOption

--- a/src/sentry/services/hybrid_cloud/project/model.py
+++ b/src/sentry/services/hybrid_cloud/project/model.py
@@ -3,9 +3,10 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from typing import List, Optional, TypedDict
+from typing import List, Optional
 
 from pydantic.fields import Field
+from typing_extensions import TypedDict
 
 from sentry.constants import ObjectStatus
 from sentry.db.models import ValidateFunction, Value

--- a/src/sentry/services/hybrid_cloud/repository/service.py
+++ b/src/sentry/services/hybrid_cloud/repository/service.py
@@ -6,7 +6,6 @@
 from abc import abstractmethod
 from typing import List, Optional, cast
 
-from sentry.constants import ObjectStatus
 from sentry.services.hybrid_cloud.region import ByOrganizationId
 from sentry.services.hybrid_cloud.repository import RpcRepository
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method
@@ -33,7 +32,7 @@ class RepositoryService(RpcService):
         providers: Optional[List[str]] = None,
         has_integration: Optional[bool] = None,
         has_provider: Optional[bool] = None,
-        status: Optional[ObjectStatus] = None,
+        status: Optional[int] = None,
     ) -> List[RpcRepository]:
         pass
 


### PR DESCRIPTION
Fix a few pydantic related warnings that are showing up during application startup. There are a few more related to the hook service, but I've ticketed those up separately as it is a more involved set of changes to make.
