### PR TITLE
fix: use secrets instead of uuid

### DIFF
--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -50,7 +50,7 @@ class OAuth2Login(AuthView):
         if "code" in request.GET:
             return helper.next_step()
 
-        state = secrets.token_urlsafe()
+        state = secrets.token_hex()
 
         params = self.get_authorize_params(state=state, redirect_uri=helper.get_redirect_url())
         authorization_url = f"{self.get_authorize_url()}?{urlencode(params)}"

--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -1,9 +1,9 @@
 import abc
 import logging
+import secrets
 from time import time
 from typing import Any, Mapping
 from urllib.parse import parse_qsl, urlencode
-from uuid import uuid4
 
 from django.http import HttpResponse
 from rest_framework.request import Request
@@ -50,7 +50,7 @@ class OAuth2Login(AuthView):
         if "code" in request.GET:
             return helper.next_step()
 
-        state = uuid4().hex
+        state = secrets.token_urlsafe()
 
         params = self.get_authorize_params(state=state, redirect_uri=helper.get_redirect_url())
         authorization_url = f"{self.get_authorize_url()}?{urlencode(params)}"

--- a/src/sentry/auth/system.py
+++ b/src/sentry/auth/system.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import ipaddress
 import logging
+import secrets
 from typing import Any
-from uuid import uuid4
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -28,7 +28,7 @@ def is_internal_ip(request: HttpRequest) -> bool:
 def get_system_token() -> str:
     token = options.get("sentry:system-token")
     if not token:
-        token = uuid4().hex
+        token = secrets.token_hex()
         options.set("sentry:system-token", token, channel=options.UpdateChannel.APPLICATION)
     return token
 

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -239,7 +239,7 @@ class OAuth2LoginView(PipelineView):
             if param in request.GET:
                 return pipeline.next_step()
 
-        state = secrets.token_urlsafe()
+        state = secrets.token_hex()
 
         params = self.get_authorize_params(
             state=state, redirect_uri=absolute_uri(pipeline.redirect_url())

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -1,9 +1,9 @@
 __all__ = ["OAuth2Provider", "OAuth2CallbackView", "OAuth2LoginView"]
 
 import logging
+import secrets
 from time import time
 from urllib.parse import parse_qsl, urlencode
-from uuid import uuid4
 
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
@@ -239,7 +239,7 @@ class OAuth2LoginView(PipelineView):
             if param in request.GET:
                 return pipeline.next_step()
 
-        state = uuid4().hex
+        state = secrets.token_urlsafe()
 
         params = self.get_authorize_params(
             state=state, redirect_uri=absolute_uri(pipeline.redirect_url())

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -1,6 +1,6 @@
+import secrets
 from typing import List
 from urllib.parse import urlparse
-from uuid import uuid4
 
 import petname
 from django.db import models, router, transaction
@@ -24,7 +24,9 @@ def generate_name():
 
 
 def generate_token():
-    return uuid4().hex + uuid4().hex
+    # `client_id` on `ApiApplication` is currently limited to 64 characters
+    # so we need to restrict the length of the secret
+    return secrets.token_hex(nbytes=64)  # generates a 256-bit secure token
 
 
 class ApiApplicationStatus:

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -26,7 +26,7 @@ def generate_name():
 def generate_token():
     # `client_id` on `ApiApplication` is currently limited to 64 characters
     # so we need to restrict the length of the secret
-    return secrets.token_hex(nbytes=64)  # generates a 256-bit secure token
+    return secrets.token_hex(nbytes=32)  # generates a 128-bit secure token
 
 
 class ApiApplicationStatus:

--- a/src/sentry/models/apigrant.py
+++ b/src/sentry/models/apigrant.py
@@ -16,7 +16,7 @@ def default_expiration():
 
 
 def generate_code():
-    return secrets.token_hex(nbytes=64)  # generates a 256-bit secure token
+    return secrets.token_hex(nbytes=32)  # generates a 128-bit secure token
 
 
 @control_silo_only_model

--- a/src/sentry/models/apigrant.py
+++ b/src/sentry/models/apigrant.py
@@ -1,6 +1,6 @@
+import secrets
 from datetime import timedelta
 from typing import TypedDict
-from uuid import uuid4
 
 from django.db import models
 from django.utils import timezone
@@ -16,7 +16,7 @@ def default_expiration():
 
 
 def generate_code():
-    return uuid4().hex
+    return secrets.token_hex(nbytes=64)  # generates a 256-bit secure token
 
 
 @control_silo_only_model

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -1,5 +1,5 @@
+import secrets
 from typing import TypedDict
-from uuid import uuid4
 
 from django.db import models
 from django.utils import timezone
@@ -75,7 +75,7 @@ class ApiKey(Model):
 
     @classmethod
     def generate_api_key(cls):
-        return uuid4().hex
+        return secrets.token_hex(nbytes=32)  # generates a 128-bit secure token
 
     @property
     def is_active(self):

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -75,7 +75,7 @@ class ApiKey(Model):
 
     @classmethod
     def generate_api_key(cls):
-        return secrets.token_hex(nbytes=32)  # generates a 128-bit secure token
+        return secrets.token_hex(nbytes=16)
 
     @property
     def is_active(self):

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import secrets
 from datetime import timedelta
-from uuid import uuid4
 
 from django.db import models, router, transaction
 from django.utils import timezone
@@ -24,7 +24,7 @@ def default_expiration():
 
 
 def generate_token():
-    return uuid4().hex + uuid4().hex
+    return secrets.token_hex(nbytes=64)  # generates a 256-bit secure token
 
 
 @control_silo_only_model

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -24,7 +24,7 @@ def default_expiration():
 
 
 def generate_token():
-    return secrets.token_hex(nbytes=64)  # generates a 256-bit secure token
+    return secrets.token_hex(nbytes=32)
 
 
 @control_silo_only_model

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import datetime
+import secrets
 from collections import defaultdict
 from datetime import timedelta
 from enum import Enum
 from hashlib import md5
 from typing import TYPE_CHECKING, FrozenSet, List, Mapping, MutableMapping, Set, TypedDict
 from urllib.parse import urlencode
-from uuid import uuid4
 
 from django.conf import settings
 from django.db import models, router, transaction
@@ -352,7 +352,7 @@ class OrganizationMember(Model):
         return checksum.hexdigest()
 
     def generate_token(self):
-        return uuid4().hex + uuid4().hex
+        return secrets.token_hex(nbytes=64)
 
     def get_invite_link(self):
         if not self.is_pending or not self.invite_approved:

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -352,7 +352,7 @@ class OrganizationMember(Model):
         return checksum.hexdigest()
 
     def generate_token(self):
-        return secrets.token_hex(nbytes=64)
+        return secrets.token_hex(nbytes=32)
 
     def get_invite_link(self):
         if not self.is_pending or not self.invite_approved:

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -1,6 +1,6 @@
 import re
+import secrets
 from urllib.parse import urlparse
-from uuid import uuid4
 
 import petname
 from django.conf import settings
@@ -22,7 +22,7 @@ from sentry.db.models import (
 )
 from sentry.tasks.relay import schedule_invalidate_project_config
 
-_uuid4_re = re.compile(r"^[a-f0-9]{32}$")
+_token_re = re.compile(r"^[a-f0-9]{32}$")
 
 # TODO(dcramer): pull in enum library
 
@@ -105,11 +105,11 @@ class ProjectKey(Model):
 
     @classmethod
     def generate_api_key(cls):
-        return uuid4().hex
+        return secrets.token_hex(nbytes=32)
 
     @classmethod
     def looks_like_api_key(cls, key):
-        return bool(_uuid4_re.match(key))
+        return bool(_token_re.match(key))
 
     @classmethod
     def from_dsn(cls, dsn):

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -105,7 +105,7 @@ class ProjectKey(Model):
 
     @classmethod
     def generate_api_key(cls):
-        return secrets.token_hex(nbytes=32)
+        return secrets.token_hex(nbytes=16)
 
     @classmethod
     def looks_like_api_key(cls, key):

--- a/src/sentry/models/servicehook.py
+++ b/src/sentry/models/servicehook.py
@@ -44,7 +44,7 @@ class ServiceHookProject(Model):
 
 def generate_secret():
     # the `secret` field on `ServiceHook` does not have a max_length so we can use the default length
-    # at 64 bytes (512-bits). This is sufficiently secure and will update over time to sane defaults.
+    # of 64 characters. This is sufficiently secure and will update over time to sane defaults.
     return secrets.token_hex()
 
 

--- a/src/sentry/models/servicehook.py
+++ b/src/sentry/models/servicehook.py
@@ -1,4 +1,5 @@
 import hmac
+import secrets
 from functools import cached_property
 from hashlib import sha256
 from uuid import uuid4
@@ -42,7 +43,9 @@ class ServiceHookProject(Model):
 
 
 def generate_secret():
-    return uuid4().hex + uuid4().hex
+    # the `secret` field on `ServiceHook` does not have a max_length so we can use the default length
+    # at 64 bytes (512-bits). This is sufficiently secure and will update over time to sane defaults.
+    return secrets.token_hex()
 
 
 @region_silo_only_model

--- a/src/sentry_plugins/bitbucket/repository_provider.py
+++ b/src/sentry_plugins/bitbucket/repository_provider.py
@@ -1,4 +1,4 @@
-from uuid import uuid4
+import secrets
 
 from sentry.locks import locks
 from sentry.models import OrganizationOption
@@ -55,7 +55,7 @@ class BitbucketRepositoryProvider(BitbucketMixin, RepositoryProvider):
                 organization=organization, key="bitbucket:webhook_secret"
             )
             if secret is None:
-                secret = uuid4().hex + uuid4().hex
+                secret = secrets.token_hex()
                 OrganizationOption.objects.set_value(
                     organization=organization, key="bitbucket:webhook_secret", value=secret
                 )


### PR DESCRIPTION
The `uuid` library provides good randomness, but no guarantees around cryptographic strength. Instead, we should use the [`secrets`](https://docs.python.org/3/library/secrets.html) library to do so.
