### PR TITLE
ref(HC): Update silo annotations in testutils methods

### DIFF
--- a/src/sentry/sentry_apps/apps.py
+++ b/src/sentry/sentry_apps/apps.py
@@ -15,6 +15,7 @@ from sentry_sdk.api import push_scope
 from sentry import analytics, audit_log
 from sentry.constants import SentryAppStatus
 from sentry.coreapi import APIError
+from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.models import (
     ApiApplication,
     ApiToken,
@@ -273,7 +274,7 @@ class SentryAppCreator:
             ), "Internal apps should not require installation verification"
 
     def run(self, *, user: User, request: Request | None = None) -> SentryApp:
-        with transaction.atomic():
+        with transaction.atomic(), in_test_hide_transaction_boundary():
             slug = self._generate_and_validate_slug()
             proxy = self._create_proxy_user(slug=slug)
             api_app = self._create_api_application(proxy=proxy)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1973,7 +1973,7 @@ class IntegrationRepositoryTestCase(APITestCase):
     def add_create_repository_responses(self, repository_config):
         raise NotImplementedError(f"implement for {type(self).__module__}.{type(self).__name__}")
 
-    @assume_test_silo_mode(SiloMode.REGION)
+    @assume_test_silo_mode(SiloMode.MONOLITH)
     def create_repository(
         self, repository_config, integration_id, organization_slug=None, add_responses=True
     ):

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -137,6 +137,7 @@ from sentry.search.events.constants import (
     SPAN_METRICS_MAP,
 )
 from sentry.sentry_metrics import indexer
+from sentry.silo import SiloMode
 from sentry.snuba.metrics.datasource import get_series
 from sentry.tagstore.snuba import SnubaTagStorage
 from sentry.testutils.factories import get_fixture_path
@@ -167,7 +168,7 @@ from . import assert_status_code
 from .factories import Factories
 from .fixtures import Fixtures
 from .helpers import AuthProvider, Feature, TaskRunner, override_options, parse_queries
-from .silo import exempt_from_silo_limits
+from .silo import assume_test_silo_mode
 from .skips import requires_snuba
 
 DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
@@ -279,13 +280,13 @@ class BaseTestCase(Fixtures):
         self, user, organization_id=None, organization_ids=None, superuser=False, superuser_sso=True
     ):
         if isinstance(user, OrganizationMember):
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 user = User.objects.get(id=user.user_id)
 
         user.backend = settings.AUTHENTICATION_BACKENDS[0]
 
         request = self.make_request()
-        with exempt_from_silo_limits():
+        with override_settings(SILO_MODE=SiloMode.MONOLITH):
             login(request, user)
         request.user = user
 
@@ -1001,7 +1002,7 @@ class IntegrationTestCase(TestCase):
         super().setUp()
 
         self.organization = self.create_organization(name="foo", owner=self.user)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             rpc_organization = serialize_rpc_organization(self.organization)
 
         self.login_as(self.user)
@@ -1972,7 +1973,7 @@ class IntegrationRepositoryTestCase(APITestCase):
     def add_create_repository_responses(self, repository_config):
         raise NotImplementedError(f"implement for {type(self).__module__}.{type(self).__name__}")
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.REGION)
     def create_repository(
         self, repository_config, integration_id, organization_slug=None, add_responses=True
     ):

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -950,16 +950,18 @@ class Factories:
 
             install.status = SentryAppInstallationStatus.INSTALLED if status is None else status
             install.save()
-        rpc_install = serialize_sentry_app_installation(install, install.sentry_app)
-        if not prevent_token_exchange and (install.sentry_app.status != SentryAppStatus.INTERNAL):
+            rpc_install = serialize_sentry_app_installation(install, install.sentry_app)
+            if not prevent_token_exchange and (
+                install.sentry_app.status != SentryAppStatus.INTERNAL
+            ):
 
-            token_exchange.GrantExchanger.run(
-                install=rpc_install,
-                code=install.api_grant.code,
-                client_id=install.sentry_app.application.client_id,
-                user=install.sentry_app.proxy_user,
-            )
-            install = SentryAppInstallation.objects.get(id=install.id)
+                token_exchange.GrantExchanger.run(
+                    install=rpc_install,
+                    code=install.api_grant.code,
+                    client_id=install.sentry_app.application.client_id,
+                    user=install.sentry_app.proxy_user,
+                )
+                install = SentryAppInstallation.objects.get(id=install.id)
         return install
 
     @staticmethod
@@ -1137,9 +1139,11 @@ class Factories:
             doc_integration = Factories.create_doc_integration()
         photo = File.objects.create(name="test.png", type="avatar.file")
         photo.putfile(io.BytesIO(b"imaginethiswasphotobytes"))
-        return DocIntegrationAvatar.objects.create(
-            doc_integration=doc_integration, avatar_type=0, file_id=photo.id
-        )
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return DocIntegrationAvatar.objects.create(
+                doc_integration=doc_integration, avatar_type=0, file_id=photo.id
+            )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -16,10 +16,11 @@ from sentry.models import (
 )
 from sentry.models.actor import Actor, get_actor_id_for_user
 from sentry.services.hybrid_cloud.user import RpcUser
+from sentry.silo import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode
 
 # XXX(dcramer): this is a compatibility layer to transition to pytest-based fixtures
 # all of the memoized fixtures are copypasta due to our inability to use pytest fixtures
@@ -29,29 +30,25 @@ from sentry.types.activity import ActivityType
 
 class Fixtures:
     @cached_property
-    @exempt_from_silo_limits()
     def session(self):
         return Factories.create_session()
 
     @cached_property
-    @exempt_from_silo_limits()
     def projectkey(self):
         return self.create_project_key(project=self.project)
 
     @cached_property
-    @exempt_from_silo_limits()
     def user(self):
         return self.create_user("admin@localhost", is_superuser=True)
 
     @cached_property
-    @exempt_from_silo_limits()
     def organization(self):
         # XXX(dcramer): ensure that your org slug doesnt match your team slug
         # and the same for your project slug
         return self.create_organization(name="baz", slug="baz", owner=self.user)
 
     @cached_property
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.REGION)
     def team(self):
         team = self.create_team(organization=self.organization, name="foo", slug="foo")
         # XXX: handle legacy team fixture
@@ -61,30 +58,24 @@ class Fixtures:
         return team
 
     @cached_property
-    @exempt_from_silo_limits()
     def project(self):
         return self.create_project(
             name="Bar", slug="bar", teams=[self.team], fire_project_created=True
         )
 
     @cached_property
-    @exempt_from_silo_limits()
     def release(self):
         return self.create_release(project=self.project, version="foo-1.0")
 
     @cached_property
-    @exempt_from_silo_limits()
     def environment(self):
         return self.create_environment(name="development", project=self.project)
 
     @cached_property
-    @exempt_from_silo_limits()
     def group(self):
-        # こんにちは konichiwa
         return self.create_group(message="\u3053\u3093\u306b\u3061\u306f")
 
     @cached_property
-    @exempt_from_silo_limits()
     def event(self):
         return self.store_event(
             data={
@@ -96,7 +87,7 @@ class Fixtures:
         )
 
     @cached_property
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.REGION)
     def activity(self):
         return Activity.objects.create(
             group=self.group,
@@ -107,7 +98,7 @@ class Fixtures:
         )
 
     @cached_property
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def integration(self):
         integration = Integration.objects.create(
             provider="github", name="GitHub", external_id="github:1"
@@ -116,7 +107,7 @@ class Fixtures:
         return integration
 
     @cached_property
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def organization_integration(self):
         return self.integration.add_organization(self.organization, self.user)
 

--- a/src/sentry/testutils/helpers/api_gateway.py
+++ b/src/sentry/testutils/helpers/api_gateway.py
@@ -2,6 +2,7 @@ from urllib.parse import parse_qs
 
 import responses
 from django.conf import settings
+from django.db import router
 from django.test import override_settings
 from django.urls import re_path
 from rest_framework.permissions import AllowAny
@@ -135,7 +136,7 @@ class ApiGatewayTestCase(APITestCase):
             adding_headers={"test": "header"},
         )
 
-        with in_test_psql_role_override("postgres"):
+        with in_test_psql_role_override("postgres", using=router.db_for_write(OrganizationMapping)):
             OrganizationMapping.objects.get(organization_id=self.organization.id).update(
                 region_name="region1"
             )

--- a/src/sentry/testutils/helpers/slack.py
+++ b/src/sentry/testutils/helpers/slack.py
@@ -16,7 +16,8 @@ from sentry.models import (
     Team,
     User,
 )
-from sentry.testutils.silo import exempt_from_silo_limits
+from sentry.silo import SiloMode
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils import json
 
@@ -31,7 +32,7 @@ def get_response_text(data: SlackBody) -> str:
     )
 
 
-@exempt_from_silo_limits()
+@assume_test_silo_mode(SiloMode.CONTROL)
 def install_slack(organization: Organization, workspace_id: str = "TXXXXXXX1") -> Integration:
     integration = Integration.objects.create(
         external_id=workspace_id,

--- a/tests/sentry/hybrid_cloud/test_rpc.py
+++ b/tests/sentry/hybrid_cloud/test_rpc.py
@@ -158,17 +158,23 @@ class DispatchRemoteCallTest(TestCase):
         mock_response.read.return_value = serial_response
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
-    @override_settings(SILO_MODE=SiloMode.REGION, DEV_HYBRID_CLOUD_RPC_SENDER=_REGION_SILO_CREDS)
     @mock.patch("sentry.services.hybrid_cloud.rpc.urlopen")
     def test_region_to_control_happy_path(self, mock_urlopen):
         org = self.create_organization()
-        response_value = RpcUserOrganizationContext(organization=serialize_rpc_organization(org))
-        self._set_up_mock_response(mock_urlopen, response_value.dict())
 
-        result = dispatch_remote_call(
-            None, "organization", "get_organization_by_id", {"id": org.id}
-        )
-        assert result == response_value
+        with override_settings(
+            SILO_MODE=SiloMode.REGION,
+            DEV_HYBRID_CLOUD_RPC_SENDER=self._REGION_SILO_CREDS,
+        ):
+            response_value = RpcUserOrganizationContext(
+                organization=serialize_rpc_organization(org)
+            )
+            self._set_up_mock_response(mock_urlopen, response_value.dict())
+
+            result = dispatch_remote_call(
+                None, "organization", "get_organization_by_id", {"id": org.id}
+            )
+            assert result == response_value
 
     @override_settings(SILO_MODE=SiloMode.REGION, DEV_HYBRID_CLOUD_RPC_SENDER=_REGION_SILO_CREDS)
     @mock.patch("sentry.services.hybrid_cloud.rpc.urlopen")


### PR DESCRIPTION
Based off of PR #52386, updates our factories to actually change contexts instead of simply ignoring then context changes when making cross-silo mutations in testing.
