### PR TITLE
fix(hc): Fix exception check in remove_non_compliant_members

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -396,11 +396,14 @@ class DatabaseBackedOrganizationService(OrganizationService):
         org.save()
         return serialize_rpc_organization(org)
 
-    def remove_user(self, *, organization_id: int, user_id: int) -> RpcOrganizationMember:
+    def remove_user(self, *, organization_id: int, user_id: int) -> Optional[RpcOrganizationMember]:
         with outbox_context(transaction.atomic()):
-            org_member = OrganizationMember.objects.get(
-                organization_id=organization_id, user_id=user_id
-            )
+            try:
+                org_member = OrganizationMember.objects.get(
+                    organization_id=organization_id, user_id=user_id
+                )
+            except OrganizationMember.DoesNotExist:
+                return None
             org_member.remove_user()
             org_member.save()
         return serialize_member(org_member)

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -404,8 +404,13 @@ class DatabaseBackedOrganizationService(OrganizationService):
                 )
             except OrganizationMember.DoesNotExist:
                 return None
+
             org_member.remove_user()
-            org_member.save()
+            if org_member.email:
+                org_member.save()
+            else:
+                return None
+
         return serialize_member(org_member)
 
     def merge_users(self, *, organization_id: int, from_user_id: int, to_user_id: int) -> None:

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -247,7 +247,7 @@ class OrganizationService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
-    def remove_user(self, *, organization_id: int, user_id: int) -> RpcOrganizationMember:
+    def remove_user(self, *, organization_id: int, user_id: int) -> Optional[RpcOrganizationMember]:
         pass
 
     @regional_rpc_method(resolve=ByRegionName())

--- a/src/sentry/tasks/auth.py
+++ b/src/sentry/tasks/auth.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import abc
 import logging
 
-from django.db import IntegrityError
 from django.db.models import F
 from django.urls import reverse
 
@@ -89,9 +88,10 @@ class OrganizationComplianceTask(abc.ABC):
             user = user_service.get_user(user_id=member.user_id)
             logging_data = {"organization_id": org_id, "user_id": user.id, "member_id": member.id}
 
-            try:
-                organization_service.remove_user(organization_id=org_id, user_id=user.id)
-            except (AssertionError, IntegrityError):
+            removed_member = organization_service.remove_user(
+                organization_id=org_id, user_id=user.id
+            )
+            if removed_member is None:
                 logger.warning(
                     f"Could not remove {self.log_label} noncompliant user from org",
                     extra=logging_data,


### PR DESCRIPTION
Change `OrganizationService.remove_user` to return `None` when it doesn't leave behind an `OrganizationMember` representing a valid invite. This includes a corner case where the email is null, where `remove_non_compliant_members` was previously relying on catching an `AssertionError`.