### PR TITLE
chore(hybrid-cloud): Update get_default_identity to return RpcIdentity

### DIFF
--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -74,8 +74,7 @@ class GitlabIdentityProvider(OAuth2Provider):
             "data": self.get_oauth_data(data),
         }
 
-    def get_refresh_token_params(self, refresh_token, *args, **kwargs):
-        identity = kwargs.get("identity")
+    def get_refresh_token_params(self, refresh_token: str, identity: RpcIdentity):
         client_id = identity.data.get("client_id")
         client_secret = identity.data.get("client_secret")
 
@@ -97,8 +96,7 @@ class GitlabIdentityProvider(OAuth2Provider):
         if not refresh_token_url:
             raise IdentityNotValid("Missing refresh token url")
 
-        kwargs["identity"] = identity
-        data = self.get_refresh_token_params(refresh_token, *args, **kwargs)
+        data = self.get_refresh_token_params(refresh_token=refresh_token, identity=identity)
 
         req = safe_urlopen(
             url=refresh_token_url, headers={}, data=data, verify_ssl=kwargs["verify_ssl"]

--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -4,6 +4,8 @@ from sentry import http
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.identity.oauth2 import OAuth2Provider
+from sentry.services.hybrid_cloud.identity import identity_service
+from sentry.services.hybrid_cloud.identity.model import RpcIdentity
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
@@ -85,7 +87,7 @@ class GitlabIdentityProvider(OAuth2Provider):
             "client_secret": client_secret,
         }
 
-    def refresh_identity(self, identity, *args, **kwargs):
+    def refresh_identity(self, identity: RpcIdentity, *args, **kwargs):
         refresh_token = identity.data.get("refresh_token")
         refresh_token_url = kwargs.get("refresh_token_url")
 
@@ -123,5 +125,5 @@ class GitlabIdentityProvider(OAuth2Provider):
         self.handle_refresh_error(req, payload)
 
         identity.data.update(get_oauth_data(payload))
-        identity.update(data=identity.data)
+        identity_service.update_data(identity_id=identity.id, data=identity.data)
         return identity

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -360,7 +360,9 @@ class IntegrationInstallation:
         """For Integrations that rely solely on user auth for authentication."""
         if self.org_integration is None or self.org_integration.default_auth_id is None:
             raise Identity.DoesNotExist
-        identity = identity_service.get_identity(id=self.org_integration.default_auth_id)
+        identity = identity_service.get_identity(
+            filter={"id": self.org_integration.default_auth_id}
+        )
         if identity is None:
             raise Identity.DoesNotExist
         return identity

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -24,6 +24,8 @@ from sentry.exceptions import InvalidIdentity
 from sentry.models import ExternalActor, Identity, Integration, Team
 from sentry.pipeline import PipelineProvider
 from sentry.pipeline.views.base import PipelineView
+from sentry.services.hybrid_cloud.identity import identity_service
+from sentry.services.hybrid_cloud.identity.model import RpcIdentity
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.shared_integrations.constants import (
     ERR_INTERNAL,
@@ -354,11 +356,14 @@ class IntegrationInstallation:
         # Return the api client for a given provider
         raise NotImplementedError
 
-    def get_default_identity(self) -> Identity:
+    def get_default_identity(self) -> RpcIdentity:
         """For Integrations that rely solely on user auth for authentication."""
-        if not self.org_integration:
+        if self.org_integration is None or self.org_integration.default_auth_id is None:
             raise Identity.DoesNotExist
-        return Identity.objects.get(id=self.org_integration.default_auth_id)
+        identity = identity_service.get_identity(id=self.org_integration.default_auth_id)
+        if identity is None:
+            raise Identity.DoesNotExist
+        return identity
 
     def error_message_from_json(self, data: Mapping[str, Any]) -> Any:
         return data.get("message", "unknown error")

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -22,6 +22,7 @@ from sentry.integrations import (
 from sentry.integrations.mixins import RepositoryMixin
 from sentry.integrations.mixins.commit_context import CommitContextMixin
 from sentry.models import Repository
+from sentry.models.identity import Identity
 from sentry.pipeline import NestedPipelineView, PipelineView
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.utils.hashlib import sha1_text
@@ -104,7 +105,10 @@ class GitlabIntegration(
 
     def get_client(self):
         if self.default_identity is None:
-            self.default_identity = self.get_default_identity()
+            try:
+                self.default_identity = self.get_default_identity()
+            except Identity.DoesNotExist:
+                raise IntegrationError("Identity not found.")
 
         return GitLabProxyApiClient(self)
 

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -24,7 +24,6 @@ from sentry.integrations import (
 )
 from sentry.integrations.mixins import RepositoryMixin
 from sentry.integrations.vsts.issues import VstsIssueSync
-from sentry.models import Identity
 from sentry.models import Integration as IntegrationModel
 from sentry.models import (
     IntegrationExternalProject,
@@ -34,6 +33,7 @@ from sentry.models import (
     generate_token,
 )
 from sentry.pipeline import NestedPipelineView, Pipeline, PipelineView
+from sentry.services.hybrid_cloud.identity.model import RpcIdentity
 from sentry.services.hybrid_cloud.integration import RpcOrganizationIntegration, integration_service
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.services.hybrid_cloud.repository import RpcRepository, repository_service
@@ -121,7 +121,7 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.org_integration: RpcOrganizationIntegration | None
-        self.default_identity: Identity | None = None
+        self.default_identity: RpcIdentity | None = None
 
     def reinstall(self) -> None:
         self.reinstall_repositories()
@@ -180,7 +180,7 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
             identity_id=self.org_integration.default_auth_id,
         )
 
-    def check_domain_name(self, default_identity: Identity) -> None:
+    def check_domain_name(self, default_identity: RpcIdentity) -> None:
         if re.match("^https://.+/$", self.model.metadata["domain_name"]):
             return
 

--- a/src/sentry/models/identity.py
+++ b/src/sentry/models/identity.py
@@ -18,6 +18,7 @@ from sentry.db.models import (
     control_silo_only_model,
 )
 from sentry.db.models.fields.jsonfield import JSONField
+from sentry.identity.base import Provider
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import ExternalProviders
 
@@ -207,7 +208,7 @@ class Identity(Model):
         db_table = "sentry_identity"
         unique_together = (("idp", "external_id"), ("idp", "user"))
 
-    def get_provider(self):
+    def get_provider(self) -> Provider:
         from sentry.identity import get
 
         return get(self.idp.type)

--- a/src/sentry/models/identity.py
+++ b/src/sentry/models/identity.py
@@ -18,11 +18,11 @@ from sentry.db.models import (
     control_silo_only_model,
 )
 from sentry.db.models.fields.jsonfield import JSONField
-from sentry.identity.base import Provider
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import ExternalProviders
 
 if TYPE_CHECKING:
+    from sentry.identity.base import Provider
     from sentry.models import User
     from sentry.services.hybrid_cloud.identity import RpcIdentityProvider
 

--- a/src/sentry/services/hybrid_cloud/identity/impl.py
+++ b/src/sentry/services/hybrid_cloud/identity/impl.py
@@ -104,13 +104,7 @@ class DatabaseBackedIdentityService(IdentityService):
             return Identity.objects
 
         def filter_arg_validator(self) -> Callable[[IdentityFilterArgs], Optional[str]]:
-            return self._filter_has_any_key_validator(
-                "user_id",
-                "identity_ext_id",
-                "provider_id",
-                "provider_ext_id",
-                "provider_type",
-            )
+            return self._filter_has_any_key_validator(*IdentityFilterArgs.__annotations__.keys())
 
         def serialize_api(self, serializer: Optional[None]) -> Serializer:
             raise NotImplementedError("API Serialization not supported for IdentityService")

--- a/src/sentry/services/hybrid_cloud/identity/impl.py
+++ b/src/sentry/services/hybrid_cloud/identity/impl.py
@@ -83,7 +83,7 @@ class DatabaseBackedIdentityService(IdentityService):
         ).delete()
 
     def update_data(self, *, identity_id: int, data: Any) -> Optional[RpcIdentity]:
-        identity: Identity = Identity.objects.filter(id=identity_id).first()
+        identity: Optional[Identity] = Identity.objects.filter(id=identity_id).first()
         if identity is None:
             return None
         identity.update(data=data)

--- a/src/sentry/services/hybrid_cloud/identity/impl.py
+++ b/src/sentry/services/hybrid_cloud/identity/impl.py
@@ -86,6 +86,8 @@ class DatabaseBackedIdentityService(IdentityService):
         FilterQueryDatabaseImpl[Identity, IdentityFilterArgs, RpcIdentity, None]
     ):
         def apply_filters(self, query: QuerySet, filters: IdentityFilterArgs) -> QuerySet:
+            if "id" in filters:
+                query = query.filter(id=filters["id"])
             if "user_id" in filters:
                 query = query.filter(user_id=filters["user_id"])
             if "identity_ext_id" in filters:

--- a/src/sentry/services/hybrid_cloud/identity/impl.py
+++ b/src/sentry/services/hybrid_cloud/identity/impl.py
@@ -82,6 +82,13 @@ class DatabaseBackedIdentityService(IdentityService):
             user_id=user_id, auth_provider__organization_id=organization_id
         ).delete()
 
+    def update_data(self, *, identity_id: int, data: Any) -> Optional[RpcIdentity]:
+        identity: Identity = Identity.objects.filter(id=identity_id).first()
+        if identity is None:
+            return None
+        identity.update(data=data)
+        return serialize_identity(identity)
+
     class _IdentityFilterQuery(
         FilterQueryDatabaseImpl[Identity, IdentityFilterArgs, RpcIdentity, None]
     ):

--- a/src/sentry/services/hybrid_cloud/identity/model.py
+++ b/src/sentry/services/hybrid_cloud/identity/model.py
@@ -25,7 +25,7 @@ class RpcIdentity(RpcModel):
     external_id: str
     data: str
 
-    def get_identity(self) -> Provider:
+    def get_identity(self) -> "Provider":
         from sentry.identity import get
 
         identity_provider = identity_service.get_provider(provider_id=self.idp_id)

--- a/src/sentry/services/hybrid_cloud/identity/model.py
+++ b/src/sentry/services/hybrid_cloud/identity/model.py
@@ -6,8 +6,6 @@ from typing import Optional
 
 from typing_extensions import TypedDict
 
-from sentry.identity.base import Provider
-from sentry.models.identity import IdentityProvider
 from sentry.services.hybrid_cloud import RpcModel
 from sentry.services.hybrid_cloud.identity import identity_service
 

--- a/src/sentry/services/hybrid_cloud/identity/model.py
+++ b/src/sentry/services/hybrid_cloud/identity/model.py
@@ -23,6 +23,7 @@ class RpcIdentity(RpcModel):
 
 
 class IdentityFilterArgs(TypedDict, total=False):
+    id: int
     user_id: int
     identity_ext_id: str
     provider_id: int

--- a/src/sentry/services/hybrid_cloud/identity/model.py
+++ b/src/sentry/services/hybrid_cloud/identity/model.py
@@ -2,7 +2,7 @@
 #     from __future__ import annotations
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from typing_extensions import TypedDict
 
@@ -27,6 +27,8 @@ class RpcIdentity(RpcModel):
 
     def get_identity(self) -> "Provider":
         from sentry.identity import get
+        from sentry.models.identity import IdentityProvider
+        from sentry.services.hybrid_cloud.identity import identity_service
 
         identity_provider = identity_service.get_provider(provider_id=self.idp_id)
         if identity_provider is None:

--- a/src/sentry/services/hybrid_cloud/identity/model.py
+++ b/src/sentry/services/hybrid_cloud/identity/model.py
@@ -2,7 +2,7 @@
 #     from __future__ import annotations
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from typing_extensions import TypedDict
 

--- a/src/sentry/services/hybrid_cloud/identity/model.py
+++ b/src/sentry/services/hybrid_cloud/identity/model.py
@@ -7,7 +7,9 @@ from typing import Optional
 from typing_extensions import TypedDict
 
 from sentry.services.hybrid_cloud import RpcModel
-from sentry.services.hybrid_cloud.identity import identity_service
+
+if TYPE_CHECKING:
+    from sentry.identity.base import Provider
 
 
 class RpcIdentityProvider(RpcModel):

--- a/src/sentry/services/hybrid_cloud/identity/model.py
+++ b/src/sentry/services/hybrid_cloud/identity/model.py
@@ -20,6 +20,7 @@ class RpcIdentity(RpcModel):
     idp_id: int
     user_id: int
     external_id: str
+    data: str
 
 
 class IdentityFilterArgs(TypedDict, total=False):

--- a/src/sentry/services/hybrid_cloud/identity/model.py
+++ b/src/sentry/services/hybrid_cloud/identity/model.py
@@ -6,7 +6,10 @@ from typing import Optional
 
 from typing_extensions import TypedDict
 
+from sentry.identity.base import Provider
+from sentry.models.identity import IdentityProvider
 from sentry.services.hybrid_cloud import RpcModel
+from sentry.services.hybrid_cloud.identity import identity_service
 
 
 class RpcIdentityProvider(RpcModel):
@@ -17,10 +20,18 @@ class RpcIdentityProvider(RpcModel):
 
 class RpcIdentity(RpcModel):
     id: int
-    idp_id: int
+    idp_id: int  # IdentityProvider id
     user_id: int
     external_id: str
     data: str
+
+    def get_identity(self) -> Provider:
+        from sentry.identity import get
+
+        identity_provider = identity_service.get_provider(provider_id=self.idp_id)
+        if identity_provider is None:
+            raise IdentityProvider.DoesNotExist
+        return get(identity_provider.type)
 
 
 class IdentityFilterArgs(TypedDict, total=False):

--- a/src/sentry/services/hybrid_cloud/identity/model.py
+++ b/src/sentry/services/hybrid_cloud/identity/model.py
@@ -23,7 +23,7 @@ class RpcIdentity(RpcModel):
     idp_id: int  # IdentityProvider id
     user_id: int
     external_id: str
-    data: str
+    data: Dict[str, Any]
 
     def get_identity(self) -> "Provider":
         from sentry.identity import get

--- a/src/sentry/services/hybrid_cloud/identity/serial.py
+++ b/src/sentry/services/hybrid_cloud/identity/serial.py
@@ -20,4 +20,5 @@ def serialize_identity(identity: "Identity") -> RpcIdentity:
         idp_id=identity.idp_id,
         user_id=identity.user_id,
         external_id=identity.external_id,
+        data=identity.data,
     )

--- a/src/sentry/services/hybrid_cloud/identity/service.py
+++ b/src/sentry/services/hybrid_cloud/identity/service.py
@@ -4,7 +4,7 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
-from typing import List, Optional, cast
+from typing import Any, List, Optional, cast
 
 from sentry.services.hybrid_cloud.identity import RpcIdentity, RpcIdentityProvider
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
@@ -75,6 +75,16 @@ class IdentityService(RpcService):
         :param user_id:
         :param organization_id:
         :return:
+        """
+        pass
+
+    @rpc_method
+    @abstractmethod
+    def update_data(self, *, identity_id: int, data: Any) -> Optional[RpcIdentity]:
+        """
+        Updates an Identity's data.
+        :param identity_id:
+        :return: RpcIdentity
         """
         pass
 

--- a/tests/sentry/integrations/test_base.py
+++ b/tests/sentry/integrations/test_base.py
@@ -1,5 +1,6 @@
 from sentry.integrations import IntegrationInstallation
 from sentry.models import Identity, IdentityProvider
+from sentry.services.hybrid_cloud.identity.serial import serialize_identity
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.testutils import TestCase
 
@@ -37,7 +38,7 @@ class IntegrationTestCase(TestCase):
 
         assert integration.model == self.model
         assert integration.org_integration == self.org_integration
-        assert integration.get_default_identity() == self.identity
+        assert integration.get_default_identity() == serialize_identity(self.identity)
 
     def test_model_default_fields(self):
         # These fields are added through the DefaultFieldsModel


### PR DESCRIPTION
Key changes include:
- Refactoring the `get_refresh_token_params` and `refresh_identity` methods in the `GitlabIdentityProvider` class to explicitly take an `RpcIdentity` as an argument.
- Updating the `get_default_identity` method in the `IntegrationInstallation` class to use the `identity_service` and to return `RpcIdentity`; replacing the previous use of the `Identity` model directly.
- Adding type hints to various methods.
- Implementing a new `update_data` method in the `identity_service` to allow updating an `Identity`'s data.