### PR TITLE
fix(starfish): Fixes span samples slideout panel sometimes stuck in idle query

### DIFF
--- a/static/app/views/starfish/queries/useSpanMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.tsx
@@ -24,7 +24,8 @@ export const useSpanMetrics = (
   span?: Pick<IndexedSpan, 'group'>,
   queryFilters: SpanSummaryQueryFilters = {},
   fields: string[] = [],
-  referrer: string = 'span-metrics'
+  referrer: string = 'span-metrics',
+  enabled: boolean = true
 ) => {
   const location = useLocation();
   const eventView = span ? getEventView(span, location, queryFilters, fields) : undefined;
@@ -33,7 +34,7 @@ export const useSpanMetrics = (
   const result = useSpansQuery<SpanMetrics[]>({
     eventView,
     initialData: [],
-    enabled: Boolean(span),
+    enabled: Boolean(span) && enabled,
     referrer,
   });
 

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -24,7 +24,8 @@ export const useSpanMetricsSeries = (
   span?: Pick<IndexedSpan, 'group'>,
   queryFilters: SpanSummaryQueryFilters = {},
   yAxis: string[] = [],
-  referrer = 'span-metrics-series'
+  referrer = 'span-metrics-series',
+  enabled: boolean = true
 ) => {
   const location = useLocation();
   const pageFilters = usePageFilters();
@@ -38,6 +39,7 @@ export const useSpanMetricsSeries = (
     eventView,
     initialData: [],
     referrer,
+    enabled,
   });
 
   const parsedData = keyBy(

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -21,11 +21,10 @@ export type SpanMetrics = {
 };
 
 export const useSpanMetricsSeries = (
-  span?: Pick<IndexedSpan, 'group'>,
+  span: Pick<IndexedSpan, 'group'>,
   queryFilters: SpanSummaryQueryFilters = {},
   yAxis: string[] = [],
-  referrer = 'span-metrics-series',
-  enabled: boolean = true
+  referrer = 'span-metrics-series'
 ) => {
   const location = useLocation();
   const pageFilters = usePageFilters();
@@ -33,6 +32,9 @@ export const useSpanMetricsSeries = (
   const eventView = span
     ? getEventView(span, location, pageFilters.selection, yAxis, queryFilters)
     : undefined;
+
+  const enabled =
+    Boolean(span?.group) && Object.values(queryFilters).every(value => Boolean(value));
 
   // TODO: Add referrer
   const result = useSpansQuery<SpanMetrics[]>({

--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -19,9 +19,9 @@ import {DATE_FORMAT} from 'sentry/views/starfish/utils/useSpansQuery';
 const {SPAN_SELF_TIME} = SpanMetricsFields;
 
 type Options = {
-  groupId?: string;
-  transactionMethod?: string;
-  transactionName?: string;
+  groupId: string;
+  transactionMethod: string;
+  transactionName: string;
 };
 
 export type SpanSample = Pick<
@@ -49,11 +49,10 @@ export const useSpanSamples = (options: Options) => {
   const dateCondtions = getDateConditions(pageFilter.selection);
 
   const {isLoading: isLoadingSeries, data: spanMetricsSeriesData} = useSpanMetricsSeries(
-    groupId ? {group: groupId} : undefined,
+    {group: groupId},
     {transactionName, 'transaction.method': transactionMethod},
     [`p95(${SPAN_SELF_TIME})`],
-    'sidebar-span-metrics',
-    Boolean(groupId && transactionName && transactionMethod)
+    'sidebar-span-metrics'
   );
 
   const maxYValue = computeAxisMax([spanMetricsSeriesData?.[`p95(${SPAN_SELF_TIME})`]]);

--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -52,7 +52,8 @@ export const useSpanSamples = (options: Options) => {
     groupId ? {group: groupId} : undefined,
     {transactionName, 'transaction.method': transactionMethod},
     [`p95(${SPAN_SELF_TIME})`],
-    'sidebar-span-metrics'
+    'sidebar-span-metrics',
+    Boolean(groupId && transactionName && transactionMethod)
   );
 
   const maxYValue = computeAxisMax([spanMetricsSeriesData?.[`p95(${SPAN_SELF_TIME})`]]);

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -270,13 +270,11 @@ function SpanSummaryPage({params, location}: Props) {
                 />
               )}
 
-              {transaction && span?.group && (
-                <SampleList
-                  groupId={span.group}
-                  transactionName={transaction}
-                  transactionMethod={transactionMethod}
-                />
-              )}
+              <SampleList
+                groupId={span.group}
+                transactionName={transaction}
+                transactionMethod={transactionMethod}
+              />
             </Layout.Main>
           </Layout.Body>
         </PageErrorProvider>

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -67,14 +67,16 @@ function DurationChart({
     {group: groupId},
     {transactionName, 'transaction.method': transactionMethod},
     [`p95(${SPAN_SELF_TIME})`],
-    'sidebar-span-metrics'
+    'sidebar-span-metrics',
+    Boolean(groupId && transactionName && transactionMethod)
   );
 
   const {data: spanMetrics, error: spanMetricsError} = useSpanMetrics(
     {group: groupId},
     {transactionName, 'transaction.method': transactionMethod},
     [`p95(${SPAN_SELF_TIME})`, SPAN_OP],
-    'span-summary-panel-samples-table-p95'
+    'span-summary-panel-samples-table-p95',
+    Boolean(groupId && transactionName && transactionMethod)
   );
 
   const p95 = spanMetrics?.[`p95(${SPAN_SELF_TIME})`] || 0;

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -67,8 +67,7 @@ function DurationChart({
     {group: groupId},
     {transactionName, 'transaction.method': transactionMethod},
     [`p95(${SPAN_SELF_TIME})`],
-    'sidebar-span-metrics',
-    Boolean(groupId && transactionName && transactionMethod)
+    'sidebar-span-metrics'
   );
 
   const {data: spanMetrics, error: spanMetricsError} = useSpanMetrics(

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -22,11 +22,15 @@ export function SampleList({groupId, transactionName, transactionMethod}: Props)
   const [highlightedSpanId, setHighlightedSpanId] = useState<string | undefined>(
     undefined
   );
+  const detailKey =
+    groupId && transactionName && transactionMethod
+      ? `${groupId}:${transactionName}:${transactionMethod}`
+      : undefined;
 
   return (
     <PageErrorProvider>
       <DetailPanel
-        detailKey={groupId}
+        detailKey={detailKey}
         onClose={() => {
           router.push({
             pathname: router.location.pathname,

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -29,7 +29,8 @@ function SampleInfo(props: Props) {
       `p95(${SPAN_SELF_TIME})`,
       'time_spent_percentage(local)',
     ],
-    'span-summary-panel-metrics'
+    'span-summary-panel-metrics',
+    Boolean(groupId && transactionName && transactionMethod)
   );
 
   const style: CSSProperties = {

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -36,7 +36,8 @@ function SampleTable({
     {group: groupId},
     {transactionName, 'transaction.method': transactionMethod},
     [`p95(${SPAN_SELF_TIME})`, SPAN_OP],
-    'span-summary-panel-samples-table-p95'
+    'span-summary-panel-samples-table-p95',
+    Boolean(groupId && transactionName && transactionMethod)
   );
   const organization = useOrganization();
 


### PR DESCRIPTION
Fixes detail panel key to be actually unique and also updates detail panel to optimize caching by not needlessly canceling queries on collapse
