### PR TITLE
Query ArtifactBundleIndex joining the release/dist

### DIFF
--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -349,15 +349,15 @@ def get_artifact_bundles_containing_url(
     Returns the most recently uploaded bundle containing a file matching the `release`, `dist` and `url`.
     """
     return set(
-        ArtifactBundleIndex.objects.filter(
+        ArtifactBundle.objects.filter(
             organization_id=project.organization.id,
-            release_name=release_name,
-            dist_name=dist_name,
-            url=url,
-            artifact_bundle__projectartifactbundle__project_id=project.id,
-        ).values_list("artifact_bundle_id", "date_added")
+            projectartifactbundle__project_id=project.id,
+            releaseartifactbundle__release_name=release_name,
+            releaseartifactbundle__dist_name=dist_name,
+            artifactbundleindex__url=url,
+        ).values_list("id", "date_added")
         # we want to always return the most recent bundle matching the file
-        .order_by("-date_last_modified", "-artifact_bundle_id")[:1]
+        .order_by("-date_last_modified", "-id")[:1]
     )
 
 


### PR DESCRIPTION
Instead of using the `release`/`dist` directly on the table, we rather join that from the `ReleaseArtifactBundle` table in a more normalized manner. This is one more join, but we have to join the `ProjectArtifactBundle` anyway, so what is one more join...