### PR TITLE
fix(starfish): WSV Chart divides by zero if no data

### DIFF
--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -67,7 +67,7 @@ export function SpanGroupBreakdown({
     const totalTimeAtIndex = data.reduce((acc, datum) => acc + datum.data[i].value, 0);
     dataAsPercentages.forEach(segment => {
       const clone = {...segment.data[i]};
-      clone.value = clone.value / totalTimeAtIndex;
+      clone.value = totalTimeAtIndex === 0 ? 0 : clone.value / totalTimeAtIndex;
       segment.data[i] = clone;
     });
   }


### PR DESCRIPTION
Quick fix for the WSV percentages chart, there was no check to ensure that we do not divide by zero if there is no data at a particular index.

![image](https://github.com/getsentry/sentry/assets/16740047/73fe3453-ee01-48db-befd-e583bfa668dc)
