### PR TITLE
fix(org-token): Fix view when no token has last used project

### DIFF
--- a/static/app/views/settings/organizationAuthTokens/index.spec.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.spec.tsx
@@ -97,6 +97,44 @@ describe('OrganizationAuthTokensIndex', function () {
     );
   });
 
+  it('shows unused tokens', async function () {
+    const tokens: OrgAuthToken[] = [
+      {
+        id: '1',
+        name: 'My Token 1',
+        tokenLastCharacters: '1234',
+        dateCreated: new Date('2023-01-01T00:00:00.000Z'),
+        scopes: ['org:read'],
+      },
+      {
+        id: '2',
+        name: 'My Token 2',
+        tokenLastCharacters: 'ABCD',
+        dateCreated: new Date('2023-01-01T00:00:00.000Z'),
+        scopes: ['org:read'],
+      },
+    ];
+
+    MockApiClient.addMockResponse({
+      url: ENDPOINT,
+      method: 'GET',
+      body: tokens,
+    });
+
+    render(<OrganizationAuthTokensIndex {...defaultProps} />);
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+
+    // Then list
+    expect(screen.getByText('My Token 1')).toBeInTheDocument();
+    expect(screen.getByText('My Token 2')).toBeInTheDocument();
+    expect(screen.getAllByText('never used')).toHaveLength(2);
+
+    expect(screen.queryByTestId('loading-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+  });
+
   it('handle error when loading tokens', async function () {
     const mock = MockApiClient.addMockResponse({
       url: ENDPOINT,

--- a/static/app/views/settings/organizationAuthTokens/index.spec.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.spec.tsx
@@ -129,10 +129,6 @@ describe('OrganizationAuthTokensIndex', function () {
     expect(screen.getByText('My Token 1')).toBeInTheDocument();
     expect(screen.getByText('My Token 2')).toBeInTheDocument();
     expect(screen.getAllByText('never used')).toHaveLength(2);
-
-    expect(screen.queryByTestId('loading-error')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
   });
 
   it('handle error when loading tokens', async function () {

--- a/static/app/views/settings/organizationAuthTokens/index.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.tsx
@@ -56,11 +56,13 @@ function TokenList({
 
   const idQueryParams = projectIds.map(id => `id:${id}`).join(' ');
 
+  const hasProjects = projectIds.length > 0;
+
   const {data: projects, isLoading: isLoadingProjects} = useApiQuery<Project[]>(
     [apiEndpoint, {query: {query: idQueryParams}}],
     {
       staleTime: 0,
-      enabled: projectIds.length > 0,
+      enabled: hasProjects,
     }
   );
 
@@ -78,7 +80,7 @@ function TokenList({
             isRevoking={isRevoking}
             revokeToken={revokeToken ? () => revokeToken({token}) : undefined}
             projectLastUsed={projectLastUsed}
-            isProjectLoading={isLoadingProjects}
+            isProjectLoading={hasProjects && isLoadingProjects}
           />
         );
       })}


### PR DESCRIPTION
Fix a UI bug where the loading state would never disappear when no org token has a last used project. This wasn't covered by the tests before, oops.