### PR TITLE
fix(social-auth): change social auth url logic

### DIFF
--- a/src/sentry_plugins/github/README.rst
+++ b/src/sentry_plugins/github/README.rst
@@ -10,9 +10,6 @@ Ensure you've configured GitHub auth in Sentry::
     GITHUB_API_SECRET = 'GitHub Application Client Secret'
     GITHUB_EXTENDED_PERMISSIONS = ['repo']
 
-If the callback URL you've registered with GitHub uses HTTPS, you'll need this in your config::
-
-    SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
 
 If your server is behind a reverse proxy, you'll need to enable the X-Forwarded-Proto
 and X-Forwarded-Host headers, and use this config::

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -23,6 +23,7 @@ from django.utils.crypto import constant_time_compare, get_random_string
 from requests_oauthlib import OAuth1
 
 from sentry.utils import json
+from sentry.utils.http import absolute_uri
 from social_auth.exceptions import (
     AuthCanceled,
     AuthFailed,
@@ -355,13 +356,7 @@ class BaseAuth:
         instances.delete()
 
     def build_absolute_uri(self, path=None):
-        """Build absolute URI for given path. Replace http:// schema with
-        https:// if SOCIAL_AUTH_REDIRECT_IS_HTTPS is defined.
-        """
-        uri = self.request.build_absolute_uri(path)
-        if setting("SOCIAL_AUTH_REDIRECT_IS_HTTPS"):
-            uri = uri.replace("http://", "https://")
-        return uri
+        return absolute_uri(path)
 
 
 class OAuthAuth(BaseAuth):


### PR DESCRIPTION
This fixes a bug that prevents installing social auth integrations in a local env. Instead of getting the URL from the request, we generate the URL from `url-prefix`. Note this change also removes the need for `SOCIAL_AUTH_REDIRECT_IS_HTTPS`

Closes 44424