### PR TITLE
ref: fix test pollution caused by leaked cache

### DIFF
--- a/tests/sentry/utils/test_assets.py
+++ b/tests/sentry/utils/test_assets.py
@@ -15,6 +15,7 @@ def reset_cache() -> Generator[None, None, None]:
     # https://github.com/python/mypy/issues/5107
     assets._frontend_versions.cache_clear()  # type: ignore[attr-defined]
     yield
+    assets._frontend_versions.cache_clear()  # type: ignore[attr-defined]
 
 
 @pytest.fixture


### PR DESCRIPTION
fixes this error in several other tests:

```
Traceback (most recent call last):
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/home/runner/work/sentry/sentry/src/sentry/web/frontend/base.py", line 338, in dispatch
    return self.handle(request, *args, **kwargs)
  File "/home/runner/work/sentry/sentry/src/sentry/web/frontend/base.py", line 356, in handle
    return super().dispatch(request, *args, **kwargs)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/views/generic/base.py", line 97, in dispatch
    return handler(request, *args, **kwargs)
  File "/home/runner/work/sentry/sentry/src/sentry/web/frontend/auth_logout.py", line 21, in get
    return self.respond("sentry/logout.html")
  File "/home/runner/work/sentry/sentry/src/sentry/web/frontend/base.py", line 405, in respond
    return render_to_response(template, default_context, self.request, status=status)
  File "/home/runner/work/sentry/sentry/src/sentry/web/helpers.py", line 40, in render_to_response
    response = HttpResponse(render_to_string(template, context, request))
  File "/home/runner/work/sentry/sentry/src/sentry/web/helpers.py", line 27, in render_to_string
    rendered = loader.render_to_string(template, context=context, request=request)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/loader.py", line 62, in render_to_string
    return template.render(context, request)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/backends/django.py", line 61, in render
    return self.template.render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/base.py", line 171, in render
    return self._render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/test/utils.py", line 96, in instrumented_test_render
    return self.nodelist.render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/base.py", line 937, in render
    bit = node.render_annotated(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/base.py", line 904, in render_annotated
    return self.render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/loader_tags.py", line 150, in render
    return compiled_parent._render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/test/utils.py", line 96, in instrumented_test_render
    return self.nodelist.render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/base.py", line 937, in render
    bit = node.render_annotated(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/base.py", line 904, in render_annotated
    return self.render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/loader_tags.py", line 150, in render
    return compiled_parent._render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/test/utils.py", line 96, in instrumented_test_render
    return self.nodelist.render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/base.py", line 937, in render
    bit = node.render_annotated(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/base.py", line 904, in render_annotated
    return self.render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/loader_tags.py", line 150, in render
    return compiled_parent._render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/test/utils.py", line 96, in instrumented_test_render
    return self.nodelist.render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/base.py", line 937, in render
    bit = node.render_annotated(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/base.py", line 904, in render_annotated
    return self.render(context)
  File "/home/runner/work/sentry/sentry/.venv/lib/python3.8/site-packages/django/template/library.py", line 192, in render
    output = self.func(*resolved_args, **resolved_kwargs)
  File "/home/runner/work/sentry/sentry/src/sentry/utils/assets.py", line 39, in get_frontend_app_asset_url
    key = versions[key]
KeyError: 'sentry.css'
```




<!-- Describe your PR here. -->