### PR TITLE
ref(getting-started-docs): Migrate remix doc to sentry main repo 

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1635,11 +1635,11 @@ SENTRY_FEATURES = {
     # Enable u2f verification on superuser form
     "organizations:u2f-superuser-form": False,
     # Enable project creation for all
-    "organizations:team-project-creation-all": False,
+    "organizations:team-project-creation-all": True,
     # Enable project creation for all and puts organization into test group
-    "organizations:team-project-creation-all-allowlist": False,
+    "organizations:team-project-creation-all-allowlist": True,
     # Enable setting team-level roles and receiving permissions from them
-    "organizations:team-roles": False,
+    "organizations:team-roles": True,
     # Enable team member role provisioning through scim
     "organizations:scim-team-roles": False,
     # Enable the setting of org roles for team

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1635,11 +1635,11 @@ SENTRY_FEATURES = {
     # Enable u2f verification on superuser form
     "organizations:u2f-superuser-form": False,
     # Enable project creation for all
-    "organizations:team-project-creation-all": True,
+    "organizations:team-project-creation-all": False,
     # Enable project creation for all and puts organization into test group
-    "organizations:team-project-creation-all-allowlist": True,
+    "organizations:team-project-creation-all-allowlist": False,
     # Enable setting team-level roles and receiving permissions from them
-    "organizations:team-roles": True,
+    "organizations:team-roles": False,
     # Enable team member role provisioning through scim
     "organizations:scim-team-roles": False,
     # Enable the setting of org roles for team

--- a/static/app/components/onboarding/gettingStartedDoc/layout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/layout.tsx
@@ -5,7 +5,11 @@ import HookOrDefault from 'sentry/components/hookOrDefault';
 import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
-import {Step, StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {
+  Step,
+  StepProps,
+  StepType,
+} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   ProductSelection,
   ProductSolution,
@@ -27,20 +31,17 @@ type NextStep = {
 
 type CurrentSteps = [
   {
-    code: string;
-    description: React.ReactNode;
+    configurations: StepProps['configurations'];
     language: string;
     type: StepType.INSTALL;
   },
   {
-    code: string;
-    description: React.ReactNode;
+    configurations: StepProps['configurations'];
     language: string;
     type: StepType.CONFIGURE;
   },
   {
-    code: string;
-    description: React.ReactNode;
+    configurations: StepProps['configurations'];
     language: string;
     type: StepType.VERIFY;
   }
@@ -74,8 +75,7 @@ export function Layout({steps, nextSteps, newOrg}: LayoutProps) {
           <Step
             key={step.type}
             type={step.type}
-            description={step.description}
-            code={step.code}
+            configurations={step.configurations}
             language={step.language}
           />
         ))}

--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -6,7 +6,7 @@ import {Organization, PlatformIntegration, Project, ProjectKey} from 'sentry/typ
 import {useApiQuery} from 'sentry/utils/queryClient';
 
 // Documents already migrated from sentry-docs to main sentry repository
-export const migratedDocs = ['javascript-react'];
+export const migratedDocs = ['javascript-react', 'javascript-remix'];
 
 type SdkDocumentationProps = {
   activeProductSelection: ProductSolution[];

--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
@@ -15,7 +16,7 @@ export const StepTitle = {
   [StepType.VERIFY]: t('Verify'),
 };
 
-export type StepProps = {
+type Configuration = {
   /**
    * The code snippet to display
    */
@@ -24,6 +25,10 @@ export type StepProps = {
    * A brief description of the step
    */
   description: React.ReactNode;
+};
+
+export type StepProps = {
+  configurations: Configuration[];
   /**
    * The language of the selected platform (python, javascript, etc)
    */
@@ -34,16 +39,28 @@ export type StepProps = {
   type: StepType;
 };
 
-export function Step({type, description, language, code}: StepProps) {
+export function Step({type, configurations, language}: StepProps) {
   return (
     <div>
       <h4>{StepTitle[type]}</h4>
-      <p>{description}</p>
-      <CodeSnippet dark language={language}>
-        {language === 'javascript'
-          ? beautify.js(code, {indent_size: 2, e4x: true})
-          : beautify.html(code, {indent_size: 2})}
-      </CodeSnippet>
+      <Configurations>
+        {configurations.map((configuration, index) => (
+          <div key={index}>
+            <p>{configuration.description}</p>
+            <CodeSnippet dark language={language}>
+              {language === 'javascript'
+                ? beautify.js(configuration.code, {indent_size: 2, e4x: true})
+                : beautify.html(configuration.code, {indent_size: 2})}
+            </CodeSnippet>
+          </div>
+        ))}
+      </Configurations>
     </div>
   );
 }
+
+const Configurations = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -1,6 +1,7 @@
 import integrationDocsPlatforms from 'integration-docs-platforms';
 import sortBy from 'lodash/sortBy';
 
+import {migratedDocs} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {t} from 'sentry/locale';
 import {PlatformIntegration} from 'sentry/types';
 
@@ -12,11 +13,18 @@ const migratedJavascriptPlatforms = {
   integrations: [
     ...(integrationDocsPlatforms.platforms
       .filter(platform => platform.id === 'javascript')?.[0]
-      ?.integrations?.filter(integration => integration.id !== 'javascript-react') ?? []),
+      ?.integrations?.filter(integration => !migratedDocs.includes(integration.id)) ??
+      []),
     {
       id: 'javascript-react',
       link: 'https://docs.sentry.io/platforms/javascript/guides/react/',
       name: 'React',
+      type: 'framework',
+    },
+    {
+      id: 'javascript-remix',
+      link: 'https://docs.sentry.io/platforms/javascript/guides/remix/',
+      name: 'Remix',
       type: 'framework',
     },
   ],
@@ -37,7 +45,7 @@ const otherPlatform = {
 
 const platformIntegrations: PlatformIntegration[] = [
   ...(integrationDocsPlatforms.platforms.filter(
-    platform => platform.id !== 'javascript'
+    platform => !migratedDocs.includes(platform.id)
   ) ?? []),
   migratedJavascriptPlatforms,
   otherPlatform,

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -45,7 +45,7 @@ const otherPlatform = {
 
 const platformIntegrations: PlatformIntegration[] = [
   ...(integrationDocsPlatforms.platforms.filter(
-    platform => !migratedDocs.includes(platform.id)
+    platform => platform.id !== 'javascript'
   ) ?? []),
   migratedJavascriptPlatforms,
   otherPlatform,

--- a/static/app/gettingStartedDocs/javascript/remix.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.spec.tsx
@@ -1,0 +1,44 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {ProductSolution} from 'sentry/components/onboarding/productSelection';
+
+import GettingStartedWithRemix, {nextSteps, steps} from './remix';
+
+describe('GettingStartedWithRemix', function () {
+  it('all products are selected', function () {
+    const {container} = render(
+      <GettingStartedWithRemix
+        dsn="test-dsn"
+        activeProductSelection={[
+          ProductSolution.PERFORMANCE_MONITORING,
+          ProductSolution.SESSION_REPLAY,
+        ]}
+      />
+    );
+
+    // Steps
+    for (const step of steps()) {
+      expect(
+        screen.getByRole('heading', {name: StepTitle[step.type]})
+      ).toBeInTheDocument();
+    }
+
+    // Next Steps
+    const filteredNextStepsLinks = nextSteps.filter(
+      nextStep =>
+        ![
+          ProductSolution.PERFORMANCE_MONITORING,
+          ProductSolution.SESSION_REPLAY,
+        ].includes(nextStep.id as ProductSolution)
+    );
+
+    for (const filteredNextStepsLink of filteredNextStepsLinks) {
+      expect(
+        screen.getByRole('link', {name: filteredNextStepsLink.name})
+      ).toBeInTheDocument();
+    }
+
+    expect(container).toSnapshot();
+  });
+});

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -205,7 +205,9 @@ export function ProjectInstallPlatform({location, params, route, router}: Props)
   // This is a feature flag that is currently only enabled for a subset of internal users until the feature is fully implemented,
   // but the purpose of the feature is to make the product selection feature in documents available to all users
   // and guide them to upgrade to a plan if one of the products is not available on their current plan.
-  const gettingStartedDocWithProductSelection = true;
+  const gettingStartedDocWithProductSelection = !!organization?.features.includes(
+    'getting-started-doc-with-product-selection'
+  );
 
   const recentCreatedProject = useRecentCreatedProject({
     orgSlug: organization.slug,

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -205,9 +205,7 @@ export function ProjectInstallPlatform({location, params, route, router}: Props)
   // This is a feature flag that is currently only enabled for a subset of internal users until the feature is fully implemented,
   // but the purpose of the feature is to make the product selection feature in documents available to all users
   // and guide them to upgrade to a plan if one of the products is not available on their current plan.
-  const gettingStartedDocWithProductSelection = !!organization?.features.includes(
-    'getting-started-doc-with-product-selection'
-  );
+  const gettingStartedDocWithProductSelection = true;
 
   const recentCreatedProject = useRecentCreatedProject({
     orgSlug: organization.slug,


### PR DESCRIPTION
This PR represents the outcome of our chosen [PoC with React](https://github.com/getsentry/sentry/pull/50169), aiming to enhance our getting started documentation in the Sentry repository using React. It introduces a new structure and successfully migrates the javascript-remix documentation from sentry-docs to our main Sentry repository.


**Closes:** https://github.com/getsentry/sentry/issues/52124


**Todo:** Remove the folder https://github.com/getsentry/sentry-docs/tree/master/src/wizard/javascript/remix from sentry docs 

**Note:** The migration of this document was peculiar because it required modifying the layout to accommodate multiple configurations.
