### PR TITLE
ref(rules): Delete issue alert rules

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -14,10 +14,10 @@ from sentry.api.serializers.rest_framework.rule import RuleSerializer as DrfRule
 from sentry.integrations.slack.utils import RedisRuleStatus
 from sentry.mediators import project_rules
 from sentry.models import (
+    RegionScheduledDeletion,
     RuleActivity,
     RuleActivityType,
     RuleStatus,
-    ScheduledDeletion,
     SentryAppComponent,
     Team,
     User,
@@ -207,7 +207,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         RuleActivity.objects.create(
             rule=rule, user_id=request.user.id, type=RuleActivityType.DELETED.value
         )
-        scheduled = ScheduledDeletion.schedule(rule, days=0, actor=request.user)
+        scheduled = RegionScheduledDeletion.schedule(rule, days=0, actor=request.user)
         self.create_audit_entry(
             request=request,
             organization=project.organization,

--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -164,6 +164,7 @@ def load_defaults():
     default_manager.register(models.Team, defaults.TeamDeletionTask)
     default_manager.register(models.UserReport, BulkModelDeletionTask)
     default_manager.register(models.ArtifactBundle, ArtifactBundleDeletionTask)
+    default_manager.register(models.Rule, defaults.RuleDeletionTask)
 
 
 load_defaults()

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -13,6 +13,7 @@ from .project import *  # noqa: F401,F403
 from .release import *  # noqa: F401,F403
 from .repository import *  # noqa: F401,F403
 from .repositoryprojectpathconfig import *  # noqa: F401,F403
+from .rule import *  # noqa: F401,F403
 from .sentry_app import *  # noqa: F401,F403
 from .sentry_app_installation import *  # noqa: F401,F403
 from .sentry_app_installation_token import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/rule.py
+++ b/src/sentry/deletions/defaults/rule.py
@@ -1,0 +1,19 @@
+from ..base import ModelDeletionTask, ModelRelation
+
+
+class RuleDeletionTask(ModelDeletionTask):
+    def get_child_relations(self, instance):
+        from sentry.models import GroupRuleStatus, RuleActivity, RuleFireHistory
+
+        return [
+            ModelRelation(GroupRuleStatus, {"rule": instance}),
+            ModelRelation(RuleFireHistory, {"rule": instance}),
+            ModelRelation(RuleActivity, {"rule": instance}),
+        ]
+
+    def mark_deletion_in_progress(self, instance_list):
+        from sentry.models import RuleStatus
+
+        for instance in instance_list:
+            if instance.status != RuleStatus.PENDING_DELETION:
+                instance.update(status=RuleStatus.PENDING_DELETION)

--- a/src/sentry/deletions/defaults/rule.py
+++ b/src/sentry/deletions/defaults/rule.py
@@ -7,9 +7,9 @@ class RuleDeletionTask(ModelDeletionTask):
         from sentry.models.rulefirehistory import RuleFireHistory
 
         return [
-            ModelRelation(GroupRuleStatus, {"rule": instance}),
-            ModelRelation(RuleFireHistory, {"rule": instance}),
-            ModelRelation(RuleActivity, {"rule": instance}),
+            ModelRelation(GroupRuleStatus, {"rule_id": instance.id}),
+            ModelRelation(RuleFireHistory, {"rule_id": instance.id}),
+            ModelRelation(RuleActivity, {"rule_id": instance.id}),
         ]
 
     def mark_deletion_in_progress(self, instance_list):

--- a/src/sentry/deletions/defaults/rule.py
+++ b/src/sentry/deletions/defaults/rule.py
@@ -3,7 +3,8 @@ from ..base import ModelDeletionTask, ModelRelation
 
 class RuleDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
-        from sentry.models import GroupRuleStatus, RuleActivity, RuleFireHistory
+        from sentry.models import GroupRuleStatus, RuleActivity
+        from sentry.models.rulefirehistory import RuleFireHistory
 
         return [
             ModelRelation(GroupRuleStatus, {"rule": instance}),

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -758,11 +758,11 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
     method = "DELETE"
 
     def test_simple(self):
+        rule = self.create_project_rule(self.project)
         self.get_success_response(
-            self.organization.slug, self.project.slug, self.rule.id, status_code=202
+            self.organization.slug, rule.project.slug, rule.id, status_code=202
         )
-        self.rule.refresh_from_db()
-        assert self.rule.status == RuleStatus.PENDING_DELETION
-        assert RuleActivity.objects.filter(
-            rule=self.rule, type=RuleActivityType.DELETED.value
+        rule.refresh_from_db()
+        assert not Rule.objects.filter(
+            id=self.rule.id, project=self.project, status=RuleStatus.PENDING_DELETION
         ).exists()

--- a/tests/sentry/deletions/test_rule.py
+++ b/tests/sentry/deletions/test_rule.py
@@ -1,10 +1,10 @@
 from sentry.models import (
     GroupRuleStatus,
+    RegionScheduledDeletion,
     Rule,
     RuleActivity,
     RuleActivityType,
     RuleStatus,
-    ScheduledDeletion,
 )
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.tasks.deletion.scheduled import run_deletion
@@ -27,7 +27,7 @@ class DeleteRuleTest(TestCase):
         )
         rule_activity = RuleActivity.objects.create(rule=rule, type=RuleActivityType.CREATED.value)
 
-        deletion = ScheduledDeletion.schedule(rule, days=0)
+        deletion = RegionScheduledDeletion.schedule(rule, days=0)
         deletion.update(in_progress=True)
 
         with self.tasks():

--- a/tests/sentry/deletions/test_rule.py
+++ b/tests/sentry/deletions/test_rule.py
@@ -3,10 +3,10 @@ from sentry.models import (
     Rule,
     RuleActivity,
     RuleActivityType,
-    RuleFireHistory,
     RuleStatus,
     ScheduledDeletion,
 )
+from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.tasks.deletion.scheduled import run_deletion
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test


### PR DESCRIPTION
Currently we only ever "soft delete" rules and we have 12m that are "pending deletion". The only way to truly delete a rule is to delete the parent project or organization, but if you delete a single rule, today we don't actually get rid of it. This PR adds in actually deleting rules, and I'll follow this up with a migration to delete all the rules "pending deletion". 