### PR TITLE
feat(api): Document hydration error and custom filters

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -445,6 +445,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             GlobalParams.slug("The slug for the project."),
             ProjectParams.platform("The platform for the project."),
             ProjectParams.IS_BOOKMARKED,
+            ProjectParams.OPTIONS,
         ],
         request=ProjectAdminSerializer,
         responses={

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -51,7 +51,9 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
     )
     def put(self, request: Request, project, filter_id) -> Response:
         """
-        Update various inbound data filters for a project. The hydration filter and custom inbound
+        Update various inbound data filters for a project.
+
+        Note that the hydration filter and custom inbound
         filters must be updated using the [Update a
         Project](https://docs.sentry.io/api/projects/update-a-project/) endpoint.
         """

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -51,9 +51,10 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
     )
     def put(self, request: Request, project, filter_id) -> Response:
         """
-        Update various inbound data filters for a project.
+        Update various inbound data filters for a project. The hydration filter and custom inbound
+        filters must be updated using the [Update a
+        Project](https://docs.sentry.io/api/projects/update-a-project/) endpoint.
         """
-
         for flt in inbound_filters.get_all_filter_specs():
             if flt.id == filter_id:
                 current_filter = flt

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -314,6 +314,38 @@ Configures multiple options for the Javascript Loader Script.
         description="Enables starring the project within the projects tab.",
     )
 
+    OPTIONS = OpenApiParameter(
+        name="options",
+        location="query",
+        required=False,
+        type=inline_serializer(
+            name="OptionsSerializer",
+            fields={
+                "filters:react-hydration-errors": serializers.BooleanField(required=False),
+                "filters:blacklisted_ips": serializers.CharField(required=False),
+                "filters:releases": serializers.CharField(required=False),
+                "filters:error_messages": serializers.CharField(required=False),
+            },
+        ),
+        description="""
+Configure various project filters:
+- `Hydration Errors`: Filter out react hydration errors that are often unactionable
+- `IP Addresses`: Filter events from these IP addresses separated with newlines.
+- `Releases`: Filter events from these releases separated with newlines. Allows [glob pattern matching](https://docs.sentry.io/product/data-management-settings/filtering/#glob-matching).
+- `Error Message`: Filter events by error messages separated with newlines. Allows [glob pattern matching](https://docs.sentry.io/product/data-management-settings/filtering/#glob-matching).
+```json
+{
+    options: {
+        filters:react-hydration-errors: true,
+        filters:blacklisted_ips: "127.0.0.1\\n192.168. 0.1"
+        filters:releases: "[!3]\\n4"
+        filters:error_messages: "TypeError*\\n*ConnectionError*"
+    }
+}
+```
+""",
+    )
+
     RATE_LIMIT = OpenApiParameter(
         name="rateLimit",
         location="query",


### PR DESCRIPTION
Project Update w/ filters:
<img width="1144" alt="Screenshot 2023-07-10 at 1 42 31 PM" src="https://github.com/getsentry/sentry/assets/67301797/b247f43c-f6a9-4199-9b72-3f31e1a1ce68">
<img width="1130" alt="Screenshot 2023-07-10 at 1 42 44 PM" src="https://github.com/getsentry/sentry/assets/67301797/714615f9-37cc-4685-bfbe-485c3a2a68b7">

Note in `Update an Inbound Filter endpoint` detailing where to find other filters
<img width="1090" alt="Screenshot 2023-07-10 at 1 52 15 PM" src="https://github.com/getsentry/sentry/assets/67301797/7cb05fbd-ec2a-4eb9-8274-2c783c75b372">
