### PR TITLE
feat(alerts): common field support for on-demand metrics

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -185,7 +185,7 @@ def is_on_demand_query(dataset: Optional[Union[str, Dataset]], query: Optional[s
     if not dataset or not query:
         return False
 
-    on_demand_query_fields = [_SEARCH_TO_PROTOCOL_FIELDS.keys(), "measurements"]
+    on_demand_query_fields = list(_SEARCH_TO_PROTOCOL_FIELDS.keys()) + ["measurements"]
     query_has_on_demand_fields = [s for s in on_demand_query_fields if s in query] is not None
 
     return Dataset(dataset) == Dataset.PerformanceMetrics and query_has_on_demand_fields

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -186,7 +186,7 @@ def is_on_demand_query(dataset: Optional[Union[str, Dataset]], query: Optional[s
         return False
 
     on_demand_query_fields = list(_SEARCH_TO_PROTOCOL_FIELDS.keys()) + ["measurements"]
-    query_has_on_demand_fields = [s for s in on_demand_query_fields if s in query] is not None
+    query_has_on_demand_fields = len([s for s in on_demand_query_fields if s in query]) > 0
 
     return Dataset(dataset) == Dataset.PerformanceMetrics and query_has_on_demand_fields
 

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -131,7 +131,6 @@ CompareOp = Literal["eq", "gt", "gte", "lt", "lte", "glob"]
 
 QueryOp = Literal["AND", "OR"]
 QueryToken = Union[SearchFilter, QueryOp, ParenExpression]
-T = TypeVar("T")
 
 
 class ComparingRuleCondition(TypedDict):
@@ -323,6 +322,9 @@ def _map_field_name(search_key: str) -> str:
         return f"event.tags.{resolved[5:-1]}"
 
     raise ValueError(f"Unsupported query field {search_key}")
+
+
+T = TypeVar("T")
 
 
 class SearchQueryConverter:

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -39,6 +39,7 @@ RuleCondition = Union["LogicalRuleCondition", "ComparingRuleCondition", "NotRule
 # Maps from Discover's field names to event protocol paths. See Relay's
 # ``FieldValueProvider`` for supported fields. All fields need to be prefixed
 # with "event.".
+# List of UI supported search fields is defined in sentry/static/app/utils/fields/index.ts
 _SEARCH_TO_PROTOCOL_FIELDS = {
     # Top-level fields
     "release": "release",
@@ -63,7 +64,6 @@ _SEARCH_TO_PROTOCOL_FIELDS = {
     "os.name": "contexts.os.name",
     "os.version": "contexts.os.version",
     "browser.name": "contexts.browser.name",
-    "browser.version": "contexts.browser.version",
     "transaction.op": "contexts.trace.op",
     "transaction.status": "contexts.trace.status",
     "http.status_code": "contexts.response.status_code",

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -35,7 +35,6 @@ QUERY_HASH_KEY = "query_hash"
 # TODO: Streamline with dynamic sampling.
 RuleCondition = Union["LogicalRuleCondition", "ComparingRuleCondition", "NotRuleCondition"]
 
-
 # Maps from Discover's field names to event protocol paths. See Relay's
 # ``FieldValueProvider`` for supported fields. All fields need to be prefixed
 # with "event.".
@@ -186,7 +185,10 @@ def is_on_demand_query(dataset: Optional[Union[str, Dataset]], query: Optional[s
     if not dataset or not query:
         return False
 
-    return Dataset(dataset) == Dataset.PerformanceMetrics and "transaction.duration" in query
+    on_demand_query_fields = [_SEARCH_TO_PROTOCOL_FIELDS.keys(), "measurements"]
+    query_has_on_demand_fields = [s for s in on_demand_query_fields if s in query] is not None
+
+    return Dataset(dataset) == Dataset.PerformanceMetrics and query_has_on_demand_fields
 
 
 class OndemandMetricSpec:

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -19,12 +19,6 @@ def test_empty_query():
     assert convert_query_to_metric(alert.snuba_query) is None
 
 
-def test_standard_metric_query():
-    alert = create_alert("transaction:/my/api/url/")
-
-    assert convert_query_to_metric(alert.snuba_query) is None
-
-
 def test_simple_query_count():
     snuba_query = SnubaQuery(
         aggregate="count()",

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -11,6 +11,12 @@ def test_is_on_demand_query_no_query():
     assert is_on_demand_query(Dataset.PerformanceMetrics, "") is False
 
 
+def test_is_on_demand_query_invalid_query():
+    assert is_on_demand_query(Dataset.PerformanceMetrics, "AND") is False
+    assert is_on_demand_query(Dataset.PerformanceMetrics, "(AND transaction.duration:>=1") is False
+    assert is_on_demand_query(Dataset.PerformanceMetrics, "transaction.duration:>=abc") is False
+
+
 def test_is_on_demand_query_true():
     dataset = Dataset.PerformanceMetrics
 
@@ -27,7 +33,7 @@ def test_is_on_demand_query_true():
     )
 
 
-def test_is_not_on_demand_false():
+def test_is_on_demand_query_false():
     dataset = Dataset.PerformanceMetrics
 
     assert is_on_demand_query(dataset, "") is False

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -1,0 +1,41 @@
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.metrics.extraction import is_on_demand_query
+
+
+def test_is_on_demand_query_wrong_dataset():
+    assert is_on_demand_query(Dataset.Transactions, "geo.city:=Vienna") is False
+    assert is_on_demand_query(Dataset.Metrics, "browser.version:=1 os.name:=android") is False
+
+
+def test_is_on_demand_query_no_query():
+    assert is_on_demand_query(Dataset.PerformanceMetrics, "") is False
+
+
+def test_is_on_demand_query_true():
+    dataset = Dataset.PerformanceMetrics
+
+    # transaction.duration is a non-standard field
+    assert is_on_demand_query(dataset, "transaction.duration:>=1") is True
+    # transaction.duration is a non-standard field
+    assert is_on_demand_query(dataset, "geo.city:=Vienna") is True
+    # os.name is a standard field, browser.version is not
+    assert is_on_demand_query(dataset, "browser.version:=1 os.name:=android") is True
+    # os.version is not a standard field
+    assert (
+        is_on_demand_query(dataset, "(release:=a OR transaction.op:=b) transaction.duration:>1s")
+        is True
+    )
+
+
+def test_is_not_on_demand_false():
+    dataset = Dataset.PerformanceMetrics
+
+    assert is_on_demand_query(dataset, "") is False
+    assert is_on_demand_query(dataset, "environment:=dev") is False
+    assert is_on_demand_query(dataset, "release:=initial OR os.name:=android") is False
+    assert (
+        is_on_demand_query(
+            dataset, "(http.method:=POST OR http.status_code:=404) browser.name:=chrome"
+        )
+        is False
+    )


### PR DESCRIPTION
Part of [Allow common fields in alert creation](https://github.com/getsentry/sentry/issues/52503)