### PR TITLE
fix(crons): Re-enable Evidence section for crons

### DIFF
--- a/static/app/utils/issueTypeConfig/cronConfig.tsx
+++ b/static/app/utils/issueTypeConfig/cronConfig.tsx
@@ -1,0 +1,32 @@
+import {t} from 'sentry/locale';
+import {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
+
+const cronConfig: IssueCategoryConfigMapping = {
+  _categoryDefaults: {
+    actions: {
+      delete: {
+        enabled: false,
+        disabledReason: t('Not yet supported for cron issues'),
+      },
+      deleteAndDiscard: {
+        enabled: false,
+        disabledReason: t('Not yet supported for cron issues'),
+      },
+      merge: {
+        enabled: false,
+        disabledReason: t('Not yet supported for cron issues'),
+      },
+      ignore: {enabled: true},
+      share: {enabled: true},
+    },
+    attachments: {enabled: false},
+    grouping: {enabled: false},
+    mergedIssues: {enabled: false},
+    replays: {enabled: false},
+    similarIssues: {enabled: false},
+    userFeedback: {enabled: false},
+    usesIssuePlatform: true,
+  },
+};
+
+export default cronConfig;

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -39,7 +39,8 @@ const issueTypeConfig: Config = {
   [IssueCategory.ERROR]: errorConfig,
   [IssueCategory.PERFORMANCE]: performanceConfig,
   [IssueCategory.PROFILE]: performanceConfig,
-  [IssueCategory.CRON]: performanceConfig,
+  // TODO(crons): We may need a custom config similar to performance
+  [IssueCategory.CRON]: errorConfig,
 };
 
 const eventOccurrenceTypeToIssueCategory = (eventOccurrenceType: number) => {

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -1,5 +1,6 @@
 import {t} from 'sentry/locale';
 import {IssueCategory, IssueType} from 'sentry/types';
+import cronConfig from 'sentry/utils/issueTypeConfig/cronConfig';
 import errorConfig from 'sentry/utils/issueTypeConfig/errorConfig';
 import performanceConfig from 'sentry/utils/issueTypeConfig/performanceConfig';
 import {
@@ -39,8 +40,7 @@ const issueTypeConfig: Config = {
   [IssueCategory.ERROR]: errorConfig,
   [IssueCategory.PERFORMANCE]: performanceConfig,
   [IssueCategory.PROFILE]: performanceConfig,
-  // TODO(crons): We may need a custom config similar to performance
-  [IssueCategory.CRON]: errorConfig,
+  [IssueCategory.CRON]: cronConfig,
 };
 
 const eventOccurrenceTypeToIssueCategory = (eventOccurrenceType: number) => {


### PR DESCRIPTION
Brings back the `Evidence` section

Create an issue page config for crons. Hides some tabs, disables some actions like delete