### PR TITLE
feat(sdk-crashes): Set SDK version as release

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -65,6 +65,9 @@ class SDKCrashDetection:
                 },
             )
 
+            sdk_version = get_path(sdk_crash_event_data, "sdk", "version")
+            set_path(sdk_crash_event_data, "release", value=sdk_version)
+
             # So Sentry can tell how many projects are impacted by this SDK crash
             set_path(sdk_crash_event_data, "user", "id", value=event.project.id)
 

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -54,6 +54,8 @@ class BaseSDKCrashDetectionMixin(BaseTestCase, metaclass=abc.ABCMeta):
             assert reported_event_data["user"] == {
                 "id": event.project_id,
             }
+
+            assert reported_event_data["release"] == get_path(event_data, "sdk", "version")
         else:
             assert mock_sdk_crash_reporter.report.call_count == 0
 


### PR DESCRIPTION
Set SDK version as release to understand on which SDK versions the SDK crashes occur.
