### PR TITLE
fix(monitors): Extend check_monitors task time limit

### DIFF
--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -34,7 +34,7 @@ MONITOR_LIMIT = 10_000
 CHECKINS_LIMIT = 10_000
 
 
-@instrumented_task(name="sentry.monitors.tasks.check_monitors", time_limit=15, soft_time_limit=10)
+@instrumented_task(name="sentry.monitors.tasks.check_monitors", time_limit=30, soft_time_limit=20)
 def check_monitors(current_datetime=None):
     if current_datetime is None:
         current_datetime = timezone.now()


### PR DESCRIPTION
We currently have a large back-log of monitors with in-progress
check-ins. Unfortunately our task is failing to actually complete which
I believe may be causing it to struggle to burn down the in-progress
check-ins.