### PR TITLE
fix(sdk-crash): Keep SDK frames based on filename

### DIFF
--- a/src/sentry/utils/sdk_crashes/event_stripper.py
+++ b/src/sentry/utils/sdk_crashes/event_stripper.py
@@ -109,7 +109,7 @@ def strip_event_data(
 
     stripped_event_data = _strip_event_data_with_allowlist(event_data_copy, EVENT_DATA_ALLOWLIST)
 
-    if (stripped_event_data is None) or (stripped_event_data == {}):
+    if not stripped_event_data:
         return {}
 
     return stripped_event_data

--- a/src/sentry/utils/sdk_crashes/event_stripper.py
+++ b/src/sentry/utils/sdk_crashes/event_stripper.py
@@ -97,7 +97,7 @@ def strip_event_data(
 ) -> Mapping[str, Any]:
 
     frames = get_path(event_data, "exception", "values", -1, "stacktrace", "frames")
-    if frames is None:
+    if not frames:
         return {}
 
     # We strip the frames first because applying the allowlist removes fields that are needed

--- a/src/sentry/utils/sdk_crashes/event_stripper.py
+++ b/src/sentry/utils/sdk_crashes/event_stripper.py
@@ -95,19 +95,24 @@ EVENT_DATA_ALLOWLIST = {
 def strip_event_data(
     event_data: NodeData, sdk_crash_detector: SDKCrashDetector
 ) -> Mapping[str, Any]:
-    new_event_data = _strip_event_data_with_allowlist(event_data, EVENT_DATA_ALLOWLIST)
 
-    if (new_event_data is None) or (new_event_data == {}):
+    frames = get_path(event_data, "exception", "values", -1, "stacktrace", "frames")
+    if frames is None:
         return {}
 
-    frames = get_path(new_event_data, "exception", "values", -1, "stacktrace", "frames")
+    # We strip the frames first because applying the allowlist removes fields that are needed
+    # for deciding wether to keep a frame or not.
+    stripped_frames = _strip_frames(frames, sdk_crash_detector)
 
-    if frames is not None:
-        stripped_frames = _strip_frames(frames, sdk_crash_detector)
+    event_data_copy = dict(event_data)
+    event_data_copy["exception"]["values"][0]["stacktrace"]["frames"] = stripped_frames
 
-        new_event_data["exception"]["values"][0]["stacktrace"]["frames"] = stripped_frames
+    stripped_event_data = _strip_event_data_with_allowlist(event_data_copy, EVENT_DATA_ALLOWLIST)
 
-    return new_event_data
+    if (stripped_event_data is None) or (stripped_event_data == {}):
+        return {}
+
+    return stripped_event_data
 
 
 def _strip_event_data_with_allowlist(

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -5,6 +5,7 @@ from fixtures.sdk_crash_detection.crash_event import (
     get_crash_event_with_frames,
     get_frames,
 )
+from sentry.db.models import NodeData
 from sentry.testutils import TestCase
 from sentry.testutils.cases import BaseTestCase
 from sentry.testutils.silo import region_silo_test
@@ -304,6 +305,24 @@ class EventStripperTestMixin(BaseEventStripperMixin):
             "in_app": True,
             "image_addr": "0x100304000",
         }
+
+    def test_strip_event_without_data_returns_empty_dict(self):
+        stripped_event_data = strip_event_data(NodeData({}), CocoaSDKCrashDetector())
+
+        assert stripped_event_data == {}
+
+    def test_strip_event_without_frames_returns_empty_dict(self):
+        event_data = get_crash_event_with_frames([])
+        set_path(event_data, "exception", value=None)
+
+        event = self.create_event(
+            data=event_data,
+            project_id=self.project.id,
+        )
+
+        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+
+        assert stripped_event_data == {}
 
 
 @region_silo_test


### PR DESCRIPTION
Adding a test case with an anonymized real-world Cocoa SDK crash in the thread inspector surfaced a bug in the frame stripping logic. The event stripper removed SDK frames cause it applied the allow list before stripping the frames, which removed information required to detect whether a frame is an SDK frame. This PR fixes that problem by calling the frame stripping logic before applying the allow list.
