### PR TITLE
fix(mute-metric-alerts): Use incident link in metric alert emails for muting

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -266,26 +266,14 @@ def generate_incident_trigger_email_context(
         query="referrer=alert_email",
     )
 
-    rule_link = organization.absolute_url(
-        reverse(
-            "sentry-metric-alert-details",
-            kwargs={
-                "organization_slug": organization.slug,
-                "alert_rule_id": incident.alert_rule.id,
-            },
-        ),
-        query="referrer=alert_email",
-    )
-
     snooze_alert = False
     snooze_alert_url = None
     if features.has("organizations:mute-metric-alerts", organization):
         snooze_alert = True
-        snooze_alert_url = rule_link + "&" + urlencode({"mute": "1"})
+        snooze_alert_url = alert_link + "&" + urlencode({"mute": "1"})
 
     return {
         "link": alert_link,
-        "rule_link": rule_link,
         "project_slug": project.slug,
         "incident_name": incident.title,
         "environment": environment_string,

--- a/src/sentry/templates/sentry/emails/incidents/trigger.html
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.html
@@ -77,7 +77,7 @@
            <a class='mute' href="{{ snooze_alert_url }}">Mute this alert</a>
         {% endif %}
         This email was triggered by
-            <a href="{{ rule_link }}">{{ incident_name }}</a>
+            <a href="{{ link }}">{{ incident_name }}</a>
     </p>
     </div>
   {% endif %}

--- a/src/sentry/templates/sentry/emails/incidents/trigger.txt
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.txt
@@ -8,7 +8,6 @@ controls are enabled. For more details about this alert alert, view on Sentry:
 {{ incident_link }}.
 {% else %}
 Alert: {{ link }}
-Rule: {{ rule_link }}
 Status: {{ status }}
 Project: {{ project_slug }}
 

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -223,17 +223,15 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
         incident = self.create_incident()
         action = self.create_alert_rule_trigger_action(triggered_for_incident=incident)
         aggregate = action.alert_rule_trigger.alert_rule.snuba_query.aggregate
-        alert_link = (
-            self.organization.absolute_url(
-                reverse(
-                    "sentry-metric-alert",
-                    kwargs={
-                        "organization_slug": incident.organization.slug,
-                        "incident_id": incident.identifier,
-                    },
-                ),
-                query="referrer=alert_email",
+        alert_link = self.organization.absolute_url(
+            reverse(
+                "sentry-metric-alert",
+                kwargs={
+                    "organization_slug": incident.organization.slug,
+                    "incident_id": incident.identifier,
+                },
             ),
+            query="referrer=alert_email",
         )
         expected = {
             "link": alert_link,

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -223,18 +223,8 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
         incident = self.create_incident()
         action = self.create_alert_rule_trigger_action(triggered_for_incident=incident)
         aggregate = action.alert_rule_trigger.alert_rule.snuba_query.aggregate
-        rule_link = self.organization.absolute_url(
-            reverse(
-                "sentry-metric-alert-details",
-                kwargs={
-                    "organization_slug": self.organization.slug,
-                    "alert_rule_id": incident.alert_rule.id,
-                },
-            ),
-            query="referrer=alert_email",
-        )
-        expected = {
-            "link": self.organization.absolute_url(
+        alert_link = (
+            self.organization.absolute_url(
                 reverse(
                     "sentry-metric-alert",
                     kwargs={
@@ -244,7 +234,9 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
                 ),
                 query="referrer=alert_email",
             ),
-            "rule_link": rule_link,
+        )
+        expected = {
+            "link": alert_link,
             "incident_name": incident.title,
             "aggregate": aggregate,
             "query": action.alert_rule_trigger.alert_rule.snuba_query.query,
@@ -262,7 +254,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             "chart_url": None,
             "timezone": settings.SENTRY_DEFAULT_TIME_ZONE,
             "snooze_alert": True,
-            "snooze_alert_url": rule_link + "&mute=1",
+            "snooze_alert_url": alert_link + "&mute=1",
         }
         assert expected == generate_incident_trigger_email_context(
             self.project,


### PR DESCRIPTION
this pr changes the mute link in metric alert emails to use the incident link. With https://github.com/getsentry/sentry/pull/52362, we can pass the mute query parameter for the incident redirect link. the prior  was of trying to bypass the incident redirect had the potential to show a missing alert rule if the alert rule had been edited. 