### PR TITLE
chore(gh-growth): Add feature flag for automatic repo linking

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1301,7 +1301,7 @@ SENTRY_FEATURES = {
     "organizations:assign-to-me": False,
     # Enables the cron job to auto-enable codecov integrations.
     "organizations:auto-enable-codecov": False,
-    # Enabled automatically linking repositories using commit webhook data
+    # Enables automatically linking repositories using commit webhook data
     "organizations:auto-repo-linking": False,
     # The overall flag for codecov integration, gated by plans.
     "organizations:codecov-integration": False,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1301,6 +1301,8 @@ SENTRY_FEATURES = {
     "organizations:assign-to-me": False,
     # Enables the cron job to auto-enable codecov integrations.
     "organizations:auto-enable-codecov": False,
+    # Enabled automatically linking repositories using commit webhook data
+    "organizations:auto-repo-linking": False,
     # The overall flag for codecov integration, gated by plans.
     "organizations:codecov-integration": False,
     # Enables getting commit sha from git blame for codecov.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -69,6 +69,7 @@ default_manager.add("organizations:alert-crash-free-metrics", OrganizationFeatur
 default_manager.add("organizations:alert-filters", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:api-keys", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:auto-repo-linking", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:crash-rate-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:mute-metric-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:crons-issue-platform", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
This feature flag will be used to enable/disable creating repositories through the commit webhook. This won't impact inking all repositories at install time.

