### PR TITLE
fix(issue-details): Ensure that Loaded Images section displays correct info when navigating events

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -100,7 +100,7 @@ class DebugMetaWithRouter extends PureComponent<Props, State> {
     this.openImageDetailsModal();
   }
 
-  componentDidUpdate(_prevProps: Props, prevState: State) {
+  componentDidUpdate(prevProps: Props, prevState: State) {
     if (
       this.state.isOpen ||
       (prevState.filteredImages.length === 0 && this.state.filteredImages.length > 0)
@@ -109,6 +109,11 @@ class DebugMetaWithRouter extends PureComponent<Props, State> {
     }
 
     this.openImageDetailsModal();
+
+    if (this.props.event?.id !== prevProps.event?.id) {
+      this.getRelevantImages();
+      this.updateGrid();
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/52557

The problem was that the `DebugMeta` component stores the images in state but does not reset the state when a new event is provided. This simply update that state when the new event comes in.

Can test this by going to this event: https://sentry-sdks.dev.getsentry.net:7999/issues/3910248271/events/2846df1d33844d72a0aece40fa59bece

And clicking the previous event should take you to an event that has a different "Images Loaded" section