### PR TITLE
fix(hybrid-cloud): Fix getattr

### DIFF
--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -26,7 +26,7 @@ class ApiHostError(ApiError):
 
     @classmethod
     def from_exception(cls, exception: RequestException) -> ApiHostError:
-        if getattr(exception, "request"):
+        if hasattr(exception, "request"):
             return cls.from_request(exception.request)
         return cls("Unable to reach host")
 

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -26,7 +26,7 @@ class ApiHostError(ApiError):
 
     @classmethod
     def from_exception(cls, exception: RequestException) -> ApiHostError:
-        if hasattr(exception, "request"):
+        if getattr(exception, "request", None):
             return cls.from_request(exception.request)
         return cls("Unable to reach host")
 


### PR DESCRIPTION
Fixes SENTRY-137A

Calling `getattr(exception, "request")` may raise an `Exception` if `exception` has no attribute `request`.