### PR TITLE
fix(mute-metric-alerts): Add query params to incident redirect

### DIFF
--- a/static/app/views/alerts/incidentRedirect.tsx
+++ b/static/app/views/alerts/incidentRedirect.tsx
@@ -6,6 +6,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 import {fetchIncident} from './utils/apiCalls';
@@ -20,6 +21,7 @@ type Props = {
  */
 function IncidentRedirect({organization, params}: Props) {
   const api = useApi();
+  const location = useLocation();
   const [hasError, setHasError] = useState(false);
 
   const track = useCallback(() => {
@@ -37,13 +39,13 @@ function IncidentRedirect({organization, params}: Props) {
       browserHistory.replace(
         normalizeUrl({
           pathname: alertDetailsLink(organization, incident),
-          query: {alert: incident.identifier},
+          query: {...location.query, alert: incident.identifier},
         })
       );
     } catch (err) {
       setHasError(true);
     }
-  }, [setHasError, api, params.alertId, organization]);
+  }, [setHasError, api, params.alertId, organization, location.query]);
 
   useEffect(() => {
     fetchData();


### PR DESCRIPTION
this pr changes the incident redirect url to include any existing query parameters, which in the past were getting erased as we redirected to the metric alert rule. 