### PR TITLE
feat(hybridcloud) Fix `sentry upgrade` failing for control silo

### DIFF
--- a/src/sentry/db/router.py
+++ b/src/sentry/db/router.py
@@ -89,10 +89,15 @@ class SiloRouter:
             if active_mode == silo_mode:
                 return "default"
 
-            raise ValueError(
-                f"Cannot resolve table {table} in {silo_mode}. "
-                f"Application silo mode is {active_mode} and simulated silos are not enabled."
-            )
+            # If we're in tests raise an error, otherwise return 'no decision'
+            # so that django skips migration operations that won't work.
+            if "pytest" in sys.modules:
+                raise ValueError(
+                    f"Cannot resolve table {table} in {silo_mode}. "
+                    f"Application silo mode is {active_mode} and simulated silos are not enabled."
+                )
+            else:
+                return None
 
     def _find_model(self, table: str, app_label: str) -> Optional[Model]:
         # Use django's model inventory to find our table and what silo it is on.

--- a/src/sentry/runner/commands/repair.py
+++ b/src/sentry/runner/commands/repair.py
@@ -5,6 +5,8 @@ import click
 from django.db import transaction
 
 from sentry.runner.decorators import configuration
+from sentry.services.hybrid_cloud.util import region_silo_function
+from sentry.silo.base import SiloLimit
 from sentry.types.activity import ActivityType
 
 
@@ -36,6 +38,7 @@ def sync_docs():
         click.echo(" - skipping, path does not exist: %r" % DOC_FOLDER)
 
 
+@region_silo_function
 def create_missing_dsns():
     from sentry.models import Project, ProjectKey
 
@@ -48,6 +51,7 @@ def create_missing_dsns():
             pass
 
 
+@region_silo_function
 def fix_group_counters():
     from django.db import connection
 
@@ -83,5 +87,9 @@ def repair(with_docs):
     if with_docs:
         sync_docs()
 
-    create_missing_dsns()
-    fix_group_counters()
+    try:
+        create_missing_dsns()
+        fix_group_counters()
+    except SiloLimit.AvailabilityError:
+        click.echo("Skipping repair operations due to silo restrictions")
+        pass

--- a/src/sentry/services/hybrid_cloud/util.py
+++ b/src/sentry/services/hybrid_cloud/util.py
@@ -25,7 +25,7 @@ class FunctionSiloLimit(SiloLimit):
                 f"Called {original_method.__name__} in "
                 f"{current_mode} mode. This function is available only in: {mode_str}"
             )
-            raise ValueError(message)
+            raise self.AvailabilityError(message)
         return original_method
 
     def __call__(self, decorated_obj: Any) -> Any:

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -460,7 +460,7 @@ class FunctionSiloLimitTest(APITestCase):
             if expect_to_be_active:
                 decorated_function()
             else:
-                with raises(ValueError):
+                with raises(FunctionSiloLimit.AvailabilityError):
                     decorated_function()
 
     def test_with_active_mode(self):

--- a/tests/sentry/types/test_region.py
+++ b/tests/sentry/types/test_region.py
@@ -5,7 +5,7 @@ from django.test import override_settings
 from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models import OrganizationMapping
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.silo import SiloMode
+from sentry.silo import SiloLimit, SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.region import override_regions
 from sentry.types.region import (
@@ -129,5 +129,5 @@ class RegionMappingTest(TestCase):
             assert actual_regions == {"na"}
 
         with override_settings(SILO_MODE=SiloMode.REGION):
-            with pytest.raises(ValueError):
+            with pytest.raises(SiloLimit.AvailabilityError):
                 find_regions_for_user(user_id=user.id)


### PR DESCRIPTION
While the silo routing error is very helpful in tests, it blocks us being able to run migrations for control/region silos in isolation.

Instead we need to return `None` to indicate that our router was unable to make a routing decision. Because there are no other routers in our application migration operations that effect the 'other' silo are skipped.

The tasks in `commands.repair` are run every time `sentry upgrade` is run for development and self-hosted environments. Applying silo decorators and catching the silo error felt like a decent solution.