### PR TITLE
fix(hc): Stabilize notification util tests

### DIFF
--- a/tests/sentry/notifications/utils/test_get_most_specific.py
+++ b/tests/sentry/notifications/utils/test_get_most_specific.py
@@ -8,13 +8,13 @@ from sentry.notifications.types import (
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
-from sentry.services.hybrid_cloud.actor import RpcActor
+from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.testutils import TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.types.integrations import ExternalProviders
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class GetMostSpecificNotificationSettingValueTestCase(TestCase):
     def setUp(self) -> None:
         self.user = self.create_user()
@@ -22,7 +22,7 @@ class GetMostSpecificNotificationSettingValueTestCase(TestCase):
     def test_get_most_specific_notification_setting_value_empty_workflow(self):
         value = get_most_specific_notification_setting_value(
             notification_settings_by_scope={},
-            recipient=RpcActor.from_object(self.user),
+            recipient=RpcActor(id=self.user.id, actor_type=ActorType.USER),
             parent_id=1,
             type=NotificationSettingTypes.WORKFLOW,
         )
@@ -31,7 +31,7 @@ class GetMostSpecificNotificationSettingValueTestCase(TestCase):
     def test_get_most_specific_notification_setting_value_empty_alerts(self):
         value = get_most_specific_notification_setting_value(
             notification_settings_by_scope={},
-            recipient=RpcActor.from_object(self.user),
+            recipient=RpcActor(id=self.user.id, actor_type=ActorType.USER),
             parent_id=1,
             type=NotificationSettingTypes.ISSUE_ALERTS,
         )
@@ -48,7 +48,7 @@ class GetMostSpecificNotificationSettingValueTestCase(TestCase):
         }
         value = get_most_specific_notification_setting_value(
             notification_settings_by_scope,
-            recipient=RpcActor.from_object(self.user),
+            recipient=RpcActor(id=self.user.id, actor_type=ActorType.USER),
             parent_id=1,
             type=NotificationSettingTypes.ISSUE_ALERTS,
         )
@@ -73,7 +73,7 @@ class GetMostSpecificNotificationSettingValueTestCase(TestCase):
         }
         value = get_most_specific_notification_setting_value(
             notification_settings_by_scope,
-            recipient=RpcActor.from_object(self.user),
+            recipient=RpcActor(id=self.user.id, actor_type=ActorType.USER),
             parent_id=project_id,
             type=NotificationSettingTypes.ISSUE_ALERTS,
         )

--- a/tests/sentry/notifications/utils/test_get_scope.py
+++ b/tests/sentry/notifications/utils/test_get_scope.py
@@ -5,7 +5,7 @@ from sentry.testutils import TestCase
 from sentry.testutils.silo import control_silo_test
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class GetScopeTestCase(TestCase):
     def setUp(self) -> None:
         self.user = self.create_user()


### PR DESCRIPTION
These two test-only changes were pulled out of #51854 which was reverted due to an analytics issue relating to the other case which isn't included here.