### PR TITLE
feat(search-shortcuts): Reorder arrow keys, mobile layout

### DIFF
--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -348,7 +348,7 @@ function DropdownItem({
   } else if (item.type === ItemType.RECOMMENDED) {
     children = (
       <RecommendedItem>
-        <div>{item.title}</div>
+        <RecommendedItemTitle>{item.title}</RecommendedItemTitle>
         {item.desc && (
           <RecommendedItemDescription>{item.desc}</RecommendedItemDescription>
         )}
@@ -659,6 +659,10 @@ const IconOpenWithMargin = styled(IconOpen)`
 
 const RecommendedItem = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const RecommendedItemTitle = styled('div')`
+  ${p => p.theme.overflowEllipsis}
 `;
 
 const RecommendedItemDescription = styled('div')`

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -109,20 +109,6 @@ function IssueListSearchBar({organization, tags, ...props}: Props) {
       {
         type: ItemType.RECOMMENDED,
         kind: FieldKind.FIELD,
-        title: t('Assignee'),
-        desc: t('Filter by team or member.'),
-        value: 'assigned_or_suggested:',
-      },
-      {
-        type: ItemType.RECOMMENDED,
-        kind: FieldKind.FIELD,
-        title: t('Release'),
-        desc: t('Filter by release version.'),
-        value: 'release:',
-      },
-      {
-        type: ItemType.RECOMMENDED,
-        kind: FieldKind.FIELD,
         title: t('Level'),
         desc: t('Filter by fatal, error, etc.'),
         value: 'level:',
@@ -130,9 +116,23 @@ function IssueListSearchBar({organization, tags, ...props}: Props) {
       {
         type: ItemType.RECOMMENDED,
         kind: FieldKind.FIELD,
+        title: t('Assignee'),
+        desc: t('Filter by team or member.'),
+        value: 'assigned_or_suggested:',
+      },
+      {
+        type: ItemType.RECOMMENDED,
+        kind: FieldKind.FIELD,
         title: t('Unhandled'),
         desc: t('Filter by unhandled events.'),
         value: 'error.unhandled:true ',
+      },
+      {
+        type: ItemType.RECOMMENDED,
+        kind: FieldKind.FIELD,
+        title: t('Release'),
+        desc: t('Filter by release version.'),
+        value: 'release:',
       },
       {
         type: ItemType.RECOMMENDED,
@@ -162,17 +162,29 @@ function IssueListSearchBar({organization, tags, ...props}: Props) {
 
 export default withIssueTags(IssueListSearchBar);
 
+// Using grid-template-rows to order the items top to bottom, then left to right
 const RecommendedWrapper = styled('div')`
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: ${space(1.5)};
-  padding: ${space(1.5)};
+  grid-template-rows: 1fr 1fr 1fr;
+  grid-auto-flow: column;
+  gap: ${space(1)};
+  padding: ${space(1)};
 
   & > li {
     ${p => p.theme.overflowEllipsis}
     border-radius: ${p => p.theme.borderRadius};
     border: 1px solid ${p => p.theme.border};
-    padding: ${space(1.5)} ${space(2)};
+    padding: ${space(1)} ${space(1.5)};
     margin: 0;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    grid-template-rows: 1fr 1fr;
+    gap: ${space(1.5)};
+    padding: ${space(1.5)};
+
+    & > li {
+      padding: ${space(1.5)} ${space(2)};
+    }
   }
 `;


### PR DESCRIPTION
bunch of style changes

- Changes the order of items selected when using arrow keys. This was a css layout change. fixes #51887
- Adjust mobile layout to be less cramped

Using arrow keys navigates like this now - instead of left to right
<img width="808" alt="Screenshot 2023-07-06 at 5 03 23 PM" src="https://github.com/getsentry/sentry/assets/1400464/352b48ef-89bf-4368-a8af-0a47de661ea0">

old mobile layout
<img width="439" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/922321de-8378-423e-b11d-fd02466b0a7e">


new mobile layout
<img width="444" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/7a1419b0-e8de-4261-b67e-a18cd7dc3358">
