### PR TITLE
fix(functions): Truncate functions fingerprint to 32 bits

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_profiling_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_functions.py
@@ -100,7 +100,7 @@ class OrganizationProfilingFunctionTrendsEndpointTest(ProfilesSnubaTestCase):
                 "change": "improvement",
                 "project": str(self.project.id),
                 "transaction": str(
-                    self.function_fingerprint({"package": "foo", "function": "bar"})
+                    self.function_fingerprint({"package": "foo", "function": "bar"}) & 0xFFFFFFFF
                 ),
                 "trend_difference": -10000000.0,
                 "trend_percentage": 0.9090909090909091,
@@ -115,7 +115,7 @@ class OrganizationProfilingFunctionTrendsEndpointTest(ProfilesSnubaTestCase):
                 "change": "improvement",
                 "project": str(self.project.id),
                 "transaction": str(
-                    self.function_fingerprint({"package": "foo", "function": "baz"})
+                    self.function_fingerprint({"package": "foo", "function": "baz"}) & 0xFFFFFFFF
                 ),
                 "trend_difference": -900000000.0,
                 "trend_percentage": 0.1,
@@ -177,7 +177,7 @@ class OrganizationProfilingFunctionTrendsEndpointTest(ProfilesSnubaTestCase):
                 "change": "regression",
                 "project": str(self.project.id),
                 "transaction": str(
-                    self.function_fingerprint({"package": "foo", "function": "baz"})
+                    self.function_fingerprint({"package": "foo", "function": "baz"}) & 0xFFFFFFFF
                 ),
                 "trend_difference": 400000000.0,
                 "trend_percentage": 5.0,
@@ -192,7 +192,7 @@ class OrganizationProfilingFunctionTrendsEndpointTest(ProfilesSnubaTestCase):
                 "change": "regression",
                 "project": str(self.project.id),
                 "transaction": str(
-                    self.function_fingerprint({"package": "foo", "function": "bar"})
+                    self.function_fingerprint({"package": "foo", "function": "bar"}) & 0xFFFFFFFF
                 ),
                 "trend_difference": 900000000.0,
                 "trend_percentage": 10.0,
@@ -256,7 +256,7 @@ class OrganizationProfilingFunctionTrendsEndpointTest(ProfilesSnubaTestCase):
                 "change": "improvement",
                 "project": str(self.project.id),
                 "transaction": str(
-                    self.function_fingerprint({"package": "foo", "function": "bar"})
+                    self.function_fingerprint({"package": "foo", "function": "bar"}) & 0xFFFFFFFF
                 ),
                 "trend_difference": -400000000.0,
                 "trend_percentage": 0.2,
@@ -271,7 +271,7 @@ class OrganizationProfilingFunctionTrendsEndpointTest(ProfilesSnubaTestCase):
                 "change": "improvement",
                 "project": str(self.project.id),
                 "transaction": str(
-                    self.function_fingerprint({"package": "foo", "function": "baz"})
+                    self.function_fingerprint({"package": "foo", "function": "baz"}) & 0xFFFFFFFF
                 ),
                 "trend_difference": -900000000.0,
                 "trend_percentage": 0.1,

--- a/tests/sentry/search/events/builder/test_profile_functions.py
+++ b/tests/sentry/search/events/builder/test_profile_functions.py
@@ -62,12 +62,12 @@ def params():
         ),
         pytest.param(
             "fingerprint:123",
-            Condition(Column("fingerprint"), Op("="), 123),
+            Condition(Function("toUInt32", [Column("fingerprint")], "fingerprint"), Op("="), 123),
             id="fingerprint",
         ),
         pytest.param(
             "!fingerprint:123",
-            Condition(Column("fingerprint"), Op("!="), 123),
+            Condition(Function("toUInt32", [Column("fingerprint")], "fingerprint"), Op("!="), 123),
             id="not fingerprint",
         ),
     ],


### PR DESCRIPTION
Snuba doesn't handle 64 bit unsigned integers well. Here we truncate the function fingerprint to 32 bits as that should still provide enough uniqueness. Long erm, we will want to generate a 32 bit fingerprint and update the underlying table but this will ensure correctness for the time being.