### PR TITLE
fix(alerts): on-demand metric alert creation 

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -72,6 +72,12 @@ class MetricsQueryBuilder(QueryBuilder):
         # always true if this is being called
         kwargs["has_metrics"] = True
         assert dataset is None or dataset in [Dataset.PerformanceMetrics, Dataset.Metrics]
+        self.dataset = dataset
+
+        self._on_demand_spec = self._resolve_on_demand_spec(
+            kwargs.get("selected_columns", []), kwargs.get("query", "")
+        )
+
         if granularity is not None:
             self._granularity = granularity
         super().__init__(
@@ -87,10 +93,6 @@ class MetricsQueryBuilder(QueryBuilder):
         if org_id is None or not isinstance(org_id, int):
             raise InvalidSearchQuery("Organization id required to create a metrics query")
         self.organization_id: int = org_id
-
-        self._on_demand_spec = self._resolve_on_demand_spec(
-            kwargs.get("selected_columns", []), kwargs.get("query", "")
-        )
 
     def _resolve_on_demand_spec(
         self, selected_cols: List[Optional[str]], query: str
@@ -190,7 +192,7 @@ class MetricsQueryBuilder(QueryBuilder):
             tag_match = constants.TAG_KEY_RE.search(col)
             col = tag_match.group("tag") if tag_match else col
 
-        if self.use_metrics_layer:
+        if self.use_metrics_layer or self._on_demand_spec:
             if col in ["project_id", "timestamp"]:
                 return col
             # TODO: update resolve params so this isn't needed
@@ -684,7 +686,7 @@ class MetricsQueryBuilder(QueryBuilder):
                 raise IncompatibleMetricsQuery("Can't orderby tags")
 
     def run_query(self, referrer: str, use_cache: bool = False) -> Any:
-        if self.use_metrics_layer:
+        if self.use_metrics_layer or self._on_demand_spec:
             from sentry.snuba.metrics.datasource import get_series
             from sentry.snuba.metrics.mqb_query_transformer import (
                 transform_mqb_query_to_metrics_query,


### PR DESCRIPTION
Makes on-demand metric extraction independent of `organizations:use-metrics-layer` feature flag.