### PR TITLE
feat(issue-details): Remove reprocessing banner on issue details

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -14,7 +14,6 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import MutedBox from 'sentry/components/mutedBox';
 import {TransactionProfileIdProvider} from 'sentry/components/profiling/transactionProfileIdProvider';
-import ReprocessedBox from 'sentry/components/reprocessedBox';
 import ResolutionBox from 'sentry/components/resolutionBox';
 import {space} from 'sentry/styles/space';
 import {
@@ -169,27 +168,6 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
     return null;
   };
 
-  const renderReprocessedBox = () => {
-    if (
-      groupReprocessingStatus !== ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT &&
-      groupReprocessingStatus !== ReprocessingStatus.REPROCESSED_AND_HAS_EVENT
-    ) {
-      return null;
-    }
-
-    const {count, id: groupId} = group;
-    const groupCount = Number(count);
-
-    return (
-      <ReprocessedBox
-        reprocessActivity={mostRecentActivity as GroupActivityReprocess}
-        groupCount={groupCount}
-        groupId={groupId}
-        orgSlug={organization.slug}
-      />
-    );
-  };
-
   const renderContent = () => {
     if (loadingEvent) {
       return <LoadingIndicator />;
@@ -247,7 +225,6 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
                             project={project}
                           />
                         )}
-                        {renderReprocessedBox()}
                         {renderContent()}
                       </QuickTraceContext.Provider>
                     </StyledLayoutMain>


### PR DESCRIPTION
this pr removes the reprocessing banner from the issue details page as part of the issue details cleanup.

closes https://github.com/getsentry/sentry/issues/52536