### PR TITLE
feat(starish): update sample list to use "near baseline"

### DIFF
--- a/static/app/views/starfish/components/samplesTable/common.tsx
+++ b/static/app/views/starfish/components/samplesTable/common.tsx
@@ -16,8 +16,8 @@ type Props = {
 export function DurationComparisonCell({duration, p95, containerProps}: Props) {
   const diff = duration - p95;
 
-  if (Math.floor(duration) === Math.floor(p95)) {
-    return <TextAlignRight>{t('At baseline')}</TextAlignRight>;
+  if (isNearBaseline(duration, p95)) {
+    return <TextAlignRight {...containerProps}>{t('Near baseline')}</TextAlignRight>;
   }
 
   const readableDiff = getDuration(diff / 1000, 2, true, true);
@@ -29,6 +29,12 @@ export function DurationComparisonCell({duration, p95, containerProps}: Props) {
     </ComparisonLabel>
   );
 }
+
+export const isNearBaseline = (duration: number, p95: number) => {
+  const maxDiff = 0.03 * p95;
+  const diff = Math.abs(duration - p95);
+  return diff < maxDiff;
+};
 
 export const PlaintextLabel = styled('div')``;
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -3,6 +3,7 @@ import {useTheme} from '@emotion/react';
 import {EChartClickHandler, EChartHighlightHandler, Series} from 'sentry/types/echarts';
 import {P95_COLOR} from 'sentry/views/starfish/colours';
 import Chart from 'sentry/views/starfish/components/chart';
+import {isNearBaseline} from 'sentry/views/starfish/components/samplesTable/common';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {SpanSample, useSpanSamples} from 'sentry/views/starfish/queries/useSpanSamples';
@@ -33,7 +34,14 @@ function DurationChart({
 }: Props) {
   const theme = useTheme();
 
-  const getSampleSymbol = (duration: number, p95: number) => {
+  const getSampleSymbol = (duration: number, p95: number): Series[''] => {
+    if (isNearBaseline(duration, p95)) {
+      return {
+        symbol: 'path://M 0 0 V -8 L 5 0 L 0 8 L -5 0 L 0 -8',
+        color: theme.gray300,
+      };
+    }
+
     return duration > p95
       ? {
           symbol: 'path://M 5 4 L 0 -4 L -5 4 L 5 4',

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -34,7 +34,10 @@ function DurationChart({
 }: Props) {
   const theme = useTheme();
 
-  const getSampleSymbol = (duration: number, p95: number): Series[''] => {
+  const getSampleSymbol = (
+    duration: number,
+    p95: number
+  ): {color: string; symbol: string} => {
     if (isNearBaseline(duration, p95)) {
       return {
         symbol: 'path://M 0 0 V -8 L 5 0 L 0 8 L -5 0 L 0 -8',


### PR DESCRIPTION
1. Changes text to "near baseline"
2. Adds near baseline logic, such that the p95 and duration don't have to be exactly the same, instead they are within 3% of the p95. (this 3% is arbitrary).
3. Adds a diamond icon for near baseline samples
4. Fixes bug where the "near baseline text" would not highlight on hover.

<img width="717" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/0847c0aa-e72d-4a5b-b0f5-305d17b8daaa">
