### PR TITLE
ref(query-client): Cleanup extra AsyncComponent and AsyncView files

### DIFF
--- a/static/app/components/asyncComponent.tsx
+++ b/static/app/components/asyncComponent.tsx
@@ -1,1 +1,0 @@
-export {default} from 'sentry/components/deprecatedAsyncComponent';

--- a/static/app/views/asyncView.tsx
+++ b/static/app/views/asyncView.tsx
@@ -1,1 +1,0 @@
-export {default} from 'sentry/views/deprecatedAsyncView';


### PR DESCRIPTION
Followup to https://github.com/getsentry/sentry/pull/52550

Needed these reexport files to keep getsentry green but now that https://github.com/getsentry/getsentry/pull/11080 is merged we can get rid of them.