### PR TITLE
feat(sdk-crash): Add simulator device context

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event.py
+++ b/fixtures/sdk_crash_detection/crash_event.py
@@ -178,6 +178,7 @@ def get_crash_event_with_frames(
                 "boot_time": "2023-02-01T05:21:23Z",
                 "timezone": "PST",
                 "type": "device",
+                "simulator": True,
             },
             "os": {
                 "name": "iOS",

--- a/src/sentry/utils/sdk_crashes/event_stripper.py
+++ b/src/sentry/utils/sdk_crashes/event_stripper.py
@@ -82,6 +82,7 @@ EVENT_DATA_ALLOWLIST = {
             "family": Allow.SIMPLE_TYPE,
             "model": Allow.SIMPLE_TYPE,
             "arch": Allow.SIMPLE_TYPE,
+            "simulator": Allow.SIMPLE_TYPE,
         },
         "os": {
             "name": Allow.SIMPLE_TYPE,

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -65,6 +65,7 @@ class EventStripperTestMixin(BaseEventStripperMixin):
                 "family": "iOS",
                 "model": "iPhone14,8",
                 "arch": "arm64e",
+                "simulator": True,
             },
         }
 


### PR DESCRIPTION
Keep the simulator device context in the event stripper.




