### PR TITLE
ref(vercel): Fix deletion from Sentry

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -309,7 +309,13 @@ class VercelIntegration(IntegrationInstallation):
 
     def uninstall(self):
         client = self.get_client()
-        client.uninstall(self.get_configuration_id())
+        try:
+            client.uninstall(self.get_configuration_id())
+        except ApiError as error:
+            if error.code == 403:
+                pass
+            else:
+                raise error
 
 
 class VercelIntegrationProvider(IntegrationProvider):

--- a/tests/sentry/integrations/vercel/test_uninstall.py
+++ b/tests/sentry/integrations/vercel/test_uninstall.py
@@ -3,7 +3,7 @@ import responses
 from fixtures.vercel import SECRET
 from sentry.constants import ObjectStatus
 from sentry.integrations.vercel import VercelClient
-from sentry.models import Integration, OrganizationIntegration
+from sentry.models import Integration, OrganizationIntegration, ScheduledDeletion
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import control_silo_test
@@ -350,6 +350,29 @@ class VercelUninstallWithConfigurationsTest(APITestCase):
         Test that if we uninstall from Sentry and fail to remove the integration using Vercel's
         delete integration endpoint, we continue and delete the integration in Sentry.
         """
+        org = self.create_organization(owner=self.user)
+        metadata = {
+            "access_token": "my_access_token",
+            "installation_id": "my_config_id",
+            "installation_type": "user",
+            "webhook_id": "my_webhook_id",
+            "configurations": {
+                "my_config_id": {
+                    "access_token": "my_access_token",
+                    "webhook_id": "my_webhook_id",
+                    "organization_id": org.id,
+                }
+            },
+        }
+        integration = Integration.objects.create(
+            provider="vercel",
+            external_id="vercel_user_id",
+            name="My Vercel Team",
+            metadata=metadata,
+        )
+        integration.add_organization(org)
+        oi = OrganizationIntegration.objects.get(integration=integration)
+
         self.login_as(self.user)
         with self.tasks():
             config_id = "my_config_id"
@@ -359,13 +382,10 @@ class VercelUninstallWithConfigurationsTest(APITestCase):
                 json={"error": {"message": "You don't have permission to access this resource."}},
                 status=403,
             )
-            path = (
-                f"/api/0/organizations/{self.organization.slug}/integrations/{self.integration.id}/"
-            )
+            path = f"/api/0/organizations/{org.slug}/integrations/{integration.id}/"
             response = self.client.delete(path, format="json")
-        assert response.status_code == 204
 
-        assert not OrganizationIntegration.objects.filter(
-            integration=self.integration, status=ObjectStatus.ACTIVE
+        assert response.status_code == 204
+        assert ScheduledDeletion.objects.filter(
+            model_name="OrganizationIntegration", object_id=oi.id
         ).exists()
-        assert not Integration.objects.filter(id=self.integration.id).exists()


### PR DESCRIPTION
If for some reason we get a 403 from Vercel when we hit their delete integration endpoint after initiating a deletion from within Sentry, we should proceed to schedule a deletion for the integration.