### PR TITLE
ref(hc): test validates transaction patching handles parent patch.

### DIFF
--- a/src/sentry/silo/patches/silo_aware_transaction_patch.py
+++ b/src/sentry/silo/patches/silo_aware_transaction_patch.py
@@ -68,8 +68,14 @@ def determine_using_by_silo_mode(using):
     return using
 
 
+_patched = False
+
+
 def patch_silo_aware_atomic():
-    global _default_on_commit, _default_get_connection, _default_atomic_impl
+    global _default_on_commit, _default_get_connection, _default_atomic_impl, _patched
+
+    assert not _patched
+    _patched = True
 
     current_django_version = get_version()
     assert current_django_version.startswith("2.2."), (

--- a/tests/sentry/silo/test_silo_aware_transaction_patch.py
+++ b/tests/sentry/silo/test_silo_aware_transaction_patch.py
@@ -1,15 +1,15 @@
 import os
+from typing import Any
+from unittest.mock import patch
 
 import pytest
-from django.db import router
+from django.db import router, transaction
 from django.test import override_settings
 
 from sentry.models import Organization, OrganizationMapping
 from sentry.silo import SiloMode
-from sentry.silo.patches.silo_aware_transaction_patch import (
-    MismatchedSiloTransactionError,
-    siloed_atomic,
-)
+from sentry.silo.patches import silo_aware_transaction_patch
+from sentry.silo.patches.silo_aware_transaction_patch import MismatchedSiloTransactionError
 from sentry.testutils import TestCase
 
 
@@ -17,22 +17,41 @@ def is_running_in_split_db_mode() -> bool:
     return bool(os.environ.get("SENTRY_USE_SPLIT_DBS"))
 
 
+class TestTransactionPatching(TestCase):
+    def test_preserves_parent_patching(self):
+        def other_patch(*args: Any, **kargs: Any) -> str:
+            assert kargs["using"] == "default"
+            return "other-patch"
+
+        with patch("sentry.silo.patches.silo_aware_transaction_patch._patched", new=False), patch(
+            "sentry.silo.patches.silo_aware_transaction_patch._default_atomic_impl", new=None
+        ), patch(
+            "sentry.silo.patches.silo_aware_transaction_patch._default_on_commit", new=None
+        ), patch(
+            "sentry.silo.patches.silo_aware_transaction_patch._default_get_connection", new=None
+        ), patch(
+            "django.db.transaction.atomic", new=other_patch
+        ):
+            silo_aware_transaction_patch.patch_silo_aware_atomic()
+            assert transaction.atomic() == "other-patch"
+
+
 class TestSiloAwareTransactionPatchInSingleDbMode(TestCase):
     @pytest.mark.skipif(is_running_in_split_db_mode(), reason="only runs in single db mode")
     def test_routes_to_correct_db_in_control_silo(self):
         with override_settings(SILO_MODE=SiloMode.CONTROL):
-            transaction_in_test = siloed_atomic()
+            transaction_in_test = transaction.atomic()
             assert transaction_in_test.using == "default"
 
     @pytest.mark.skipif(is_running_in_split_db_mode(), reason="only runs in single db mode")
     def test_routes_to_correct_db_in_region_silo(self):
 
         with override_settings(SILO_MODE=SiloMode.REGION):
-            transaction_in_test = siloed_atomic()
+            transaction_in_test = transaction.atomic()
             assert transaction_in_test.using == "default"
 
     def test_correctly_accepts_using_for_atomic(self):
-        transaction_in_test = siloed_atomic(using="foobar")
+        transaction_in_test = transaction.atomic(using="foobar")
         assert transaction_in_test.using == "foobar"
 
 
@@ -40,7 +59,7 @@ class TestSiloAwareTransactionPatchInSplitDbMode(TestCase):
     @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
     def test_routes_to_correct_db_in_control_silo(self):
         with override_settings(SILO_MODE=SiloMode.REGION):
-            transaction_in_test = siloed_atomic()
+            transaction_in_test = transaction.atomic()
             assert transaction_in_test.using == "default"
 
     @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
@@ -48,12 +67,12 @@ class TestSiloAwareTransactionPatchInSplitDbMode(TestCase):
         with override_settings(SILO_MODE=SiloMode.REGION), pytest.raises(
             MismatchedSiloTransactionError
         ):
-            siloed_atomic(using=router.db_for_write(OrganizationMapping))
+            transaction.atomic(using=router.db_for_write(OrganizationMapping))
 
     @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
     def test_routes_to_correct_db_in_region_silo(self):
         with override_settings(SILO_MODE=SiloMode.CONTROL):
-            transaction_in_test = siloed_atomic()
+            transaction_in_test = transaction.atomic()
             assert transaction_in_test.using == "control"
 
     @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
@@ -61,4 +80,4 @@ class TestSiloAwareTransactionPatchInSplitDbMode(TestCase):
         with override_settings(SILO_MODE=SiloMode.CONTROL), pytest.raises(
             MismatchedSiloTransactionError
         ):
-            siloed_atomic(using=router.db_for_write(Organization))
+            transaction.atomic(using=router.db_for_write(Organization))


### PR DESCRIPTION
Added assert guarantee that we don't double patch.
Add test that validates why we should capture the original methods at the same place we replace them (otherwise parent patches may be lost in the chain, depending on import ordering).  This strengthens the intention of the implementation.
Strengthen test that ensures patching is working by using `transaction.atomic` at the outer level.

I can't reproduce by any means, debugger included, any issue with the way we capture the globals.  It seems to work robustly.  Let me know of any specific issues that are seen that we can address.  