### PR TITLE
ref(hc): Add failing transaction check test case

### DIFF
--- a/tests/sentry/db/postgres/test_transactions.py
+++ b/tests/sentry/db/postgres/test_transactions.py
@@ -1,0 +1,15 @@
+from sentry.db.postgres.transactions import in_test_assert_no_transaction
+from sentry.testutils import TestCase
+from sentry.testutils.silo import control_silo_test, region_silo_test
+
+
+@control_silo_test(stable=True)
+class ControlTransactionTestCase(TestCase):
+    def test_no_transaction(self):
+        in_test_assert_no_transaction("unexpected transaction")
+
+
+@region_silo_test(stable=True)
+class RegionTransactionTestCase(TestCase):
+    def test_no_transaction(self):
+        in_test_assert_no_transaction("unexpected transaction")


### PR DESCRIPTION
```bash
$ SENTRY_FORCE_SILOED_TESTS=1 SENTRY_USE_SPLIT_DBS=1 pytest tests/sentry/db/postgres/test_transactions.py
```

ControlTransactionTestCase.test_no_transaction__in_control_silo:
```
tests/sentry/db/postgres/test_transactions.py:9: in test_no_transaction
    in_test_assert_no_transaction("unexpected transaction")
src/sentry/db/postgres/transactions.py:91: in in_test_assert_no_transaction
    assert not hybrid_cloud.simulated_transaction_watermarks.connection_above_watermark(
src/sentry/testutils/hybrid_cloud.py:151: in connection_above_watermark
    connection = transaction.get_connection(using)
src/sentry/silo/patches/silo_aware_transaction_patch.py:35: in siloed_get_connection
    using = determine_using_by_silo_mode(using)
src/sentry/silo/patches/silo_aware_transaction_patch.py:66: in determine_using_by_silo_mode
    raise MismatchedSiloTransactionError(
E   sentry.silo.patches.silo_aware_transaction_patch.MismatchedSiloTransactionError: Cannot use transaction.atomic(default) except in Region Mode
```

RegionTransactionTestCase.test_no_transaction__in_region_silo:
```
tests/sentry/db/postgres/test_transactions.py:15: in test_no_transaction
    in_test_assert_no_transaction("unexpected transaction")
src/sentry/db/postgres/transactions.py:91: in in_test_assert_no_transaction
    assert not hybrid_cloud.simulated_transaction_watermarks.connection_above_watermark(
src/sentry/testutils/hybrid_cloud.py:151: in connection_above_watermark
    connection = transaction.get_connection(using)
src/sentry/silo/patches/silo_aware_transaction_patch.py:35: in siloed_get_connection
    using = determine_using_by_silo_mode(using)
src/sentry/silo/patches/silo_aware_transaction_patch.py:61: in determine_using_by_silo_mode
    raise MismatchedSiloTransactionError(
E   sentry.silo.patches.silo_aware_transaction_patch.MismatchedSiloTransactionError: Cannot use transaction.atomic(control) except in Control Mode
```