### PR TITLE
feat(functions): Tune function trends default threshold

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -66,7 +66,7 @@ class FunctionTrendsSerializer(serializers.Serializer):
     function = serializers.CharField(max_length=10)
     trend = TrendTypeField()
     query = serializers.CharField(required=False)
-    threshold = serializers.IntegerField(min_value=0, max_value=1000, required=False)
+    threshold = serializers.IntegerField(min_value=0, max_value=1000, default=16, required=False)
 
 
 @region_silo_endpoint
@@ -115,8 +115,6 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
                 use_aggregate_conditions=True,
                 transform_alias_to_input_format=True,
             )
-
-            set_measurement("profiling.top_functions", len(top_functions.get("data", [])))
 
             results = functions.top_events_timeseries(
                 timeseries_columns=columns,
@@ -172,6 +170,9 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
 
         trending_functions = get_trends_data(stats_data)
 
+        all_trending_functions_count = len(trending_functions)
+        set_measurement("profiling.top_functions", all_trending_functions_count)
+
         # Profiling functions have a resolution of ~10ms. To increase the confidence
         # of the results, the caller can specify a min threshold for the trend difference.
         threshold = data.get("threshold")
@@ -181,6 +182,11 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
                 for data in trending_functions
                 if abs(data["trend_difference"]) >= threshold * 1e6
             ]
+
+        filtered_trending_functions_count = all_trending_functions_count - len(trending_functions)
+        set_measurement(
+            "profiling.top_functions.below_threshold", filtered_trending_functions_count
+        )
 
         # Make sure to sort the results so that it's in order of largest change
         # to smallest change (ASC/DESC depends on the trend type)


### PR DESCRIPTION
The original threshold of 20ms was too high. After some experimenting, lowering it to 16ms seems like reasonable middleground between surfacing noisy results and hiding true regressions.