### PR TITLE
ref(getting-started-docs): Add configure source maps step to gatsby

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/layout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/layout.tsx
@@ -31,7 +31,7 @@ export type LayoutProps = {
   nextSteps?: NextStep[];
 };
 
-export function Layout({steps, nextSteps, newOrg}: LayoutProps) {
+export function Layout({steps, nextSteps = [], newOrg}: LayoutProps) {
   const organization = useOrganization();
   const {isSelfHosted} = useLegacyStore(ConfigStore);
 
@@ -53,7 +53,7 @@ export function Layout({steps, nextSteps, newOrg}: LayoutProps) {
           <Step key={step.type} {...step} />
         ))}
       </Steps>
-      {nextSteps && (
+      {nextSteps.length > 0 && (
         <Fragment>
           <Divider />
           <h4>{t('Next Steps')}</h4>

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -112,12 +112,6 @@ export const steps = ({
 
 export const nextSteps = [
   {
-    id: 'source-maps',
-    name: t('Source Maps'),
-    description: t('Learn how to enable readable stack traces in your Sentry errors.'),
-    link: 'https://docs.sentry.io/platforms/javascript/guides/gatsby/sourcemaps/',
-  },
-  {
     id: 'performance-monitoring',
     name: t('Performance Monitoring'),
     description: t(

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -1,5 +1,6 @@
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
 
@@ -92,6 +93,9 @@ export const steps = ({
       },
     ],
   },
+  getUploadSourceMapsStep(
+    'https://docs.sentry.io/platforms/javascript/guides/gatsby/sourcemaps/'
+  ),
   {
     language: 'javascript',
     type: StepType.VERIFY,


### PR DESCRIPTION
This PR:

- Adds the new step "Upload Source Maps" to the Gatsby doc
- Remove "source maps" from the next steps

Related to https://github.com/getsentry/sentry/issues/52500

**Preview:**

![image](https://github.com/getsentry/sentry/assets/29228205/26f1b6e2-a7c9-476a-8e5c-ed1a9c530e85)
