### PR TITLE
fix(starfish): Dont show percentages in WSV chart if duration selected

### DIFF
--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -144,7 +144,9 @@ export function SpanGroupBreakdown({
             }
             tooltipFormatterOptions={{
               valueFormatter: value =>
-                tooltipFormatterUsingAggregateOutputType(value, 'percentage'),
+                dataDisplayType === DataDisplayType.PERCENTAGE
+                  ? tooltipFormatterUsingAggregateOutputType(value, 'percentage')
+                  : tooltipFormatterUsingAggregateOutputType(value, 'duration'),
             }}
             onLegendSelectChanged={event => {
               trackAnalytics('starfish.web_service_view.breakdown.legend_change', {


### PR DESCRIPTION
Updates the tooltip in the WSV chart to conditionally format values depending on the type of chart that is selected

### Before
![image](https://github.com/getsentry/sentry/assets/16740047/0e998301-7f06-4f4b-a738-e6a6877a2a1c)

### After
![image](https://github.com/getsentry/sentry/assets/16740047/6f9db619-ede1-4d61-b127-a67d631ec234)
