### PR TITLE
fix: correctly reflect open membership behavior

### DIFF
--- a/static/app/data/forms/organizationGeneralSettings.tsx
+++ b/static/app/data/forms/organizationGeneralSettings.tsx
@@ -78,7 +78,7 @@ const formGroups: JsonFormObject[] = [
         type: 'boolean',
         required: true,
         label: t('Open Membership'),
-        help: t('Allow organization members to freely join or leave any team'),
+        help: t('Allow organization members to freely join any team'),
       },
       {
         name: 'eventsMemberAdmin',


### PR DESCRIPTION
When "Open Membership" is toggled off, members cannot freely join teams, but they are able to leave teams freely. This updates the help text under the setting to match the behavior.