### PR TITLE
ref(sdk-crashes): event_stripper to function tests

### DIFF
--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -1,335 +1,312 @@
-import abc
+import pytest
 
 from fixtures.sdk_crash_detection.crash_event import (
     get_crash_event,
     get_crash_event_with_frames,
     get_frames,
 )
-from sentry.db.models import NodeData
-from sentry.testutils import TestCase
-from sentry.testutils.cases import BaseTestCase
-from sentry.testutils.silo import region_silo_test
+from sentry.utils.pytest.fixtures import django_db_all
 from sentry.utils.safe import get_path, set_path
 from sentry.utils.sdk_crashes.cocoa_sdk_crash_detector import CocoaSDKCrashDetector
 from sentry.utils.sdk_crashes.event_stripper import strip_event_data
 
 
-class BaseEventStripperMixin(BaseTestCase, metaclass=abc.ABCMeta):
-    @abc.abstractmethod
-    def create_event(self, data, project_id, assert_no_errors=True):
-        pass
+@pytest.fixture
+def store_event(default_project, factories):
+    def inner(data):
+        return factories.store_event(data=data, project_id=default_project.id)
 
-    def execute_test(self):
-        pass
+    return inner
 
 
-class EventStripperTestMixin(BaseEventStripperMixin):
-    def test_strip_event_data_keeps_allowed_keys(self):
-        event = self.create_event(
-            data=get_crash_event(),
-            project_id=self.project.id,
-        )
+@pytest.fixture
+def store_and_strip_event(store_event):
+    def inner(data):
+        event = store_event(data=data)
+        return strip_event_data(event.data, CocoaSDKCrashDetector())
 
-        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+    return inner
 
-        keys_removed = {"tags", "user", "threads", "breadcrumbs", "environment"}
-        for key in keys_removed:
-            assert stripped_event_data.get(key) is None, f"key {key} should be removed"
 
-        keys_kept = {
-            "type",
-            "timestamp",
-            "platform",
-            "sdk",
-            "exception",
-            "contexts",
-        }
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_data_keeps_allowed_keys(store_and_strip_event):
+    stripped_event_data = store_and_strip_event(data=get_crash_event())
 
-        for key in keys_kept:
-            assert stripped_event_data.get(key) is not None, f"key {key} should be kept"
+    keys_removed = {"tags", "user", "threads", "breadcrumbs", "environment"}
+    for key in keys_removed:
+        assert stripped_event_data.get(key) is None, f"key {key} should be removed"
 
-    def test_strip_event_data_strips_context(self):
-        event = self.create_event(
-            data=get_crash_event(),
-            project_id=self.project.id,
-        )
+    keys_kept = {
+        "type",
+        "timestamp",
+        "platform",
+        "sdk",
+        "exception",
+        "contexts",
+    }
 
-        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+    for key in keys_kept:
+        assert stripped_event_data.get(key) is not None, f"key {key} should be kept"
 
-        assert stripped_event_data.get("contexts") == {
-            "os": {
-                "name": "iOS",
-                "version": "16.3",
-                "build": "20D47",
+
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_data_strips_context(store_and_strip_event):
+    stripped_event_data = store_and_strip_event(data=get_crash_event())
+
+    assert stripped_event_data.get("contexts") == {
+        "os": {
+            "name": "iOS",
+            "version": "16.3",
+            "build": "20D47",
+        },
+        "device": {
+            "family": "iOS",
+            "model": "iPhone14,8",
+            "arch": "arm64e",
+            "simulator": True,
+        },
+    }
+
+
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_data_strips_sdk(store_and_strip_event):
+    stripped_event_data = store_and_strip_event(data=get_crash_event())
+
+    assert stripped_event_data.get("sdk") == {
+        "name": "sentry.cocoa",
+        "version": "8.2.0",
+    }
+
+
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_data_strips_value_if_not_simple_type(store_event):
+    event = store_event(data=get_crash_event())
+    event.data["type"] = {"foo": "bar"}
+
+    stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+
+    assert stripped_event_data.get("type") is None
+
+
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_data_keeps_simple_types(store_event):
+    event = store_event(data=get_crash_event())
+    event.data["type"] = True
+    event.data["datetime"] = 0.1
+    event.data["timestamp"] = 1
+    event.data["platform"] = "cocoa"
+
+    stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+
+    assert stripped_event_data.get("type") is True
+    assert stripped_event_data.get("datetime") == 0.1
+    assert stripped_event_data.get("timestamp") == 1
+    assert stripped_event_data.get("platform") == "cocoa"
+
+
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_data_keeps_simple_exception_properties(store_and_strip_event):
+    stripped_event_data = store_and_strip_event(data=get_crash_event())
+
+    assert get_path(stripped_event_data, "exception", "values", 0, "type") == "EXC_BAD_ACCESS"
+    assert get_path(stripped_event_data, "exception", "values", 0, "value") is None
+
+
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_data_keeps_exception_mechanism(store_event):
+    event = store_event(data=get_crash_event())
+
+    # set extra data that should be stripped
+    set_path(event.data, "exception", "values", 0, "mechanism", "foo", value="bar")
+    set_path(
+        event.data, "exception", "values", 0, "mechanism", "meta", "signal", "foo", value="bar"
+    )
+    set_path(
+        event.data,
+        "exception",
+        "values",
+        0,
+        "mechanism",
+        "meta",
+        "mach_exception",
+        "foo",
+        value="bar",
+    )
+
+    stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+
+    mechanism = get_path(stripped_event_data, "exception", "values", 0, "mechanism")
+
+    assert mechanism == {
+        "handled": False,
+        "type": "mach",
+        "meta": {
+            "signal": {"number": 11, "code": 0, "name": "SIGSEGV", "code_name": "SEGV_NOOP"},
+            "mach_exception": {
+                "exception": 1,
+                "code": 1,
+                "subcode": 0,
+                "name": "EXC_BAD_ACCESS",
             },
-            "device": {
-                "family": "iOS",
-                "model": "iPhone14,8",
-                "arch": "arm64e",
-                "simulator": True,
-            },
+        },
+    }
+
+
+@django_db_all
+@pytest.mark.snuba
+def test_set_in_app_only_for_sdk_frames(store_and_strip_event):
+    frames = get_frames("SentryCrashMonitor_CPPException.cpp", sentry_frame_in_app=False)
+
+    system_frame_in_app = [
+        {
+            "abs_path": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
+            "in_app": True,
         }
+    ]
 
-    def test_strip_event_data_strips_sdk(self):
-        event = self.create_event(
-            data=get_crash_event(),
-            project_id=self.project.id,
-        )
+    event_data = get_crash_event_with_frames(system_frame_in_app + list(frames))
 
-        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+    stripped_event_data = store_and_strip_event(data=event_data)
 
-        assert stripped_event_data.get("sdk") == {
-            "name": "sentry.cocoa",
-            "version": "8.2.0",
-        }
+    stripped_frames = get_path(
+        stripped_event_data, "exception", "values", -1, "stacktrace", "frames"
+    )
 
-    def test_strip_event_data_strips_value_if_not_simple_type(self):
-        event = self.create_event(
-            data=get_crash_event(),
-            project_id=self.project.id,
-        )
-        event.data["type"] = {"foo": "bar"}
+    for stripped_frame in stripped_frames[0::-1]:
+        assert stripped_frame["in_app"] is False
 
-        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+    cocoa_sdk_frame = stripped_frames[-1]
+    assert cocoa_sdk_frame == {
+        "function": "SentryCrashMonitor_CPPException.cpp",
+        "package": "Sentry.framework",
+        "in_app": True,
+        "image_addr": "0x100304000",
+    }
 
-        assert stripped_event_data.get("type") is None
 
-    def test_strip_event_data_keeps_simple_types(self):
-        event = self.create_event(
-            data=get_crash_event(),
-            project_id=self.project.id,
-        )
-        event.data["type"] = True
-        event.data["datetime"] = 0.1
-        event.data["timestamp"] = 1
-        event.data["platform"] = "cocoa"
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_data_keeps_exception_stacktrace(store_and_strip_event):
+    stripped_event_data = store_and_strip_event(data=get_crash_event())
 
-        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+    first_frame = get_path(stripped_event_data, "exception", "values", 0, "stacktrace", "frames", 0)
 
-        assert stripped_event_data.get("type") is True
-        assert stripped_event_data.get("datetime") == 0.1
-        assert stripped_event_data.get("timestamp") == 1
-        assert stripped_event_data.get("platform") == "cocoa"
+    assert first_frame == {
+        "function": "function",
+        "raw_function": "raw_function",
+        "module": "module",
+        "abs_path": "abs_path",
+        "in_app": False,
+        "instruction_addr": "0x1a4e8f000",
+        "addr_mode": "0x1a4e8f000",
+        "symbol": "symbol",
+        "symbol_addr": "0x1a4e8f000",
+        "image_addr": "0x1a4e8f000",
+        "package": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
+        "platform": "platform",
+    }
 
-    def test_strip_event_data_keeps_simple_exception_properties(self):
-        event = self.create_event(
-            data=get_crash_event(),
-            project_id=self.project.id,
-        )
 
-        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+@django_db_all
+@pytest.mark.snuba
+def test_strip_frames(store_and_strip_event):
+    frames = get_frames("SentryCrashMonitor_CPPException.cpp", sentry_frame_in_app=False)
 
-        assert get_path(stripped_event_data, "exception", "values", 0, "type") == "EXC_BAD_ACCESS"
-        assert get_path(stripped_event_data, "exception", "values", 0, "value") is None
+    frames_kept = [
+        {
+            "abs_path": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
+        },
+        {
+            "module": "/usr/lib/system/libsystem_c.dylib",
+        },
+    ]
 
-    def test_strip_event_data_keeps_exception_mechanism(self):
-        event = self.create_event(
-            data=get_crash_event(),
-            project_id=self.project.id,
-        )
+    frames_stripped = [
+        {
+            "abs_path": "/System/Librry/PrivateFrameworks/UIKitCore.framework/UIKitCore",
+        },
+        {
+            "module": "a/usr/lib/system/libsystem_c.dylib",
+        },
+    ]
 
-        # set extra data that should be stripped
-        set_path(event.data, "exception", "values", 0, "mechanism", "foo", value="bar")
-        set_path(
-            event.data, "exception", "values", 0, "mechanism", "meta", "signal", "foo", value="bar"
-        )
-        set_path(
-            event.data,
-            "exception",
-            "values",
-            0,
-            "mechanism",
-            "meta",
-            "mach_exception",
-            "foo",
-            value="bar",
-        )
+    event_data = get_crash_event_with_frames(frames_kept + frames_stripped + list(frames))
 
-        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+    stripped_event_data = store_and_strip_event(data=event_data)
 
-        mechanism = get_path(stripped_event_data, "exception", "values", 0, "mechanism")
+    stripped_frames = get_path(
+        stripped_event_data, "exception", "values", -1, "stacktrace", "frames"
+    )
 
-        assert mechanism == {
-            "handled": False,
-            "type": "mach",
-            "meta": {
-                "signal": {"number": 11, "code": 0, "name": "SIGSEGV", "code_name": "SEGV_NOOP"},
-                "mach_exception": {
-                    "exception": 1,
-                    "code": 1,
-                    "subcode": 0,
-                    "name": "EXC_BAD_ACCESS",
-                },
-            },
-        }
+    assert len(stripped_frames) == 10
 
-    def test_set_in_app_only_for_sdk_frames(self):
-        frames = get_frames("SentryCrashMonitor_CPPException.cpp", sentry_frame_in_app=False)
-
-        system_frame_in_app = [
-            {
-                "abs_path": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
-                "in_app": True,
-            }
-        ]
-
-        event_data = get_crash_event_with_frames(system_frame_in_app + list(frames))
-
-        event = self.create_event(
-            data=event_data,
-            project_id=self.project.id,
-        )
-
-        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
-
-        stripped_frames = get_path(
-            stripped_event_data, "exception", "values", -1, "stacktrace", "frames"
-        )
-
-        for stripped_frame in stripped_frames[0::-1]:
-            assert stripped_frame["in_app"] is False
-
-        cocoa_sdk_frame = stripped_frames[-1]
-        assert cocoa_sdk_frame == {
+    cocoa_sdk_frames = stripped_frames[-2:]
+    assert cocoa_sdk_frames == [
+        {
+            "function": "__49-[SentrySwizzleWrapper swizzleSendAction:forKey:]_block_invoke_2",
+            "package": "Sentry.framework",
+            "in_app": True,
+            "image_addr": "0x100304000",
+        },
+        {
             "function": "SentryCrashMonitor_CPPException.cpp",
             "package": "Sentry.framework",
             "in_app": True,
             "image_addr": "0x100304000",
-        }
-
-    def test_strip_event_data_keeps_exception_stacktrace(self):
-        event = self.create_event(
-            data=get_crash_event(),
-            project_id=self.project.id,
-        )
-
-        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
-
-        first_frame = get_path(
-            stripped_event_data, "exception", "values", 0, "stacktrace", "frames", 0
-        )
-
-        assert first_frame == {
-            "function": "function",
-            "raw_function": "raw_function",
-            "module": "module",
-            "abs_path": "abs_path",
-            "in_app": False,
-            "instruction_addr": "0x1a4e8f000",
-            "addr_mode": "0x1a4e8f000",
-            "symbol": "symbol",
-            "symbol_addr": "0x1a4e8f000",
-            "image_addr": "0x1a4e8f000",
-            "package": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
-            "platform": "platform",
-        }
-
-    def test_strip_frames(self):
-        frames = get_frames("SentryCrashMonitor_CPPException.cpp", sentry_frame_in_app=False)
-
-        frames_kept = [
-            {
-                "abs_path": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
-            },
-            {
-                "module": "/usr/lib/system/libsystem_c.dylib",
-            },
-        ]
-
-        frames_stripped = [
-            {
-                "abs_path": "/System/Librry/PrivateFrameworks/UIKitCore.framework/UIKitCore",
-            },
-            {
-                "module": "a/usr/lib/system/libsystem_c.dylib",
-            },
-        ]
-
-        event_data = get_crash_event_with_frames(frames_kept + frames_stripped + list(frames))
-
-        event = self.create_event(
-            data=event_data,
-            project_id=self.project.id,
-        )
-
-        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
-
-        stripped_frames = get_path(
-            stripped_event_data, "exception", "values", -1, "stacktrace", "frames"
-        )
-
-        assert len(stripped_frames) == 10
-
-        cocoa_sdk_frames = stripped_frames[-2:]
-        assert cocoa_sdk_frames == [
-            {
-                "function": "__49-[SentrySwizzleWrapper swizzleSendAction:forKey:]_block_invoke_2",
-                "package": "Sentry.framework",
-                "in_app": True,
-                "image_addr": "0x100304000",
-            },
-            {
-                "function": "SentryCrashMonitor_CPPException.cpp",
-                "package": "Sentry.framework",
-                "in_app": True,
-                "image_addr": "0x100304000",
-            },
-        ]
-
-    def test_strip_frames_sdk_frames(self):
-        frames = get_frames("SentryCrashMonitor_CPPException.cpp", sentry_frame_in_app=False)
-        # When statically linked the package or module is usually set to the app name
-        sentry_sdk_frame = frames[-1]
-        sentry_sdk_frame["package"] = "SomeApp"
-        sentry_sdk_frame["module"] = "SomeModule"
-        sentry_sdk_frame["abs_path"] = "SomeApp/SentryDispatchQueueWrapper.m"
-
-        event_data = get_crash_event_with_frames(frames)
-
-        event = self.create_event(
-            data=event_data,
-            project_id=self.project.id,
-        )
-
-        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
-
-        stripped_frames = get_path(
-            stripped_event_data, "exception", "values", -1, "stacktrace", "frames"
-        )
-
-        cocoa_sdk_frame = stripped_frames[-1]
-        assert cocoa_sdk_frame == {
-            "function": "SentryCrashMonitor_CPPException.cpp",
-            "package": "Sentry.framework",
-            "abs_path": "Sentry.framework",
-            "module": "Sentry.framework",
-            "in_app": True,
-            "image_addr": "0x100304000",
-        }
-
-    def test_strip_event_without_data_returns_empty_dict(self):
-        stripped_event_data = strip_event_data(NodeData({}), CocoaSDKCrashDetector())
-
-        assert stripped_event_data == {}
-
-    def test_strip_event_without_frames_returns_empty_dict(self):
-        event_data = get_crash_event_with_frames([])
-        set_path(event_data, "exception", value=None)
-
-        event = self.create_event(
-            data=event_data,
-            project_id=self.project.id,
-        )
-
-        stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
-
-        assert stripped_event_data == {}
+        },
+    ]
 
 
-@region_silo_test
-class EventStripperTest(
-    TestCase,
-    EventStripperTestMixin,
-):
-    def create_event(self, data, project_id, assert_no_errors=True):
-        return self.store_event(data=data, project_id=project_id, assert_no_errors=assert_no_errors)
+@django_db_all
+@pytest.mark.snuba
+def test_strip_frames_sdk_frames(store_and_strip_event):
+    frames = get_frames("SentryCrashMonitor_CPPException.cpp", sentry_frame_in_app=False)
+    # When statically linked the package or module is usually set to the app name
+    sentry_sdk_frame = frames[-1]
+    sentry_sdk_frame["package"] = "SomeApp"
+    sentry_sdk_frame["module"] = "SomeModule"
+    sentry_sdk_frame["abs_path"] = "SomeApp/SentryDispatchQueueWrapper.m"
+
+    event_data = get_crash_event_with_frames(frames)
+
+    stripped_event_data = store_and_strip_event(data=event_data)
+
+    stripped_frames = get_path(
+        stripped_event_data, "exception", "values", -1, "stacktrace", "frames"
+    )
+
+    cocoa_sdk_frame = stripped_frames[-1]
+    assert cocoa_sdk_frame == {
+        "function": "SentryCrashMonitor_CPPException.cpp",
+        "package": "Sentry.framework",
+        "abs_path": "Sentry.framework",
+        "module": "Sentry.framework",
+        "in_app": True,
+        "image_addr": "0x100304000",
+    }
+
+
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_without_data_returns_empty_dict(store_and_strip_event):
+    stripped_event_data = store_and_strip_event(data={})
+
+    assert stripped_event_data == {}
+
+
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_without_frames_returns_empty_dict(store_and_strip_event):
+    event_data = get_crash_event_with_frames([])
+    set_path(event_data, "exception", value=None)
+
+    stripped_event_data = store_and_strip_event(data=event_data)
+
+    assert stripped_event_data == {}


### PR DESCRIPTION
Refactor test_event_stripper tests to function tests as TestCase and class-based tests are soft deprecated.

