### PR TITLE
fix(hc): Fix integration request notification test silo

### DIFF
--- a/tests/sentry/notifications/notifications/organization_request/test_integration_request.py
+++ b/tests/sentry/notifications/notifications/organization_request/test_integration_request.py
@@ -3,10 +3,10 @@ from sentry.notifications.notifications.organization_request.integration_request
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import region_silo_test
 
 
-@control_silo_test
+@region_silo_test(stable=True)
 class TestIntegrationRequestNotification(TestCase):
     def test_get_context(self):
         owner = self.create_user("owner@example.com")


### PR DESCRIPTION
`IntegrationRequestNotification` is only used in a single place (aside from the debug email view) which is a region endpoint: https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/integrations/install_request.py#L42