### PR TITLE
ref(github-comments): capture API error when queueing comment task

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime, timedelta
 
+import sentry_sdk
 from celery.exceptions import MaxRetriesExceededError
 from django.utils import timezone
 from sentry_sdk import set_tag
@@ -51,8 +52,14 @@ def queue_comment_task_if_needed(
         extra={"organization_id": commit.organization_id, "merge_commit_sha": commit.key},
     )
 
-    # client will raise ApiError if the request is not successful
-    response = installation.get_client().get_pullrequest_from_commit(repo=repo.name, sha=commit.key)
+    # client will raise an Exception if the request is not successful
+    try:
+        response = installation.get_client().get_pullrequest_from_commit(
+            repo=repo.name, sha=commit.key
+        )
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
+        return
 
     if not isinstance(response, list) or len(response) != 1:
         # the response should return a single PR, return if multiple

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -556,6 +556,37 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
 
     @with_feature("organizations:pr-comment-bot")
     @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry_sdk.capture_exception")
+    @responses.activate
+    def test_gh_comment_api_error(self, mock_capture_exception, get_jwt, mock_comment_workflow):
+        """Captures exception if Github API call errors"""
+
+        responses.add(
+            responses.POST,
+            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
+            json={"token": self.access_token, "expires_at": self.expires_at},
+        )
+        responses.add(
+            responses.GET,
+            self.base_url + f"/repos/example/commits/{self.commit.key}/pulls",
+            status=400,
+            json={"message": "error"},
+        )
+
+        with self.tasks():
+            event_frames = get_frame_paths(self.event)
+            process_commit_context(
+                event_id=self.event.event_id,
+                event_platform=self.event.platform,
+                event_frames=event_frames,
+                group_id=self.event.group_id,
+                project_id=self.event.project_id,
+            )
+            assert mock_capture_exception.called
+            assert not mock_comment_workflow.called
+
+    @with_feature("organizations:pr-comment-bot")
+    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate
     def test_gh_comment_commit_not_in_default_branch(self, get_jwt, mock_comment_workflow):
         """No comments on commit not in default branch"""
@@ -602,12 +633,6 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
                 project_id=self.event.project_id,
             )
             assert not mock_comment_workflow.called
-
-    @with_feature("organizations:pr-comment-bot")
-    def test_gh_comment_org_settings(self, mock_comment_workflow):
-        """No comments on org who disabled feature"""
-        # TODO(Cathy or Aniket): implement once the toggle is merged
-        pass
 
     @with_feature("organizations:pr-comment-bot")
     @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")


### PR DESCRIPTION
Attempting to fetch the pull request from the suspect commit in `process_commit_context` will error out if there is a GitHub outage. We should be capturing the exception rather than erroring out because the latter will cause the parent function (`process_commit_context`) to also error out and prevent the rest of the suspect commit logic from executing.