### PR TITLE
ref: Make eventstore.processing use LazyServiceWrapper, second attempt

### DIFF
--- a/src/sentry/eventstore/processing/__init__.py
+++ b/src/sentry/eventstore/processing/__init__.py
@@ -1,9 +1,12 @@
 from django.conf import settings
 
-from sentry.utils.imports import import_string
+from sentry.eventstore.processing.base import EventProcessingStore
+from sentry.utils.services import LazyServiceWrapper
 
-event_processing_store = import_string(settings.SENTRY_EVENT_PROCESSING_STORE)(
-    **settings.SENTRY_EVENT_PROCESSING_STORE_OPTIONS
+event_processing_store = LazyServiceWrapper(
+    EventProcessingStore,
+    settings.SENTRY_EVENT_PROCESSING_STORE,
+    settings.SENTRY_EVENT_PROCESSING_STORE_OPTIONS,
 )
 
 

--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -5,6 +5,7 @@ import sentry_sdk
 
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.kvstore.abstract import KVStorage
+from sentry.utils.services import Service
 
 DEFAULT_TIMEOUT = 60 * 60 * 24
 
@@ -12,7 +13,7 @@ DEFAULT_TIMEOUT = 60 * 60 * 24
 Event = Any
 
 
-class EventProcessingStore:
+class EventProcessingStore(Service):
     """
     Store for event blobs during processing
 

--- a/src/sentry/eventstore/processing/bigtable.py
+++ b/src/sentry/eventstore/processing/bigtable.py
@@ -5,16 +5,18 @@ from sentry.utils.kvstore.encoding import KVStorageCodecWrapper
 from .base import EventProcessingStore
 
 
-def BigtableEventProcessingStore(**options) -> EventProcessingStore:
+class BigtableEventProcessingStore(EventProcessingStore):
     """
     Creates an instance of the processing store which uses Bigtable as its
     backend.
 
     Keyword argument are forwarded to the ``BigtableKVStorage`` constructor.
     """
-    return EventProcessingStore(
-        KVStorageCodecWrapper(
-            BigtableKVStorage(**options),
-            JSONCodec() | BytesCodec(),  # maintains functional parity with cache backend
+
+    def __init__(self, **options):
+        super().__init__(
+            KVStorageCodecWrapper(
+                BigtableKVStorage(**options),
+                JSONCodec() | BytesCodec(),  # maintains functional parity with cache backend
+            )
         )
-    )

--- a/src/sentry/eventstore/processing/redis.py
+++ b/src/sentry/eventstore/processing/redis.py
@@ -6,13 +6,15 @@ from sentry.utils.redis import redis_clusters
 from .base import EventProcessingStore
 
 
-def RedisClusterEventProcessingStore(**options) -> EventProcessingStore:
+class RedisClusterEventProcessingStore(EventProcessingStore):
     """
     Creates an instance of the processing store which uses a Redis Cluster
     client as its backend.
     """
-    return EventProcessingStore(
-        KVStorageCodecWrapper(
-            RedisKVStorage(redis_clusters.get(options.pop("cluster", "default"))), JSONCodec()
+
+    def __init__(self, **options):
+        super().__init__(
+            KVStorageCodecWrapper(
+                RedisKVStorage(redis_clusters.get(options.pop("cluster", "default"))), JSONCodec()
+            )
         )
-    )


### PR DESCRIPTION
This reverts commit 81dcc62d1b6cb65555049103bbd555bbfebd03ff.

prev: https://github.com/getsentry/sentry/pull/51870

we got rid of the custom eventstore in getsentry in https://github.com/getsentry/getsentry/pull/11021 -- so this should work now
