### PR TITLE
fix(cursors): Preserve the ssl scheme in cursor links.

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -32,7 +32,7 @@ from sentry.utils import json
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.cursors import Cursor
 from sentry.utils.dates import to_datetime
-from sentry.utils.http import is_valid_origin, origin_from_request
+from sentry.utils.http import absolute_uri, is_valid_origin, origin_from_request
 from sentry.utils.sdk import capture_exception, merge_context_into_scope
 
 from .authentication import ApiKeyAuthentication, OrgAuthTokenAuthentication, TokenAuthentication
@@ -184,7 +184,7 @@ class Endpoint(APIView):
             mutable_query_dict.pop("cursor")
             querystring = mutable_query_dict.urlencode()
 
-        base_url = request.build_absolute_uri(urlquote(request.path))
+        base_url = absolute_uri(urlquote(request.path))
 
         if querystring is not None:
             base_url = f"{base_url}?{querystring}"

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -32,7 +32,12 @@ from sentry.utils import json
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.cursors import Cursor
 from sentry.utils.dates import to_datetime
-from sentry.utils.http import absolute_uri, is_valid_origin, origin_from_request
+from sentry.utils.http import (
+    absolute_uri,
+    is_using_customer_domain,
+    is_valid_origin,
+    origin_from_request,
+)
 from sentry.utils.sdk import capture_exception, merge_context_into_scope
 
 from .authentication import ApiKeyAuthentication, OrgAuthTokenAuthentication, TokenAuthentication
@@ -55,6 +60,7 @@ from ..utils.pagination_factory import (
     get_cursor,
     get_paginator,
 )
+from .utils import generate_organization_url
 
 ONE_MINUTE = 60
 ONE_HOUR = ONE_MINUTE * 60
@@ -184,7 +190,12 @@ class Endpoint(APIView):
             mutable_query_dict.pop("cursor")
             querystring = mutable_query_dict.urlencode()
 
-        base_url = absolute_uri(urlquote(request.path))
+        url_prefix = (
+            generate_organization_url(request.subdomain)
+            if is_using_customer_domain(request)
+            else None
+        )
+        base_url = absolute_uri(urlquote(request.path), url_prefix=url_prefix)
 
         if querystring is not None:
             base_url = f"{base_url}?{querystring}"

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -245,8 +245,11 @@ class BaseTestCase(Fixtures):
         is_superuser=False,
         path="/",
         secure_scheme=False,
+        subdomain=None,
     ) -> HttpRequest:
         request = HttpRequest()
+        if subdomain:
+            setattr(request, "subdomain", subdomain)
         if method:
             request.method = method
         request.path = path

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -238,7 +238,13 @@ class BaseTestCase(Fixtures):
         self.client.cookies[name].update({k.replace("_", "-"): v for k, v in params.items()})
 
     def make_request(
-        self, user=None, auth=None, method=None, is_superuser=False, path="/"
+        self,
+        user=None,
+        auth=None,
+        method=None,
+        is_superuser=False,
+        path="/",
+        secure_scheme=False,
     ) -> HttpRequest:
         request = HttpRequest()
         if method:
@@ -247,6 +253,9 @@ class BaseTestCase(Fixtures):
         request.META["REMOTE_ADDR"] = "127.0.0.1"
         request.META["SERVER_NAME"] = "testserver"
         request.META["SERVER_PORT"] = 80
+        if secure_scheme:
+            secure_header = settings.SECURE_PROXY_SSL_HEADER
+            request.META[secure_header[0]] = secure_header[1]
 
         # order matters here, session -> user -> other things
         request.session = self.session

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -69,6 +69,9 @@ def pytest_configure(config):
         else:
             raise RuntimeError("oops, wrong database: %r" % test_db)
 
+    # Ensure we can test secure ssl settings
+    settings.SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
     # silence (noisy) loggers by default when testing
     settings.LOGGING["loggers"]["sentry"]["level"] = "ERROR"  # type: ignore[index]
 

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -318,6 +318,25 @@ class CursorGenerationTest(APITestCase):
             ' rel="next"; results="true"; cursor="1492107369532:0:0"'
         )
 
+    def test_handles_customer_domains(self):
+        request = self.make_request(
+            method="GET", path="/api/0/organizations/", secure_scheme=True, subdomain="bebe"
+        )
+        request.GET = QueryDict("member=1&cursor=foo")
+        endpoint = Endpoint()
+        with override_options(
+            {
+                "system.url-prefix": "https://testserver",
+                "system.organization-url-template": "https://{hostname}",
+            }
+        ):
+            result = endpoint.build_cursor_link(request, "next", "1492107369532:0:0")
+
+        assert result == (
+            "<https://bebe.testserver/api/0/organizations/?member=1&cursor=1492107369532:0:0>;"
+            ' rel="next"; results="true"; cursor="1492107369532:0:0"'
+        )
+
     def test_unicode_path(self):
         request = self.make_request(method="GET", path="/api/0/organizations/üuuuu/")
         endpoint = Endpoint()

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -306,6 +306,18 @@ class CursorGenerationTest(APITestCase):
             ' rel="next"; results="true"; cursor="1492107369532:0:0"'
         )
 
+    def test_preserves_ssl_proto(self):
+        request = self.make_request(method="GET", path="/api/0/organizations/", secure_scheme=True)
+        request.GET = QueryDict("member=1&cursor=foo")
+        endpoint = Endpoint()
+        with override_options({"system.url-prefix": "https://testserver"}):
+            result = endpoint.build_cursor_link(request, "next", "1492107369532:0:0")
+
+        assert result == (
+            "<https://testserver/api/0/organizations/?member=1&cursor=1492107369532:0:0>;"
+            ' rel="next"; results="true"; cursor="1492107369532:0:0"'
+        )
+
     def test_unicode_path(self):
         request = self.make_request(method="GET", path="/api/0/organizations/üuuuu/")
         endpoint = Endpoint()


### PR DESCRIPTION
In production, we are currently returning `http://` links in our pagination protocol, resulting in leaked user credentials.  We didn't have a test to validate this, adding one, and ensuring that we use our helper that seems to, at the very least, respect system url-prefix. 