### PR TITLE
ref(search): clean-up assign-to-me feature flag usage

### DIFF
--- a/static/app/utils/withIssueTags.spec.tsx
+++ b/static/app/utils/withIssueTags.spec.tsx
@@ -64,7 +64,9 @@ describe('withIssueTags HoC', function () {
       ]);
     });
 
-    expect(screen.getByText(/assigned: me, \[me, none\]/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/assigned: me, my_teams, \[me, my_teams, none\]/)
+    ).toBeInTheDocument();
 
     act(() => {
       TeamStore.loadInitialData([
@@ -78,7 +80,7 @@ describe('withIssueTags HoC', function () {
 
     expect(
       screen.getByText(
-        /assigned: me, \[me, none\], #best-team-na, foo@example.com, joe@example.com/
+        /assigned: me, my_teams, \[me, my_teams, none\], #best-team-na, foo@example.com, joe@example.com/
       )
     ).toBeInTheDocument();
 

--- a/static/app/utils/withIssueTags.spec.tsx
+++ b/static/app/utils/withIssueTags.spec.tsx
@@ -113,7 +113,7 @@ describe('withIssueTags HoC', function () {
     });
 
     expect(screen.getByTestId('Suggested Values')).toHaveTextContent(
-      'me, [me, none], #best-team'
+      'me, my_teams, [me, my_teams, none], #best-team'
     );
 
     expect(screen.getByTestId('All Values')).toHaveTextContent(

--- a/static/app/utils/withIssueTags.tsx
+++ b/static/app/utils/withIssueTags.tsx
@@ -60,9 +60,7 @@ function withIssueTags<Props extends WithIssueTagsProps>(
         .filter(team => !team.isMember)
         .map(team => `#${team.slug}`);
 
-      const meAndMyTeams = props.organization.features.includes('assign-to-me')
-        ? ['my_teams', '[me, my_teams, none]']
-        : ['[me, none]'];
+      const meAndMyTeams = ['my_teams', '[me, my_teams, none]'];
       const suggestedAssignees: string[] = ['me', ...meAndMyTeams, ...userTeams];
       const assigndValues: SearchGroup[] | string[] =
         props.organization.features.includes('issue-search-shortcuts')

--- a/static/app/views/issueList/utils.spec.tsx
+++ b/static/app/views/issueList/utils.spec.tsx
@@ -27,12 +27,5 @@ describe('getTabs', () => {
       'is:ignored',
       '__custom__',
     ]);
-
-    expect(getTabs(TestStubs.Organization({features: []})).map(tab => tab[0])).toEqual([
-      'is:unresolved',
-      'is:unresolved is:for_review assigned_or_suggested:[me, none]',
-      'is:ignored',
-      '__custom__',
-    ]);
   });
 });

--- a/static/app/views/issueList/utils.spec.tsx
+++ b/static/app/views/issueList/utils.spec.tsx
@@ -21,9 +21,7 @@ describe('getTabs', () => {
   });
 
   it('should enable/disable my_teams filter in For Review tab', () => {
-    expect(
-      getTabs(TestStubs.Organization({features: ['assign-to-me']})).map(tab => tab[0])
-    ).toEqual([
+    expect(getTabs(TestStubs.Organization({features: []})).map(tab => tab[0])).toEqual([
       'is:unresolved',
       'is:unresolved is:for_review assigned_or_suggested:[me, my_teams, none]',
       'is:ignored',

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -4,7 +4,6 @@ import {t, tct} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 
 export enum Query {
-  FOR_REVIEW_OLD = 'is:unresolved is:for_review assigned_or_suggested:[me, none]',
   FOR_REVIEW = 'is:unresolved is:for_review assigned_or_suggested:[me, my_teams, none]',
   UNRESOLVED = 'is:unresolved',
   IGNORED = 'is:ignored',
@@ -47,7 +46,6 @@ type OverviewTab = {
  */
 export function getTabs(organization: Organization) {
   const hasEscalatingIssuesUi = organization.features.includes('escalating-issues');
-  const hasAssignToMe = organization.features.includes('assign-to-me');
   const tabs: Array<[string, OverviewTab]> = [
     [
       Query.UNRESOLVED,
@@ -59,7 +57,7 @@ export function getTabs(organization: Organization) {
       },
     ],
     [
-      hasAssignToMe ? Query.FOR_REVIEW : Query.FOR_REVIEW_OLD,
+      Query.FOR_REVIEW,
       {
         name: t('For Review'),
         analyticsName: 'needs_review',
@@ -219,7 +217,7 @@ export const DISCOVER_EXCLUSION_FIELDS: string[] = [
   '__text',
 ];
 
-export const FOR_REVIEW_QUERIES: string[] = [Query.FOR_REVIEW, Query.FOR_REVIEW_OLD];
+export const FOR_REVIEW_QUERIES: string[] = [Query.FOR_REVIEW];
 
 export const SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY =
   'issue-stream-saved-searches-sidebar-open';


### PR DESCRIPTION
Cleaning up the `organizations:assign-to-me` feature flag since we've GAed the feature.