### PR TITLE
Remove 'demo' from list of reserved slugs

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -117,7 +117,6 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         "customers",
         "de",
         "debug",
-        "demo",
         "devinfra",
         "docs",
         "enterprise",


### PR DESCRIPTION
This is needed to claim `demo` org for internal use. Inactive customer has already been vacated through COPS process. Once deployed we intend to immediately claim the org and later rename `testorg-az` to `demo` in a separate change.
