### PR TITLE
fix(trends): Remove metrics incompatible filters for trendsv2

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
@@ -141,7 +141,13 @@ function TrendChart({
   const trendDisplay = generateTrendFunctionAsString(trendFunction, trendParameter);
 
   const trendView = eventView.clone() as TrendView;
-  modifyTrendView(trendView, location, TrendChangeType.ANY, projects, organization);
+  modifyTrendView(
+    trendView,
+    location,
+    TrendChangeType.ANY,
+    projects,
+    shouldGetBreakpoint
+  );
 
   function transformTimeseriesData(
     data: EventsStatsData,

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -217,9 +217,11 @@ function ChangedTransactions(props: Props) {
 
   const {isLoading: isCardinalityCheckLoading, outcome} = useMetricsCardinalityContext();
 
+  const canUseMetricsTrends = withBreakpoint && !outcome?.forceTransactionsOnly;
+
   const trendView = props.trendView.clone();
   const chartTitle = getChartTitle(trendChangeType);
-  modifyTrendView(trendView, location, trendChangeType, projects, organization);
+  modifyTrendView(trendView, location, trendChangeType, projects, canUseMetricsTrends);
 
   const onCursor = makeTrendsCursorHandler(trendChangeType);
   const cursor = decodeScalar(location.query[trendCursorNames[trendChangeType]]);
@@ -240,7 +242,7 @@ function ChangedTransactions(props: Props) {
       cursor={cursor}
       limit={5}
       setError={error => setError(error?.message)}
-      withBreakpoint={withBreakpoint && !outcome?.forceTransactionsOnly}
+      withBreakpoint={canUseMetricsTrends}
     >
       {({isLoading, trendsData, pageLinks}) => {
         const trendFunction = getCurrentTrendFunction(location);


### PR DESCRIPTION
More clean up work ensuring that metrics incompatible filters aren't sent with the trends v2 request