### PR TITLE
fix(slider): Show disabled tooltip on hover

### DIFF
--- a/static/app/components/slider/index.tsx
+++ b/static/app/components/slider/index.tsx
@@ -203,28 +203,28 @@ function BaseSlider(
       : [min, state.values[0]];
 
   return (
-    <SliderGroup {...groupProps} className={className}>
-      {label && (
-        <SliderLabelWrapper className="label-container">
-          <SliderLabel {...labelProps}>{label}</SliderLabel>
-          <SliderLabelOutput {...outputProps}>
-            {nThumbs > 1
-              ? `${getFormattedValue(selectedRange[0])}–${getFormattedValue(
-                  selectedRange[1]
-                )}`
-              : getFormattedValue(selectedRange[1])}
-          </SliderLabelOutput>
-        </SliderLabelWrapper>
-      )}
+    <Tooltip
+      title={disabledReason}
+      disabled={!disabled}
+      skipWrapper
+      isHoverable
+      position="bottom"
+      offset={8}
+    >
+      <SliderGroup {...groupProps} className={className}>
+        {label && (
+          <SliderLabelWrapper className="label-container">
+            <SliderLabel {...labelProps}>{label}</SliderLabel>
+            <SliderLabelOutput {...outputProps}>
+              {nThumbs > 1
+                ? `${getFormattedValue(selectedRange[0])}–${getFormattedValue(
+                    selectedRange[1]
+                  )}`
+                : getFormattedValue(selectedRange[1])}
+            </SliderLabelOutput>
+          </SliderLabelWrapper>
+        )}
 
-      <Tooltip
-        title={disabledReason}
-        disabled={!disabled}
-        skipWrapper
-        isHoverable
-        position="bottom"
-        offset={8}
-      >
         <SliderTrack
           ref={trackRef}
           {...trackProps}
@@ -281,6 +281,7 @@ function BaseSlider(
               index={index}
               state={state}
               trackRef={trackRef}
+              isDisabled={disabled}
               showLabel={showThumbLabels && !label}
               getFormattedValue={getFormattedValue}
               isRequired={required}
@@ -292,8 +293,8 @@ function BaseSlider(
             />
           ))}
         </SliderTrack>
-      </Tooltip>
-    </SliderGroup>
+      </SliderGroup>
+    </Tooltip>
   );
 }
 


### PR DESCRIPTION
**Before ——** `disabledReason` is defined but hovering over slider does not show it (due to https://github.com/getsentry/sentry/pull/52601)
<img width="353" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/ca6f931b-1da6-473d-a141-da4ee8319126">


**After ——** `disabledReason` shows up on hover
<img width="353" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/35b0e33b-5b0f-4a5a-ab3e-584b30edee95">
