### PR TITLE
fix(dynamic-sampling): Add query timeout logging for more functions

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -193,7 +193,9 @@ def fetch_projects_with_total_root_transaction_count_and_rates(
             break
     else:
         log_query_timeout(
-            query="fetch_projects_with_total_root_transaction_count_and_rates", offset=offset
+            query="fetch_projects_with_total_root_transaction_count_and_rates",
+            offset=offset,
+            timeout_seconds=MAX_SECONDS,
         )
 
     return aggregated_projects

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -292,6 +292,8 @@ def get_orgs_with_project_counts(
             break
     if len(last_result) > 0:
         yield [org_id for org_id, _ in last_result]
+    else:
+        log_query_timeout(query="get_orgs_with_project_counts", offset=offset)
 
 
 def fetch_project_transaction_totals(org_ids: List[int]) -> Iterator[ProjectTransactionsTotals]:

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -290,10 +290,11 @@ def get_orgs_with_project_counts(
         last_result = last_result[first_idx:]
         if not more_results:
             break
-    if len(last_result) > 0:
-        yield [org_id for org_id, _ in last_result]
     else:
         log_query_timeout(query="get_orgs_with_project_counts", offset=offset)
+
+    if len(last_result) > 0:
+        yield [org_id for org_id, _ in last_result]
 
 
 def fetch_project_transaction_totals(org_ids: List[int]) -> Iterator[ProjectTransactionsTotals]:

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -291,7 +291,9 @@ def get_orgs_with_project_counts(
         if not more_results:
             break
     else:
-        log_query_timeout(query="get_orgs_with_project_counts", offset=offset)
+        log_query_timeout(
+            query="get_orgs_with_project_counts", offset=offset, timeout_seconds=MAX_SECONDS
+        )
 
     if len(last_result) > 0:
         yield [org_id for org_id, _ in last_result]
@@ -372,7 +374,9 @@ def fetch_project_transaction_totals(org_ids: List[int]) -> Iterator[ProjectTran
             }
 
     else:
-        log_query_timeout(query="fetch_project_transaction_totals", offset=offset)
+        log_query_timeout(
+            query="fetch_project_transaction_totals", offset=offset, timeout_seconds=MAX_SECONDS
+        )
 
     return None
 
@@ -498,7 +502,11 @@ def fetch_transactions_with_total_volumes(
                 }
             break
     else:
-        log_query_timeout(query="fetch_transactions_with_total_volumes", offset=offset)
+        log_query_timeout(
+            query="fetch_transactions_with_total_volumes",
+            offset=offset,
+            timeout_seconds=MAX_SECONDS,
+        )
 
     return None
 

--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -108,10 +108,11 @@ def get_active_orgs_with_projects_counts(
         last_result = last_result[first_idx:]
         if not more_results:
             break
-    if len(last_result) > 0:
-        yield [org_id for org_id, _ in last_result]
     else:
         log_query_timeout(query="get_active_orgs_with_projects_counts", offset=offset)
+
+    if len(last_result) > 0:
+        yield [org_id for org_id, _ in last_result]
 
 
 def fetch_orgs_with_total_root_transactions_count(

--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -109,7 +109,9 @@ def get_active_orgs_with_projects_counts(
         if not more_results:
             break
     else:
-        log_query_timeout(query="get_active_orgs_with_projects_counts", offset=offset)
+        log_query_timeout(
+            query="get_active_orgs_with_projects_counts", offset=offset, timeout_seconds=MAX_SECONDS
+        )
 
     if len(last_result) > 0:
         yield [org_id for org_id, _ in last_result]
@@ -178,7 +180,11 @@ def fetch_orgs_with_total_root_transactions_count(
         if not more_results:
             break
     else:
-        log_query_timeout(query="fetch_orgs_with_total_root_transactions_count", offset=offset)
+        log_query_timeout(
+            query="fetch_orgs_with_total_root_transactions_count",
+            offset=offset,
+            timeout_seconds=MAX_SECONDS,
+        )
 
     return aggregated_projects
 

--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -110,6 +110,8 @@ def get_active_orgs_with_projects_counts(
             break
     if len(last_result) > 0:
         yield [org_id for org_id, _ in last_result]
+    else:
+        log_query_timeout(query="get_active_orgs_with_projects_counts", offset=offset)
 
 
 def fetch_orgs_with_total_root_transactions_count(

--- a/src/sentry/dynamic_sampling/tasks/constants.py
+++ b/src/sentry/dynamic_sampling/tasks/constants.py
@@ -16,7 +16,6 @@ MAX_REBALANCE_FACTOR = 10
 
 # Parameters to bound the execution time of queries in Snuba.
 MAX_SECONDS = 60
-RECALIBRATE_ORGS_MAX_SECONDS = 600
 # Snuba's limit is 10000, and we fetch CHUNK_SIZE + 1.
 CHUNK_SIZE = 9998
 

--- a/src/sentry/dynamic_sampling/tasks/constants.py
+++ b/src/sentry/dynamic_sampling/tasks/constants.py
@@ -16,6 +16,7 @@ MAX_REBALANCE_FACTOR = 10
 
 # Parameters to bound the execution time of queries in Snuba.
 MAX_SECONDS = 60
+RECALIBRATE_ORGS_MAX_SECONDS = 600
 # Snuba's limit is 10000, and we fetch CHUNK_SIZE + 1.
 CHUNK_SIZE = 9998
 

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -31,6 +31,7 @@ from sentry.dynamic_sampling.tasks.helpers.recalibrate_orgs import (
 )
 from sentry.dynamic_sampling.tasks.logging import (
     log_action_if,
+    log_query_timeout,
     log_recalibrate_org_error,
     log_recalibrate_org_state,
     log_sample_rate_source,
@@ -212,6 +213,8 @@ def get_active_orgs(
 
         if not more_results:
             return
+    else:
+        log_query_timeout(query="get_active_orgs", offset=offset)
 
 
 def fetch_org_volumes(

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -217,7 +217,9 @@ def get_active_orgs(
         if not more_results:
             return
     else:
-        log_query_timeout(query="get_active_orgs", offset=offset)
+        log_query_timeout(
+            query="get_active_orgs", offset=offset, timeout_seconds=RECALIBRATE_ORGS_MAX_SECONDS
+        )
 
 
 def fetch_org_volumes(

--- a/src/sentry/dynamic_sampling/tasks/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window.py
@@ -208,6 +208,10 @@ def fetch_projects_with_total_root_transactions_count(
         if not more_results:
             break
     else:
-        log_query_timeout(query="fetch_projects_with_total_root_transactions_count", offset=offset)
+        log_query_timeout(
+            query="fetch_projects_with_total_root_transactions_count",
+            offset=offset,
+            timeout_seconds=MAX_SECONDS,
+        )
 
     return aggregated_projects


### PR DESCRIPTION
This PR adds more timeouts loggers and increases the time for execution of org recalibration.