### PR TITLE
ref(sort): Allow saving priority as default search

### DIFF
--- a/static/app/views/issueList/issueListSetAsDefault.tsx
+++ b/static/app/views/issueList/issueListSetAsDefault.tsx
@@ -94,8 +94,8 @@ function IssueListSetAsDefault({organization, sort, query}: IssueListSetAsDefaul
   // Hide if we are already on the default search,
   // except when the user has a different search pinned.
   if (
-    isDefaultIssueStreamSearch({query, sort, organization}) &&
-    (!pinnedSearch || isDefaultIssueStreamSearch({organization, ...pinnedSearch}))
+    isDefaultIssueStreamSearch({query, sort}) &&
+    (!pinnedSearch || isDefaultIssueStreamSearch(pinnedSearch))
   ) {
     return null;
   }

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -183,19 +183,8 @@ export enum IssueSortOptions {
 
 export const DEFAULT_ISSUE_STREAM_SORT = IssueSortOptions.DATE;
 
-export function isDefaultIssueStreamSearch({
-  query,
-  sort,
-  organization,
-}: {
-  organization: Organization;
-  query: string;
-  sort: string;
-}) {
-  const defaultSort = organization.features.includes('issue-list-better-priority-sort')
-    ? IssueSortOptions.BETTER_PRIORITY
-    : DEFAULT_ISSUE_STREAM_SORT;
-  return query === DEFAULT_QUERY && sort === defaultSort;
+export function isDefaultIssueStreamSearch({query, sort}: {query: string; sort: string}) {
+  return query === DEFAULT_QUERY && sort === DEFAULT_ISSUE_STREAM_SORT;
 }
 
 export function getSortLabel(key: string) {


### PR DESCRIPTION
Undoes https://github.com/getsentry/sentry/pull/51958/files since we've decided not to make the new priority sort the default. 