### PR TITLE
fix(migration): move ahead if we can't parse out the search term

### DIFF
--- a/src/sentry/migrations/0502_savedsearch_update_me_myteams.py
+++ b/src/sentry/migrations/0502_savedsearch_update_me_myteams.py
@@ -93,22 +93,25 @@ def update_saved_search_query(apps, schema_editor):
 
         all_idx = [m.span() for m in list(assigned_me_idx_iter) + list(assigned_me_in_idx_iter)]
 
-        replacements = []
-        for start, stop in all_idx or ():
-            maybe_replacement = replacement_term(query[start:stop])
-            if maybe_replacement:
-                replacements.append((start, stop, maybe_replacement))
+        try:
+            replacements = []
+            for start, stop in all_idx or ():
+                maybe_replacement = replacement_term(query[start:stop])
+                if maybe_replacement:
+                    replacements.append((start, stop, maybe_replacement))
 
-        if replacements:
-            result = []
-            i = 0
-            for start, end, replacement in replacements:
-                result.append(query[i:start] + replacement)
-                i = end
-            result.append(query[i:])
+            if replacements:
+                result = []
+                i = 0
+                for start, end, replacement in replacements:
+                    result.append(query[i:start] + replacement)
+                    i = end
+                result.append(query[i:])
 
-            ss.query = " ".join(result).strip()
-            ss.save(update_fields=["query"])
+                ss.query = " ".join(result).strip()
+                ss.save(update_fields=["query"])
+        except Exception:
+            continue
 
 
 class Migration(CheckedMigration):


### PR DESCRIPTION
Adds some error handling when we encounter a query we can't parse. 

Encountered some errors when parsing the following:
`assigned_or_suggested:[me, user:id:<redacted-user-id> none]`
which parses into:
```
[
SearchFilter(key=SearchKey(name='assigned_or_suggested'), operator='=', value=SearchValue(raw_value='[me,')), 

SearchFilter(key=SearchKey(name='user'), operator='=', value=SearchValue(raw_value='id:<redacted>')), 

SearchFilter(key=SearchKey(name='message'), operator='=', value=SearchValue(raw_value='none]'))
]
```

This looks like an invalid search query. This should be safe to ignore. 
