### PR TITLE
feat(perf-detector-threshold-configuration) Added frontend changes addressing bug bash points.

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -67,7 +67,7 @@ export function SpanEvidenceSection({event, organization, projectSlug}: Props) {
             size="xs"
           >
             <StyledSettingsIcon size="xs" />
-            Settings
+            Threshold Settings
           </LinkButton>
         )
       }

--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
@@ -5,7 +5,7 @@ import {
   userEvent,
 } from 'sentry-test/reactTestingLibrary';
 
-import ConfigStore from 'sentry/stores/configStore';
+import * as utils from 'sentry/utils/isActiveSuperuser';
 import ProjectPerformance, {
   allowedDurationValues,
   allowedPercentageValues,
@@ -150,7 +150,7 @@ describe('projectPerformance', function () {
   });
 
   it('renders detector threshold configuration - admin ui', async function () {
-    jest.spyOn(ConfigStore, 'get').mockReturnValue(TestStubs.User({isSuperuser: true}));
+    jest.spyOn(utils, 'isActiveSuperuser').mockReturnValue(true);
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/performance-issues/configure/',
       method: 'GET',

--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
@@ -5,7 +5,7 @@ import {
   userEvent,
 } from 'sentry-test/reactTestingLibrary';
 
-import * as utils from 'sentry/utils/isActiveSuperuser';
+import ConfigStore from 'sentry/stores/configStore';
 import ProjectPerformance, {
   allowedDurationValues,
   allowedPercentageValues,
@@ -150,7 +150,7 @@ describe('projectPerformance', function () {
   });
 
   it('renders detector threshold configuration - admin ui', async function () {
-    jest.spyOn(utils, 'isActiveSuperuser').mockReturnValue(true);
+    jest.spyOn(ConfigStore, 'get').mockReturnValue(TestStubs.User({isSuperuser: true}));
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/performance-issues/configure/',
       method: 'GET',


### PR DESCRIPTION
 1. Changed label for settings button from Span Evidence.
 2. Improved descriptions and threshold labels.
 3. Pressing on slider thumb triggers request, even when value didn't change. Fixed here: [PR](https://github.com/getsentry/sentry/pull/52602)
 4. Made use of new range slider functionality.
 5. Added toast for case where admin ui is visible but super user cookie in the backend has expired. Causes 403s.
<img width="524" alt="Screenshot 2023-07-11 at 12 36 32 PM" src="https://github.com/getsentry/sentry/assets/60121741/3ee94925-edb6-4181-b9a9-d10886439740">

