### PR TITLE
feat(auth): Add /userinfo endpoint for OIDC

### DIFF
--- a/src/sentry/api/endpoints/oauth_userinfo.py
+++ b/src/sentry/api/endpoints/oauth_userinfo.py
@@ -33,11 +33,7 @@ class OAuthUserInfoEndpoint(Endpoint):
             user_output["avatar_url"] = user.avatar_url
             user_output["date_joined"] = user.date_joined
         if "email" in scopes:
-            try:
-                email = UserEmail.objects.get(user=user)
-                user_output["email"] = email.email
-                user_output["email_verified"] = email.is_verified
-            except UserEmail.DoesNotExist:
-                user_output["email"] = None
-                user_output["email_verified"] = None
+            email = UserEmail.objects.get(user=user)
+            user_output["email"] = email.email
+            user_output["email_verified"] = email.is_verified
         return Response(user_output)

--- a/src/sentry/api/endpoints/oauth_userinfo.py
+++ b/src/sentry/api/endpoints/oauth_userinfo.py
@@ -29,7 +29,6 @@ class OAuthUserInfoEndpoint(Endpoint):
         user_output = {"sub": user.id}
         if "profile" in scopes:
             user_output["name"] = user.name
-            user_output["username"]: user.username
             user_output["avatar_type"] = user.avatar_type
             user_output["avatar_url"] = user.avatar_url
             user_output["date_joined"] = user.date_joined

--- a/src/sentry/api/endpoints/oauth_userinfo.py
+++ b/src/sentry/api/endpoints/oauth_userinfo.py
@@ -28,12 +28,15 @@ class OAuthUserInfoEndpoint(Endpoint):
         user = token_details.user
         user_output = {"sub": user.id}
         if "profile" in scopes:
-            user_output["name"] = user.name
-            user_output["avatar_type"] = user.avatar_type
-            user_output["avatar_url"] = user.avatar_url
-            user_output["date_joined"] = user.date_joined
+            profile_details = {
+                "name": user.name,
+                "avatar_type": user.avatar_type,
+                "avatar_url": user.avatar_url,
+                "date_joined": user.date_joined,
+            }
+            user_output.update(profile_details)
         if "email" in scopes:
             email = UserEmail.objects.get(user=user)
-            user_output["email"] = email.email
-            user_output["email_verified"] = email.is_verified
+            email_details = {"email": email.email, "email_verified": email.is_verified}
+            user_output.update(email_details)
         return Response(user_output)

--- a/src/sentry/api/endpoints/oauth_userinfo.py
+++ b/src/sentry/api/endpoints/oauth_userinfo.py
@@ -1,0 +1,44 @@
+from rest_framework.authentication import get_authorization_header
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.models import ApiToken, UserEmail
+
+
+@control_silo_endpoint
+class OAuthUserInfoEndpoint(Endpoint):
+    authentication_classes = ()
+    permission_classes = ()
+
+    def get(self, request: Request) -> Response:
+        try:
+            access_token = get_authorization_header(request).split()[1].decode("utf-8")
+        except IndexError:
+            return Response("No access token found.", status=401)
+        try:
+            token_details = ApiToken.objects.get(token=access_token)
+        except ApiToken.DoesNotExist:
+            return Response(status=400)
+
+        scopes = token_details.get_scopes()
+        if "openid" not in scopes:
+            return Response(status=403)
+
+        user = token_details.user
+        user_output = {"sub": user.id}
+        if "profile" in scopes:
+            user_output["name"] = user.name
+            user_output["username"]: user.username
+            user_output["avatar_type"] = user.avatar_type
+            user_output["avatar_url"] = user.avatar_url
+            user_output["date_joined"] = user.date_joined
+        if "email" in scopes:
+            try:
+                email = UserEmail.objects.get(user=user)
+                user_output["email"] = email.email
+                user_output["email_verified"] = email.is_verified
+            except UserEmail.DoesNotExist:
+                user_output["email"] = None
+                user_output["email_verified"] = None
+        return Response(user_output)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -233,7 +233,6 @@ from .endpoints.notifications import (
     NotificationActionsDetailsEndpoint,
     NotificationActionsIndexEndpoint,
 )
-from .endpoints.oauth_userinfo import OAuthUserInfoEndpoint
 from .endpoints.organization_access_request_details import OrganizationAccessRequestDetailsEndpoint
 from .endpoints.organization_activity import OrganizationActivityEndpoint
 from .endpoints.organization_api_key_details import OrganizationApiKeyDetailsEndpoint
@@ -2821,12 +2820,6 @@ urlpatterns = [
     re_path(
         r"^internal/",
         include(INTERNAL_URLS),
-    ),
-    # OAuth (Sentry as a provider)
-    re_path(
-        r"^oauth/userinfo/$",
-        OAuthUserInfoEndpoint.as_view(),
-        name="sentry-api-0-oauth-userinfo",
     ),
     # Catch all
     re_path(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -233,6 +233,7 @@ from .endpoints.notifications import (
     NotificationActionsDetailsEndpoint,
     NotificationActionsIndexEndpoint,
 )
+from .endpoints.oauth_userinfo import OAuthUserInfoEndpoint
 from .endpoints.organization_access_request_details import OrganizationAccessRequestDetailsEndpoint
 from .endpoints.organization_activity import OrganizationActivityEndpoint
 from .endpoints.organization_api_key_details import OrganizationApiKeyDetailsEndpoint
@@ -673,6 +674,11 @@ AUTH_URLS = [
         r"^login/$",
         AuthLoginEndpoint.as_view(),
         name="sentry-api-0-auth-login",
+    ),
+    re_path(
+        r"^oauth/userinfo/$",
+        OAuthUserInfoEndpoint.as_view(),
+        name="sentry-api-0-oauth-userinfo",
     ),
 ]
 

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -675,11 +675,6 @@ AUTH_URLS = [
         AuthLoginEndpoint.as_view(),
         name="sentry-api-0-auth-login",
     ),
-    re_path(
-        r"^oauth/userinfo/$",
-        OAuthUserInfoEndpoint.as_view(),
-        name="sentry-api-0-oauth-userinfo",
-    ),
 ]
 
 BROADCAST_URLS = [
@@ -2826,6 +2821,12 @@ urlpatterns = [
     re_path(
         r"^internal/",
         include(INTERNAL_URLS),
+    ),
+    # OAuth (Sentry as a provider)
+    re_path(
+        r"^oauth/userinfo/$",
+        OAuthUserInfoEndpoint.as_view(),
+        name="sentry-api-0-oauth-userinfo",
     ),
     # Catch all
     re_path(

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -8,6 +8,7 @@ from django.http import HttpResponse
 from django.urls import URLPattern, URLResolver, re_path
 from django.views.generic import RedirectView
 
+from sentry.api.endpoints.oauth_userinfo import OAuthUserInfoEndpoint
 from sentry.auth.providers.saml2.provider import SAML2AcceptACSView, SAML2MetadataView, SAML2SLSView
 from sentry.charts.endpoints import serve_chartcuterie_config
 from sentry.web import api
@@ -163,6 +164,11 @@ urlpatterns += [
                 re_path(
                     r"^token/$",
                     OAuthTokenView.as_view(),
+                ),
+                re_path(
+                    r"userinfo/$",
+                    OAuthUserInfoEndpoint.as_view(),
+                    name="sentry-api-0-oauth-userinfo",
                 ),
             ]
         ),

--- a/tests/sentry/api/endpoints/test_oauth_userinfo.py
+++ b/tests/sentry/api/endpoints/test_oauth_userinfo.py
@@ -24,6 +24,11 @@ class OAuthUserInfoTest(APITestCase):
         assert response.status_code == 401
         assert response.data == "No access token found."
 
+    def test_declines_invalid_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer  abcd")
+        response = self.client.get(self.path)
+        assert response.status_code == 400
+
     def test_declines_if_no_openid_scope(self):
         token_without_openid_scope = ApiToken.objects.create(user=self.user, scope_list=[])
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + token_without_openid_scope.token)

--- a/tests/sentry/api/endpoints/test_oauth_userinfo.py
+++ b/tests/sentry/api/endpoints/test_oauth_userinfo.py
@@ -1,0 +1,96 @@
+import datetime
+
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from sentry.models import ApiToken
+from sentry.testutils import APITestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test(stable=True)
+class OAuthUserInfoTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+        self.path = reverse(
+            "sentry-api-0-oauth-userinfo",
+        )
+        self.client = APIClient()
+
+    def test_requires_access_token(self):
+        response = self.client.get(self.path)
+
+        assert response.status_code == 401
+        assert response.data == "No access token found."
+
+    def test_declines_if_no_openid_scope(self):
+        token_without_openid_scope = ApiToken.objects.create(user=self.user, scope_list=[])
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + token_without_openid_scope.token)
+
+        response = self.client.get(self.path)
+
+        assert response.status_code == 403
+
+    def test_gets_sub_with_openid_scope(self):
+        """
+        Ensures we get `sub`, and only `sub`, if the only scope is openid.
+        """
+        openid_only_token = ApiToken.objects.create(user=self.user, scope_list=["openid"])
+
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + openid_only_token.token)
+
+        response = self.client.get(self.path)
+
+        assert response.status_code == 200
+        assert response.data == {"sub": self.user.id}
+
+    def test_gets_email_information(self):
+        email_token = ApiToken.objects.create(user=self.user, scope_list=["openid", "email"])
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + email_token.token)
+
+        response = self.client.get(self.path)
+
+        assert response.status_code == 200
+        assert response.data == {
+            "sub": self.user.id,
+            "email": self.user.email,
+            "email_verified": True,
+        }
+
+    def test_gets_profile_information(self):
+        profile_token = ApiToken.objects.create(user=self.user, scope_list=["openid", "profile"])
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + profile_token.token)
+
+        response = self.client.get(self.path)
+
+        assert response.status_code == 200
+
+        assert response.data["avatar_type"] == 0
+        assert response.data["avatar_url"] is None
+        assert isinstance(response.data["date_joined"], datetime.datetime)
+        assert response.data["name"] == ""
+        assert response.data["sub"] == self.user.id
+
+    def test_gets_multiple_scopes(self):
+        all_access_token = ApiToken.objects.create(
+            user=self.user, scope_list=["openid", "profile", "email", "address", "phone"]
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + all_access_token.token)
+
+        response = self.client.get(self.path)
+
+        assert response.status_code == 200
+
+        # profile information
+        assert response.data["avatar_type"] == 0
+        assert response.data["avatar_url"] is None
+        assert isinstance(response.data["date_joined"], datetime.datetime)
+        assert response.data["name"] == ""
+
+        # email information
+        assert response.data["email"] == self.user.email
+        assert response.data["email_verified"]
+
+        # openid information
+        assert response.data["sub"] == self.user.id


### PR DESCRIPTION
Implements the `/userinfo` endpoint for OIDC compliance (initial spec is [here](https://connect2id.com/products/server/docs/api/userinfo)). 

Note that anyone can call this endpoint - the authentication/authorization comes from the bearer token they pass in.