### PR TITLE
feat(escalating-issues): Auto transition escalating -> ongoing

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1082,16 +1082,10 @@ CELERYBEAT_SCHEDULE_REGION = {
         # TODO: Increase expiry time to x4 once we change this to run weekly
         "options": {"expires": 60 * 60 * 3},
     },
-    "schedule_auto_transition_new": {
-        "task": "sentry.tasks.schedule_auto_transition_new",
-        # Run job every 6 hours
+    "schedule_auto_transition_to_ongoing": {
+        "task": "sentry.tasks.schedule_auto_transition_to_ongoing",
+        # Run job every 10 minutes
         "schedule": crontab(minute="*/10"),
-        "options": {"expires": 3600},
-    },
-    "schedule_auto_transition_regressed": {
-        "task": "sentry.tasks.schedule_auto_transition_regressed",
-        # Run job every 6 hours
-        "schedule": crontab(minute=0, hour="*/6"),
         "options": {"expires": 3600},
     },
     "schedule_auto_archive_issues": {

--- a/src/sentry/tasks/auto_archive_issues.py
+++ b/src/sentry/tasks/auto_archive_issues.py
@@ -19,7 +19,7 @@ from sentry.models import (
     record_group_history_from_activity_type,
     remove_group_from_inbox,
 )
-from sentry.tasks.auto_ongoing_issues import skip_if_queue_has_items
+from sentry.tasks.auto_ongoing_issues import log_error_if_queue_has_items
 from sentry.tasks.base import instrumented_task, retry
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
@@ -38,7 +38,7 @@ ITERATOR_CHUNK = 10_000
 )
 @retry
 @monitor(monitor_slug="auto-archive-job-monitor")
-@skip_if_queue_has_items
+@log_error_if_queue_has_items
 def run_auto_archive() -> None:
     """
     Automatically transition issues that are ongoing for 14 days to archived until escalating.
@@ -66,7 +66,7 @@ def run_auto_archive() -> None:
     soft_time_limit=20 * 60,
 )
 @retry
-@skip_if_queue_has_items
+@log_error_if_queue_has_items
 def run_auto_archive_for_project(project_ids: List[int]) -> None:
     now = datetime.now(tz=pytz.UTC)
     fourteen_days_ago = now - timedelta(days=14)

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -58,16 +58,16 @@ def skip_if_queue_has_items(func):
 
 
 @instrumented_task(
-    name="sentry.tasks.schedule_auto_transition_new",
+    name="sentry.tasks.schedule_auto_transition_to_ongoing",
     queue="auto_transition_issue_states",
     max_retries=3,
     default_retry_delay=60,
     acks_late=True,
 )
 @retry(on=(OperationalError,))
-@monitor(monitor_slug="schedule_auto_transition_new")
+@monitor(monitor_slug="schedule_auto_transition_to_ongoing")
 @skip_if_queue_has_items
-def schedule_auto_transition_new() -> None:
+def schedule_auto_transition_to_ongoing() -> None:
 
     now = datetime.now(tz=pytz.UTC)
     seven_days_ago = now - timedelta(days=TRANSITION_AFTER_DAYS)
@@ -83,6 +83,18 @@ def schedule_auto_transition_new() -> None:
             auto_transition_issues_new_to_ongoing.delay(
                 project_ids=project_ids,
                 first_seen_lte=int(seven_days_ago.timestamp()),
+                expires=now + timedelta(hours=1),
+            )
+
+            auto_transition_issues_regressed_to_ongoing.delay(
+                project_ids=project_ids,
+                date_added_lte=int(seven_days_ago.timestamp()),
+                expires=now + timedelta(hours=1),
+            )
+
+            auto_transition_issues_escalating_to_ongoing.delay(
+                project_ids=project_ids,
+                date_added_lte=int(seven_days_ago.timestamp()),
                 expires=now + timedelta(hours=1),
             )
 
@@ -129,36 +141,6 @@ def auto_transition_issues_new_to_ongoing(
 
 
 @instrumented_task(
-    name="sentry.tasks.schedule_auto_transition_regressed",
-    queue="auto_transition_issue_states",
-    max_retries=3,
-    default_retry_delay=60,
-    acks_late=True,
-)
-@retry(on=(OperationalError,))
-@monitor(monitor_slug="schedule_auto_transition_regressed")
-@skip_if_queue_has_items
-def schedule_auto_transition_regressed() -> None:
-
-    now = datetime.now(tz=pytz.UTC)
-    seven_days_ago = now - timedelta(days=TRANSITION_AFTER_DAYS)
-
-    for org in RangeQuerySetWrapper(Organization.objects.filter(status=OrganizationStatus.ACTIVE)):
-        if features.has("organizations:escalating-issues", org):
-            project_ids = list(
-                Project.objects.filter(
-                    organization_id=org.id, status=ObjectStatus.ACTIVE
-                ).values_list("id", flat=True)
-            )
-
-            auto_transition_issues_regressed_to_ongoing.delay(
-                project_ids=project_ids,
-                date_added_lte=int(seven_days_ago.timestamp()),
-                expires=now + timedelta(hours=1),
-            )
-
-
-@instrumented_task(
     name="sentry.tasks.auto_transition_issues_regressed_to_ongoing",
     queue="auto_transition_issue_states",
     time_limit=25 * 60,
@@ -199,5 +181,50 @@ def auto_transition_issues_regressed_to_ongoing(
             GroupStatus.UNRESOLVED,
             GroupSubStatus.REGRESSED,
             groups_with_regressed_history,
+            activity_data={"after_days": TRANSITION_AFTER_DAYS},
+        )
+
+
+@instrumented_task(
+    name="sentry.tasks.auto_transition_issues_escalating_to_ongoing",
+    queue="auto_transition_issue_states",
+    time_limit=25 * 60,
+    soft_time_limit=20 * 60,
+    max_retries=3,
+    default_retry_delay=60,
+    acks_late=True,
+)
+@retry(on=(OperationalError,))
+@skip_if_queue_has_items
+def auto_transition_issues_escalating_to_ongoing(
+    project_ids: List[int],
+    date_added_lte: int,
+    project_id: Optional[int] = None,  # TODO(nisanthan): Remove this arg in next PR
+    **kwargs,
+) -> None:
+    # TODO(nisanthan): Remove this conditional in next PR
+    if project_id is not None:
+        project_ids = [project_id]
+
+    for new_groups in chunked(
+        RangeQuerySetWrapper(
+            Group.objects.filter(
+                project_id__in=project_ids,
+                status=GroupStatus.UNRESOLVED,
+                substatus=GroupSubStatus.ESCALATING,
+                grouphistory__status=GroupHistoryStatus.ESCALATING,
+            )
+            .annotate(recent_escalating_history=Max("grouphistory__date_added"))
+            .filter(
+                recent_escalating_history__lte=datetime.fromtimestamp(date_added_lte, pytz.UTC)
+            ),
+            step=ITERATOR_CHUNK,
+        ),
+        ITERATOR_CHUNK,
+    ):
+        bulk_transition_group_to_ongoing(
+            GroupStatus.UNRESOLVED,
+            GroupSubStatus.ESCALATING,
+            new_groups,
             activity_data={"after_days": TRANSITION_AFTER_DAYS},
         )

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -79,7 +79,12 @@ def get_daily_10min_bucket(now: datetime):
 @monitor(monitor_slug="schedule_auto_transition_to_ongoing")
 @log_error_if_queue_has_items
 def schedule_auto_transition_to_ongoing() -> None:
-
+    """
+    This func will be instantiated by a cron every 10min.
+    We create 144 buckets, which comes from the 10min intervals in 24hrs.
+    We distribute all the orgs evenly in 144 buckets. For a given cron-tick's
+     10min interval, we fetch the orgs from that bucket and transition eligible Groups to ongoing
+    """
     now = datetime.now(tz=pytz.UTC)
 
     bucket = get_daily_10min_bucket(now)

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -14,7 +14,7 @@ from sentry.models import (
     remove_group_from_inbox,
 )
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
-from sentry.tasks.auto_ongoing_issues import skip_if_queue_has_items
+from sentry.tasks.auto_ongoing_issues import log_error_if_queue_has_items
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.types.activity import ActivityType
@@ -28,7 +28,7 @@ ONE_HOUR = 3600
     time_limit=75,
     soft_time_limit=60,
 )
-@skip_if_queue_has_items
+@log_error_if_queue_has_items
 def schedule_auto_resolution():
     options = ProjectOption.objects.filter(
         key__in=["sentry:resolve_age", "sentry:_last_auto_resolve"]
@@ -58,7 +58,7 @@ def schedule_auto_resolution():
     time_limit=75,
     soft_time_limit=60,
 )
-@skip_if_queue_has_items
+@log_error_if_queue_has_items
 def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwargs):
     project = Project.objects.get_from_cache(id=project_id)
 

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from unittest import mock
 
 import pytz
+from freezegun import freeze_time
 
 from sentry.models import (
     Activity,
@@ -14,10 +15,8 @@ from sentry.models import (
     add_group_to_inbox,
     record_group_history,
 )
-from sentry.receivers import create_default_projects
 from sentry.tasks.auto_ongoing_issues import (
     TRANSITION_AFTER_DAYS,
-    auto_transition_issues_new_to_ongoing,
     schedule_auto_transition_to_ongoing,
 )
 from sentry.testutils import TestCase
@@ -28,10 +27,12 @@ from sentry.types.group import GroupSubStatus
 
 @apply_feature_flag_on_cls("organizations:escalating-issues")
 class ScheduleAutoNewOngoingIssuesTest(TestCase):
+    @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_simple(self, mock_backend):
         now = datetime.now(tz=pytz.UTC)
-        project = self.create_project()
+        organization = self.organization
+        project = self.create_project(organization=organization)
         group = self.create_group(
             project=project, status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.NEW
         )
@@ -56,6 +57,7 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
 
         assert GroupHistory.objects.filter(group=group, status=GroupHistoryStatus.ONGOING).exists()
 
+    @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_reprocessed(self, mock_backend):
         now = datetime.now(tz=pytz.UTC)
@@ -79,6 +81,7 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
 
         assert not GroupInbox.objects.filter(group=group).exists()
 
+    @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_multiple_old_new(self, mock_backend):
         now = datetime.now(tz=pytz.UTC)
@@ -147,59 +150,10 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
             ).values_list("id", flat=True)
         ) == {g.id for g in older_groups}
 
-    @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
-    @mock.patch(
-        "sentry.tasks.auto_ongoing_issues.auto_transition_issues_new_to_ongoing.delay",
-        wraps=lambda project_ids, first_seen_lte, **kwargs: auto_transition_issues_new_to_ongoing(
-            project_ids, first_seen_lte, kwargs=kwargs
-        ),
-    )
-    def test_paginated_transition(self, mocked, mock_backend):
-        create_default_projects()
-        now = datetime.now(tz=pytz.UTC)
-        project = self.create_project()
-
-        groups = Group.objects.bulk_create(
-            [
-                Group(
-                    project=project,
-                    status=GroupStatus.UNRESOLVED,
-                    substatus=GroupSubStatus.NEW,
-                    first_seen=now - timedelta(days=TRANSITION_AFTER_DAYS, hours=idx, minutes=1),
-                )
-                for idx in range(12)
-            ]
-        )
-
-        mock_backend.get_size.return_value = 0
-
-        # before
-        assert Group.objects.filter(project_id=project.id).count() == len(groups) == 12
-
-        with self.tasks():
-            schedule_auto_transition_to_ongoing()
-
-        # Should create a new task for each project
-        assert mocked.call_count == 2
-
-        # after
-        assert (
-            Group.objects.filter(
-                project=project, status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.NEW
-            ).count()
-            == 0
-        )
-        assert set(
-            Group.objects.filter(
-                project=project,
-                status=GroupStatus.UNRESOLVED,
-                substatus=GroupSubStatus.ONGOING,
-            ).values_list("id", flat=True)
-        ) == {g.id for g in groups}
-
 
 @apply_feature_flag_on_cls("organizations:escalating-issues")
 class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
+    @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_simple(self, mock_backend):
         now = datetime.now(tz=pytz.UTC)
@@ -238,6 +192,7 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
 
 @apply_feature_flag_on_cls("organizations:escalating-issues")
 class ScheduleAutoEscalatingOngoingIssuesTest(TestCase):
+    @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_simple(self, mock_backend):
         now = datetime.now(tz=pytz.UTC)


### PR DESCRIPTION
## Objective:

- Automatically move issues from Escalating to Ongoing after 7 days. 
- Also I merged the crons into 1 cron to reduce the number of time we query for organizations & projects.
- We now divide the orgs equally into 144 buckets (10min intervals in 24 hrs). For a cron-tick's task, we check the bucket that time interval is in and grab only the orgs from that bucket. This should address the load balancing concerns by Ops.