### PR TITLE
feat(group-attributes): log a metric when certain fields for Group and related tables are updated

### DIFF
--- a/src/sentry/issues/attributes.py
+++ b/src/sentry/issues/attributes.py
@@ -45,15 +45,13 @@ def post_save_log_group_attributes_changed(
         else:
             # we have no guarantees update_fields is used everywhere save() is called
             # we'll need to assume any of the attributes are updated in that case
-            attributes_updated = {"status", "substatus", "first_seen", "num_comments"}.intersection(
+            attributes_updated = {"status", "substatus", "num_comments"}.intersection(
                 update_fields or ()
             )
             if attributes_updated:
                 _log_group_attributes_changed(
                     Operation.UPDATED, "group", "-".join(sorted(attributes_updated))
                 )
-            else:
-                _log_group_attributes_changed(Operation.UPDATED, "group", "unknown")
     except Exception:
         logger.error("failed to log group attributes after group post_save", exc_info=True)
 

--- a/src/sentry/issues/attributes.py
+++ b/src/sentry/issues/attributes.py
@@ -1,16 +1,100 @@
+import logging
+from enum import Enum
 from typing import Optional
 
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from sentry.models import Group, GroupOwner
+from sentry.signals import issue_assigned, issue_unassigned
 from sentry.utils import metrics
 
+logger = logging.getLogger(__name__)
 
-def _log_create_or_update(
-    created: bool, model_inducing_snapshot: str, column_inducing_snapshot: Optional[str] = None
+
+class Operation(Enum):
+    CREATED = "created"
+    UPDATED = "updated"
+    DELETED = "deleted"
+
+
+def _log_group_attributes_changed(
+    operation: Operation,
+    model_inducing_snapshot: str,
+    column_inducing_snapshot: Optional[str] = None,
 ) -> None:
     metrics.incr(
-        "group_attributes.create_or_update",
+        "group_attributes.changed",
         tags={
-            "operation": "create" if created else "update",
+            "operation": operation.value,
             "model": model_inducing_snapshot,
             "column": column_inducing_snapshot,
         },
     )
+
+
+@receiver(
+    post_save, sender=Group, dispatch_uid="post_save_log_group_attributes_changed", weak=False
+)
+def post_save_log_group_attributes_changed(
+    instance, sender, created, update_fields, *args, **kwargs
+):
+    try:
+        if created:
+            _log_group_attributes_changed(Operation.CREATED, "group", None)
+        else:
+            # we have no guarantees update_fields is used everywhere save() is called
+            # we'll need to assume any of the attributes are updated in that case
+            attributes_updated = {"status", "substatus", "first_seen", "num_comments"}.intersection(
+                update_fields or ()
+            )
+            if attributes_updated:
+                _log_group_attributes_changed(
+                    Operation.UPDATED, "group", "-".join(sorted(attributes_updated))
+                )
+            else:
+                _log_group_attributes_changed(Operation.UPDATED, "group", "unknown")
+    except Exception:
+        logger.error("failed to log group attributes after group post_save", exc_info=True)
+
+
+@issue_assigned.connect(weak=False)
+def on_issue_assigned_log_group_assignee_attributes_changed(project, group, user, **kwargs):
+    try:
+        _log_group_attributes_changed(Operation.UPDATED, "group_assignee", "all")
+    except Exception:
+        logger.error(
+            "failed to log group attributes after group_assignee assignment", exc_info=True
+        )
+
+
+@issue_unassigned.connect(weak=False)
+def on_issue_unassigned_log_group_assignee_attributes_changed(project, group, user, **kwargs):
+    try:
+        _log_group_attributes_changed(Operation.DELETED, "group_assignee", "all")
+    except Exception:
+        logger.error(
+            "failed to log group attributes after group_assignee unassignment", exc_info=True
+        )
+
+
+@receiver(
+    post_save, sender=GroupOwner, dispatch_uid="post_save_log_group_owner_changed", weak=False
+)
+def post_save_log_group_owner_changed(instance, sender, created, update_fields, *args, **kwargs):
+    try:
+        _log_group_attributes_changed(
+            Operation.CREATED if created else Operation.UPDATED, "group_owner", "all"
+        )
+    except Exception:
+        logger.error("failed to log group attributes after group_owner updated", exc_info=True)
+
+
+@receiver(
+    post_delete, sender=GroupOwner, dispatch_uid="post_delete_log_group_owner_changed", weak=False
+)
+def post_delete_log_group_owner_changed(instance, sender, created, update_fields, *args, **kwargs):
+    try:
+        _log_group_attributes_changed(Operation.DELETED, "group_owner", "all")
+    except Exception:
+        logger.error("failed to log group attributes after group_owner delete", exc_info=True)

--- a/src/sentry/issues/attributes.py
+++ b/src/sentry/issues/attributes.py
@@ -1,0 +1,16 @@
+from typing import Optional
+
+from sentry.utils import metrics
+
+
+def _log_create_or_update(
+    created: bool, model_inducing_snapshot: str, column_inducing_snapshot: Optional[str] = None
+) -> None:
+    metrics.incr(
+        "group_attributes.create_or_update",
+        tags={
+            "operation": "create" if created else "update",
+            "model": model_inducing_snapshot,
+            "column": column_inducing_snapshot,
+        },
+    )

--- a/src/sentry/issues/attributes.py
+++ b/src/sentry/issues/attributes.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 from sentry.models import Group, GroupOwner
-from sentry.signals import issue_assigned, issue_unassigned
+from sentry.signals import issue_assigned, issue_deleted, issue_unassigned
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -56,6 +56,14 @@ def post_save_log_group_attributes_changed(
                 _log_group_attributes_changed(Operation.UPDATED, "group", "unknown")
     except Exception:
         logger.error("failed to log group attributes after group post_save", exc_info=True)
+
+
+@issue_deleted.connect(weak=False)
+def on_issue_deleted_log_deleted(group, user, delete_type, **kwargs):
+    try:
+        _log_group_attributes_changed(Operation.DELETED, "group", "all")
+    except Exception:
+        logger.error("failed to log group attributes after group delete", exc_info=True)
 
 
 @issue_assigned.connect(weak=False)

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -133,6 +133,8 @@ class Activity(Model):
 
         # HACK: support Group.num_comments
         if self.type == ActivityType.NOTE.value:
+            from sentry.models import Group
+
             self.group.update(num_comments=F("num_comments") + 1)
             post_save.send_robust(
                 sender=Group, instance=self.group, created=True, update_fields=["num_comments"]
@@ -143,6 +145,8 @@ class Activity(Model):
 
         # HACK: support Group.num_comments
         if self.type == ActivityType.NOTE.value:
+            from sentry.models import Group
+
             self.group.update(num_comments=F("num_comments") - 1)
             post_save.send_robust(
                 sender=Group, instance=self.group, created=True, update_fields=["num_comments"]

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Mapping, Optional, Sequence
 
 from django.db import models
 from django.db.models import Q, QuerySet
-from django.db.models.signals import post_save, pre_save
+from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.http import urlencode
@@ -812,24 +812,3 @@ def pre_save_group_default_substatus(instance, sender, *args, **kwargs):
                     "Invalid substatus for UNRESOLVED group",
                     extra={"substatus": instance.substatus},
                 )
-
-
-@receiver(
-    post_save, sender=Group, dispatch_uid="post_save_log_group_attributes_changed", weak=False
-)
-def post_save_log_group_attributes_changed(
-    instance, sender, created, update_fields, *args, **kwargs
-):
-    from sentry.issues.attributes import _log_create_or_update
-
-    try:
-        if created:
-            _log_create_or_update(True, "group", None)
-        else:
-            attributes_updated = {"status", "substatus", "first_seen", "num_comments"}.intersection(
-                update_fields
-            )
-            if attributes_updated:
-                _log_create_or_update(False, "group", "-".join(sorted(attributes_updated)))
-    except Exception:
-        logger.error("failed to log group attributes after group post_save", exc_info=True)

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -159,6 +159,7 @@ ownership_rule_created = BetterSignal()  # ["project"]
 
 # issues
 issue_assigned = BetterSignal()  # ["project", "group", "user"]
+issue_unassigned = BetterSignal()  # ["project", "group", "user"]
 issue_deleted = BetterSignal()  # ["group", "user", "delete_type"]
 # ["organization_id", "project", "group", "user", "resolution_type"]
 issue_resolved = BetterSignal()

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence, Tuple, Type
 
 import sentry_sdk
 from django.conf import settings
+from django.db.models.signals import post_save
 from django.utils import timezone
 from google.api_core.exceptions import ServiceUnavailable
 
@@ -368,6 +369,12 @@ def handle_group_owners(project, group, issue_owners):
                         )
             if new_group_owners:
                 GroupOwner.objects.bulk_create(new_group_owners)
+                for go in new_group_owners:
+                    post_save.send_robust(
+                        sender=GroupOwner,
+                        instance=go,
+                        created=True,
+                    )
 
     except UnableToAcquireLock:
         pass


### PR DESCRIPTION
We're gathering metrics when any of the following postgres DB tables are mutated:
- Group, GroupAssignee, GroupOwner rows are created or deleted
- Group.status, Group.substatus, Group.first_seen, Group.num_comments are updated

These metrics will help us gauge how 'active' these columns are for the purposes of replicating these values to snuba.
