### PR TITLE
fix(starfish): Only renders contents when the date range is valid in starfish

### DIFF
--- a/static/app/views/starfish/components/pageFilterContainer.tsx
+++ b/static/app/views/starfish/components/pageFilterContainer.tsx
@@ -14,7 +14,8 @@ function StarfishPageFilterContainer(props: {children: React.ReactNode}) {
   const datetime = selection.datetime;
 
   const {endTime, startTime} = getDateFilters(selection);
-  if (endTime.diff(startTime, 'days') > MAXIMUM_DATE_RANGE) {
+  const invalidDateFilters = endTime.diff(startTime, 'days') > MAXIMUM_DATE_RANGE;
+  if (invalidDateFilters) {
     datetime.period = DEFAULT_STATS_PERIOD;
     datetime.start = null;
     datetime.end = null;
@@ -27,6 +28,10 @@ function StarfishPageFilterContainer(props: {children: React.ReactNode}) {
         end: null,
       },
     });
+  }
+
+  if (invalidDateFilters) {
+    return null;
   }
 
   return <PageFiltersContainer>{props.children}</PageFiltersContainer>;

--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -77,6 +77,7 @@ export function useWrappedDiscoverTimeseriesQuery<T>({
 }) {
   const location = useLocation();
   const organization = useOrganization();
+  const {isReady: pageFiltersReady} = usePageFilters();
   const result = useGenericDiscoverQuery<
     {
       data: any[];
@@ -99,7 +100,7 @@ export function useWrappedDiscoverTimeseriesQuery<T>({
       cursor,
     }),
     options: {
-      enabled,
+      enabled: enabled && pageFiltersReady,
       refetchOnWindowFocus: false,
       retry: shouldRetryHandler,
       retryDelay: getRetryDelay,
@@ -137,6 +138,7 @@ export function useWrappedDiscoverQuery<T>({
 }) {
   const location = useLocation();
   const organization = useOrganization();
+  const {isReady: pageFiltersReady} = usePageFilters();
   const result = useDiscoverQuery({
     eventView,
     orgSlug: organization.slug,
@@ -145,7 +147,7 @@ export function useWrappedDiscoverQuery<T>({
     cursor,
     limit,
     options: {
-      enabled,
+      enabled: enabled && pageFiltersReady,
       refetchOnWindowFocus: false,
       retry: shouldRetryHandler,
       retryDelay: getRetryDelay,


### PR DESCRIPTION
Updates queries to wait for pageFilters to be ready before querying and also update starfish pageFilterContainer to not render contents if the date range is not valid. This prevents queries and ui from being fired/rendered with incorrect date range