### PR TITLE
ref(metrics): Convert discover queries directly without QueryBuilder

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import re
 from typing import (
     Any,
     Dict,
@@ -197,9 +198,12 @@ class OndemandMetricSpec:
         2. Generation of rules for on-demand metric extraction.
 
         """
-        relay_field, metric_type, op = _extract_field_info(field)
 
-        self._query = query
+        # On-demand metrics are implicitly transaction metrics. Remove the
+        # filter from the query since it can't be translated to a RuleCondition.
+        self._query = re.sub(r"event\.type:transaction\s*", "", query)
+
+        relay_field, metric_type, op = _extract_field_info(field)
         self.field = relay_field
         self.metric_type = metric_type
         self.mri = f"{metric_type}:{CUSTOM_ALERT_METRIC_NAME}@none"

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -131,12 +131,19 @@ def test_nested_conditions():
 
 
 def test_wildcard_condition():
-    alert = create_alert("release.version:1.*")
+    # transaction.duration is required for convert_query_to_metric
+    alert = create_alert("release.version:1.* transaction.duration:1s")
     metric = convert_query_to_metric(alert.snuba_query)
 
     expected = {
         "category": "transaction",
-        "condition": {"name": "event.release.version.short", "op": "glob", "value": ["1.*"]},
+        "condition": {
+            "op": "and",
+            "inner": [
+                {"name": "event.release.version.short", "op": "glob", "value": ["1.*"]},
+                {"name": "event.duration", "op": "eq", "value": 1000.0},
+            ],
+        },
         "field": "event.measurements.fp",
         "mri": "d:transactions/on_demand@none",
         "tags": [{"key": "query_hash", "value": ANY}],


### PR DESCRIPTION
Instead of using QueryBuilder's internal methods, this switches the
on-demand metric converter to using plain event search parsers. All
mappings have been updated to map directly from UI language to the event
protocol.

The event search query parser does not resolve hierarchies of logical
operations and instead emits a flat token stream. For this reason,
conditions are now converted by a simple recursive descent utility.

Tests will not pass until #52356 is merged in, since the converter
requires `transaction.duration` in the query string.

Closes #52432