### PR TITLE
feat(sdk-crashes): Grouping keeps in app

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event.py
+++ b/fixtures/sdk_crash_detection/crash_event.py
@@ -104,6 +104,127 @@ def get_crash_event(handled=False, function="-[Sentry]", **kwargs) -> Dict[str, 
     return get_crash_event_with_frames(get_frames(function), handled=handled, **kwargs)
 
 
+def get_metric_kit_crash_event() -> Dict[str, Collection[str]]:
+    """
+    The frames stem from a real world crash caused by our MetricKit integration.
+    All data was anonymized.
+    """
+    frames = [
+        {
+            "function": "_dispatch_workloop_worker_thread",
+            "package": "/usr/lib/system/libdispatch.dylib",
+            "in_app": False,
+        },
+        {
+            "function": "_dispatch_lane_serial_drain$VARIANT$armv81",
+            "package": "/usr/lib/system/libdispatch.dylib",
+            "in_app": False,
+        },
+        {
+            "function": "__44-[MXMetricManager deliverDiagnosticPayload:]_block_invoke",
+            "package": "/System/Library/Frameworks/MetricKit.framework/MetricKit",
+            "in_app": False,
+        },
+        {
+            "function": "Sequence.forEach",
+            "raw_function": "specialized Sequence.forEach((A.Element))",
+            "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
+            "filename": "<compiler-generated>",
+            "abs_path": "<compiler-generated>",
+            "in_app": True,
+        },
+        {
+            "function": "SentryMXManager.didReceive",
+            "raw_function": "closure #1 (MXDiagnosticPayload) in SentryMXManager.didReceive([MXDiagnosticPayload])",
+            "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
+            "filename": "SentryMXManager.swift",
+            "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Swift/MetricKit/SentryMXManager.swift",
+            "in_app": True,
+        },
+        {
+            "function": "Sequence.forEach",
+            "raw_function": "specialized Sequence.forEach((A.Element))",
+            "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
+            "filename": "<compiler-generated>",
+            "abs_path": "<compiler-generated>",
+            "in_app": True,
+        },
+        {
+            "function": "SentryMXManager.didReceive",
+            "raw_function": "closure #1 (SentryMXCallStackTree) in closure #3 (MXCPUExceptionDiagnostic) in closure #1 (MXDiagnosticPayload) in SentryMXManager.didReceive([MXDiagnosticPayload])",
+            "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
+            "filename": "SentryMXManager.swift",
+            "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Swift/MetricKit/SentryMXManager.swift",
+            "in_app": True,
+        },
+        {
+            "function": "-[SentryMetricKitIntegration captureEventNotPerThread:params:]",
+            "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
+            "filename": "SentryMetricKitIntegration.m",
+            "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Sentry/SentryMetricKitIntegration.m",
+            "in_app": False,
+        },
+        {
+            "function": "+[SentrySDK captureEvent:]",
+            "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
+            "filename": "SentrySDK.m",
+            "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Sentry/SentrySDK.m",
+            "in_app": False,
+        },
+        {
+            "function": "-[SentryFileManager readAppStateFrom:]",
+            "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
+            "filename": "SentryFileManager.m",
+            "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Sentry/SentryFileManager.m",
+            "in_app": False,
+        },
+        {
+            "function": "+[SentrySerialization appStateWithData:]",
+            "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
+            "filename": "SentrySerialization.m",
+            "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Sentry/SentrySerialization.m",
+            "in_app": False,
+        },
+        {
+            "function": "-[SentryAppState initWithJSONObject:]",
+            "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
+            "filename": "SentryAppState.m",
+            "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Sentry/SentryAppState.m",
+            "in_app": False,
+        },
+        {
+            "function": "+[NSDate(SentryExtras) sentry_fromIso8601String:]",
+            "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
+            "filename": "NSDate+SentryExtras.m",
+            "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Sentry/NSDate+SentryExtras.m",
+            "in_app": True,
+        },
+        {
+            "function": "-[NSDateFormatter getObjectValue:forString:errorDescription:]",
+            "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+            "in_app": False,
+        },
+        {
+            "function": "CFDateFormatterGetAbsoluteTimeFromString",
+            "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+            "in_app": False,
+        },
+        {
+            "function": "__cficu_ucal_clear",
+            "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+            "in_app": False,
+        },
+        {
+            "function": "icu::Calendar::clear",
+            "raw_function": "icu::Calendar::clear()",
+            "package": "/usr/lib/libicucore.A.dylib",
+            "in_app": False,
+        },
+    ]
+
+    return get_crash_event_with_frames(frames)
+
+
 def get_crash_event_with_frames(
     frames: Sequence[Mapping[str, Any]], handled=False, **kwargs
 ) -> Dict[str, Collection[str]]:

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -280,8 +280,10 @@ def normalize_stacktraces_for_grouping(data, grouping_config=None):
                     frame["raw_function"] = raw_func
                     frame["function"] = function_name
 
+    is_sdk_crash_event = bool(get_path(data, "contexts", "sdk_crash_detection"))
+
     # If a grouping config is available, run grouping enhancers
-    if grouping_config is not None:
+    if grouping_config is not None and not is_sdk_crash_event:
         with sentry_sdk.start_span(op=op, description="apply_modifications_to_frame"):
             counter = 0
             for frames, exception_data in zip(stacktraces, stacktrace_exceptions):

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -8,6 +8,7 @@ from fixtures.sdk_crash_detection.crash_event import (
     IN_APP_FRAME,
     get_crash_event,
     get_crash_event_with_frames,
+    get_metric_kit_crash_event,
     get_sentry_frame,
 )
 from sentry.eventstore.snuba.backend import SnubaEventStorage
@@ -136,126 +137,7 @@ class CococaSDKTestMixin(BaseSDKCrashDetectionMixin):
         self.execute_test(event, True, mock_sdk_crash_reporter)
 
     def test_metric_kit_crash_is_detected(self, mock_sdk_crash_reporter):
-        """
-        The frames stem from a real world crash caused by our MetricKit integration.
-        All data was anonymized.
-        """
-        frames = [
-            {
-                "function": "_dispatch_workloop_worker_thread",
-                "package": "/usr/lib/system/libdispatch.dylib",
-                "in_app": False,
-            },
-            {
-                "function": "_dispatch_lane_serial_drain$VARIANT$armv81",
-                "package": "/usr/lib/system/libdispatch.dylib",
-                "in_app": False,
-            },
-            {
-                "function": "__44-[MXMetricManager deliverDiagnosticPayload:]_block_invoke",
-                "package": "/System/Library/Frameworks/MetricKit.framework/MetricKit",
-                "in_app": False,
-            },
-            {
-                "function": "Sequence.forEach",
-                "raw_function": "specialized Sequence.forEach((A.Element))",
-                "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
-                "filename": "<compiler-generated>",
-                "abs_path": "<compiler-generated>",
-                "in_app": True,
-            },
-            {
-                "function": "SentryMXManager.didReceive",
-                "raw_function": "closure #1 (MXDiagnosticPayload) in SentryMXManager.didReceive([MXDiagnosticPayload])",
-                "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
-                "filename": "SentryMXManager.swift",
-                "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Swift/MetricKit/SentryMXManager.swift",
-                "in_app": True,
-            },
-            {
-                "function": "Sequence.forEach",
-                "raw_function": "specialized Sequence.forEach((A.Element))",
-                "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
-                "filename": "<compiler-generated>",
-                "abs_path": "<compiler-generated>",
-                "in_app": True,
-            },
-            {
-                "function": "SentryMXManager.didReceive",
-                "raw_function": "closure #1 (SentryMXCallStackTree) in closure #3 (MXCPUExceptionDiagnostic) in closure #1 (MXDiagnosticPayload) in SentryMXManager.didReceive([MXDiagnosticPayload])",
-                "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
-                "filename": "SentryMXManager.swift",
-                "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Swift/MetricKit/SentryMXManager.swift",
-                "in_app": True,
-            },
-            {
-                "function": "-[SentryMetricKitIntegration captureEventNotPerThread:params:]",
-                "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
-                "filename": "SentryMetricKitIntegration.m",
-                "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Sentry/SentryMetricKitIntegration.m",
-                "in_app": False,
-            },
-            {
-                "function": "+[SentrySDK captureEvent:]",
-                "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
-                "filename": "SentrySDK.m",
-                "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Sentry/SentrySDK.m",
-                "in_app": False,
-            },
-            {
-                "function": "-[SentryFileManager readAppStateFrom:]",
-                "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
-                "filename": "SentryFileManager.m",
-                "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Sentry/SentryFileManager.m",
-                "in_app": False,
-            },
-            {
-                "function": "+[SentrySerialization appStateWithData:]",
-                "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
-                "filename": "SentrySerialization.m",
-                "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Sentry/SentrySerialization.m",
-                "in_app": False,
-            },
-            {
-                "function": "-[SentryAppState initWithJSONObject:]",
-                "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
-                "filename": "SentryAppState.m",
-                "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Sentry/SentryAppState.m",
-                "in_app": False,
-            },
-            {
-                "function": "+[NSDate(SentryExtras) sentry_fromIso8601String:]",
-                "package": "/private/var/containers/Bundle/Application/CA061D22-C965-4C50-B383-59D8F14A6DDF/Sentry.app/Sentry",
-                "filename": "NSDate+SentryExtras.m",
-                "abs_path": "/Users/sentry/Library/Developer/Xcode/DerivedData/Consumer/SourcePackages/checkouts/sentry-cocoa/Sources/Sentry/NSDate+SentryExtras.m",
-                "in_app": True,
-            },
-            {
-                "function": "-[NSDateFormatter getObjectValue:forString:errorDescription:]",
-                "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
-                "in_app": False,
-            },
-            {
-                "function": "CFDateFormatterGetAbsoluteTimeFromString",
-                "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
-                "in_app": False,
-            },
-            {
-                "function": "__cficu_ucal_clear",
-                "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
-                "in_app": False,
-            },
-            {
-                "function": "icu::Calendar::clear",
-                "raw_function": "icu::Calendar::clear()",
-                "package": "/usr/lib/libicucore.A.dylib",
-                "in_app": False,
-            },
-        ]
-
-        event = get_crash_event_with_frames(frames)
-
-        self.execute_test(event, True, mock_sdk_crash_reporter)
+        self.execute_test(get_metric_kit_crash_event(), True, mock_sdk_crash_reporter)
 
         reported_event_data = mock_sdk_crash_reporter.report.call_args.args[0]
         actual_frames = get_path(


### PR DESCRIPTION
Processing changes the in_app to false for almost all Cocoa SDK frames, which we desire for regular events, but for Cocoa SDK crash events, we want to set all Cocoa SDK frames to in_app true. The SDK crash detection sets all Cocoa SDK frames `in_app = true` for grouping. Therefore, processing should keep the original in_app flags when it processes an SDK crash.

