### PR TITLE
feat(hc): Split DB tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -67,7 +67,7 @@ jobs:
     needs: files-changed
     name: backend test
     runs-on: ubuntu-20.04
-    timeout-minutes: 40
+    timeout-minutes: 80
     strategy:
       # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
       # and reducing the risk that one of many runs would turn red again (read: intermittent tests)


### PR DESCRIPTION
| Date | Failures | Total | Passing |
| ----- | ------- | ----- | -------- |
| 2023-09-07 | [0](https://github.com/getsentry/sentry/actions/runs/6111491233) 🎉 | 23,147 | 100% |
| 2023-09-05 | [3](https://github.com/getsentry/sentry/actions/runs/6087711171) | 23,003 | 99.9% |
| 2023-08-28 | [13](https://github.com/getsentry/sentry/actions/runs/6006074929) | 22,792 | 99.9% |
| 2023-08-17 | [12](https://github.com/getsentry/sentry/actions/runs/5896691851) | 22,513 | 99.9% |
| 2023-08-15 | [11](https://github.com/getsentry/sentry/actions/runs/5882521370) | 22,397 | 99.9% |
| 2023-08-14 | [12](https://github.com/getsentry/sentry/actions/runs/5861605527) | 22,272 | 99.9% |
| 2023-08-11 | [17](https://github.com/getsentry/sentry/actions/runs/5837945306) | 22,244 | 99.9% |
| 2023-08-10 | [17](https://github.com/getsentry/sentry/actions/runs/5826739023) | 22,219 | 99.9% |
| 2023-08-09 | [49](https://github.com/getsentry/sentry/actions/runs/5823303211) | 21,759 | 99.8% |
| 2023-08-08 | [70](https://github.com/getsentry/sentry/actions/runs/5803024252) | 21,642 | 99.7% |
| 2023-08-07 | [70](https://github.com/getsentry/sentry/actions/runs/5791849016) | 21,642 | 99.7% |
| 2023-08-04 | [72](https://github.com/getsentry/sentry/actions/runs/5767412926) | 21,566 | 99.7% |
| 2023-08-03 | [101](https://github.com/getsentry/sentry/actions/runs/5756450851) | 21,425 | 99.5% |
| 2023-08-02 | [101](https://github.com/getsentry/sentry/actions/runs/5744875078) | 21,088 | 99.5% |
| 2023-08-01 | [119](https://github.com/getsentry/sentry/actions/runs/5733020604) | 21,032 | 99.4% |
| 2023-07-31 | [125](https://github.com/getsentry/sentry/actions/runs/5720781681) | 21,007 | 99.4% |
| 2023-07-28 | [204](https://github.com/getsentry/sentry/actions/runs/5697162606) | 20,947 | 99.0% |
| 2023-07-26 | [277](https://github.com/getsentry/sentry/actions/runs/5674415363) | 20,891 | 98.7% |
| 2023-07-25 | [254](https://github.com/getsentry/sentry/actions/runs/5663453319) | 20,746 | 98.8% |
| 2023-07-24 | [2,323](https://github.com/getsentry/sentry/actions/runs/5652162287)* |  |  |
| 2023-07-21 | [612](https://github.com/getsentry/sentry/actions/runs/5628240631) | 20,111 | 97.0% |
| 2023-07-20 | [2,532](https://github.com/getsentry/sentry/actions/runs/5617519501) | 20,072 | 87.4% |
| 2023-07-19 | [631](https://github.com/getsentry/sentry/actions/runs/5604776773) | 19,987 | 96.8% |
| 2023-06-27 | [724](https://github.com/getsentry/sentry/actions/runs/5393798971) | 20,032 | 96.4% |

\* plus 3 jobs timed out