### PR TITLE
fix(starfish): Time spent local was always querying light time spent

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -235,6 +235,7 @@ class QueryBuilder(BaseQueryBuilder):
         self.raw_equations = equations
         self.use_metrics_layer = use_metrics_layer
         self.auto_fields = auto_fields
+        self.query = query
         self.functions_acl = set() if functions_acl is None else functions_acl
         self.equation_config = {} if equation_config is None else equation_config
         self.tips: Dict[str, Set[str]] = {

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -236,6 +236,7 @@ class QueryBuilder(BaseQueryBuilder):
         self.use_metrics_layer = use_metrics_layer
         self.auto_fields = auto_fields
         self.query = query
+        self.groupby_columns = groupby_columns
         self.functions_acl = set() if functions_acl is None else functions_acl
         self.equation_config = {} if equation_config is None else equation_config
         self.tips: Dict[str, Set[str]] = {

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -378,6 +378,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
             dataset=self.builder.dataset,
             params={},
             snuba_params=self.builder.params,
+            query=self.builder.query if scope == "local" else None,
             selected_columns=["sum(span.self_time)"],
         )
 

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -379,13 +379,9 @@ class SpansMetricsDatasetConfig(DatasetConfig):
             params={},
             snuba_params=self.builder.params,
             query=self.builder.query if scope == "local" else None,
+            groupby_columns=self.builder.groupby_columns,
             selected_columns=["sum(span.self_time)"],
         )
-
-        total_query.columns += self.builder.resolve_groupby()
-
-        if scope == "local":
-            total_query.where = self.builder.where
 
         total_results = total_query.run_query(
             Referrer.API_DISCOVER_TOTAL_SUM_TRANSACTION_DURATION_FIELD.value

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -379,7 +379,6 @@ class SpansMetricsDatasetConfig(DatasetConfig):
             params={},
             snuba_params=self.builder.params,
             query=self.builder.query if scope == "local" else None,
-            groupby_columns=self.builder.groupby_columns,
             selected_columns=["sum(span.self_time)"],
         )
 


### PR DESCRIPTION
This was because the where condition & groupby was being resolved
after the base query is resolved and the if transaction was in any
of those two things, the fallback to `span.exclusive_time` doesn't
get picked up