### PR TITLE
fix(starfish): Always use resolve_division to avoid infinite

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1501,8 +1501,10 @@ class QueryBuilder(BaseQueryBuilder):
         )
 
     @classmethod
-    def handle_invalid_float(cls, value: float) -> Optional[float]:
-        if math.isnan(value):
+    def handle_invalid_float(cls, value: Optional[float]) -> Optional[float]:
+        if value is None:
+            return value
+        elif math.isnan(value):
             return 0
         elif math.isinf(value):
             return None

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -250,24 +250,21 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                 ),
                 fields.MetricsFunction(
                     "http_error_rate",
-                    snql_distribution=lambda args, alias: Function(
-                        "divide",
-                        [
-                            self._resolve_http_error_count(args),
-                            Function(
-                                "countIf",
-                                [
-                                    Column("value"),
-                                    Function(
-                                        "equals",
-                                        [
-                                            Column("metric_id"),
-                                            self.resolve_metric("span.self_time"),
-                                        ],
-                                    ),
-                                ],
-                            ),
-                        ],
+                    snql_distribution=lambda args, alias: self.builder.resolve_division(
+                        self._resolve_http_error_count(args),
+                        Function(
+                            "countIf",
+                            [
+                                Column("value"),
+                                Function(
+                                    "equals",
+                                    [
+                                        Column("metric_id"),
+                                        self.resolve_metric("span.self_time"),
+                                    ],
+                                ),
+                            ],
+                        ),
                         alias,
                     ),
                     default_result_type="percentage",
@@ -408,18 +405,15 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         )
         metric_id = self.resolve_metric("span.self_time")
 
-        return Function(
-            "divide",
-            [
-                Function(
-                    "sumIf",
-                    [
-                        Column("value"),
-                        Function("equals", [Column("metric_id"), metric_id]),
-                    ],
-                ),
-                total_time,
-            ],
+        return self.builder.resolve_division(
+            Function(
+                "sumIf",
+                [
+                    Column("value"),
+                    Function("equals", [Column("metric_id"), metric_id]),
+                ],
+            ),
+            total_time,
             alias,
         )
 
@@ -561,28 +555,12 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         return self._resolve_percent_change_function(first_half, second_half, alias)
 
     def _resolve_percent_change_function(self, first_half, second_half, alias):
-        return Function(
-            "if",
-            [
-                Function(
-                    "greater",
-                    [
-                        first_half,
-                        0,
-                    ],
-                ),
-                Function(
-                    "divide",
-                    [
-                        Function(
-                            "minus",
-                            [second_half, first_half],
-                        ),
-                        first_half,
-                    ],
-                ),
-                None,
-            ],
+        return self.builder.resolve_division(
+            Function(
+                "minus",
+                [second_half, first_half],
+            ),
+            first_half,
             alias,
         )
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -262,6 +262,24 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[1]["transaction"] == "bar_transaction"
         assert meta["dataset"] == "spansMetrics"
 
+    def test_time_spent_percentage_local(self):
+        response = self.do_request(
+            {
+                "field": ["time_spent_percentage(local)"],
+                "query": "",
+                "orderby": ["-time_spent_percentage(local)"],
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["time_spent_percentage(local)"] is None
+        assert meta["dataset"] == "spansMetrics"
+
     def test_http_error_rate_and_count(self):
         for _ in range(4):
             self.store_span_metric(


### PR DESCRIPTION
- This fixes SENTRY-121B
- Always check the denominator is greater than zero before dividing to avoid infinity