### PR TITLE
ref(getting-started-docs): Migrate vanilla javascript doc to sentry main repo 

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -14,6 +14,7 @@ export const migratedDocs = [
   'javascript-gatsby',
   'javascript-ember',
   'javascript-svelte',
+  'javascript',
 ];
 
 type SdkDocumentationProps = {
@@ -45,7 +46,7 @@ export function SdkDocumentation({
   const platformPath =
     platform?.type === 'framework'
       ? platform?.id.replace(`${platform.language}-`, `${platform.language}/`)
-      : platform?.id;
+      : `${platform?.language}/${platform?.id}`;
 
   const {
     data: projectKeys = [],

--- a/static/app/gettingStartedDocs/javascript/javascript.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.spec.tsx
@@ -1,0 +1,44 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {ProductSolution} from 'sentry/components/onboarding/productSelection';
+
+import GettingStartedWithJavaScript, {nextSteps, steps} from './javascript';
+
+describe('GettingStartedWithJavaScript', function () {
+  it('all products are selected', function () {
+    const {container} = render(
+      <GettingStartedWithJavaScript
+        dsn="test-dsn"
+        activeProductSelection={[
+          ProductSolution.PERFORMANCE_MONITORING,
+          ProductSolution.SESSION_REPLAY,
+        ]}
+      />
+    );
+
+    // Steps
+    for (const step of steps()) {
+      expect(
+        screen.getByRole('heading', {name: StepTitle[step.type]})
+      ).toBeInTheDocument();
+    }
+
+    // Next Steps
+    const filteredNextStepsLinks = nextSteps.filter(
+      nextStep =>
+        ![
+          ProductSolution.PERFORMANCE_MONITORING,
+          ProductSolution.SESSION_REPLAY,
+        ].includes(nextStep.id as ProductSolution)
+    );
+
+    for (const filteredNextStepsLink of filteredNextStepsLinks) {
+      expect(
+        screen.getByRole('link', {name: filteredNextStepsLink.name})
+      ).toBeInTheDocument();
+    }
+
+    expect(container).toSnapshot();
+  });
+});

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -1,0 +1,154 @@
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
+import {ProductSolution} from 'sentry/components/onboarding/productSelection';
+import {t} from 'sentry/locale';
+
+// Configuration Start
+const replayIntegration = `
+new Sentry.Replay(),
+`;
+
+const replayOtherConfig = `
+// Session Replay
+replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+`;
+
+const performanceIntegration = `
+new Sentry.BrowserTracing({
+  // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
+  tracePropagationTargets: ["localhost", "https:yourserver.io/api/"],
+}),
+`;
+
+const performanceOtherConfig = `
+// Performance Monitoring
+tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
+`;
+
+export const steps = ({
+  sentryInitContent,
+}: {
+  sentryInitContent?: string;
+} = {}): LayoutProps['steps'] => [
+  {
+    language: 'bash',
+    type: StepType.INSTALL,
+    description: t(
+      'Sentry captures data by using an SDK within your application’s runtime.'
+    ),
+    configurations: [
+      {
+        code: `
+        # Using yarn
+        yarn add @sentry/browser
+
+        # Using npm
+        npm install --save @sentry/browser
+        `,
+      },
+    ],
+  },
+  {
+    language: 'javascript',
+    type: StepType.CONFIGURE,
+    description: t(
+      "Initialize Sentry as early as possible in your application's lifecycle."
+    ),
+    configurations: [
+      {
+        code: `
+        import * as Sentry from "@sentry/browser";
+
+        Sentry.init({
+          ${sentryInitContent}
+        });
+        `,
+      },
+    ],
+  },
+  getUploadSourceMapsStep('https://docs.sentry.io/platforms/javascript/sourcemaps/'),
+  {
+    language: 'javascript',
+    type: StepType.VERIFY,
+    description: t(
+      "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+    ),
+    configurations: [
+      {
+        code: 'myUndefinedFunction();',
+      },
+    ],
+  },
+];
+
+export const nextSteps = [
+  {
+    id: 'performance-monitoring',
+    name: t('Performance Monitoring'),
+    description: t(
+      'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
+    ),
+    link: 'https://docs.sentry.io/platforms/javascript/performance/',
+  },
+  {
+    id: 'session-replay',
+    name: t('Session Replay'),
+    description: t(
+      'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
+    ),
+    link: 'https://docs.sentry.io/platforms/javascript/session-replay/',
+  },
+];
+// Configuration End
+
+type Props = {
+  activeProductSelection: ProductSolution[];
+  dsn: string;
+  newOrg?: boolean;
+};
+
+export default function GettingStartedWithJavaScript({
+  dsn,
+  activeProductSelection,
+  newOrg,
+}: Props) {
+  const integrations: string[] = [];
+  const otherConfigs: string[] = [];
+  let nextStepDocs = [...nextSteps];
+
+  if (activeProductSelection.includes(ProductSolution.PERFORMANCE_MONITORING)) {
+    integrations.push(performanceIntegration.trim());
+    otherConfigs.push(performanceOtherConfig.trim());
+    nextStepDocs = nextStepDocs.filter(
+      step => step.id !== ProductSolution.PERFORMANCE_MONITORING
+    );
+  }
+
+  if (activeProductSelection.includes(ProductSolution.SESSION_REPLAY)) {
+    integrations.push(replayIntegration.trim());
+    otherConfigs.push(replayOtherConfig.trim());
+    nextStepDocs = nextStepDocs.filter(
+      step => step.id !== ProductSolution.SESSION_REPLAY
+    );
+  }
+
+  let sentryInitContent: string[] = [`dsn: "${dsn}",`];
+
+  if (integrations.length > 0) {
+    sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
+  }
+
+  if (otherConfigs.length > 0) {
+    sentryInitContent = sentryInitContent.concat(otherConfigs);
+  }
+
+  return (
+    <Layout
+      steps={steps({sentryInitContent: sentryInitContent.join('\n')})}
+      nextSteps={nextStepDocs}
+      newOrg={newOrg}
+    />
+  );
+}

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -226,6 +226,10 @@ function SetupDocs({route, router, location, recentCreatedProject: project}: Ste
     currentPlatform === 'javascript'
   );
 
+  useEffect(() => {
+    setShowLoaderOnboarding(currentPlatform === 'javascript');
+  }, [currentPlatform]);
+
   const integrationSlug = project?.platform && platformToIntegrationMap[project.platform];
   const [integrationUseManualSetup, setIntegrationUseManualSetup] = useState(false);
 
@@ -322,14 +326,6 @@ function SetupDocs({route, router, location, recentCreatedProject: project}: Ste
                 setIntegrationUseManualSetup(true);
               }}
             />
-          ) : showDocsWithProductSelection ? (
-            <DocWithProductSelection
-              organization={organization}
-              projectSlug={project.slug}
-              location={location}
-              currentPlatform={currentPlatform}
-              newOrg
-            />
           ) : showLoaderOnboarding ? (
             <Fragment>
               <SetupIntroduction
@@ -347,6 +343,14 @@ function SetupDocs({route, router, location, recentCreatedProject: project}: Ste
                 close={hideLoaderOnboarding}
               />
             </Fragment>
+          ) : showDocsWithProductSelection ? (
+            <DocWithProductSelection
+              organization={organization}
+              projectSlug={project.slug}
+              location={location}
+              currentPlatform={currentPlatform}
+              newOrg
+            />
           ) : (
             <ProjectDocs
               platform={loadedPlatform}

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -48,6 +48,10 @@ export function SetupDocsLoader({
   const [hasLoadingError, setHasLoadingError] = useState(false);
   const [projectKeyUpdateError, setProjectKeyUpdateError] = useState(false);
 
+  const productsQuery =
+    (location.query.product as ProductSolution | ProductSolution[] | undefined) ?? [];
+  const products = decodeList(productsQuery) as ProductSolution[];
+
   const fetchData = useCallback(async () => {
     const keysApiUrl = `/projects/${organization.slug}/${project.slug}/keys/`;
 
@@ -71,10 +75,6 @@ export function SetupDocsLoader({
   // Note that on initial visit, this will also update the project key with the default products (=all products)
   // This DOES NOT take into account any initial products that may already be set on the project key - they will always be overwritten!
   const handleUpdateSelectedProducts = useCallback(async () => {
-    const productsQuery =
-      (location.query.product as ProductSolution | ProductSolution[] | undefined) ?? [];
-    const products = decodeList(productsQuery);
-
     const keyId = projectKey?.id;
 
     if (!keyId) {
@@ -115,7 +115,7 @@ export function SetupDocsLoader({
       handleXhrErrorResponse(message, error);
       setProjectKeyUpdateError(true);
     }
-  }, [api, location.query.product, organization.slug, project.slug, projectKey?.id]);
+  }, [api, organization.slug, project.slug, projectKey?.id, products]);
 
   const track = useCallback(() => {
     if (!project?.id) {
@@ -174,6 +174,7 @@ export function SetupDocsLoader({
             platform={platform}
             organization={organization}
             project={project}
+            products={products}
           />
         )
       ) : (
@@ -191,9 +192,11 @@ function ProjectKeyInfo({
   platform,
   organization,
   project,
+  products,
 }: {
   organization: Organization;
   platform: PlatformKey | null;
+  products: ProductSolution[];
   project: Project;
   projectKey: ProjectKey;
 }) {
@@ -301,6 +304,28 @@ Sentry.onLoad(function() {
             {': '}
             {t('Learn how to configure your SDK using our Loader Script')}
           </li>
+          {!products.includes(ProductSolution.PERFORMANCE_MONITORING) && (
+            <li>
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/performance/">
+                {t('Performance Monitoring')}
+              </ExternalLink>
+              {': '}
+              {t(
+                'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
+              )}
+            </li>
+          )}
+          {!products.includes(ProductSolution.SESSION_REPLAY) && (
+            <li>
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/">
+                {t('Session Replay')}
+              </ExternalLink>
+              {': '}
+              {t(
+                'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
+              )}
+            </li>
+          )}
         </ul>
       </DocumentationWrapper>
     </DocsWrapper>

--- a/static/app/views/projectInstall/platform.spec.tsx
+++ b/static/app/views/projectInstall/platform.spec.tsx
@@ -22,6 +22,18 @@ function mockProjectApiResponses(projects) {
     url: '/projects/org-slug/project-slug/',
     body: projects,
   });
+
+  MockApiClient.addMockResponse({
+    url: '/projects/org-slug/project-slug/keys/',
+    method: 'GET',
+    body: [TestStubs.ProjectKeys()[0]],
+  });
+
+  MockApiClient.addMockResponse({
+    url: `/projects/org-slug/project-slug/keys/${TestStubs.ProjectKeys()[0].public}/`,
+    method: 'PUT',
+    body: {},
+  });
 }
 
 describe('ProjectInstallPlatform', function () {


### PR DESCRIPTION
This PR represents the outcome of our chosen https://github.com/getsentry/sentry/pull/50169, aiming to enhance our getting started documentation in the Sentry repository using React. It introduces a new structure and successfully migrates the javascript vanilla to our main Sentry repository.

Closes: https://github.com/getsentry/sentry/issues/52622