### PR TITLE
fix(django_admin): Disable django_admin on prod

### DIFF
--- a/src/sentry/conf/urls.py
+++ b/src/sentry/conf/urls.py
@@ -29,7 +29,7 @@ urlpatterns: list[URLResolver | URLPattern] = [
     ),
 ]
 
-if "django.contrib.admin" in settings.INSTALLED_APPS:
+if "django.contrib.admin" in settings.INSTALLED_APPS and settings.ADMIN_ENABLED:
     from sentry import django_admin
 
     urlpatterns += django_admin.urlpatterns


### PR DESCRIPTION
Disable django_admin on prod ，fix #23742 , https://github.com/getsentry/self-hosted/issues/1039

cc @BYK 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
