### PR TITLE
ref(starfish): Isolate & save date filter values

### DIFF
--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -181,7 +181,7 @@ function Chart({
   const router = useRouter();
   const theme = useTheme();
   const pageFilter = usePageFilters();
-  const {startTime, endTime} = getDateFilters(pageFilter.selection);
+  const {startTime, endTime} = getDateFilters(pageFilter.selection.datetime);
 
   const defaultRef = useRef<ReactEchartsRef>(null);
   const chartRef = forwardedRef || defaultRef;

--- a/static/app/views/starfish/components/datePicker.tsx
+++ b/static/app/views/starfish/components/datePicker.tsx
@@ -4,8 +4,11 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import {MAXIMUM_DATE_RANGE} from 'sentry/views/starfish/components/pageFilterContainer';
 
+import {setStarfishDateFilterStorage} from '../utils/dateFilterStorage';
+
 function StarfishDatePicker() {
   const organization = useOrganization();
+
   return (
     <DatePageFilter
       maxDateRange={MAXIMUM_DATE_RANGE}
@@ -19,7 +22,13 @@ function StarfishDatePicker() {
       }}
       defaultPeriod="24h"
       alignDropdown="left"
-      onChange={({start, end, relative}) => {
+      onChange={({start, end, relative, utc}) => {
+        setStarfishDateFilterStorage(organization.slug, {
+          period: relative,
+          start,
+          end,
+          utc,
+        });
         trackAnalytics('starfish.page_filter.data_change', {
           organization,
           start,

--- a/static/app/views/starfish/components/pageFilterContainer.tsx
+++ b/static/app/views/starfish/components/pageFilterContainer.tsx
@@ -1,35 +1,80 @@
+import {useEffect} from 'react';
+
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import {getPageFilterStorage} from 'sentry/components/organizations/pageFilters/persistence';
+import {getUtcDateString} from 'sentry/utils/dates';
 import {useLocation} from 'sentry/utils/useLocation';
-import usePageFilters from 'sentry/utils/usePageFilters';
+import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 import {getDateFilters} from 'sentry/views/starfish/utils/getDateFilters';
+
+import {
+  getStarfishDateFilterStorage,
+  setStarfishDateFilterStorage,
+} from '../utils/dateFilterStorage';
 
 export const MAXIMUM_DATE_RANGE = 7;
 export const DEFAULT_STATS_PERIOD = '24h';
 
+function limitDateRange(datetime, maximum = MAXIMUM_DATE_RANGE) {
+  const {endTime, startTime} = getDateFilters(datetime);
+
+  return endTime.diff(startTime, 'days') > maximum
+    ? {period: DEFAULT_STATS_PERIOD, start: null, end: null}
+    : {
+        period: datetime.period,
+        start: datetime.start ? getUtcDateString(datetime.start) : null,
+        end: datetime.end ? getUtcDateString(datetime.end) : null,
+        utc: datetime.utc,
+      };
+}
+
 function StarfishPageFilterContainer(props: {children: React.ReactNode}) {
   const router = useRouter();
+  const organization = useOrganization();
   const location = useLocation();
-  const {selection} = usePageFilters();
-  const datetime = selection.datetime;
 
-  const {endTime, startTime} = getDateFilters(selection);
-  if (endTime.diff(startTime, 'days') > MAXIMUM_DATE_RANGE) {
-    datetime.period = DEFAULT_STATS_PERIOD;
-    datetime.start = null;
-    datetime.end = null;
+  useEffect(() => {
+    const globalDatetimeStorage = getPageFilterStorage(organization.slug)?.state ?? {};
+    const starfishDatetimeStorage = getStarfishDateFilterStorage(organization.slug);
+    let datetime;
+
+    // If user opened a shared link, use the filter values encoded in the link
+    if (location.query.statsPeriod || (location.query.start && location.query.end)) {
+      datetime = limitDateRange({
+        start: location.query.start,
+        end: location.query.end,
+        period: location.query.statsPeriod,
+        utc: location.query.utc,
+      });
+      // Else, use stored Starfish-specific values if available
+    } else if (starfishDatetimeStorage) {
+      datetime = limitDateRange(starfishDatetimeStorage);
+      // Else, fall back to saved _global_ values
+    } else {
+      datetime = limitDateRange(globalDatetimeStorage);
+      setStarfishDateFilterStorage(organization.slug, datetime);
+    }
+
     router.replace({
-      pathname: location.pathname,
+      ...location,
       query: {
         ...location.query,
-        statsPeriod: DEFAULT_STATS_PERIOD,
-        start: null,
-        end: null,
+        statsPeriod: datetime.period,
+        start: datetime.start ? datetime.start : undefined,
+        end: datetime.end ? datetime.end : undefined,
+        utc: datetime.utc,
       },
     });
-  }
+    // On run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  return <PageFiltersContainer>{props.children}</PageFiltersContainer>;
+  return (
+    <PageFiltersContainer disablePersistence skipInitializeUrlParams>
+      {props.children}
+    </PageFiltersContainer>
+  );
 }
 
 export default StarfishPageFilterContainer;

--- a/static/app/views/starfish/utils/dateFilterStorage.tsx
+++ b/static/app/views/starfish/utils/dateFilterStorage.tsx
@@ -1,0 +1,31 @@
+import {PageFilters} from 'sentry/types';
+import {getUtcDateString} from 'sentry/utils/dates';
+import localStorage from 'sentry/utils/localStorage';
+
+function getStarfishStorageKey(orgSlug) {
+  return `starfish-selection:${orgSlug}`;
+}
+
+export function setStarfishDateFilterStorage(
+  orgSlug: string,
+  {start, end, period, utc}: Partial<PageFilters['datetime']>
+) {
+  localStorage.setItem(
+    getStarfishStorageKey(orgSlug),
+    JSON.stringify({
+      start: start ? getUtcDateString(start) : null,
+      end: end ? getUtcDateString(end) : null,
+      period,
+      utc,
+    })
+  );
+}
+
+export function getStarfishDateFilterStorage(orgSlug: string) {
+  const storedItem = localStorage.getItem(getStarfishStorageKey(orgSlug));
+  if (!storedItem) {
+    return null;
+  }
+
+  return JSON.parse(storedItem);
+}

--- a/static/app/views/starfish/utils/getDateConditions.tsx
+++ b/static/app/views/starfish/utils/getDateConditions.tsx
@@ -5,7 +5,7 @@ import {getDateFilters} from 'sentry/views/starfish/utils/getDateFilters';
 export const getDateConditions = (
   selection: PageFilters
 ): {end?: string | undefined; start?: string | undefined; statsPeriod?: string} => {
-  const {startTime, endTime, statsPeriod} = getDateFilters(selection);
+  const {startTime, endTime, statsPeriod} = getDateFilters(selection.datetime);
   const {start, end} = normalizeDateTimeParams({
     start: startTime.toDate(),
     end: endTime.toDate(),

--- a/static/app/views/starfish/utils/getDateFilters.tsx
+++ b/static/app/views/starfish/utils/getDateFilters.tsx
@@ -5,12 +5,10 @@ import {PageFilters} from 'sentry/types';
 export const PERIOD_REGEX = /^(\d+)([h,d])$/;
 export const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
-export function getDateFilters(selection: PageFilters) {
-  const [_, num, unit] = selection.datetime.period?.match(PERIOD_REGEX) ?? [];
+export function getDateFilters(selection: Partial<PageFilters['datetime']>) {
+  const [_, num, unit] = selection.period?.match(PERIOD_REGEX) ?? [];
   const startTime =
-    num && unit
-      ? moment().subtract(num, unit as 'h' | 'd')
-      : moment(selection.datetime.start);
-  const endTime = moment(selection.datetime.end ?? undefined);
-  return {startTime, endTime, statsPeriod: selection.datetime.period};
+    num && unit ? moment().subtract(num, unit as 'h' | 'd') : moment(selection.start);
+  const endTime = moment(selection.end ?? undefined);
+  return {startTime, endTime, statsPeriod: selection.period};
 }


### PR DESCRIPTION
Better isolate the date page filter's value inside Starfish from the global filter context. Requirements include:
 - The date filter's value inside Starfish is independent of the outer global value (which applies to most other pages). This means changes to the filter's value inside Starfish should not leak out into the global context, and vice versa.
 - The filter's value persists across sessions. If the user navigates out of Starfish and then back in, or if they close the tab and reopens it, the old value should be automatically selected.

**Before ——**
The date filter's global value is "90D" (seen in the Issues page). Navigate to Starfish, and change the filter's value to "24H" —> the global value is also changed to "24H".

https://github.com/getsentry/sentry/assets/44172267/8ea8f20a-80d5-4c53-bed6-c0057c4544ea

<br />

**After ——**
Any change to the date filter's value is contained inside Starfish. The global value (seen in the Issues page) is still at "90D".

https://github.com/getsentry/sentry/assets/44172267/9d9130cf-c06e-4fb7-9e14-cbd007d68901

