### PR TITLE
ref(hybrid-cloud): Removes exempt_from_silo decorators in favor of assume_test_silo_mode

### DIFF
--- a/src/sentry/testutils/outbox.py
+++ b/src/sentry/testutils/outbox.py
@@ -4,8 +4,9 @@ import contextlib
 import functools
 from typing import Any
 
+from sentry.silo import SiloMode
 from sentry.tasks.deliver_from_outbox import enqueue_outbox_jobs
-from sentry.testutils.silo import exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode
 
 
 @contextlib.contextmanager
@@ -28,6 +29,6 @@ def outbox_runner(wrapped: Any | None = None) -> Any:
     yield
     from sentry.testutils.helpers.task_runner import TaskRunner
 
-    with TaskRunner(), exempt_from_silo_limits():
+    with TaskRunner(), assume_test_silo_mode(SiloMode.MONOLITH):
         while enqueue_outbox_jobs():
             pass

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -5,18 +5,7 @@ import inspect
 import re
 import sys
 from contextlib import contextmanager
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generator,
-    Iterable,
-    MutableMapping,
-    MutableSet,
-    Set,
-    Tuple,
-    Type,
-)
+from typing import Any, Callable, Dict, Iterable, MutableMapping, MutableSet, Set, Tuple, Type
 from unittest import TestCase
 
 import pytest
@@ -202,32 +191,6 @@ def assume_test_silo_mode(desired_silo: SiloMode) -> Any:
         with override_settings(**overrides):
             yield
     else:
-        yield
-
-
-@contextmanager
-def exempt_from_silo_limits() -> Generator[None, None, None]:
-    """Exempt test setup code from silo mode checks.
-
-    This can be used to decorate functions that are used exclusively in setting
-    up test cases, so that those functions don't produce false exceptions from
-    writing to tables that wouldn't be allowed in a certain SiloModeTest case.
-
-    It can also be used as a context manager to enclose setup code within a test
-    method. Such setup code would ideally be moved to the test class's `setUp`
-    method or a helper function where possible, but this is available as a
-    kludge when that's too inconvenient. For example:
-
-    ```
-    @SiloModeTest(SiloMode.REGION)
-    class MyTest(TestCase):
-        def test_something(self):
-            with exempt_from_mode_limits():
-                org = self.create_organization()  # would be wrong if under test
-            do_something(org)  # the actual code under test
-    ```
-    """
-    with override_settings(SILO_MODE=SiloMode.MONOLITH):
         yield
 
 

--- a/tests/integration/test_sso.py
+++ b/tests/integration/test_sso.py
@@ -1,24 +1,22 @@
 from sentry.models import AuthIdentity, AuthProvider
 from sentry.testutils import AuthProviderTestCase
-from sentry.testutils.silo import exempt_from_silo_limits
 from sentry.utils.auth import SsoSession
 
 
 # @control_silo_test(stable=True)
 class OrganizationAuthLoginTest(AuthProviderTestCase):
     def test_sso_auth_required(self):
-        with exempt_from_silo_limits():
-            user = self.create_user("foo@example.com", is_superuser=False)
-            organization = self.create_organization(name="foo")
-            member = self.create_member(user=user, organization=organization)
-            setattr(member.flags, "sso:linked", True)
-            member.save()
+        user = self.create_user("foo@example.com", is_superuser=False)
+        organization = self.create_organization(name="foo")
+        member = self.create_member(user=user, organization=organization)
+        setattr(member.flags, "sso:linked", True)
+        member.save()
 
-            auth_provider = AuthProvider.objects.create(
-                organization_id=organization.id, provider="dummy", flags=0
-            )
+        auth_provider = AuthProvider.objects.create(
+            organization_id=organization.id, provider="dummy", flags=0
+        )
 
-            AuthIdentity.objects.create(auth_provider=auth_provider, user=user)
+        AuthIdentity.objects.create(auth_provider=auth_provider, user=user)
 
         self.login_as(user)
 

--- a/tests/sentry/api/endpoints/test_auth_config.py
+++ b/tests/sentry/api/endpoints/test_auth_config.py
@@ -4,8 +4,9 @@ from django.test.utils import override_settings
 
 from sentry import newsletter
 from sentry.receivers import create_default_projects
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test(stable=True)
@@ -30,7 +31,7 @@ class AuthConfigEndpointTest(APITestCase):
         assert response.data["nextUri"] == "/organizations/ricks-org/issues/"
 
     @override_settings(SENTRY_SINGLE_ORGANIZATION=True)
-    @exempt_from_silo_limits()  # Single org IS monolith mode
+    @assume_test_silo_mode(SiloMode.MONOLITH)  # Single org IS monolith mode
     def test_single_org(self):
         create_default_projects()
         response = self.client.get(self.path)

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 
 from sentry.models import ApiToken, File, FileBlob, FileBlobIndex, FileBlobOwner
 from sentry.models.debugfile import ProjectDebugFile
+from sentry.silo import SiloMode
 from sentry.tasks.assemble import (
     AssembleTask,
     ChunkFileState,
@@ -15,14 +16,14 @@ from sentry.tasks.assemble import (
     set_assemble_status,
 )
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
 class DifAssembleEndpoint(APITestCase):
     def setUp(self):
         self.organization = self.create_organization(owner=self.user)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.token = ApiToken.objects.create(user=self.user, scope_list=["project:write"])
         self.team = self.create_team(organization=self.organization)
         self.project = self.create_project(

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -26,8 +26,9 @@ from sentry.models import (
     Release,
 )
 from sentry.plugins.base import plugins
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase, SnubaTestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 
 
@@ -240,7 +241,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             datetime=timezone.now(),
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             user.delete()
 
         url = f"/api/0/issues/{group.id}/"
@@ -424,7 +425,7 @@ class GroupUpdateTest(APITestCase):
         # hitting an endpoint that uses `client.{get,put,post}` to redirect to
         # another endpoint. This catches a regression that happened when
         # migrating to DRF 3.x.
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             api_key = ApiKey.objects.create(
                 organization_id=self.organization.id, scope_list=["event:write"]
             )

--- a/tests/sentry/api/endpoints/test_group_notes.py
+++ b/tests/sentry/api/endpoints/test_group_notes.py
@@ -2,9 +2,10 @@ import datetime
 
 from sentry.models import Activity, ExternalIssue, Group, GroupLink, GroupSubscription
 from sentry.notifications.types import GroupSubscriptionReason
+from sentry.silo import SiloMode
 from sentry.tasks.merge import merge_groups
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 
 
@@ -243,7 +244,7 @@ class GroupNoteCreateTest(APITestCase):
         )
 
         self.user.name = "Sentry Admin"
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.user.save()
         self.login_as(user=self.user)
 

--- a/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
@@ -7,10 +7,11 @@ from django.urls import reverse
 from sentry.constants import ObjectStatus
 from sentry.models import ApiToken, FileBlob, FileBlobOwner
 from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.silo import SiloMode
 from sentry.tasks.assemble import ChunkFileState, assemble_artifacts
 from sentry.testutils import APITestCase
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 
@@ -343,7 +344,7 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         )
 
         # right org, wrong permission level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             bad_token_str = generate_token(self.organization.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=self.organization.id,
@@ -365,7 +366,7 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         assert response.status_code == 403
 
         # wrong org, right permission level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             bad_org_token_str = generate_token(self.organization.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org2.id,
@@ -387,7 +388,7 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         assert response.status_code == 403
 
         # right org, right permission level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             good_token_str = generate_token(self.organization.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=self.organization.id,
@@ -411,7 +412,7 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         assert response.status_code == 200
 
         # Make sure org token usage was updated
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             org_token = OrgAuthToken.objects.get(token_hashed=hash_token(good_token_str))
         assert org_token.date_last_used is not None
         assert org_token.project_last_used_id == self.project.id

--- a/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
@@ -6,8 +6,9 @@ from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.repository import Repository
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -86,7 +87,7 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
             "projectId": self.project.id,
             "stacktraceFilename": "stack/root/file.py",
         }
-        with exempt_from_silo_limits(), in_test_psql_role_override("postgres"):
+        with assume_test_silo_mode(SiloMode.CONTROL), in_test_psql_role_override("postgres"):
             Integration.objects.all().delete()
         response = self.client.get(self.url, data=config_data, format="json")
         assert response.status_code == 404, response.content
@@ -132,7 +133,7 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
             "defaultBranch": "master",
             "repoName": "name",
         }
-        with exempt_from_silo_limits(), in_test_psql_role_override("postgres"):
+        with assume_test_silo_mode(SiloMode.CONTROL), in_test_psql_role_override("postgres"):
             Integration.objects.all().delete()
         response = self.client.post(self.url, data=config_data, format="json")
         assert response.status_code == 404, response.content

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -207,7 +207,7 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         assert org.name == data["name"]
 
         # TODO(HC) Re-enable this check once organization mapping stabilizes
-        # with exempt_from_silo_limits():
+        # with assume_test_silo_mode(SiloMode.CONTROL):
         #     assert OrganizationMapping.objects.filter(
         #         organization_id=organization_id,
         #         slug=data["slug"],

--- a/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from sentry.integrations.aws_lambda.integration import AwsLambdaIntegration
 from sentry.models import Integration, ProjectKey
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import region_silo_test
 
 cloudformation_arn = (
     "arn:aws:cloudformation:us-east-2:599817902985:stack/"
@@ -34,7 +34,6 @@ class AbstractServerlessTest(APITestCase):
         return super().get_response(self.organization.slug, self.integration.id, **kwargs)
 
     @property
-    @exempt_from_silo_limits()
     def sentry_dsn(self):
         return ProjectKey.get_default(project=self.project).get_dsn(public=True)
 

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -5,13 +5,14 @@ import responses
 from django.core import mail
 
 from sentry.models import AuthProvider, InviteStatus, OrganizationMember, OrganizationOption
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
 from sentry.testutils.cases import SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.slack import get_attachment_no_text
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
 
@@ -61,7 +62,7 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
 
     @patch("sentry.api.endpoints.organization_member.requests.join.logger")
     def test_org_sso_enabled(self, mock_log):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             AuthProvider.objects.create(organization_id=self.organization.id, provider="google")
 
         self.get_error_response(self.organization.slug, email=self.email, status_code=403)

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -13,11 +13,12 @@ from sentry.models import (
     OrganizationMemberTeam,
     UserEmail,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase, TestCase
 from sentry.testutils.helpers import Feature, with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -74,7 +75,7 @@ class OrganizationMemberSerializerTest(TestCase):
 
         request = self.make_request(user=user)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             UserEmail.objects.filter(user=user, email=user.email).update(is_verified=False)
 
             invite_state = get_invite_state(member.id, org.slug, user.id)
@@ -323,7 +324,7 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase, HybridCloudTest
         )
 
         # Two authenticators to ensure the user list is distinct
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             Authenticator.objects.create(user_id=member_2fa.user_id, type=1)
             Authenticator.objects.create(user_id=member_2fa.user_id, type=2)
 

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -3,8 +3,9 @@ from base64 import b64encode
 from django.urls import reverse
 
 from sentry.models import ApiKey
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -18,7 +19,7 @@ class OrganizationProjectsTestBase(APITestCase):
         ]
 
     def test_api_key(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             key = ApiKey.objects.create(
                 organization_id=self.organization.id, scope_list=["org:read"]
             )

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -21,8 +21,9 @@ from sentry.models import (
     Repository,
 )
 from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
@@ -1034,7 +1035,7 @@ class UpdateReleaseDetailsTest(APITestCase):
     def test_org_auth_token(self):
         org = self.organization
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             good_token_str = generate_token(org.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org.id,

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -40,6 +40,7 @@ from sentry.search.events.constants import (
     SEMVER_BUILD_ALIAS,
     SEMVER_PACKAGE_ALIAS,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import (
     APITestCase,
     ReleaseCommitPatchTest,
@@ -48,7 +49,7 @@ from sentry.testutils import (
     TestCase,
 )
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
@@ -1629,7 +1630,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         url = reverse("sentry-api-0-organization-releases", kwargs={"organization_slug": org.slug})
 
         # test right org, wrong permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             bad_api_key = ApiKey.objects.create(organization_id=org.id, scope_list=["project:read"])
         response = self.client.post(
             url,
@@ -1639,7 +1640,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         assert response.status_code == 403
 
         # test wrong org, right permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             wrong_org_api_key = ApiKey.objects.create(
                 organization_id=org2.id, scope_list=["project:write"]
             )
@@ -1651,7 +1652,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         assert response.status_code == 403
 
         # test right org, right permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             good_api_key = ApiKey.objects.create(
                 organization_id=org.id, scope_list=["project:write"]
             )
@@ -1679,7 +1680,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         url = reverse("sentry-api-0-organization-releases", kwargs={"organization_slug": org.slug})
 
         # test right org, wrong permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             bad_token_str = generate_token(org.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org.id,
@@ -1697,7 +1698,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         assert response.status_code == 403
 
         # test wrong org, right permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             wrong_org_token_str = generate_token(org2.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org2.id,
@@ -1715,7 +1716,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         assert response.status_code == 403
 
         # test right org, right permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             good_token_str = generate_token(org.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org.id,
@@ -1735,7 +1736,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         assert response.status_code == 201, response.content
 
         # Make sure org token usage was updated
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             org_token = OrgAuthToken.objects.get(token_hashed=hash_token(good_token_str))
         assert org_token.date_last_used is not None
         assert org_token.project_last_used_id == project1.id
@@ -1754,7 +1755,7 @@ class OrganizationReleaseCreateTest(APITestCase):
             organization_id=org.id, name="getsentry/sentry-plugins", provider="dummy"
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             api_token = ApiToken.objects.create(user=user, scope_list=["project:releases"])
 
         team1 = self.create_team(organization=org)

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -19,9 +19,10 @@ from sentry.models import (
     Repository,
 )
 from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase, ReleaseCommitPatchTest, TestCase
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 
@@ -506,7 +507,7 @@ class ProjectReleaseCreateTest(APITestCase):
         )
 
         # test right org, wrong permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             bad_token_str = generate_token(org.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org.id,
@@ -524,7 +525,7 @@ class ProjectReleaseCreateTest(APITestCase):
         assert response.status_code == 403
 
         # test wrong org, right permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             wrong_org_token_str = generate_token(org2.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org2.id,
@@ -542,7 +543,7 @@ class ProjectReleaseCreateTest(APITestCase):
         assert response.status_code == 403
 
         # test right org, right permissions level
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             good_token_str = generate_token(org.slug, "")
             OrgAuthToken.objects.create(
                 organization_id=org.id,
@@ -562,7 +563,7 @@ class ProjectReleaseCreateTest(APITestCase):
         assert response.status_code == 201, response.content
 
         # Make sure org token usage was updated
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             org_token = OrgAuthToken.objects.get(token_hashed=hash_token(good_token_str))
         assert org_token.date_last_used is not None
         assert org_token.project_last_used_id == project1.id

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -13,9 +13,10 @@ from sentry.integrations.slack.utils.channel import strip_channel_name
 from sentry.models import Environment, Integration, Rule, RuleActivity, RuleActivityType
 from sentry.models.actor import Actor, get_actor_for_user
 from sentry.models.rulefirehistory import RuleFireHistory
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import install_slack
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
 
@@ -28,7 +29,7 @@ def assert_rule_from_payload(rule: Rule, payload: Mapping[str, Any]) -> None:
 
     owner_id = payload.get("owner")
     if owner_id:
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             assert Actor.objects.get(id=rule.owner_id)
     else:
         assert rule.owner is None

--- a/tests/sentry/api/endpoints/test_scim_team_index.py
+++ b/tests/sentry/api/endpoints/test_scim_team_index.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from sentry.models import Team
 from sentry.signals import receivers_raise_on_send
 from sentry.testutils import SCIMTestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import region_silo_test
 
 CREATE_TEAM_POST_DATA = {
     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
@@ -49,12 +49,12 @@ class SCIMGroupIndexTests(SCIMTestCase):
             "members": [],
             "meta": {"resourceType": "Group"},
         }
-        with exempt_from_silo_limits():
-            assert Team.objects.filter(id=team_id).exists()
-            assert Team.objects.get(id=team_id).slug == "test-scimv2"
-            assert Team.objects.get(id=team_id).name == "Test SCIMv2"
-            assert Team.objects.get(id=team_id).idp_provisioned
-            assert len(Team.objects.get(id=team_id).member_set) == 0
+
+        assert Team.objects.filter(id=team_id).exists()
+        assert Team.objects.get(id=team_id).slug == "test-scimv2"
+        assert Team.objects.get(id=team_id).name == "Test SCIMv2"
+        assert Team.objects.get(id=team_id).idp_provisioned
+        assert len(Team.objects.get(id=team_id).member_set) == 0
         mock_metrics.incr.assert_called_with(
             "sentry.scim.team.provision",
         )

--- a/tests/sentry/api/endpoints/test_scim_user_details.py
+++ b/tests/sentry/api/endpoints/test_scim_user_details.py
@@ -6,8 +6,9 @@ from django.urls import reverse
 from sentry.models import AuthProvider, OrganizationMember
 from sentry.models.authidentity import AuthIdentity
 from sentry.scim.endpoints.utils import SCIMFilterError, parse_filter_conditions
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase, SCIMAzureTestCase, SCIMTestCase
-from sentry.testutils.silo import exempt_from_silo_limits, no_silo_test, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, no_silo_test, region_silo_test
 
 CREATE_USER_POST_DATA = {
     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
@@ -42,7 +43,7 @@ class SCIMMemberTestsPermissions(APITestCase):
         assert response.status_code == 403
 
     def test_cant_use_scim_even_with_authprovider(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             AuthProvider.objects.create(organization_id=self.organization.id, provider="dummy")
         url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
         response = self.client.get(url)
@@ -355,7 +356,7 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         member = self.create_member(
             user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             AuthIdentity.objects.create(
                 user_id=member.user_id, auth_provider=self.auth_provider, ident="test_ident"
             )
@@ -374,14 +375,14 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         with pytest.raises(OrganizationMember.DoesNotExist):
             OrganizationMember.objects.get(organization=self.organization, id=member.id)
 
-        with pytest.raises(AuthIdentity.DoesNotExist), exempt_from_silo_limits():
+        with pytest.raises(AuthIdentity.DoesNotExist), assume_test_silo_mode(SiloMode.CONTROL):
             AuthIdentity.objects.get(auth_provider=self.auth_provider, id=member.id)
 
     def test_user_details_set_inactive_dict(self):
         member = self.create_member(
             user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             AuthIdentity.objects.create(
                 user_id=member.user_id, auth_provider=self.auth_provider, ident="test_ident"
             )
@@ -400,14 +401,14 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         with pytest.raises(OrganizationMember.DoesNotExist):
             OrganizationMember.objects.get(organization=self.organization, id=member.id)
 
-        with pytest.raises(AuthIdentity.DoesNotExist), exempt_from_silo_limits():
+        with pytest.raises(AuthIdentity.DoesNotExist), assume_test_silo_mode(SiloMode.CONTROL):
             AuthIdentity.objects.get(auth_provider=self.auth_provider, id=member.id)
 
     def test_user_details_set_inactive_with_bool_string(self):
         member = self.create_member(
             user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             AuthIdentity.objects.create(
                 user_id=member.user_id, auth_provider=self.auth_provider, ident="test_ident"
             )
@@ -426,14 +427,14 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         with pytest.raises(OrganizationMember.DoesNotExist):
             OrganizationMember.objects.get(organization=self.organization, id=member.id)
 
-        with pytest.raises(AuthIdentity.DoesNotExist), exempt_from_silo_limits():
+        with pytest.raises(AuthIdentity.DoesNotExist), assume_test_silo_mode(SiloMode.CONTROL):
             AuthIdentity.objects.get(auth_provider=self.auth_provider, id=member.id)
 
     def test_user_details_set_inactive_with_dict_bool_string(self):
         member = self.create_member(
             user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             AuthIdentity.objects.create(
                 user_id=member.user_id, auth_provider=self.auth_provider, ident="test_ident"
             )
@@ -452,14 +453,14 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         with pytest.raises(OrganizationMember.DoesNotExist):
             OrganizationMember.objects.get(organization=self.organization, id=member.id)
 
-        with pytest.raises(AuthIdentity.DoesNotExist), exempt_from_silo_limits():
+        with pytest.raises(AuthIdentity.DoesNotExist), assume_test_silo_mode(SiloMode.CONTROL):
             AuthIdentity.objects.get(auth_provider=self.auth_provider, id=member.id)
 
     def test_invalid_patch_op(self):
         member = self.create_member(
             user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             AuthIdentity.objects.create(
                 user_id=member.user_id, auth_provider=self.auth_provider, ident="test_ident"
             )
@@ -479,7 +480,7 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         member = self.create_member(
             user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             AuthIdentity.objects.create(
                 user_id=member.user_id, auth_provider=self.auth_provider, ident="test_ident"
             )
@@ -517,7 +518,7 @@ class SCIMMemberDetailsTests(SCIMTestCase):
 
     def test_delete_route(self):
         member = self.create_member(user=self.create_user(), organization=self.organization)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             AuthIdentity.objects.create(
                 user_id=member.user_id, auth_provider=self.auth_provider, ident="test_ident"
             )
@@ -529,7 +530,7 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         assert response.status_code == 204, response.content
         with pytest.raises(OrganizationMember.DoesNotExist):
             OrganizationMember.objects.get(organization=self.organization, id=member.id)
-        with pytest.raises(AuthIdentity.DoesNotExist), exempt_from_silo_limits():
+        with pytest.raises(AuthIdentity.DoesNotExist), assume_test_silo_mode(SiloMode.CONTROL):
             AuthIdentity.objects.get(auth_provider=self.auth_provider, id=member.id)
 
     def test_patch_inactive_alternate_schema(self):

--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -5,8 +5,9 @@ from django.utils import timezone
 
 from sentry.mediators import GrantTypes
 from sentry.models import ApiApplication, ApiToken
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test(stable=True)
@@ -98,7 +99,7 @@ class TestSentryAppAuthorizations(APITestCase):
 
         url = reverse("sentry-api-0-organization-details", args=[self.organization.slug])
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
 
         assert response.status_code == 200

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -5,9 +5,10 @@ from django.urls import reverse
 from sentry import audit_log, deletions
 from sentry.constants import SentryAppStatus
 from sentry.models import AuditLogEntry, OrganizationMember, SentryApp
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -401,7 +402,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.data == {"allowedOrigins": ["'*' not allowed in origin"]}
 
     def test_members_cant_update(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             member_om = OrganizationMember.objects.get(user_id=self.user.id, organization=self.org)
             member_om.role = "member"
             member_om.save()
@@ -411,7 +412,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.status_code == 403
 
     def test_create_integration_exceeding_scopes(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             member_om = OrganizationMember.objects.get(user_id=self.user.id, organization=self.org)
             member_om.role = "manager"
             member_om.save()

--- a/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
@@ -9,10 +9,11 @@ from sentry import audit_log
 from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models import AuditLogEntry, Authenticator, Organization, OrganizationMember, UserEmail
 from sentry.services.hybrid_cloud.organization.serial import serialize_member
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from tests.sentry.api.endpoints.test_user_authenticator_details import assert_security_email_sent
 
 
@@ -285,13 +286,13 @@ class AcceptOrganizationInviteTest(APITestCase):
         assert self.client.session["invite_organization_id"] == om.organization_id
 
     def create_existing_om(self):
-        with exempt_from_silo_limits(), outbox_runner():
+        with assume_test_silo_mode(SiloMode.REGION), outbox_runner():
             OrganizationMember.objects.create(
                 user_id=self.user.id, role="member", organization=self.organization
             )
 
     def get_om_and_init_invite(self):
-        with exempt_from_silo_limits(), outbox_runner():
+        with assume_test_silo_mode(SiloMode.REGION), outbox_runner():
             om = OrganizationMember.objects.create(
                 email="newuser@example.com",
                 role="member",
@@ -311,19 +312,21 @@ class AcceptOrganizationInviteTest(APITestCase):
         return om
 
     def assert_invite_accepted(self, response, member_id: int) -> None:
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.get(id=member_id)
         assert om.user_id == self.user.id
         assert om.email is None
 
-        with exempt_from_silo_limits():
-            AuditLogEntry.objects.get(
-                organization_id=self.organization.id,
-                target_object=om.id,
-                target_user=self.user,
-                event=audit_log.get_event_id("MEMBER_ACCEPT"),
-                data=serialize_member(om).get_audit_log_metadata(),
-            )
+        with assume_test_silo_mode(SiloMode.REGION):
+            serialized_member = serialize_member(om).get_audit_log_metadata()
+
+        AuditLogEntry.objects.get(
+            organization_id=self.organization.id,
+            target_object=om.id,
+            target_user=self.user,
+            event=audit_log.get_event_id("MEMBER_ACCEPT"),
+            data=serialized_member,
+        )
 
         assert not self.client.session.get("invite_token")
         assert not self.client.session.get("invite_member_id")
@@ -351,7 +354,7 @@ class AcceptOrganizationInviteTest(APITestCase):
     def test_cannot_accept_invite_pending_invite__2fa_required(self):
         om = self.get_om_and_init_invite()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.get(id=om.id)
         assert om.user_id is None
         assert om.email == "newuser@example.com"
@@ -428,7 +431,7 @@ class AcceptOrganizationInviteTest(APITestCase):
         self.create_existing_om()
         self.setup_u2f(om)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             assert not OrganizationMember.objects.filter(id=om.id).exists()
 
         log.info.assert_called_once_with(
@@ -443,12 +446,12 @@ class AcceptOrganizationInviteTest(APITestCase):
 
         # Mutate the OrganizationMember, putting it out of sync with the
         # pending member cookie.
-        with exempt_from_silo_limits(), in_test_psql_role_override("postgres"):
+        with assume_test_silo_mode(SiloMode.REGION), in_test_psql_role_override("postgres"):
             om.update(id=om.id + 1)
 
         self.setup_u2f(om)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.get(id=om.id)
         assert om.user_id is None
         assert om.email == "newuser@example.com"
@@ -463,12 +466,12 @@ class AcceptOrganizationInviteTest(APITestCase):
 
         # Mutate the OrganizationMember, putting it out of sync with the
         # pending member cookie.
-        with exempt_from_silo_limits(), in_test_psql_role_override("postgres"):
+        with assume_test_silo_mode(SiloMode.REGION), in_test_psql_role_override("postgres"):
             om.update(token="123")
 
         self.setup_u2f(om)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.get(id=om.id)
         assert om.user_id is None
         assert om.email == "newuser@example.com"

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -15,9 +15,10 @@ from sentry.models import (
     UserOption,
 )
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.cases import PerformanceIssueTestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
 
 
@@ -249,7 +250,7 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
         for default_value, project_value, is_subscribed, has_details in combinations:
             UserOption.objects.clear_local_cache()
 
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 for provider in [ExternalProviders.EMAIL, ExternalProviders.SLACK]:
                     NotificationSetting.objects.update_settings(
                         provider,
@@ -283,7 +284,7 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
             user_id=user.id, group=group, project=group.project, is_active=True
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.WORKFLOW,
@@ -310,7 +311,7 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
             user_id=user.id, group=group, project=group.project, is_active=True
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.WORKFLOW,

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -20,7 +20,7 @@ from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import with_feature
-from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits, no_silo_test
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, no_silo_test
 
 
 def silo_from_user(
@@ -64,15 +64,15 @@ class AccessFactoryTestCase(TestCase):
             return access.from_request(*args, **kwds)
         return silo_from_request(*args, **kwds)
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def create_api_key(self, organization: Organization, **kwds):
         return ApiKey.objects.create(organization_id=organization.id, **kwds)
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def create_auth_provider(self, organization: Organization, **kwds):
         return AuthProvider.objects.create(organization_id=organization.id, **kwds)
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def create_auth_identity(self, auth_provider: AuthProvider, user: User, **kwds):
         return AuthIdentity.objects.create(auth_provider=auth_provider, user=user, **kwds)
 
@@ -416,7 +416,7 @@ class FromUserTest(AccessFactoryTestCase):
 
     def test_superuser_permissions(self):
         user = self.create_user(is_superuser=True)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             UserPermission.objects.create(user=user, permission="test.permission")
 
         result = self.from_user(user)
@@ -544,7 +544,7 @@ class FromRequestTest(AccessFactoryTestCase):
 
     def test_member_role_in_organization_closed_membership(self):
         # disable default allow_joinleave
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.org.update(flags=0)
         member_user = self.create_user(is_superuser=False)
         self.create_member(
@@ -568,7 +568,7 @@ class FromRequestTest(AccessFactoryTestCase):
         assert not result.has_project_access(self.project2)
 
     def test_member_role_in_organization_open_membership(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.org.flags.allow_joinleave = True
             self.org.save()
         member_user = self.create_user(is_superuser=False)
@@ -745,7 +745,7 @@ class FromSentryAppTest(AccessFactoryTestCase):
 
     def test_has_app_scopes(self):
         app_with_scopes = self.create_sentry_app(name="ScopeyTheApp", organization=self.org)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             app_with_scopes.update(scope_list=["team:read", "team:write"])
         self.create_sentry_app_installation(
             organization=self.org, slug=app_with_scopes.slug, user=self.user

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -544,7 +544,7 @@ class FromRequestTest(AccessFactoryTestCase):
 
     def test_member_role_in_organization_closed_membership(self):
         # disable default allow_joinleave
-        with assume_test_silo_mode(SiloMode.CONTROL):
+        with assume_test_silo_mode(SiloMode.REGION):
             self.org.update(flags=0)
         member_user = self.create_user(is_superuser=False)
         self.create_member(
@@ -568,7 +568,7 @@ class FromRequestTest(AccessFactoryTestCase):
         assert not result.has_project_access(self.project2)
 
     def test_member_role_in_organization_open_membership(self):
-        with assume_test_silo_mode(SiloMode.CONTROL):
+        with assume_test_silo_mode(SiloMode.REGION):
             self.org.flags.allow_joinleave = True
             self.org.save()
         member_user = self.create_user(is_superuser=False)

--- a/tests/sentry/auth/test_idpmigration.py
+++ b/tests/sentry/auth/test_idpmigration.py
@@ -4,8 +4,9 @@ from django.urls import reverse
 
 import sentry.auth.idpmigration as idpmigration
 from sentry.models import AuthProvider, OrganizationMember
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -22,7 +23,7 @@ class IDPMigrationTests(TestCase):
     IDENTITY_ID = "drgUQCLzOyfHxmTyVs0G"
 
     def test_send_one_time_account_confirm_link(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.create(organization=self.org, user_id=self.user.id)
         link = idpmigration.send_one_time_account_confirm_link(
             self.user, self.org, self.provider, self.email, self.IDENTITY_ID

--- a/tests/sentry/deletions/test_release.py
+++ b/tests/sentry/deletions/test_release.py
@@ -7,12 +7,13 @@ from sentry.models import (
     ReleaseFile,
     ScheduledDeletion,
 )
+from sentry.silo import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.tasks.deletion.scheduled import run_deletion
 from sentry.testutils import TransactionTestCase
 from sentry.testutils.helpers import TaskRunner
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode
 
 
 class DeleteReleaseTest(TransactionTestCase):
@@ -50,7 +51,7 @@ class DeleteReleaseTest(TransactionTestCase):
         assert release1.owner_id
         assert release2.owner_id
 
-        with exempt_from_silo_limits(), outbox_runner():
+        with assume_test_silo_mode(SiloMode.CONTROL), outbox_runner():
             self.user.delete()
 
         with TaskRunner():

--- a/tests/sentry/hybrid_cloud/test_auth.py
+++ b/tests/sentry/hybrid_cloud/test_auth.py
@@ -5,9 +5,10 @@ from sentry.services.hybrid_cloud.auth import (
     RpcOrganizationAuthConfig,
     auth_service,
 )
+from sentry.silo import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.hybrid_cloud import use_real_service
-from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 from sentry.utils.pytest.fixtures import django_db_all
 
 
@@ -19,7 +20,7 @@ def test_get_org_auth_config():
     org_without_api_keys = Factories.create_organization()
     Factories.create_organization()  # unrelated, not in the results.
 
-    with exempt_from_silo_limits():
+    with assume_test_silo_mode(SiloMode.CONTROL):
         ApiKey.objects.create(organization_id=org_with_many_api_keys.id)
         ApiKey.objects.create(organization_id=org_with_many_api_keys.id)
         ap = AuthProvider.objects.create(

--- a/tests/sentry/hybrid_cloud/test_hook_service.py
+++ b/tests/sentry/hybrid_cloud/test_hook_service.py
@@ -2,8 +2,9 @@ from sentry.models import ServiceHook
 from sentry.sentry_apps import expand_events
 from sentry.sentry_apps.apps import consolidate_events
 from sentry.services.hybrid_cloud.hook import hook_service
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 
 
 @all_silo_test(stable=True)
@@ -28,7 +29,7 @@ class TestHookService(TestCase):
     def test_creates_service_hook(self):
         self.call_create_hook()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             service_hook = ServiceHook.objects.get(
                 application_id=self.sentry_app.application_id,
                 actor_id=self.sentry_app.proxy_user.id,

--- a/tests/sentry/hybrid_cloud/test_integration.py
+++ b/tests/sentry/hybrid_cloud/test_integration.py
@@ -18,12 +18,15 @@ from sentry.services.hybrid_cloud.integration.serial import (
     serialize_integration,
     serialize_organization_integration,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 
 
 class BaseIntegrationServiceTest(TestCase):
-    @exempt_from_silo_limits()
+    # TODO(hybrid-cloud): Refactor this to use individual assume_test_silos
+    #  for each colocated model init.
+    @assume_test_silo_mode(SiloMode.MONOLITH)
     def setUp(self):
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
@@ -243,7 +246,7 @@ class OrganizationIntegrationServiceTest(BaseIntegrationServiceTest):
 
     def test_get_organization_context(self):
         new_org = self.create_organization()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             org_integration = self.integration3.add_organization(new_org)
 
         result_integration, result_org_integration = integration_service.get_organization_context(

--- a/tests/sentry/hybrid_cloud/test_log.py
+++ b/tests/sentry/hybrid_cloud/test_log.py
@@ -1,7 +1,8 @@
 from sentry.models import AuditLogEntry, OutboxScope, RegionOutbox, UserIP
 from sentry.services.hybrid_cloud.log import AuditLogEvent, UserIpEvent, log_service
+from sentry.silo import SiloMode
 from sentry.testutils.factories import Factories
-from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 from sentry.utils.pytest.fixtures import django_db_all
 
 
@@ -21,7 +22,7 @@ def test_audit_log_event():
         )
     )
 
-    with exempt_from_silo_limits():
+    with assume_test_silo_mode(SiloMode.REGION):
         RegionOutbox.for_shard(
             shard_scope=OutboxScope.AUDIT_LOG_SCOPE, shard_identifier=organization.id
         ).drain_shard()
@@ -48,7 +49,7 @@ def test_user_ip_event():
         )
     )
 
-    with exempt_from_silo_limits():
+    with assume_test_silo_mode(SiloMode.REGION):
         RegionOutbox.for_shard(
             shard_scope=OutboxScope.USER_IP_SCOPE, shard_identifier=user.id
         ).drain_shard()

--- a/tests/sentry/hybrid_cloud/test_organizationmapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmapping.py
@@ -8,15 +8,16 @@ from sentry.services.hybrid_cloud.organization_mapping import (
     RpcOrganizationMappingUpdate,
     organization_mapping_service,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import TransactionTestCase
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test(stable=True)
 class OrganizationMappingTest(TransactionTestCase):
     def test_create_on_organization_save(self):
-        with outbox_context(flush=False), exempt_from_silo_limits():
+        with outbox_context(flush=False), assume_test_silo_mode(SiloMode.REGION):
             organization = self.create_organization(
                 name="test name",
             )
@@ -61,7 +62,7 @@ class OrganizationMappingTest(TransactionTestCase):
         assert new_org_mapping.status == self.organization.status
 
     def test_upsert__update_if_found(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             self.organization = self.create_organization(
                 name="test name",
                 slug="foobar",

--- a/tests/sentry/hybrid_cloud/test_region.py
+++ b/tests/sentry/hybrid_cloud/test_region.py
@@ -11,9 +11,10 @@ from sentry.services.hybrid_cloud.region import (
     UnimplementedRegionResolution,
 )
 from sentry.services.hybrid_cloud.rpc import RpcServiceUnimplementedException
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.region import override_regions
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.types.region import Region, RegionCategory
 
 
@@ -55,7 +56,7 @@ class RegionResolutionTest(TestCase):
     def test_by_organization_id_attribute(self):
         with override_regions(self.regions):
             region_resolution = ByOrganizationIdAttribute("organization_member")
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.REGION):
                 org_member = OrganizationMember.objects.create(
                     organization_id=self.organization.id,
                     user_id=self.user.id,

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -6,8 +6,9 @@ from freezegun import freeze_time
 from sentry.incidents.action_handlers import MsTeamsActionHandler
 from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus
 from sentry.models import Integration
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
 from . import FireTest
@@ -18,7 +19,7 @@ from . import FireTest
 class MsTeamsActionHandlerTest(FireTest, TestCase):
     @responses.activate
     def setUp(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="msteams",
                 name="Galactic Empire",

--- a/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
@@ -1,8 +1,9 @@
 from functools import cached_property
 
 from sentry.incidents.models import IncidentActivity, IncidentActivityType
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -95,7 +96,7 @@ class OrganizationIncidentCommentUpdateEndpointTest(BaseIncidentCommentDetailsTe
 
     def test_superuser_can_edit(self):
         self.user.is_superuser = True
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.user.save()
 
         edited_comment = "this comment has been edited"
@@ -135,7 +136,7 @@ class OrganizationIncidentCommentDeleteEndpointTest(BaseIncidentCommentDetailsTe
 
     def test_superuser_can_delete(self):
         self.user.is_superuser = True
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.user.save()
 
         with self.feature("organizations:incidents"):

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -4,8 +4,9 @@ from freezegun import freeze_time
 
 from sentry.api.serializers import serialize
 from sentry.incidents.models import Incident, IncidentActivity, IncidentStatus
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 class BaseIncidentDetailsTest:
@@ -50,7 +51,7 @@ class OrganizationIncidentDetailsTest(BaseIncidentDetailsTest, APITestCase):
 
         expected = serialize(incident)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             user_data = serialize(self.user)
         seen_by = [user_data]
 

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -11,8 +11,9 @@ from sentry.models import Integration, OrganizationIntegration, ProjectKey
 from sentry.pipeline import PipelineView
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
+from sentry.silo import SiloMode
 from sentry.testutils import IntegrationTestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 arn = (
     "arn:aws:cloudformation:us-east-2:599817902985:stack/"
@@ -36,7 +37,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
     def test_project_select(self, mock_react_view):
         resp = self.client.get(self.setup_path)
         assert resp.status_code == 200
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             serialized_projects = serialize([self.projectA, self.projectB])
         mock_react_view.assert_called_with(
             ANY, "awsLambdaProjectSelect", {"projects": serialized_projects}
@@ -44,7 +45,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
 
     @patch.object(PipelineView, "render_react_view", return_value=HttpResponse())
     def test_one_project(self, mock_react_view):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.MONOLITH):
             self.projectB.delete()
         resp = self.client.get(self.setup_path)
         assert resp.status_code == 200
@@ -179,7 +180,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
             "project_id": self.projectA.id,
         }
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             sentry_project_dsn = ProjectKey.get_default(project=self.projectA).get_dsn(public=True)
 
         # TODO: pass in lambdaA=false
@@ -247,7 +248,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
             "project_id": self.projectA.id,
         }
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             sentry_project_dsn = ProjectKey.get_default(project=self.projectA).get_dsn(public=True)
 
         resp = self.client.post(

--- a/tests/sentry/integrations/bitbucket_server/test_repository.py
+++ b/tests/sentry/integrations/bitbucket_server/test_repository.py
@@ -19,8 +19,9 @@ from fixtures.bitbucket_server import (
 from sentry.integrations.bitbucket_server.repository import BitbucketServerRepositoryProvider
 from sentry.models import Identity, IdentityProvider, IdentityStatus, Integration, Repository
 from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test(stable=True)
@@ -62,7 +63,7 @@ class BitbucketServerRepositoryProviderTest(APITestCase):
 
     @responses.activate
     def test_compare_commits(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.MONOLITH):
             repo = Repository.objects.create(
                 provider="bitbucket_server",
                 name="sentryuser/newsdiffs",
@@ -109,7 +110,7 @@ class BitbucketServerRepositoryProviderTest(APITestCase):
 
     @responses.activate
     def test_compare_commits_with_two_pages(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.MONOLITH):
             repo = Repository.objects.create(
                 provider="bitbucket_server",
                 name="sentryuser/newsdiffs",
@@ -239,7 +240,7 @@ class BitbucketServerRepositoryProviderTest(APITestCase):
         }
 
     def test_repository_external_slug(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.MONOLITH):
             repo = Repository.objects.create(
                 provider="bitbucket_server",
                 name="sentryuser/newsdiffs",

--- a/tests/sentry/integrations/custom_scm/test_integration.py
+++ b/tests/sentry/integrations/custom_scm/test_integration.py
@@ -1,7 +1,8 @@
 from sentry.integrations.custom_scm import CustomSCMIntegrationProvider
 from sentry.models import Integration, OrganizationIntegration, Repository
+from sentry.silo import SiloMode
 from sentry.testutils import IntegrationTestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test(stable=True)
@@ -40,7 +41,7 @@ class CustomSCMIntegrationTest(IntegrationTestCase):
         Test that only repositories without both an integration and a provider
         are valid to be added.
         """
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             unknown_repo = Repository.objects.create(
                 name="my-org/some-repo", organization_id=self.organization.id
             )

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -9,9 +9,10 @@ from fixtures.github import COMPARE_COMMITS_EXAMPLE, GET_COMMIT_EXAMPLE, GET_LAS
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.models import Integration, PullRequest, Repository
 from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.asserts import assert_commit_shape
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -44,7 +45,7 @@ class GitHubAppsProviderTest(TestCase):
     def repository(self):
         # TODO: Refactor this out with a call to the relevant factory if possible to avoid
         # explicitly having to exempt it from silo limits
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             return Repository.objects.create(
                 name="getsentry/example-repo",
                 provider="integrations:github",

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -12,8 +12,9 @@ from fixtures.github import (
 )
 from sentry import options
 from sentry.models import Commit, CommitAuthor, GroupLink, Integration, PullRequest, Repository
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -86,7 +87,7 @@ class PushEventWebhookTest(APITestCase):
         )
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 external_id="12345",
                 provider="github",
@@ -143,7 +144,7 @@ class PushEventWebhookTest(APITestCase):
         options.set("github-app.webhook-secret", secret)
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="github",
                 external_id="12345",
@@ -221,7 +222,7 @@ class PushEventWebhookTest(APITestCase):
         )
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 external_id="12345",
                 provider="github",
@@ -240,7 +241,7 @@ class PushEventWebhookTest(APITestCase):
         )
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 external_id="99",
                 provider="github",
@@ -285,7 +286,7 @@ class PullRequestEventWebhook(APITestCase):
         options.set("github-app.webhook-secret", secret)
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="github",
                 external_id="12345",
@@ -339,7 +340,7 @@ class PullRequestEventWebhook(APITestCase):
         options.set("github-app.webhook-secret", secret)
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="github",
                 external_id="12345",
@@ -389,7 +390,7 @@ class PullRequestEventWebhook(APITestCase):
         options.set("github-app.webhook-secret", secret)
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="github",
                 external_id="12345",

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -12,8 +12,9 @@ from fixtures.github_enterprise import (
     PUSH_EVENT_EXAMPLE_INSTALLATION,
 )
 from sentry.models import Commit, CommitAuthor, Integration, PullRequest, Repository
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -192,7 +193,7 @@ class PushEventWebhookTest(APITestCase):
             "verify_ssl": True,
         }
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="github_enterprise",
                 external_id="35.232.149.196:12345",
@@ -358,7 +359,7 @@ class PullRequestEventWebhook(APITestCase):
             "verify_ssl": True,
         }
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="github_enterprise",
                 external_id="35.232.149.196:234",
@@ -416,7 +417,7 @@ class PullRequestEventWebhook(APITestCase):
             "verify_ssl": True,
         }
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="github_enterprise",
                 external_id="35.232.149.196:234",
@@ -472,7 +473,7 @@ class PullRequestEventWebhook(APITestCase):
             "verify_ssl": True,
         }
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.create(
                 provider="github_enterprise",
                 external_id="35.232.149.196:234",

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -19,7 +19,7 @@ from sentry.models import (
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils import IntegrationTestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -213,7 +213,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         external_id = 4
         integration = Integration.objects.get(provider=self.provider.key)
         instance = integration.metadata["instance"]
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             repo = Repository.objects.create(
                 organization_id=self.organization.id,
                 name="Get Sentry / Example Repo",
@@ -244,7 +244,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         external_id = 4
         integration = Integration.objects.get(provider=self.provider.key)
         instance = integration.metadata["instance"]
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             repo = Repository.objects.create(
                 organization_id=self.organization.id,
                 name="Get Sentry / Example Repo",
@@ -273,7 +273,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         external_id = 4
         integration = Integration.objects.get(provider=self.provider.key)
         instance = integration.metadata["instance"]
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             repo = Repository.objects.create(
                 organization_id=self.organization.id,
                 name="Get Sentry / Example Repo",
@@ -315,7 +315,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         external_id = 4
         integration = Integration.objects.get(provider=self.provider.key)
         instance = integration.metadata["instance"]
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             repo = Repository.objects.create(
                 organization_id=self.organization.id,
                 name="Get Sentry / Example Repo",
@@ -350,7 +350,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         external_id = 4
         integration = Integration.objects.get(provider=self.provider.key)
         instance = integration.metadata["instance"]
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             repo = Repository.objects.create(
                 organization_id=self.organization.id,
                 name="Get Sentry / Example Repo",

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -7,9 +7,10 @@ from fixtures.gitlab import COMMIT_DIFF_RESPONSE, COMMIT_LIST_RESPONSE, COMPARE_
 from sentry.integrations.gitlab.repository import GitlabRepositoryProvider
 from sentry.models import Identity, IdentityProvider, Integration, PullRequest, Repository
 from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.silo import SiloMode
 from sentry.testutils import IntegrationRepositoryTestCase
 from sentry.testutils.asserts import assert_commit_shape
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -69,7 +70,7 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
             json={"id": 99},
         )
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.REGION)
     def get_repository(self, **kwargs) -> Repository:
         return Repository.objects.get(**kwargs)
 

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -20,9 +20,10 @@ from sentry.models import (
     OrganizationIntegration,
 )
 from sentry.models.activity import Activity, ActivityIntegration
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
 from sentry.testutils.asserts import assert_mock_called_once_with_partial
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
 
@@ -180,7 +181,7 @@ class StatusActionTest(APITestCase):
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
     def test_ignore_issue_with_additional_user_auth(self, verify):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             auth_idp = AuthProvider.objects.create(organization_id=self.org.id, provider="nobody")
             AuthIdentity.objects.create(auth_provider=auth_idp, user=self.user)
 
@@ -269,7 +270,7 @@ class StatusActionTest(APITestCase):
     def test_assign_to_me_multiple_identities(self, verify):
         org2 = self.create_organization(owner=None)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             integration2 = Integration.objects.create(
                 provider="msteams",
                 name="Army of Mordor",
@@ -321,10 +322,7 @@ class StatusActionTest(APITestCase):
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
     def test_unassign_issue(self, verify):
-        with exempt_from_silo_limits():
-            GroupAssignee.objects.create(
-                group=self.group1, project=self.project1, user_id=self.user.id
-            )
+        GroupAssignee.objects.create(group=self.group1, project=self.project1, user_id=self.user.id)
         resp = self.post_webhook(action_type=ACTION_TYPE.UNASSIGN, resolve_input="resolved")
         self.group1 = Group.objects.get(id=self.group1.id)
 
@@ -348,7 +346,7 @@ class StatusActionTest(APITestCase):
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
     def test_no_integration(self, verify):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.delete()
         resp = self.post_webhook()
         assert resp.status_code == 404

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -16,9 +16,10 @@ from sentry.models import (
     Team,
 )
 from sentry.notifications.types import NotificationScopeType
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import add_identity, get_response_text, install_slack, link_team
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 
@@ -125,7 +126,7 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
             in get_response_text(data)
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             team_settings = NotificationSetting.objects.filter(
                 scope_type=NotificationScopeType.TEAM.value, team_id=self.team.id
             )
@@ -163,7 +164,7 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
         # Create another organization and team for this user that is linked through `self.integration`.
         organization2 = self.create_organization(owner=self.user)
         team2 = self.create_team(organization=organization2, members=[self.user])
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             OrganizationIntegration.objects.create(
                 organization_id=organization2.id, integration=self.integration
             )
@@ -213,7 +214,7 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
             in get_response_text(data)
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             team_settings = NotificationSetting.objects.filter(
                 scope_type=NotificationScopeType.TEAM.value, team_id=self.team.id
             )
@@ -256,7 +257,7 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
             in get_response_text(data)
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             team_settings = NotificationSetting.objects.filter(
                 scope_type=NotificationScopeType.TEAM.value, team_id=self.team.id
             )
@@ -267,7 +268,7 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
         # Create another organization and team for this user that is linked through `self.integration`.
         organization2 = self.create_organization(owner=self.user)
         team2 = self.create_team(organization=organization2, members=[self.user])
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             OrganizationIntegration.objects.create(
                 organization_id=organization2.id, integration=self.integration
             )

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -21,8 +21,9 @@ from sentry.models import (
     Release,
 )
 from sentry.models.activity import Activity, ActivityIntegration
+from sentry.silo import SiloMode
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
@@ -145,7 +146,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         """
         Ensure that we can act as a user even when the organization has SSO enabled
         """
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             auth_idp = AuthProvider.objects.create(
                 organization_id=self.organization.id, provider="dummy"
             )
@@ -497,7 +498,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         "sentry.integrations.slack.requests.SlackRequest._check_signing_secret", return_value=True
     )
     def test_no_integration(self, check_signing_secret_mock):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.delete()
         resp = self.post_webhook()
         assert resp.status_code == 403
@@ -658,7 +659,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         )
 
     def test_identity_not_linked(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             Identity.objects.filter(user=self.user).delete()
         resp = self.post_webhook(action_data=[{"value": "approve_member"}], callback_id="")
 

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -18,7 +18,7 @@ from sentry.signals import receivers_raise_on_send
 from sentry.silo.base import SiloMode
 from sentry.testutils import IntegrationTestCase
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 class ExamplePlugin(IssuePlugin2):
@@ -413,7 +413,7 @@ class FinishPipelineTestCase(IntegrationTestCase):
 
     @patch("sentry.mediators.plugins.Migrator.call")
     def test_disabled_plugin_when_fully_migrated(self, call, *args):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             Repository.objects.create(
                 organization_id=self.organization.id,
                 name="user/repo",

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -18,8 +18,9 @@ from sentry.models import (
     SentryAppInstallationForProvider,
     SentryAppInstallationToken,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import IntegrationTestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -143,7 +144,7 @@ class VercelIntegrationTest(IntegrationTestCase):
 
         org = self.organization
         project_id = self.project.id
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             enabled_dsn = ProjectKey.get_default(
                 project=Project.objects.get(id=project_id)
             ).get_dsn(public=True)
@@ -254,7 +255,7 @@ class VercelIntegrationTest(IntegrationTestCase):
 
         org = self.organization
         project_id = self.project.id
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             enabled_dsn = ProjectKey.get_default(
                 project=Project.objects.get(id=project_id)
             ).get_dsn(public=True)
@@ -381,7 +382,7 @@ class VercelIntegrationTest(IntegrationTestCase):
         org = self.organization
         data = {"project_mappings": [[project_id, self.project_id]]}
         integration = Integration.objects.get(provider=self.provider.key)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             installation = integration.get_installation(org.id)
 
         dsn = ProjectKey.get_default(project=Project.objects.get(id=project_id))

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -22,9 +22,10 @@ from sentry.models import (
     SentryAppInstallationForProvider,
     SentryAppInstallationToken,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import override_options
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
@@ -211,7 +212,7 @@ class VercelReleasesTest(APITestCase):
             absolute_uri("/api/0/organizations/%s/releases/" % self.organization.slug),
             json={},
         )
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.MONOLITH):
             self.project.delete()
 
         with override_options({"vercel.client-secret": SECRET}):

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -14,7 +14,7 @@ from sentry.integrations.vsts.integration import VstsIntegrationProvider
 from sentry.models import Identity, IdentityProvider, Integration, Repository
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -141,7 +141,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
 
         self.assert_installation()
         integration = Integration.objects.get(provider="vsts")
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             repo = Repository.objects.create(
                 provider="visualstudio",
                 name="example",

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -14,7 +14,8 @@ from sentry.models import (
     Repository,
 )
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationProviderError
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.silo import SiloMode
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 FULL_SCOPES = ["vso.code", "vso.graph", "vso.serviceendpoint_manage", "vso.work_write"]
 LIMITED_SCOPES = ["vso.graph", "vso.serviceendpoint_manage", "vso.work_write"]
@@ -49,7 +50,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         assert metadata["domain_name"] == self.vsts_base_url
 
     def test_migrate_repositories(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             accessible_repo = Repository.objects.create(
                 organization_id=self.organization.id,
                 name=self.project_a["name"],
@@ -72,7 +73,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
             self.assert_installation()
         integration = Integration.objects.get(provider="vsts")
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             assert Repository.objects.get(id=accessible_repo.id).integration_id == integration.id
             assert Repository.objects.get(id=inaccessible_repo.id).integration_id is None
 

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -9,8 +9,9 @@ from sentry.notifications.types import (
 )
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.silo import SiloMode
 from sentry.testutils.cases import ActivityTestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.types.integrations import ExternalProviders
 
@@ -185,14 +186,15 @@ class ReleaseTestCase(ActivityTestCase):
         user6 = self.create_user()
         self.create_member(user=user6, organization=self.org, teams=[self.team])
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.DEPLOY,
                 NotificationSettingOptionValues.ALWAYS,
                 user_id=user6.id,
             )
-            release, deploy = self.another_release("b")
+
+        release, deploy = self.another_release("b")
 
         email = ReleaseActivityNotification(
             Activity(

--- a/tests/sentry/middleware/test_auth.py
+++ b/tests/sentry/middleware/test_auth.py
@@ -11,7 +11,7 @@ from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 from sentry.utils.auth import login
 
 
@@ -44,13 +44,13 @@ class AuthenticationMiddlewareTestCase(TestCase):
 
     def test_process_request_user(self):
         request = self.request
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.MONOLITH):
             assert login(request, self.user)
         with outbox_runner():
             self.middleware.process_request(request)
             # Force the user object to materialize
             request.user.id  # noqa
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             assert UserIP.objects.filter(user=self.user, ip_address="127.0.0.1").exists()
 
         assert request.user.is_authenticated
@@ -61,7 +61,7 @@ class AuthenticationMiddlewareTestCase(TestCase):
         request = self.request
         user = self.user
         user.session_nonce = "xxx"
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             user.save()
             assert login(request, user)
         self.middleware.process_request(request)
@@ -73,7 +73,7 @@ class AuthenticationMiddlewareTestCase(TestCase):
         request = self.request
         user = self.user
         user.session_nonce = "xxx"
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             user.save()
             assert login(request, user)
         del request.session["_nonce"]
@@ -84,7 +84,7 @@ class AuthenticationMiddlewareTestCase(TestCase):
         request = self.request
         user = self.user
         user.session_nonce = "xxx"
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             user.save()
             assert login(request, user)
         request.session["_nonce"] = "gtfo"
@@ -92,7 +92,7 @@ class AuthenticationMiddlewareTestCase(TestCase):
         assert request.user.is_anonymous
 
     def test_process_request_valid_authtoken(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["event:read", "org:read"])
         request = self.make_request(method="GET")
         request.META["HTTP_AUTHORIZATION"] = f"Bearer {token.token}"
@@ -109,7 +109,7 @@ class AuthenticationMiddlewareTestCase(TestCase):
         assert request.auth is None
 
     def test_process_request_valid_apikey(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             apikey = ApiKey.objects.create(
                 organization_id=self.organization.id, allowed_origins="*"
             )
@@ -141,7 +141,7 @@ class AuthenticationMiddlewareTestCase(TestCase):
         }
         request = self.request
         request.META["REMOTE_ADDR"] = "8.8.8.8"
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.MONOLITH):
             assert login(request, self.user)
 
         with outbox_runner():
@@ -151,7 +151,7 @@ class AuthenticationMiddlewareTestCase(TestCase):
         assert request.user.id == self.user.id
         assert mock_geo_by_addr.call_count == 1
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             userip = UserIP.objects.get(user=self.user)
         assert userip.ip_address == "8.8.8.8"
         assert userip.country_code == "US"

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -10,8 +10,9 @@ from sentry.notifications.types import (
 )
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
 
 
@@ -100,7 +101,7 @@ class GetParticipantsTest(TestCase):
         self.update_user_settings_always()
         self.user = user_service.get_user(self.user.id)  # Redo the serialization for diffs
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def update_user_settings_always(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -109,7 +110,7 @@ class GetParticipantsTest(TestCase):
             user_id=self.user.id,
         )
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def update_user_setting_subscribe_only(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -118,7 +119,7 @@ class GetParticipantsTest(TestCase):
             user_id=self.user.id,
         )
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def update_user_setting_never(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -127,7 +128,7 @@ class GetParticipantsTest(TestCase):
             user_id=self.user.id,
         )
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def update_project_setting_always(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -137,7 +138,7 @@ class GetParticipantsTest(TestCase):
             project=self.group.project,
         )
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def update_project_setting_subscribe_only(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -147,7 +148,7 @@ class GetParticipantsTest(TestCase):
             project=self.group.project,
         )
 
-    @exempt_from_silo_limits()
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def update_project_setting_never(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -223,7 +224,7 @@ class GetParticipantsTest(TestCase):
         self.update_project_setting_never()
         self._assert_subscribers_are()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -237,7 +238,7 @@ class GetParticipantsTest(TestCase):
         self.update_project_setting_never()
         self._assert_subscribers_are()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -259,7 +260,7 @@ class GetParticipantsTest(TestCase):
         self.update_user_setting_never()
         self._assert_subscribers_are(slack={self.user: GroupSubscriptionReason.comment})
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -275,7 +276,7 @@ class GetParticipantsTest(TestCase):
         self.update_project_setting_never()
         self._assert_subscribers_are(slack={self.user: GroupSubscriptionReason.comment})
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -295,7 +296,7 @@ class GetParticipantsTest(TestCase):
 
         self._assert_subscribers_are(email={self.user: GroupSubscriptionReason.implicit})
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.WORKFLOW,
@@ -305,7 +306,7 @@ class GetParticipantsTest(TestCase):
             )
         self._assert_subscribers_are()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -318,7 +319,7 @@ class GetParticipantsTest(TestCase):
         self.update_project_setting_never()
         self._assert_subscribers_are()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -340,7 +341,7 @@ class GetParticipantsTest(TestCase):
         )
 
         subscription.delete()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -362,7 +363,7 @@ class GetParticipantsTest(TestCase):
         )
 
         subscription.delete()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -386,7 +387,7 @@ class GetParticipantsTest(TestCase):
         )
 
         subscription.delete()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.remove_for_user(
                 self.user, NotificationSettingTypes.WORKFLOW
             )
@@ -428,7 +429,7 @@ class GetParticipantsTest(TestCase):
         # explicit participation, included by default
         self._assert_subscribers_are(group)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.WORKFLOW,
@@ -445,7 +446,7 @@ class GetParticipantsTest(TestCase):
         # implicit participation, participating only
         self._assert_subscribers_are(group)
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.WORKFLOW,

--- a/tests/sentry/models/test_integration.py
+++ b/tests/sentry/models/test_integration.py
@@ -2,10 +2,11 @@ import pytest
 from django.db import ProgrammingError, transaction
 
 from sentry.models import Integration, PagerDutyService, ProjectIntegration
+from sentry.silo import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils import TestCase
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test(stable=True)
@@ -24,7 +25,7 @@ class IntegrationTest(TestCase):
         integration = self.create_integration(org, "blahblah")
         org_int = integration.add_organization(org)
         int_id = integration.id
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             ProjectIntegration.objects.create(project=project, integration_id=integration.id)
             pds = PagerDutyService.objects.create(
                 organization_integration_id=org_int.id,
@@ -34,18 +35,18 @@ class IntegrationTest(TestCase):
                 service_name="this_is_a_service",
             )
 
-            with outbox_runner():
-                integration.delete()
+        with outbox_runner():
+            integration.delete()
 
         assert not Integration.objects.filter(id=int_id).exists()
 
         # cascade is asynchronous, ensure there is still related search,
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             assert ProjectIntegration.objects.filter(integration_id=int_id).exists()
             with self.tasks():
                 schedule_hybrid_cloud_foreign_key_jobs()
 
         # Ensure they are all now gone.
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             assert not PagerDutyService.objects.filter(id=pds.id).exists()
             assert not ProjectIntegration.objects.filter(integration_id=int_id).exists()

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -25,8 +25,9 @@ from sentry.models import (
     add_group_to_inbox,
 )
 from sentry.signals import buffer_incr_complete, receivers_raise_on_send
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 
 
@@ -165,14 +166,14 @@ class ResolvedInCommitTest(TestCase):
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.MANUAL)
         user = self.create_user(name="Foo Bar", email="foo@example.com", is_active=True)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             email = UserEmail.objects.get_primary_email(user=user)
         email.is_verified = True
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             email.save()
         repo = Repository.objects.create(name="example", organization_id=self.group.organization.id)
         OrganizationMember.objects.create(organization=group.project.organization, user_id=user.id)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             UserOption.objects.set_value(user=user, key="self_assign_issue", value="1")
 
         author = CommitAuthor.objects.create(
@@ -207,17 +208,14 @@ class ResolvedInCommitTest(TestCase):
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.MANUAL)
         user = self.create_user(name="Foo Bar", email="foo@example.com", is_active=True)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             email = UserEmail.objects.get_primary_email(user=user)
             email.is_verified = True
             email.save()
-            repo = Repository.objects.create(
-                name="example", organization_id=self.group.organization.id
-            )
-            OrganizationMember.objects.create(
-                organization=group.project.organization, user_id=user.id
-            )
             UserOption.objects.set_value(user=user, key="self_assign_issue", value="0")
+
+        repo = Repository.objects.create(name="example", organization_id=self.group.organization.id)
+        OrganizationMember.objects.create(organization=group.project.organization, user_id=user.id)
 
         commit = Commit.objects.create(
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -6,10 +6,11 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user import UserSerializer
 from sentry.constants import SentryAppInstallationStatus
 from sentry.models import Activity, Commit, GroupAssignee, GroupLink, Release, Repository
+from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 # This testcase needs to be an APITestCase because all of the logic to resolve
 # Issues and kick off side effects are just chillin in the endpoint code -_-
@@ -153,7 +154,7 @@ class TestIssueWorkflowNotifications(APITestCase):
 
     def test_notify_pending_installation(self, delay):
         self.install.status = SentryAppInstallationStatus.PENDING
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             self.install.save()
 
         self.update_issue()
@@ -188,7 +189,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
         with Feature("organizations:sentry-functions"):
             self.update_issue()
             sub_data = {"resolution_type": "now"}
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -206,7 +207,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
                 {"statusDetails": {"inCommit": {"repository": repo.name, "commit": commit.key}}}
             )
             sub_data = {"resolution_type": "in_commit"}
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -221,7 +222,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
             release = self.create_release(project=self.project)
             self.update_issue({"statusDetails": {"inRelease": release.version}})
             sub_data = {"resolution_type": "in_release"}
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -237,7 +238,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
 
             self.update_issue({"statusDetails": {"inRelease": "latest"}})
             sub_data = {"resolution_type": "in_release"}
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -254,7 +255,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
 
             sub_data = {"resolution_type": "in_next_release"}
 
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -305,7 +306,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
         with Feature("organizations:sentry-functions"):
             self.update_issue({"status": "ignored"})
             sub_data = {}
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -321,7 +322,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
         ):
             self.update_issue({"status": "ignored"})
             sub_data = {}
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 sub_data["user"] = serialize(self.user)
 
             assert delay.call_count == 2
@@ -575,7 +576,7 @@ class TestCommentsSentryFunctions(APITestCase):
                 "comment": "hello world",
                 "project_slug": self.project.slug,
             }
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -597,7 +598,7 @@ class TestCommentsSentryFunctions(APITestCase):
                 "comment": "goodbye cruel world",
                 "project_slug": self.project.slug,
             }
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,
@@ -617,7 +618,7 @@ class TestCommentsSentryFunctions(APITestCase):
                 "comment": "hello world",
                 "project_slug": self.project.slug,
             }
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 data["user"] = serialize(self.user)
             delay.assert_called_once_with(
                 self.sentryFunction.external_id,

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -4,9 +4,10 @@ import pytest
 from rest_framework import serializers
 
 from sentry.rules.actions.sentry_apps import NotifyEventSentryAppAction
+from sentry.silo import SiloMode
 from sentry.tasks.sentry_apps import notify_sentry_app
 from sentry.testutils.cases import RuleTestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 ValidationError = serializers.ValidationError
 SENTRY_APP_ALERT_ACTION = "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"
@@ -118,7 +119,7 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
         test_install = self.create_sentry_app_installation(
             organization=self.organization, slug="test-application"
         )
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             test_install.delete()
         rule = self.get_rule(
             data={"hasSchemaFormConfig": True, "sentryAppInstallationUuid": test_install.uuid}

--- a/tests/sentry/sentry_apps/test_sentry_app_component_preparer.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_component_preparer.py
@@ -3,8 +3,9 @@ from unittest.mock import call, patch
 from sentry.models import Organization
 from sentry.sentry_apps.components import SentryAppComponentPreparer
 from sentry.services.hybrid_cloud.app.serial import serialize_sentry_app_installation
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
 
@@ -20,7 +21,7 @@ class TestPreparerIssueLink(TestCase):
         self.install = self.create_sentry_app_installation(slug=self.sentry_app.slug)
 
         self.component = self.sentry_app.components.first()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             self.project = Organization.objects.get(
                 id=self.install.organization_id
             ).project_set.first()

--- a/tests/sentry/sentry_apps/test_sentry_app_installation_creator.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_installation_creator.py
@@ -6,8 +6,9 @@ from sentry import audit_log
 from sentry.constants import SentryAppInstallationStatus
 from sentry.models import ApiGrant, AuditLogEntry, ServiceHook, ServiceHookProject
 from sentry.sentry_apps import SentryAppInstallationCreator
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test(stable=True)
@@ -60,7 +61,7 @@ class TestCreator(TestCase):
         responses.add(responses.POST, "https://example.com/webhook")
         install = self.run_creator()
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             hook = ServiceHook.objects.get(organization_id=self.org.id)
 
         assert hook.application_id == self.sentry_app.application.id
@@ -69,7 +70,7 @@ class TestCreator(TestCase):
         assert hook.events == self.sentry_app.events
         assert hook.url == self.sentry_app.webhook_url
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             assert not ServiceHookProject.objects.all()
 
     @responses.activate

--- a/tests/sentry/sentry_apps/test_sentry_app_updater.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_updater.py
@@ -8,8 +8,9 @@ from sentry.coreapi import APIError
 from sentry.models import ApiToken, SentryApp, SentryAppComponent, ServiceHook
 from sentry.sentry_apps import expand_events
 from sentry.sentry_apps.apps import SentryAppUpdater
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test(stable=True)
@@ -123,7 +124,7 @@ class TestUpdater(TestCase):
         )
         updater.run(self.user)
         assert set(sentry_app.events) == expand_events(["issue"])
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             service_hook = ServiceHook.objects.filter(application_id=sentry_app.application_id)[0]
         assert set(service_hook.events) == expand_events(["issue"])
 
@@ -138,7 +139,7 @@ class TestUpdater(TestCase):
         updater = SentryAppUpdater(sentry_app=sentry_app, webhook_url="http://example.com/hooks")
         updater.run(self.user)
         assert sentry_app.webhook_url == "http://example.com/hooks"
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             service_hook = ServiceHook.objects.get(application_id=sentry_app.application_id)
         assert service_hook.url == "http://example.com/hooks"
         assert set(service_hook.events) == expand_events(["event.alert"])
@@ -194,13 +195,13 @@ class TestUpdater(TestCase):
         internal_app = self.create_internal_integration(
             name="Internal", organization=self.org, webhook_url=None, scopes=("event:read",)
         )
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             assert len(ServiceHook.objects.filter(application_id=internal_app.application_id)) == 0
         updater = SentryAppUpdater(sentry_app=internal_app)
         updater.webhook_url = "https://sentry.io/hook"
         updater.events = ("issue",)
         updater.run(self.user)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             service_hook = ServiceHook.objects.get(application_id=internal_app.application_id)
         assert service_hook.url == "https://sentry.io/hook"
         assert set(service_hook.events) == expand_events(["issue"])
@@ -210,10 +211,10 @@ class TestUpdater(TestCase):
         internal_app = self.create_internal_integration(
             name="Internal", organization=self.org, webhook_url="https://sentry.io/hook"
         )
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             assert len(ServiceHook.objects.filter(application_id=internal_app.application_id)) == 1
         updater = SentryAppUpdater(sentry_app=internal_app)
         updater.webhook_url = ""
         updater.run(self.user)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             assert len(ServiceHook.objects.filter(application_id=internal_app.application_id)) == 0

--- a/tests/sentry/tasks/test_groupowner.py
+++ b/tests/sentry/tasks/test_groupowner.py
@@ -4,13 +4,14 @@ from django.utils import timezone
 
 from sentry.models import GroupRelease, Repository
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.silo import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.tasks.groupowner import PREFERRED_GROUP_OWNER_AGE, process_suspect_commits
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import TaskRunner
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils.committers import get_frame_paths, get_serialized_event_file_committers
 
 
@@ -115,7 +116,7 @@ class TestGroupOwners(TestCase):
         )
 
         assert GroupOwner.objects.count() == 2
-        with exempt_from_silo_limits(), outbox_runner():
+        with assume_test_silo_mode(SiloMode.CONTROL), outbox_runner():
             self.user.delete()
         assert GroupOwner.objects.count() == 2
 

--- a/tests/sentry/utils/test_audit.py
+++ b/tests/sentry/utils/test_audit.py
@@ -13,7 +13,7 @@ from sentry.models import (
 from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 from sentry.utils.audit import (
     create_audit_entry,
     create_audit_entry_from_user,
@@ -39,7 +39,7 @@ class CreateAuditEntryTest(TestCase):
         self.project = self.create_project(teams=[self.team], platform="java")
 
     def assert_no_delete_log_created(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             assert not DeletedOrganization.objects.filter(slug=self.org.slug).exists()
             assert not DeletedTeam.objects.filter(slug=self.team.slug).exists()
             assert not DeletedProject.objects.filter(slug=self.project.slug).exists()
@@ -91,7 +91,7 @@ class CreateAuditEntryTest(TestCase):
         self.assert_valid_deleted_log(deleted_org, self.org)
 
     def test_audit_entry_org_restore_log(self):
-        with exempt_from_silo_limits(), in_test_psql_role_override("postgres"):
+        with assume_test_silo_mode(SiloMode.REGION), in_test_psql_role_override("postgres"):
             Organization.objects.filter(id=self.organization.id).update(
                 status=OrganizationStatus.PENDING_DELETION
             )
@@ -181,7 +181,7 @@ class CreateAuditEntryTest(TestCase):
                 event=audit_log.get_event_id("PROJECT_ADD"),
             )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             assert (
                 AuditLogEntry.objects.get(event=audit_log.get_event_id("PROJECT_ADD")).actor_label
                 == key.key

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -12,10 +12,11 @@ from sentry.auth.authenticators.totp import TotpInterface
 from sentry.auth.helper import AuthHelperSessionStore
 from sentry.auth.providers.saml2.provider import Attributes, SAML2Provider
 from sentry.models import AuditLogEntry, AuthIdentity, AuthProvider, Organization
+from sentry.silo import SiloMode
 from sentry.testutils import AuthProviderTestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 dummy_provider_config = {
     "idp": {
@@ -207,7 +208,7 @@ class AuthSAML2Test(AuthProviderTestCase):
     def test_auth_setup(self, auth_log):
         # enable require 2FA and enroll user
         TotpInterface().enroll(self.user)
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             self.org.update(flags=models.F("flags").bitor(Organization.flags.require_2fa))
         assert self.org.flags.require_2fa.is_set
 

--- a/tests/sentry/web/frontend/test_msteams_extension.py
+++ b/tests/sentry/web/frontend/test_msteams_extension.py
@@ -3,8 +3,9 @@ from unittest.mock import patch
 from django.core.signing import SignatureExpired
 
 from sentry.models import OrganizationMember
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils.signing import sign
 from sentry.web.frontend.msteams_extension_configuration import MsTeamsExtensionConfigurationView
 
@@ -14,7 +15,7 @@ class MsTeamsExtensionConfigurationTest(TestCase):
     def hit_configure(self, params):
         self.login_as(self.user)
         org = self.create_organization()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             OrganizationMember.objects.create(user_id=self.user.id, organization=org, role="admin")
         path = "/extensions/msteams/configure/"
         return self.client.get(path, params)

--- a/tests/sentry/web/frontend/test_user_avatar.py
+++ b/tests/sentry/web/frontend/test_user_avatar.py
@@ -3,8 +3,9 @@ from io import BytesIO
 from django.urls import reverse
 
 from sentry.models import File, UserAvatar
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.web.frontend.generic import FOREVER_CACHE
 
 
@@ -12,7 +13,7 @@ from sentry.web.frontend.generic import FOREVER_CACHE
 class UserAvatarTest(TestCase):
     def test_headers(self):
         user = self.create_user(email="a@example.com")
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             photo = File.objects.create(name="test.png", type="avatar.file")
             photo.putfile(BytesIO(b"test"))
         avatar = UserAvatar.objects.create(user=user, file_id=photo.id)

--- a/tests/sentry/web/frontend/test_vercel_extension_configuration.py
+++ b/tests/sentry/web/frontend/test_vercel_extension_configuration.py
@@ -6,9 +6,10 @@ from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.identity.vercel import VercelIdentityProvider
 from sentry.integrations.vercel import VercelClient
 from sentry.models import OrganizationMember
+from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import with_feature
-from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test(stable=True)
@@ -69,7 +70,7 @@ class VercelExtensionConfigurationTest(TestCase):
         assert resp.url.endswith("?next=https%3A%2F%2Fexample.com")
 
     def test_logged_in_as_member(self):
-        with in_test_psql_role_override("postgres"), exempt_from_silo_limits():
+        with in_test_psql_role_override("postgres"), assume_test_silo_mode(SiloMode.REGION):
             OrganizationMember.objects.filter(user_id=self.user.id, organization=self.org).update(
                 role="member"
             )
@@ -91,7 +92,7 @@ class VercelExtensionConfigurationTest(TestCase):
         self.login_as(self.user)
 
         org = self.create_organization()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             OrganizationMember.objects.create(user_id=self.user.id, organization=org)
 
         resp = self.client.get(self.path, self.params)
@@ -111,7 +112,7 @@ class VercelExtensionConfigurationTest(TestCase):
         self.login_as(self.user)
 
         org = self.create_organization()
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.REGION):
             OrganizationMember.objects.create(user_id=self.user.id, organization=org)
         self.params["orgSlug"] = org.slug
 

--- a/tests/sentry_plugins/github/endpoints/test_pull_request_event.py
+++ b/tests/sentry_plugins/github/endpoints/test_pull_request_event.py
@@ -1,8 +1,9 @@
 from uuid import uuid4
 
 from sentry.models import OrganizationOption, PullRequest, Repository
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry_plugins.github.testutils import (
     PULL_REQUEST_CLOSED_EVENT_EXAMPLE,
     PULL_REQUEST_EDITED_EVENT_EXAMPLE,
@@ -16,7 +17,7 @@ class PullRequestEventWebhook(APITestCase):
     def test_opened(self):
         project = self.project  # force creation
         user = self.create_user(email="alberto@sentry.io")
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             UserSocialAuth.objects.create(provider="github", user=user, uid=6752317)
         self.create_member(organization=project.organization, user=user, role="member")
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -49,11 +49,12 @@ from sentry.search.events.constants import (
     SEMVER_BUILD_ALIAS,
     SEMVER_PACKAGE_ALIAS,
 )
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import Feature, with_feature
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json
@@ -771,7 +772,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert len(response.data) == 0
 
     def test_token_auth(self):
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["event:read"])
         response = self.client.get(
             reverse("sentry-api-0-organization-group-index", args=[self.project.organization.slug]),

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -20,11 +20,12 @@ from sentry.models import (
     UserOption,
 )
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.cases import PerformanceIssueTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.performance_issues.store_transaction import PerfIssueTransactionTestMixin
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
@@ -274,7 +275,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         )
 
         for default_value, project_value, is_subscribed, has_details in combinations:
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 UserOption.objects.clear_local_cache()
 
                 NotificationSetting.objects.update_settings(
@@ -323,7 +324,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
             user_id=user.id, group=group, project=group.project, is_active=True
         )
 
-        with exempt_from_silo_limits():
+        with assume_test_silo_mode(SiloMode.CONTROL):
             for provider in [ExternalProviders.EMAIL, ExternalProviders.SLACK]:
                 NotificationSetting.objects.update_settings(
                     provider,
@@ -345,7 +346,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         )
 
         for provider in [ExternalProviders.EMAIL, ExternalProviders.SLACK]:
-            with exempt_from_silo_limits():
+            with assume_test_silo_mode(SiloMode.CONTROL):
                 NotificationSetting.objects.update_settings(
                     provider,
                     NotificationSettingTypes.WORKFLOW,


### PR DESCRIPTION
The `exempt_from_silo` decorator has a nasty habit of masking actual cross-silo accesses and concerns within our tests. Because of this, we're adopting `assume_test_silo_mode` which forces the test or fixture to adopt the given silo mode before proceeding.


