### PR TITLE
ref(gettings-started-docs): Add react to the list of platforms

### DIFF
--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -36,7 +36,7 @@ const otherPlatform = {
 };
 
 const platformIntegrations: PlatformIntegration[] = [
-  ...integrationDocsPlatforms.platforms,
+  ...integrationDocsPlatforms.platforms.filter(platform => platform.id !== 'javascript'),
   migratedJavascriptPlatforms,
   otherPlatform,
 ]

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -6,7 +6,7 @@ import {PlatformIntegration} from 'sentry/types';
 
 import {tracing} from './platformCategories';
 
-const migratedPlatforms = {
+const migratedJavascriptPlatforms = {
   id: 'javascript',
   name: 'Browser JavaScript',
   integrations: [
@@ -37,7 +37,7 @@ const otherPlatform = {
 
 const platformIntegrations: PlatformIntegration[] = [
   ...integrationDocsPlatforms.platforms,
-  migratedPlatforms,
+  migratedJavascriptPlatforms,
   otherPlatform,
 ]
   .map(platform => {

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -10,9 +10,9 @@ const migratedJavascriptPlatforms = {
   id: 'javascript',
   name: 'Browser JavaScript',
   integrations: [
-    ...integrationDocsPlatforms.platforms
-      .filter(platform => platform.id === 'javascript')[0]
-      .integrations.filter(integration => integration.id !== 'javascript-react'),
+    ...(integrationDocsPlatforms.platforms
+      .filter(platform => platform.id === 'javascript')?.[0]
+      ?.integrations?.filter(integration => integration.id !== 'javascript-react') ?? []),
     {
       id: 'javascript-react',
       link: 'https://docs.sentry.io/platforms/javascript/guides/react/',
@@ -36,7 +36,9 @@ const otherPlatform = {
 };
 
 const platformIntegrations: PlatformIntegration[] = [
-  ...integrationDocsPlatforms.platforms.filter(platform => platform.id !== 'javascript'),
+  ...(integrationDocsPlatforms.platforms.filter(
+    platform => platform.id !== 'javascript'
+  ) ?? []),
   migratedJavascriptPlatforms,
   otherPlatform,
 ]

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -6,6 +6,22 @@ import {PlatformIntegration} from 'sentry/types';
 
 import {tracing} from './platformCategories';
 
+const migratedPlatforms = {
+  id: 'javascript',
+  name: 'Browser JavaScript',
+  integrations: [
+    ...integrationDocsPlatforms.platforms.filter(
+      platform => platform.id === 'javascript'
+    )[0].integrations,
+    {
+      id: 'javascript-react',
+      link: 'https://docs.sentry.io/platforms/javascript/guides/react/',
+      name: 'React',
+      type: 'framework',
+    },
+  ],
+};
+
 const otherPlatform = {
   integrations: [
     {
@@ -21,6 +37,7 @@ const otherPlatform = {
 
 const platformIntegrations: PlatformIntegration[] = [
   ...integrationDocsPlatforms.platforms,
+  migratedPlatforms,
   otherPlatform,
 ]
   .map(platform => {

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -10,9 +10,9 @@ const migratedJavascriptPlatforms = {
   id: 'javascript',
   name: 'Browser JavaScript',
   integrations: [
-    ...integrationDocsPlatforms.platforms.filter(
-      platform => platform.id === 'javascript'
-    )[0].integrations,
+    ...integrationDocsPlatforms.platforms
+      .filter(platform => platform.id === 'javascript')[0]
+      .integrations.filter(integration => integration.id !== 'javascript-react'),
     {
       id: 'javascript-react',
       link: 'https://docs.sentry.io/platforms/javascript/guides/react/',


### PR DESCRIPTION
This is part of the docs migration from `sentry-docs` to `sentry`. Since we are removing `javascript-react` from the wizard docs, we have to manually add it to the platforms list, so it will be shown in the "select platform" page