### PR TITLE
fix(discover-tags): Add optional check for responseJSON

### DIFF
--- a/static/app/views/discover/tags.tsx
+++ b/static/app/views/discover/tags.tsx
@@ -117,7 +117,7 @@ class Tags extends Component<Props, State> {
     } catch (err) {
       if (
         err.status !== 400 &&
-        err.responseJSON.detail !==
+        err.responseJSON?.detail !==
           'Invalid date range. Please try a more recent date range.'
       ) {
         Sentry.captureException(err);


### PR DESCRIPTION
Missed an optional key in responseJSON objects

Fixes JAVASCRIPT-2N6P