### PR TITLE
fix(hc): Move get participants test to region silo

### DIFF
--- a/tests/sentry/notifications/notifications/test_organization_request.py
+++ b/tests/sentry/notifications/notifications/test_organization_request.py
@@ -1,12 +1,13 @@
-from sentry.models import NotificationSetting, OrganizationMember
+from sentry.models import OrganizationMember
 from sentry.notifications.notifications.organization_request import OrganizationRequestNotification
 from sentry.notifications.notifications.strategies.role_based_recipient_strategy import (
     RoleBasedRecipientStrategy,
 )
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.services.hybrid_cloud.actor import RpcActor
+from sentry.services.hybrid_cloud.notifications.service import notifications_service
 from sentry.testutils import TestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import region_silo_test
 from sentry.types.integrations import ExternalProviders
 
 
@@ -21,7 +22,7 @@ class DummyRequestNotification(OrganizationRequestNotification):
     RoleBasedRecipientStrategyClass = DummyRoleBasedRecipientStrategy
 
 
-@control_silo_test
+@region_silo_test(stable=True)
 class GetParticipantsTest(TestCase):
     def setUp(self):
         self.user2 = self.create_user()
@@ -37,17 +38,16 @@ class GetParticipantsTest(TestCase):
         }
 
     def test_turn_off_settings(self):
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.SLACK,
-            NotificationSettingTypes.APPROVAL,
-            NotificationSettingOptionValues.ALWAYS,
+        notifications_service.update_settings(
+            external_provider=ExternalProviders.SLACK,
+            notification_type=NotificationSettingTypes.APPROVAL,
+            setting_option=NotificationSettingOptionValues.ALWAYS,
             user_id=self.user.id,
         )
-
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.APPROVAL,
-            NotificationSettingOptionValues.ALWAYS,
+        notifications_service.update_settings(
+            external_provider=ExternalProviders.EMAIL,
+            notification_type=NotificationSettingTypes.APPROVAL,
+            setting_option=NotificationSettingOptionValues.ALWAYS,
             user_id=self.user2.id,
         )
 


### PR DESCRIPTION
All `OrganizationRequestNotification` based notifications are being sent from region silo endpoints so this moves the test case over to being a region silo test.

For background, these classes inherit from `OrganizationRequestNotification`:

- `AbstractInviteRequestNotification`
  - `JoinRequestNotification`: Only sent from `OrganizationJoinRequestEndpoint` (region_silo_endpoint)
  - `InviteRequestNotification`: Only sent from `OrganizationInviteRequestIndexEndpoint` (region_silo_endpoint)
- `IntegrationRequestNotification`: Only sent from `OrganizationIntegrationRequestEndpoint` (region_silo_endpoint)

#52353 will be closed in favor of this change.
#52473 has a similar change for `IntegrationRequestNotification` tests.