### PR TITLE
ref(integrations): integration repo creation

### DIFF
--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -19,7 +19,7 @@ from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.signals import repo_linked
 
 
-class RepoExists(APIException):
+class RepoExistsError(APIException):
     status_code = 400
     detail = {"errors": {"__all__": "A repository with that name already exists"}}
 
@@ -104,7 +104,7 @@ class IntegrationRepositoryProvider:
                 except IntegrationError:
                     pass
 
-                raise RepoExists
+                raise RepoExistsError
 
         return result, repo
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import MutableMapping
+from typing import Any, MutableMapping
 
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, transaction
@@ -55,7 +55,7 @@ class IntegrationRepositoryProvider:
 
     def create_repository(
         self,
-        repo_config: MutableMapping[str, any],
+        repo_config: MutableMapping[str, Any],
         organization,
     ):
         result = self.build_repository_config(organization=organization, data=repo_config)

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -7,7 +7,7 @@ from django.db import IntegrityError
 
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.models import Repository
-from sentry.plugins.providers.integration_repository import RepoExists
+from sentry.plugins.providers.integration_repository import RepoExistsError
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
@@ -67,7 +67,7 @@ class IntegrationRepositoryTestCase(TestCase):
     def test_create_repository__repo_exists(self, get_jwt):
         self._create_repo()
 
-        with pytest.raises(RepoExists):
+        with pytest.raises(RepoExistsError):
             self.provider.create_repository(self.config, self.organization)
 
     @patch("sentry.models.Repository.objects.create")
@@ -79,5 +79,5 @@ class IntegrationRepositoryTestCase(TestCase):
         mock_repo.side_effect = IntegrityError
         mock_on_delete.side_effect = IntegrationError
 
-        with pytest.raises(RepoExists):
+        with pytest.raises(RepoExistsError):
             self.provider.create_repository(self.config, self.organization)

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -1,0 +1,83 @@
+from functools import cached_property
+from unittest.mock import patch
+
+import pytest
+import responses
+from django.db import IntegrityError
+
+from sentry.integrations.github.repository import GitHubRepositoryProvider
+from sentry.models import Repository
+from sentry.plugins.providers.integration_repository import RepoExists
+from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test(stable=True)
+class IntegrationRepositoryTestCase(TestCase):
+    @responses.activate
+    def setUp(self):
+        super().setUp()
+        self.integration = self.create_integration(
+            organization=self.organization, provider="github", external_id="654321"
+        )
+        self.repo_name = "getsentry/sentry"
+        self.config = {
+            "identifier": self.repo_name,
+            "external_id": "654321",
+            "integration_id": self.integration.id,
+        }
+
+        responses.add(
+            responses.GET,
+            "https://api.github.com/repos/" + self.repo_name,
+            json={
+                "id": 1296269,
+                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+                "name": "example-repo",
+                "full_name": self.repo_name,
+            },
+        )
+
+    @cached_property
+    def provider(self):
+        return GitHubRepositoryProvider("integrations:github")
+
+    def _create_repo(self):
+        return Repository.objects.create(
+            name=self.repo_name,
+            provider="integrations:github",
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            url="https://github.com/" + self.repo_name,
+            config={"name": self.repo_name},
+        )
+
+    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    def test_create_repository(self, get_jwt):
+        self.provider.create_repository(self.config, self.organization)
+
+        repos = Repository.objects.all()
+        assert len(repos) == 1
+
+        assert repos[0].name == self.repo_name
+        assert repos[0].provider == "integrations:github"
+
+    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    def test_create_repository__repo_exists(self, get_jwt):
+        self._create_repo()
+
+        with pytest.raises(RepoExists):
+            self.provider.create_repository(self.config, self.organization)
+
+    @patch("sentry.models.Repository.objects.create")
+    @patch("sentry.plugins.providers.IntegrationRepositoryProvider.on_delete_repository")
+    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    def test_create_repository__delete_webhook(self, get_jwt, mock_on_delete, mock_repo):
+        self._create_repo()
+
+        mock_repo.side_effect = IntegrityError
+        mock_on_delete.side_effect = IntegrationError
+
+        with pytest.raises(RepoExists):
+            self.provider.create_repository(self.config, self.organization)


### PR DESCRIPTION
The `dispatch` method contains all the logic to create a `Repository` row from external repository information and we want to reuse this code for general repo creation.

For ER-1714