### PR TITLE
feat(helpful-event): Pass release context when navigating from the release details page

### DIFF
--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -244,6 +244,7 @@ class GroupList extends Component<Props, State> {
       queryFilterDescription,
       narrowGroups,
       source,
+      query,
     } = this.props;
     const {loading, error, errorData, groups, memberList, pageLinks} = this.state;
 
@@ -308,6 +309,7 @@ class GroupList extends Component<Props, State> {
                   queryFilterDescription={queryFilterDescription}
                   narrowGroups={narrowGroups}
                   source={source}
+                  query={query}
                 />
               );
             })}

--- a/static/app/views/releases/detail/overview/releaseIssues.spec.jsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.spec.jsx
@@ -141,4 +141,25 @@ describe('ReleaseIssues', function () {
       '/organizations/org-slug/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&query=release%3A1.0.0&sort=freq&start=2020-03-23T01%3A02%3A00Z'
     );
   });
+
+  it('includes release context when linking to issue', async function () {
+    newIssuesEndpoint = MockApiClient.addMockResponse({
+      url: `/organizations/${props.organization.slug}/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&limit=10&query=first-release%3A1.0.0%20is%3Aunresolved&sort=freq&start=2020-03-23T01%3A02%3A00Z`,
+      body: [TestStubs.Group({id: '123'})],
+    });
+
+    const {routerContext} = initializeOrg();
+
+    render(<ReleaseIssues {...props} />, {context: routerContext});
+
+    await userEvent.click(screen.getByRole('radio', {name: /New Issues/}));
+
+    const link = await screen.findByRole('link', {name: /RequestError/});
+
+    // Should pass the query param `query` with value `release:1.0.0`
+    expect(link).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/issues/123/?_allp=1&query=release%3A1.0.0&referrer=release-issue-stream'
+    );
+  });
 });

--- a/static/app/views/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.tsx
@@ -368,7 +368,7 @@ class ReleaseIssues extends Component<Props, State> {
 
   render() {
     const {issuesType, count, pageLinks, onCursor} = this.state;
-    const {organization, queryFilterDescription, withChart} = this.props;
+    const {organization, queryFilterDescription, withChart, version} = this.props;
     const {path, queryParams} = this.getIssuesEndpoint();
     const issuesTypes = [
       {value: IssuesType.ALL, label: t('All Issues'), issueCount: count.all},
@@ -427,7 +427,7 @@ class ReleaseIssues extends Component<Props, State> {
             orgId={organization.slug}
             endpointPath={path}
             queryParams={queryParams}
-            query=""
+            query={`release:${version}`}
             canSelectGroups={false}
             queryFilterDescription={queryFilterDescription}
             withChart={withChart}


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/52487