### PR TITLE
fix(hc): Mark some endpoint tests stable

### DIFF
--- a/tests/sentry/api/endpoints/test_user_emails.py
+++ b/tests/sentry/api/endpoints/test_user_emails.py
@@ -5,7 +5,7 @@ from sentry.testutils import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserEmailsTest(APITestCase):
     def setUp(self):
         super().setUp()

--- a/tests/sentry/api/endpoints/test_user_emails_confirm.py
+++ b/tests/sentry/api/endpoints/test_user_emails_confirm.py
@@ -5,7 +5,7 @@ from sentry.testutils import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserEmailsConfirmTest(APITestCase):
     endpoint = "sentry-api-0-user-emails-confirm"
     method = "post"

--- a/tests/sentry/api/endpoints/test_user_identity.py
+++ b/tests/sentry/api/endpoints/test_user_identity.py
@@ -3,7 +3,7 @@ from sentry.testutils import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserIdentityTest(APITestCase):
     endpoint = "sentry-api-0-user-identity"
     method = "get"

--- a/tests/sentry/api/endpoints/test_user_identity_config.py
+++ b/tests/sentry/api/endpoints/test_user_identity_config.py
@@ -26,7 +26,7 @@ def mock_is_login_provider_effect(provider_key: str) -> bool:
     return provider_key in ("github", "vsts", "google")
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserIdentityConfigEndpointTest(UserIdentityConfigTest):
     endpoint = "sentry-api-0-user-identity-config"
     method = "get"
@@ -150,7 +150,7 @@ class UserIdentityConfigEndpointTest(UserIdentityConfigTest):
         assert identity["status"] == "needed_for_org_auth"
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserIdentityConfigDetailsEndpointGetTest(UserIdentityConfigTest):
     endpoint = "sentry-api-0-user-identity-config-details"
     method = "get"
@@ -193,7 +193,7 @@ class UserIdentityConfigDetailsEndpointGetTest(UserIdentityConfigTest):
         )
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserIdentityConfigDetailsEndpointDeleteTest(UserIdentityConfigTest):
     endpoint = "sentry-api-0-user-identity-config-details"
     method = "delete"

--- a/tests/sentry/api/endpoints/test_user_identity_details.py
+++ b/tests/sentry/api/endpoints/test_user_identity_details.py
@@ -3,7 +3,7 @@ from sentry.testutils import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class DeleteUserIdentityTest(APITestCase):
     endpoint = "sentry-api-0-user-identity-details"
     method = "delete"

--- a/tests/sentry/api/endpoints/test_user_ips.py
+++ b/tests/sentry/api/endpoints/test_user_ips.py
@@ -7,7 +7,7 @@ from sentry.testutils import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserEmailsTest(APITestCase):
     endpoint = "sentry-api-0-user-ips"
 

--- a/tests/sentry/api/endpoints/test_user_password.py
+++ b/tests/sentry/api/endpoints/test_user_password.py
@@ -6,7 +6,7 @@ from sentry.testutils import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserPasswordTest(APITestCase):
     endpoint = "sentry-api-0-user-password"
     method = "put"

--- a/tests/sentry/api/endpoints/test_user_social_identities_index.py
+++ b/tests/sentry/api/endpoints/test_user_social_identities_index.py
@@ -3,7 +3,7 @@ from sentry.testutils.silo import control_silo_test
 from social_auth.models import UserSocialAuth
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserSocialIdentitiesIndexTest(APITestCase):
     endpoint = "sentry-api-0-user-social-identities-index"
 

--- a/tests/sentry/api/endpoints/test_user_social_identity_details.py
+++ b/tests/sentry/api/endpoints/test_user_social_identity_details.py
@@ -3,7 +3,7 @@ from sentry.testutils.silo import control_silo_test
 from social_auth.models import UserSocialAuth
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserSocialIdentityDetailsEndpointTest(APITestCase):
     endpoint = "sentry-api-0-user-social-identity-details"
     method = "delete"

--- a/tests/sentry/api/endpoints/test_user_subscriptions.py
+++ b/tests/sentry/api/endpoints/test_user_subscriptions.py
@@ -11,7 +11,7 @@ from sentry.testutils.silo import control_silo_test
     settings.SENTRY_NEWSLETTER != "sentry.newsletter.dummy.DummyNewsletter",
     reason="Requires DummyNewsletter.",
 )
-@control_silo_test
+@control_silo_test(stable=True)
 class UserSubscriptionsNewsletterTest(APITestCase):
     endpoint = "sentry-api-0-user-subscriptions"
     method = "put"


### PR DESCRIPTION
These cases pass already without any additional changes needed, including when running manually with `SENTRY_USE_SPLIT_DBS=1`.