### PR TITLE
ref(hc): More graceful slug region resolution handling

### DIFF
--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 
 from sentry.api.base import resolve_region
 from sentry.api.utils import generate_organization_url
-from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.models import OrganizationMapping
 from sentry.utils import auth
 from sentry.utils.http import absolute_uri
 
@@ -19,9 +19,7 @@ from sentry.utils.http import absolute_uri
 def _org_exists(slug):
     if not slug:
         return False
-    return (
-        organization_service.check_organization_by_slug(slug=slug, only_visible=False) is not None
-    )
+    return OrganizationMapping.objects.filter(slug=slug).exists()
 
 
 def _query_string(request):

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Iterable, List, Mapping, Optional, Set, Union, cast
+from typing import Any, Iterable, List, Mapping, Optional, Set, Union
 
 from django.db import IntegrityError, models, transaction
 from django.dispatch import Signal
@@ -26,7 +26,7 @@ from sentry.models import (
     outbox_context,
 )
 from sentry.models.organizationmember import InviteStatus
-from sentry.services.hybrid_cloud import OptionValue, logger
+from sentry.services.hybrid_cloud import OptionValue
 from sentry.services.hybrid_cloud.organization import (
     OrganizationService,
     OrganizationSignalService,
@@ -241,17 +241,6 @@ class DatabaseBackedOrganizationService(OrganizationService):
                 except OrganizationMember.DoesNotExist:
                     return None
         return serialize_member(org_member)
-
-    def check_organization_by_slug(self, *, slug: str, only_visible: bool) -> Optional[int]:
-        try:
-            org = Organization.objects.get_from_cache(slug=slug)
-            if only_visible and org.status != OrganizationStatus.ACTIVE:
-                raise Organization.DoesNotExist
-            return cast(int, org.id)
-        except Organization.DoesNotExist:
-            logger.info("Organization by slug [%s] not found", slug)
-
-        return None
 
     def _query_organizations(
         self, user_id: int, scope: Optional[str], only_visible: bool

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -160,14 +160,6 @@ class OrganizationService(RpcService):
         """
         pass
 
-    @regional_rpc_method(resolve=ByOrganizationSlug())
-    @abstractmethod
-    def check_organization_by_slug(self, *, slug: str, only_visible: bool) -> Optional[int]:
-        """
-        If exists and matches the only_visible requirement, returns an organization's id by the slug.
-        """
-        pass
-
     def get_organization_by_slug(
         self, *, slug: str, only_visible: bool, user_id: Optional[int] = None
     ) -> Optional[RpcUserOrganizationContext]:

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import inspect
 import logging
+import sys
 import urllib.response
 from abc import abstractmethod
 from collections.abc import Iterable
@@ -353,6 +354,15 @@ class RpcService(abc.ABC):
 
                 service = fallback()
                 method = getattr(service, method_name)
+
+                if "pytest" in sys.modules:
+                    from django.test import override_settings
+
+                    if cls.local_mode == SiloMode.REGION:
+                        region = signature.resolve_to_region(kwargs)
+                        with override_settings(SENTRY_REGION=region.name):
+                            return method(**kwargs)
+
                 return method(**kwargs)
 
             return remote_method_with_fallback

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -17,7 +17,7 @@ from sentry.api.utils import generate_organization_url
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import WARN_SESSION_EXPIRED
 from sentry.http import get_server_hostname
-from sentry.models import AuthProvider, Organization, OrganizationStatus
+from sentry.models import AuthProvider, Organization, OrganizationMapping, OrganizationStatus
 from sentry.services.hybrid_cloud import coerce_id_from
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.signals import join_request_link_viewed, user_signup
@@ -132,9 +132,9 @@ class AuthLoginView(BaseView):
         organization = kwargs.pop("organization", None)
 
         org_exists = bool(
-            organization_service.check_organization_by_slug(
-                slug=request.subdomain, only_visible=True
-            )
+            OrganizationMapping.objects.filter(
+                slug=request.subdomain, status=OrganizationStatus.ACTIVE
+            ).exists()
         )
 
         if request.method == "GET" and request.subdomain and org_exists:


### PR DESCRIPTION
Kind of a work in progress, but

In general we need the ability to test region resolution in tests, and have it activate the `SENTRY_REGION` value when calling stubbed RPC.

This unfortunately reveals a problem with slug region resolution -- when it fails, we don't get a nice return value, but an exception.  Worth discussing how we want to approach this.