### PR TITLE
feat(alerts): add warnings for on-demand metric alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -620,5 +620,5 @@ const StyledPanelBody = styled(PanelBody)`
 const TriggerChartPlaceholder = styled(Placeholder)`
   height: 200px;
   text-align: center;
-  padding: 20px;
+  padding: ${space(3)};
 `;

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -504,7 +504,9 @@ class MetricChart extends PureComponent<Props, State> {
 
     if (isOnDemandMetricAlert(rule.query)) {
       return this.renderEmpty(
-        t('Alert rule contains a field for which we have no data available.')
+        t(
+          'Alert rule contains a field for which we have no previous data. We started collecting this metric when the alert was created and will be able to display it soon.'
+        )
       );
     }
 

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -54,6 +54,7 @@ import {
   MetricRule,
   TimePeriod,
 } from 'sentry/views/alerts/rules/metric/types';
+import {isOnDemandMetricAlert} from 'sentry/views/alerts/rules/metric/utils/onDemandMetricAlert';
 import {getChangeStatus} from 'sentry/views/alerts/utils/getChangeStatus';
 import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
@@ -453,11 +454,11 @@ class MetricChart extends PureComponent<Props, State> {
     );
   }
 
-  renderEmpty() {
+  renderEmpty(placeholderText = '') {
     return (
       <ChartPanel>
         <PanelBody withPadding>
-          <Placeholder height="200px" />
+          <Placeholder height="200px">{placeholderText}</Placeholder>
         </PanelBody>
       </ChartPanel>
     );
@@ -500,6 +501,12 @@ class MetricChart extends PureComponent<Props, State> {
       dataset,
       newAlertOrQuery: false,
     });
+
+    if (isOnDemandMetricAlert(rule.query)) {
+      return this.renderEmpty(
+        t('Alert rule contains a field for which we have no data available.')
+      );
+    }
 
     return isCrashFreeAlert(dataset) ? (
       <SessionsRequest

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -458,7 +458,7 @@ class MetricChart extends PureComponent<Props, State> {
     return (
       <ChartPanel>
         <PanelBody withPadding>
-          <Placeholder height="200px">{placeholderText}</Placeholder>
+          <TriggerChartPlaceholder>{placeholderText}</TriggerChartPlaceholder>
         </PanelBody>
       </ChartPanel>
     );
@@ -615,4 +615,10 @@ const ValueItem = styled('div')`
 /* Override padding to make chart appear centered */
 const StyledPanelBody = styled(PanelBody)`
   padding-right: 6px;
+`;
+
+const TriggerChartPlaceholder = styled(Placeholder)`
+  height: 200px;
+  text-align: center;
+  padding: 20px;
 `;

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -845,6 +845,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const wizardBuilderChart = (
       <TriggersChart
         {...chartProps}
+        isOnDemandMetricAlert={isOnDemandMetricAlert(query)}
         header={
           <ChartHeader>
             <AlertName>{AlertWizardAlertNames[alertType]}</AlertName>

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -292,14 +292,14 @@ class TriggersChart extends PureComponent<Props, State> {
         <TransparentLoadingMask visible={isReloading} />
         {isLoading && !error ? (
           <ChartPlaceholder />
+        ) : isOnDemandMetricAlert ? (
+          <WarningChart />
         ) : error ? (
           <ErrorChart
             isAllowIndexed={orgFeatures.includes('alert-allow-indexed')}
             errorMessage={errorMessage}
             isQueryValid={isQueryValid}
           />
-        ) : isOnDemandMetricAlert ? (
-          <WarningChart />
         ) : (
           <ThresholdsChart
             period={statsPeriod}
@@ -485,7 +485,9 @@ const ChartPlaceholder = styled(Placeholder)`
 `;
 
 const StyledErrorPanel = styled(ErrorPanel)`
+  /* Height and margin should with the alert should match up placeholer height of (184px) */
   padding: ${space(2)};
+  height: 119px;
 `;
 
 const ChartErrorWrapper = styled('div')`


### PR DESCRIPTION
Closes [Hide alert graph with notice when extended query is used](https://github.com/getsentry/sentry/issues/52095)
