### PR TITLE
adds default condition to alert rule

### DIFF
--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -29,7 +29,6 @@ export interface IssueAlertRuleActionTemplate {
   id: string;
   label: string;
   name: string;
-  prompt: string;
   actionType?: 'ticket' | 'sentryapp';
   formFields?:
     | {
@@ -54,7 +53,7 @@ export interface IssueAlertRuleAction
 
 export type IssueAlertRuleCondition = Omit<
   IssueAlertRuleConditionTemplate,
-  'formFields' | 'enabled' | 'prompt' | 'name'
+  'formFields' | 'enabled' | 'name'
 > & {
   dynamic_form_fields?: IssueConfigField[];
 } & {

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -36,6 +36,7 @@ export interface IssueAlertRuleActionTemplate {
       }
     | SchemaFormConfig;
   link?: string;
+  prompt?: string;
   sentryAppInstallationUuid?: string;
   ticketType?: string;
 }

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -54,7 +54,7 @@ export interface IssueAlertRuleAction
 
 export type IssueAlertRuleCondition = Omit<
   IssueAlertRuleConditionTemplate,
-  'formFields' | 'enabled'
+  'formFields' | 'enabled' | 'prompt' | 'name'
 > & {
   dynamic_form_fields?: IssueConfigField[];
 } & {

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -53,7 +53,7 @@ export interface IssueAlertRuleAction
 
 export type IssueAlertRuleCondition = Omit<
   IssueAlertRuleConditionTemplate,
-  'formFields' | 'enabled' | 'name'
+  'formFields' | 'enabled' | 'prompt'
 > & {
   dynamic_form_fields?: IssueConfigField[];
 } & {

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -54,7 +54,7 @@ export interface IssueAlertRuleAction
 
 export type IssueAlertRuleCondition = Omit<
   IssueAlertRuleConditionTemplate,
-  'formFields' | 'enabled' | 'prompt'
+  'formFields' | 'enabled'
 > & {
   dynamic_form_fields?: IssueConfigField[];
 } & {

--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -135,7 +135,10 @@ describe('ProjectAlertsCreate', function () {
       createWrapper();
       expect(await screen.findByText('All Environments')).toBeInTheDocument();
       await waitFor(() => {
-        expect(screen.getAllByText('all')).toHaveLength(2);
+        expect(screen.getByText('any')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText('all')).toBeInTheDocument();
       });
       await waitFor(() => {
         expect(screen.getByText('24 hours')).toBeInTheDocument();
@@ -158,7 +161,7 @@ describe('ProjectAlertsCreate', function () {
         'The issue is older or newer than...',
       ]);
 
-      await userEvent.click(screen.getByLabelText('Delete Node'));
+      await userEvent.click(screen.getAllByLabelText('Delete Node')[1]);
 
       await userEvent.click(screen.getByText('Save Rule'));
 
@@ -167,9 +170,14 @@ describe('ProjectAlertsCreate', function () {
           expect.any(String),
           expect.objectContaining({
             data: {
-              actionMatch: 'all',
+              actionMatch: 'any',
               actions: [],
-              conditions: [],
+              conditions: [
+                expect.objectContaining({
+                  id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
+                  name: 'A new issue is created',
+                }),
+              ],
               filterMatch: 'all',
               filters: [],
               frequency: 60 * 24,
@@ -188,6 +196,8 @@ describe('ProjectAlertsCreate', function () {
         method: 'POST',
         body: TestStubs.ProjectAlertRule(),
       });
+      // delete node
+      await userEvent.click(screen.getByLabelText('Delete Node'));
 
       // Change name of alert rule
       await userEvent.type(screen.getByPlaceholderText('Enter Alert Name'), 'myname');
@@ -215,7 +225,7 @@ describe('ProjectAlertsCreate', function () {
           expect.any(String),
           expect.objectContaining({
             data: {
-              actionMatch: 'all',
+              actionMatch: 'any',
               actions: [],
               conditions: [],
               filterMatch: 'all',
@@ -245,7 +255,7 @@ describe('ProjectAlertsCreate', function () {
         'Send a notification to all legacy integrations',
       ]);
 
-      await userEvent.click(screen.getByLabelText('Delete Node'));
+      await userEvent.click(screen.getAllByLabelText('Delete Node')[1]);
 
       await userEvent.click(screen.getByText('Save Rule'));
 
@@ -254,9 +264,14 @@ describe('ProjectAlertsCreate', function () {
           expect.any(String),
           expect.objectContaining({
             data: {
-              actionMatch: 'all',
+              actionMatch: 'any',
               actions: [],
-              conditions: [],
+              conditions: [
+                expect.objectContaining({
+                  id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
+                  name: 'A new issue is created',
+                }),
+              ],
               filterMatch: 'all',
               filters: [],
               frequency: 60 * 24,
@@ -290,10 +305,13 @@ describe('ProjectAlertsCreate', function () {
         await selectEvent.select(screen.getByText('All Environments'), ['production']);
 
         // Change actionMatch and filterMatch dropdown
-        const allDropdowns = screen.getAllByText('all');
-        expect(allDropdowns).toHaveLength(2);
-        await selectEvent.select(allDropdowns[0], ['any']);
-        await selectEvent.select(allDropdowns[1], ['any']);
+        const anyDropdown = screen.getByText('any');
+        expect(anyDropdown).toBeInTheDocument();
+        const allDropdown = screen.getByText('all');
+        expect(allDropdown).toBeInTheDocument();
+
+        await selectEvent.select(anyDropdown, ['all']);
+        await selectEvent.select(allDropdown, ['any']);
 
         // Change name of alert rule
         await userEvent.type(screen.getByPlaceholderText('Enter Alert Name'), 'myname');
@@ -304,9 +322,14 @@ describe('ProjectAlertsCreate', function () {
           expect.any(String),
           expect.objectContaining({
             data: {
-              actionMatch: 'any',
+              actionMatch: 'all',
               filterMatch: 'any',
-              conditions: [],
+              conditions: [
+                expect.objectContaining({
+                  id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
+                  name: 'A new issue is created',
+                }),
+              ],
               actions: [],
               filters: [],
               environment: 'production',
@@ -349,9 +372,14 @@ describe('ProjectAlertsCreate', function () {
           expect.any(String),
           expect.objectContaining({
             data: {
-              actionMatch: 'all',
+              actionMatch: 'any',
               actions: [],
-              conditions: [],
+              conditions: [
+                expect.objectContaining({
+                  id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
+                  name: 'A new issue is created',
+                }),
+              ],
               filterMatch: 'all',
               filters: [
                 {
@@ -382,6 +410,8 @@ describe('ProjectAlertsCreate', function () {
         // Change name of alert rule
         await userEvent.click(screen.getByPlaceholderText('Enter Alert Name'));
         await userEvent.paste('myname');
+        // delete one condition
+        await userEvent.click(screen.getAllByLabelText('Delete Node')[0]);
 
         // Add a new filter
         await selectEvent.select(screen.getByText('Add optional filter...'), [
@@ -396,7 +426,7 @@ describe('ProjectAlertsCreate', function () {
           expect.any(String),
           expect.objectContaining({
             data: {
-              actionMatch: 'all',
+              actionMatch: 'any',
               filterMatch: 'all',
               filters: [
                 {
@@ -443,11 +473,16 @@ describe('ProjectAlertsCreate', function () {
           expect.any(String),
           expect.objectContaining({
             data: {
-              actionMatch: 'all',
+              actionMatch: 'any',
               actions: [
                 {id: 'sentry.mail.actions.NotifyEmailAction', targetType: 'IssueOwners'},
               ],
-              conditions: [],
+              conditions: [
+                expect.objectContaining({
+                  id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
+                  name: 'A new issue is created',
+                }),
+              ],
               filterMatch: 'all',
               filters: [],
               frequency: '60',
@@ -489,8 +524,13 @@ describe('ProjectAlertsCreate', function () {
           expect.any(String),
           expect.objectContaining({
             data: {
-              actionMatch: 'all',
-              conditions: [],
+              actionMatch: 'any',
+              conditions: [
+                expect.objectContaining({
+                  id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
+                  name: 'A new issue is created',
+                }),
+              ],
               filterMatch: 'all',
               filters: [],
               frequency: 60 * 24,
@@ -508,20 +548,6 @@ describe('ProjectAlertsCreate', function () {
         expect(screen.getByText(group.shortId)).toBeInTheDocument();
       }
       expect(screen.getAllByText('3mo ago')[0]).toBeInTheDocument();
-
-      await selectEvent.select(screen.getByText('Add optional trigger...'), [
-        'A new issue is created',
-      ]);
-      await waitFor(() => {
-        expect(mock).toHaveBeenLastCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            data: expect.objectContaining({
-              endpoint: 'endpoint',
-            }),
-          })
-        );
-      });
     });
 
     it('invalid preview alert', async () => {
@@ -531,6 +557,9 @@ describe('ProjectAlertsCreate', function () {
         statusCode: 400,
       });
       createWrapper();
+      // delete existion condition
+      await userEvent.click(screen.getAllByLabelText('Delete Node')[0]);
+
       await waitFor(() => {
         expect(mock).toHaveBeenCalled();
       });
@@ -572,9 +601,10 @@ describe('ProjectAlertsCreate', function () {
 
     it('shows error for incompatible conditions', async () => {
       createWrapper();
-      await selectEvent.select(screen.getByText('Add optional trigger...'), [
-        'A new issue is created',
-      ]);
+      const anyDropdown = screen.getByText('any');
+      expect(anyDropdown).toBeInTheDocument();
+      await selectEvent.select(anyDropdown, ['all']);
+
       await selectEvent.select(screen.getByText('Add optional trigger...'), [
         'The issue changes state from resolved to unresolved',
       ]);
@@ -591,12 +621,8 @@ describe('ProjectAlertsCreate', function () {
 
     it('test any filterMatch', async () => {
       createWrapper();
-      const allDropdowns = screen.getAllByText('all');
-      await selectEvent.select(screen.getByText('Add optional trigger...'), [
-        'A new issue is created',
-      ]);
-
-      await selectEvent.select(allDropdowns[1], ['any']);
+      const allDropdown = screen.getByText('all');
+      await selectEvent.select(allDropdown, ['any']);
       await selectEvent.select(screen.getByText('Add optional filter...'), [
         'The issue is older or newer than...',
       ]);

--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -134,15 +134,9 @@ describe('ProjectAlertsCreate', function () {
     it('loads default values', async function () {
       createWrapper();
       expect(await screen.findByText('All Environments')).toBeInTheDocument();
-      await waitFor(() => {
-        expect(screen.getByText('any')).toBeInTheDocument();
-      });
-      await waitFor(() => {
-        expect(screen.getByText('all')).toBeInTheDocument();
-      });
-      await waitFor(() => {
-        expect(screen.getByText('24 hours')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('any')).toBeInTheDocument();
+      expect(await screen.findByText('all')).toBeInTheDocument();
+      expect(await screen.findByText('24 hours')).toBeInTheDocument();
     });
 
     it('can remove filters', async function () {

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -347,6 +347,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
         {
           id,
           label: CHANGE_ALERT_PLACEHOLDERS_LABELS[id],
+          name: 'A new issue is created',
         },
       ]);
     }

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -103,9 +103,10 @@ const ACTION_MATCH_OPTIONS_MIGRATED = [
 ];
 
 const defaultRule: UnsavedIssueAlertRule = {
-  actionMatch: 'all',
+  actionMatch: 'any',
   filterMatch: 'all',
   actions: [],
+  // note we update the default conditions in onLoadAllEndpointsSuccess
   conditions: [],
   filters: [],
   name: '',
@@ -330,10 +331,24 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
 
   onLoadAllEndpointsSuccess() {
     const {rule} = this.state;
+    const {
+      params: {ruleId},
+    } = this.props;
     if (rule) {
       ((rule as IssueAlertRule)?.errors || []).map(({detail}) =>
         addErrorMessage(detail, {append: true})
       );
+    }
+    if (!ruleId) {
+      // now that we've loaded all the possible conditions, we can populate the
+      // value of conditions for a new alert
+      const id = 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition';
+      this.handleChange('conditions', [
+        {
+          id,
+          label: CHANGE_ALERT_PLACEHOLDERS_LABELS[id],
+        },
+      ]);
     }
   }
 

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -582,7 +582,7 @@ function RuleNode({
                       {...deps}
                       sentryAppInstallationUuid={sentryAppInstallationUuid}
                       config={node.formFields as SchemaFormConfig}
-                      appName={node.prompt}
+                      appName={node.prompt ?? node.label}
                       onSubmitSuccess={updateParentFromSentryAppRule}
                       resetValues={data}
                     />


### PR DESCRIPTION
This PR adds a default condition for new alert rules for `A new Issue is created`. The uprose is to prevent people from accidentally making alert rules that trigger on every event which is generally not advisable except if you're pushing the events to some 3rd party data ingestion service.

<img width="1221" alt="Screen Shot 2023-07-07 at 3 11 53 PM" src="https://github.com/getsentry/sentry/assets/8533851/e5265133-c414-4983-abab-a2705159bc6f">
