### PR TITLE
feat(starfish): Add a metrics fidelity

### DIFF
--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -50,7 +50,7 @@ export function useShortInterval(datetimeObj: DateTimeObject): boolean {
   return diffInMinutes <= TWENTY_FOUR_HOURS;
 }
 
-export type Fidelity = 'high' | 'medium' | 'low';
+export type Fidelity = 'high' | 'medium' | 'low' | 'metrics';
 
 export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'medium') {
   const diffInMinutes = getDiffInMinutes(datetimeObj);
@@ -61,6 +61,9 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
       return '4h';
     }
     if (fidelity === 'medium') {
+      return '1d';
+    }
+    if (fidelity === 'metrics') {
       return '1d';
     }
     return '2d';
@@ -74,6 +77,9 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
     if (fidelity === 'medium') {
       return '4h';
     }
+    if (fidelity === 'metrics') {
+      return '1d';
+    }
     return '1d';
   }
 
@@ -82,6 +88,9 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
       return '30m';
     }
     if (fidelity === 'medium') {
+      return '1h';
+    }
+    if (fidelity === 'metrics') {
       return '1h';
     }
     return '12h';
@@ -95,6 +104,9 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
     if (fidelity === 'medium') {
       return '1h';
     }
+    if (fidelity === 'metrics') {
+      return '1h';
+    }
     return '6h';
   }
 
@@ -106,6 +118,9 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
     if (fidelity === 'medium') {
       return '15m';
     }
+    if (fidelity === 'metrics') {
+      return '1h';
+    }
     return '1h';
   }
 
@@ -115,6 +130,9 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
   }
   if (fidelity === 'medium') {
     return '5m';
+  }
+  if (fidelity === 'metrics') {
+    return '1m';
   }
   return '10m';
 }

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -251,7 +251,7 @@ const getEventView = (
       yAxis: ['sps()', `p50(${SPAN_SELF_TIME})`, `p95(${SPAN_SELF_TIME})`],
       query,
       dataset: DiscoverDatasets.SPANS_METRICS,
-      interval: getInterval(pageFilters.datetime, 'low'),
+      interval: getInterval(pageFilters.datetime, 'metrics'),
       version: 2,
     },
     location


### PR DESCRIPTION
- This is because even if you pick the 6h interval, we'll still need to use the 1h granularity and merge the same number of buckets than if we just picked the 1h interval.
- So when the metrics fidelity is picked we'll always just pick the closest interval to an existing granularity (ie. 60, 3600, 86400)