### PR TITLE
chore(roles): Show a disabled team-role select when flag is false

### DIFF
--- a/static/app/components/teamRoleSelect.tsx
+++ b/static/app/components/teamRoleSelect.tsx
@@ -28,9 +28,7 @@ function TeamRoleSelect({
   size,
 }: Props) {
   const {orgRoleList, teamRoleList, features} = organization;
-  if (!features.includes('team-roles')) {
-    return null;
-  }
+  const hasTeamRoles = features.includes('team-roles');
 
   // Determine the org-role, including if the current team has an org role
   // and adding the user to the current team changes their minimum team-role
@@ -72,7 +70,7 @@ function TeamRoleSelect({
 
   return (
     <RoleSelectControl
-      disabled={disabled}
+      disabled={disabled || !hasTeamRoles}
       disableUnallowed={false}
       roles={teamRoleList}
       value={teamRole.id}

--- a/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
@@ -80,7 +80,7 @@ function TeamSelect({
 
     return (
       <React.Fragment>
-        {organization.features.includes('team-roles') && effectiveOrgRole && (
+        {effectiveOrgRole && (
           <RoleOverwritePanelAlert
             orgRole={effectiveOrgRole?.id}
             orgRoleList={orgRoleList}
@@ -164,18 +164,16 @@ function TeamRow({
 
       <TeamOrgRole>{orgRoleFromTeam}</TeamOrgRole>
 
-      {organization.features.includes('team-roles') && (
-        <RoleSelectWrapper>
-          <TeamRoleSelect
-            disabled={disabled}
-            size="xs"
-            organization={organization}
-            team={team}
-            member={member}
-            onChangeTeamRole={newRole => onChangeTeamRole(team.slug, newRole)}
-          />
-        </RoleSelectWrapper>
-      )}
+      <RoleSelectWrapper>
+        <TeamRoleSelect
+          disabled={disabled}
+          size="xs"
+          organization={organization}
+          team={team}
+          member={member}
+          onChangeTeamRole={newRole => onChangeTeamRole(team.slug, newRole)}
+        />
+      </RoleSelectWrapper>
 
       <Button
         size="xs"

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -285,9 +285,8 @@ class OrganizationMemberDetail extends DeprecatedAsyncView<Props, State> {
       return <NotFound />;
     }
 
-    const {access, features, orgRoleList} = organization;
+    const {access, orgRoleList} = organization;
     const canEdit = access.includes('org:write') && !this.memberDeactivated;
-    const hasTeamRoles = features.includes('team-roles');
 
     const {email, expired, pending, invite_link: inviteLink} = member;
     const canResend = !expired;
@@ -400,7 +399,7 @@ class OrganizationMemberDetail extends DeprecatedAsyncView<Props, State> {
 
         <OrganizationRoleSelect
           enforceAllowed={false}
-          enforceRetired={hasTeamRoles}
+          enforceRetired={this.hasTeamRoles}
           disabled={!canEdit}
           roleList={orgRoleList}
           roleSelected={orgRole}

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -169,10 +169,6 @@ class AllTeamsRow extends Component<Props, State> {
 
   getTeamRoleName = () => {
     const {organization, team} = this.props;
-    if (!organization.features.includes('team-roles') || !team.teamRole) {
-      return null;
-    }
-
     const {teamRoleList} = organization;
     const roleName = teamRoleList.find(r => r.id === team.teamRole)?.name;
 
@@ -207,7 +203,6 @@ class AllTeamsRow extends Component<Props, State> {
 
     const orgRoleFromTeam = team.orgRole ? `${startCase(team.orgRole)} Team` : null;
     const isHidden = orgRoleFromTeam === null && this.getTeamRoleName() === null;
-    // TODO(team-roles): team admins can also manage membership
     const isDisabled = isIdpProvisioned || isPermissionGroup;
 
     return (

--- a/static/app/views/settings/organizationTeams/organizationTeams.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.tsx
@@ -99,14 +99,12 @@ function OrganizationTeams({
       <Panel>
         <PanelHeader>{t('Your Teams')}</PanelHeader>
         <PanelBody>
-          {features.has('team-roles') && (
-            <RoleOverwritePanelAlert
-              orgRole={orgRole}
-              orgRoleList={orgRoleList}
-              teamRoleList={teamRoleList}
-              isSelf
-            />
-          )}
+          <RoleOverwritePanelAlert
+            orgRole={orgRole}
+            orgRoleList={orgRoleList}
+            teamRoleList={teamRoleList}
+            isSelf
+          />
           {initiallyLoaded ? (
             <AllTeamsList
               organization={organization}

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
@@ -335,7 +335,7 @@ describe('TeamMembers', function () {
     expect(deleteMock).toHaveBeenCalled();
   });
 
-  it('does not renders team-level roles', async function () {
+  it('renders team-level roles without flag', async function () {
     const me = TestStubs.Member({
       id: '123',
       email: 'foo@example.com',
@@ -357,9 +357,9 @@ describe('TeamMembers', function () {
     );
 
     const admins = screen.queryByText('Team Admin');
-    expect(admins).not.toBeInTheDocument();
+    expect(admins).toHaveLength(3);
     const contributors = screen.queryByText('Team Contributor');
-    expect(contributors).not.toBeInTheDocument();
+    expect(contributors).toHaveLength(2);
   });
 
   it('renders team-level roles with flag', async function () {

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
@@ -336,15 +336,16 @@ describe('TeamMembers', function () {
   });
 
   it('renders team-level roles without flag', async function () {
-    const me = TestStubs.Member({
+    const owner = TestStubs.Member({
       id: '123',
       email: 'foo@example.com',
+      orgRole: 'owner',
       role: 'owner',
     });
     MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team.slug}/members/`,
       method: 'GET',
-      body: [...members, me],
+      body: [...members, owner],
     });
 
     await render(
@@ -356,9 +357,9 @@ describe('TeamMembers', function () {
       />
     );
 
-    const admins = screen.queryByText('Team Admin');
+    const admins = screen.queryAllByText('Team Admin');
     expect(admins).toHaveLength(3);
-    const contributors = screen.queryByText('Team Contributor');
+    const contributors = screen.queryAllByText('Contributor');
     expect(contributors).toHaveLength(2);
   });
 
@@ -367,6 +368,7 @@ describe('TeamMembers', function () {
       id: '123',
       email: 'foo@example.com',
       orgRole: 'manager',
+      role: 'manager',
     });
     MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team.slug}/members/`,
@@ -384,6 +386,7 @@ describe('TeamMembers', function () {
         team={team}
       />
     );
+
     const admins = screen.queryAllByText('Team Admin');
     expect(admins).toHaveLength(3);
     const contributors = screen.queryAllByText('Contributor');


### PR DESCRIPTION
Purely a cosmetic update. No backend changes needed, `OrganizationMemberDetailsEndpoint` will remove team-role key/value in requests from organizations without the feature flag enabled.

### Organization Teams
<img width="1164" alt="Screenshot 2023-07-05 at 8 16 14 PM" src="https://github.com/getsentry/sentry/assets/1748388/996c883e-1538-41aa-9c55-6888ecc8413e">

### Team Settings
<img width="1146" alt="Screenshot 2023-07-05 at 8 16 29 PM" src="https://github.com/getsentry/sentry/assets/1748388/96f12851-df30-467c-9ed1-43b418712ab1">

### Member Details
<img width="1144" alt="Screenshot 2023-07-05 at 8 16 44 PM" src="https://github.com/getsentry/sentry/assets/1748388/b82f0e0d-dbee-4d4a-853d-d2743652591b">

