### PR TITLE
nit(api): Reorder filters

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -232,12 +232,12 @@ class ProjectParams:
 - `browser-extensions`: Filter out errors known to be caused by browser extensions.
 - `localhost`: Filter out events coming from localhost. This applies to both IPv4 (``127.0.0.1``)
 and IPv6 (``::1``) addresses.
+- `filtered-transaction`: Filter out transactions for healthcheck and ping endpoints.
 - `web-crawlers`: Filter out known web crawlers. Some crawlers may execute pages in incompatible
 ways which then cause errors that are unlikely to be seen by a normal user.
 - `legacy-browser`: Filter out known errors from legacy browsers. Older browsers often give less
 accurate information, and while they may report valid issues, the context to understand them is
 incorrect or missing.
-- `filtered-transaction`: Filter out transactions for healthcheck and ping endpoints.
 """,
     )
 
@@ -246,7 +246,7 @@ incorrect or missing.
         location="query",
         required=False,
         type=bool,
-        description="Toggle the browser-extensions, localhost, web-crawlers, or filtered-transaction  filter on or off.",
+        description="Toggle the browser-extensions, localhost, filtered-transaction, or web-crawlers filter on or off.",
     )
 
     BROWSER_SDK_VERSION = OpenApiParameter(


### PR DESCRIPTION
Reorder filters on API to match UI

UI order:
![Screenshot 2023-07-10 at 10 46 20 AM](https://github.com/getsentry/sentry/assets/67301797/4c58862f-297e-4bb3-9dd1-830cc4e7ef7b)

Updated API order:
<img width="540" alt="Screenshot 2023-07-10 at 2 01 14 PM" src="https://github.com/getsentry/sentry/assets/67301797/7a0d2221-946b-49bf-b93d-ff1772eaba94">
