### PR TITLE
fix(starfish): use transaction method filter in span metrics and sample requests

### DIFF
--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -50,7 +50,7 @@ export const useSpanSamples = (options: Options) => {
 
   const {isLoading: isLoadingSeries, data: spanMetricsSeriesData} = useSpanMetricsSeries(
     groupId ? {group: groupId} : undefined,
-    {transactionName},
+    {transactionName, 'transaction.method': transactionMethod},
     [`p95(${SPAN_SELF_TIME})`],
     'sidebar-span-metrics'
   );

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -57,7 +57,9 @@ function SpanSummaryPage({params, location}: Props) {
   const {groupId} = params;
   const {transaction, transactionMethod, endpoint, endpointMethod} = location.query;
 
-  const queryFilter = endpoint ? {transactionName: endpoint} : undefined;
+  const queryFilter = endpoint
+    ? {transactionName: endpoint, 'transaction.method': transactionMethod}
+    : undefined;
   const sort =
     fromSorts(location.query[QueryParameterNames.SORT]).filter(isAValidSort)[0] ??
     DEFAULT_SORT; // We only allow one sort on this table in this view


### PR DESCRIPTION
update remaining queries to use transaction method filter in span metrics and sample requests