### PR TITLE
feat(starfish): consolidates and reduces the amount of unnecessary calls in span summary

### DIFF
--- a/static/app/views/starfish/queries/useSpanMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.tsx
@@ -36,7 +36,7 @@ export const useSpanMetrics = (
     referrer,
   });
 
-  return {...result, data: result?.data[0] ?? {}};
+  return {...result, data: result?.data?.[0] ?? {}};
 };
 
 function getEventView(

--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -38,6 +38,7 @@ export const useSpanTransactionMetrics = (
     eventView,
     initialData: [],
     enabled: Boolean(span),
+    referrer: _referrer,
   });
 };
 

--- a/static/app/views/starfish/queries/useTransactions.tsx
+++ b/static/app/views/starfish/queries/useTransactions.tsx
@@ -34,6 +34,9 @@ export function useTransactions(eventIDs: string[], referrer = 'use-transactions
     referrer,
     options: {
       enabled,
+      refetchOnWindowFocus: false,
+      retry: false,
+      staleTime: Infinity,
     },
   });
   const data = (response.data?.data ?? []) as unknown as Transaction[];

--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -12,6 +12,7 @@ import {
 } from 'sentry/utils/discover/genericDiscoverQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {TrackResponse} from 'sentry/views/starfish/utils/trackResponse';
 
 export const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
@@ -36,12 +37,15 @@ export function useSpansQuery<T = any[]>({
     ? useWrappedDiscoverTimeseriesQuery
     : useWrappedDiscoverQuery;
 
+  const {isReady: pageFiltersReady} = usePageFilters();
+
   if (eventView) {
     const response = queryFunction<T>({
       eventView,
       initialData,
       limit,
-      enabled,
+      // We always want to wait until the pageFilters are ready to prevent clobbering requests
+      enabled: (enabled || enabled === undefined) && pageFiltersReady,
       referrer,
       cursor,
     });
@@ -93,6 +97,8 @@ export function useWrappedDiscoverTimeseriesQuery<T>({
     options: {
       enabled,
       refetchOnWindowFocus: false,
+      retry: false,
+      staleTime: Infinity,
     },
     referrer,
   });
@@ -136,6 +142,8 @@ export function useWrappedDiscoverQuery<T>({
     options: {
       enabled,
       refetchOnWindowFocus: false,
+      retry: false,
+      staleTime: Infinity,
     },
   });
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -54,7 +54,7 @@ function DurationChart({
 
   const {data: spanMetrics} = useSpanMetrics(
     {group: groupId},
-    {transactionName},
+    {transactionName, 'transaction.method': transactionMethod},
     [`p95(${SPAN_SELF_TIME})`, SPAN_OP],
     'span-summary-panel-samples-table-p95'
   );

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -63,7 +63,7 @@ export function SpanTransactionsTable({
   const organization = useOrganization();
 
   const {
-    data: spanTransactionMetrics,
+    data: spanTransactionMetrics = [],
     meta,
     isLoading,
     pageLinks,
@@ -161,6 +161,7 @@ function TransactionCell({span, row, endpoint, endpointMethod, location}: CellPr
         to={`/starfish/${extractRoute(location) ?? 'spans'}/span/${encodeURIComponent(
           span.group
         )}?${qs.stringify({
+          ...location.query,
           endpoint,
           endpointMethod,
           transaction: row.transaction,


### PR DESCRIPTION
Consolidates and reduces the amount of unnecessary calls in span summary. Also fixes scenarios where ephemeral state changes (especially to page filter) would cause re-requests.