### PR TITLE
feat(crons): Add monitor check-ins org killswitch

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -207,6 +207,16 @@ ALL_KILLSWITCH_OPTIONS = {
         """,
         fields={"organization_id": "An organization ID to disable last deploys for."},
     ),
+    "crons.organization.disable-check-in": KillswitchInfo(
+        description="""
+        Do not consumer monitor check-ins for a specific organization.
+
+        This is valuable in scenarios where a organization is slamming in
+        progress check-ins without actually marking the check-in as complete
+        for whatever reason. This can cuase extranious strain on the system.
+        """,
+        fields={"organization_id": "An organization ID to disable check-ins for."},
+    ),
 }
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1347,3 +1347,6 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Killswitch for monitor check-ins
+register("crons.organization.disable-check-in", type=Sequence, default=[])


### PR DESCRIPTION
Adds a new killswitch to disable monitors at the organization level: `crons.organization.disable-check-in`