### PR TITLE
ref(sort): Don't make new priority sort default

### DIFF
--- a/static/app/components/modals/savedSearchModal/createSavedSearchModal.tsx
+++ b/static/app/components/modals/savedSearchModal/createSavedSearchModal.tsx
@@ -29,10 +29,11 @@ function validateSortOption({
     'issue-list-better-priority-sort'
   );
   const sortOptions = [
-    ...(hasBetterPrioritySort ? [IssueSortOptions.BETTER_PRIORITY] : []), // show better priority for EA orgs
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    ...(hasBetterPrioritySort ? [] : [IssueSortOptions.PRIORITY]), // hide regular priority for EA orgs
+    ...(hasBetterPrioritySort
+      ? [IssueSortOptions.BETTER_PRIORITY]
+      : [IssueSortOptions.PRIORITY]), // show better priority for EA orgs
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/components/modals/savedSearchModal/savedSearchModalContent.tsx
+++ b/static/app/components/modals/savedSearchModal/savedSearchModalContent.tsx
@@ -24,10 +24,11 @@ export function SavedSearchModalContent({organization}: SavedSearchModalContentP
   );
 
   const sortOptions = [
-    ...(hasBetterPrioritySort ? [IssueSortOptions.BETTER_PRIORITY] : []), // show better priority for EA orgs
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    ...(hasBetterPrioritySort ? [] : [IssueSortOptions.PRIORITY]), // hide regular priority for EA orgs
+    ...(hasBetterPrioritySort
+      ? [IssueSortOptions.BETTER_PRIORITY]
+      : [IssueSortOptions.PRIORITY]), // show better priority for EA orgs
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -74,10 +74,11 @@ function getTableSortOptions(organization: Organization, _widgetQuery: WidgetQue
     'issue-list-better-priority-sort'
   );
   const sortOptions = [
-    ...(hasBetterPrioritySort ? [IssueSortOptions.BETTER_PRIORITY] : []), // show better priority for EA orgs
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    ...(hasBetterPrioritySort ? [] : [IssueSortOptions.PRIORITY]), // hide regular priority for EA orgs
+    ...(hasBetterPrioritySort
+      ? [IssueSortOptions.BETTER_PRIORITY]
+      : [IssueSortOptions.PRIORITY]), // show better priority for EA orgs
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -41,11 +41,12 @@ function IssueListSortOptions({onSelect, sort, query}: Props) {
   );
   const sortKey = sort || IssueSortOptions.DATE;
   const sortKeys = [
-    ...(hasBetterPrioritySort ? [IssueSortOptions.BETTER_PRIORITY] : []), // show better priority for EA orgs
     ...(FOR_REVIEW_QUERIES.includes(query || '') ? [IssueSortOptions.INBOX] : []),
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    ...(hasBetterPrioritySort ? [] : [IssueSortOptions.PRIORITY]), // hide regular priority for EA orgs
+    ...(hasBetterPrioritySort
+      ? [IssueSortOptions.BETTER_PRIORITY]
+      : [IssueSortOptions.PRIORITY]), // show better priority for EA orgs
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -304,13 +304,7 @@ class IssueListOverview extends Component<Props, State> {
     if (location.query.sort) {
       return location.query.sort as string;
     }
-
-    const hasBetterPrioritySort = this.props.organization.features.includes(
-      'issue-list-better-priority-sort'
-    );
-    return hasBetterPrioritySort
-      ? IssueSortOptions.BETTER_PRIORITY
-      : DEFAULT_ISSUE_STREAM_SORT;
+    return DEFAULT_ISSUE_STREAM_SORT;
   }
 
   getQuery(): string {


### PR DESCRIPTION
We've decided not to release the new priority sort as the default sort, but rather simply replace the existing priority sort with it. 