### PR TITLE
fix(profiling): fix broken workflow to fetch spans data.

### DIFF
--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -75,7 +75,7 @@ def get_span_intervals(
         where=[
             Condition(Column("project_id"), Op.EQ, project_id),
             Condition(Column("transaction_id"), Op.IN, transaction_ids),
-            Condition(Column("group"), Op.EQ, span_group),
+            Condition(Column("group_raw"), Op.EQ, span_group),
             Condition(Column("timestamp"), Op.GTE, params["start"]),
             Condition(Column("timestamp"), Op.LT, params["end"]),
         ],


### PR DESCRIPTION
Recently some breaking changes have been made where the `group` field in the spans dataset does not store the span hash anymore but instead it stores the hash of an even more aggresively normalized span description.

The old span hash is now stored in the column `group_raw`.

This PR fixes the current workflow based on the old span hash.