### PR TITLE
Import dashboard from json file (internal feature)

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -268,6 +268,16 @@ export async function openAddToDashboardModal(options) {
   });
 }
 
+export async function openImportDashboardFromFileModal(options) {
+  const mod = await import('sentry/components/modals/importDashboardFromFileModal');
+  const {default: Modal, modalCss} = mod;
+
+  openModal(deps => <Modal {...deps} {...options} />, {
+    closeEvents: 'escape-key',
+    modalCss,
+  });
+}
+
 export async function openReprocessEventModal({
   onClose,
   ...options

--- a/static/app/components/modals/importDashboardFromFileModal.tsx
+++ b/static/app/components/modals/importDashboardFromFileModal.tsx
@@ -1,0 +1,127 @@
+import {Fragment, useState} from 'react';
+import {browserHistory} from 'react-router';
+import {css} from '@emotion/react';
+
+import {createDashboard} from 'sentry/actionCreators/dashboards';
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {Button} from 'sentry/components/button';
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {IconUpload} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {
+  assignDefaultLayout,
+  getInitialColumnDepths,
+} from 'sentry/views/dashboards/layoutUtils';
+import {Wrapper} from 'sentry/views/discover/table/quickContext/styles';
+
+function ImportDashboardFromFileModal({
+  Header,
+  Body,
+  Footer,
+  organization,
+  api,
+  location,
+}) {
+  const [dashboardData, setDashboardData] = useState('');
+  const [validated, setValidated] = useState(false);
+
+  function validateFile(fileToUpload) {
+    if (!(fileToUpload.type === 'application/json')) {
+      addErrorMessage('The uploaded file must be JSON');
+      setValidated(false);
+      return false;
+    }
+
+    setValidated(true);
+    return true;
+  }
+
+  const handleFileChange = e => {
+    if (e.target.files) {
+      const fileToUpload = e.target.files[0];
+      if (validateFile(fileToUpload)) {
+        const fileReader = new FileReader();
+        fileReader.readAsText(fileToUpload, 'UTF-8');
+        fileReader.onload = event => {
+          const target = event.target;
+          if (target) {
+            const parsed = JSON.parse(target.result);
+            const formatted = JSON.stringify(parsed, null, '\t');
+            setDashboardData(formatted);
+          }
+        };
+      }
+    }
+  };
+
+  const handleUploadClick = async () => {
+    const dashboard = JSON.parse(dashboardData);
+
+    try {
+      const newDashboard = await createDashboard(
+        api,
+        organization.slug,
+        {
+          ...dashboard,
+          widgets: assignDefaultLayout(dashboard.widgets, getInitialColumnDepths()),
+        },
+        true
+      );
+
+      addSuccessMessage(`${dashboard.title} dashboard template successfully added`);
+      loadDashboard(newDashboard.id);
+    } catch (error) {
+      addErrorMessage('Could not upload dashboard, JSON may be invalid');
+    }
+  };
+
+  const loadDashboard = (dashboardId: string) => {
+    browserHistory.push(
+      normalizeUrl({
+        pathname: `/organizations/${organization.slug}/dashboards/${dashboardId}/`,
+        query: location.query,
+      })
+    );
+  };
+
+  return (
+    <div>
+      <Header closeButton>
+        <h4>{t('Import Dashboard from JSON File')}</h4>
+      </Header>
+      <Body>
+        <Wrapper>
+          <input type="file" onChange={handleFileChange} />
+        </Wrapper>
+        <Wrapper>
+          <Button
+            onClick={handleUploadClick}
+            size="md"
+            disabled={!validated}
+            priority="primary"
+            icon={<IconUpload />}
+          >
+            {t('Import')}
+          </Button>
+        </Wrapper>
+      </Body>
+      {validated && (
+        <Fragment>
+          <Footer />
+          <Wrapper>
+            <h4>{t('Preview')}</h4>
+          </Wrapper>
+          <CodeSnippet language="json">{dashboardData}</CodeSnippet>
+        </Fragment>
+      )}
+    </div>
+  );
+}
+
+export default ImportDashboardFromFileModal;
+
+export const modalCss = css`
+  max-width: 700px;
+  margin: 70px auto;
+`;

--- a/static/app/components/modals/importDashboardFromFileModal.tsx
+++ b/static/app/components/modals/importDashboardFromFileModal.tsx
@@ -38,7 +38,7 @@ function ImportDashboardFromFileModal({
   }
 
   const handleFileChange = e => {
-    if (e.target.files) {
+    if (e.target.files.length) {
       const fileToUpload = e.target.files[0];
       if (validateFile(fileToUpload)) {
         const fileReader = new FileReader();

--- a/static/app/components/modals/importDashboardFromFileModal.tsx
+++ b/static/app/components/modals/importDashboardFromFileModal.tsx
@@ -86,7 +86,7 @@ function ImportDashboardFromFileModal({
   };
 
   return (
-    <div>
+    <Fragment>
       <Header closeButton>
         <h4>{t('Import Dashboard from JSON File')}</h4>
       </Header>

--- a/static/app/components/modals/importDashboardFromFileModal.tsx
+++ b/static/app/components/modals/importDashboardFromFileModal.tsx
@@ -15,6 +15,7 @@ import {
 } from 'sentry/views/dashboards/layoutUtils';
 import {Wrapper} from 'sentry/views/discover/table/quickContext/styles';
 
+// Internal feature - no specs written.
 function ImportDashboardFromFileModal({
   Header,
   Body,
@@ -27,9 +28,10 @@ function ImportDashboardFromFileModal({
   const [validated, setValidated] = useState(false);
 
   function validateFile(fileToUpload) {
-    if (!(fileToUpload.type === 'application/json')) {
-      addErrorMessage('The uploaded file must be JSON');
+    if (!fileToUpload || !(fileToUpload.type === 'application/json')) {
+      addErrorMessage('You must upload a JSON file');
       setValidated(false);
+      setDashboardData('');
       return false;
     }
 
@@ -38,20 +40,18 @@ function ImportDashboardFromFileModal({
   }
 
   const handleFileChange = e => {
-    if (e.target.files.length) {
-      const fileToUpload = e.target.files[0];
-      if (validateFile(fileToUpload)) {
-        const fileReader = new FileReader();
-        fileReader.readAsText(fileToUpload, 'UTF-8');
-        fileReader.onload = event => {
-          const target = event.target;
-          if (target) {
-            const parsed = JSON.parse(target.result);
-            const formatted = JSON.stringify(parsed, null, '\t');
-            setDashboardData(formatted);
-          }
-        };
-      }
+    const fileToUpload = e.target.files[0];
+    if (validateFile(fileToUpload)) {
+      const fileReader = new FileReader();
+      fileReader.readAsText(fileToUpload, 'UTF-8');
+      fileReader.onload = event => {
+        const target = event.target;
+        if (target && typeof target.result === 'string') {
+          const parsed = JSON.parse(target.result);
+          const formatted = JSON.stringify(parsed, null, '\t');
+          setDashboardData(formatted);
+        }
+      };
     }
   };
 

--- a/static/app/components/modals/importDashboardFromFileModal.tsx
+++ b/static/app/components/modals/importDashboardFromFileModal.tsx
@@ -115,7 +115,7 @@ function ImportDashboardFromFileModal({
           <CodeSnippet language="json">{dashboardData}</CodeSnippet>
         </Fragment>
       )}
-    </div>
+    </Fragment>
   );
 }
 

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -180,18 +180,20 @@ class ManageDashboards extends AsyncView<Props, State> {
           onChange={opt => this.handleSortChange(opt.value)}
           position="bottom-end"
         />
-        <Wrapper>
-          <Button
-            onClick={() => {
-              openImportDashboardFromFileModal({organization, api, location});
-            }}
-            size="sm"
-            priority="primary"
-            icon={<IconAdd isCircled />}
-          >
-            {t('Import Dashboard from JSON')}
-          </Button>
-        </Wrapper>
+        <Feature features={['dashboards-import']}>
+          <Wrapper>
+            <Button
+              onClick={() => {
+                openImportDashboardFromFileModal({organization, api, location});
+              }}
+              size="sm"
+              priority="primary"
+              icon={<IconAdd isCircled />}
+            >
+              {t('Import Dashboard from JSON')}
+            </Button>
+          </Wrapper>
+        </Feature>
       </StyledActions>
     );
   }

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -4,6 +4,7 @@ import pick from 'lodash/pick';
 
 import {createDashboard} from 'sentry/actionCreators/dashboards';
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {openImportDashboardFromFileModal} from 'sentry/actionCreators/modal';
 import {Client} from 'sentry/api';
 import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/alert';
@@ -27,6 +28,7 @@ import withApi from 'sentry/utils/withApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
+import {Wrapper} from 'sentry/views/discover/table/quickContext/styles';
 
 import {DASHBOARDS_TEMPLATES} from '../data';
 import {assignDefaultLayout, getInitialColumnDepths} from '../layoutUtils';
@@ -161,6 +163,7 @@ class ManageDashboards extends AsyncView<Props, State> {
 
   renderActions() {
     const activeSort = this.getActiveSort();
+    const {organization, api, location} = this.props;
 
     return (
       <StyledActions>
@@ -177,6 +180,18 @@ class ManageDashboards extends AsyncView<Props, State> {
           onChange={opt => this.handleSortChange(opt.value)}
           position="bottom-end"
         />
+        <Wrapper>
+          <Button
+            onClick={() => {
+              openImportDashboardFromFileModal({organization, api, location});
+            }}
+            size="sm"
+            priority="primary"
+            icon={<IconAdd isCircled />}
+          >
+            {t('Import Dashboard from JSON')}
+          </Button>
+        </Wrapper>
       </StyledActions>
     );
   }

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -28,7 +28,6 @@ import withApi from 'sentry/utils/withApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
-import {Wrapper} from 'sentry/views/discover/table/quickContext/styles';
 
 import {DASHBOARDS_TEMPLATES} from '../data';
 import {assignDefaultLayout, getInitialColumnDepths} from '../layoutUtils';
@@ -163,8 +162,6 @@ class ManageDashboards extends AsyncView<Props, State> {
 
   renderActions() {
     const activeSort = this.getActiveSort();
-    const {organization, api, location} = this.props;
-
     return (
       <StyledActions>
         <SearchBar
@@ -180,20 +177,6 @@ class ManageDashboards extends AsyncView<Props, State> {
           onChange={opt => this.handleSortChange(opt.value)}
           position="bottom-end"
         />
-        <Feature features={['dashboards-import']}>
-          <Wrapper>
-            <Button
-              onClick={() => {
-                openImportDashboardFromFileModal({organization, api, location});
-              }}
-              size="sm"
-              priority="primary"
-              icon={<IconAdd isCircled />}
-            >
-              {t('Import Dashboard from JSON')}
-            </Button>
-          </Wrapper>
-        </Feature>
       </StyledActions>
     );
   }
@@ -296,7 +279,7 @@ class ManageDashboards extends AsyncView<Props, State> {
 
   renderBody() {
     const {showTemplates} = this.state;
-    const {organization} = this.props;
+    const {organization, api, location} = this.props;
 
     return (
       <Feature
@@ -341,6 +324,22 @@ class ManageDashboards extends AsyncView<Props, State> {
                     >
                       {t('Create Dashboard')}
                     </Button>
+                    <Feature features={['dashboards-import']}>
+                      <Button
+                        onClick={() => {
+                          openImportDashboardFromFileModal({
+                            organization,
+                            api,
+                            location,
+                          });
+                        }}
+                        size="sm"
+                        priority="primary"
+                        icon={<IconAdd isCircled />}
+                      >
+                        {t('Import Dashboard from JSON')}
+                      </Button>
+                    </Feature>
                   </ButtonBar>
                 </Layout.HeaderActions>
               </Layout.Header>


### PR DESCRIPTION
## Overview

(working with @narsaynorath - requesting code review directly from Nar)

Allows upload & import of dashboard via a JSON file.

- basic filetype validation
- preview of file contents before import

### Related PRs
- Feature flag: https://github.com/getsentry/sentry/pull/52234
- Dashboard export: https://github.com/sergiosentry/sentry/pull/1

## Screenshots
![Screenshot 2023-07-06 at 2 11 57 PM](https://github.com/getsentry/sentry/assets/12092849/5afd5936-24e0-4a3f-a447-058fe723de7e)

![Screenshot 2023-07-06 at 2 12 07 PM](https://github.com/getsentry/sentry/assets/12092849/7b2a904d-0a57-4e9e-b9b6-3ba5c16d7220)

<img width="1579" alt="Screenshot 2023-07-05 at 11 58 04 AM" src="https://github.com/cstavitsky/sentry/assets/12092849/65b155c0-59c8-421c-adb4-e193a4db3f93">

