### PR TITLE
fix(issue-events): Ensure proper behavior for full=false in issue events endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -97,7 +97,7 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
         if environments:
             params["environment"] = [env.name for env in environments]
 
-        full = request.GET.get("full", False)
+        full = request.GET.get("full") in ("1", "true")
 
         def data_fn(offset: int, limit: int) -> Any:
             try:

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -60,6 +60,9 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
+        # Should default to full=false which does not include context property
+        assert "context" not in response.data[0]
+        assert "context" not in response.data[1]
 
     def test_full_false(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/52444

The issue here was that the code pulling the `full` query param does not convert the value to a boolean. As such, any value passed for `full` (e.g. `full=false`) will result in a truthy value. The changes here ensure that only `full=1` or `full=true` trigger the full event serializer whereas `full=false` will not.