### PR TITLE
ref(HC): Patches Django Transaction to have silo aware get_connection and on_commit methods

### DIFF
--- a/src/sentry/silo/patches/silo_aware_transaction_patch.py
+++ b/src/sentry/silo/patches/silo_aware_transaction_patch.py
@@ -36,9 +36,9 @@ def siloed_get_connection(using: Optional[str] = None) -> BaseDatabaseWrapper:
     return _default_get_connection(using=using)
 
 
-def siloed_on_commit(cb: Callable[..., Any], using: Optional[str] = None) -> None:
+def siloed_on_commit(func: Callable[..., Any], using: Optional[str] = None) -> None:
     using = determine_using_by_silo_mode(using)
-    return _default_on_commit(cb, using)
+    return _default_on_commit(func, using)
 
 
 def determine_using_by_silo_mode(using):
@@ -82,5 +82,5 @@ def patch_silo_aware_atomic():
     _default_get_connection = transaction.get_connection
 
     transaction.atomic = siloed_atomic  # type:ignore
-    transaction.on_commit = siloed_on_commit  # type:ignore
-    transaction.get_connection = siloed_get_connection  # type:ignore
+    transaction.on_commit = siloed_on_commit
+    transaction.get_connection = siloed_get_connection

--- a/src/sentry/silo/patches/silo_aware_transaction_patch.py
+++ b/src/sentry/silo/patches/silo_aware_transaction_patch.py
@@ -1,29 +1,35 @@
-from typing import TYPE_CHECKING, Optional, Type
+from typing import Any, Callable, Optional
 
 from django import get_version
 from django.db import router, transaction
+from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.transaction import Atomic
 
-if TYPE_CHECKING:
-    from sentry.db.models import Model
-
 _default_atomic_impl = transaction.atomic
+_default_on_commit = transaction.on_commit
+_default_get_connection = transaction.get_connection
 
 
 class MismatchedSiloTransactionError(Exception):
     pass
 
 
-def _get_db_for_model_if_available(model: Type["Model"]) -> Optional[str]:
-    from sentry.db.router import SiloConnectionUnavailableError
-
-    try:
-        return router.db_for_write(model)
-    except SiloConnectionUnavailableError:
-        return None
-
-
 def siloed_atomic(using: Optional[str] = None, savepoint: bool = True) -> Atomic:
+    using = determine_using_by_silo_mode(using)
+    return _default_atomic_impl(using=using, savepoint=savepoint)
+
+
+def siloed_get_connection(using: Optional[str] = None) -> BaseDatabaseWrapper:
+    using = determine_using_by_silo_mode(using)
+    return _default_get_connection(using=using)
+
+
+def siloed_on_commit(cb: Callable[..., Any], using: Optional[str] = None) -> None:
+    using = determine_using_by_silo_mode(using)
+    return _default_on_commit(cb, using)
+
+
+def determine_using_by_silo_mode(using):
     from sentry.models import ControlOutbox, RegionOutbox
     from sentry.silo import SiloMode
 
@@ -31,27 +37,31 @@ def siloed_atomic(using: Optional[str] = None, savepoint: bool = True) -> Atomic
     if not using:
         model_to_route_to = RegionOutbox if current_silo_mode == SiloMode.REGION else ControlOutbox
         using = router.db_for_write(model_to_route_to)
-
-    control_db = _get_db_for_model_if_available(ControlOutbox)
-    region_db = _get_db_for_model_if_available(RegionOutbox)
-    both_silos_route_to_same_db = control_db == region_db
-
+    both_silos_route_to_same_db = router.db_for_write(ControlOutbox) == router.db_for_write(
+        RegionOutbox
+    )
     if both_silos_route_to_same_db or current_silo_mode == SiloMode.MONOLITH:
         pass
-    elif using == control_db and SiloMode.get_current_mode() != SiloMode.CONTROL:
+    elif (
+        using == router.db_for_write(ControlOutbox)
+        and SiloMode.get_current_mode() != SiloMode.CONTROL
+    ):
         raise MismatchedSiloTransactionError(
             f"Cannot use transaction.atomic({using}) in Control Mode"
         )
-    elif using == region_db and SiloMode.get_current_mode() != SiloMode.REGION:
+
+    elif (
+        using == router.db_for_write(RegionOutbox)
+        and SiloMode.get_current_mode() != SiloMode.REGION
+    ):
         raise MismatchedSiloTransactionError(
             f"Cannot use transaction.atomic({using}) in Region Mode"
         )
-
-    return _default_atomic_impl(using=using, savepoint=savepoint)
+    return using
 
 
 def patch_silo_aware_atomic():
-    global _default_atomic_impl
+    global _default_atomic_impl, _default_on_commit, _default_get_connection
 
     current_django_version = get_version()
     assert current_django_version.startswith("2.2."), (
@@ -60,4 +70,9 @@ def patch_silo_aware_atomic():
     )
 
     _default_atomic_impl = transaction.atomic
+    _default_on_commit = transaction.on_commit
+    _default_get_connection = transaction.get_connection
+
     transaction.atomic = siloed_atomic  # type:ignore
+    transaction.on_commit = siloed_on_commit  # type:ignore
+    transaction.get_connection = siloed_get_connection  # type:ignore

--- a/src/sentry/silo/patches/silo_aware_transaction_patch.py
+++ b/src/sentry/silo/patches/silo_aware_transaction_patch.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional, Type
 
 from django import get_version
 from django.db import router, transaction
@@ -9,9 +9,21 @@ _default_atomic_impl = transaction.atomic
 _default_on_commit = transaction.on_commit
 _default_get_connection = transaction.get_connection
 
+if TYPE_CHECKING:
+    from sentry.db.models import Model
+
 
 class MismatchedSiloTransactionError(Exception):
     pass
+
+
+def _get_db_for_model_if_available(model: Type["Model"]) -> Optional[str]:
+    from sentry.db.router import SiloConnectionUnavailableError
+
+    try:
+        return router.db_for_write(model)
+    except SiloConnectionUnavailableError:
+        return None
 
 
 def siloed_atomic(using: Optional[str] = None, savepoint: bool = True) -> Atomic:
@@ -34,28 +46,24 @@ def determine_using_by_silo_mode(using):
     from sentry.silo import SiloMode
 
     current_silo_mode = SiloMode.get_current_mode()
+    control_db = _get_db_for_model_if_available(ControlOutbox)
+    region_db = _get_db_for_model_if_available(RegionOutbox)
+
     if not using:
-        model_to_route_to = RegionOutbox if current_silo_mode == SiloMode.REGION else ControlOutbox
-        using = router.db_for_write(model_to_route_to)
-    both_silos_route_to_same_db = router.db_for_write(ControlOutbox) == router.db_for_write(
-        RegionOutbox
-    )
+        using = region_db if current_silo_mode == SiloMode.REGION else control_db
+
+    both_silos_route_to_same_db = control_db == region_db
+
     if both_silos_route_to_same_db or current_silo_mode == SiloMode.MONOLITH:
         pass
-    elif (
-        using == router.db_for_write(ControlOutbox)
-        and SiloMode.get_current_mode() != SiloMode.CONTROL
-    ):
+    elif using == control_db and current_silo_mode != SiloMode.CONTROL:
         raise MismatchedSiloTransactionError(
-            f"Cannot use transaction.atomic({using}) in Control Mode"
+            f"Cannot use transaction.atomic({using}) except in Control Mode"
         )
 
-    elif (
-        using == router.db_for_write(RegionOutbox)
-        and SiloMode.get_current_mode() != SiloMode.REGION
-    ):
+    elif using == region_db and current_silo_mode != SiloMode.REGION:
         raise MismatchedSiloTransactionError(
-            f"Cannot use transaction.atomic({using}) in Region Mode"
+            f"Cannot use transaction.atomic({using}) except in Region Mode"
         )
     return using
 


### PR DESCRIPTION
Adds patched silo aware implementations for Django's `transaction.on_commit` and `transaction.get_connection` methods to ensure that any path where we obtain a connection to the DB will be silo-aware.

_Note:_ This has been pulled from a larger parent PR (#52334) that comprehensively tackles multiple different test-related transaction issues.

