### PR TITLE
ref: Simplify the context when we include replay link on New Issue emails

### DIFF
--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -179,11 +179,9 @@ class AlertRuleNotification(ProjectNotification):
         show_replay_link = features.has(
             "organizations:session-replay-issue-emails", self.organization
         )
-        replay_id = get_replay_id(self.event)
-        if has_session_replay and show_replay_link and replay_id:
+        if has_session_replay and show_replay_link and get_replay_id(self.event):
             context.update(
                 {
-                    "replay_id": replay_id,
                     "issue_replays_url": get_issue_replay_link(self.group, sentry_query_params),
                 }
             )

--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -226,7 +226,7 @@
 
       {% block table %}{% endblock %}
 
-      {% if replay_id and issue_replays_url %}
+      {% if issue_replays_url %}
       <div class="interface">
         <h3 class="title">Session Replay</h3>
         <table>


### PR DESCRIPTION
We don't render the replay_id in the template, so we don't really need to pass it along. If there is a url, then we'll render the url section.