### PR TITLE
feat(spikes): Setup OrganizationStats for client-side pagination of Spikes

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -12,7 +12,7 @@ import {Platform} from 'sentry/data/platformCategories';
 import {SVGIconProps} from 'sentry/icons/svgIcon';
 import type {Group} from 'sentry/types';
 import {UseExperiment} from 'sentry/utils/useExperiment';
-import {UsageStatsOrganizationProps} from 'sentry/views/organizationStats/usageStatsOrg';
+import {OrganizationStatsProps} from 'sentry/views/organizationStats/index';
 import {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 import type {NavigationItem, NavigationSection} from 'sentry/views/settings/types';
 
@@ -165,7 +165,7 @@ export type ComponentHooks = {
   'component:disabled-custom-symbol-sources': () => React.ComponentType<DisabledCustomSymbolSources>;
   'component:disabled-member': () => React.ComponentType<DisabledMemberViewProps>;
   'component:disabled-member-tooltip': () => React.ComponentType<DisabledMemberTooltipProps>;
-  'component:enhanced-org-stats': () => React.ComponentType<UsageStatsOrganizationProps>;
+  'component:enhanced-org-stats': () => React.ComponentType<OrganizationStatsProps>;
   'component:first-party-integration-additional-cta': () => React.ComponentType<FirstPartyIntegrationAdditionalCTAProps>;
   'component:first-party-integration-alert': () => React.ComponentType<FirstPartyIntegrationAlertProps>;
   'component:header-date-range': () => React.ComponentType<DateRangeProps>;

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -18,6 +18,7 @@ import withProjects from 'sentry/utils/withProjects';
 
 import {UsageSeries} from './types';
 import UsageTable, {CellProject, CellStat, TableStat} from './usageTable';
+import {getOffsetFromCursor, getPaginationPageLink} from './utils';
 
 type Props = {
   dataCategory: DataCategoryInfo['plural'];
@@ -160,10 +161,9 @@ class UsageStatsProjects extends DeprecatedAsyncComponent<Props, State> {
     }
   }
 
-  get tableCursor() {
+  get tableOffset() {
     const {tableCursor} = this.props;
-    const offset = Number(tableCursor?.split(':')[1]);
-    return isNaN(offset) ? 0 : offset;
+    return getOffsetFromCursor(tableCursor);
   }
 
   /**
@@ -172,17 +172,14 @@ class UsageStatsProjects extends DeprecatedAsyncComponent<Props, State> {
    * page doesn't scroll too deeply for organizations with a lot of projects
    */
   get pageLink() {
+    const offset = this.tableOffset;
     const numRows = this.filteredProjects.length;
-    const offset = this.tableCursor;
-    const prevOffset = offset - UsageStatsProjects.MAX_ROWS_USAGE_TABLE;
-    const nextOffset = offset + UsageStatsProjects.MAX_ROWS_USAGE_TABLE;
 
-    return `<link>; rel="previous"; results="${prevOffset >= 0}"; cursor="0:${Math.max(
-      0,
-      prevOffset
-    )}:1", <link>; rel="next"; results="${
-      nextOffset < numRows
-    }"; cursor="0:${nextOffset}:0"`;
+    return getPaginationPageLink({
+      numRows,
+      pageSize: UsageStatsProjects.MAX_ROWS_USAGE_TABLE,
+      offset,
+    });
   }
 
   get projectSelectionFilter(): (p: Project) => boolean {
@@ -399,7 +396,7 @@ class UsageStatsProjects extends DeprecatedAsyncComponent<Props, State> {
           : a.project.slug.localeCompare(b.project.slug);
       });
 
-      const offset = this.tableCursor;
+      const offset = this.tableOffset;
 
       return {
         tableStats: tableStats.slice(

--- a/static/app/views/organizationStats/utils.tsx
+++ b/static/app/views/organizationStats/utils.tsx
@@ -105,3 +105,34 @@ export function isDisplayUtc(datetime: DateTimeObject): boolean {
   const hours = parsePeriodToHours(interval);
   return hours >= 24;
 }
+
+/**
+ * HACK(dlee): client-side pagination
+ */
+export function getOffsetFromCursor(cursor?: string) {
+  const offset = Number(cursor?.split(':')[1]);
+  return isNaN(offset) ? 0 : offset;
+}
+
+/**
+ * HACK(dlee): client-side pagination
+ */
+export function getPaginationPageLink({
+  numRows,
+  pageSize,
+  offset,
+}: {
+  numRows: number;
+  offset: number;
+  pageSize: number;
+}) {
+  const prevOffset = offset - pageSize;
+  const nextOffset = offset + pageSize;
+
+  return `<link>; rel="previous"; results="${prevOffset >= 0}"; cursor="0:${Math.max(
+    0,
+    prevOffset
+  )}:1", <link>; rel="next"; results="${
+    nextOffset < numRows
+  }"; cursor="0:${nextOffset}:0"`;
+}


### PR DESCRIPTION
There'll be 2 tables with pagination on this page.

![screencapture-default-dev-getsentry-net-8000-stats-2023-06-28-19_09_20](https://github.com/getsentry/sentry/assets/1748388/b1ae6dcb-b2a7-47bc-a103-1ed08377c762)
