### PR TITLE
ref(getting-started-docs): Add configure source maps step to angular docs

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils.tsx
@@ -1,0 +1,21 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {tct} from 'sentry/locale';
+
+export function getUploadSourceMapsStep(guideLink: string) {
+  return {
+    language: 'bash',
+    type: StepType.UPLOAD_SOURCE_MAPS,
+    configurations: [
+      {
+        description: tct(
+          'Automatically upload your source maps to enable readable stack traces for Errors. If you prefer to manually set up source maps, please follow [guideLink:this guide].',
+          {
+            guideLink: <ExternalLink href={guideLink} />,
+          }
+        ),
+        code: `npx @sentry/wizard@latest -i sourcemaps`,
+      },
+    ],
+  };
+}

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list/';
 import ListItem from 'sentry/components/list/listItem';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
@@ -159,6 +160,23 @@ export const steps = ({
     ],
   },
   {
+    language: 'bash',
+    type: StepType.UPLOAD_SOURCE_MAPS,
+    configurations: [
+      {
+        description: tct(
+          'Automatically upload your source maps to enable readable stack traces for Errors. If you prefer to manually set up source maps, please follow [guideLink:this guide].',
+          {
+            guideLink: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/angular/sourcemaps/" />
+            ),
+          }
+        ),
+        code: `npx @sentry/wizard@latest -i sourcemaps`,
+      },
+    ],
+  },
+  {
     language: 'javascript',
     type: StepType.VERIFY,
     configurations: [
@@ -173,12 +191,6 @@ export const steps = ({
 ];
 
 export const nextSteps = [
-  {
-    id: 'source-maps',
-    name: t('Source Maps'),
-    description: t('Learn how to enable readable stack traces in your Sentry errors.'),
-    link: 'https://docs.sentry.io/platforms/javascript/guides/angular/sourcemaps/',
-  },
   {
     id: 'angular-features',
     name: t('Angular Features'),

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
 
-import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list/';
 import ListItem from 'sentry/components/list/listItem';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -159,23 +159,9 @@ export const steps = ({
       },
     ],
   },
-  {
-    language: 'bash',
-    type: StepType.UPLOAD_SOURCE_MAPS,
-    configurations: [
-      {
-        description: tct(
-          'Automatically upload your source maps to enable readable stack traces for Errors. If you prefer to manually set up source maps, please follow [guideLink:this guide].',
-          {
-            guideLink: (
-              <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/angular/sourcemaps/" />
-            ),
-          }
-        ),
-        code: `npx @sentry/wizard@latest -i sourcemaps`,
-      },
-    ],
-  },
+  getUploadSourceMapsStep(
+    'https://docs.sentry.io/platforms/javascript/guides/angular/sourcemaps/'
+  ),
   {
     language: 'javascript',
     type: StepType.VERIFY,

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -1,8 +1,8 @@
-import ExternalLink from 'sentry/components/links/externalLink';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 
 // Configuration Start
 const replayIntegration = `
@@ -70,23 +70,9 @@ export const steps = ({
       },
     ],
   },
-  {
-    language: 'bash',
-    type: StepType.UPLOAD_SOURCE_MAPS,
-    configurations: [
-      {
-        description: tct(
-          'Automatically upload your source maps to enable readable stack traces for Errors. If you prefer to manually set up source maps, please follow [guideLink:this guide].',
-          {
-            guideLink: (
-              <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/" />
-            ),
-          }
-        ),
-        code: `npx @sentry/wizard@latest -i sourcemaps`,
-      },
-    ],
-  },
+  getUploadSourceMapsStep(
+    'https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/'
+  ),
   {
     language: 'javascript',
     type: StepType.VERIFY,


### PR DESCRIPTION
This PR:
- Adds the new step "Upload Source Maps" to the Angular doc
- Remove "source maps" from the next steps

Related to https://github.com/getsentry/sentry/issues/52500

**Previews:**
![image](https://github.com/getsentry/sentry/assets/29228205/87e24ccd-998f-4b87-b526-7f15506a53d2)

![Screenshot 2023-07-11 at 10 08 51](https://github.com/getsentry/sentry/assets/29228205/92a5cfff-dd35-40c4-ad70-d72734d132b1)


