### PR TITLE
ref(sourcemaps): Remove option for enabling artifact bundles upload

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -31,6 +31,7 @@ CHUNK_UPLOAD_ACCEPT = (
     "bcsymbolmaps",  # BCSymbolMaps and associated PLists/UuidMaps
     "il2cpp",  # Il2cpp LineMappingJson files
     "portablepdbs",  # Portable PDB debug file
+    "artifact_bundles",  # Artifact Bundles for JavaScript Source Maps
 )
 
 
@@ -80,13 +81,6 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
             url = absolute_uri(relative_url, endpoint)
 
         accept = CHUNK_UPLOAD_ACCEPT
-        # We keep checking for the early adopter flag, since we don't want existing early adopters to have a time in
-        # which the system rolls back to release bundles, since we want to change the option after deploying.
-        if (
-            options.get("sourcemaps.enable-artifact-bundles") == 1.0
-            or organization.flags.early_adopter
-        ):
-            accept += ("artifact_bundles",)
 
         # We introduced the new missing chunks functionality for artifact bundles and in order to synchronize upload
         # capabilities we need to tell CLI to use the new upload style. This is done since if we have mismatched

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1287,8 +1287,6 @@ register(
 )
 
 register("hybrid_cloud.outbox_rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# Controls whether we allow people to upload artifact bundles instead of release bundles.
-register("sourcemaps.enable-artifact-bundles", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Decides whether an incoming transaction triggers an update of the clustering rule applied to it.
 register("txnames.bump-lifetime-sample-rate", default=0.1, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Decides whether an incoming span triggers an update of the clustering rule applied to it.

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from sentry import options
 from sentry.api.endpoints.chunk import (
     API_PREFIX,
+    CHUNK_UPLOAD_ACCEPT,
     HASH_ALGORITHM,
     MAX_CHUNKS_PER_REQUEST,
     MAX_CONCURRENCY,
@@ -44,6 +45,7 @@ class ChunkUploadTest(APITestCase):
         assert response.data["concurrency"] == MAX_CONCURRENCY
         assert response.data["hashAlgorithm"] == HASH_ALGORITHM
         assert response.data["url"] == options.get("system.url-prefix") + self.url
+        assert response.data["accept"] == CHUNK_UPLOAD_ACCEPT
 
         options.set("system.upload-url-prefix", "test")
         response = self.client.get(
@@ -51,26 +53,6 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.data["url"] == options.get("system.upload-url-prefix") + self.url
-
-    def test_accept_with_artifact_bundles_option(self):
-        with self.options({"sourcemaps.enable-artifact-bundles": 0.0}):
-            response = self.client.get(
-                self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="json"
-            )
-            assert "artifact_bundles" not in response.data["accept"]
-
-        with self.options({"sourcemaps.enable-artifact-bundles": 1.0}):
-            response = self.client.get(
-                self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="json"
-            )
-            assert "artifact_bundles" in response.data["accept"]
-
-        with self.options({"sourcemaps.enable-artifact-bundles": 0.0}):
-            self.organization.update(flags=F("flags").bitor(Organization.flags.early_adopter))
-            response = self.client.get(
-                self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="json"
-            )
-            assert "artifact_bundles" in response.data["accept"]
 
     def test_accept_with_artifact_bundles_v2_option(self):
         with self.options({"sourcemaps.artifact_bundles.assemble_with_missing_chunks": False}):


### PR DESCRIPTION
This PR removes the option `sourcemaps.enable-artifact-bundles` that was controlling whether Sentry was supporting artifact bundles or not.