### PR TITLE
feat(sdk-crash): Require sentry-cocoa 8.2.0

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event.py
+++ b/fixtures/sdk_crash_detection/crash_event.py
@@ -232,7 +232,7 @@ def get_crash_event_with_frames(
         "environment": "test-app",
         "sdk": {
             "name": "sentry.cocoa",
-            "version": "8.1.0",
+            "version": "8.2.0",
             "integrations": [
                 "Crash",
                 "PerformanceTracking",

--- a/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
@@ -1,10 +1,44 @@
 from typing import Any, Mapping, Sequence
 
+from packaging.version import InvalidVersion, Version
+
+from sentry.db.models import NodeData
 from sentry.utils.glob import glob_match
+from sentry.utils.safe import get_path
 from sentry.utils.sdk_crashes.sdk_crash_detector import SDKCrashDetector
 
 
 class CocoaSDKCrashDetector(SDKCrashDetector):
+    def should_detect_sdk_crash(self, event_data: NodeData) -> bool:
+        sdk_name = get_path(event_data, "sdk", "name")
+        if sdk_name and sdk_name != "sentry.cocoa":
+            return False
+
+        sdk_version = get_path(event_data, "sdk", "version")
+        if not sdk_version:
+            return False
+
+        try:
+            # Since changing the debug image type to macho (https://github.com/getsentry/sentry-cocoa/pull/2701)
+            # released in sentry-cocoa 8.2.0 (https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#820),
+            # the frames contain the full paths required for detecting system frames in is_system_library_frame.
+            # Therefore, we require at least sentry-cocoa 8.2.0.
+            minimum_cocoa_sdk_version = Version("8.2.0")
+            cocoa_sdk_version = Version(sdk_version)
+
+            if cocoa_sdk_version < minimum_cocoa_sdk_version:
+                return False
+        except InvalidVersion:
+            return False
+
+        is_unhandled = (
+            get_path(event_data, "exception", "values", -1, "mechanism", "handled") is False
+        )
+        if is_unhandled is False:
+            return False
+
+        return True
+
     def is_sdk_crash(self, frames: Sequence[Mapping[str, Any]]) -> bool:
         if not frames:
             return False

--- a/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
@@ -34,7 +34,7 @@ class CocoaSDKCrashDetector(SDKCrashDetector):
         is_unhandled = (
             get_path(event_data, "exception", "values", -1, "mechanism", "handled") is False
         )
-        if is_unhandled is False:
+        if not is_unhandled:
             return False
 
         return True

--- a/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
@@ -9,6 +9,16 @@ from sentry.utils.sdk_crashes.sdk_crash_detector import SDKCrashDetector
 
 
 class CocoaSDKCrashDetector(SDKCrashDetector):
+    @property
+    def min_sdk_version(self) -> str:
+        """
+        Since changing the debug image type to macho (https://github.com/getsentry/sentry-cocoa/pull/2701)
+        released in sentry-cocoa 8.2.0 (https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#820),
+        the frames contain the full paths required for detecting system frames in is_system_library_frame.
+        Therefore, we require at least sentry-cocoa 8.2.0.
+        """
+        return "8.2.0"
+
     def should_detect_sdk_crash(self, event_data: NodeData) -> bool:
         sdk_name = get_path(event_data, "sdk", "name")
         if sdk_name and sdk_name != "sentry.cocoa":
@@ -19,11 +29,7 @@ class CocoaSDKCrashDetector(SDKCrashDetector):
             return False
 
         try:
-            # Since changing the debug image type to macho (https://github.com/getsentry/sentry-cocoa/pull/2701)
-            # released in sentry-cocoa 8.2.0 (https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#820),
-            # the frames contain the full paths required for detecting system frames in is_system_library_frame.
-            # Therefore, we require at least sentry-cocoa 8.2.0.
-            minimum_cocoa_sdk_version = Version("8.2.0")
+            minimum_cocoa_sdk_version = Version(self.min_sdk_version)
             cocoa_sdk_version = Version(sdk_version)
 
             if cocoa_sdk_version < minimum_cocoa_sdk_version:

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -32,24 +32,17 @@ class SDKCrashDetection:
     def detect_sdk_crash(
         self, event: Event, event_project_id: int, sample_rate: float
     ) -> Optional[Event]:
+
         should_detect_sdk_crash = (
             event.group
             and event.group.issue_category == GroupCategory.ERROR
-            and event.group.platform == "cocoa"
+            and self.cocoa_sdk_crash_detector.should_detect_sdk_crash(event.data)
         )
         if not should_detect_sdk_crash:
             return None
 
         context = get_path(event.data, "contexts", "sdk_crash_detection")
         if context is not None:
-            return None
-
-        # Getting the frames and checking if the event is unhandled might different per platform.
-        # We will change this once we implement this for more platforms.
-        is_unhandled = (
-            get_path(event.data, "exception", "values", -1, "mechanism", "handled") is False
-        )
-        if is_unhandled is False:
             return None
 
         frames = get_path(event.data, "exception", "values", -1, "stacktrace", "frames")

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
@@ -1,11 +1,17 @@
 from abc import ABC, abstractmethod
 from typing import Any, Mapping, Sequence, Set
 
+from sentry.db.models import NodeData
+
 
 class SDKCrashDetector(ABC):
     @property
     def fields_containing_paths(self) -> Set[str]:
         return {"package", "module", "abs_path"}
+
+    @abstractmethod
+    def should_detect_sdk_crash(self, event_data: NodeData) -> bool:
+        raise NotImplementedError
 
     @abstractmethod
     def is_sdk_crash(self, frames: Sequence[Mapping[str, Any]]) -> bool:

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -80,7 +80,7 @@ class EventStripperTestMixin(BaseEventStripperMixin):
 
         assert stripped_event_data.get("sdk") == {
             "name": "sentry.cocoa",
-            "version": "8.1.0",
+            "version": "8.2.0",
         }
 
     def test_strip_event_data_strips_value_if_not_simple_type(self):

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -74,8 +74,29 @@ class CococaSDKTestMixin(BaseSDKCrashDetectionMixin):
     def test_wrong_function_not_detected(self, mock_sdk_crash_reporter):
         self.execute_test(get_crash_event(function="Senry"), False, mock_sdk_crash_reporter)
 
-    def test_wrong_platform_not_detected(self, mock_sdk_crash_reporter):
-        self.execute_test(get_crash_event(platform="coco"), False, mock_sdk_crash_reporter)
+    def test_wrong_sdk_not_detected(self, mock_sdk_crash_reporter):
+        event = get_crash_event()
+        set_path(event, "sdk", "name", value="sentry.coco")
+
+        self.execute_test(event, False, mock_sdk_crash_reporter)
+
+    def test_beta_sdk_version_detected(self, mock_sdk_crash_reporter):
+        event = get_crash_event()
+        set_path(event, "sdk", "version", value="8.2.1-beta.1")
+
+        self.execute_test(event, True, mock_sdk_crash_reporter)
+
+    def test_too_low_min_sdk_version_not_detected(self, mock_sdk_crash_reporter):
+        event = get_crash_event()
+        set_path(event, "sdk", "version", value="8.1.1")
+
+        self.execute_test(event, False, mock_sdk_crash_reporter)
+
+    def test_invalid_sdk_version_not_detected(self, mock_sdk_crash_reporter):
+        event = get_crash_event()
+        set_path(event, "sdk", "version", value="foo")
+
+        self.execute_test(event, False, mock_sdk_crash_reporter)
 
     def test_no_exception_not_detected(self, mock_sdk_crash_reporter):
         self.execute_test(get_crash_event(exception=[]), False, mock_sdk_crash_reporter)


### PR DESCRIPTION
The CocoaSDKCrashDetector requires minimum sentry-cocoa 8.2.0 to work properly, cause only since that version the SDK sends the full paths required for detecting system frames in is_system_library_frame.

