### PR TITLE
fix(gridEditable): Hide overflow-y to avoid scrolling table

### DIFF
--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -52,6 +52,7 @@ export const Body = styled(({children, ...props}) => (
   </Panel>
 ))`
   overflow-x: auto;
+  overflow-y: hidden;
   z-index: ${Z_INDEX_PANEL};
 `;
 


### PR DESCRIPTION
The table had extra whitespace which caused it to overflow and get a scroll bar when there wasn't really more content. I noticed this on the performance page as well as Discover. Adding a quick fix to use `overflow-y: hidden`


https://github.com/getsentry/sentry/assets/22846452/aa15b75a-aab8-4d83-9be1-2e7ad72ea529

