### PR TITLE
feat(crons): Return shortId with check-in data

### DIFF
--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional
 
 from django.db import transaction
 from django.utils import timezone
@@ -9,7 +9,7 @@ from rest_framework.request import Request
 from sentry.api.serializers.rest_framework.rule import RuleSerializer
 from sentry.db.models import BoundedPositiveIntegerField
 from sentry.mediators import project_rules
-from sentry.models import Rule, RuleActivity, RuleActivityType, RuleSource, User
+from sentry.models import Group, Rule, RuleActivity, RuleActivityType, RuleSource, User
 from sentry.models.project import Project
 from sentry.signals import first_cron_checkin_received, first_cron_monitor_created
 
@@ -65,7 +65,7 @@ def valid_duration(duration: Optional[int]) -> bool:
 
 def fetch_associated_groups(
     trace_ids: List[str], organization_id: int, project_id: int, start: datetime, end
-) -> Dict[str, Set[int]]:
+) -> Dict[str, List[Dict[str, int]]]:
     """
     Returns serializer appropriate group_ids corresponding with check-in trace ids
     :param trace_ids: list of trace_ids from the given check-ins
@@ -144,7 +144,8 @@ def fetch_associated_groups(
         },
     )
 
-    trace_groups: Dict[str, Set[int]] = defaultdict(set)
+    group_id_data: Dict[int, str] = {}
+    trace_groups: Dict[str, List[Dict[str, int]]] = defaultdict(list)
 
     result = raw_snql_query(snql_request, "api.serializer.checkins.trace-ids", use_cache=False)
     # if query completes successfully, add the set of group id's to the corresponding check-in trace
@@ -153,7 +154,14 @@ def fetch_associated_groups(
         for event in result["data"]:
             trace_id_event_name = Columns.TRACE_ID.value.event_name
             assert trace_id_event_name is not None
-            trace_groups[event[trace_id_event_name]].add(event["group_id"])
+
+            # create dict with group_id and trace_id
+            group_id_data[event["group_id"]] = event[trace_id_event_name]
+
+        group_ids = group_id_data.keys()
+        for group in Group.objects.filter(project_id=project_id, id__in=group_ids):
+            trace_id = group_id_data[group.id]
+            trace_groups[trace_id].append({"id": group.id, "shortId": group.qualified_short_id})
 
     return trace_groups
 

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -148,7 +148,7 @@ def fetch_associated_groups(
     trace_groups: Dict[str, List[Dict[str, Union[int, str]]]] = defaultdict(list)
 
     result = raw_snql_query(snql_request, "api.serializer.checkins.trace-ids", use_cache=False)
-    # if query completes successfully, add the set of group id's to the corresponding check-in trace
+    # if query completes successfully, add an array of objects with group id and short id
     # otherwise, return an empty dict to return an empty array through the serializer
     if "error" not in result:
         for event in result["data"]:

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -144,7 +144,7 @@ def fetch_associated_groups(
         },
     )
 
-    group_id_data: Dict[int, str] = {}
+    group_id_data: Dict[int, List[str]] = defaultdict(list)
     trace_groups: Dict[str, List[Dict[str, int]]] = defaultdict(list)
 
     result = raw_snql_query(snql_request, "api.serializer.checkins.trace-ids", use_cache=False)
@@ -156,12 +156,12 @@ def fetch_associated_groups(
             assert trace_id_event_name is not None
 
             # create dict with group_id and trace_id
-            group_id_data[event["group_id"]] = event[trace_id_event_name]
+            group_id_data[event["group_id"]].append(event[trace_id_event_name])
 
         group_ids = group_id_data.keys()
         for group in Group.objects.filter(project_id=project_id, id__in=group_ids):
-            trace_id = group_id_data[group.id]
-            trace_groups[trace_id].append({"id": group.id, "shortId": group.qualified_short_id})
+            for trace_id in group_id_data[group.id]:
+                trace_groups[trace_id].append({"id": group.id, "shortId": group.qualified_short_id})
 
     return trace_groups
 

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from django.db import transaction
 from django.utils import timezone
@@ -145,7 +145,7 @@ def fetch_associated_groups(
     )
 
     group_id_data: Dict[int, List[str]] = defaultdict(list)
-    trace_groups: Dict[str, List[Dict[str, int]]] = defaultdict(list)
+    trace_groups: Dict[str, List[Dict[str, Union[int, str]]]] = defaultdict(list)
 
     result = raw_snql_query(snql_request, "api.serializer.checkins.trace-ids", use_cache=False)
     # if query completes successfully, add the set of group id's to the corresponding check-in trace

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Set, Union
 
 from django.db import transaction
 from django.utils import timezone
@@ -144,7 +144,7 @@ def fetch_associated_groups(
         },
     )
 
-    group_id_data: Dict[int, List[str]] = defaultdict(list)
+    group_id_data: Dict[int, Set[str]] = defaultdict(set)
     trace_groups: Dict[str, List[Dict[str, Union[int, str]]]] = defaultdict(list)
 
     result = raw_snql_query(snql_request, "api.serializer.checkins.trace-ids", use_cache=False)
@@ -156,7 +156,7 @@ def fetch_associated_groups(
             assert trace_id_event_name is not None
 
             # create dict with group_id and trace_id
-            group_id_data[event["group_id"]].append(event[trace_id_event_name])
+            group_id_data[event["group_id"]].add(event[trace_id_event_name])
 
         group_ids = group_id_data.keys()
         for group in Group.objects.filter(project_id=project_id, id__in=group_ids):


### PR DESCRIPTION
Returns `{"id": id, "shortId": short-id}` as an array for `expand[]=groups` on the monitor check-ins endpoint