### PR TITLE
Simplify Debug File renewal code

### DIFF
--- a/src/sentry/debug_files/debug_files.py
+++ b/src/sentry/debug_files/debug_files.py
@@ -7,7 +7,6 @@ from django.db import router
 from django.db.models import Q
 from django.utils import timezone
 
-from sentry import options
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.utils import metrics
 from sentry.utils.db import atomic_transaction
@@ -17,29 +16,21 @@ from sentry.utils.db import atomic_transaction
 AVAILABLE_FOR_RENEWAL_DAYS = 30
 
 
-def maybe_renew_debug_files(query: Q, debug_files: Sequence[ProjectDebugFile] | None = None):
-    if options.get("debug-files.enable-renewal"):
-        # NOTE: this metric also covers the early-return
-        with metrics.timer("debug_files_renewal"):
-            renew_debug_files(query, debug_files or list())
-
-
-def renew_debug_files(query: Q, debug_files: Sequence[ProjectDebugFile]):
+def maybe_renew_debug_files(query: Q, debug_files: Sequence[ProjectDebugFile]):
     # We take a snapshot in time that MUST be consistent across all updates.
     now = timezone.now()
     # We compute the threshold used to determine whether we want to renew the specific bundle.
     threshold_date = now - timedelta(days=AVAILABLE_FOR_RENEWAL_DAYS)
 
-    # in case we have `debug_files` to consider, we check first if they need renewal,
-    # before going to the database.
-    needs_bump = not debug_files or any(dif.date_accessed <= threshold_date for dif in debug_files)
-
+    # We first check if any file needs renewal, before going to the database.
+    needs_bump = any(dif.date_accessed <= threshold_date for dif in debug_files)
     if not needs_bump:
         return
 
-    with atomic_transaction(using=(router.db_for_write(ProjectDebugFile),)):
-        updated_rows_count = ProjectDebugFile.objects.filter(
-            query, date_accessed__lte=threshold_date
-        ).update(date_accessed=now)
-        if updated_rows_count > 0:
-            metrics.incr("debug_files_renewal.were_renewed", updated_rows_count)
+    with metrics.timer("debug_files_renewal"):
+        with atomic_transaction(using=(router.db_for_write(ProjectDebugFile),)):
+            updated_rows_count = ProjectDebugFile.objects.filter(
+                query, date_accessed__lte=threshold_date
+            ).update(date_accessed=now)
+            if updated_rows_count > 0:
+                metrics.incr("debug_files_renewal.were_renewed", updated_rows_count)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1316,10 +1316,6 @@ register("hybrid_cloud.outbox_rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABL
 register("txnames.bump-lifetime-sample-rate", default=0.1, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Decides whether an incoming span triggers an update of the clustering rule applied to it.
 register("span_descs.bump-lifetime-sample-rate", default=0.25, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# Decides whether artifact bundles asynchronous renewal is enabled.
-register("sourcemaps.artifact-bundles.enable-renewal", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# Whether renewal of Debug Files is enabled.
-register("debug-files.enable-renewal", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # === Backpressure related runtime options ===
 

--- a/tests/sentry/api/endpoints/test_project_artifact_lookup.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_lookup.py
@@ -458,160 +458,146 @@ class ArtifactLookupTest(APITestCase):
 
     @freeze_time("2023-05-23 10:00:00")
     def test_renewal_with_debug_id(self):
-        with self.options({"sourcemaps.artifact-bundles.enable-renewal": 1.0}):
-            for days_before, expected_date_added, debug_id in (
-                (
-                    2,
-                    datetime.now(tz=pytz.UTC) - timedelta(days=2),
-                    "2432d9ad-fe87-4f77-938d-50cc9b2b2e2a",
-                ),
-                (35, datetime.now(tz=pytz.UTC), "ef88bc3e-d334-4809-9723-5c5dbc8bd4e9"),
-            ):
-                file_zip = make_compressed_zip_file(
-                    {
-                        "path/in/zip/c": {
-                            "url": "~/path/to/app.js",
-                            "type": "source_map",
-                            "content": b"baz_renew",
-                            "headers": {
-                                "debug-id": debug_id,
-                            },
-                        },
-                    },
-                )
-                file = make_file("bundle_c.zip", file_zip)
-                bundle_id = uuid4()
-                date_added = datetime.now(tz=pytz.UTC) - timedelta(days=days_before)
-
-                artifact_bundle = ArtifactBundle.objects.create(
-                    organization_id=self.organization.id,
-                    bundle_id=bundle_id,
-                    file=file,
-                    artifact_count=1,
-                    date_added=date_added,
-                )
-                ProjectArtifactBundle.objects.create(
-                    organization_id=self.organization.id,
-                    project_id=self.project.id,
-                    artifact_bundle=artifact_bundle,
-                    date_added=date_added,
-                )
-                DebugIdArtifactBundle.objects.create(
-                    organization_id=self.organization.id,
-                    debug_id=debug_id,
-                    artifact_bundle=artifact_bundle,
-                    source_file_type=SourceFileType.SOURCE_MAP.value,
-                    date_added=date_added,
-                )
-
-                self.login_as(user=self.user)
-
-                url = reverse(
-                    "sentry-api-0-project-artifact-lookup",
-                    kwargs={
-                        "organization_slug": self.project.organization.slug,
-                        "project_slug": self.project.slug,
-                    },
-                )
-
-                with self.tasks():
-                    self.client.get(f"{url}?debug_id={debug_id}")
-
-                assert (
-                    ArtifactBundle.objects.get(id=artifact_bundle.id).date_added
-                    == expected_date_added
-                )
-                assert (
-                    ProjectArtifactBundle.objects.get(
-                        artifact_bundle_id=artifact_bundle.id
-                    ).date_added
-                    == expected_date_added
-                )
-                assert (
-                    DebugIdArtifactBundle.objects.get(
-                        artifact_bundle_id=artifact_bundle.id
-                    ).date_added
-                    == expected_date_added
-                )
-
-    @freeze_time("2023-05-23 10:00:00")
-    def test_renewal_with_url(self):
-        with self.options({"sourcemaps.artifact-bundles.enable-renewal": 1.0}):
+        for days_before, expected_date_added, debug_id in (
+            (
+                2,
+                datetime.now(tz=pytz.UTC) - timedelta(days=2),
+                "2432d9ad-fe87-4f77-938d-50cc9b2b2e2a",
+            ),
+            (35, datetime.now(tz=pytz.UTC), "ef88bc3e-d334-4809-9723-5c5dbc8bd4e9"),
+        ):
             file_zip = make_compressed_zip_file(
                 {
                     "path/in/zip/c": {
                         "url": "~/path/to/app.js",
                         "type": "source_map",
                         "content": b"baz_renew",
+                        "headers": {
+                            "debug-id": debug_id,
+                        },
                     },
                 },
             )
             file = make_file("bundle_c.zip", file_zip)
+            bundle_id = uuid4()
+            date_added = datetime.now(tz=pytz.UTC) - timedelta(days=days_before)
 
-            for days_before, expected_date_added, release in (
-                (
-                    2,
-                    datetime.now(tz=pytz.UTC) - timedelta(days=2),
-                    self.create_release(version="1.0"),
-                ),
-                (35, datetime.now(tz=pytz.UTC), self.create_release(version="2.0")),
-            ):
-                dist = release.add_dist("android")
-                bundle_id = uuid4()
-                date_added = datetime.now(tz=pytz.UTC) - timedelta(days=days_before)
+            artifact_bundle = ArtifactBundle.objects.create(
+                organization_id=self.organization.id,
+                bundle_id=bundle_id,
+                file=file,
+                artifact_count=1,
+                date_added=date_added,
+            )
+            ProjectArtifactBundle.objects.create(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                artifact_bundle=artifact_bundle,
+                date_added=date_added,
+            )
+            DebugIdArtifactBundle.objects.create(
+                organization_id=self.organization.id,
+                debug_id=debug_id,
+                artifact_bundle=artifact_bundle,
+                source_file_type=SourceFileType.SOURCE_MAP.value,
+                date_added=date_added,
+            )
 
-                artifact_bundle = ArtifactBundle.objects.create(
-                    organization_id=self.organization.id,
-                    bundle_id=bundle_id,
-                    file=file,
-                    artifact_count=1,
-                    date_added=date_added,
-                )
-                ProjectArtifactBundle.objects.create(
-                    organization_id=self.organization.id,
-                    project_id=self.project.id,
-                    artifact_bundle=artifact_bundle,
-                    date_added=date_added,
-                )
-                ReleaseArtifactBundle.objects.create(
-                    organization_id=self.organization.id,
-                    release_name=release.version,
-                    dist_name=dist.name,
-                    artifact_bundle=artifact_bundle,
-                    date_added=date_added,
-                )
+            self.login_as(user=self.user)
 
-                self.login_as(user=self.user)
+            url = reverse(
+                "sentry-api-0-project-artifact-lookup",
+                kwargs={
+                    "organization_slug": self.project.organization.slug,
+                    "project_slug": self.project.slug,
+                },
+            )
 
-                url = reverse(
-                    "sentry-api-0-project-artifact-lookup",
-                    kwargs={
-                        "organization_slug": self.project.organization.slug,
-                        "project_slug": self.project.slug,
-                    },
-                )
+            with self.tasks():
+                self.client.get(f"{url}?debug_id={debug_id}")
 
-                with self.tasks():
-                    self.client.get(
-                        f"{url}?release={release.version}&dist={dist.name}&url=path/to/app"
-                    )
+            assert (
+                ArtifactBundle.objects.get(id=artifact_bundle.id).date_added == expected_date_added
+            )
+            assert (
+                ProjectArtifactBundle.objects.get(artifact_bundle_id=artifact_bundle.id).date_added
+                == expected_date_added
+            )
+            assert (
+                DebugIdArtifactBundle.objects.get(artifact_bundle_id=artifact_bundle.id).date_added
+                == expected_date_added
+            )
 
-                assert (
-                    ArtifactBundle.objects.get(id=artifact_bundle.id).date_added
-                    == expected_date_added
-                )
-                assert (
-                    ProjectArtifactBundle.objects.get(
-                        artifact_bundle_id=artifact_bundle.id
-                    ).date_added
-                    == expected_date_added
-                )
-                assert (
-                    ReleaseArtifactBundle.objects.get(
-                        artifact_bundle_id=artifact_bundle.id
-                    ).date_added
-                    == expected_date_added
-                )
+    @freeze_time("2023-05-23 10:00:00")
+    def test_renewal_with_url(self):
+        file_zip = make_compressed_zip_file(
+            {
+                "path/in/zip/c": {
+                    "url": "~/path/to/app.js",
+                    "type": "source_map",
+                    "content": b"baz_renew",
+                },
+            },
+        )
+        file = make_file("bundle_c.zip", file_zip)
+
+        for days_before, expected_date_added, release in (
+            (
+                2,
+                datetime.now(tz=pytz.UTC) - timedelta(days=2),
+                self.create_release(version="1.0"),
+            ),
+            (35, datetime.now(tz=pytz.UTC), self.create_release(version="2.0")),
+        ):
+            dist = release.add_dist("android")
+            bundle_id = uuid4()
+            date_added = datetime.now(tz=pytz.UTC) - timedelta(days=days_before)
+
+            artifact_bundle = ArtifactBundle.objects.create(
+                organization_id=self.organization.id,
+                bundle_id=bundle_id,
+                file=file,
+                artifact_count=1,
+                date_added=date_added,
+            )
+            ProjectArtifactBundle.objects.create(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                artifact_bundle=artifact_bundle,
+                date_added=date_added,
+            )
+            ReleaseArtifactBundle.objects.create(
+                organization_id=self.organization.id,
+                release_name=release.version,
+                dist_name=dist.name,
+                artifact_bundle=artifact_bundle,
+                date_added=date_added,
+            )
+
+            self.login_as(user=self.user)
+
+            url = reverse(
+                "sentry-api-0-project-artifact-lookup",
+                kwargs={
+                    "organization_slug": self.project.organization.slug,
+                    "project_slug": self.project.slug,
+                },
+            )
+
+            with self.tasks():
+                self.client.get(f"{url}?release={release.version}&dist={dist.name}&url=path/to/app")
+
+            assert (
+                ArtifactBundle.objects.get(id=artifact_bundle.id).date_added == expected_date_added
+            )
+            assert (
+                ProjectArtifactBundle.objects.get(artifact_bundle_id=artifact_bundle.id).date_added
+                == expected_date_added
+            )
+            assert (
+                ReleaseArtifactBundle.objects.get(artifact_bundle_id=artifact_bundle.id).date_added
+                == expected_date_added
+            )
 
     def test_access_control(self):
         # release file


### PR DESCRIPTION
This removes the feature flag that was just there temporarily when landing these features.

Also simplifies the code a bit, and fixes the case where an UPDATE query was issued for debug file refresh even though the corresponding SELECT did not yield anything.