### PR TITLE
ref(search): clean-up organizations:assign-to-me feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1298,8 +1298,6 @@ SENTRY_FEATURES = {
     "organizations:alert-allow-indexed": False,
     # Enables tagging javascript errors from the browser console.
     "organizations:javascript-console-error-tag": False,
-    # Enables separate filters for user and user's teams
-    "organizations:assign-to-me": True,
     # Enables the cron job to auto-enable codecov integrations.
     "organizations:auto-enable-codecov": False,
     # Enables automatically linking repositories using commit webhook data

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -63,7 +63,6 @@ default_manager.add("organizations:create", SystemFeature, FeatureHandlerStrateg
 
 # Organization scoped features that are in development or in customer trials.
 default_manager.add("organizations:javascript-console-error-tag", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:assign-to-me", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:alert-allow-indexed", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:alert-filters", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -10,7 +10,7 @@ from django.db.models import Q, QuerySet
 from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
 
-from sentry import features, quotas
+from sentry import quotas
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import ErrorGroupType
@@ -25,8 +25,6 @@ from sentry.models import (
     GroupOwner,
     GroupStatus,
     GroupSubscription,
-    OrganizationMember,
-    OrganizationMemberTeam,
     PlatformExternalIssue,
     Project,
     Release,
@@ -41,7 +39,6 @@ from sentry.search.snuba.executors import (
     PostgresSnubaQueryExecutor,
     PrioritySortWeights,
 )
-from sentry.search.utils import get_teams_for_users
 from sentry.utils.cursors import Cursor, CursorResult
 
 
@@ -79,17 +76,6 @@ def assigned_to_filter(
                 ).values_list("group_id", flat=True)
             }
         )
-        organization = projects[0].organization
-        # Only add teams to query if assign-to-me flag is off
-        if not features.has("organizations:assign-to-me", organization, actor=None):
-            query |= Q(
-                **{
-                    f"{field_filter}__in": GroupAssignee.objects.filter(
-                        project_id__in=[p.id for p in projects],
-                        team_id__in=[team for team in get_teams_for_users(projects, users)],
-                    ).values_list("group_id", flat=True)
-                }
-            )
 
     if include_none:
         query |= unassigned_filter(True, projects, field_filter=field_filter)
@@ -218,21 +204,7 @@ def assigned_or_suggested_filter(
     if "User" in types_to_owners:
         users = types_to_owners["User"]
         user_ids: List[int] = [u.id for u in users if u is not None]
-        team_ids = list(
-            Team.objects.filter(
-                id__in=OrganizationMemberTeam.objects.filter(
-                    organizationmember__in=OrganizationMember.objects.filter(
-                        user_id__in=user_ids, organization_id=organization_id
-                    ),
-                    is_active=True,
-                ).values("team")
-            ).values_list("id", flat=True)
-        )
-        organization = projects[0].organization
         query_ids = Q(user_id__in=user_ids)
-        # Only add team_ids to query if assign-to-me flag is off
-        if not features.has("organizations:assign-to-me", organization, actor=None):
-            query_ids = query_ids | Q(team_id__in=team_ids)
         owned_by_me = Q(
             **{
                 f"{field_filter}__in": GroupOwner.objects.filter(

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -56,7 +56,6 @@ class OrganizationSerializerTest(TestCase):
         assert result["id"] == str(organization.id)
         assert result["features"] == {
             "advanced-search",
-            "assign-to-me",
             "change-alerts",
             "crash-rate-alerts",
             "custom-symbol-sources",

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -26,7 +26,7 @@ from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES, GroupStatus
 from sentry.search.utils import get_teams_for_users
 from sentry.testutils import TestCase
-from sentry.testutils.helpers.features import apply_feature_flag_on_cls, with_feature
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.silo import region_silo_test
 from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
 
@@ -181,7 +181,6 @@ class ConvertJavaScriptConsoleTagTest(TestCase):
 
 @region_silo_test(stable=True)
 class ConvertQueryValuesTest(TestCase):
-    @with_feature("organizations:assign-to-me")
     def test_valid_assign_me_converter(self):
         filters = [SearchFilter(SearchKey("assigned_to"), "=", SearchValue("me"))]
         expected = value_converters["assigned_to"](
@@ -190,14 +189,12 @@ class ConvertQueryValuesTest(TestCase):
         filters = convert_query_values(filters, [self.project], self.user, None)
         assert filters[0].value.raw_value == expected
 
-    @with_feature("organizations:assign-to-me")
     def test_valid_assign_me_no_converter(self):
         search_val = SearchValue("me")
         filters = [SearchFilter(SearchKey("something"), "=", search_val)]
         filters = convert_query_values(filters, [self.project], self.user, None)
         assert filters[0].value.raw_value == search_val.raw_value
 
-    @with_feature("organizations:assign-to-me")
     def test_valid_assign_my_teams_converter(self):
         filters = [SearchFilter(SearchKey("assigned_to"), "=", SearchValue("my_teams"))]
         expected = value_converters["assigned_to"](
@@ -206,7 +203,6 @@ class ConvertQueryValuesTest(TestCase):
         filters = convert_query_values(filters, [self.project], self.user, None)
         assert filters[0].value.raw_value == expected
 
-    @with_feature("organizations:assign-to-me")
     def test_valid_assign_my_teams_no_converter(self):
         search_val = SearchValue("my_teams")
         filters = [SearchFilter(SearchKey("something"), "=", search_val)]
@@ -342,7 +338,6 @@ class ConvertActorOrNoneValueTest(TestCase):
             ["me"], [self.project], self.user, None
         ) == convert_user_value(["me"], [self.project], self.user, None)
 
-    @with_feature("organizations:assign-to-me")
     def test_my_team(self):
         assert convert_actor_or_none_value(
             ["my_teams"], [self.project], self.user, None

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1125,17 +1125,16 @@ class EventsSnubaSearchTest(SharedSnubaTest):
                 user_id=self.user.id, group=my_team_group
             ).exists()
 
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                "assigned:me",
-                [self.group2],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned:my_teams",
-                [my_team_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            "assigned:me",
+            [self.group2],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned:my_teams",
+            [my_team_group],
+            user=self.user,
+        )
 
     def test_assigned_to_me_my_teams_in_syntax(self):
         my_team_group = self.store_event(
@@ -1169,22 +1168,21 @@ class EventsSnubaSearchTest(SharedSnubaTest):
                 user_id=self.user.id, group=my_team_group
             ).exists()
 
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                "assigned:[me]",
-                [self.group2],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned:[my_teams]",
-                [my_team_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned:[me, my_teams]",
-                [self.group2, my_team_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            "assigned:[me]",
+            [self.group2],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned:[my_teams]",
+            [my_team_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned:[me, my_teams]",
+            [self.group2, my_team_group],
+            user=self.user,
+        )
 
     def test_assigned_to_in_syntax(self):
         group_3 = self.store_event(
@@ -1434,20 +1432,18 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             project_id=self.project.id,
         ).group
 
-        # after the change to me -> (me + my_teams)
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                "assigned_or_suggested:me",
-                [],
-                [group, group1, group2, assigned_group, assigned_to_other_group, my_team_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:my_teams",
-                [],
-                [group, group1, group2, assigned_group, assigned_to_other_group, my_team_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            "assigned_or_suggested:me",
+            [],
+            [group, group1, group2, assigned_group, assigned_to_other_group, my_team_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:my_teams",
+            [],
+            [group, group1, group2, assigned_group, assigned_to_other_group, my_team_group],
+            user=self.user,
+        )
 
         GroupOwner.objects.create(
             group=assigned_to_other_group,
@@ -1469,20 +1465,18 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             user_id=None, team_id=self.team.id, group=my_team_group, project=my_team_group.project
         )
 
-        # after the change to me -> (me + my_teams)
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                "assigned_or_suggested:me",
-                [group, assigned_to_other_group],
-                [group1, group2, assigned_group, my_team_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:my_teams",
-                [my_team_group],
-                [group, group1, group2, assigned_group, assigned_to_other_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            "assigned_or_suggested:me",
+            [group, assigned_to_other_group],
+            [group1, group2, assigned_group, my_team_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:my_teams",
+            [my_team_group],
+            [group, group1, group2, assigned_group, assigned_to_other_group],
+            user=self.user,
+        )
 
         # Because assigned_to_other_event is assigned to self.other_user, it should not show up in assigned_or_suggested search for anyone but self.other_user. (aka. they are now the only owner)
         other_user = self.create_user("other@user.com", is_superuser=False)
@@ -1492,39 +1486,35 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             user_id=other_user.id,
         )
 
-        # after the change to me -> (me + my_teams)
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                "assigned_or_suggested:me",
-                [group],
-                [group1, group2, assigned_group, my_team_group, assigned_to_other_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:my_teams",
-                [my_team_group],
-                [group, group1, group2, assigned_group, assigned_to_other_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                f"assigned_or_suggested:{other_user.email}",
-                [assigned_to_other_group],
-                [group, group1, group2, assigned_group, my_team_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            "assigned_or_suggested:me",
+            [group],
+            [group1, group2, assigned_group, my_team_group, assigned_to_other_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:my_teams",
+            [my_team_group],
+            [group, group1, group2, assigned_group, assigned_to_other_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            f"assigned_or_suggested:{other_user.email}",
+            [assigned_to_other_group],
+            [group, group1, group2, assigned_group, my_team_group],
+            user=self.user,
+        )
 
         GroupAssignee.objects.create(
             group=assigned_group, project=self.project, user_id=self.user.id
         )
 
-        # after the change to me -> (me + my_teams)
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                f"assigned_or_suggested:{self.user.email}",
-                [assigned_group, group],
-                [group1, group2, my_team_group, assigned_to_other_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            f"assigned_or_suggested:{self.user.email}",
+            [assigned_group, group],
+            [group1, group2, my_team_group, assigned_to_other_group],
+            user=self.user,
+        )
 
         GroupOwner.objects.create(
             group=group,
@@ -1535,14 +1525,12 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             user_id=None,
         )
 
-        # after the change to me -> (me + my_teams)
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                f"assigned_or_suggested:#{self.team.slug}",
-                [group, my_team_group],
-                [group1, group2, assigned_group, assigned_to_other_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            f"assigned_or_suggested:#{self.team.slug}",
+            [group, my_team_group],
+            [group1, group2, assigned_group, assigned_to_other_group],
+            user=self.user,
+        )
 
     def test_assigned_or_suggested_my_teams_in_syntax(self):
         Group.objects.all().delete()
@@ -1598,26 +1586,24 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             project_id=self.project.id,
         ).group
 
-        # after the change to me -> (me + my_teams)
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                "assigned_or_suggested:[me]",
-                [],
-                [group, group1, group2, assigned_group, assigned_to_other_group, my_team_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:[my_teams]",
-                [],
-                [group, group1, group2, assigned_group, assigned_to_other_group, my_team_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:[me, my_teams]",
-                [],
-                [group, group1, group2, assigned_group, assigned_to_other_group, my_team_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            "assigned_or_suggested:[me]",
+            [],
+            [group, group1, group2, assigned_group, assigned_to_other_group, my_team_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:[my_teams]",
+            [],
+            [group, group1, group2, assigned_group, assigned_to_other_group, my_team_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:[me, my_teams]",
+            [],
+            [group, group1, group2, assigned_group, assigned_to_other_group, my_team_group],
+            user=self.user,
+        )
 
         GroupOwner.objects.create(
             group=assigned_to_other_group,
@@ -1639,26 +1625,24 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             user_id=None, team_id=self.team.id, group=my_team_group, project=my_team_group.project
         )
 
-        # after the change to me -> (me + my_teams)
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                "assigned_or_suggested:[me]",
-                [group, assigned_to_other_group],
-                [group1, group2, assigned_group, my_team_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:[my_teams]",
-                [my_team_group],
-                [group, group1, group2, assigned_group, assigned_to_other_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:[me, my_teams]",
-                [group, assigned_to_other_group, my_team_group],
-                [group1, group2, assigned_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            "assigned_or_suggested:[me]",
+            [group, assigned_to_other_group],
+            [group1, group2, assigned_group, my_team_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:[my_teams]",
+            [my_team_group],
+            [group, group1, group2, assigned_group, assigned_to_other_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:[me, my_teams]",
+            [group, assigned_to_other_group, my_team_group],
+            [group1, group2, assigned_group],
+            user=self.user,
+        )
 
         # Because assigned_to_other_event is assigned to self.other_user, it should not show up in assigned_or_suggested search for anyone but self.other_user. (aka. they are now the only owner)
         other_user = self.create_user("other@user.com", is_superuser=False)
@@ -1668,45 +1652,41 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             user_id=other_user.id,
         )
 
-        # after the change to me -> (me + my_teams)
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                "assigned_or_suggested:[me]",
-                [group],
-                [group1, group2, assigned_group, my_team_group, assigned_to_other_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:[my_teams]",
-                [my_team_group],
-                [group, group1, group2, assigned_group, assigned_to_other_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:[me, my_teams]",
-                [group, my_team_group],
-                [group1, group2, assigned_group, assigned_to_other_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                f"assigned_or_suggested:[{other_user.email}]",
-                [assigned_to_other_group],
-                [group, group1, group2, assigned_group, my_team_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            "assigned_or_suggested:[me]",
+            [group],
+            [group1, group2, assigned_group, my_team_group, assigned_to_other_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:[my_teams]",
+            [my_team_group],
+            [group, group1, group2, assigned_group, assigned_to_other_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:[me, my_teams]",
+            [group, my_team_group],
+            [group1, group2, assigned_group, assigned_to_other_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            f"assigned_or_suggested:[{other_user.email}]",
+            [assigned_to_other_group],
+            [group, group1, group2, assigned_group, my_team_group],
+            user=self.user,
+        )
 
         GroupAssignee.objects.create(
             group=assigned_group, project=self.project, user_id=self.user.id
         )
 
-        # after the change to me -> (me + my_teams)
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                f"assigned_or_suggested:[{self.user.email}]",
-                [assigned_group, group],
-                [group1, group2, my_team_group, assigned_to_other_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            f"assigned_or_suggested:[{self.user.email}]",
+            [assigned_group, group],
+            [group1, group2, my_team_group, assigned_to_other_group],
+            user=self.user,
+        )
 
         GroupOwner.objects.create(
             group=group,
@@ -1717,32 +1697,30 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             user_id=None,
         )
 
-        # after the change to me -> (me + my_teams)
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                f"assigned_or_suggested:[#{self.team.slug}]",
-                [group, my_team_group],
-                [group1, group2, assigned_group, assigned_to_other_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:[me, none]",
-                [group, group1, group2, assigned_group],
-                [my_team_group, assigned_to_other_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:[my_teams, none]",
-                [group, group1, group2, my_team_group],
-                [assigned_to_other_group, assigned_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:[me, my_teams, none]",
-                [group, group1, group2, my_team_group, assigned_group],
-                [assigned_to_other_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            f"assigned_or_suggested:[#{self.team.slug}]",
+            [group, my_team_group],
+            [group1, group2, assigned_group, assigned_to_other_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:[me, none]",
+            [group, group1, group2, assigned_group],
+            [my_team_group, assigned_to_other_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:[my_teams, none]",
+            [group, group1, group2, my_team_group],
+            [assigned_to_other_group, assigned_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:[me, my_teams, none]",
+            [group, group1, group2, my_team_group, assigned_group],
+            [assigned_to_other_group],
+            user=self.user,
+        )
 
         not_me = self.create_user(email="notme@sentry.io")
         GroupOwner.objects.create(
@@ -1754,67 +1732,63 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             user_id=not_me.id,
         )
 
-        # after the change to me -> (me + my_teams)
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                "assigned_or_suggested:[me, none]",
-                [group, group1, assigned_group],
-                [group2, my_team_group, assigned_to_other_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:[my_teams, none]",
-                [group, group1, my_team_group],
-                [group2, assigned_group, assigned_to_other_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                "assigned_or_suggested:[me, my_teams, none]",
-                [group, group1, my_team_group, assigned_group],
-                [group2, assigned_to_other_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            "assigned_or_suggested:[me, none]",
+            [group, group1, assigned_group],
+            [group2, my_team_group, assigned_to_other_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:[my_teams, none]",
+            [group, group1, my_team_group],
+            [group2, assigned_group, assigned_to_other_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            "assigned_or_suggested:[me, my_teams, none]",
+            [group, group1, my_team_group, assigned_group],
+            [group2, assigned_to_other_group],
+            user=self.user,
+        )
 
         GroupOwner.objects.filter(group=group, user_id=self.user.id).delete()
 
-        # after the change to me -> (me + my_teams)
-        with self.feature("organizations:assign-to-me"):
-            self.run_test_query(
-                f"assigned_or_suggested:[me, none, #{self.team.slug}]",
-                [group, group1, assigned_group, my_team_group],
-                [assigned_to_other_group, group2],
-                user=self.user,
-            )
-            self.run_test_query(
-                f"assigned_or_suggested:[my_teams, none, #{self.team.slug}]",
-                [group, group1, my_team_group],
-                [assigned_to_other_group, group2, assigned_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                f"assigned_or_suggested:[me, my_teams, none, #{self.team.slug}]",
-                [group, group1, my_team_group, assigned_group],
-                [assigned_to_other_group, group2],
-                user=self.user,
-            )
-            self.run_test_query(
-                f"assigned_or_suggested:[me, none, #{self.team.slug}, {not_me.email}]",
-                [group, group1, group2, assigned_group, my_team_group],
-                [assigned_to_other_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                f"assigned_or_suggested:[my_teams, none, #{self.team.slug}, {not_me.email}]",
-                [group, group1, group2, my_team_group],
-                [assigned_to_other_group, assigned_group],
-                user=self.user,
-            )
-            self.run_test_query(
-                f"assigned_or_suggested:[me, my_teams, none, #{self.team.slug}, {not_me.email}]",
-                [group, group1, group2, my_team_group, assigned_group],
-                [assigned_to_other_group],
-                user=self.user,
-            )
+        self.run_test_query(
+            f"assigned_or_suggested:[me, none, #{self.team.slug}]",
+            [group, group1, assigned_group, my_team_group],
+            [assigned_to_other_group, group2],
+            user=self.user,
+        )
+        self.run_test_query(
+            f"assigned_or_suggested:[my_teams, none, #{self.team.slug}]",
+            [group, group1, my_team_group],
+            [assigned_to_other_group, group2, assigned_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            f"assigned_or_suggested:[me, my_teams, none, #{self.team.slug}]",
+            [group, group1, my_team_group, assigned_group],
+            [assigned_to_other_group, group2],
+            user=self.user,
+        )
+        self.run_test_query(
+            f"assigned_or_suggested:[me, none, #{self.team.slug}, {not_me.email}]",
+            [group, group1, group2, assigned_group, my_team_group],
+            [assigned_to_other_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            f"assigned_or_suggested:[my_teams, none, #{self.team.slug}, {not_me.email}]",
+            [group, group1, group2, my_team_group],
+            [assigned_to_other_group, assigned_group],
+            user=self.user,
+        )
+        self.run_test_query(
+            f"assigned_or_suggested:[me, my_teams, none, #{self.team.slug}, {not_me.email}]",
+            [group, group1, group2, my_team_group, assigned_group],
+            [assigned_to_other_group],
+            user=self.user,
+        )
 
     def test_assigned_to_with_environment(self):
         results = self.make_query(

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1211,8 +1211,8 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         ga_2.update(team=self.team, user_id=None)
         self.run_test_query(
             f"assigned:[{self.user.username}, {other_user.username}]",
-            [self.group2, group_3],
-            [self.group1],
+            [group_3],
+            [self.group1, self.group2],
         )
         self.run_test_query(
             f"assigned:[#{self.team.slug}, {other_user.username}]",
@@ -1222,8 +1222,8 @@ class EventsSnubaSearchTest(SharedSnubaTest):
 
         self.run_test_query(
             f"assigned:[me, none, {other_user.username}]",
-            [self.group1, self.group2, group_3],
-            [],
+            [self.group1, group_3],
+            [self.group2],
         )
 
     def test_assigned_or_suggested_in_syntax(self):

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1075,7 +1075,7 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         assert GroupAssignee.objects.get(id=ga.id).user_id is None
 
         results = self.make_query(search_filter_query="assigned:%s" % self.user.username)
-        assert set(results) == {self.group2}
+        assert set(results) == set()
 
         # test when there should be no results
         other_user = self.create_user()


### PR DESCRIPTION
Removes `organization:assign-to-me` feature flag and references which GA's the changes to `assign_to` and `assign_or_suggested` issue search filters to differentiate between `me` and `my_teams` values.

Also cleaned up some tests that were created before the functional split change where the `me` filter value included the user's team(s).