### PR TITLE
feat(perf-detector-threshold-configuration) Added frontend changes for more threshold configurations.

### DIFF
--- a/static/app/components/forms/formPanel.tsx
+++ b/static/app/components/forms/formPanel.tsx
@@ -29,6 +29,7 @@ type Props = {
    * The name of the field that should be highlighted
    */
   highlighted?: string;
+  initiallyCollapsed?: boolean;
   /**
    * Renders inside of PanelBody before PanelBody close
    */
@@ -52,9 +53,10 @@ function FormPanel({
   renderFooter,
   renderHeader,
   collapsible,
+  initiallyCollapsed = false,
   ...otherProps
 }: Props) {
-  const [collapsed, setCollapse] = useState(false);
+  const [collapsed, setCollapse] = useState(initiallyCollapsed);
   const handleCollapseToggle = useCallback(() => setCollapse(current => !current), []);
 
   return (
@@ -64,7 +66,11 @@ function FormPanel({
           {title}
           {collapsible && (
             <Collapse onClick={handleCollapseToggle}>
-              <IconChevron direction={collapsed ? 'down' : 'up'} size="xs" />
+              <IconChevron
+                data-test-id="form-panel-collapse-chevron"
+                direction={collapsed ? 'down' : 'up'}
+                size="xs"
+              />
             </Collapse>
           )}
         </PanelHeader>

--- a/static/app/components/forms/jsonForm.tsx
+++ b/static/app/components/forms/jsonForm.tsx
@@ -130,6 +130,7 @@ class JsonForm extends Component<Props, State> {
     const {
       access,
       collapsible,
+      initiallyCollapsed,
       fields,
       title,
       forms,
@@ -154,6 +155,7 @@ class JsonForm extends Component<Props, State> {
       renderHeader,
       highlighted: this.state.highlighted,
       collapsible,
+      initiallyCollapsed,
     };
 
     return (

--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
@@ -9,6 +9,9 @@ import {
 import * as utils from 'sentry/utils/isActiveSuperuser';
 import ProjectPerformance, {
   allowedDurationValues,
+  allowedPercentageValues,
+  allowedSizeValues,
+  DetectorConfigCustomer,
 } from 'sentry/views/settings/projectPerformance/projectPerformance';
 
 describe('projectPerformance', function () {
@@ -191,7 +194,7 @@ describe('projectPerformance', function () {
   it.each([
     {
       title: 'N+1 DB Queries',
-      threshold: 'n_plus_one_db_duration_threshold',
+      threshold: DetectorConfigCustomer.N_PLUS_DB_DURATION,
       allowedValues: allowedDurationValues,
       defaultValue: 100,
       newValue: 500,
@@ -200,12 +203,75 @@ describe('projectPerformance', function () {
     },
     {
       title: 'Slow DB Queries',
-      threshold: 'slow_db_query_duration_threshold',
+      threshold: DetectorConfigCustomer.SLOW_DB_DURATION,
       allowedValues: allowedDurationValues.slice(1),
       defaultValue: 1000,
       newValue: 3000,
       newValueIndex: 7,
       sliderIndex: 2,
+    },
+    {
+      title: 'Large Render Blocking Asset',
+      threshold: DetectorConfigCustomer.RENDER_BLOCKING_ASSET_RATIO,
+      allowedValues: allowedPercentageValues,
+      defaultValue: 0.33,
+      newValue: 0.5,
+      newValueIndex: 6,
+      sliderIndex: 3,
+    },
+    {
+      title: 'Large HTTP Payload',
+      threshold: DetectorConfigCustomer.LARGE_HTT_PAYLOAD_SIZE,
+      allowedValues: allowedSizeValues.slice(1),
+      defaultValue: 1000000,
+      newValue: 5000000,
+      newValueIndex: 13,
+      sliderIndex: 4,
+    },
+    {
+      title: 'DB on Main Thread',
+      threshold: DetectorConfigCustomer.DB_ON_MAIN_THREAD_DURATION,
+      allowedValues: [10, 16, 33, 50],
+      defaultValue: 16,
+      newValue: 33,
+      newValueIndex: 2,
+      sliderIndex: 5,
+    },
+    {
+      title: 'File I/O on Main Thread',
+      threshold: DetectorConfigCustomer.FILE_IO_MAIN_THREAD_DURATION,
+      allowedValues: [10, 16, 33, 50],
+      defaultValue: 16,
+      newValue: 50,
+      newValueIndex: 3,
+      sliderIndex: 6,
+    },
+    {
+      title: 'Consecutive DB Queries',
+      threshold: DetectorConfigCustomer.CONSECUTIVE_DB_MIN_TIME_SAVED,
+      allowedValues: allowedDurationValues.slice(0, 11),
+      defaultValue: 100,
+      newValue: 5000,
+      newValueIndex: 10,
+      sliderIndex: 7,
+    },
+    {
+      title: 'Uncompressed Asset',
+      threshold: DetectorConfigCustomer.UNCOMPRESSED_ASSET_SIZE,
+      allowedValues: allowedSizeValues.slice(1),
+      defaultValue: 512000,
+      newValue: 700000,
+      newValueIndex: 6,
+      sliderIndex: 8,
+    },
+    {
+      title: 'Uncompressed Asset',
+      threshold: DetectorConfigCustomer.UNCOMPRESSED_ASSET_DURATION,
+      allowedValues: allowedDurationValues.slice(1),
+      defaultValue: 500,
+      newValue: 400,
+      newValueIndex: 3,
+      sliderIndex: 9,
     },
   ])(
     'renders detector thresholds settings for $title issue',
@@ -246,6 +312,12 @@ describe('projectPerformance', function () {
         await screen.findByText('Performance Issues - Detector Threshold Settings')
       ).toBeInTheDocument();
       expect(screen.getByText(title)).toBeInTheDocument();
+
+      // Open collapsed panels
+      const chevrons = screen.getAllByTestId('form-panel-collapse-chevron');
+      for (const chevron of chevrons) {
+        await userEvent.click(chevron);
+      }
 
       const slider = screen.getAllByRole('slider')[sliderIndex];
       const indexOfValue = allowedValues.indexOf(defaultValue);

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -20,6 +20,7 @@ import {space} from 'sentry/styles/space';
 import {Organization, Project, Scope} from 'sentry/types';
 import {DynamicSamplingBiasType} from 'sentry/types/sampling';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {formatPercentage} from 'sentry/utils/formatters';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import AsyncView from 'sentry/views/asyncView';
@@ -39,16 +40,38 @@ export const allowedDurationValues: number[] = [
   10000,
 ]; // In milliseconds
 
+export const allowedPercentageValues: number[] = [
+  0.2, 0.25, 0.3, 0.33, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95,
+];
+
+export const allowedSizeValues: number[] = [
+  50000, 100000, 300000, 400000, 500000, 512000, 600000, 700000, 800000, 900000, 1000000,
+  2000000, 3000000, 4000000, 5000000, 6000000, 7000000, 8000000, 9000000, 10000000,
+]; // 50kb to 10MB in bytes
+
 type ProjectPerformanceSettings = {[key: string]: number | boolean};
 
 enum DetectorConfigAdmin {
   N_PLUS_DB_ENABLED = 'n_plus_one_db_queries_detection_enabled',
   SLOW_DB_ENABLED = 'slow_db_queries_detection_enabled',
+  DB_MAIN_THREAD_ENABLED = 'db_on_main_thread_detection_enabled',
+  FILE_IO_ENABLED = 'file_io_on_main_thread_detection_enabled',
+  CONSECUTIVE_DB_ENABLED = 'consecutive_db_queries_detection_enabled',
+  RENDER_BLOCK_ASSET_ENABLED = 'large_render_blocking_asset_detection_enabled',
+  UNCOMPRESSED_ASSET_ENABLED = 'uncompressed_assets_detection_enabled',
+  LARGE_HTTP_PAYLOAD_ENABLED = 'large_http_payload_detection_enabled',
 }
 
-enum DetectorConfigCustomer {
+export enum DetectorConfigCustomer {
   SLOW_DB_DURATION = 'slow_db_query_duration_threshold',
   N_PLUS_DB_DURATION = 'n_plus_one_db_duration_threshold',
+  RENDER_BLOCKING_ASSET_RATIO = 'render_blocking_fcp_ratio',
+  LARGE_HTT_PAYLOAD_SIZE = 'large_http_payload_size_threshold',
+  DB_ON_MAIN_THREAD_DURATION = 'db_on_main_thread_duration_threshold',
+  FILE_IO_MAIN_THREAD_DURATION = 'file_io_on_main_thread_duration_threshold',
+  UNCOMPRESSED_ASSET_DURATION = 'uncompressed_asset_duration_threshold',
+  UNCOMPRESSED_ASSET_SIZE = 'uncompressed_asset_size_threshold',
+  CONSECUTIVE_DB_MIN_TIME_SAVED = 'consecutive_db_min_time_saved_threshold',
 }
 
 type RouteParams = {orgId: string; projectId: string};
@@ -284,6 +307,84 @@ class ProjectPerformance extends AsyncView<Props, State> {
             },
           }),
       },
+      {
+        name: DetectorConfigAdmin.RENDER_BLOCK_ASSET_ENABLED,
+        type: 'boolean',
+        label: t('Large Render Blocking Asset Detection Enabled'),
+        defaultValue: true,
+        onChange: value =>
+          this.setState({
+            performance_issue_settings: {
+              ...this.state.performance_issue_settings,
+              large_render_blocking_asset_detection_enabled: value,
+            },
+          }),
+      },
+      {
+        name: DetectorConfigAdmin.CONSECUTIVE_DB_ENABLED,
+        type: 'boolean',
+        label: t('Consecutive DB Queries Detection Enabled'),
+        defaultValue: true,
+        onChange: value =>
+          this.setState({
+            performance_issue_settings: {
+              ...this.state.performance_issue_settings,
+              consecutive_db_queries_detection_enabled: value,
+            },
+          }),
+      },
+      {
+        name: DetectorConfigAdmin.LARGE_HTTP_PAYLOAD_ENABLED,
+        type: 'boolean',
+        label: t('Large HTTP Payload Detection Enabled'),
+        defaultValue: true,
+        onChange: value =>
+          this.setState({
+            performance_issue_settings: {
+              ...this.state.performance_issue_settings,
+              large_http_payload_detection_enabled: value,
+            },
+          }),
+      },
+      {
+        name: DetectorConfigAdmin.DB_MAIN_THREAD_ENABLED,
+        type: 'boolean',
+        label: t('DB On Main Thread Detection Enabled'),
+        defaultValue: true,
+        onChange: value =>
+          this.setState({
+            performance_issue_settings: {
+              ...this.state.performance_issue_settings,
+              db_on_main_thread_detection_enabled: value,
+            },
+          }),
+      },
+      {
+        name: DetectorConfigAdmin.FILE_IO_ENABLED,
+        type: 'boolean',
+        label: t('File I/O on Main Thread Detection Enabled'),
+        defaultValue: true,
+        onChange: value =>
+          this.setState({
+            performance_issue_settings: {
+              ...this.state.performance_issue_settings,
+              file_io_on_main_thread_detection_enabled: value,
+            },
+          }),
+      },
+      {
+        name: DetectorConfigAdmin.UNCOMPRESSED_ASSET_ENABLED,
+        type: 'boolean',
+        label: t('Uncompressed Assets Detection Enabled'),
+        defaultValue: true,
+        onChange: value =>
+          this.setState({
+            performance_issue_settings: {
+              ...this.state.performance_issue_settings,
+              uncompressed_assets_detection_enabled: value,
+            },
+          }),
+      },
     ];
   }
 
@@ -301,7 +402,20 @@ class ProjectPerformance extends AsyncView<Props, State> {
       : null;
 
     const formatDuration = (value: number | ''): string => {
-      return value && value < 1000 ? `${value}ms` : `${(value as number) / 1000}s`;
+      return value ? (value < 1000 ? `${value}ms` : `${value / 1000}s`) : '';
+    };
+
+    const formatSize = (value: number | ''): string => {
+      return value
+        ? value < 1000000
+          ? `${value / 1000}KB`
+          : `${value / 1000000}MB`
+        : '';
+    };
+
+    const formatFrameRate = (value: number | ''): string => {
+      const fps = value && 1000 / value;
+      return fps ? `${Math.floor(fps / 5) * 5}fps` : '';
     };
 
     return [
@@ -339,6 +453,145 @@ class ProjectPerformance extends AsyncView<Props, State> {
             allowedValues: allowedDurationValues.slice(1),
             disabled: !(
               hasAccess && performanceSettings[DetectorConfigAdmin.SLOW_DB_ENABLED]
+            ),
+            formatLabel: formatDuration,
+            disabledReason,
+          },
+        ],
+      },
+      {
+        title: t('Large Render Blocking Asset'),
+        fields: [
+          {
+            name: DetectorConfigCustomer.RENDER_BLOCKING_ASSET_RATIO,
+            type: 'range',
+            label: t('FCP Ratio'),
+            defaultValue: 0.33,
+            help: t(
+              'Setting the value to 50%, means that an eligible event will be stored as a Large Render Blocking Asset Issue only if the duration of the involved span is at least 50% of First Contentful Paint (FCP).'
+            ),
+            allowedValues: allowedPercentageValues,
+            disabled: !(
+              hasAccess &&
+              performanceSettings[DetectorConfigAdmin.RENDER_BLOCK_ASSET_ENABLED]
+            ),
+            formatLabel: value => value && formatPercentage(value),
+            disabledReason,
+          },
+        ],
+      },
+      {
+        title: t('Large HTTP Payload'),
+        fields: [
+          {
+            name: DetectorConfigCustomer.LARGE_HTT_PAYLOAD_SIZE,
+            type: 'range',
+            label: t('Size'),
+            defaultValue: 1000000, // 1MB in bytes
+            help: t(
+              'Setting the value to 200KB, means that an eligible event will be stored as a Large HTTP Payload Issue only if the involved HTTP span has a payload size that exceeds 200KB.'
+            ),
+            allowedValues: allowedSizeValues.slice(1),
+            disabled: !(
+              hasAccess &&
+              performanceSettings[DetectorConfigAdmin.LARGE_HTTP_PAYLOAD_ENABLED]
+            ),
+            formatLabel: formatSize,
+            disabledReason,
+          },
+        ],
+      },
+      {
+        title: t('DB on Main Thread'),
+        fields: [
+          {
+            name: DetectorConfigCustomer.DB_ON_MAIN_THREAD_DURATION,
+            type: 'range',
+            label: t('Duration'),
+            defaultValue: 16, // ms
+            help: t(
+              'Setting the value to 20fps, means that an eligible event will be stored as a DB on Main Thread Issue only if database spans on the main thread cause frame rate to drop below 20fps.'
+            ),
+            allowedValues: [10, 16, 33, 50], // representation of 100 to 20 fps in milliseconds
+            disabled: !(
+              hasAccess && performanceSettings[DetectorConfigAdmin.DB_MAIN_THREAD_ENABLED]
+            ),
+            formatLabel: formatFrameRate,
+            disabledReason,
+          },
+        ],
+      },
+      {
+        title: t('File I/O on Main Thread'),
+        fields: [
+          {
+            name: DetectorConfigCustomer.FILE_IO_MAIN_THREAD_DURATION,
+            type: 'range',
+            label: t('Duration'),
+            defaultValue: 16, // ms
+            help: t(
+              'Setting the value to 20fps, means that an eligible event will be stored as a DB on Main Thread Issue only if File I/O spans on the main thread cause frame rate to drop below 20fps.'
+            ),
+            allowedValues: [10, 16, 33, 50], // representation of 100, 60, 30, 20 fps in milliseconds
+            disabled: !(
+              hasAccess && performanceSettings[DetectorConfigAdmin.FILE_IO_ENABLED]
+            ),
+            formatLabel: formatFrameRate,
+            disabledReason,
+          },
+        ],
+      },
+      {
+        title: t('Consecutive DB Queries'),
+        fields: [
+          {
+            name: DetectorConfigCustomer.CONSECUTIVE_DB_MIN_TIME_SAVED,
+            type: 'range',
+            label: t('Minimum Time Saved'),
+            defaultValue: 100, // ms
+            help: t(
+              'Setting the value to 500ms, means that an eligible event will be stored as a Consecutive DB Queries Issue only if the time saved by parallelizing the queries exceeds 500ms.'
+            ),
+            allowedValues: allowedDurationValues.slice(0, 11),
+            disabled: !(
+              hasAccess && performanceSettings[DetectorConfigAdmin.CONSECUTIVE_DB_ENABLED]
+            ),
+            formatLabel: formatDuration,
+            disabledReason,
+          },
+        ],
+      },
+      {
+        title: t('Uncompressed Asset'),
+        fields: [
+          {
+            name: DetectorConfigCustomer.UNCOMPRESSED_ASSET_SIZE,
+            type: 'range',
+            label: t('Size'),
+            defaultValue: 512000, // in kilobytes
+            help: t(
+              'Setting the value to 1MB, means that an eligible event will be stored as an Uncompressed Asset Issue only if the size of the uncompressed asset being transferred exceeds 1MB.'
+            ),
+            allowedValues: allowedSizeValues.slice(1),
+            disabled: !(
+              hasAccess &&
+              performanceSettings[DetectorConfigAdmin.UNCOMPRESSED_ASSET_ENABLED]
+            ),
+            formatLabel: formatSize,
+            disabledReason,
+          },
+          {
+            name: DetectorConfigCustomer.UNCOMPRESSED_ASSET_DURATION,
+            type: 'range',
+            label: t('Duration'),
+            defaultValue: 500, // in ms
+            help: t(
+              'Setting the value to 200ms, means that an eligible event will be stored as an Uncompressed Asset Issue only if the duration of the span responsible for transferring the uncompressed asset exceeds 200ms.'
+            ),
+            allowedValues: allowedDurationValues.slice(1),
+            disabled: !(
+              hasAccess &&
+              performanceSettings[DetectorConfigAdmin.UNCOMPRESSED_ASSET_ENABLED]
             ),
             formatLabel: formatDuration,
             disabledReason,
@@ -403,6 +656,7 @@ class ProjectPerformance extends AsyncView<Props, State> {
     const projectEndpoint = this.getProjectEndpoint(params);
     const performanceIssuesEndpoint = this.getPerformanceIssuesEndpoint(params);
     const isSuperUser = isActiveSuperuser();
+
     return (
       <Fragment>
         <SettingsPageHeader title={t('Performance')} />
@@ -560,6 +814,7 @@ class ProjectPerformance extends AsyncView<Props, State> {
                     <StyledJsonForm
                       forms={this.project_owner_detector_settings(hasAccess)}
                       collapsible
+                      initiallyCollapsed
                     />
                     <StyledPanelFooter>
                       <Actions>


### PR DESCRIPTION
- Frontend changes rely on backend changes from this PR: [link](https://github.com/getsentry/sentry/pull/52239) for issues other than n+1 db queries and slow db queries. 
- Adds detection enabled toggles and sliders for configuring thresholds covering the following issues:
<img width="1024" alt="Screenshot 2023-07-05 at 9 54 41 AM" src="https://github.com/getsentry/sentry/assets/60121741/cebc729e-bac4-4b27-ae58-3dd7d5377355">

- Will be handling n+1 api calls and consecutive http spans separately
- Added tests.
