### PR TITLE
feat(backup): Support alert rules

### DIFF
--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -150,6 +150,8 @@ class DateUpdatedComparator(JSONScrubbingComparator):
 ComparatorList = List[JSONScrubbingComparator]
 ComparatorMap = Dict[str, ComparatorList]
 DEFAULT_COMPARATORS: ComparatorMap = {
+    "sentry.alertrule": [DateUpdatedComparator("date_modified")],
+    "sentry.querysubscription": [DateUpdatedComparator("date_updated")],
     "sentry.userrole": [DateUpdatedComparator("date_updated")],
     "sentry.userroleuser": [DateUpdatedComparator("date_updated")],
 }

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1302,11 +1302,13 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)
-    def create_alert_rule_trigger(alert_rule, label=None, alert_threshold=100):
+    def create_alert_rule_trigger(
+        alert_rule, label=None, alert_threshold=100, excluded_projects=None
+    ):
         if not label:
             label = petname.generate(2, " ", letters=10).title()
 
-        return create_alert_rule_trigger(alert_rule, label, alert_threshold)
+        return create_alert_rule_trigger(alert_rule, label, alert_threshold, excluded_projects)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/tests/sentry/backup/test_models.py
+++ b/tests/sentry/backup/test_models.py
@@ -65,6 +65,24 @@ class ModelBackupTests(TransactionTestCase):
             config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
         )
 
+    def test_alert_rule(self):
+        self.create_alert_rule()
+        self.import_export_then_validate()
+
+    def test_alert_rule_excluded_projects(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        excluded = self.create_project(organization=org)
+        self.create_alert_rule(include_all_projects=True, excluded_projects=[excluded])
+        self.import_export_then_validate()
+
+    def test_alert_rule_trigger(self):
+        excluded = self.create_project()
+        rule = self.create_alert_rule(include_all_projects=True)
+        trigger = self.create_alert_rule_trigger(alert_rule=rule, excluded_projects=[excluded])
+        self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
+        self.import_export_then_validate()
+
     def test_environment(self):
         self.create_environment()
         self.import_export_then_validate()


### PR DESCRIPTION
Adds a number of tests for exportable AlertRule* Sentry models, which necessitates testing for SnubaQuery* and QuerySubscription models as well, as these are included in AlertRule instances by default.

Issue: getsentry/team-ospo#156