### PR TITLE
feat(perf-detector-threshold-configuration) Added frontend for creating audit logs

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidence.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.spec.tsx
@@ -99,6 +99,7 @@ describe('spanEvidence', () => {
         },
       ],
     });
+    organization.features = ['project-performance-settings-admin'];
 
     render(
       <SpanEvidenceSection

--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -45,6 +45,7 @@ export function SpanEvidenceSection({event, organization, projectSlug}: Props) {
 
   const issueType = getIssueTypeFromOccurenceType(event.occurrence?.type);
   const hasConfigurableThresholds =
+    organization.features.includes('project-performance-settings-admin') &&
     issueType &&
     ![
       IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS, // TODO Abdullah Khan: Remove check when thresholds for these two issues are configurable.

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -90,6 +90,7 @@ export const getIssueTypeFromOccurenceType = (
     1009: IssueType.PERFORMANCE_CONSECUTIVE_HTTP,
     1010: IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
     1012: IssueType.PERFORMANCE_UNCOMPRESSED_ASSET,
+    1013: IssueType.PERFORMANCE_DB_MAIN_THREAD,
     1015: IssueType.PERFORMANCE_LARGE_HTTP_PAYLOAD,
   };
   if (!typeId) {

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -17,7 +17,10 @@ import {shouldUse24Hours} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
-import {retentionPrioritiesLabels} from 'sentry/views/settings/projectPerformance/projectPerformance';
+import {
+  projectDetectorSettingsId,
+  retentionPrioritiesLabels,
+} from 'sentry/views/settings/projectPerformance/projectPerformance';
 
 const avatarStyle = {
   width: 36,
@@ -148,6 +151,26 @@ function AuditNote({
             </Link>
           ),
           note: entry.note.replace('edited project settings ', ''),
+        })}
+      </Note>
+    );
+  }
+
+  if (entry.event === 'project.change-performance-issue-detection') {
+    return (
+      <Note>
+        {tct('Edited project [projectSettingsLink] [note]', {
+          projectSettingsLink: (
+            <Link
+              to={`/settings/${orgSlug}/projects/${project.slug}/performance/#${projectDetectorSettingsId}`}
+            >
+              {entry.data.slug} performance issue detector settings
+            </Link>
+          ),
+          note: entry.note.replace(
+            'edited project performance issue detector settings ',
+            ''
+          ),
         })}
       </Note>
     );

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -781,7 +781,9 @@ class ProjectPerformance extends AsyncView<Props, State> {
                 apiEndpoint={performanceIssuesEndpoint}
               >
                 <JsonForm
-                  title={t('Performance Issues - Admin Detector Settings')}
+                  title={t(
+                    '### INTERNAL ONLY ### - Performance Issues Admin Detector Settings'
+                  )}
                   fields={this.performanceIssueDetectorAdminFields}
                   disabled={!isSuperUser}
                 />


### PR DESCRIPTION
- PR depends on backend PR: [link](https://github.com/getsentry/sentry/pull/52495)
- Added frontend for creating audit logs when admin setting toggles are used to enable/disable performance issue detection:
<img width="1512" alt="Screenshot 2023-07-09 at 8 06 10 PM" src="https://github.com/getsentry/sentry/assets/60121741/4a9acc37-66fe-4b09-99b9-b6602d607f46">

- Added test
- Added feature flag check for settings button that leads to detector settings from span evidence. 