### PR TITLE
test(backup): Ensure expected models are in output

### DIFF
--- a/tests/sentry/backup/test_models.py
+++ b/tests/sentry/backup/test_models.py
@@ -17,6 +17,12 @@ from sentry.incidents.models import (
     AlertRuleTriggerAction,
     AlertRuleTriggerExclusion,
 )
+from sentry.models.dashboard import Dashboard, DashboardTombstone
+from sentry.models.dashboard_widget import (
+    DashboardWidget,
+    DashboardWidgetQuery,
+    DashboardWidgetTypes,
+)
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorType, ScheduleType
@@ -95,6 +101,15 @@ class ModelBackupTests(TransactionTestCase):
         # we have at least once instance of all the "tested for" models in the actual output.
         return actual
 
+    def create_dashboard(self):
+        """Re-usable dashboard object for test cases."""
+
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        return Dashboard.objects.create(
+            title="Dashboard 1", created_by_id=user.id, organization=org
+        )
+
     def create_monitor(self):
         """Re-usable monitor object for test cases."""
 
@@ -127,6 +142,29 @@ class ModelBackupTests(TransactionTestCase):
         rule = self.create_alert_rule(include_all_projects=True)
         trigger = self.create_alert_rule_trigger(alert_rule=rule, excluded_projects=[excluded])
         self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
+        return self.import_export_then_validate()
+
+    @targets_models([Dashboard])
+    def test_dashboard(self):
+        self.create_dashboard()
+        return self.import_export_then_validate()
+
+    @targets_models([DashboardTombstone])
+    def test_dashboard_tombstone(self):
+        DashboardTombstone.objects.create(organization=self.organization, slug="test-tombstone")
+        return self.import_export_then_validate()
+
+    @targets_models([DashboardWidget, DashboardWidgetQuery])
+    def test_dashboard_widget(self):
+        dashboard = self.create_dashboard()
+        widget = DashboardWidget.objects.create(
+            dashboard=dashboard,
+            order=1,
+            title="Test Widget",
+            display_type=0,
+            widget_type=DashboardWidgetTypes.DISCOVER,
+        )
+        DashboardWidgetQuery.objects.create(widget=widget, order=1, name="Test Query")
         return self.import_export_then_validate()
 
     @targets_models([Environment])


### PR DESCRIPTION
We add a new decorator, `@targets_models`, for the `.../backup/test_models.py` test suite. The goal is two-fold: for each individual test, the decorator provides a concise way to express which models must be included in the output, lest we end up with a test that passes the equality check, but only because it excluded our target model(s) altogether. The second goal is to make the set of models being exercised in the `ModelBackupTests` class easily visible to static analysis tools like flake8, so that we may later create a check ensuring that all `__include_in_export__ = True` marked models in this repository are included in this test suite.

Issue: getsentry/team-ospo#156
Issue: getsentry/team-ospo#160