### PR TITLE
feat(functions): Split function trends stats query

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from enum import Enum
 from typing import Any
@@ -25,8 +24,6 @@ from sentry.utils import json
 from sentry.utils.dates import parse_stats_period, validate_interval
 from sentry.utils.sdk import set_measurement
 from sentry.utils.snuba import bulk_snql_query
-
-_query_thread_pool = ThreadPoolExecutor(max_workers=10)
 
 ads_connection_pool = connection_from_url(
     settings.ANOMALY_DETECTION_URL,

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -147,8 +147,32 @@ def top_events_timeseries(
 
     if len(top_events["data"]) == limit and include_other:
         assert False, "Other is not supported"  # TODO: support other
-    else:
-        result = top_functions_builder.run_query(referrer)
+
+    result = top_functions_builder.run_query(referrer)
+    return format_top_events_timeseries_results(
+        result,
+        top_functions_builder,
+        params,
+        rollup,
+        top_events=top_events,
+        allow_empty=allow_empty,
+        zerofill_results=zerofill_results,
+        result_key_order=result_key_order,
+    )
+
+
+def format_top_events_timeseries_results(
+    result,
+    query_builder,
+    params,
+    rollup,
+    top_events=None,
+    allow_empty=True,
+    zerofill_results=True,
+    result_key_order=None,
+):
+    if top_events is None:
+        assert top_events, "Need to provide top events"  # TODO: support this use case
 
     if not allow_empty and not len(result.get("data", [])):
         return SnubaTSResult(
@@ -166,10 +190,10 @@ def top_events_timeseries(
         op="discover.discover", description="top_events.transform_results"
     ) as span:
         span.set_data("result_count", len(result.get("data", [])))
-        result = top_functions_builder.process_results(result)
+        result = query_builder.process_results(result)
 
         if result_key_order is None:
-            result_key_order = top_functions_builder.translated_groupby
+            result_key_order = query_builder.translated_groupby
 
         results: Dict[str, Any] = {}
 


### PR DESCRIPTION
Querying 50 timeseries can be slow. This splits the query into batches of 10 so it can be parallelized.
