### PR TITLE
feat(crons): Add SENTRY_BLOCKED_MONITOR_CHECK_IN_ORGS

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3533,6 +3533,10 @@ SENTRY_FEATURE_ADOPTION_CACHE_OPTIONS = {
 MAX_MONITORS_PER_ORG = 10000
 MAX_ENVIRONMENTS_PER_MONITOR = 1000
 
+# List of organization IDs to drop check-ins from. This may be used for
+# temporary abuse rate limiting.
+SENTRY_BLOCKED_MONITOR_CHECK_IN_ORGS = []
+
 # Raise schema validation errors and make the indexer crash (only useful in
 # tests)
 SENTRY_METRICS_INDEXER_RAISE_VALIDATION_ERRORS = False

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -127,6 +127,14 @@ def _process_message(wrapper: Dict) -> None:
         "source_sdk": source_sdk,
     }
 
+    if project.organization_id in settings.SENTRY_BLOCKED_MONITOR_CHECK_IN_ORGS:
+        metrics.incr(
+            "monitors.checkin.dropped.blocked",
+            tags={**metric_kwargs},
+        )
+        logger.debug("monitor check in blocked: %s", monitor_slug)
+        return
+
     if ratelimits.is_limited(
         f"monitor-checkins:{ratelimit_key}",
         limit=CHECKIN_QUOTA_LIMIT,

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -457,3 +457,10 @@ class MonitorConsumerTest(TestCase):
 
         monitor_environments = MonitorEnvironment.objects.filter(monitor=monitor)
         assert len(monitor_environments) == settings.MAX_ENVIRONMENTS_PER_MONITOR
+
+    def test_monitor_blocked_orgs(self):
+        monitor = self._create_monitor(slug="my-monitor")
+        with override_settings(SENTRY_BLOCKED_MONITOR_CHECK_IN_ORGS=[self.organization.id]):
+            self.send_message(monitor.slug)
+
+        assert not MonitorCheckIn.objects.filter(guid=self.guid).exists()


### PR DESCRIPTION
Allows us to explicitly limit specific organizations from flooding us with check-ins in specific cases.