### PR TITLE
ref(hc): Mark GetParticipantsTest stable

### DIFF
--- a/src/sentry/integrations/msteams/analytics.py
+++ b/src/sentry/integrations/msteams/analytics.py
@@ -8,7 +8,7 @@ class MSTeamsIntegrationNotificationSent(analytics.Event):
         analytics.Attribute("organization_id"),
         analytics.Attribute("project_id", required=False),
         analytics.Attribute("category"),
-        analytics.Attribute("actor_id"),
+        analytics.Attribute("actor_id", required=False),
         analytics.Attribute("user_id", required=False),
     )
 

--- a/src/sentry/integrations/slack/analytics.py
+++ b/src/sentry/integrations/slack/analytics.py
@@ -26,7 +26,7 @@ class SlackIntegrationNotificationSent(analytics.Event):
         analytics.Attribute("organization_id"),
         analytics.Attribute("project_id", required=False),
         analytics.Attribute("category"),
-        analytics.Attribute("actor_id"),
+        analytics.Attribute("actor_id", required=False),
         analytics.Attribute("user_id", required=False),
         analytics.Attribute("group_id", required=False),
     )

--- a/src/sentry/notifications/notifications/organization_request/base.py
+++ b/src/sentry/notifications/notifications/organization_request/base.py
@@ -36,7 +36,10 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
         return {}
 
     def determine_recipients(self) -> Iterable[RpcActor]:
-        return RpcActor.many_from_object(self.role_based_recipient_strategy.determine_recipients())
+        return [
+            RpcActor(id=member.user_id, actor_type=ActorType.USER)
+            for member in self.role_based_recipient_strategy.determine_member_recipients()
+        ]
 
     def get_notification_title(
         self, provider: ExternalProviders, context: Mapping[str, Any] | None = None
@@ -67,6 +70,6 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
 
         return {
             **super().get_log_params(recipient),
-            "user_id": self.requester.id,
+            "source_user_id": self.requester.id,
             "target_user_id": recipient.id,
         }

--- a/tests/sentry/notifications/notifications/test_organization_request.py
+++ b/tests/sentry/notifications/notifications/test_organization_request.py
@@ -1,4 +1,4 @@
-from sentry.models import NotificationSetting, OrganizationMember
+from sentry.models import NotificationSetting, OrganizationMemberMapping
 from sentry.notifications.notifications.organization_request import OrganizationRequestNotification
 from sentry.notifications.notifications.strategies.role_based_recipient_strategy import (
     RoleBasedRecipientStrategy,
@@ -12,7 +12,7 @@ from sentry.types.integrations import ExternalProviders
 
 class DummyRoleBasedRecipientStrategy(RoleBasedRecipientStrategy):
     def determine_member_recipients(self):
-        return OrganizationMember.objects.filter(organization=self.organization)
+        return OrganizationMemberMapping.objects.filter(organization_id=self.organization.id)
 
 
 class DummyRequestNotification(OrganizationRequestNotification):
@@ -21,7 +21,7 @@ class DummyRequestNotification(OrganizationRequestNotification):
     RoleBasedRecipientStrategyClass = DummyRoleBasedRecipientStrategy
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class GetParticipantsTest(TestCase):
     def setUp(self):
         self.user2 = self.create_user()


### PR DESCRIPTION
This reworks `OrganizationRequestNotification.determine_recipients` to remove the cross-silo call by directly creating RpcActors. Because these actors will no longer have an `actor_id`, the analytics events are also updated to no longer require `actor_id`.

Finally, since `actor_id` is no longer present on those events, this change also updates `OrganizationRequestNotification.get_log_params` to no longer override the `user_id` set in `BaseNotification`. This will both make the behavior more consistent with all other notifications (where `user_id` is the recipient) and should also ensure it's always set (since some requests are from `AnonymousUser`s).