### PR TITLE
ref(rule): Schedule rule deletion in migration

### DIFF
--- a/src/sentry/migrations/0507_delete_pending_deletion_rules.py
+++ b/src/sentry/migrations/0507_delete_pending_deletion_rules.py
@@ -10,9 +10,10 @@ def delete_rules(apps, schema_editor):
     from sentry.constants import ObjectStatus
 
     Rule = apps.get_model("sentry", "Rule")
+    RegionScheduledDeletion = apps.get_model("sentry", "RegionScheduledDeletion")
     for rule in RangeQuerySetWrapperWithProgressBar(Rule.objects.all()):
         if rule.status in (ObjectStatus.PENDING_DELETION, ObjectStatus.DISABLED):
-            rule.delete()
+            RegionScheduledDeletion.schedule(rule, days=0)
 
 
 class Migration(CheckedMigration):

--- a/src/sentry/migrations/0507_delete_pending_deletion_rules.py
+++ b/src/sentry/migrations/0507_delete_pending_deletion_rules.py
@@ -23,23 +23,14 @@ def schedule(cls, instance, days=30):
 
     model = type(instance)
     model_name = model.__name__
-    record, created = cls.objects.create_or_update(
+    cls.objects.update_or_create(
         app_label=instance._meta.app_label,
         model_name=model_name,
         object_id=instance.pk,
-        values={
-            "date_scheduled": timezone.now() + timedelta(days=days, hours=0),
-            "data": {},
-            "actor_id": None,
-        },
+        date_scheduled=timezone.now() + timedelta(days=days, hours=0),
+        data={},
+        actor_id=None,
     )
-    if not created:
-        record = cls.objects.get(
-            app_label=instance._meta.app_label,
-            model_name=model_name,
-            object_id=instance.pk,
-        )
-    return record
 
 
 def delete_rules(apps, schema_editor):


### PR DESCRIPTION
A follow up to https://github.com/getsentry/sentry/pull/52411 to modify the migration to schedule the objects for deletion rather than directly deleting them since the migration timed out. 