### PR TITLE
fix(issues): Add hidden tab for custom queries

### DIFF
--- a/static/app/views/issueList/header.tsx
+++ b/static/app/views/issueList/header.tsx
@@ -22,6 +22,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import IssueListSetAsDefault from 'sentry/views/issueList/issueListSetAsDefault';
 
 import {
+  CUSTOM_TAB_VALUE,
   FOR_REVIEW_QUERIES,
   getTabs,
   IssueSortOptions,
@@ -91,6 +92,7 @@ function IssueListHeader({
   const visibleTabs = displayReprocessingTab
     ? tabs
     : tabs.filter(([tab]) => tab !== Query.REPROCESSING);
+  const tabValues = new Set(visibleTabs.map(([val]) => val));
   // Remove cursor and page when switching tabs
   const {cursor: _, page: __, ...queryParms} = router?.location?.query ?? {};
   const sortParam =
@@ -130,11 +132,11 @@ function IssueListHeader({
         </ButtonBar>
       </Layout.HeaderActions>
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />
-      <StyledTabs selectedKey={query} onSelectionChange={() => {}}>
+      <StyledTabs value={tabValues.has(query) ? query : CUSTOM_TAB_VALUE}>
         <TabList hideBorder>
           {[
             ...visibleTabs.map(
-              ([tabQuery, {name: queryName, tooltipTitle, tooltipHoverable}]) => {
+              ([tabQuery, {name: queryName, tooltipTitle, tooltipHoverable, hidden}]) => {
                 const to = normalizeUrl({
                   query: {
                     ...queryParms,
@@ -147,7 +149,12 @@ function IssueListHeader({
                 });
 
                 return (
-                  <TabList.Item key={tabQuery} to={to} textValue={queryName}>
+                  <TabList.Item
+                    key={tabQuery}
+                    to={to}
+                    textValue={queryName}
+                    hidden={hidden}
+                  >
                     <GuideAnchor
                       disabled={tabQuery !== Query.ARCHIVED}
                       target="issue_stream_archive_tab"

--- a/static/app/views/issueList/utils.spec.tsx
+++ b/static/app/views/issueList/utils.spec.tsx
@@ -6,11 +6,18 @@ describe('getTabs', () => {
       getTabs(TestStubs.Organization({features: ['escalating-issues']})).map(
         tab => tab[1].name
       )
-    ).toEqual(['Unresolved', 'For Review', 'Regressed', 'Escalating', 'Archived']);
+    ).toEqual([
+      'Unresolved',
+      'For Review',
+      'Regressed',
+      'Escalating',
+      'Archived',
+      'Custom',
+    ]);
 
     expect(
       getTabs(TestStubs.Organization({features: []})).map(tab => tab[1].name)
-    ).toEqual(['All Unresolved', 'For Review', 'Ignored']);
+    ).toEqual(['All Unresolved', 'For Review', 'Ignored', 'Custom']);
   });
 
   it('should enable/disable my_teams filter in For Review tab', () => {
@@ -20,12 +27,14 @@ describe('getTabs', () => {
       'is:unresolved',
       'is:unresolved is:for_review assigned_or_suggested:[me, my_teams, none]',
       'is:ignored',
+      '__custom__',
     ]);
 
     expect(getTabs(TestStubs.Organization({features: []})).map(tab => tab[0])).toEqual([
       'is:unresolved',
       'is:unresolved is:for_review assigned_or_suggested:[me, none]',
       'is:ignored',
+      '__custom__',
     ]);
   });
 });

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -15,6 +15,8 @@ export enum Query {
   REPROCESSING = 'is:reprocessing',
 }
 
+export const CUSTOM_TAB_VALUE = '__custom__';
+
 type OverviewTab = {
   /**
    * Emitted analytics event tab name
@@ -29,6 +31,7 @@ type OverviewTab = {
    */
   enabled: boolean;
   name: string;
+  hidden?: boolean;
   /**
    * Tooltip text to be hoverable when text has links
    */
@@ -126,6 +129,19 @@ export function getTabs(organization: Organization) {
           }
         ),
         tooltipHoverable: true,
+      },
+    ],
+    [
+      // Hidden tab to account for custom queries that don't match any of the queries
+      // above. It's necessary because if Tabs's value doesn't match that of any tab item
+      // then Tabs will fall back to a default value, causing unexpected behaviors.
+      CUSTOM_TAB_VALUE,
+      {
+        name: t('Custom'),
+        analyticsName: 'custom',
+        hidden: true,
+        count: false,
+        enabled: true,
       },
     ],
   ];


### PR DESCRIPTION
Fix a problem with the tab bar's selection value in Issues Index. This problem doesn't currently affect the user experience because we implemented a workaround for it.
<img width="637" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/4d7198f5-1227-4bc8-871e-56ec26dec3a5">

More about the problem in the comments below. The fix doesn't affect the UI.