### PR TITLE
fix(starfish): start and end show up in url when set to null

### DIFF
--- a/static/app/views/starfish/components/pageFilterContainer.tsx
+++ b/static/app/views/starfish/components/pageFilterContainer.tsx
@@ -1,3 +1,5 @@
+import {LocationDescriptorObject} from 'history';
+
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -18,14 +20,16 @@ function StarfishPageFilterContainer(props: {children: React.ReactNode}) {
     datetime.period = DEFAULT_STATS_PERIOD;
     datetime.start = null;
     datetime.end = null;
+    const query: LocationDescriptorObject['query'] = {
+      ...location.query,
+      statsPeriod: DEFAULT_STATS_PERIOD,
+    };
+    delete query.start;
+    delete query.end;
+
     router.replace({
       pathname: location.pathname,
-      query: {
-        ...location.query,
-        statsPeriod: DEFAULT_STATS_PERIOD,
-        start: null,
-        end: null,
-      },
+      query,
     });
   }
 


### PR DESCRIPTION
Fixes a bug where start/end query params would be in the url because the date selection is >7days.