### PR TITLE
fix(slider): Expand to full width

### DIFF
--- a/static/app/components/slider/index.tsx
+++ b/static/app/components/slider/index.tsx
@@ -303,6 +303,7 @@ const Slider = forwardRef(BaseSlider);
 export {Slider};
 
 const SliderGroup = styled('div')`
+  width: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
When `<Slider />` is rendered inside a flex container with explicit item alignment (e.g. `align-items: end;`, anything that's not `stretch`/`auto`), it shrinks to zero width:
<img width="823" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/3bf4e0d5-4e16-4ad2-b72d-2f365243c048">

That's because `<Slider />` doesn't have a defined width. Setting the width to `100%` fixes this:
<img width="823" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/866135ae-b4e9-4076-9452-a1d3e10b1077">

