### PR TITLE
Get "Starfish" out of the UI

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -233,8 +233,8 @@ function Sidebar({location, organization}: Props) {
       <SidebarAccordion
         {...sidebarItemProps}
         icon={<IconStar />}
-        aria-label={t('Starfish')}
-        label={<GuideAnchor target="starfish">{t('Starfish')}</GuideAnchor>}
+        aria-label={t('New Performance')}
+        label={<GuideAnchor target="starfish">{t('New Performance')}</GuideAnchor>}
         to={`/organizations/${organization.slug}/starfish/`}
         id="starfish"
         exact

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -233,10 +233,11 @@ function Sidebar({location, organization}: Props) {
       <SidebarAccordion
         {...sidebarItemProps}
         icon={<IconStar />}
-        aria-label={t('New Performance')}
-        label={<GuideAnchor target="starfish">{t('New Performance')}</GuideAnchor>}
+        aria-label={t('Performance')}
+        label={<GuideAnchor target="starfish">{t('Performance')}</GuideAnchor>}
         to={`/organizations/${organization.slug}/starfish/`}
         id="starfish"
+        isAlpha
         exact
       >
         <SidebarItem


### PR DESCRIPTION
"Starfish" is an internal name. We're talking on All Hands about showing this to customers as soon as next month. Customers should never hear the word "Starfish." Turns out we've used `starfish` throughout the codebase while building this out. IMO that's quite questionable, but at the very least we should take the word "Starfish" out of our UI ASAP. Let's take a customer-centric view of our product!

<img width="209" alt="old" src="https://github.com/getsentry/sentry/assets/134455/f037a154-0fa5-49fb-9917-177e880eb725">

<img width="215" alt="new" src="https://github.com/getsentry/sentry/assets/134455/9f4be9c0-e855-4ef3-b209-46bdf6217157">

Not sure what's up with the padding (it matters).