### PR TITLE
feat(org-tokens): Prepare settings UI for Developer Settings structure

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -861,7 +861,7 @@ function buildRoutes() {
         />
       </Route>
       <Redirect from="developer-settings/sentry-functions/" to="developer-settings/" />
-      <Route path="developer-settings/" name={t('Developer Settings')}>
+      <Route path="developer-settings/" name={t('Custom Integrations')}>
         <IndexRoute
           component={make(
             () => import('sentry/views/settings/organizationDeveloperSettings')

--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -90,103 +90,6 @@ const organizationNavigation: NavigationSection[] = [
         id: 'integrations',
         recordAnalytics: true,
       },
-      {
-        path: `${pathPrefix}/developer-settings/`,
-        title: t('Developer Settings'),
-        description: t('Manage developer applications'),
-        id: 'developer-settings',
-      },
-    ],
-  },
-];
-
-export const organizationNavigationWithAuthTokens: NavigationSection[] = [
-  {
-    name: t('Organization'),
-    items: [
-      {
-        path: `${pathPrefix}/`,
-        title: t('General Settings'),
-        index: true,
-        description: t('Configure general settings for an organization'),
-        id: 'general',
-      },
-      {
-        path: `${pathPrefix}/projects/`,
-        title: t('Projects'),
-        description: t("View and manage an organization's projects"),
-        id: 'projects',
-      },
-      {
-        path: `${pathPrefix}/teams/`,
-        title: t('Teams'),
-        description: t("Manage an organization's teams"),
-        id: 'teams',
-      },
-      {
-        path: `${pathPrefix}/members/`,
-        title: t('Members'),
-        show: ({access}) => access!.has('member:read'),
-        description: t('Manage user membership for an organization'),
-        id: 'members',
-      },
-      {
-        path: `${pathPrefix}/security-and-privacy/`,
-        title: t('Security & Privacy'),
-        description: t(
-          'Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Scrubbing)'
-        ),
-        id: 'security-and-privacy',
-      },
-      {
-        path: `${pathPrefix}/auth/`,
-        title: t('Auth'),
-        description: t('Configure single sign-on'),
-        id: 'sso',
-      },
-      {
-        path: `${pathPrefix}/api-keys/`,
-        title: t('API Keys'),
-        show: ({access, features}) =>
-          features!.has('api-keys') && access!.has('org:admin'),
-        id: 'api-keys',
-      },
-      {
-        path: `${pathPrefix}/audit-log/`,
-        title: t('Audit Log'),
-        show: ({access}) => access!.has('org:write'),
-        description: t('View the audit log for an organization'),
-        id: 'audit-log',
-      },
-      {
-        path: `${pathPrefix}/rate-limits/`,
-        title: t('Rate Limits'),
-        show: ({access, features}) =>
-          features!.has('legacy-rate-limits') && access!.has('org:write'),
-        description: t('Configure rate limits for all projects in the organization'),
-        id: 'rate-limits',
-      },
-      {
-        path: `${pathPrefix}/relay/`,
-        title: t('Relay'),
-        description: t('Manage relays connected to the organization'),
-        id: 'relay',
-      },
-      {
-        path: `${pathPrefix}/repos/`,
-        title: t('Repositories'),
-        description: t('Manage repositories connected to the organization'),
-        id: 'repos',
-      },
-      {
-        path: `${pathPrefix}/integrations/`,
-        title: t('Integrations'),
-        description: t(
-          'Manage organization-level integrations, including: Slack, Github, Bitbucket, Jira, and Azure DevOps'
-        ),
-        id: 'integrations',
-        recordAnalytics: true,
-      },
     ],
   },
   {
@@ -197,6 +100,7 @@ export const organizationNavigationWithAuthTokens: NavigationSection[] = [
         title: t('Auth Tokens'),
         description: t('Manage organization auth tokens'),
         id: 'auth-tokens',
+        show: ({features}) => features!.has('org-auth-tokens'),
       },
       {
         path: `${pathPrefix}/developer-settings/`,

--- a/static/app/views/settings/organization/organizationSettingsNavigation.tsx
+++ b/static/app/views/settings/organization/organizationSettingsNavigation.tsx
@@ -5,9 +5,7 @@ import {Organization} from 'sentry/types';
 import {HookName, Hooks} from 'sentry/types/hooks';
 import withOrganization from 'sentry/utils/withOrganization';
 import SettingsNavigation from 'sentry/views/settings/components/settingsNavigation';
-import navigationConfiguration, {
-  organizationNavigationWithAuthTokens,
-} from 'sentry/views/settings/organization/navigationConfiguration';
+import navigationConfiguration from 'sentry/views/settings/organization/navigationConfiguration';
 import {NavigationSection} from 'sentry/views/settings/types';
 
 type Props = {
@@ -74,13 +72,9 @@ class OrganizationSettingsNavigation extends Component<Props, State> {
     const access = new Set(organization.access);
     const features = new Set(organization.features);
 
-    const navigationObjects = features.has('org-auth-tokens')
-      ? organizationNavigationWithAuthTokens
-      : navigationConfiguration;
-
     return (
       <SettingsNavigation
-        navigationObjects={navigationObjects}
+        navigationObjects={navigationConfiguration}
         access={access}
         features={features}
         organization={organization}

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -60,7 +60,7 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
 
   getTitle() {
     const {organization} = this.props;
-    return routeTitleGen(t('Developer Settings'), organization.slug, false);
+    return routeTitleGen(t('Custom Integrations'), organization.slug, false);
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
@@ -213,12 +213,10 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
       tabs.push(['sentryfx', t('Sentry Function')]);
     }
 
-    const hasAuthTokens = organization.features.includes('org-auth-tokens');
-
     return (
       <div>
         <SettingsPageHeader
-          title={hasAuthTokens ? t('Custom Integrations') : t('Developer Settings')}
+          title={t('Custom Integrations')}
           body={
             <Fragment>
               {t(


### PR DESCRIPTION
This PR prepares the org settings for the org auth tokens. Previously, we still used the old structure for users without the feature flag. This has the problem that using a different structure leads to deep linking not working for users with the feature flag. Also, there should be no problem already using the new structure for the custom integrations even without org tokens. So this streamlines this and makes the org tokens work better while still feature flagged.

Without the feature flag, this looks like this now:

<img width="1486" alt="Screenshot 2023-07-07 at 10 26 23" src="https://github.com/getsentry/sentry/assets/2411343/cc1d49c7-8628-4767-bc09-c280189b5b46">

(Before, the "Custom Integrations" menu point was called "Developer Settings" and could be found directly below "Integrations")