### PR TITLE
ref(rangeField): Save on change end

### DIFF
--- a/static/app/components/forms/fields/rangeField.tsx
+++ b/static/app/components/forms/fields/rangeField.tsx
@@ -57,7 +57,7 @@ function RangeField({
           aria-label={label}
           showThumbLabels
           value={value}
-          onBlur={onBlur}
+          onChangeEnd={val => onBlur(val, new MouseEvent(''))}
           onChange={val => fieldOnChange(val, new MouseEvent(''))}
         />
       )}


### PR DESCRIPTION
Rather than saving on blur/click outside:

https://github.com/getsentry/sentry/assets/44172267/9496fffb-1717-4cfd-b542-56f20c225060

We can save on change end (when the user stops dragging):

https://github.com/getsentry/sentry/assets/44172267/7f67e608-abce-44c2-a3d3-85f359efc0ac

