### PR TITLE
ref(rules): Replace RuleStatus with ObjectStatus

### DIFF
--- a/src/sentry/api/bases/rule.py
+++ b/src/sentry/api/bases/rule.py
@@ -4,7 +4,8 @@ from rest_framework.request import Request
 
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models import Rule, RuleStatus
+from sentry.constants import ObjectStatus
+from sentry.models import Rule
 
 
 class RuleEndpoint(ProjectEndpoint):
@@ -21,7 +22,9 @@ class RuleEndpoint(ProjectEndpoint):
 
         try:
             kwargs["rule"] = Rule.objects.get(
-                project=project, id=rule_id, status__in=[RuleStatus.ACTIVE, RuleStatus.INACTIVE]
+                project=project,
+                id=rule_id,
+                status=ObjectStatus.ACTIVE,
             )
         except Rule.DoesNotExist:
             raise ResourceDoesNotExist

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -11,13 +11,13 @@ from sentry.api.bases.rule import RuleEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer
 from sentry.api.serializers.rest_framework.rule import RuleSerializer as DrfRuleSerializer
+from sentry.constants import ObjectStatus
 from sentry.integrations.slack.utils import RedisRuleStatus
 from sentry.mediators import project_rules
 from sentry.models import (
     RegionScheduledDeletion,
     RuleActivity,
     RuleActivityType,
-    RuleStatus,
     SentryAppComponent,
     Team,
     User,
@@ -203,7 +203,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         """
         Delete a rule
         """
-        rule.update(status=RuleStatus.PENDING_DELETION)
+        rule.update(status=ObjectStatus.PENDING_DELETION)
         RuleActivity.objects.create(
             rule=rule, user_id=request.user.id, type=RuleActivityType.DELETED.value
         )

--- a/src/sentry/api/endpoints/project_rule_task_details.py
+++ b/src/sentry/api/endpoints/project_rule_task_details.py
@@ -5,8 +5,9 @@ from rest_framework.response import Response
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.serializers import serialize
+from sentry.constants import ObjectStatus
 from sentry.integrations.slack.utils import RedisRuleStatus
-from sentry.models import Rule, RuleStatus
+from sentry.models import Rule
 
 
 @region_silo_endpoint
@@ -35,7 +36,7 @@ class ProjectRuleTaskDetailsEndpoint(ProjectEndpoint):
                 rule = Rule.objects.get(
                     project=project,
                     id=int(rule_id),
-                    status__in=[RuleStatus.ACTIVE, RuleStatus.INACTIVE],
+                    status=ObjectStatus.ACTIVE,
                 )
                 context["rule"] = serialize(rule, request.user)
             except Rule.DoesNotExist:

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -8,9 +8,10 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.rule import RuleSerializer
+from sentry.constants import ObjectStatus
 from sentry.integrations.slack.utils import RedisRuleStatus
 from sentry.mediators import project_rules
-from sentry.models import Rule, RuleActivity, RuleActivityType, RuleStatus, Team, User
+from sentry.models import Rule, RuleActivity, RuleActivityType, Team, User
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.processor import is_condition_slow
 from sentry.signals import alert_rule_created
@@ -33,7 +34,8 @@ class ProjectRulesEndpoint(ProjectEndpoint):
 
         """
         queryset = Rule.objects.filter(
-            project=project, status__in=[RuleStatus.ACTIVE, RuleStatus.INACTIVE]
+            project=project,
+            status=ObjectStatus.ACTIVE,
         ).select_related("project")
 
         return self.paginate(
@@ -81,7 +83,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 new_rule_is_slow = True
                 break
 
-        rules = Rule.objects.filter(project=project, status=RuleStatus.ACTIVE)
+        rules = Rule.objects.filter(project=project, status=ObjectStatus.ACTIVE)
         slow_rules = 0
         for rule in rules:
             for condition in rule.data["conditions"]:

--- a/src/sentry/deletions/defaults/rule.py
+++ b/src/sentry/deletions/defaults/rule.py
@@ -13,8 +13,8 @@ class RuleDeletionTask(ModelDeletionTask):
         ]
 
     def mark_deletion_in_progress(self, instance_list):
-        from sentry.models import RuleStatus
+        from sentry.constants import ObjectStatus
 
         for instance in instance_list:
-            if instance.status != RuleStatus.PENDING_DELETION:
-                instance.update(status=RuleStatus.PENDING_DELETION)
+            if instance.status != ObjectStatus.PENDING_DELETION:
+                instance.update(status=ObjectStatus.PENDING_DELETION)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -22,7 +22,7 @@ from sentry.api.utils import InvalidParams
 from sentry.constants import ObjectStatus
 from sentry.incidents.models import AlertRule, Incident
 from sentry.incidents.serializers import AlertRuleSerializer
-from sentry.models import OrganizationMemberTeam, Project, Rule, RuleStatus, Team
+from sentry.models import OrganizationMemberTeam, Project, Rule, Team
 from sentry.models.rule import RuleSource
 from sentry.snuba.dataset import Dataset
 from sentry.utils.cursors import Cursor, StringCursor
@@ -74,7 +74,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
             # Filter to only error alert rules
             alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
         issue_rules = Rule.objects.filter(
-            status__in=[RuleStatus.ACTIVE, RuleStatus.INACTIVE],
+            status=ObjectStatus.ACTIVE,
             source__in=[RuleSource.ISSUE],
             project__in=projects,
         )

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -14,12 +14,13 @@ from sentry.api.paginator import (
     OffsetPaginator,
 )
 from sentry.api.serializers import CombinedRuleSerializer, serialize
+from sentry.constants import ObjectStatus
 from sentry.incidents.logic import get_slack_actions_with_async_lookups
 from sentry.incidents.models import AlertRule
 from sentry.incidents.serializers import AlertRuleSerializer
 from sentry.incidents.utils.sentry_apps import trigger_sentry_app_action_creators_for_incidents
 from sentry.integrations.slack.utils import RedisRuleStatus
-from sentry.models import Rule, RuleStatus
+from sentry.models import Rule
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.signals import alert_rule_created
 from sentry.snuba.dataset import Dataset
@@ -40,7 +41,8 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
         alert_rule_intermediary = CombinedQuerysetIntermediary(alert_rules, ["date_added"])
         rule_intermediary = CombinedQuerysetIntermediary(
             Rule.objects.filter(
-                project=project, status__in=[RuleStatus.ACTIVE, RuleStatus.INACTIVE]
+                project=project,
+                status=ObjectStatus.ACTIVE,
             ),
             ["date_added"],
         )

--- a/src/sentry/models/rule.py
+++ b/src/sentry/models/rule.py
@@ -4,6 +4,7 @@ from typing import Sequence, Tuple
 from django.db import models
 from django.utils import timezone
 
+from sentry.constants import ObjectStatus
 from sentry.db.models import (
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
@@ -15,14 +16,6 @@ from sentry.db.models import (
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager import BaseManager
 from sentry.utils.cache import cache
-
-
-# TODO(dcramer): pull in enum library
-class RuleStatus:
-    ACTIVE = 0
-    INACTIVE = 1
-    PENDING_DELETION = 2
-    DELETION_IN_PROGRESS = 3
 
 
 class RuleSource(IntEnum):
@@ -51,8 +44,8 @@ class Rule(Model):
     # `data` contain all the specifics of the rule - conditions, actions, frequency, etc.
     data = GzippedDictField()
     status = BoundedPositiveIntegerField(
-        default=RuleStatus.ACTIVE,
-        choices=((RuleStatus.ACTIVE, "Active"), (RuleStatus.INACTIVE, "Inactive")),
+        default=ObjectStatus.ACTIVE,
+        choices=((ObjectStatus.ACTIVE, "Active"), (ObjectStatus.DISABLED, "Disabled")),
         db_index=True,
     )
     # source is currently used as a way to distinguish rules created specifically
@@ -79,7 +72,7 @@ class Rule(Model):
         cache_key = f"project:{project_id}:rules"
         rules_list = cache.get(cache_key)
         if rules_list is None:
-            rules_list = list(cls.objects.filter(project=project_id, status=RuleStatus.ACTIVE))
+            rules_list = list(cls.objects.filter(project=project_id, status=ObjectStatus.ACTIVE))
             cache.set(cache_key, rules_list, 60)
         return rules_list
 

--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -21,7 +21,7 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.parameters import GlobalParams, MonitorParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
-from sentry.models import Rule, RuleActivity, RuleActivityType, RuleStatus, ScheduledDeletion
+from sentry.models import Rule, RuleActivity, RuleActivityType, ScheduledDeletion
 from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorStatus
 from sentry.monitors.serializers import MonitorSerializer, MonitorSerializerResponse
 from sentry.monitors.utils import create_alert_rule, update_alert_rule
@@ -202,14 +202,14 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
                         )
                         .exclude(
                             status__in=[
-                                RuleStatus.PENDING_DELETION,
-                                RuleStatus.DELETION_IN_PROGRESS,
+                                ObjectStatus.PENDING_DELETION,
+                                ObjectStatus.DELETION_IN_PROGRESS,
                             ]
                         )
                         .first()
                     )
                     if rule:
-                        rule.update(status=RuleStatus.PENDING_DELETION)
+                        rule.update(status=ObjectStatus.PENDING_DELETION)
                         RuleActivity.objects.create(
                             rule=rule, user_id=request.user.id, type=RuleActivityType.DELETED.value
                         )

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -36,7 +36,7 @@ from sentry.issues.grouptype import (
     MonitorCheckInTimeout,
 )
 from sentry.locks import locks
-from sentry.models import Environment, Organization, Rule, RuleSource, RuleStatus
+from sentry.models import Environment, Organization, Rule, RuleSource
 from sentry.utils.retries import TimedRetryPolicy
 
 logger = logging.getLogger(__name__)
@@ -312,7 +312,7 @@ class Monitor(Model):
                 project_id=self.project_id,
                 id=alert_rule_id,
                 source=RuleSource.CRON_MONITOR,
-                status__in=[RuleStatus.ACTIVE, RuleStatus.INACTIVE],
+                status=ObjectStatus.ACTIVE,
             ).first()
             if alert_rule:
                 return alert_rule

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -8,8 +8,9 @@ import responses
 from freezegun import freeze_time
 from pytz import UTC
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.slack.utils.channel import strip_channel_name
-from sentry.models import Environment, Integration, Rule, RuleActivity, RuleActivityType, RuleStatus
+from sentry.models import Environment, Integration, Rule, RuleActivity, RuleActivityType
 from sentry.models.actor import Actor, get_actor_for_user
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.testutils import APITestCase
@@ -764,5 +765,5 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         )
         rule.refresh_from_db()
         assert not Rule.objects.filter(
-            id=self.rule.id, project=self.project, status=RuleStatus.PENDING_DELETION
+            id=self.rule.id, project=self.project, status=ObjectStatus.PENDING_DELETION
         ).exists()

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -8,7 +8,8 @@ import responses
 from django.test import override_settings
 from rest_framework import status
 
-from sentry.models import Environment, Rule, RuleActivity, RuleActivityType, RuleStatus
+from sentry.constants import ObjectStatus
+from sentry.models import Environment, Rule, RuleActivity, RuleActivityType
 from sentry.models.actor import get_actor_for_user, get_actor_id_for_user
 from sentry.models.user import User
 from sentry.testutils import APITestCase
@@ -212,7 +213,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             == "You may not exceed 1 rules with this type of condition per project."
         )
         # Make sure pending deletions don't affect the process
-        Rule.objects.filter(project=self.project).update(status=RuleStatus.PENDING_DELETION)
+        Rule.objects.filter(project=self.project).update(status=ObjectStatus.PENDING_DELETION)
         self.run_test(conditions=conditions, actions=actions)
 
     @override_settings(MAX_SLOW_CONDITION_ISSUE_ALERTS=1)
@@ -245,7 +246,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             == "You may not exceed 1 rules with this type of condition per project."
         )
         # Make sure pending deletions don't affect the process
-        Rule.objects.filter(project=self.project).update(status=RuleStatus.PENDING_DELETION)
+        Rule.objects.filter(project=self.project).update(status=ObjectStatus.PENDING_DELETION)
         self.run_test(conditions=conditions, actions=actions)
 
     def test_owner_perms(self):

--- a/tests/sentry/deletions/test_rule.py
+++ b/tests/sentry/deletions/test_rule.py
@@ -1,10 +1,10 @@
+from sentry.constants import ObjectStatus
 from sentry.models import (
     GroupRuleStatus,
     RegionScheduledDeletion,
     Rule,
     RuleActivity,
     RuleActivityType,
-    RuleStatus,
 )
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
@@ -33,7 +33,7 @@ class DeleteRuleTest(TestCase):
             run_scheduled_deletions()
 
         assert not Rule.objects.filter(
-            id=rule.id, project=project, status=RuleStatus.PENDING_DELETION
+            id=rule.id, project=project, status=ObjectStatus.PENDING_DELETION
         ).exists()
         assert not GroupRuleStatus.objects.filter(id=group_rule_status.id).exists()
         assert not RuleFireHistory.objects.filter(id=rule_fire_history.id).exists()

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -1,14 +1,7 @@
 import pytest
 
 from sentry.constants import ObjectStatus
-from sentry.models import (
-    Environment,
-    Rule,
-    RuleActivity,
-    RuleActivityType,
-    RuleStatus,
-    ScheduledDeletion,
-)
+from sentry.models import Environment, Rule, RuleActivity, RuleActivityType, ScheduledDeletion
 from sentry.monitors.models import Monitor, MonitorEnvironment, ScheduleType
 from sentry.testutils import MonitorTestCase
 from sentry.testutils.silo import region_silo_test
@@ -517,7 +510,7 @@ class DeleteMonitorTest(MonitorTestCase):
         )
 
         rule = Rule.objects.get(project_id=monitor.project_id, id=monitor.config["alert_rule_id"])
-        assert rule.status == RuleStatus.PENDING_DELETION
+        assert rule.status == ObjectStatus.PENDING_DELETION
         assert RuleActivity.objects.filter(rule=rule, type=RuleActivityType.DELETED.value).exists()
 
     def test_simple_with_alert_rule_deleted(self):


### PR DESCRIPTION
Use `ObjectStatus` as a replacement for `RuleStatus` to be more consistent with other models. The enums match up perfectly to do this:

```
class RuleStatus:
    ACTIVE = 0
    INACTIVE = 1
    PENDING_DELETION = 2
    DELETION_IN_PROGRESS = 3
```

```
class ObjectStatus:
    VISIBLE = 0
    HIDDEN = 1
    PENDING_DELETION = 2
    DELETION_IN_PROGRESS = 3

    ACTIVE = 0
    DISABLED = 1
```

`RuleStatus.INACTIVE` is unused - currently 1 rule has this status but it will be removed in the migration mentioned below. The concept of an inactive rule is served by the `RuleSnooze` table, so we're not losing any potential functionality.


[getsentry PR](https://github.com/getsentry/getsentry/pull/11069)