### PR TITLE
ref(tests): use MockApiClient instead of Client

### DIFF
--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -32,7 +32,7 @@ interface MatchCallable {
 }
 
 type AsyncDelay = undefined | number;
-type ResponseType = ApiNamespace.ResponseMeta & {
+interface ResponseType extends ApiNamespace.ResponseMeta {
   body: any;
   callCount: 0;
   headers: Record<string, string>;
@@ -49,7 +49,7 @@ type ResponseType = ApiNamespace.ResponseMeta & {
    * This will override `MockApiClient.asyncDelay` for this request.
    */
   asyncDelay?: AsyncDelay;
-};
+}
 
 type MockResponse = [resp: ResponseType, mock: jest.Mock];
 

--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -171,7 +171,9 @@ class Client implements ApiNamespace.Client {
    * In the real client, this clears in-flight responses. It's NOT
    * clearMockResponses. You probably don't want to call this from a test.
    */
-  clear() {}
+  clear() {
+    Object.values(this.activeRequests).forEach(r => r.cancel());
+  }
 
   wrapCallback<T extends any[]>(
     _id: string,

--- a/static/app/actionCreators/events.spec.tsx
+++ b/static/app/actionCreators/events.spec.tsx
@@ -1,8 +1,7 @@
 import {doEventsRequest} from 'sentry/actionCreators/events';
-import {Client} from 'sentry/api';
 
 describe('Events ActionCreator', function () {
-  const api = new Client();
+  const api = new MockApiClient();
   const organization = TestStubs.Organization();
   const project = TestStubs.Project();
   const opts = {

--- a/static/app/actionCreators/group.spec.tsx
+++ b/static/app/actionCreators/group.spec.tsx
@@ -1,14 +1,7 @@
 import {bulkUpdate, mergeGroups, paramsToQueryArgs} from 'sentry/actionCreators/group';
-import {Client} from 'sentry/api';
 import GroupStore from 'sentry/stores/groupStore';
 
 describe('group', () => {
-  let api: Client;
-
-  beforeEach(function () {
-    api = new MockApiClient();
-  });
-
   describe('paramsToQueryArgs()', function () {
     it('should convert itemIds properties to id array', function () {
       expect(
@@ -92,7 +85,7 @@ describe('group', () => {
       });
 
       bulkUpdate(
-        api,
+        new MockApiClient(),
         {
           orgId: '1337',
           projectId: '1337',
@@ -117,7 +110,7 @@ describe('group', () => {
       });
 
       bulkUpdate(
-        api,
+        new MockApiClient(),
         {
           orgId: '1337',
           projectId: '1337',
@@ -142,7 +135,7 @@ describe('group', () => {
       });
 
       bulkUpdate(
-        api,
+        new MockApiClient(),
         {
           orgId: '1337',
           project: [99],
@@ -174,7 +167,7 @@ describe('group', () => {
       });
 
       mergeGroups(
-        api,
+        new MockApiClient(),
         {
           orgId: '1337',
           projectId: '1337',
@@ -198,7 +191,7 @@ describe('group', () => {
       });
 
       mergeGroups(
-        api,
+        new MockApiClient(),
         {
           orgId: '1337',
           projectId: '1337',

--- a/static/app/actionCreators/projects.spec.tsx
+++ b/static/app/actionCreators/projects.spec.tsx
@@ -1,10 +1,9 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import {_debouncedLoadStats} from 'sentry/actionCreators/projects';
-import {Client} from 'sentry/api';
 
 describe('Projects ActionCreators', function () {
-  const api = new Client();
+  const api = new MockApiClient();
   const {organization, project} = initializeOrg();
 
   it('loadStatsForProject', function () {

--- a/static/app/api.spec.tsx
+++ b/static/app/api.spec.tsx
@@ -1,4 +1,4 @@
-import {Client, Request} from 'sentry/api';
+import {Request} from 'sentry/api';
 import {PROJECT_MOVED} from 'sentry/constants/apiErrorCodes';
 
 jest.unmock('sentry/api');
@@ -7,7 +7,7 @@ describe('api', function () {
   let api;
 
   beforeEach(function () {
-    api = new Client();
+    api = new MockApiClient();
   });
 
   describe('Client', function () {

--- a/static/app/components/assigneeSelector.spec.jsx
+++ b/static/app/components/assigneeSelector.spec.jsx
@@ -1,7 +1,6 @@
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {openInviteMembersModal} from 'sentry/actionCreators/modal';
-import {Client} from 'sentry/api';
 import AssigneeSelectorComponent from 'sentry/components/assigneeSelector';
 import {putSessionUserFirst} from 'sentry/components/assigneeSelectorDropdown';
 import ConfigStore from 'sentry/stores/configStore';
@@ -88,7 +87,7 @@ describe('AssigneeSelector', () => {
     jest.spyOn(ProjectsStore, 'getAll').mockImplementation(() => [PROJECT_1]);
     jest.spyOn(GroupStore, 'get').mockImplementation(() => GROUP_1);
 
-    assignMock = Client.addMockResponse({
+    assignMock = MockApiClient.addMockResponse({
       method: 'PUT',
       url: `/issues/${GROUP_1.id}/`,
       body: {
@@ -97,7 +96,7 @@ describe('AssigneeSelector', () => {
       },
     });
 
-    assignGroup2Mock = Client.addMockResponse({
+    assignGroup2Mock = MockApiClient.addMockResponse({
       method: 'PUT',
       url: `/issues/${GROUP_2.id}/`,
       body: {
@@ -118,7 +117,7 @@ describe('AssigneeSelector', () => {
   };
 
   afterEach(() => {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
   });
 
   describe('render with props', () => {
@@ -218,8 +217,8 @@ describe('AssigneeSelector', () => {
   });
 
   it('successfully assigns teams', async () => {
-    Client.clearMockResponses();
-    assignMock = Client.addMockResponse({
+    MockApiClient.clearMockResponses();
+    assignMock = MockApiClient.addMockResponse({
       method: 'PUT',
       url: `/issues/${GROUP_1.id}/`,
       body: {
@@ -329,7 +328,7 @@ describe('AssigneeSelector', () => {
     render(<AssigneeSelectorComponent id={GROUP_2.id} />);
     act(() => MemberListStore.loadInitialData([USER_1, USER_2, USER_3, USER_4]));
 
-    assignMock = Client.addMockResponse({
+    assignMock = MockApiClient.addMockResponse({
       method: 'PUT',
       url: `/issues/${GROUP_2.id}/`,
       statusCode: 400,

--- a/static/app/components/discover/transactionsList.spec.jsx
+++ b/static/app/components/discover/transactionsList.spec.jsx
@@ -1,7 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import TransactionsList from 'sentry/components/discover/transactionsList';
 import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
@@ -35,7 +34,6 @@ describe('TransactionsList', function () {
   };
 
   beforeEach(function () {
-    api = new Client();
     location = {
       pathname: '/',
       query: {},

--- a/static/app/components/events/interfaces/spans/spanTreeModel.spec.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.spec.tsx
@@ -1,6 +1,5 @@
 import {waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import SpanTreeModel from 'sentry/components/events/interfaces/spans/spanTreeModel';
 import {EnhancedProcessedSpanType} from 'sentry/components/events/interfaces/spans/types';
 import {
@@ -13,7 +12,7 @@ import {assert} from 'sentry/types/utils';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
 
 describe('SpanTreeModel', () => {
-  const api: Client = new Client();
+  const api = new MockApiClient();
 
   const event = {
     id: '2b658a829a21496b87fd1f14a61abf65',

--- a/static/app/components/group/sentryAppExternalIssueForm.spec.jsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.spec.jsx
@@ -2,7 +2,6 @@ import selectEvent from 'react-select-event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import SentryAppExternalIssueForm from 'sentry/components/group/sentryAppExternalIssueForm';
 import {addQueryParamsToExistingUrl} from 'sentry/utils/queryString';
 
@@ -39,7 +38,7 @@ describe('SentryAppExternalIssueForm', () => {
           appName={sentryApp.name}
           config={component.schema.create}
           action="create"
-          api={new Client()}
+          api={new MockApiClient()}
         />
       );
 
@@ -89,7 +88,7 @@ describe('SentryAppExternalIssueForm', () => {
           appName={sentryApp.name}
           config={component.schema.create}
           action="create"
-          api={new Client()}
+          api={new MockApiClient()}
         />
       );
       expect(screen.getByRole('textbox', {name: 'Title'})).toHaveValue(`${group.title}`);
@@ -112,7 +111,7 @@ describe('SentryAppExternalIssueForm', () => {
           appName={sentryApp.name}
           config={component.schema.link}
           action="link"
-          api={new Client()}
+          api={new MockApiClient()}
         />
       );
 
@@ -173,7 +172,7 @@ describe('SentryAppExternalIssueForm Async Field', () => {
         appName={sentryApp.name}
         config={component.schema.create}
         action="create"
-        api={new Client()}
+        api={new MockApiClient()}
       />
     );
 
@@ -238,7 +237,7 @@ describe('SentryAppExternalIssueForm Dependent fields', () => {
         appName={sentryApp.name}
         config={component.schema.create}
         action="create"
-        api={new Client()}
+        api={new MockApiClient()}
       />
     );
 

--- a/static/app/components/modals/dashboardWidgetQuerySelectorModal.spec.tsx
+++ b/static/app/components/modals/dashboardWidgetQuerySelectorModal.spec.tsx
@@ -1,14 +1,13 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import DashboardWidgetQuerySelectorModal from 'sentry/components/modals/dashboardWidgetQuerySelectorModal';
 import {t} from 'sentry/locale';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
 const stubEl: any = (props: any) => <div>{props.children}</div>;
 
-const api: Client = new Client();
+const api = new MockApiClient();
 
 function renderModal({initialData, widget}) {
   return render(

--- a/static/app/components/modals/sudoModal.spec.jsx
+++ b/static/app/components/modals/sudoModal.spec.jsx
@@ -1,7 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import ConfigStore from 'sentry/stores/configStore';
 import App from 'sentry/views/app';
 
@@ -18,22 +17,22 @@ describe('Sudo Modal', function () {
       },
     };
 
-    Client.clearMockResponses();
-    Client.addMockResponse({
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
       url: '/internal/health/',
       body: {
         problems: [],
       },
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/assistant/',
       body: [],
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/organizations/',
       body: [TestStubs.Organization()],
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/',
       method: 'DELETE',
       statusCode: 401,
@@ -44,7 +43,7 @@ describe('Sudo Modal', function () {
         },
       },
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/authenticators/',
       body: [],
     });
@@ -67,7 +66,6 @@ describe('Sudo Modal', function () {
       </App>
     );
 
-    const api = new Client();
     const successCb = jest.fn();
     const errorCb = jest.fn();
 
@@ -75,7 +73,7 @@ describe('Sudo Modal', function () {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
     // Should return w/ `sudoRequired`
-    api.request('/organizations/org-slug/', {
+    new MockApiClient().request('/organizations/org-slug/', {
       method: 'DELETE',
       success: successCb,
       error: errorCb,
@@ -89,13 +87,13 @@ describe('Sudo Modal', function () {
     expect(errorCb).not.toHaveBeenCalled();
 
     // Clear mocks and allow DELETE
-    Client.clearMockResponses();
-    const orgDeleteMock = Client.addMockResponse({
+    MockApiClient.clearMockResponses();
+    const orgDeleteMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/',
       method: 'DELETE',
       statusCode: 200,
     });
-    const sudoMock = Client.addMockResponse({
+    const sudoMock = MockApiClient.addMockResponse({
       url: '/auth/',
       method: 'PUT',
       statusCode: 200,
@@ -145,13 +143,11 @@ describe('Sudo Modal', function () {
       </App>
     );
 
-    const api = new Client();
-
     // No Modal
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
     // Should return w/ `sudoRequired` and trigger the the modal to open
-    api.requestPromise('/organizations/org-slug/', {method: 'DELETE'});
+    new MockApiClient().request('/organizations/org-slug/', {method: 'DELETE'});
 
     // Should have Modal + input
     expect(await screen.findByRole('dialog')).toBeInTheDocument();

--- a/static/app/components/repositoryRow.spec.tsx
+++ b/static/app/components/repositoryRow.spec.tsx
@@ -5,7 +5,6 @@ import {
   userEvent,
 } from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import RepositoryRow from 'sentry/components/repositoryRow';
 
 describe('RepositoryRow', function () {
@@ -28,7 +27,7 @@ describe('RepositoryRow', function () {
     },
     status: 'pending_deletion',
   });
-  const api = new Client();
+  const api = new MockApiClient();
 
   describe('rendering with access', function () {
     const organization = TestStubs.Organization({

--- a/static/app/utils/discover/discoverQuery.spec.jsx
+++ b/static/app/utils/discover/discoverQuery.spec.jsx
@@ -1,13 +1,11 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 
 describe('DiscoverQuery', function () {
-  let location, api, eventView;
+  let location, eventView;
   beforeEach(() => {
-    api = new Client();
     location = {
       pathname: '/events',
       query: {},
@@ -33,7 +31,7 @@ describe('DiscoverQuery', function () {
     render(
       <DiscoverQuery
         orgSlug="test-org"
-        api={api}
+        api={new MockApiClient()}
         location={location}
         eventView={eventView}
       >
@@ -63,7 +61,7 @@ describe('DiscoverQuery', function () {
     render(
       <DiscoverQuery
         orgSlug="test-org"
-        api={api}
+        api={new MockApiClient()}
         location={location}
         eventView={eventView}
         limit={3}
@@ -105,7 +103,7 @@ describe('DiscoverQuery', function () {
     render(
       <DiscoverQuery
         orgSlug="test-org"
-        api={api}
+        api={new MockApiClient()}
         location={location}
         eventView={eventView}
         setError={e => (errorValue = e)}
@@ -140,7 +138,7 @@ describe('DiscoverQuery', function () {
     render(
       <DiscoverQuery
         orgSlug="test-org"
-        api={api}
+        api={new MockApiClient()}
         location={location}
         eventView={eventView}
         setError={e => (errorValue = e)}

--- a/static/app/utils/performance/quickTrace/quickTraceQuery.spec.jsx
+++ b/static/app/utils/performance/quickTrace/quickTraceQuery.spec.jsx
@@ -2,7 +2,6 @@ import {Fragment} from 'react';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery';
 
 const traceId = 'abcdef1234567890';
@@ -28,9 +27,8 @@ function renderQuickTrace({isLoading, error, trace, type}) {
 }
 
 describe('TraceLiteQuery', function () {
-  let api, location, event, traceLiteMock, traceFullMock, traceMetaMock;
+  let location, event, traceLiteMock, traceFullMock, traceMetaMock;
   beforeEach(function () {
-    api = new Client();
     location = {
       pathname: '/',
       query: {},
@@ -67,7 +65,7 @@ describe('TraceLiteQuery', function () {
     render(
       <QuickTraceQuery
         event={event}
-        api={api}
+        api={new MockApiClient()}
         location={location}
         orgSlug="test-org"
         statsPeriod="24h"
@@ -85,7 +83,7 @@ describe('TraceLiteQuery', function () {
       <QuickTraceQuery
         withMeta={false}
         event={event}
-        api={api}
+        api={new MockApiClient()}
         location={location}
         orgSlug="test-org"
         statsPeriod="24h"
@@ -104,7 +102,7 @@ describe('TraceLiteQuery', function () {
       <QuickTraceQuery
         withMeta={false}
         event={event}
-        api={api}
+        api={new MockApiClient()}
         location={location}
         orgSlug="test-org"
         statsPeriod="24h"
@@ -140,7 +138,7 @@ describe('TraceLiteQuery', function () {
       <QuickTraceQuery
         withMeta={false}
         event={event}
-        api={api}
+        api={new MockApiClient()}
         location={location}
         orgSlug="test-org"
         statsPeriod="24h"

--- a/static/app/utils/performance/quickTrace/traceFullQuery.spec.jsx
+++ b/static/app/utils/performance/quickTrace/traceFullQuery.spec.jsx
@@ -2,7 +2,6 @@ import {Fragment} from 'react';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import {
   TraceFullDetailedQuery,
   TraceFullQuery,
@@ -28,9 +27,8 @@ function renderTraceFull({isLoading, error, type}) {
 }
 
 describe('TraceFullQuery', function () {
-  let api, location;
+  let location;
   beforeEach(function () {
-    api = new Client();
     location = {
       pathname: '/',
       query: {},
@@ -44,7 +42,7 @@ describe('TraceFullQuery', function () {
     });
     render(
       <TraceFullQuery
-        api={api}
+        api={new MockApiClient()}
         traceId={traceId}
         eventId={eventId}
         location={location}
@@ -67,7 +65,7 @@ describe('TraceFullQuery', function () {
     });
     render(
       <TraceFullDetailedQuery
-        api={api}
+        api={new MockApiClient()}
         traceId={traceId}
         eventId={eventId}
         location={location}

--- a/static/app/utils/useApi.spec.tsx
+++ b/static/app/utils/useApi.spec.tsx
@@ -1,13 +1,12 @@
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import useApi from 'sentry/utils/useApi';
 
 describe('useApi', function () {
   it('provides an api client', function () {
     const {result} = reactHooks.renderHook(useApi);
 
-    expect(result.current).toBeInstanceOf(Client);
+    expect(result.current).toBeInstanceOf(MockApiClient);
   });
 
   it('cancels pending API requests when unmounted', function () {
@@ -31,7 +30,7 @@ describe('useApi', function () {
   });
 
   it('uses pass through API when provided', function () {
-    const myClient = new Client();
+    const myClient = new MockApiClient();
     const {unmount} = reactHooks.renderHook(useApi, {initialProps: {api: myClient}});
 
     jest.spyOn(myClient, 'clear');

--- a/static/app/utils/withApi.spec.tsx
+++ b/static/app/utils/withApi.spec.tsx
@@ -1,6 +1,6 @@
 import {render} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
+import type {Client} from 'sentry/api';
 import withApi from 'sentry/utils/withApi';
 
 describe('withApi', function () {

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
@@ -1,7 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import TriggersChart from 'sentry/views/alerts/rules/metric/triggers/chart';
 import {
   AlertRuleComparisonType,
@@ -20,7 +19,7 @@ describe('Incident Rules Create', () => {
     body: {count: 5},
   });
 
-  const api = new Client();
+  const api = new MockApiClient();
 
   it('renders a metric', async () => {
     const {organization, project, router} = initializeOrg();

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -8,7 +8,6 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import * as modal from 'sentry/actionCreators/modal';
-import {Client} from 'sentry/api';
 import * as LineChart from 'sentry/components/charts/lineChart';
 import SimpleTableChart from 'sentry/components/charts/simpleTableChart';
 import {MINUTE, SECOND} from 'sentry/utils/formatters';
@@ -71,7 +70,7 @@ describe('Dashboards > WidgetCard', function () {
     },
   };
 
-  const api = new Client();
+  const api = new MockApiClient();
   let eventsMock;
 
   beforeEach(function () {

--- a/static/app/views/dashboards/widgetCard/issueWidgetCard.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetCard.spec.tsx
@@ -1,7 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import MemberListStore from 'sentry/stores/memberListStore';
 import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboards/types';
 import WidgetCard from 'sentry/views/dashboards/widgetCard';
@@ -42,7 +41,7 @@ describe('Dashboards > IssueWidgetCard', function () {
     },
   };
 
-  const api = new Client();
+  const api = new MockApiClient();
 
   beforeEach(function () {
     MockApiClient.addMockResponse({

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
@@ -1,7 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import {
   DashboardFilterKeys,
   DisplayType,
@@ -65,7 +64,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
     },
   };
 
-  const api = new Client();
+  const api = new MockApiClient();
 
   afterEach(function () {
     MockApiClient.clearMockResponses();

--- a/static/app/views/dashboards/widgetCard/widgetQueries.spec.jsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.spec.jsx
@@ -1,7 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {DashboardFilterKeys} from 'sentry/views/dashboards/types';
 import {DashboardsMEPContext} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
@@ -79,8 +78,6 @@ describe('Dashboards > WidgetQueries', function () {
     },
   };
 
-  const api = new Client();
-
   afterEach(function () {
     MockApiClient.clearMockResponses();
   });
@@ -98,7 +95,7 @@ describe('Dashboards > WidgetQueries', function () {
     });
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={multipleQueryWidget}
         organization={initialData.organization}
         selection={selection}
@@ -120,7 +117,7 @@ describe('Dashboards > WidgetQueries', function () {
     });
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={singleQueryWidget}
         organization={initialData.organization}
         selection={selection}
@@ -148,7 +145,7 @@ describe('Dashboards > WidgetQueries', function () {
     });
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={tableWidget}
         organization={initialData.organization}
         selection={selection}
@@ -185,7 +182,7 @@ describe('Dashboards > WidgetQueries', function () {
     let error = '';
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={multipleQueryWidget}
         organization={initialData.organization}
         selection={selection}
@@ -220,7 +217,7 @@ describe('Dashboards > WidgetQueries', function () {
     };
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={widget}
         organization={initialData.organization}
         selection={longSelection}
@@ -254,7 +251,7 @@ describe('Dashboards > WidgetQueries', function () {
 
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={widget}
         organization={initialData.organization}
         selection={selection}
@@ -286,7 +283,7 @@ describe('Dashboards > WidgetQueries', function () {
     let childProps = undefined;
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={tableWidget}
         organization={initialData.organization}
         selection={selection}
@@ -363,7 +360,7 @@ describe('Dashboards > WidgetQueries', function () {
     let childProps = undefined;
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={widget}
         organization={initialData.organization}
         selection={selection}
@@ -397,7 +394,7 @@ describe('Dashboards > WidgetQueries', function () {
     let childProps = undefined;
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={{
           title: 'SDK',
           interval: '5m',
@@ -456,7 +453,7 @@ describe('Dashboards > WidgetQueries', function () {
     let childProps = undefined;
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={{
           title: 'SDK',
           interval: '5m',
@@ -546,7 +543,7 @@ describe('Dashboards > WidgetQueries', function () {
     let childProps = undefined;
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={widget}
         organization={initialData.organization}
         selection={selection}
@@ -580,7 +577,7 @@ describe('Dashboards > WidgetQueries', function () {
     };
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={barWidget}
         organization={initialData.organization}
         selection={selection}
@@ -643,7 +640,7 @@ describe('Dashboards > WidgetQueries', function () {
     const child = jest.fn(() => <div data-test-id="child" />);
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={barWidget}
         organization={initialData.organization}
         selection={selection}
@@ -677,7 +674,7 @@ describe('Dashboards > WidgetQueries', function () {
     };
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={areaWidget}
         organization={initialData.organization}
         selection={{
@@ -713,7 +710,7 @@ describe('Dashboards > WidgetQueries', function () {
     let childProps;
     const {rerender} = renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={lineWidget}
         organization={initialData.organization}
         selection={selection}
@@ -732,7 +729,7 @@ describe('Dashboards > WidgetQueries', function () {
     rerender(
       <MEPSettingProvider forceTransactions={false}>
         <WidgetQueries
-          api={api}
+          api={new MockApiClient()}
           widget={{
             ...lineWidget,
             queries: [
@@ -900,7 +897,7 @@ describe('Dashboards > WidgetQueries', function () {
         }}
       >
         <WidgetQueries
-          api={api}
+          api={new MockApiClient()}
           widget={singleQueryWidget}
           organization={{
             ...organization,
@@ -946,7 +943,7 @@ describe('Dashboards > WidgetQueries', function () {
         }}
       >
         <WidgetQueries
-          api={api}
+          api={new MockApiClient()}
           widget={{...singleQueryWidget, displayType: 'table'}}
           organization={{
             ...organization,
@@ -997,7 +994,7 @@ describe('Dashboards > WidgetQueries', function () {
     };
     renderWithProviders(
       <WidgetQueries
-        api={api}
+        api={new MockApiClient()}
         widget={areaWidget}
         organization={testData.organization}
         selection={selection}

--- a/static/app/views/discover/tags.spec.jsx
+++ b/static/app/views/discover/tags.spec.jsx
@@ -6,7 +6,6 @@ import {
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import EventView from 'sentry/utils/discover/eventView';
 import {Tags} from 'sentry/views/discover/tags';
 
@@ -17,7 +16,7 @@ describe('Tags', function () {
 
   const org = TestStubs.Organization();
   beforeEach(function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/events-facets/`,
       body: [
         {
@@ -46,12 +45,10 @@ describe('Tags', function () {
   });
 
   afterEach(function () {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
   });
 
   it('renders', async function () {
-    const api = new Client();
-
     const view = new EventView({
       fields: [],
       sorts: [],
@@ -61,7 +58,7 @@ describe('Tags', function () {
     render(
       <Tags
         eventView={view}
-        api={api}
+        api={new MockApiClient()}
         totalValues={30}
         organization={org}
         selection={{projects: [], environments: [], datetime: {}}}
@@ -81,8 +78,6 @@ describe('Tags', function () {
   });
 
   it('creates URLs with generateUrl', async function () {
-    const api = new Client();
-
     const view = new EventView({
       fields: [],
       sorts: [],
@@ -99,7 +94,7 @@ describe('Tags', function () {
     render(
       <Tags
         eventView={view}
-        api={api}
+        api={new MockApiClient()}
         organization={org}
         totalValues={30}
         selection={{projects: [], environments: [], datetime: {}}}
@@ -126,8 +121,6 @@ describe('Tags', function () {
   });
 
   it('renders tag keys', async function () {
-    const api = new Client();
-
     const view = new EventView({
       fields: [],
       sorts: [],
@@ -137,7 +130,7 @@ describe('Tags', function () {
     render(
       <Tags
         eventView={view}
-        api={api}
+        api={new MockApiClient()}
         totalValues={30}
         organization={org}
         selection={{projects: [], environments: [], datetime: {}}}
@@ -157,8 +150,6 @@ describe('Tags', function () {
   });
 
   it('excludes top tag values on current page query', async function () {
-    const api = new Client();
-
     const initialData = initializeOrg({
       organization: org,
       router: {
@@ -175,7 +166,7 @@ describe('Tags', function () {
     render(
       <Tags
         eventView={view}
-        api={api}
+        api={new MockApiClient()}
         totalValues={30}
         organization={org}
         selection={{projects: [], environments: [], datetime: {}}}
@@ -203,13 +194,13 @@ describe('Tags', function () {
   });
 
   it('has a Show More button when there are more tags', async () => {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/events-facets/`,
       match: [MockApiClient.matchQuery({cursor: undefined})],
       headers: {
         Link:
-          '<http://localhost/api/0/organizations/org-slug/events-facets/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1",' +
-          '<http://localhost/api/0/organizations/org-slug/events-facets/?cursor=0:10:0>; rel="next"; results="true"; cursor="0:10:0"',
+          '<http://localhost/api/0new /organizations()/org-slug/events-facets/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1",' +
+          '<http://localhost/api/0new /organizations()/org-slug/events-facets/?cursor=0:10:0>; rel="next"; results="true"; cursor="0:10:0"',
       },
       body: [
         {
@@ -219,18 +210,16 @@ describe('Tags', function () {
       ],
     });
 
-    const mockRequest = Client.addMockResponse({
+    const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/events-facets/`,
       match: [MockApiClient.matchQuery({cursor: '0:10:0'})],
       body: [],
       headers: {
         Link:
-          '<http://localhost/api/0/organizations/org-slug/events-facets/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:10:1",' +
-          '<http://localhost/api/0/organizations/org-slug/events-facets/?cursor=0:20:0>; rel="next"; results="false"; cursor="0:20:0"',
+          '<http://localhost/api/0new /organizations()/org-slug/events-facets/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:10:1",' +
+          '<http://localhost/api/0new /organizations()/org-slug/events-facets/?cursor=0:20:0>; rel="next"; results="false"; cursor="0:20:0"',
       },
     });
-
-    const api = new Client();
 
     const view = new EventView({
       fields: [],
@@ -241,7 +230,7 @@ describe('Tags', function () {
     render(
       <Tags
         eventView={view}
-        api={api}
+        api={new MockApiClient()}
         totalValues={30}
         organization={org}
         selection={{projects: [], environments: [], datetime: {}}}

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.spec.jsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.spec.jsx
@@ -3,7 +3,6 @@ import {browserHistory} from 'react-router';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import EventView from 'sentry/utils/discover/eventView';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -39,8 +38,6 @@ function initialize(projects, query, additionalFeatures = []) {
   ProjectsStore.loadInitialData(initialData.organization.projects);
   const eventView = EventView.fromLocation(initialData.router.location);
 
-  const api = new Client();
-
   const spanOperationBreakdownFilter = SpanOperationBreakdownFilter.NONE;
   const transactionName = 'example-transaction';
 
@@ -50,7 +47,7 @@ function initialize(projects, query, additionalFeatures = []) {
     transactionName,
     location: initialData.router.location,
     eventView,
-    api,
+    api: MockApiClient,
   };
 }
 

--- a/static/app/views/settings/account/accountAuthorizations.spec.jsx
+++ b/static/app/views/settings/account/accountAuthorizations.spec.jsx
@@ -1,15 +1,14 @@
 import {render} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import AccountAuthorizations from 'sentry/views/settings/account/accountAuthorizations';
 
 describe('AccountAuthorizations', function () {
   beforeEach(function () {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
   });
 
   it('renders empty', function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/api-authorizations/',
       method: 'GET',
       body: [],

--- a/static/app/views/settings/account/accountEmails.spec.jsx
+++ b/static/app/views/settings/account/accountEmails.spec.jsx
@@ -1,6 +1,5 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import AccountEmails from 'sentry/views/settings/account/accountEmails';
 
 jest.mock('scroll-to-element', () => {});
@@ -9,8 +8,8 @@ const ENDPOINT = '/users/me/emails/';
 
 describe('AccountEmails', function () {
   beforeEach(function () {
-    Client.clearMockResponses();
-    Client.addMockResponse({
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: TestStubs.AccountEmails(),
     });
@@ -23,7 +22,7 @@ describe('AccountEmails', function () {
   });
 
   it('can remove an email', async function () {
-    const mock = Client.addMockResponse({
+    const mock = MockApiClient.addMockResponse({
       url: ENDPOINT,
       method: 'DELETE',
       statusCode: 200,
@@ -46,7 +45,7 @@ describe('AccountEmails', function () {
   });
 
   it('can change a secondary email to primary an email', async function () {
-    const mock = Client.addMockResponse({
+    const mock = MockApiClient.addMockResponse({
       url: ENDPOINT,
       method: 'PUT',
       statusCode: 200,
@@ -69,7 +68,7 @@ describe('AccountEmails', function () {
   });
 
   it('can resend verification email', async function () {
-    const mock = Client.addMockResponse({
+    const mock = MockApiClient.addMockResponse({
       url: `${ENDPOINT}confirm/`,
       method: 'POST',
       statusCode: 200,
@@ -94,7 +93,7 @@ describe('AccountEmails', function () {
   });
 
   it('can add a secondary email', async function () {
-    const mock = Client.addMockResponse({
+    const mock = MockApiClient.addMockResponse({
       url: ENDPOINT,
       method: 'POST',
       statusCode: 200,

--- a/static/app/views/settings/account/accountIdentities.spec.jsx
+++ b/static/app/views/settings/account/accountIdentities.spec.jsx
@@ -5,18 +5,17 @@ import {
   userEvent,
 } from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import AccountIdentities from 'sentry/views/settings/account/accountIdentities';
 
 const ENDPOINT = '/users/me/user-identities/';
 
 describe('AccountIdentities', function () {
   beforeEach(function () {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
   });
 
   it('renders empty', function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       method: 'GET',
       body: [],
@@ -27,7 +26,7 @@ describe('AccountIdentities', function () {
   });
 
   it('renders list', function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       method: 'GET',
       body: [
@@ -49,7 +48,7 @@ describe('AccountIdentities', function () {
   });
 
   it('disconnects identity', async function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       method: 'GET',
       body: [
@@ -73,7 +72,7 @@ describe('AccountIdentities', function () {
       method: 'DELETE',
     };
 
-    const mock = Client.addMockResponse(disconnectRequest);
+    const mock = MockApiClient.addMockResponse(disconnectRequest);
 
     expect(mock).not.toHaveBeenCalled();
 

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.jsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.jsx
@@ -1,13 +1,12 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import AccountSecurityEnroll from 'sentry/views/settings/account/accountSecurity/accountSecurityEnroll';
 
 const ENDPOINT = '/users/me/authenticators/';
 
 describe('AccountSecurityEnroll', function () {
   describe('Totp', function () {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
     const authenticator = TestStubs.Authenticators().Totp({
       isEnrolled: false,
       qrcode: 'otpauth://totp/test%40sentry.io?issuer=Sentry&secret=secret',
@@ -31,7 +30,7 @@ describe('AccountSecurityEnroll', function () {
     ]);
 
     beforeAll(function () {
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `${ENDPOINT}${authenticator.authId}/enroll/`,
         body: authenticator,
       });
@@ -52,7 +51,7 @@ describe('AccountSecurityEnroll', function () {
     });
 
     it('can enroll', async function () {
-      const enrollMock = Client.addMockResponse({
+      const enrollMock = MockApiClient.addMockResponse({
         url: `${ENDPOINT}${authenticator.authId}/enroll/`,
         method: 'POST',
       });
@@ -74,7 +73,7 @@ describe('AccountSecurityEnroll', function () {
     });
 
     it('can redirect with already enrolled error', function () {
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `${ENDPOINT}${authenticator.authId}/enroll/`,
         body: {details: 'Already enrolled'},
         statusCode: 400,

--- a/static/app/views/settings/account/accountSecurity/index.spec.jsx
+++ b/static/app/views/settings/account/accountSecurity/index.spec.jsx
@@ -6,7 +6,6 @@ import {
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import ModalStore from 'sentry/stores/modalStore';
 import AccountSecurity from 'sentry/views/settings/account/accountSecurity';
 import AccountSecurityWrapper from 'sentry/views/settings/account/accountSecurity/accountSecurityWrapper';
@@ -20,12 +19,12 @@ describe('AccountSecurity', function () {
   beforeEach(function () {
     jest.spyOn(window.location, 'assign').mockImplementation(() => {});
 
-    Client.clearMockResponses();
-    Client.addMockResponse({
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
       body: TestStubs.Organizations(),
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ACCOUNT_EMAILS_ENDPOINT,
       body: TestStubs.AccountEmails(),
     });
@@ -45,7 +44,7 @@ describe('AccountSecurity', function () {
   }
 
   it('renders empty', function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [],
     });
@@ -56,7 +55,7 @@ describe('AccountSecurity', function () {
   });
 
   it('renders a primary interface that is enrolled', function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({configureButton: 'Info'})],
     });
@@ -73,7 +72,7 @@ describe('AccountSecurity', function () {
   });
 
   it('can delete enrolled authenticator', async function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [
         TestStubs.Authenticators().Totp({
@@ -83,7 +82,7 @@ describe('AccountSecurity', function () {
       ],
     });
 
-    const deleteMock = Client.addMockResponse({
+    const deleteMock = MockApiClient.addMockResponse({
       url: `${ENDPOINT}15/`,
       method: 'DELETE',
     });
@@ -97,7 +96,7 @@ describe('AccountSecurity', function () {
     ).toBeInTheDocument();
 
     // next authenticators request should have totp disabled
-    const authenticatorsMock = Client.addMockResponse({
+    const authenticatorsMock = MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [
         TestStubs.Authenticators().Totp({
@@ -123,7 +122,7 @@ describe('AccountSecurity', function () {
   });
 
   it('can remove one of multiple 2fa methods when org requires 2fa', async function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [
         TestStubs.Authenticators().Totp({
@@ -133,11 +132,11 @@ describe('AccountSecurity', function () {
         TestStubs.Authenticators().U2f(),
       ],
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
       body: TestStubs.Organizations({require2FA: true}),
     });
-    const deleteMock = Client.addMockResponse({
+    const deleteMock = MockApiClient.addMockResponse({
       url: `${ENDPOINT}15/`,
       method: 'DELETE',
     });
@@ -159,7 +158,7 @@ describe('AccountSecurity', function () {
   });
 
   it('can not remove last 2fa method when org requires 2fa', async function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [
         TestStubs.Authenticators().Totp({
@@ -168,11 +167,11 @@ describe('AccountSecurity', function () {
         }),
       ],
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
       body: TestStubs.Organizations({require2FA: true}),
     });
-    const deleteMock = Client.addMockResponse({
+    const deleteMock = MockApiClient.addMockResponse({
       url: `${ENDPOINT}15/`,
       method: 'DELETE',
     });
@@ -196,11 +195,11 @@ describe('AccountSecurity', function () {
   });
 
   it('cannot enroll without verified email', async function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ACCOUNT_EMAILS_ENDPOINT,
       body: [
         {
@@ -225,7 +224,7 @@ describe('AccountSecurity', function () {
   });
 
   it('renders a backup interface that is not enrolled', function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: false})],
     });
@@ -240,7 +239,7 @@ describe('AccountSecurity', function () {
   });
 
   it('renders a primary interface that is not enrolled', function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
     });
@@ -255,7 +254,7 @@ describe('AccountSecurity', function () {
   });
 
   it('does not render primary interface that disallows new enrollments', function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [
         TestStubs.Authenticators().Totp({disallowNewEnrollment: false}),
@@ -272,7 +271,7 @@ describe('AccountSecurity', function () {
   });
 
   it('renders primary interface if new enrollments are disallowed, but we are enrolled', function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [
         TestStubs.Authenticators().Sms({isEnrolled: true, disallowNewEnrollment: true}),
@@ -286,7 +285,7 @@ describe('AccountSecurity', function () {
   });
 
   it('renders a backup interface that is enrolled', function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: true})],
     });
@@ -298,13 +297,13 @@ describe('AccountSecurity', function () {
   });
 
   it('can change password', async function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: false})],
     });
 
     const url = '/users/me/password/';
-    const mock = Client.addMockResponse({
+    const mock = MockApiClient.addMockResponse({
       url,
       method: 'PUT',
     });
@@ -340,12 +339,12 @@ describe('AccountSecurity', function () {
   });
 
   it('requires current password to be entered', async function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: false})],
     });
     const url = '/users/me/password/';
-    const mock = Client.addMockResponse({
+    const mock = MockApiClient.addMockResponse({
       url,
       method: 'PUT',
     });
@@ -367,11 +366,11 @@ describe('AccountSecurity', function () {
   });
 
   it('can expire all sessions', async function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: false})],
     });
-    const mock = Client.addMockResponse({
+    const mock = MockApiClient.addMockResponse({
       url: AUTH_ENDPOINT,
       body: {all: true},
       method: 'DELETE',

--- a/static/app/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -7,7 +7,6 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import OrganizationDeveloperSettings from 'sentry/views/settings/organizationDeveloperSettings/index';
 
 describe('Organization Developer Settings', function () {
@@ -24,12 +23,12 @@ describe('Organization Developer Settings', function () {
   });
 
   beforeEach(() => {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
   });
 
   describe('when no Apps exist', () => {
     it('displays empty state', async () => {
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/sentry-apps/`,
         body: [],
       });
@@ -45,7 +44,7 @@ describe('Organization Developer Settings', function () {
 
   describe('with unpublished apps', () => {
     beforeEach(() => {
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/sentry-apps/`,
         body: [sentryApp],
       });
@@ -71,7 +70,7 @@ describe('Organization Developer Settings', function () {
     });
 
     it('allows for deletion', async () => {
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/`,
         method: 'DELETE',
         body: [],
@@ -101,7 +100,7 @@ describe('Organization Developer Settings', function () {
     });
 
     it('can make a request to publish an integration', async () => {
-      const mock = Client.addMockResponse({
+      const mock = MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/publish-request/`,
         method: 'POST',
       });
@@ -162,7 +161,7 @@ describe('Organization Developer Settings', function () {
   describe('with published apps', () => {
     beforeEach(() => {
       const publishedSentryApp = TestStubs.SentryApp({status: 'published'});
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/sentry-apps/`,
         body: [publishedSentryApp],
       });
@@ -204,7 +203,7 @@ describe('Organization Developer Settings', function () {
     beforeEach(() => {
       const internalIntegration = TestStubs.SentryApp({status: 'internal'});
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/sentry-apps/`,
         body: [internalIntegration],
       });
@@ -225,7 +224,7 @@ describe('Organization Developer Settings', function () {
   describe('without Owner permissions', () => {
     const newOrg = TestStubs.Organization({access: ['org:read']});
     beforeEach(() => {
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/organizations/${newOrg.slug}/sentry-apps/`,
         body: [sentryApp],
       });

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -2,7 +2,6 @@ import selectEvent from 'react-select-event';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import SentryApplicationDetails from 'sentry/views/settings/organizationDeveloperSettings/sentryApplicationDetails';
 
 describe('Sentry Application Details', function () {
@@ -15,7 +14,7 @@ describe('Sentry Application Details', function () {
   const maskedValue = '*'.repeat(64);
 
   beforeEach(() => {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
 
     org = TestStubs.Organization({features: ['sentry-app-logo-upload']});
   });
@@ -29,7 +28,7 @@ describe('Sentry Application Details', function () {
     }
 
     beforeEach(() => {
-      createAppRequest = Client.addMockResponse({
+      createAppRequest = MockApiClient.addMockResponse({
         url: '/sentry-apps/',
         method: 'POST',
         body: [],
@@ -163,12 +162,12 @@ describe('Sentry Application Details', function () {
       sentryApp = TestStubs.SentryApp();
       sentryApp.events = ['issue'];
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/`,
         body: sentryApp,
       });
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/api-tokens/`,
         body: [],
       });
@@ -220,12 +219,12 @@ describe('Sentry Application Details', function () {
       token = TestStubs.SentryAppToken();
       sentryApp.events = ['issue'];
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/`,
         body: sentryApp,
       });
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/api-tokens/`,
         body: [token],
       });
@@ -282,12 +281,12 @@ describe('Sentry Application Details', function () {
       token = TestStubs.SentryAppToken({token: maskedValue, refreshToken: maskedValue});
       sentryApp.events = ['issue'];
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/`,
         body: sentryApp,
       });
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/api-tokens/`,
         body: [token],
       });
@@ -321,19 +320,19 @@ describe('Sentry Application Details', function () {
       token = TestStubs.SentryAppToken();
       sentryApp.events = ['issue'];
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/`,
         body: sentryApp,
       });
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/api-tokens/`,
         body: [token],
       });
     });
 
     it('adding token to list', async function () {
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/api-tokens/`,
         method: 'POST',
         body: [
@@ -353,7 +352,7 @@ describe('Sentry Application Details', function () {
     });
 
     it('removing token from list', async function () {
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/api-tokens/${token.token}/`,
         method: 'DELETE',
         body: {},
@@ -385,18 +384,18 @@ describe('Sentry Application Details', function () {
       sentryApp.events = ['issue'];
       sentryApp.scopes = ['project:read', 'event:read'];
 
-      editAppRequest = Client.addMockResponse({
+      editAppRequest = MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/`,
         method: 'PUT',
         body: [],
       });
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/`,
         body: sentryApp,
       });
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/api-tokens/`,
         body: [],
       });
@@ -467,7 +466,7 @@ describe('Sentry Application Details', function () {
     beforeEach(() => {
       sentryApp = TestStubs.SentryApp();
 
-      editAppRequest = Client.addMockResponse({
+      editAppRequest = MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/`,
         method: 'PUT',
         statusCode: 400,
@@ -479,12 +478,12 @@ describe('Sentry Application Details', function () {
         },
       });
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/`,
         body: sentryApp,
       });
 
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/api-tokens/`,
         body: [],
       });

--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.spec.jsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.spec.jsx
@@ -1,16 +1,15 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import IntegrationListDirectory from 'sentry/views/settings/organizationIntegrations/integrationListDirectory';
 
 const mockResponse = mocks => {
-  mocks.forEach(([url, body]) => Client.addMockResponse({url, body}));
+  mocks.forEach(([url, body]) => MockApiClient.addMockResponse({url, body}));
 };
 
 describe('IntegrationListDirectory', function () {
   beforeEach(function () {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
   });
 
   const {organization: org, routerContext} = initializeOrg();

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.jsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.jsx
@@ -11,7 +11,6 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {Client} from 'sentry/api';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -88,13 +87,13 @@ describe('OrganizationMembersList', function () {
   });
 
   beforeEach(function () {
-    Client.clearMockResponses();
-    Client.addMockResponse({
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/me/',
       method: 'GET',
       body: {roles},
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',
       method: 'GET',
       body: [...TestStubs.Members(), member],
@@ -103,7 +102,7 @@ describe('OrganizationMembersList', function () {
       url: `/organizations/org-slug/members/${member.id}/`,
       body: member,
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/access-requests/',
       method: 'GET',
       body: [
@@ -124,7 +123,7 @@ describe('OrganizationMembersList', function () {
         },
       ],
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/auth-provider/',
       method: 'GET',
       body: {
@@ -132,12 +131,12 @@ describe('OrganizationMembersList', function () {
         require_link: true,
       },
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/teams/',
       method: 'GET',
       body: [TestStubs.Team(), ownerTeam],
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/invite-requests/',
       method: 'GET',
       body: [],
@@ -192,7 +191,7 @@ describe('OrganizationMembersList', function () {
   });
 
   it('can leave org', async function () {
-    const deleteMock = Client.addMockResponse({
+    const deleteMock = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/members/${members[1].id}/`,
       method: 'DELETE',
     });
@@ -214,7 +213,7 @@ describe('OrganizationMembersList', function () {
   });
 
   it('can redirect to remaining org after leaving', async function () {
-    const deleteMock = Client.addMockResponse({
+    const deleteMock = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/members/${members[1].id}/`,
       method: 'DELETE',
     });
@@ -246,7 +245,7 @@ describe('OrganizationMembersList', function () {
   });
 
   it('displays error message when failing to leave org', async function () {
-    const deleteMock = Client.addMockResponse({
+    const deleteMock = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/members/${members[1].id}/`,
       method: 'DELETE',
       statusCode: 500,

--- a/static/app/views/settings/organizationProjects/index.spec.jsx
+++ b/static/app/views/settings/organizationProjects/index.spec.jsx
@@ -1,6 +1,5 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import OrganizationProjectsContainer from 'sentry/views/settings/organizationProjects';
 
 describe('OrganizationProjects', function () {
@@ -15,24 +14,24 @@ describe('OrganizationProjects', function () {
     project = TestStubs.Project();
     org = TestStubs.Organization();
 
-    projectsGetMock = Client.addMockResponse({
+    projectsGetMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
       body: [project],
     });
 
-    statsGetMock = Client.addMockResponse({
+    statsGetMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/stats/',
       body: [[[], 1]],
     });
 
-    projectsPutMock = Client.addMockResponse({
+    projectsPutMock = MockApiClient.addMockResponse({
       method: 'PUT',
       url: '/projects/org-slug/project-slug/',
     });
   });
 
   afterEach(function () {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
   });
 
   it('should render the projects in the store', async function () {

--- a/static/app/views/settings/organizationRepositories/index.spec.jsx
+++ b/static/app/views/settings/organizationRepositories/index.spec.jsx
@@ -1,6 +1,5 @@
 import {render} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import OrganizationRepositoriesContainer from 'sentry/views/settings/organizationRepositories';
 
 describe('OrganizationRepositoriesContainer', function () {
@@ -8,16 +7,16 @@ describe('OrganizationRepositoriesContainer', function () {
   const organization = TestStubs.Organization();
 
   beforeEach(function () {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
   });
 
   describe('without any providers', function () {
     beforeEach(function () {
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: '/organizations/org-slug/repos/',
         body: [],
       });
-      Client.addMockResponse({
+      MockApiClient.addMockResponse({
         url: '/organizations/org-slug/config/repos/',
         body: {providers: []},
       });

--- a/static/app/views/settings/organizationTeams/teamDetails.spec.jsx
+++ b/static/app/views/settings/organizationTeams/teamDetails.spec.jsx
@@ -1,7 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import TeamStore from 'sentry/stores/teamStore';
 import TeamDetails from 'sentry/views/settings/organizationTeams/teamDetails';
 
@@ -15,14 +14,14 @@ describe('TeamMembers', () => {
   beforeEach(() => {
     TeamStore.init();
     TeamStore.loadInitialData([team, teamHasAccess]);
-    joinMock = Client.addMockResponse({
+    joinMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/members/me/teams/${team.slug}/`,
       method: 'POST',
     });
   });
 
   afterEach(() => {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
     TeamStore.reset();
   });
 

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
@@ -5,7 +5,6 @@ import {
   openInviteMembersModal,
   openTeamAccessRequestModal,
 } from 'sentry/actionCreators/modal';
-import {Client} from 'sentry/api';
 import TeamMembers from 'sentry/views/settings/organizationTeams/teamMembers';
 
 jest.mock('sentry/actionCreators/modal', () => ({
@@ -27,29 +26,29 @@ describe('TeamMembers', function () {
   });
 
   beforeEach(function () {
-    Client.clearMockResponses();
-    Client.addMockResponse({
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/members/`,
       method: 'GET',
       body: [member],
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team.slug}/members/`,
       method: 'GET',
       body: members,
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team.slug}/`,
       method: 'GET',
       body: team,
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${managerTeam.slug}/`,
       method: 'GET',
       body: managerTeam,
     });
 
-    createMock = Client.addMockResponse({
+    createMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/members/${member.id}/teams/${team.slug}/`,
       method: 'POST',
     });
@@ -255,7 +254,7 @@ describe('TeamMembers', function () {
   });
 
   it('can remove member from team', async function () {
-    const deleteMock = Client.addMockResponse({
+    const deleteMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/members/${members[0].id}/teams/${team.slug}/`,
       method: 'DELETE',
     });
@@ -280,13 +279,13 @@ describe('TeamMembers', function () {
       id: '123',
       email: 'foo@example.com',
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team.slug}/members/`,
       method: 'GET',
       body: [...members, me],
     });
 
-    const deleteMock = Client.addMockResponse({
+    const deleteMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/members/${me.id}/teams/${team.slug}/`,
       method: 'DELETE',
     });
@@ -320,7 +319,7 @@ describe('TeamMembers', function () {
       email: 'foo@example.com',
       role: 'owner',
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team.slug}/members/`,
       method: 'GET',
       body: [...members, me],
@@ -346,7 +345,7 @@ describe('TeamMembers', function () {
       email: 'foo@example.com',
       orgRole: 'manager',
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team.slug}/members/`,
       method: 'GET',
       body: [...members, manager],
@@ -368,7 +367,7 @@ describe('TeamMembers', function () {
   });
 
   it('adding member to manager team makes them team admin', async function () {
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${managerTeam.slug}/members/`,
       method: 'GET',
       body: [],
@@ -409,18 +408,18 @@ describe('TeamMembers', function () {
       },
     });
 
-    Client.clearMockResponses();
-    Client.addMockResponse({
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/members/`,
       method: 'GET',
       body: [...members, me],
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team2.slug}/members/`,
       method: 'GET',
       body: members,
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team2.slug}/`,
       method: 'GET',
       body: team2,
@@ -449,18 +448,18 @@ describe('TeamMembers', function () {
       role: 'member',
     });
 
-    Client.clearMockResponses();
-    Client.addMockResponse({
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/members/`,
       method: 'GET',
       body: [...members, me],
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team2.slug}/members/`,
       method: 'GET',
       body: members,
     });
-    Client.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team2.slug}/`,
       method: 'GET',
       body: team2,

--- a/static/app/views/settings/organizationTeams/teamProjects.spec.jsx
+++ b/static/app/views/settings/organizationTeams/teamProjects.spec.jsx
@@ -1,7 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import {TeamProjects as OrganizationTeamProjects} from 'sentry/views/settings/organizationTeams/teamProjects';
 
 describe('OrganizationTeamProjects', function () {
@@ -30,25 +29,25 @@ describe('OrganizationTeamProjects', function () {
   beforeEach(function () {
     team = TestStubs.Team({slug: 'team-slug'});
 
-    getMock = Client.addMockResponse({
+    getMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
       body: [project, project2],
     });
 
-    putMock = Client.addMockResponse({
+    putMock = MockApiClient.addMockResponse({
       method: 'PUT',
       url: '/projects/org-slug/project-slug/',
       body: project,
     });
 
-    postMock = Client.addMockResponse({
+    postMock = MockApiClient.addMockResponse({
       method: 'POST',
       url: `/projects/org-slug/${project2.slug}/teams/${team.slug}/`,
       body: {...project2, teams: [team]},
       status: 201,
     });
 
-    deleteMock = Client.addMockResponse({
+    deleteMock = MockApiClient.addMockResponse({
       method: 'DELETE',
       url: `/projects/org-slug/${project2.slug}/teams/${team.slug}/`,
       body: {...project2, teams: []},
@@ -57,7 +56,7 @@ describe('OrganizationTeamProjects', function () {
   });
 
   afterEach(function () {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
   });
 
   it('fetches linked and unlinked projects', function () {


### PR DESCRIPTION
Seems like the majority of codebase uses MockApiClient instead of Client and having two separate usage patterns is confusing (all Client imports seem a few years old)

Tbqh, I would like to see us remove the separate mock client implementation in the future and rely on something like fetch-mock or similar where we mock the responses and keep the implementation close to the actual fetch schema. As it currently stands, the separate implementation of MockApiClient also risks falling out of sync with the Client and we risk testing code that will run differently in prod.