### PR TITLE
feat(hybrid-cloud): Add webhook parser for Bitbucket

### DIFF
--- a/src/sentry/integrations/bitbucket/constants.py
+++ b/src/sentry/integrations/bitbucket/constants.py
@@ -3,14 +3,15 @@ import ipaddress
 # Bitbucket Cloud IP range:
 # https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html#Managewebhooks-trigger_webhookTriggeringwebhooks
 BITBUCKET_IP_RANGES = (
+    # https://support.atlassian.com/bitbucket-cloud/docs/what-are-the-bitbucket-cloud-ip-addresses-i-should-use-to-configure-my-corporate-firewall/
     ipaddress.ip_network("104.192.136.0/21"),
-    # Not documented in the webhook docs, but defined here:
-    # https://bitbucket.org/blog/new-ip-addresses-bitbucket-cloud
+    ipaddress.ip_network("185.166.140.0/22"),
     ipaddress.ip_network("18.205.93.0/25"),
     ipaddress.ip_network("18.234.32.128/25"),
     ipaddress.ip_network("13.52.5.0/25"),
     # Also accept any outbound IPs that atlassian has.
     # https://support.atlassian.com/organization-administration/docs/ip-addresses-and-domains-for-atlassian-cloud-products/
+    # IPv4
     ipaddress.ip_network("13.52.5.96/28"),
     ipaddress.ip_network("13.236.8.224/28"),
     ipaddress.ip_network("18.136.214.96/28"),
@@ -25,5 +26,32 @@ BITBUCKET_IP_RANGES = (
     ipaddress.ip_network("104.192.143.240/28"),
     ipaddress.ip_network("185.166.143.240/28"),
     ipaddress.ip_network("185.166.142.240/28"),
+    # IPv6
+    ipaddress.ip_network("2401:1d80:3204:3::/64"),
+    ipaddress.ip_network("2401:1d80:3204:4::/63"),
+    ipaddress.ip_network("2401:1d80:3208:3::/64"),
+    ipaddress.ip_network("2401:1d80:3208:4::/63"),
+    ipaddress.ip_network("2401:1d80:3210:3::/64"),
+    ipaddress.ip_network("2401:1d80:3210:4::/63"),
+    ipaddress.ip_network("2401:1d80:3214:3::/64"),
+    ipaddress.ip_network("2401:1d80:3214:4::/63"),
+    ipaddress.ip_network("2401:1d80:321c:3::/64"),
+    ipaddress.ip_network("2401:1d80:321c:4::/63"),
+    ipaddress.ip_network("2401:1d80:3220:2::/63"),
+    ipaddress.ip_network("2401:1d80:3224:3::/64"),
+    ipaddress.ip_network("2401:1d80:3224:4::/63"),
+    ipaddress.ip_network("2406:da18:809:e04::/63"),
+    ipaddress.ip_network("2406:da18:809:e06::/64"),
+    ipaddress.ip_network("2406:da1c:1e0:a204::/63"),
+    ipaddress.ip_network("2406:da1c:1e0:a206::/64"),
+    ipaddress.ip_network("2600:1f14:824:304::/63"),
+    ipaddress.ip_network("2600:1f14:824:306::/64"),
+    ipaddress.ip_network("2600:1f18:2146:e304::/63"),
+    ipaddress.ip_network("2600:1f18:2146:e306::/64"),
+    ipaddress.ip_network("2600:1f1c:cc5:2304::/63"),
+    ipaddress.ip_network("2a05:d014:f99:dd04::/63"),
+    ipaddress.ip_network("2a05:d014:f99:dd06::/64"),
+    ipaddress.ip_network("2a05:d018:34d:5804::/63"),
+    ipaddress.ip_network("2a05:d018:34d:5806::/64"),
 )
 BITBUCKET_IPS = ["34.198.203.127", "34.198.178.64", "34.198.32.85"]

--- a/src/sentry/integrations/bitbucket/urls.py
+++ b/src/sentry/integrations/bitbucket/urls.py
@@ -10,14 +10,17 @@ urlpatterns = [
     url(
         r"^descriptor/$",
         BitbucketDescriptorEndpoint.as_view(),
+        name="sentry-extensions-bitbucket-descriptor",
     ),
     url(
         r"^installed/$",
         BitbucketInstalledEndpoint.as_view(),
+        name="sentry-extensions-bitbucket-installed",
     ),
     url(
         r"^uninstalled/$",
         BitbucketUninstalledEndpoint.as_view(),
+        name="sentry-extensions-bitbucket-uninstalled",
     ),
     url(
         r"^organizations/(?P<organization_id>[^\/]+)/webhook/$",

--- a/src/sentry/middleware/integrations/integration_control.py
+++ b/src/sentry/middleware/integrations/integration_control.py
@@ -7,6 +7,7 @@ from typing import Mapping, Type
 from sentry.silo import SiloMode
 
 from .parsers import (
+    BitbucketRequestParser,
     GithubRequestParser,
     GitlabRequestParser,
     JiraRequestParser,
@@ -23,6 +24,7 @@ ACTIVE_PARSERS = [
     JiraRequestParser,
     SlackRequestParser,
     MsTeamsRequestParser,
+    BitbucketRequestParser,
 ]
 
 

--- a/src/sentry/middleware/integrations/parsers/__init__.py
+++ b/src/sentry/middleware/integrations/parsers/__init__.py
@@ -1,3 +1,4 @@
+from .bitbucket import BitbucketRequestParser
 from .github import GithubRequestParser
 from .gitlab import GitlabRequestParser
 from .jira import JiraRequestParser
@@ -5,9 +6,10 @@ from .msteams import MsTeamsRequestParser
 from .slack import SlackRequestParser
 
 __all__ = (
+    "BitbucketRequestParser",
     "GithubRequestParser",
-    "JiraRequestParser",
-    "SlackRequestParser",
     "GitlabRequestParser",
+    "JiraRequestParser",
     "MsTeamsRequestParser",
+    "SlackRequestParser",
 )

--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -11,7 +11,7 @@ from rest_framework import status
 
 from sentry.models.integrations import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
-from sentry.models.outbox import ControlOutbox, WebhookProviderIdentifier, outbox_context
+from sentry.models.outbox import ControlOutbox, WebhookProviderIdentifier
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
 from sentry.silo import SiloLimit, SiloMode
@@ -115,13 +115,12 @@ class BaseRequestParser(abc.ABC):
         Responds to the webhook provider with a 202 Accepted status.
         """
         if len(regions) > 0:
-            with outbox_context():
-                for outbox in ControlOutbox.for_webhook_update(
-                    webhook_identifier=self.webhook_identifier,
-                    region_names=[region.name for region in regions],
-                    request=self.request,
-                ):
-                    outbox.save()
+            for outbox in ControlOutbox.for_webhook_update(
+                webhook_identifier=self.webhook_identifier,
+                region_names=[region.name for region in regions],
+                request=self.request,
+            ):
+                outbox.save()
 
         return HttpResponse(status=status.HTTP_202_ACCEPTED)
 

--- a/src/sentry/middleware/integrations/parsers/bitbucket.py
+++ b/src/sentry/middleware/integrations/parsers/bitbucket.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import logging
+
+from sentry.middleware.integrations.parsers.base import BaseRequestParser
+from sentry.models.integrations.integration import Integration
+from sentry.models.outbox import WebhookProviderIdentifier
+from sentry.services.hybrid_cloud.util import control_silo_function
+
+logger = logging.getLogger(__name__)
+
+
+class BitbucketRequestParser(BaseRequestParser):
+    provider = "bitbucket"
+    webhook_identifier = WebhookProviderIdentifier.BITBUCKET
+
+    @control_silo_function
+    def get_integration_from_request(self) -> Integration | None:
+        pass
+
+    def get_response(self):
+        return self.get_response_from_control_silo()

--- a/src/sentry/middleware/integrations/parsers/bitbucket.py
+++ b/src/sentry/middleware/integrations/parsers/bitbucket.py
@@ -29,7 +29,7 @@ class BitbucketRequestParser(BaseRequestParser):
                 organization_id=organization_id
             )
         except OrganizationMapping.DoesNotExist as e:
-            logging_extra["error"] = e
+            logging_extra["error"] = str(e)
             logging_extra["organization_id"] = organization_id
             logger.error("no_mapping", extra=logging_extra)
             return self.get_response_from_control_silo()

--- a/src/sentry/middleware/integrations/parsers/bitbucket.py
+++ b/src/sentry/middleware/integrations/parsers/bitbucket.py
@@ -37,7 +37,7 @@ class BitbucketRequestParser(BaseRequestParser):
         try:
             region = get_region_by_name(mapping.region_name)
         except RegionResolutionError as e:
-            logging_extra["error"] = e
+            logging_extra["error"] = str(e)
             logging_extra["mapping_id"] = mapping.id
             logger.error("no_region", extra=logging_extra)
             return self.get_response_from_control_silo()

--- a/src/sentry/middleware/integrations/parsers/bitbucket.py
+++ b/src/sentry/middleware/integrations/parsers/bitbucket.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import logging
 
+from sentry.integrations.bitbucket import BitbucketWebhookEndpoint
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
-from sentry.models.integrations.integration import Integration
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.outbox import WebhookProviderIdentifier
-from sentry.services.hybrid_cloud.util import control_silo_function
+from sentry.types.region import get_region_by_name
 
 logger = logging.getLogger(__name__)
 
@@ -14,9 +15,32 @@ class BitbucketRequestParser(BaseRequestParser):
     provider = "bitbucket"
     webhook_identifier = WebhookProviderIdentifier.BITBUCKET
 
-    @control_silo_function
-    def get_integration_from_request(self) -> Integration | None:
-        pass
+    def get_bitbucket_webhook_response(self):
+        # The organization is provided in the path, so we can skip inferring organizations
+        # from the integration credentials
+        organization_id = self.match.kwargs.get("organization_id")
+        logging_extra = {"path": self.request.path}
+        if not organization_id:
+            logger.info("no_organization_id", extra=logging_extra)
+            return self.get_response_from_control_silo()
+
+        mapping: OrganizationMapping = OrganizationMapping.objects.get(
+            organization_id=organization_id
+        )
+        if not mapping:
+            logging_extra["organization_id"] = organization_id
+            logger.info("no_mapping", extra=logging_extra)
+            return self.get_response_from_control_silo()
+
+        region = get_region_by_name(mapping.region_name)
+        if not region:
+            logging_extra["mapping_id"] = mapping.id
+            logger.info("no_region", extra=logging_extra)
+            return self.get_response_from_control_silo()
+        return self.get_response_from_outbox_creation(regions=[region])
 
     def get_response(self):
+        view_class = self.match.func.view_class  # type: ignore
+        if view_class == BitbucketWebhookEndpoint:
+            return self.get_bitbucket_webhook_response()
         return self.get_response_from_control_silo()

--- a/src/sentry/middleware/integrations/parsers/bitbucket.py
+++ b/src/sentry/middleware/integrations/parsers/bitbucket.py
@@ -6,7 +6,7 @@ from sentry.integrations.bitbucket import BitbucketWebhookEndpoint
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.outbox import WebhookProviderIdentifier
-from sentry.types.region import get_region_by_name
+from sentry.types.region import RegionResolutionError, get_region_by_name
 
 logger = logging.getLogger(__name__)
 
@@ -24,18 +24,22 @@ class BitbucketRequestParser(BaseRequestParser):
             logger.info("no_organization_id", extra=logging_extra)
             return self.get_response_from_control_silo()
 
-        mapping: OrganizationMapping = OrganizationMapping.objects.get(
-            organization_id=organization_id
-        )
-        if not mapping:
+        try:
+            mapping: OrganizationMapping = OrganizationMapping.objects.get(
+                organization_id=organization_id
+            )
+        except OrganizationMapping.DoesNotExist as e:
+            logging_extra["error"] = e
             logging_extra["organization_id"] = organization_id
-            logger.info("no_mapping", extra=logging_extra)
+            logger.error("no_mapping", extra=logging_extra)
             return self.get_response_from_control_silo()
 
-        region = get_region_by_name(mapping.region_name)
-        if not region:
+        try:
+            region = get_region_by_name(mapping.region_name)
+        except RegionResolutionError as e:
+            logging_extra["error"] = e
             logging_extra["mapping_id"] = mapping.id
-            logger.info("no_region", extra=logging_extra)
+            logger.error("no_region", extra=logging_extra)
             return self.get_response_from_control_silo()
         return self.get_response_from_outbox_creation(regions=[region])
 

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -97,6 +97,7 @@ class WebhookProviderIdentifier(IntEnum):
     JIRA = 2
     GITLAB = 3
     MSTEAMS = 4
+    BITBUCKET = 5
 
 
 def _ensure_not_null(k: str, v: Any) -> Any:

--- a/tests/sentry/middleware/integrations/parsers/test_bitbucket.py
+++ b/tests/sentry/middleware/integrations/parsers/test_bitbucket.py
@@ -1,0 +1,87 @@
+from unittest import mock
+from unittest.mock import MagicMock
+
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+from django.urls import reverse
+
+from sentry.middleware.integrations.integration_control import IntegrationControlMiddleware
+from sentry.middleware.integrations.parsers.bitbucket import BitbucketRequestParser
+from sentry.models.outbox import ControlOutbox, WebhookProviderIdentifier
+from sentry.services.hybrid_cloud.organization_mapping.service import organization_mapping_service
+from sentry.silo.base import SiloMode
+from sentry.testutils import TestCase
+from sentry.testutils.region import override_regions
+from sentry.testutils.silo import control_silo_test
+from sentry.types.region import Region, RegionCategory
+
+
+@control_silo_test()
+class BitbucketRequestParserTest(TestCase):
+    get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
+    middleware = IntegrationControlMiddleware(get_response)
+    factory = RequestFactory()
+    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region_config = (region,)
+
+    def setUp(self):
+        super().setUp()
+        self.path = reverse(
+            "sentry-extensions-bitbucket-webhook", kwargs={"organization_id": self.organization.id}
+        )
+        self.integration = self.create_integration(
+            organization=self.organization, external_id="bitbucket:1", provider="bitbucket"
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_routing_endpoints(self):
+        control_routes = [
+            reverse("sentry-extensions-bitbucket-descriptor"),
+            reverse("sentry-extensions-bitbucket-installed"),
+            reverse("sentry-extensions-bitbucket-uninstalled"),
+            reverse(
+                "sentry-extensions-bitbucket-search",
+                kwargs={
+                    "organization_slug": self.organization.slug,
+                    "integration_id": self.integration.id,
+                },
+            ),
+        ]
+        for route in control_routes:
+            request = self.factory.post(route)
+            parser = BitbucketRequestParser(request=request, response_handler=self.get_response)
+            with mock.patch.object(
+                parser, "get_response_from_control_silo"
+            ) as get_response_from_control_silo:
+                assert not get_response_from_control_silo.called
+                parser.get_response()
+                assert get_response_from_control_silo.called
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_routing_webhook(self):
+        region_route = reverse(
+            "sentry-extensions-bitbucket-webhook", kwargs={"organization_id": self.organization.id}
+        )
+        request = self.factory.post(region_route)
+        parser = BitbucketRequestParser(request=request, response_handler=self.get_response)
+
+        # Missing region
+        organization_mapping_service.update(
+            organization_id=self.organization.id, update={"region_name": "eu"}
+        )
+        with mock.patch.object(
+            parser, "get_response_from_control_silo"
+        ) as get_response_from_control_silo:
+            parser.get_response()
+            assert get_response_from_control_silo.called
+
+        # Valid region
+        organization_mapping_service.update(
+            organization_id=self.organization.id, update={"region_name": "na"}
+        )
+        with override_regions(self.region_config):
+            parser.get_response()
+            outboxes = ControlOutbox.objects.filter(
+                shard_identifier=WebhookProviderIdentifier.BITBUCKET
+            )
+            assert len(outboxes) == 1


### PR DESCRIPTION
This PR introduces a webhook parser for bring Bitbucket into Hybrid Cloud. All endpoints are control silo except for the single webhook we register with the organization id as part of the path. That lets us infer a region without needing to access any integration.

I was encountering permission errors when testing this, but it turned out to be because some webhooks are delivered from the IPv6 addresses on Bitbucket's side. I've updated our checks to with the new addresses.