### PR TITLE
Skip writing release/dist to the `ArtifactBundleIndex`

### DIFF
--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -114,17 +114,19 @@ def _index_urls_in_bundle(
             if url := info.get("url"):
                 urls_to_index.append(
                     ArtifactBundleIndex(
-                        # key:
-                        organization_id=organization_id,
-                        release_name=release,
-                        dist_name=dist,
-                        url=url,
-                        # value:
+                        # key/value:
                         artifact_bundle_id=artifact_bundle.id,
+                        url=url,
                         # metadata:
+                        organization_id=organization_id,
+                        date_added=artifact_bundle.date_added,
+                        # legacy:
+                        # TODO: We fill these in with empty-ish values before they are
+                        # dropped for good
+                        release_name="",
+                        dist_name="",
                         date_last_modified=artifact_bundle.date_last_modified
                         or artifact_bundle.date_added,
-                        date_added=artifact_bundle.date_added,
                     )
                 )
     finally:

--- a/tests/sentry/debug_files/test_artifact_bundles.py
+++ b/tests/sentry/debug_files/test_artifact_bundles.py
@@ -69,9 +69,9 @@ def get_artifact_bundles(project, release_name="", dist_name=""):
 def get_indexed_files(project, release_name="", dist_name="", distinct=False):
     query = ArtifactBundleIndex.objects.filter(
         organization_id=project.organization.id,
-        # projectartifactbundle__project_id=project.id,
-        release_name=release_name,
-        dist_name=dist_name,
+        artifact_bundle__projectartifactbundle__project_id=project.id,
+        artifact_bundle__releaseartifactbundle__release_name=release_name,
+        artifact_bundle__releaseartifactbundle__dist_name=dist_name,
     ).order_by("url", "-date_last_modified")
     if distinct:
         query = query.distinct("url")


### PR DESCRIPTION
We are now joining the release/dist (and also date_last_modified) via the `{Release,}ArtifactBundle` tables, so we do not need to write those out directly.

This should slightly lower the growth of the growth of the table/index before we drop those fields completely.