### PR TITLE
ref(getting-started-docs): Add configure source maps step to vue

### DIFF
--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -1,5 +1,6 @@
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t} from 'sentry/locale';
 
@@ -108,6 +109,9 @@ export const steps = ({
       },
     ],
   },
+  getUploadSourceMapsStep(
+    'https://docs.sentry.io/platforms/javascript/guides/vue/sourcemaps/'
+  ),
   {
     language: 'javascript',
     type: StepType.VERIFY,


### PR DESCRIPTION
This PR:

- Adds the new step "Upload Source Maps" to the Vue doc
- Remove "source maps" from the next steps

Related to https://github.com/getsentry/sentry/issues/52500

**Preview:**

![image](https://github.com/getsentry/sentry/assets/29228205/98a271d4-8e36-4aa8-9409-3f03b8e591f8)

