### PR TITLE
feat(perf-detector-threshold-configuration) Added backend for creating audit log

### DIFF
--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -1,3 +1,5 @@
+from typing import Dict, Type
+
 from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -8,6 +10,7 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.permissions import SuperuserPermission
 from sentry.auth.superuser import is_active_superuser
 from sentry.issues.grouptype import (
+    GroupType,
     PerformanceConsecutiveDBQueriesGroupType,
     PerformanceConsecutiveHTTPQueriesGroupType,
     PerformanceDBMainThreadGroupType,
@@ -29,7 +32,7 @@ SETTINGS_PROJECT_OPTION_KEY = "sentry:performance_issue_settings"
 # These options should only be accessible internally and used by
 # support to enable/disable performance issue detection for an outlying project
 # on a case-by-case basis.
-map_internal_only_project_settings_to_group = {
+map_internal_only_project_settings_to_group: Dict[str, Type[GroupType]] = {
     "uncompressed_assets_detection_enabled": PerformanceUncompressedAssetsGroupType,
     "consecutive_http_spans_detection_enabled": PerformanceConsecutiveHTTPQueriesGroupType,
     "large_http_payload_detection_enabled": PerformanceLargeHTTPPayloadGroupType,

--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -2,11 +2,23 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features, projectoptions
+from sentry import audit_log, features, projectoptions
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.permissions import SuperuserPermission
 from sentry.auth.superuser import is_active_superuser
+from sentry.issues.grouptype import (
+    PerformanceConsecutiveDBQueriesGroupType,
+    PerformanceConsecutiveHTTPQueriesGroupType,
+    PerformanceDBMainThreadGroupType,
+    PerformanceFileIOMainThreadGroupType,
+    PerformanceLargeHTTPPayloadGroupType,
+    PerformanceNPlusOneAPICallsGroupType,
+    PerformanceNPlusOneGroupType,
+    PerformanceRenderBlockingAssetSpanGroupType,
+    PerformanceSlowDBQueryGroupType,
+    PerformanceUncompressedAssetsGroupType,
+)
 from sentry.utils.performance_issues.performance_detection import get_merged_settings
 
 MAX_VALUE = 2147483647
@@ -17,18 +29,18 @@ SETTINGS_PROJECT_OPTION_KEY = "sentry:performance_issue_settings"
 # These options should only be accessible internally and used by
 # support to enable/disable performance issue detection for an outlying project
 # on a case-by-case basis.
-internal_only_project_setting_options = [
-    "uncompressed_assets_detection_enabled",
-    "consecutive_http_spans_detection_enabled",
-    "large_http_payload_detection_enabled",
-    "n_plus_one_db_queries_detection_enabled",
-    "n_plus_one_api_calls_detection_enabled",
-    "db_on_main_thread_detection_enabled",
-    "file_io_on_main_thread_detection_enabled",
-    "consecutive_db_queries_detection_enabled",
-    "large_render_blocking_asset_detection_enabled",
-    "slow_db_queries_detection_enabled",
-]
+map_internal_only_project_settings_to_group = {
+    "uncompressed_assets_detection_enabled": PerformanceUncompressedAssetsGroupType,
+    "consecutive_http_spans_detection_enabled": PerformanceConsecutiveHTTPQueriesGroupType,
+    "large_http_payload_detection_enabled": PerformanceLargeHTTPPayloadGroupType,
+    "n_plus_one_db_queries_detection_enabled": PerformanceNPlusOneGroupType,
+    "n_plus_one_api_calls_detection_enabled": PerformanceNPlusOneAPICallsGroupType,
+    "db_on_main_thread_detection_enabled": PerformanceDBMainThreadGroupType,
+    "file_io_on_main_thread_detection_enabled": PerformanceFileIOMainThreadGroupType,
+    "consecutive_db_queries_detection_enabled": PerformanceConsecutiveDBQueriesGroupType,
+    "large_render_blocking_asset_detection_enabled": PerformanceRenderBlockingAssetSpanGroupType,
+    "slow_db_queries_detection_enabled": PerformanceSlowDBQueryGroupType,
+}
 
 
 class ProjectOwnerOrSuperUserPermissions(ProjectSettingPermission):
@@ -110,7 +122,10 @@ class ProjectPerformanceIssueSettingsEndpoint(ProjectEndpoint):
             return self.respond(status=status.HTTP_404_NOT_FOUND)
 
         body_has_admin_options = any(
-            [option in request.data for option in internal_only_project_setting_options]
+            [
+                option in request.data
+                for option in map_internal_only_project_settings_to_group.keys()
+            ]
         )
         if body_has_admin_options and not is_active_superuser(request):
             return Response(
@@ -139,6 +154,16 @@ class ProjectPerformanceIssueSettingsEndpoint(ProjectEndpoint):
             {**performance_issue_settings_default, **performance_issue_settings, **data},
         )
 
+        if body_has_admin_options:
+            self.create_audit_entry(
+                request=self.request,
+                actor=request.user,
+                organization=project.organization,
+                target_object=project.id,
+                event=audit_log.get_event_id("PROJECT_PERFORMANCE_ISSUE_DETECTION_CHANGE"),
+                data={**data, **project.get_audit_log_data()},
+            )
+
         return Response(data)
 
     def delete(self, request: Request, project) -> Response:
@@ -151,7 +176,7 @@ class ProjectPerformanceIssueSettingsEndpoint(ProjectEndpoint):
             settings_only_with_admin_options = {
                 option: project_settings[option]
                 for option in project_settings
-                if option in internal_only_project_setting_options
+                if option in map_internal_only_project_settings_to_group.keys()
             }
             project.update_option(SETTINGS_PROJECT_OPTION_KEY, settings_only_with_admin_options)
 

--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -119,6 +119,28 @@ class ProjectEditAuditLogEvent(AuditLogEvent):
         return "edited project settings " + items_string
 
 
+class ProjectPerformanceDetectionSettingsAuditLogEvent(AuditLogEvent):
+    def __init__(self):
+        super().__init__(
+            event_id=178,
+            name="PROJECT_PERFORMANCE_ISSUE_DETECTION_CHANGE",
+            api_name="project.change-performance-issue-detection",
+        )
+
+    def render(self, audit_log_entry: AuditLogEntry):
+        from sentry.api.endpoints.project_performance_issue_settings import (
+            map_internal_only_project_settings_to_group as map,
+        )
+
+        data = audit_log_entry.data
+        items_string = ", ".join(
+            f"to {'enable' if value else 'disable'} detection of {map[key].description} issue"
+            for (key, value) in data.items()
+            if key in map.keys()
+        )
+        return "edited project performance issue detector settings " + items_string
+
+
 def render_project_action(audit_log_entry: AuditLogEntry, action: str):
     # Most logs will just be name of the filter, but legacy browser changes can be bool, str, list, or sets
     filter_name = audit_log_entry.data["state"]

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -65,6 +65,7 @@ default_manager.add(
     )
 )
 default_manager.add(events.ProjectEditAuditLogEvent())
+default_manager.add(events.ProjectPerformanceDetectionSettingsAuditLogEvent())
 default_manager.add(
     AuditLogEvent(
         event_id=32,

--- a/tests/sentry/audit_log/test_register.py
+++ b/tests/sentry/audit_log/test_register.py
@@ -24,6 +24,7 @@ class AuditLogEventRegisterTest(TestCase):
             "team.remove",
             "project.create",
             "project.edit",
+            "project.change-performance-issue-detection",
             "project.remove",
             "project.remove-with-origin",
             "project.request-transfer",

--- a/tests/sentry/utils/test_audit.py
+++ b/tests/sentry/utils/test_audit.py
@@ -264,6 +264,42 @@ class CreateAuditEntryTest(TestCase):
         assert entry.event == audit_log.get_event_id("PROJECT_EDIT")
         assert audit_log_event.render(entry) == "edited project settings in new_slug to new"
 
+    def test_audit_entry_project_performance_setting_disable_detection(self):
+        entry = create_audit_entry(
+            request=self.req,
+            organization=self.org,
+            target_object=self.project.id,
+            event=audit_log.get_event_id("PROJECT_PERFORMANCE_ISSUE_DETECTION_CHANGE"),
+            data={"file_io_on_main_thread_detection_enabled": False},
+        )
+        audit_log_event = audit_log.get(entry.event)
+
+        assert entry.actor == self.user
+        assert entry.target_object == self.project.id
+        assert entry.event == audit_log.get_event_id("PROJECT_PERFORMANCE_ISSUE_DETECTION_CHANGE")
+        assert (
+            audit_log_event.render(entry)
+            == "edited project performance issue detector settings to disable detection of File IO on Main Thread issue"
+        )
+
+    def test_audit_entry_project_performance_setting_enable_detection(self):
+        entry = create_audit_entry(
+            request=self.req,
+            organization=self.org,
+            target_object=self.project.id,
+            event=audit_log.get_event_id("PROJECT_PERFORMANCE_ISSUE_DETECTION_CHANGE"),
+            data={"file_io_on_main_thread_detection_enabled": True},
+        )
+        audit_log_event = audit_log.get(entry.event)
+
+        assert entry.actor == self.user
+        assert entry.target_object == self.project.id
+        assert entry.event == audit_log.get_event_id("PROJECT_PERFORMANCE_ISSUE_DETECTION_CHANGE")
+        assert (
+            audit_log_event.render(entry)
+            == "edited project performance issue detector settings to enable detection of File IO on Main Thread issue"
+        )
+
     def test_audit_entry_integration_log(self):
         project = self.create_project()
         self.login_as(user=self.user)


### PR DESCRIPTION
- Added backend for creating audit logs when admin setting toggles are used to enable/disable performance issue detection:
<img width="1512" alt="Screenshot 2023-07-09 at 8 06 10 PM" src="https://github.com/getsentry/sentry/assets/60121741/87287b45-00aa-4fc5-b052-a305d4a9bd0d">
- Added test. 
