### PR TITLE
feat(sourcemaps): Delete project association on project deletion

### DIFF
--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -44,6 +44,7 @@ class ProjectDeletionTask(ModelDeletionTask):
             models.ServiceHook,
             models.UserReport,
             models.ProjectTransactionThreshold,
+            models.ProjectArtifactBundle,
             DiscoverSavedQueryProject,
             IncidentProject,
             QuerySubscription,


### PR DESCRIPTION
This PR deletes the `ProjectArtifactBundle` association when the specific project is deleted.