### PR TITLE
fix(ui): Set lazy calendar component type

### DIFF
--- a/static/app/components/calendar/index.tsx
+++ b/static/app/components/calendar/index.tsx
@@ -6,8 +6,11 @@ import Placeholder from 'sentry/components/placeholder';
 import type {DatePickerProps} from './datePicker';
 import type {DateRangePickerProps} from './dateRangePicker';
 
-const LazyDatePicker = lazy(() => import('./datePicker'));
-const LazyDateRangePicker = lazy(() => import('./dateRangePicker'));
+// Explicity set component type to avoid complex React.lazy type
+const LazyDatePicker: React.FC<DatePickerProps> = lazy(() => import('./datePicker'));
+const LazyDateRangePicker: React.FC<DateRangePickerProps> = lazy(
+  () => import('./dateRangePicker')
+);
 
 function CalendarSuspenseWrapper({children}: {children: React.ReactNode}) {
   return (


### PR DESCRIPTION
Reduces type checking on complex lazy calendar component type, we don't lose much in the way of types.

before 145ms
<img width="982" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/4e4ff68a-5033-490b-9b6f-b6f571c30c79">

after 6ms
<img width="981" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/8cbf4646-a238-489a-9164-8ff0cedc26b0">
