### PR TITLE
feat(sdk-crashes): Set project id as user id

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -65,6 +65,9 @@ class SDKCrashDetection:
                 },
             )
 
+            # So Sentry can tell how many projects are impacted by this SDK crash
+            set_path(sdk_crash_event_data, "user", "id", value=event.project.id)
+
             return self.sdk_crash_reporter.report(sdk_crash_event_data, event_project_id)
 
         return None

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -41,6 +41,9 @@ class BaseSDKCrashDetectionMixin(BaseTestCase, metaclass=abc.ABCMeta):
                 "original_project_id": event.project_id,
                 "original_event_id": event.event_id,
             }
+            assert reported_event_data["user"] == {
+                "id": event.project_id,
+            }
         else:
             assert mock_sdk_crash_reporter.report.call_count == 0
 


### PR DESCRIPTION
Set the project id as the user id, so Sentry can tell how many projects are impacted by an SDK crash.
