### PR TITLE
chore(replay): Cleanup the `organizations:session-replay-index-subquery` flag

### DIFF
--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -272,7 +272,6 @@ detailed_project = {
             "performance-n-plus-one-api-calls-detector",
             "performance-render-blocking-asset-span-post-process-group",
             "performance-uncompressed-assets-post-process-group",
-            "session-replay-index-subquery",
             "performance-issues-search",
             "performance-slow-db-issue",
             "performance-db-main-thread-ingest",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1559,8 +1559,6 @@ SENTRY_FEATURES = {
     "organizations:session-replay-sdk-errors-only": False,
     # Enable data scrubbing of replay recording payloads in Relay.
     "organizations:session-replay-recording-scrubbing": False,
-    # Enable subquery optimizations for the replay_index page
-    "organizations:session-replay-index-subquery": False,
     "organizations:session-replay-weekly-email": False,
     # Enable the new suggested assignees feature
     "organizations:streamline-targeting-context": False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -176,7 +176,6 @@ default_manager.add("organizations:session-replay-errors-tab", OrganizationFeatu
 default_manager.add("organizations:session-replay-sdk", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-sdk-errors-only", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-recording-scrubbing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:session-replay-index-subquery", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-weekly-email", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-overage-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -22,7 +22,6 @@ from snuba_sdk import (
 from snuba_sdk.expressions import Expression
 from snuba_sdk.orderby import Direction, OrderBy
 
-from sentry import features
 from sentry.api.event_search import ParenExpression, SearchConfig, SearchFilter
 from sentry.models.organization import Organization
 from sentry.replays.lib.query import (
@@ -74,24 +73,24 @@ def query_replays_collection(
     paginators = make_pagination_values(limit, offset)
 
     # Attempt to eager return with subquery.
-    if features.has("organizations:session-replay-index-subquery", organization, actor=actor):
-        try:
-            response = query_replays_dataset_with_subquery(
-                project_ids=project_ids,
-                start=start,
-                end=end,
-                fields=fields,
-                environments=environment,
-                search_filters=search_filters,
-                sort=sort,
-                pagination=paginators,
-                tenant_ids=tenant_ids,
-            )
-            return response["data"]
-        except ParseError:
-            # Subquery could not continue because it found search filters which required
-            # aggregation to satisfy.
-            pass
+
+    try:
+        response = query_replays_dataset_with_subquery(
+            project_ids=project_ids,
+            start=start,
+            end=end,
+            fields=fields,
+            environments=environment,
+            search_filters=search_filters,
+            sort=sort,
+            pagination=paginators,
+            tenant_ids=tenant_ids,
+        )
+        return response["data"]
+    except ParseError:
+        # Subquery could not continue because it found search filters which required
+        # aggregation to satisfy.
+        pass
 
     response = query_replays_dataset(
         project_ids=project_ids,

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -1170,10 +1170,3 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             assert response.status_code == 200
             response = self.client.get(self.url + "?field=browser&field=count_urls")
             assert response.status_code == 200
-
-
-@region_silo_test
-@apply_feature_flag_on_cls("organizations:global-views")
-class OrganizationReplayIndexTestSubQueryOptimized(OrganizationReplayIndexTest):
-    # run the same tests except with the subquery optimization applied
-    pass

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -1174,7 +1174,6 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
 
 @region_silo_test
 @apply_feature_flag_on_cls("organizations:global-views")
-@apply_feature_flag_on_cls("organizations:session-replay-index-subquery")
 class OrganizationReplayIndexTestSubQueryOptimized(OrganizationReplayIndexTest):
     # run the same tests except with the subquery optimization applied
     pass


### PR DESCRIPTION
This is shipped to 100% of orgs in flagr: https://flagr.getsentry.net/#/flags/356

Time to turn it down
