### PR TITLE
fix(scim): prevent last owner from being demoted

### DIFF
--- a/src/sentry/receivers/__init__.py
+++ b/src/sentry/receivers/__init__.py
@@ -7,6 +7,7 @@ from .features import *  # noqa: F401,F403
 from .onboarding import *  # noqa: F401,F403
 from .outbox.control import *  # noqa: F401,F403
 from .outbox.region import *  # noqa: F401,F403
+from .owners import *  # noqa: F401,F403
 from .releases import *  # noqa: F401,F403
 from .reprocessing import *  # noqa: F401,F403
 from .rules import *  # noqa: F401,F403

--- a/src/sentry/receivers/owners.py
+++ b/src/sentry/receivers/owners.py
@@ -1,0 +1,58 @@
+from django.db.models.signals import pre_delete, pre_save
+
+from sentry.models.organization import Organization
+from sentry.models.organizationmember import OrganizationMember
+from sentry.models.team import Team
+from sentry.roles import organization_roles
+
+
+def prevent_demoting_last_owner(instance: OrganizationMember, **kwargs):
+    # if a member is being created
+    if instance.id is None:
+        return
+
+    member = OrganizationMember.objects.get(id=instance.id)
+    # member is the last owner and the update will remove the last owner
+    assert not (
+        member.is_only_owner()
+        and organization_roles.get_top_dog().id not in instance.get_all_org_roles()
+    ), "An organization must have at least one owner"
+
+
+def prevent_removing_last_owner_team(instance: Team, **kwargs):
+    # if a team is being created
+    if instance.id is None:
+        return
+
+    team = Team.objects.get(id=instance.id)
+    organization = Organization.objects.get_from_cache(id=team.organization_id)
+    top_role = organization_roles.get_top_dog().id
+
+    all_owner_teams = organization.get_teams_with_org_roles(roles=[top_role])
+
+    # demoting last owner team
+    if len(all_owner_teams) == 1 and team.org_role == top_role and instance.org_role != top_role:
+        # organization must have at least one owner who does not have their role from a team
+        assert team.member_set.filter(
+            role=top_role
+        ).exists(), "An organization must have at least one owner"
+
+
+pre_save.connect(
+    prevent_demoting_last_owner,
+    sender=OrganizationMember,
+    dispatch_uid="prevent_demoting_last_owner",
+    weak=False,
+)
+pre_save.connect(
+    prevent_removing_last_owner_team,
+    sender=Team,
+    dispatch_uid="prevent_demoting_last_owner_team",
+    weak=False,
+)
+pre_delete.connect(
+    prevent_removing_last_owner_team,
+    sender=Team,
+    dispatch_uid="prevent_deleting_last_owner_team",
+    weak=False,
+)

--- a/src/sentry/receivers/owners.py
+++ b/src/sentry/receivers/owners.py
@@ -11,7 +11,11 @@ def prevent_demoting_last_owner(instance: OrganizationMember, **kwargs):
     if instance.id is None:
         return
 
-    member = OrganizationMember.objects.get(id=instance.id)
+    try:
+        member = OrganizationMember.objects.get(id=instance.id)
+    except OrganizationMember.DoesNotExist:
+        return
+
     # member is the last owner and the update will remove the last owner
     assert not (
         member.is_only_owner()
@@ -24,7 +28,11 @@ def prevent_removing_last_owner_team(instance: Team, **kwargs):
     if instance.id is None:
         return
 
-    team = Team.objects.get(id=instance.id)
+    try:
+        team = Team.objects.get(id=instance.id)
+    except Team.DoesNotExist:
+        return
+
     organization = Organization.objects.get_from_cache(id=team.organization_id)
     top_role = organization_roles.get_top_dog().id
 

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -403,6 +403,9 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
 
     def test_members_cant_update(self):
         with assume_test_silo_mode(SiloMode.REGION):
+            # create extra owner because we are demoting one
+            self.create_member(organization=self.org, user=self.create_user(), role="owner")
+
             member_om = OrganizationMember.objects.get(user_id=self.user.id, organization=self.org)
             member_om.role = "member"
             member_om.save()
@@ -413,6 +416,9 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
 
     def test_create_integration_exceeding_scopes(self):
         with assume_test_silo_mode(SiloMode.REGION):
+            # create extra owner because we are demoting one
+            self.create_member(organization=self.org, user=self.create_user(), role="owner")
+
             member_om = OrganizationMember.objects.get(user_id=self.user.id, organization=self.org)
             member_om.role = "manager"
             member_om.save()

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -585,6 +585,8 @@ class PostSentryAppsTest(SentryAppsTest):
         self.assert_sentry_app_status_code(sentry_app, status_code=400)
 
     def test_members_cant_create(self):
+        # create extra owner because we are demoting one
+        self.create_member(organization=self.organization, user=self.create_user(), role="owner")
         member_om = OrganizationMember.objects.get(
             user_id=self.user.id, organization=self.organization
         )
@@ -594,6 +596,8 @@ class PostSentryAppsTest(SentryAppsTest):
         self.get_error_response(**self.get_data(), status_code=403)
 
     def test_create_integration_exceeding_scopes(self):
+        # create extra owner because we are demoting one
+        self.create_member(organization=self.organization, user=self.create_user(), role="owner")
         member_om = OrganizationMember.objects.get(
             user_id=self.user.id, organization=self.organization
         )

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -512,3 +512,12 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
         assert roles[0][1].id == "owner"
         assert roles[-1][0] == manager_team.slug
         assert roles[-1][1].id == "manager"
+
+    def test_cannot_demote_last_owner(self):
+        org = self.create_organization()
+
+        with pytest.raises(AssertionError):
+            member = self.create_member(organization=org, role="owner", user=self.create_user())
+
+            member.role = "manager"
+            member.save()

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -5,6 +5,7 @@ import pytest
 from django.core import mail
 from django.db import router
 from django.utils import timezone
+from rest_framework.serializers import ValidationError
 
 from sentry import roles
 from sentry.auth import manager
@@ -516,7 +517,7 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
     def test_cannot_demote_last_owner(self):
         org = self.create_organization()
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValidationError):
             member = self.create_member(organization=org, role="owner", user=self.create_user())
 
             member.role = "manager"

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -76,7 +76,7 @@ class TeamTest(TestCase):
         org = self.create_organization()
 
         with pytest.raises(AssertionError):
-            team = self.create_team(self.organization, org_role="owner")
+            team = self.create_team(org, org_role="owner")
             self.create_member(
                 organization=org, role="member", user=self.create_user(), teams=[team]
             )
@@ -217,7 +217,7 @@ class TeamDeletionTest(TestCase):
         org = self.create_organization()
 
         with pytest.raises(AssertionError):
-            team = self.create_team(self.organization, org_role="owner")
+            team = self.create_team(org, org_role="owner")
             self.create_member(
                 organization=org, role="member", user=self.create_user(), teams=[team]
             )

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -1,4 +1,6 @@
+import pytest
 from django.test import override_settings
+from rest_framework.serializers import ValidationError
 
 from sentry.models import (
     OrganizationMember,
@@ -75,7 +77,7 @@ class TeamTest(TestCase):
     def test_cannot_demote_last_owner_team(self):
         org = self.create_organization()
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValidationError):
             team = self.create_team(org, org_role="owner")
             self.create_member(
                 organization=org, role="member", user=self.create_user(), teams=[team]
@@ -216,7 +218,7 @@ class TeamDeletionTest(TestCase):
     def test_cannot_delete_last_owner_team(self):
         org = self.create_organization()
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValidationError):
             team = self.create_team(org, org_role="owner")
             self.create_member(
                 organization=org, role="member", user=self.create_user(), teams=[team]

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -72,6 +72,17 @@ class TeamTest(TestCase):
         assert team.id < 1_000_000_000
         assert Team.objects.filter(id=team.id).exists()
 
+    def test_cannot_demote_last_owner_team(self):
+        org = self.create_organization()
+
+        with pytest.raises(AssertionError):
+            team = self.create_team(self.organization, org_role="owner")
+            self.create_member(
+                organization=org, role="member", user=self.create_user(), teams=[team]
+            )
+            team.org_role = "manager"
+            team.save()
+
 
 class TransferTest(TestCase):
     def test_simple(self):
@@ -201,3 +212,13 @@ class TeamDeletionTest(TestCase):
             type=NotificationSettingTypes.ISSUE_ALERTS,
             team_id=team_id,
         ).exists()
+
+    def test_cannot_delete_last_owner_team(self):
+        org = self.create_organization()
+
+        with pytest.raises(AssertionError):
+            team = self.create_team(self.organization, org_role="owner")
+            self.create_member(
+                organization=org, role="member", user=self.create_user(), teams=[team]
+            )
+            team.delete()


### PR DESCRIPTION
When an `OrganizationMember` object is saved, we need to check if there is still a remaining owner in the org, otherwise the org will become owner-less. Similarly, since `Team` objects can be used to give the `owner` role to org members, if the role for users in a team is modified or a team object is deleted, we need to do the same check.

This will affect any call to `OrganizationMember.save()` and `Team.save()` and `Team.delete()`.