### PR TITLE
ref(hc): Addressing transaction helpers for split db mode.

### DIFF
--- a/src/sentry/db/postgres/roles.py
+++ b/src/sentry/db/postgres/roles.py
@@ -6,6 +6,8 @@ import sys
 
 from django.db.transaction import get_connection
 
+from sentry.silo.patches.silo_aware_transaction_patch import determine_using_by_silo_mode
+
 
 @contextlib.contextmanager
 def in_test_psql_role_override(role_name: str, using: str | None = None):
@@ -17,6 +19,8 @@ def in_test_psql_role_override(role_name: str, using: str | None = None):
     if "pytest" not in sys.modules or os.environ.get("DB", "postgres") != "postgres":
         yield
         return
+
+    using = determine_using_by_silo_mode(using)
 
     with get_connection(using).cursor() as conn:
         conn.execute("SELECT user")

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable, List, Mapping, Optional, Set, Union, cast
 
-from django.db import IntegrityError, models, transaction
+from django.db import IntegrityError, models, router, transaction
 from django.dispatch import Signal
 
 from sentry import roles
@@ -459,7 +459,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
                     pass
 
     def reset_idp_flags(self, *, organization_id: int) -> None:
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             # Flags are not replicated -- these updates are safe without outbox application.
             OrganizationMember.objects.filter(
                 organization_id=organization_id,
@@ -474,7 +474,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         # Normally, calling update on a QS for organization member fails because we need to ensure that updates to
         # OrganizationMember objects produces outboxes.  In this case, it is safe to do the update directly because
         # the attribute we are changing never needs to produce an outbox.
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             OrganizationMember.objects.filter(user_id=user.id).update(
                 user_is_active=user.is_active, user_email=user.email
             )

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -1,5 +1,7 @@
 from typing import List, Optional
 
+from django.db import router
+
 from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.organization_mapping import (
@@ -61,7 +63,7 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
 
     def update(self, organization_id: int, update: RpcOrganizationMappingUpdate) -> None:
         # TODO: REMOVE FROM GETSENTRY!
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMapping)):
             try:
                 OrganizationMapping.objects.get(organization_id=organization_id).update(**update)
             except OrganizationMapping.DoesNotExist:
@@ -70,7 +72,7 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
     def upsert(
         self, organization_id: int, update: RpcOrganizationMappingUpdate
     ) -> RpcOrganizationMapping:
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMapping)):
             org_mapping, _created = OrganizationMapping.objects.update_or_create(
                 organization_id=organization_id, defaults=update
             )

--- a/src/sentry/silo/patches/silo_aware_transaction_patch.py
+++ b/src/sentry/silo/patches/silo_aware_transaction_patch.py
@@ -1,10 +1,13 @@
-from typing import Optional
+from typing import Any, Callable, Optional
 
 from django import get_version
 from django.db import router, transaction
+from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.transaction import Atomic
 
 _default_atomic_impl = transaction.atomic
+_default_on_commit = transaction.on_commit
+_default_get_connection = transaction.get_connection
 
 
 class MismatchedSiloTransactionError(Exception):
@@ -12,6 +15,21 @@ class MismatchedSiloTransactionError(Exception):
 
 
 def siloed_atomic(using: Optional[str] = None, savepoint: bool = True) -> Atomic:
+    using = determine_using_by_silo_mode(using)
+    return _default_atomic_impl(using=using, savepoint=savepoint)
+
+
+def siloed_get_connection(using: Optional[str] = None) -> BaseDatabaseWrapper:
+    using = determine_using_by_silo_mode(using)
+    return _default_get_connection(using=using)
+
+
+def siloed_on_commit(cb: Callable[..., Any], using: Optional[str] = None) -> None:
+    using = determine_using_by_silo_mode(using)
+    return _default_on_commit(cb, using)
+
+
+def determine_using_by_silo_mode(using):
     from sentry.models import ControlOutbox, RegionOutbox
     from sentry.silo import SiloMode
 
@@ -19,11 +37,9 @@ def siloed_atomic(using: Optional[str] = None, savepoint: bool = True) -> Atomic
     if not using:
         model_to_route_to = RegionOutbox if current_silo_mode == SiloMode.REGION else ControlOutbox
         using = router.db_for_write(model_to_route_to)
-
     both_silos_route_to_same_db = router.db_for_write(ControlOutbox) == router.db_for_write(
         RegionOutbox
     )
-
     if both_silos_route_to_same_db or current_silo_mode == SiloMode.MONOLITH:
         pass
     elif (
@@ -41,12 +57,11 @@ def siloed_atomic(using: Optional[str] = None, savepoint: bool = True) -> Atomic
         raise MismatchedSiloTransactionError(
             f"Cannot use transaction.atomic({using}) in Region Mode"
         )
-
-    return _default_atomic_impl(using=using, savepoint=savepoint)
+    return using
 
 
 def patch_silo_aware_atomic():
-    global _default_atomic_impl
+    global _default_atomic_impl, _default_on_commit, _default_get_connection
 
     current_django_version = get_version()
     assert current_django_version.startswith("2.2."), (
@@ -55,4 +70,9 @@ def patch_silo_aware_atomic():
     )
 
     _default_atomic_impl = transaction.atomic
+    _default_on_commit = transaction.on_commit
+    _default_get_connection = transaction.get_connection
+
     transaction.atomic = siloed_atomic  # type:ignore
+    transaction.on_commit = siloed_on_commit  # type:ignore
+    transaction.get_connection = siloed_get_connection  # type:ignore

--- a/src/sentry/tasks/check_auth.py
+++ b/src/sentry/tasks/check_auth.py
@@ -1,11 +1,12 @@
 import logging
 from datetime import timedelta
 
+from django.db import router
 from django.utils import timezone
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.db.postgres.roles import in_test_psql_role_override
-from sentry.models import AuthIdentity
+from sentry.models import AuthIdentity, OrganizationMember
 from sentry.services.hybrid_cloud.organization import RpcOrganizationMember, organization_service
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -95,7 +96,7 @@ def check_auth_identity(auth_identity_id, **kwargs):
         is_valid = True
 
     if getattr(om.flags, "sso:linked") != is_linked:
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             # flags are not replicated, so it's ok not to create outboxes here.
             setattr(om.flags, "sso:linked", is_linked)
             setattr(om.flags, "sso:invalid", not is_valid)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -16,10 +16,11 @@ from sentry.models import (
 )
 from sentry.models.actor import Actor, get_actor_id_for_user
 from sentry.services.hybrid_cloud.user import RpcUser
+from sentry.silo import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode
 
 # XXX(dcramer): this is a compatibility layer to transition to pytest-based fixtures
 # all of the memoized fixtures are copypasta due to our inability to use pytest fixtures
@@ -29,29 +30,25 @@ from sentry.types.activity import ActivityType
 
 class Fixtures:
     @cached_property
-    @exempt_from_silo_limits()
     def session(self):
         return Factories.create_session()
 
     @cached_property
-    @exempt_from_silo_limits()
     def projectkey(self):
         return self.create_project_key(project=self.project)
 
     @cached_property
-    @exempt_from_silo_limits()
     def user(self):
         return self.create_user("admin@localhost", is_superuser=True)
 
     @cached_property
-    @exempt_from_silo_limits()
     def organization(self):
         # XXX(dcramer): ensure that your org slug doesnt match your team slug
         # and the same for your project slug
         return self.create_organization(name="baz", slug="baz", owner=self.user)
 
     @cached_property
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.REGION)
     def team(self):
         team = self.create_team(organization=self.organization, name="foo", slug="foo")
         # XXX: handle legacy team fixture
@@ -61,30 +58,24 @@ class Fixtures:
         return team
 
     @cached_property
-    @exempt_from_silo_limits()
     def project(self):
         return self.create_project(
             name="Bar", slug="bar", teams=[self.team], fire_project_created=True
         )
 
     @cached_property
-    @exempt_from_silo_limits()
     def release(self):
         return self.create_release(project=self.project, version="foo-1.0")
 
     @cached_property
-    @exempt_from_silo_limits()
     def environment(self):
         return self.create_environment(name="development", project=self.project)
 
     @cached_property
-    @exempt_from_silo_limits()
     def group(self):
-        # こんにちは konichiwa
         return self.create_group(message="\u3053\u3093\u306b\u3061\u306f")
 
     @cached_property
-    @exempt_from_silo_limits()
     def event(self):
         return self.store_event(
             data={
@@ -96,7 +87,7 @@ class Fixtures:
         )
 
     @cached_property
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.REGION)
     def activity(self):
         return Activity.objects.create(
             group=self.group,
@@ -107,7 +98,7 @@ class Fixtures:
         )
 
     @cached_property
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def integration(self):
         integration = Integration.objects.create(
             provider="github", name="GitHub", external_id="github:1"
@@ -116,7 +107,7 @@ class Fixtures:
         return integration
 
     @cached_property
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def organization_integration(self):
         return self.integration.add_organization(self.organization, self.user)
 

--- a/src/sentry/testutils/helpers/api_gateway.py
+++ b/src/sentry/testutils/helpers/api_gateway.py
@@ -2,6 +2,7 @@ from urllib.parse import parse_qs
 
 import responses
 from django.conf import settings
+from django.db import router
 from django.test import override_settings
 from django.urls import re_path
 from rest_framework.permissions import AllowAny
@@ -135,7 +136,7 @@ class ApiGatewayTestCase(APITestCase):
             adding_headers={"test": "header"},
         )
 
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMapping)):
             OrganizationMapping.objects.get(organization_id=self.organization.id).update(
                 region_name="region1"
             )

--- a/src/sentry/testutils/helpers/slack.py
+++ b/src/sentry/testutils/helpers/slack.py
@@ -16,7 +16,8 @@ from sentry.models import (
     Team,
     User,
 )
-from sentry.testutils.silo import exempt_from_silo_limits
+from sentry.silo import SiloMode
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils import json
 
@@ -31,7 +32,7 @@ def get_response_text(data: SlackBody) -> str:
     )
 
 
-@exempt_from_silo_limits()
+@assume_test_silo_mode(SiloMode.CONTROL)
 def install_slack(organization: Organization, workspace_id: str = "TXXXXXXX1") -> Integration:
     integration = Integration.objects.create(
         external_id=workspace_id,

--- a/src/sentry/testutils/outbox.py
+++ b/src/sentry/testutils/outbox.py
@@ -4,8 +4,10 @@ import contextlib
 import functools
 from typing import Any
 
+from django.test import override_settings
+
+from sentry.silo import SiloMode
 from sentry.tasks.deliver_from_outbox import enqueue_outbox_jobs
-from sentry.testutils.silo import exempt_from_silo_limits
 
 
 @contextlib.contextmanager
@@ -28,6 +30,6 @@ def outbox_runner(wrapped: Any | None = None) -> Any:
     yield
     from sentry.testutils.helpers.task_runner import TaskRunner
 
-    with TaskRunner(), exempt_from_silo_limits():
+    with TaskRunner(), override_settings(SILO_MODE=SiloMode.MONOLITH):
         while enqueue_outbox_jobs():
             pass

--- a/src/sentry/utils/migrations.py
+++ b/src/sentry/utils/migrations.py
@@ -1,3 +1,4 @@
+from django.db import router
 from django.db.models import F
 
 from sentry.db.postgres.roles import in_test_psql_role_override
@@ -15,5 +16,5 @@ def clear_flag(Model, flag_name, flag_attr_name="flags"):
             update_kwargs = {
                 flag_attr_name: F(flag_attr_name).bitand(~getattr(Model, flag_attr_name)[flag_name])
             }
-            with in_test_psql_role_override("postgres"):
+            with in_test_psql_role_override("postgres", using=router.db_for_write(Model)):
                 Model.objects.filter(id=item.id).update(**update_kwargs)

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from django import forms
 from django.contrib import messages
-from django.db import transaction
+from django.db import router, transaction
 from django.db.models import F
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
@@ -91,7 +91,7 @@ class OrganizationAuthSettingsView(ControlSiloOrganizationView):
         )
 
         # This is safe -- we're not syncing flags to the org member mapping table.
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             OrganizationMember.objects.filter(organization_id=organization.id).update(
                 flags=F("flags")
                 .bitand(~OrganizationMember.flags["sso:linked"])

--- a/tests/integration/test_sso.py
+++ b/tests/integration/test_sso.py
@@ -1,24 +1,26 @@
 from sentry.models import AuthIdentity, AuthProvider
+from sentry.silo import SiloMode
 from sentry.testutils import AuthProviderTestCase
-from sentry.testutils.silo import exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils.auth import SsoSession
 
 
 # @control_silo_test(stable=True)
 class OrganizationAuthLoginTest(AuthProviderTestCase):
     def test_sso_auth_required(self):
-        with exempt_from_silo_limits():
-            user = self.create_user("foo@example.com", is_superuser=False)
-            organization = self.create_organization(name="foo")
-            member = self.create_member(user=user, organization=organization)
+        user = self.create_user("foo@example.com", is_superuser=False)
+        organization = self.create_organization(name="foo")
+        member = self.create_member(user=user, organization=organization)
+
+        with assume_test_silo_mode(SiloMode.REGION):
             setattr(member.flags, "sso:linked", True)
             member.save()
 
-            auth_provider = AuthProvider.objects.create(
-                organization_id=organization.id, provider="dummy", flags=0
-            )
+        auth_provider = AuthProvider.objects.create(
+            organization_id=organization.id, provider="dummy", flags=0
+        )
 
-            AuthIdentity.objects.create(auth_provider=auth_provider, user=user)
+        AuthIdentity.objects.create(auth_provider=auth_provider, user=user)
 
         self.login_as(user)
 

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from django.db import router
 from django.db.models import F
 from django.test import override_settings
 from django.urls import reverse
@@ -23,7 +24,7 @@ from sentry.testutils.factories import Factories
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.region import override_regions
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.types.region import Region, RegionCategory
 
 
@@ -55,7 +56,7 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
         return reverse(url, args=[self.organization.slug] + args)
 
     def _require_2fa_for_organization(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             self.organization.update(flags=F("flags").bitor(Organization.flags.require_2fa))
         assert self.organization.flags.require_2fa.is_set
 
@@ -156,30 +157,28 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
                 ),
             ]
         ):
-            with in_test_psql_role_override("postgres"):
-                self.create_organization_mapping(
-                    organization_id=101010,
-                    slug="abcslug",
-                    name="The Thing",
-                    idempotency_key="",
-                    region_name="some-region",
-                )
+            self.create_organization_mapping(
+                organization_id=101010,
+                slug="abcslug",
+                name="The Thing",
+                idempotency_key="",
+                region_name="some-region",
+            )
             self._require_2fa_for_organization()
             assert not self.user.has_2fa()
 
             self.login_as(self.user)
 
-            with exempt_from_silo_limits(), outbox_context(flush=False):
+            with assume_test_silo_mode(SiloMode.REGION), outbox_context(flush=False):
                 om = OrganizationMember.objects.create(
                     email="newuser@example.com", token="abc", organization_id=self.organization.id
                 )
-            with in_test_psql_role_override("postgres"):
-                OrganizationMemberMapping.objects.create(
-                    organization_id=101010, organizationmember_id=om.id
-                )
-                OrganizationMemberMapping.objects.create(
-                    organization_id=self.organization.id, organizationmember_id=om.id
-                )
+            OrganizationMemberMapping.objects.create(
+                organization_id=101010, organizationmember_id=om.id
+            )
+            OrganizationMemberMapping.objects.create(
+                organization_id=self.organization.id, organizationmember_id=om.id
+            )
 
             for path in self._get_paths([om.id, om.token]):
                 resp = self.client.get(path)
@@ -195,14 +194,13 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
 
         self.login_as(self.user)
 
-        with exempt_from_silo_limits(), outbox_context(flush=False):
+        with assume_test_silo_mode(SiloMode.REGION), outbox_context(flush=False):
             om = OrganizationMember.objects.create(
                 email="newuser@example.com", token="abc", organization_id=self.organization.id
             )
-        with in_test_psql_role_override("postgres"):
-            OrganizationMemberMapping.objects.create(
-                organization_id=self.organization.id, organizationmember_id=om.id
-            )
+        OrganizationMemberMapping.objects.create(
+            organization_id=self.organization.id, organizationmember_id=om.id
+        )
 
         with override_settings(SILO_MODE=SiloMode.CONTROL, SENTRY_MONOLITH_REGION="something-else"):
             resp = self.client.get(
@@ -257,7 +255,7 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
             resp = self.client.post(path)
             assert resp.status_code == 204
 
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.REGION):
                 om = OrganizationMember.objects.get(id=om.id)
             assert om.email is None
             assert om.user_id == user.id
@@ -277,7 +275,9 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
         om = Factories.create_member(
             email="newuser@example.com", token="abc", organization=self.organization
         )
-        with exempt_from_silo_limits(), in_test_psql_role_override("postgres"):
+        with assume_test_silo_mode(SiloMode.REGION), in_test_psql_role_override(
+            "postgres", using=router.db_for_write(OrganizationMember)
+        ):
             OrganizationMember.objects.filter(id=om.id).update(
                 token_expires_at=om.token_expires_at - timedelta(days=31)
             )
@@ -286,7 +286,7 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
             resp = self.client.post(path)
             assert resp.status_code == 400
 
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.REGION):
                 om = OrganizationMember.objects.get(id=om.id)
             assert om.is_pending, "should not have been accepted"
             assert om.token, "should not have been accepted"
@@ -305,7 +305,7 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
             resp = self.client.post(path)
             assert resp.status_code == 400
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.get(id=om.id)
         assert not om.invite_approved
         assert om.is_pending
@@ -328,7 +328,7 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
             resp = self.client.post(path)
             assert resp.status_code == 204
 
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.REGION):
                 om = OrganizationMember.objects.get(id=om.id)
             assert om.email is None
             assert om.user_id == user.id
@@ -344,7 +344,7 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
                 path = self._get_path(url, [om2.id, om2.token])
                 resp = self.client.post(path)
                 assert resp.status_code == 400
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.REGION):
                 assert not OrganizationMember.objects.filter(id=om2.id).exists()
             self.assert_org_member_mapping_not_exists(org_member=om2)
 
@@ -371,7 +371,7 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
 
             self._assert_pending_invite_details_not_in_session(resp)
 
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.REGION):
                 om = OrganizationMember.objects.get(id=om.id)
             assert om.email is None
             assert om.user_id == user.id

--- a/tests/sentry/api/endpoints/test_auth_config.py
+++ b/tests/sentry/api/endpoints/test_auth_config.py
@@ -4,8 +4,9 @@ from django.test.utils import override_settings
 
 from sentry import newsletter
 from sentry.receivers import create_default_projects
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import control_silo_test
 
 
 @control_silo_test(stable=True)
@@ -29,8 +30,7 @@ class AuthConfigEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data["nextUri"] == "/organizations/ricks-org/issues/"
 
-    @override_settings(SENTRY_SINGLE_ORGANIZATION=True)
-    @exempt_from_silo_limits()  # Single org IS monolith mode
+    @override_settings(SENTRY_SINGLE_ORGANIZATION=True, SILO_MODE=SiloMode.MONOLITH)
     def test_single_org(self):
         create_default_projects()
         response = self.client.get(self.path)

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -15,8 +15,9 @@ from sentry.api.endpoints.chunk import (
     MAX_REQUEST_SIZE,
 )
 from sentry.models import MAX_FILE_SIZE, ApiToken, FileBlob, Organization
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -27,7 +28,7 @@ class ChunkUploadTest(APITestCase):
 
     def setUp(self):
         self.organization = self.create_organization(owner=self.user)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.token = ApiToken.objects.create(user=self.user, scope_list=["project:write"])
         self.url = reverse("sentry-api-0-chunk-upload", args=[self.organization.slug])
 
@@ -148,7 +149,7 @@ class ChunkUploadTest(APITestCase):
         assert response.data["maxFileSize"] == MAX_FILE_SIZE
 
     def test_wrong_api_token(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["org:org"])
         response = self.client.get(self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}")
         assert response.status_code == 403, response.content

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 
 from sentry.models import ApiToken, File, FileBlob, FileBlobIndex, FileBlobOwner
 from sentry.models.debugfile import ProjectDebugFile
+from sentry.silo import SiloMode
 from sentry.tasks.assemble import (
     AssembleTask,
     ChunkFileState,
@@ -15,14 +16,14 @@ from sentry.tasks.assemble import (
     set_assemble_status,
 )
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
 class DifAssembleEndpoint(APITestCase):
     def setUp(self):
         self.organization = self.create_organization(owner=self.user)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.token = ApiToken.objects.create(user=self.user, scope_list=["project:write"])
         self.team = self.create_team(organization=self.organization)
         self.project = self.create_project(

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -26,8 +26,9 @@ from sentry.models import (
     Release,
 )
 from sentry.plugins.base import plugins
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase, SnubaTestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 
 
@@ -240,7 +241,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             datetime=timezone.now(),
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             user.delete()
 
         url = f"/api/0/issues/{group.id}/"
@@ -424,7 +425,7 @@ class GroupUpdateTest(APITestCase):
         # hitting an endpoint that uses `client.{get,put,post}` to redirect to
         # another endpoint. This catches a regression that happened when
         # migrating to DRF 3.x.
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             api_key = ApiKey.objects.create(
                 organization_id=self.organization.id, scope_list=["event:write"]
             )

--- a/tests/sentry/api/endpoints/test_group_notes.py
+++ b/tests/sentry/api/endpoints/test_group_notes.py
@@ -2,9 +2,10 @@ import datetime
 
 from sentry.models import Activity, ExternalIssue, Group, GroupLink, GroupSubscription
 from sentry.notifications.types import GroupSubscriptionReason
+from sentry.silo import SiloMode
 from sentry.tasks.merge import merge_groups
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 
 
@@ -243,7 +244,7 @@ class GroupNoteCreateTest(APITestCase):
         )
 
         self.user.name = "Sentry Admin"
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.user.save()
         self.login_as(user=self.user)
 

--- a/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
@@ -1,13 +1,15 @@
 from unittest.mock import patch
 
+from django.db import router
 from django.urls import reverse
 
 from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.repository import Repository
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -86,7 +88,9 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
             "projectId": self.project.id,
             "stacktraceFilename": "stack/root/file.py",
         }
-        with exempt_from_silo_limits(), in_test_psql_role_override("postgres"):
+        with assume_test_silo_mode(SiloMode.CONTROL), in_test_psql_role_override(
+            "postgres", using=router.db_for_write(Integration)
+        ):
             Integration.objects.all().delete()
         response = self.client.get(self.url, data=config_data, format="json")
         assert response.status_code == 404, response.content
@@ -132,7 +136,9 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
             "defaultBranch": "master",
             "repoName": "name",
         }
-        with exempt_from_silo_limits(), in_test_psql_role_override("postgres"):
+        with assume_test_silo_mode(SiloMode.CONTROL), in_test_psql_role_override(
+            "postgres", using=router.db_for_write(Integration)
+        ):
             Integration.objects.all().delete()
         response = self.client.post(self.url, data=config_data, format="json")
         assert response.status_code == 404, response.content

--- a/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from sentry.integrations.aws_lambda.integration import AwsLambdaIntegration
 from sentry.models import Integration, ProjectKey
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import region_silo_test
 
 cloudformation_arn = (
     "arn:aws:cloudformation:us-east-2:599817902985:stack/"
@@ -34,7 +34,6 @@ class AbstractServerlessTest(APITestCase):
         return super().get_response(self.organization.slug, self.integration.id, **kwargs)
 
     @property
-    @exempt_from_silo_limits()
     def sentry_dsn(self):
         return ProjectKey.get_default(project=self.project).get_dsn(public=True)
 

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -5,13 +5,14 @@ import responses
 from django.core import mail
 
 from sentry.models import AuthProvider, InviteStatus, OrganizationMember, OrganizationOption
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
 from sentry.testutils.cases import SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.slack import get_attachment_no_text
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
 
@@ -61,7 +62,7 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
 
     @patch("sentry.api.endpoints.organization_member.requests.join.logger")
     def test_org_sso_enabled(self, mock_log):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             AuthProvider.objects.create(organization_id=self.organization.id, provider="google")
 
         self.get_error_response(self.organization.slug, email=self.email, status_code=403)

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -13,11 +13,12 @@ from sentry.models import (
     OrganizationMemberTeam,
     UserEmail,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase, TestCase
 from sentry.testutils.helpers import Feature, with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -74,7 +75,7 @@ class OrganizationMemberSerializerTest(TestCase):
 
         request = self.make_request(user=user)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             UserEmail.objects.filter(user=user, email=user.email).update(is_verified=False)
 
             invite_state = get_invite_state(member.id, org.slug, user.id)
@@ -323,7 +324,7 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase, HybridCloudTest
         )
 
         # Two authenticators to ensure the user list is distinct
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL)():
             Authenticator.objects.create(user_id=member_2fa.user_id, type=1)
             Authenticator.objects.create(user_id=member_2fa.user_id, type=2)
 

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -3,8 +3,9 @@ from base64 import b64encode
 from django.urls import reverse
 
 from sentry.models import ApiKey
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -18,7 +19,7 @@ class OrganizationProjectsTestBase(APITestCase):
         ]
 
     def test_api_key(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             key = ApiKey.objects.create(
                 organization_id=self.organization.id, scope_list=["org:read"]
             )

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -21,8 +21,9 @@ from sentry.models import (
     Repository,
 )
 from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
@@ -1034,7 +1035,7 @@ class UpdateReleaseDetailsTest(APITestCase):
     def test_org_auth_token(self):
         org = self.organization
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             good_token_str = generate_token(org.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org.id,

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -40,6 +40,7 @@ from sentry.search.events.constants import (
     SEMVER_BUILD_ALIAS,
     SEMVER_PACKAGE_ALIAS,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import (
     APITestCase,
     ReleaseCommitPatchTest,
@@ -47,7 +48,7 @@ from sentry.testutils import (
     SnubaTestCase,
     TestCase,
 )
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
@@ -1628,7 +1629,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         url = reverse("sentry-api-0-organization-releases", kwargs={"organization_slug": org.slug})
 
         # test right org, wrong permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             bad_api_key = ApiKey.objects.create(organization_id=org.id, scope_list=["project:read"])
         response = self.client.post(
             url,
@@ -1638,7 +1639,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         assert response.status_code == 403
 
         # test wrong org, right permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             wrong_org_api_key = ApiKey.objects.create(
                 organization_id=org2.id, scope_list=["project:write"]
             )
@@ -1650,7 +1651,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         assert response.status_code == 403
 
         # test right org, right permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             good_api_key = ApiKey.objects.create(
                 organization_id=org.id, scope_list=["project:write"]
             )
@@ -1678,7 +1679,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         url = reverse("sentry-api-0-organization-releases", kwargs={"organization_slug": org.slug})
 
         # test right org, wrong permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             bad_token_str = generate_token(org.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org.id,
@@ -1696,7 +1697,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         assert response.status_code == 403
 
         # test wrong org, right permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             wrong_org_token_str = generate_token(org2.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org2.id,
@@ -1714,7 +1715,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         assert response.status_code == 403
 
         # test right org, right permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             good_token_str = generate_token(org.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org.id,
@@ -1745,7 +1746,7 @@ class OrganizationReleaseCreateTest(APITestCase):
             organization_id=org.id, name="getsentry/sentry-plugins", provider="dummy"
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             api_token = ApiToken.objects.create(user=user, scope_list=["project:releases"])
 
         team1 = self.create_team(organization=org)

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -4,6 +4,7 @@ from time import time
 from unittest import mock
 
 import pytz
+from django.db import router
 from django.urls import reverse
 
 from sentry import audit_log
@@ -1202,7 +1203,7 @@ class CopyProjectSettingsTest(APITestCase):
         team = self.create_team(members=[user])
         project = self.create_project(teams=[team], fire_project_created=True)
 
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             OrganizationMember.objects.filter(
                 user_id=user.id, organization=self.organization
             ).update(role="admin")
@@ -1229,7 +1230,7 @@ class CopyProjectSettingsTest(APITestCase):
         team = self.create_team(members=[user])
         project = self.create_project(teams=[team], fire_project_created=True)
 
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             OrganizationMember.objects.filter(
                 user_id=user.id, organization=self.organization
             ).update(role="admin")

--- a/tests/sentry/api/endpoints/test_project_index.py
+++ b/tests/sentry/api/endpoints/test_project_index.py
@@ -1,3 +1,4 @@
+from django.db import router
 from django.urls import reverse
 from rest_framework import status
 
@@ -29,7 +30,7 @@ class ProjectsListTest(APITestCase):
         assert response.data[0]["organization"]["id"] == str(org.id)
 
     def test_show_all_with_superuser(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(Project)):
             Project.objects.all().delete()
 
         user = self.create_user(is_superuser=True)
@@ -45,7 +46,7 @@ class ProjectsListTest(APITestCase):
         assert len(response.data) == 2
 
     def test_show_all_without_superuser(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(Project)):
             Project.objects.all().delete()
 
         user = self.create_user(is_superuser=False)
@@ -61,7 +62,7 @@ class ProjectsListTest(APITestCase):
         assert len(response.data) == 0
 
     def test_status_filter(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(Project)):
             Project.objects.all().delete()
 
         user = self.create_user()
@@ -81,7 +82,7 @@ class ProjectsListTest(APITestCase):
         assert response.data[0]["id"] == str(project2.id)
 
     def test_query_filter(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(Project)):
             Project.objects.all().delete()
 
         user = self.create_user()
@@ -100,7 +101,7 @@ class ProjectsListTest(APITestCase):
         assert len(response.data) == 0
 
     def test_slug_query(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(Project)):
             Project.objects.all().delete()
 
         user = self.create_user()
@@ -119,7 +120,7 @@ class ProjectsListTest(APITestCase):
         assert len(response.data) == 0
 
     def test_dsn_filter(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(Project)):
             Project.objects.all().delete()
 
         user = self.create_user()
@@ -139,7 +140,7 @@ class ProjectsListTest(APITestCase):
         assert len(response.data) == 0
 
     def test_id_query(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(Project)):
             Project.objects.all().delete()
 
         user = self.create_user()

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -19,8 +19,9 @@ from sentry.models import (
     Repository,
 )
 from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase, ReleaseCommitPatchTest, TestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 
@@ -505,7 +506,7 @@ class ProjectReleaseCreateTest(APITestCase):
         )
 
         # test right org, wrong permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             bad_token_str = generate_token(org.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org.id,
@@ -523,7 +524,7 @@ class ProjectReleaseCreateTest(APITestCase):
         assert response.status_code == 403
 
         # test wrong org, right permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             wrong_org_token_str = generate_token(org2.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org2.id,
@@ -541,7 +542,7 @@ class ProjectReleaseCreateTest(APITestCase):
         assert response.status_code == 403
 
         # test right org, right permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             good_token_str = generate_token(org.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org.id,

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -12,9 +12,10 @@ from sentry.integrations.slack.utils.channel import strip_channel_name
 from sentry.models import Environment, Integration, Rule, RuleActivity, RuleActivityType, RuleStatus
 from sentry.models.actor import Actor, get_actor_for_user
 from sentry.models.rulefirehistory import RuleFireHistory
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import install_slack
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
 
@@ -27,7 +28,7 @@ def assert_rule_from_payload(rule: Rule, payload: Mapping[str, Any]) -> None:
 
     owner_id = payload.get("owner")
     if owner_id:
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             assert Actor.objects.get(id=rule.owner_id)
     else:
         assert rule.owner is None

--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -5,8 +5,9 @@ from django.utils import timezone
 
 from sentry.mediators import GrantTypes
 from sentry.models import ApiApplication, ApiToken
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test(stable=True)
@@ -98,7 +99,7 @@ class TestSentryAppAuthorizations(APITestCase):
 
         url = reverse("sentry-api-0-organization-details", args=[self.organization.slug])
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
 
         assert response.status_code == 200

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -5,9 +5,10 @@ from django.urls import reverse
 from sentry import audit_log, deletions
 from sentry.constants import SentryAppStatus
 from sentry.models import AuditLogEntry, OrganizationMember, SentryApp
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -401,7 +402,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.data == {"allowedOrigins": ["'*' not allowed in origin"]}
 
     def test_members_cant_update(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             member_om = OrganizationMember.objects.get(user_id=self.user.id, organization=self.org)
             member_om.role = "member"
             member_om.save()
@@ -411,7 +412,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.status_code == 403
 
     def test_create_integration_exceeding_scopes(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             member_om = OrganizationMember.objects.get(user_id=self.user.id, organization=self.org)
             member_om.role = "manager"
             member_om.save()

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -15,9 +15,10 @@ from sentry.models import (
     UserOption,
 )
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.cases import PerformanceIssueTestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
 
 
@@ -249,7 +250,7 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
         for default_value, project_value, is_subscribed, has_details in combinations:
             UserOption.objects.clear_local_cache()
 
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 for provider in [ExternalProviders.EMAIL, ExternalProviders.SLACK]:
                     NotificationSetting.objects.update_settings(
                         provider,
@@ -283,7 +284,7 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
             user_id=user.id, group=group, project=group.project, is_active=True
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.WORKFLOW,
@@ -310,7 +311,7 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
             user_id=user.id, group=group, project=group.project, is_active=True
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.WORKFLOW,

--- a/tests/sentry/auth/test_idpmigration.py
+++ b/tests/sentry/auth/test_idpmigration.py
@@ -4,8 +4,9 @@ from django.urls import reverse
 
 import sentry.auth.idpmigration as idpmigration
 from sentry.models import AuthProvider, OrganizationMember
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -22,7 +23,7 @@ class IDPMigrationTests(TestCase):
     IDENTITY_ID = "drgUQCLzOyfHxmTyVs0G"
 
     def test_send_one_time_account_confirm_link(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.create(organization=self.org, user_id=self.user.id)
         link = idpmigration.send_one_time_account_confirm_link(
             self.user, self.org, self.provider, self.email, self.IDENTITY_ID

--- a/tests/sentry/deletions/test_release.py
+++ b/tests/sentry/deletions/test_release.py
@@ -7,12 +7,13 @@ from sentry.models import (
     ReleaseFile,
     ScheduledDeletion,
 )
+from sentry.silo import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.tasks.deletion.scheduled import run_deletion
 from sentry.testutils import TransactionTestCase
 from sentry.testutils.helpers import TaskRunner
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode
 
 
 class DeleteReleaseTest(TransactionTestCase):
@@ -50,7 +51,7 @@ class DeleteReleaseTest(TransactionTestCase):
         assert release1.owner_id
         assert release2.owner_id
 
-        with exempt_from_silo_limits(), outbox_runner():
+        with assume_test_silo_mode(SiloMode.CONTROL), outbox_runner():
             self.user.delete()
 
         with TaskRunner():

--- a/tests/sentry/hybrid_cloud/test_auth.py
+++ b/tests/sentry/hybrid_cloud/test_auth.py
@@ -5,9 +5,10 @@ from sentry.services.hybrid_cloud.auth import (
     RpcOrganizationAuthConfig,
     auth_service,
 )
+from sentry.silo import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.hybrid_cloud import use_real_service
-from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 from sentry.utils.pytest.fixtures import django_db_all
 
 
@@ -19,7 +20,7 @@ def test_get_org_auth_config():
     org_without_api_keys = Factories.create_organization()
     Factories.create_organization()  # unrelated, not in the results.
 
-    with exempt_from_silo_limits():
+    with assume_test_silo_mode(SiloMode.CONTROL):
         ApiKey.objects.create(organization_id=org_with_many_api_keys.id)
         ApiKey.objects.create(organization_id=org_with_many_api_keys.id)
         ap = AuthProvider.objects.create(

--- a/tests/sentry/hybrid_cloud/test_hook_service.py
+++ b/tests/sentry/hybrid_cloud/test_hook_service.py
@@ -2,8 +2,9 @@ from sentry.models import ServiceHook
 from sentry.sentry_apps import expand_events
 from sentry.sentry_apps.apps import consolidate_events
 from sentry.services.hybrid_cloud.hook import hook_service
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 
 
 @all_silo_test(stable=True)
@@ -28,7 +29,7 @@ class TestHookService(TestCase):
     def test_creates_service_hook(self):
         self.call_create_hook()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             service_hook = ServiceHook.objects.get(
                 application_id=self.sentry_app.application_id,
                 actor_id=self.sentry_app.proxy_user.id,

--- a/tests/sentry/hybrid_cloud/test_integration.py
+++ b/tests/sentry/hybrid_cloud/test_integration.py
@@ -18,12 +18,12 @@ from sentry.services.hybrid_cloud.integration.serial import (
     serialize_integration,
     serialize_organization_integration,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 
 
 class BaseIntegrationServiceTest(TestCase):
-    @exempt_from_silo_limits()
     def setUp(self):
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
@@ -35,9 +35,10 @@ class BaseIntegrationServiceTest(TestCase):
             status=ObjectStatus.ACTIVE,
             metadata={"meta": "data"},
         )
-        self.org_integration1 = OrganizationIntegration.objects.get(
-            organization_id=self.organization.id, integration_id=self.integration1.id
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.org_integration1 = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration_id=self.integration1.id
+            )
         self.integration2 = self.create_integration(
             organization=self.organization,
             name="Github",
@@ -45,18 +46,20 @@ class BaseIntegrationServiceTest(TestCase):
             external_id="github:1",
             oi_params={"config": {"oi_conf": "data"}, "status": ObjectStatus.PENDING_DELETION},
         )
-        self.org_integration2 = OrganizationIntegration.objects.get(
-            organization_id=self.organization.id, integration_id=self.integration2.id
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.org_integration2 = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration_id=self.integration2.id
+            )
         self.integration3 = self.create_integration(
             organization=self.organization,
             name="Example",
             provider="example",
             external_id="example:2",
         )
-        self.org_integration3 = OrganizationIntegration.objects.get(
-            organization_id=self.organization.id, integration_id=self.integration3.id
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.org_integration3 = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration_id=self.integration3.id
+            )
         self.integrations = [self.integration1, self.integration2, self.integration3]
         self.org_integrations = [
             self.org_integration1,
@@ -243,7 +246,7 @@ class OrganizationIntegrationServiceTest(BaseIntegrationServiceTest):
 
     def test_get_organization_context(self):
         new_org = self.create_organization()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             org_integration = self.integration3.add_organization(new_org)
 
         result_integration, result_org_integration = integration_service.get_organization_context(

--- a/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
@@ -1,3 +1,5 @@
+from django.db import router
+
 from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
@@ -5,10 +7,11 @@ from sentry.services.hybrid_cloud.organizationmember_mapping import (
     RpcOrganizationMemberMappingUpdate,
     organizationmember_mapping_service,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import TransactionTestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, region_silo_test
 
 
 @control_silo_test(stable=True)
@@ -58,7 +61,7 @@ class OrganizationMappingTest(TransactionTestCase, HybridCloudTestMixin):
 
     def test_upsert_happy_path(self):
         inviter = self.create_user("foo@example.com")
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             om_id = OrganizationMember.objects.get(
                 organization_id=self.organization.id, user_id=self.user.id
             ).id
@@ -104,14 +107,14 @@ class OrganizationMappingTest(TransactionTestCase, HybridCloudTestMixin):
 
         with outbox_runner():
             org = self.create_organization("test", owner=self.user)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.get(organization_id=org.id, user_id=self.user.id)
         assert not om.user_is_active
 
     def test_save_user_pushes_is_active(self):
         with outbox_runner():
             org = self.create_organization("test", owner=self.user)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.get(organization_id=org.id, user_id=self.user.id)
         assert om.user_is_active
 
@@ -119,14 +122,14 @@ class OrganizationMappingTest(TransactionTestCase, HybridCloudTestMixin):
             self.user.is_active = False
             self.user.save()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             om.refresh_from_db()
         assert not om.user_is_active
 
     def test_update_user_pushes_is_active(self):
         with outbox_runner():
             org = self.create_organization("test", owner=self.user)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.get(organization_id=org.id, user_id=self.user.id)
         assert om.user_is_active
 
@@ -140,10 +143,7 @@ class OrganizationMappingTest(TransactionTestCase, HybridCloudTestMixin):
 @region_silo_test(stable=True)
 class ReceiverTest(TransactionTestCase, HybridCloudTestMixin):
     def test_process_organization_member_update_receiver(self):
-        with exempt_from_silo_limits():
-            inviter = self.create_user("foo@example.com")
-            assert OrganizationMember.objects.all().count() == 0
-            assert OrganizationMemberMapping.objects.all().count() == 0
+        inviter = self.create_user("foo@example.com")
         fields = {
             "organization_id": self.organization.id,
             "role": "member",
@@ -155,29 +155,23 @@ class ReceiverTest(TransactionTestCase, HybridCloudTestMixin):
         # Creation step of receiver
         org_member = OrganizationMember.objects.create(**fields)
 
-        with exempt_from_silo_limits():
-            # rows are created for owner, and invited member.
-            assert OrganizationMember.objects.all().count() == 2
-            assert OrganizationMemberMapping.objects.all().count() == 2
-            for org_member in OrganizationMember.objects.all().iterator():
-                self.assert_org_member_mapping(org_member=org_member)
+        # rows are created for owner, and invited member.
+        assert OrganizationMember.objects.all().count() == 2
+        for org_member in OrganizationMember.objects.all().iterator():
+            self.assert_org_member_mapping(org_member=org_member)
 
         # Update step of receiver
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             org_member.update(role="owner")
         region_outbox = org_member.save_outbox_for_update()
         region_outbox.drain_shard()
 
-        with exempt_from_silo_limits():
-            assert OrganizationMember.objects.all().count() == 2
-            assert OrganizationMemberMapping.objects.all().count() == 2
-            for org_member in OrganizationMember.objects.all().iterator():
-                self.assert_org_member_mapping(org_member=org_member)
+        assert OrganizationMember.objects.all().count() == 2
+        for org_member in OrganizationMember.objects.all().iterator():
+            self.assert_org_member_mapping(org_member=org_member)
 
     def test_process_organization_member_deletes_receiver(self):
-        with exempt_from_silo_limits():
-            inviter = self.create_user("foo@example.com")
-            assert OrganizationMemberMapping.objects.all().count() == 0
+        inviter = self.create_user("foo@example.com")
         fields = {
             "organization_id": self.organization.id,
             "role": "member",
@@ -187,17 +181,13 @@ class ReceiverTest(TransactionTestCase, HybridCloudTestMixin):
         }
         org_member = OrganizationMember.objects.create(**fields)
 
-        with exempt_from_silo_limits():
-            # rows are created for owner, and invited member.
-            assert OrganizationMember.objects.all().count() == 2
-            assert OrganizationMemberMapping.objects.all().count() == 2
-            for om in OrganizationMember.objects.all().iterator():
-                self.assert_org_member_mapping(org_member=om)
+        # rows are created for owner, and invited member.
+        assert OrganizationMember.objects.all().count() == 2
+        for om in OrganizationMember.objects.all().iterator():
+            self.assert_org_member_mapping(org_member=om)
 
         with outbox_runner():
             org_member.delete()
 
-        with exempt_from_silo_limits():
-            assert OrganizationMember.objects.all().count() == 1
-            assert OrganizationMemberMapping.objects.all().count() == 1
-            self.assert_org_member_mapping_not_exists(org_member=org_member)
+        assert OrganizationMember.objects.all().count() == 1
+        self.assert_org_member_mapping_not_exists(org_member=org_member)

--- a/tests/sentry/hybrid_cloud/test_rpc.py
+++ b/tests/sentry/hybrid_cloud/test_rpc.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 import pytest
 from django.test import override_settings
 
-from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models import OrganizationMapping
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.services.hybrid_cloud.auth import AuthService
@@ -46,15 +45,14 @@ class RpcServiceTest(TestCase):
 
         user = self.create_user()
         organization = self.create_organization()
-        with in_test_psql_role_override("postgres"):
-            OrganizationMapping.objects.update_or_create(
-                organization_id=organization.id,
-                defaults={
-                    "slug": organization.slug,
-                    "name": organization.name,
-                    "region_name": target_region.name,
-                },
-            )
+        OrganizationMapping.objects.update_or_create(
+            organization_id=organization.id,
+            defaults={
+                "slug": organization.slug,
+                "name": organization.name,
+                "region_name": target_region.name,
+            },
+        )
 
         serial_user = RpcUser(id=user.id)
         serial_org = serialize_rpc_organization(organization)

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -6,8 +6,9 @@ from freezegun import freeze_time
 from sentry.incidents.action_handlers import MsTeamsActionHandler
 from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus
 from sentry.models import Integration
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
 from . import FireTest
@@ -18,7 +19,7 @@ from . import FireTest
 class MsTeamsActionHandlerTest(FireTest, TestCase):
     @responses.activate
     def setUp(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="msteams",
                 name="Galactic Empire",

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -4,6 +4,7 @@ from functools import cached_property
 
 import pytz
 import requests
+from django.db import router
 from freezegun import freeze_time
 
 from sentry import audit_log
@@ -339,7 +340,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
 
     def test_no_perms(self):
         # Downgrade user from "owner" to "member".
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             OrganizationMember.objects.filter(user_id=self.user.id).update(role="member")
 
         resp = self.get_response(self.organization.slug)

--- a/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
@@ -1,8 +1,9 @@
 from functools import cached_property
 
 from sentry.incidents.models import IncidentActivity, IncidentActivityType
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -95,7 +96,7 @@ class OrganizationIncidentCommentUpdateEndpointTest(BaseIncidentCommentDetailsTe
 
     def test_superuser_can_edit(self):
         self.user.is_superuser = True
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.user.save()
 
         edited_comment = "this comment has been edited"
@@ -135,7 +136,7 @@ class OrganizationIncidentCommentDeleteEndpointTest(BaseIncidentCommentDetailsTe
 
     def test_superuser_can_delete(self):
         self.user.is_superuser = True
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.user.save()
 
         with self.feature("organizations:incidents"):

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -4,8 +4,9 @@ from freezegun import freeze_time
 
 from sentry.api.serializers import serialize
 from sentry.incidents.models import Incident, IncidentActivity, IncidentStatus
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 class BaseIncidentDetailsTest:
@@ -50,7 +51,7 @@ class OrganizationIncidentDetailsTest(BaseIncidentDetailsTest, APITestCase):
 
         expected = serialize(incident)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             user_data = serialize(self.user)
         seen_by = [user_data]
 

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -9,9 +9,10 @@ from fixtures.github import COMPARE_COMMITS_EXAMPLE, GET_COMMIT_EXAMPLE, GET_LAS
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.models import Integration, PullRequest, Repository
 from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.asserts import assert_commit_shape
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -44,7 +45,7 @@ class GitHubAppsProviderTest(TestCase):
     def repository(self):
         # TODO: Refactor this out with a call to the relevant factory if possible to avoid
         # explicitly having to exempt it from silo limits
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             return Repository.objects.create(
                 name="getsentry/example-repo",
                 provider="integrations:github",

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -12,8 +12,9 @@ from fixtures.github import (
 )
 from sentry import options
 from sentry.models import Commit, CommitAuthor, GroupLink, Integration, PullRequest, Repository
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -86,7 +87,7 @@ class PushEventWebhookTest(APITestCase):
         )
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 external_id="12345",
                 provider="github",
@@ -143,7 +144,7 @@ class PushEventWebhookTest(APITestCase):
         options.set("github-app.webhook-secret", secret)
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="github",
                 external_id="12345",
@@ -221,7 +222,7 @@ class PushEventWebhookTest(APITestCase):
         )
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 external_id="12345",
                 provider="github",
@@ -240,7 +241,7 @@ class PushEventWebhookTest(APITestCase):
         )
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 external_id="99",
                 provider="github",
@@ -285,7 +286,7 @@ class PullRequestEventWebhook(APITestCase):
         options.set("github-app.webhook-secret", secret)
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="github",
                 external_id="12345",
@@ -339,7 +340,7 @@ class PullRequestEventWebhook(APITestCase):
         options.set("github-app.webhook-secret", secret)
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="github",
                 external_id="12345",
@@ -389,7 +390,7 @@ class PullRequestEventWebhook(APITestCase):
         options.set("github-app.webhook-secret", secret)
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="github",
                 external_id="12345",

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -7,9 +7,10 @@ from fixtures.gitlab import COMMIT_DIFF_RESPONSE, COMMIT_LIST_RESPONSE, COMPARE_
 from sentry.integrations.gitlab.repository import GitlabRepositoryProvider
 from sentry.models import Identity, IdentityProvider, Integration, PullRequest, Repository
 from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.silo import SiloMode
 from sentry.testutils import IntegrationRepositoryTestCase
 from sentry.testutils.asserts import assert_commit_shape
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -69,7 +70,7 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
             json={"id": 99},
         )
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.REGION)
     def get_repository(self, **kwargs) -> Repository:
         return Repository.objects.get(**kwargs)
 

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -7,7 +7,8 @@ from fixtures.gitlab import (
     GitLabTestCase,
 )
 from sentry.models import Commit, CommitAuthor, GroupLink, PullRequest
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.silo import SiloMode
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
 
@@ -116,7 +117,7 @@ class WebhookTest(GitLabTestCase):
         assert response.status_code == 204
 
     def test_push_event_multiple_organizations_one_missing_repo(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             # Create a repo on the primary organization
             repo = self.create_repo("getsentry/sentry")
 
@@ -139,7 +140,7 @@ class WebhookTest(GitLabTestCase):
             assert commit.repository_id == repo.id
 
     def test_push_event_multiple_organizations(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             # Create a repo on the primary organization
             repo = self.create_repo("getsentry/sentry")
 

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -20,9 +20,10 @@ from sentry.models import (
     OrganizationIntegration,
 )
 from sentry.models.activity import Activity, ActivityIntegration
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
 from sentry.testutils.asserts import assert_mock_called_once_with_partial
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
 
@@ -180,7 +181,7 @@ class StatusActionTest(APITestCase):
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
     def test_ignore_issue_with_additional_user_auth(self, verify):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             auth_idp = AuthProvider.objects.create(organization_id=self.org.id, provider="nobody")
             AuthIdentity.objects.create(auth_provider=auth_idp, user=self.user)
 
@@ -269,7 +270,7 @@ class StatusActionTest(APITestCase):
     def test_assign_to_me_multiple_identities(self, verify):
         org2 = self.create_organization(owner=None)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration2 = Integration.objects.create(
                 provider="msteams",
                 name="Army of Mordor",
@@ -321,7 +322,7 @@ class StatusActionTest(APITestCase):
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
     def test_unassign_issue(self, verify):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             GroupAssignee.objects.create(
                 group=self.group1, project=self.project1, user_id=self.user.id
             )
@@ -348,7 +349,7 @@ class StatusActionTest(APITestCase):
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
     def test_no_integration(self, verify):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.delete()
         resp = self.post_webhook()
         assert resp.status_code == 404

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -16,9 +16,10 @@ from sentry.models import (
     Team,
 )
 from sentry.notifications.types import NotificationScopeType
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import add_identity, get_response_text, install_slack, link_team
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 
@@ -123,7 +124,7 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
             in get_response_text(data)
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             team_settings = NotificationSetting.objects.filter(
                 scope_type=NotificationScopeType.TEAM.value, team_id=self.team.id
             )
@@ -161,7 +162,7 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
         # Create another organization and team for this user that is linked through `self.integration`.
         organization2 = self.create_organization(owner=self.user)
         team2 = self.create_team(organization=organization2, members=[self.user])
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             OrganizationIntegration.objects.create(
                 organization_id=organization2.id, integration=self.integration
             )
@@ -211,7 +212,7 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
             in get_response_text(data)
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             team_settings = NotificationSetting.objects.filter(
                 scope_type=NotificationScopeType.TEAM.value, team_id=self.team.id
             )
@@ -254,7 +255,7 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
             in get_response_text(data)
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             team_settings = NotificationSetting.objects.filter(
                 scope_type=NotificationScopeType.TEAM.value, team_id=self.team.id
             )
@@ -265,7 +266,7 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
         # Create another organization and team for this user that is linked through `self.integration`.
         organization2 = self.create_organization(owner=self.user)
         team2 = self.create_team(organization=organization2, members=[self.user])
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             OrganizationIntegration.objects.create(
                 organization_id=organization2.id, integration=self.integration
             )

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 from urllib.parse import parse_qs
 
 import responses
+from django.db import router
 from django.urls import reverse
 from freezegun import freeze_time
 
@@ -21,8 +22,9 @@ from sentry.models import (
     Release,
 )
 from sentry.models.activity import Activity, ActivityIntegration
+from sentry.silo import SiloMode
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
@@ -145,7 +147,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         """
         Ensure that we can act as a user even when the organization has SSO enabled
         """
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             auth_idp = AuthProvider.objects.create(
                 organization_id=self.organization.id, provider="dummy"
             )
@@ -497,7 +499,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         "sentry.integrations.slack.requests.SlackRequest._check_signing_secret", return_value=True
     )
     def test_no_integration(self, check_signing_secret_mock):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.delete()
         resp = self.post_webhook()
         assert resp.status_code == 403
@@ -637,7 +639,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.data["text"] == "Member invitation for hello@sentry.io no longer exists."
 
     def test_invitation_validation_error(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             OrganizationMember.objects.filter(user_id=self.user.id).update(role="manager")
         other_user = self.create_user()
         member = OrganizationMember.objects.create(
@@ -658,7 +660,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         )
 
     def test_identity_not_linked(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             Identity.objects.filter(user=self.user).delete()
         resp = self.post_webhook(action_data=[{"value": "approve_member"}], callback_id="")
 
@@ -683,7 +685,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.data["text"] == "You do not have access to the organization for the invitation."
 
     def test_no_member_admin(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             OrganizationMember.objects.filter(user_id=self.user.id).update(role="admin")
 
         other_user = self.create_user()

--- a/tests/sentry/integrations/utils/test_codecov.py
+++ b/tests/sentry/integrations/utils/test_codecov.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 import responses
+from django.db import router
 
 from sentry import options
 from sentry.db.postgres.roles import in_test_psql_role_override
@@ -26,7 +27,7 @@ class TestCodecovIntegration(APITestCase):
         options.set("codecov.client-secret", "supersecrettoken")
 
     def test_no_github_integration(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(Integration)):
             Integration.objects.all().delete()
 
         has_integration, error = has_codecov_integration(self.organization)

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -18,8 +18,9 @@ from sentry.models import (
     SentryAppInstallationForProvider,
     SentryAppInstallationToken,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import IntegrationTestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -143,7 +144,7 @@ class VercelIntegrationTest(IntegrationTestCase):
 
         org = self.organization
         project_id = self.project.id
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             enabled_dsn = ProjectKey.get_default(
                 project=Project.objects.get(id=project_id)
             ).get_dsn(public=True)
@@ -254,7 +255,7 @@ class VercelIntegrationTest(IntegrationTestCase):
 
         org = self.organization
         project_id = self.project.id
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             enabled_dsn = ProjectKey.get_default(
                 project=Project.objects.get(id=project_id)
             ).get_dsn(public=True)
@@ -381,7 +382,7 @@ class VercelIntegrationTest(IntegrationTestCase):
         org = self.organization
         data = {"project_mappings": [[project_id, self.project_id]]}
         integration = Integration.objects.get(provider=self.provider.key)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             installation = integration.get_installation(org.id)
 
         dsn = ProjectKey.get_default(project=Project.objects.get(id=project_id))

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -22,9 +22,10 @@ from sentry.models import (
     SentryAppInstallationForProvider,
     SentryAppInstallationToken,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import override_options
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
@@ -211,7 +212,7 @@ class VercelReleasesTest(APITestCase):
             absolute_uri("/api/0/organizations/%s/releases/" % self.organization.slug),
             json={},
         )
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             self.project.delete()
 
         with override_options({"vercel.client-secret": SECRET}):

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -13,7 +13,8 @@ from sentry.models import (
     Repository,
 )
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationProviderError
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.silo import SiloMode
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 FULL_SCOPES = ["vso.code", "vso.graph", "vso.serviceendpoint_manage", "vso.work_write"]
 LIMITED_SCOPES = ["vso.graph", "vso.serviceendpoint_manage", "vso.work_write"]
@@ -48,7 +49,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         assert metadata["domain_name"] == self.vsts_base_url
 
     def test_migrate_repositories(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             accessible_repo = Repository.objects.create(
                 organization_id=self.organization.id,
                 name=self.project_a["name"],
@@ -71,7 +72,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
             self.assert_installation()
         integration = Integration.objects.get(provider="vsts")
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             assert Repository.objects.get(id=accessible_repo.id).integration_id == integration.id
             assert Repository.objects.get(id=inaccessible_repo.id).integration_id is None
 

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -9,8 +9,9 @@ from sentry.notifications.types import (
 )
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.silo import SiloMode
 from sentry.testutils.cases import ActivityTestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.types.integrations import ExternalProviders
 
@@ -185,7 +186,7 @@ class ReleaseTestCase(ActivityTestCase):
         user6 = self.create_user()
         self.create_member(user=user6, organization=self.org, teams=[self.team])
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.DEPLOY,

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -10,8 +10,9 @@ from sentry.notifications.types import (
 )
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
 
 
@@ -100,7 +101,7 @@ class GetParticipantsTest(TestCase):
         self.update_user_settings_always()
         self.user = user_service.get_user(self.user.id)  # Redo the serialization for diffs
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def update_user_settings_always(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -109,7 +110,7 @@ class GetParticipantsTest(TestCase):
             user_id=self.user.id,
         )
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def update_user_setting_subscribe_only(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -118,7 +119,7 @@ class GetParticipantsTest(TestCase):
             user_id=self.user.id,
         )
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def update_user_setting_never(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -127,7 +128,7 @@ class GetParticipantsTest(TestCase):
             user_id=self.user.id,
         )
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def update_project_setting_always(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -137,7 +138,7 @@ class GetParticipantsTest(TestCase):
             project=self.group.project,
         )
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def update_project_setting_subscribe_only(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -147,7 +148,7 @@ class GetParticipantsTest(TestCase):
             project=self.group.project,
         )
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def update_project_setting_never(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -223,7 +224,7 @@ class GetParticipantsTest(TestCase):
         self.update_project_setting_never()
         self._assert_subscribers_are()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -237,7 +238,7 @@ class GetParticipantsTest(TestCase):
         self.update_project_setting_never()
         self._assert_subscribers_are()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -259,7 +260,7 @@ class GetParticipantsTest(TestCase):
         self.update_user_setting_never()
         self._assert_subscribers_are(slack={self.user: GroupSubscriptionReason.comment})
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -275,7 +276,7 @@ class GetParticipantsTest(TestCase):
         self.update_project_setting_never()
         self._assert_subscribers_are(slack={self.user: GroupSubscriptionReason.comment})
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -295,7 +296,7 @@ class GetParticipantsTest(TestCase):
 
         self._assert_subscribers_are(email={self.user: GroupSubscriptionReason.implicit})
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.WORKFLOW,
@@ -305,7 +306,7 @@ class GetParticipantsTest(TestCase):
             )
         self._assert_subscribers_are()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -318,7 +319,7 @@ class GetParticipantsTest(TestCase):
         self.update_project_setting_never()
         self._assert_subscribers_are()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -340,7 +341,7 @@ class GetParticipantsTest(TestCase):
         )
 
         subscription.delete()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -362,7 +363,7 @@ class GetParticipantsTest(TestCase):
         )
 
         subscription.delete()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -386,7 +387,7 @@ class GetParticipantsTest(TestCase):
         )
 
         subscription.delete()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -428,7 +429,7 @@ class GetParticipantsTest(TestCase):
         # explicit participation, included by default
         self._assert_subscribers_are(group)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.WORKFLOW,
@@ -445,7 +446,7 @@ class GetParticipantsTest(TestCase):
         # implicit participation, participating only
         self._assert_subscribers_are(group)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.WORKFLOW,

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from django.core import mail
+from django.db import router
 from django.utils import timezone
 
 from sentry import roles
@@ -19,11 +20,12 @@ from sentry.models import (
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -83,7 +85,7 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
 
     @patch("sentry.utils.email.MessageBuilder")
     def test_send_sso_unlink_email(self, builder):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             user = self.create_user(email="foo@example.com")
             user.password = ""
             user.save()
@@ -177,7 +179,7 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
         user = self.create_user()
         member = self.create_member(user_id=user.id, organization_id=org.id)
         self.assert_org_member_mapping(org_member=member)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             ap = AuthProvider.objects.create(
                 organization_id=org.id, provider="sentry_auth_provider", config={}
             )
@@ -190,20 +192,20 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
 
         # ensure that even if the outbox sends a general, non delete update, it doesn't cascade
         # the delete to auth identity objects.
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             assert qs.exists()
 
         with outbox_runner():
             member.delete()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             assert not qs.exists()
             self.assert_org_member_mapping_not_exists(org_member=member)
 
     def test_delete_expired_SCIM_enabled(self):
         organization = self.create_organization()
         org3 = self.create_organization()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             AuthProvider.objects.create(
                 provider="saml2",
                 organization_id=organization.id,
@@ -488,7 +490,7 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
         member = OrganizationMember.objects.get(
             user_id=self.user.id, organization=self.organization
         )
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             member.update(role="manager")
         assert member.get_allowed_org_roles_to_invite() == [
             roles.get("member"),

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -25,8 +25,9 @@ from sentry.models import (
     add_group_to_inbox,
 )
 from sentry.signals import buffer_incr_complete, receivers_raise_on_send
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 
 
@@ -165,14 +166,14 @@ class ResolvedInCommitTest(TestCase):
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.MANUAL)
         user = self.create_user(name="Foo Bar", email="foo@example.com", is_active=True)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             email = UserEmail.objects.get_primary_email(user=user)
         email.is_verified = True
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             email.save()
         repo = Repository.objects.create(name="example", organization_id=self.group.organization.id)
         OrganizationMember.objects.create(organization=group.project.organization, user_id=user.id)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             UserOption.objects.set_value(user=user, key="self_assign_issue", value="1")
 
         author = CommitAuthor.objects.create(
@@ -207,7 +208,7 @@ class ResolvedInCommitTest(TestCase):
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.MANUAL)
         user = self.create_user(name="Foo Bar", email="foo@example.com", is_active=True)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             email = UserEmail.objects.get_primary_email(user=user)
             email.is_verified = True
             email.save()

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -6,10 +6,11 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user import UserSerializer
 from sentry.constants import SentryAppInstallationStatus
 from sentry.models import Activity, Commit, GroupAssignee, GroupLink, Release, Repository
+from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 # This testcase needs to be an APITestCase because all of the logic to resolve
 # Issues and kick off side effects are just chillin in the endpoint code -_-
@@ -153,7 +154,7 @@ class TestIssueWorkflowNotifications(APITestCase):
 
     def test_notify_pending_installation(self, delay):
         self.install.status = SentryAppInstallationStatus.PENDING
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.install.save()
 
         self.update_issue()
@@ -188,7 +189,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
         with Feature("organizations:sentry-functions"):
             self.update_issue()
             sub_data = {"resolution_type": "now"}
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -206,7 +207,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
                 {"statusDetails": {"inCommit": {"repository": repo.name, "commit": commit.key}}}
             )
             sub_data = {"resolution_type": "in_commit"}
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -221,7 +222,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
             release = self.create_release(project=self.project)
             self.update_issue({"statusDetails": {"inRelease": release.version}})
             sub_data = {"resolution_type": "in_release"}
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -237,7 +238,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
 
             self.update_issue({"statusDetails": {"inRelease": "latest"}})
             sub_data = {"resolution_type": "in_release"}
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -254,7 +255,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
 
             sub_data = {"resolution_type": "in_next_release"}
 
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -305,7 +306,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
         with Feature("organizations:sentry-functions"):
             self.update_issue({"status": "ignored"})
             sub_data = {}
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -321,7 +322,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
         ):
             self.update_issue({"status": "ignored"})
             sub_data = {}
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
 
             assert delay.call_count == 2
@@ -575,7 +576,7 @@ class TestCommentsSentryFunctions(APITestCase):
                 "comment": "hello world",
                 "project_slug": self.project.slug,
             }
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -597,7 +598,7 @@ class TestCommentsSentryFunctions(APITestCase):
                 "comment": "goodbye cruel world",
                 "project_slug": self.project.slug,
             }
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -617,7 +618,7 @@ class TestCommentsSentryFunctions(APITestCase):
                 "comment": "hello world",
                 "project_slug": self.project.slug,
             }
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,

--- a/tests/sentry/receivers/test_transactions.py
+++ b/tests/sentry/receivers/test_transactions.py
@@ -1,6 +1,8 @@
 from functools import cached_property
 from unittest.mock import patch
 
+from django.db import router
+
 from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models import OrganizationMember, Project
 from sentry.signals import event_processed, transaction_processed
@@ -84,7 +86,7 @@ class RecordFirstTransactionTest(TestCase):
         )
 
     def test_analytics_event_no_owner(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             OrganizationMember.objects.filter(organization=self.organization, role="owner").delete()
         assert not self.project.flags.has_transactions
         event = self.store_event(

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -4,9 +4,10 @@ import pytest
 from rest_framework import serializers
 
 from sentry.rules.actions.sentry_apps import NotifyEventSentryAppAction
+from sentry.silo import SiloMode
 from sentry.tasks.sentry_apps import notify_sentry_app
 from sentry.testutils.cases import RuleTestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 ValidationError = serializers.ValidationError
 SENTRY_APP_ALERT_ACTION = "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"
@@ -118,7 +119,7 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
         test_install = self.create_sentry_app_installation(
             organization=self.organization, slug="test-application"
         )
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             test_install.delete()
         rule = self.get_rule(
             data={"hasSchemaFormConfig": True, "sentryAppInstallationUuid": test_install.uuid}

--- a/tests/sentry/runner/commands/test_backup.py
+++ b/tests/sentry/runner/commands/test_backup.py
@@ -1,8 +1,9 @@
 import pytest
 from click.testing import CliRunner
-from django.db import IntegrityError
+from django.db import IntegrityError, router
 
 from sentry.db.postgres.roles import in_test_psql_role_override
+from sentry.models import Organization, User
 from sentry.runner.commands.backup import export, import_
 from sentry.utils import json
 from sentry.utils.pytest.fixtures import django_db_all
@@ -18,7 +19,9 @@ def backup_json_filename(tmp_path):
 
 @django_db_all
 def test_import(backup_json_filename):
-    with in_test_psql_role_override("postgres"):
+    with in_test_psql_role_override(
+        "postgres", using=router.db_for_write(Organization)
+    ), in_test_psql_role_override("postgres", using=router.db_for_write(User)):
         rv = CliRunner().invoke(import_, backup_json_filename)
     assert rv.exit_code == 0, rv.output
 
@@ -35,7 +38,9 @@ def test_import_duplicate_key(backup_json_filename):
     with open(backup_json_filename, "w") as backup_file:
         backup_file.write(json.dumps(contents))
 
-    with in_test_psql_role_override("postgres"):
+    with in_test_psql_role_override(
+        "postgres", using=router.db_for_write(Organization)
+    ), in_test_psql_role_override("postgres", using=router.db_for_write(User)):
         rv = CliRunner().invoke(import_, backup_json_filename)
     assert (
         rv.output

--- a/tests/sentry/tasks/test_groupowner.py
+++ b/tests/sentry/tasks/test_groupowner.py
@@ -4,13 +4,14 @@ from django.utils import timezone
 
 from sentry.models import GroupRelease, Repository
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.silo import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.tasks.groupowner import PREFERRED_GROUP_OWNER_AGE, process_suspect_commits
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import TaskRunner
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils.committers import get_frame_paths, get_serialized_event_file_committers
 
 
@@ -115,7 +116,7 @@ class TestGroupOwners(TestCase):
         )
 
         assert GroupOwner.objects.count() == 2
-        with exempt_from_silo_limits(), outbox_runner():
+        with assume_test_silo_mode(SiloMode.CONTROL), outbox_runner():
             self.user.delete()
         assert GroupOwner.objects.count() == 2
 

--- a/tests/sentry/tasks/test_organization_mapping.py
+++ b/tests/sentry/tasks/test_organization_mapping.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+from django.db import router
 
 from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models.organization import Organization
@@ -12,7 +13,7 @@ from sentry.testutils.factories import Factories
 
 @pytest.fixture(autouse=True)
 def role_override():
-    with in_test_psql_role_override("postgres"):
+    with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMapping)):
         yield
 
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 import pytz
+from django.db import router
 from django.test import override_settings
 from django.utils import timezone
 
@@ -1376,7 +1377,7 @@ class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
         return_value=github_blame_return_value,
     )
     def test_logic_fallback_no_scm(self, mock_get_commit_context):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(Integration)):
             Integration.objects.all().delete()
         integration = Integration.objects.create(provider="bitbucket")
         integration.add_organization(self.organization)

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytz
 from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
+from django.db import router
 from django.db.models import F
 from django.utils import timezone
 from freezegun import freeze_time
@@ -37,7 +38,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
     @with_feature("organizations:weekly-email-refresh")
     @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_integration(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(Project)):
             Project.objects.all().delete()
 
         now = datetime.now().replace(tzinfo=pytz.utc)
@@ -65,7 +66,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
     @with_feature("organizations:weekly-email-refresh")
     @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_message_links_customer_domains(self):
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(Project)):
             Project.objects.all().delete()
 
         now = datetime.now().replace(tzinfo=pytz.utc)
@@ -116,7 +117,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
     def test_member_disabled(self, mock_send_email):
         ctx = OrganizationReportContext(0, 0, self.organization)
 
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMember)):
             OrganizationMember.objects.filter(user_id=self.user.id).update(
                 flags=F("flags").bitor(OrganizationMember.flags["member-limit:restricted"])
             )

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -12,10 +12,11 @@ from sentry.auth.authenticators.totp import TotpInterface
 from sentry.auth.helper import AuthHelperSessionStore
 from sentry.auth.providers.saml2.provider import Attributes, SAML2Provider
 from sentry.models import AuditLogEntry, AuthIdentity, AuthProvider, Organization
+from sentry.silo import SiloMode
 from sentry.testutils import AuthProviderTestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 dummy_provider_config = {
     "idp": {
@@ -207,7 +208,7 @@ class AuthSAML2Test(AuthProviderTestCase):
     def test_auth_setup(self, auth_log):
         # enable require 2FA and enroll user
         TotpInterface().enroll(self.user)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             self.org.update(flags=models.F("flags").bitor(Organization.flags.require_2fa))
         assert self.org.flags.require_2fa.is_set
 

--- a/tests/sentry/web/frontend/test_msteams_extension.py
+++ b/tests/sentry/web/frontend/test_msteams_extension.py
@@ -3,8 +3,9 @@ from unittest.mock import patch
 from django.core.signing import SignatureExpired
 
 from sentry.models import OrganizationMember
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils.signing import sign
 from sentry.web.frontend.msteams_extension_configuration import MsTeamsExtensionConfigurationView
 
@@ -14,7 +15,7 @@ class MsTeamsExtensionConfigurationTest(TestCase):
     def hit_configure(self, params):
         self.login_as(self.user)
         org = self.create_organization()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             OrganizationMember.objects.create(user_id=self.user.id, organization=org, role="admin")
         path = "/extensions/msteams/configure/"
         return self.client.get(path, params)

--- a/tests/sentry/web/frontend/test_user_avatar.py
+++ b/tests/sentry/web/frontend/test_user_avatar.py
@@ -3,8 +3,9 @@ from io import BytesIO
 from django.urls import reverse
 
 from sentry.models import File, UserAvatar
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.web.frontend.generic import FOREVER_CACHE
 
 
@@ -12,7 +13,7 @@ from sentry.web.frontend.generic import FOREVER_CACHE
 class UserAvatarTest(TestCase):
     def test_headers(self):
         user = self.create_user(email="a@example.com")
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             photo = File.objects.create(name="test.png", type="avatar.file")
             photo.putfile(BytesIO(b"test"))
         avatar = UserAvatar.objects.create(user=user, file_id=photo.id)

--- a/tests/sentry/web/frontend/test_vercel_extension_configuration.py
+++ b/tests/sentry/web/frontend/test_vercel_extension_configuration.py
@@ -1,14 +1,16 @@
 from urllib.parse import parse_qs, urlparse
 
 import responses
+from django.db import router
 
 from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.identity.vercel import VercelIdentityProvider
 from sentry.integrations.vercel import VercelClient
 from sentry.models import OrganizationMember
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import with_feature
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test(stable=True)
@@ -69,7 +71,9 @@ class VercelExtensionConfigurationTest(TestCase):
         assert resp.url.endswith("?next=https%3A%2F%2Fexample.com")
 
     def test_logged_in_as_member(self):
-        with in_test_psql_role_override("postgres"), exempt_from_silo_limits():
+        with in_test_psql_role_override(
+            "postgres", using=router.db_for_write(OrganizationMember)
+        ), assume_test_silo_mode(SiloMode.REGION):
             OrganizationMember.objects.filter(user_id=self.user.id, organization=self.org).update(
                 role="member"
             )
@@ -91,7 +95,7 @@ class VercelExtensionConfigurationTest(TestCase):
         self.login_as(self.user)
 
         org = self.create_organization()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             OrganizationMember.objects.create(user_id=self.user.id, organization=org)
 
         resp = self.client.get(self.path, self.params)
@@ -111,7 +115,7 @@ class VercelExtensionConfigurationTest(TestCase):
         self.login_as(self.user)
 
         org = self.create_organization()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             OrganizationMember.objects.create(user_id=self.user.id, organization=org)
         self.params["orgSlug"] = org.slug
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -49,11 +49,12 @@ from sentry.search.events.constants import (
     SEMVER_BUILD_ALIAS,
     SEMVER_PACKAGE_ALIAS,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import Feature, with_feature
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json
@@ -771,7 +772,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert len(response.data) == 0
 
     def test_token_auth(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["event:read"])
         response = self.client.get(
             reverse("sentry-api-0-organization-group-index", args=[self.project.organization.slug]),

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -20,11 +20,12 @@ from sentry.models import (
     UserOption,
 )
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.cases import PerformanceIssueTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.performance_issues.store_transaction import PerfIssueTransactionTestMixin
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
@@ -274,7 +275,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         )
 
         for default_value, project_value, is_subscribed, has_details in combinations:
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 UserOption.objects.clear_local_cache()
 
                 NotificationSetting.objects.update_settings(
@@ -323,7 +324,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
             user_id=user.id, group=group, project=group.project, is_active=True
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             for provider in [ExternalProviders.EMAIL, ExternalProviders.SLACK]:
                 NotificationSetting.objects.update_settings(
                     provider,
@@ -345,7 +346,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         )
 
         for provider in [ExternalProviders.EMAIL, ExternalProviders.SLACK]:
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 NotificationSetting.objects.update_settings(
                     provider,
                     NotificationSettingTypes.WORKFLOW,


### PR DESCRIPTION
@markstory @GabeVillalobos 

This PR attempts to make some necessary changes for the transaction helpers in order to move through some more issues with split db tests.

First off, we need to make sure that all `transaction.*` methods that take a `using=` parameter share out silo aware logic.  I've added patching for `get_connection` and `on_commit` to emulate how the `atomic` works now.

Nextly, and broadly, we need to start explicitly using `using=` in several places we hadn't.  I also try to share the default `using=` logic to several existing transaction helpers so that they play along.

To that point, me and @GabeVillalobos have realized that in split db mode, `exempt_from_silo_mode` is no longer sensible -- we need to force all blocks to explicitly declare the silo mode that are compatible with.  So the logic in the PR for more details.

Lastly, I addressed some subtle bugs in my transaction helpers related to django db 'water marking'.  I've added comments inline that explain that reasoning.

This PR probably will involve a few runs of test fixes to get quite right.