### PR TITLE
fix(perf): add link to transaction summary on performance change explorer

### DIFF
--- a/static/app/views/performance/trends/changeExplorer.tsx
+++ b/static/app/views/performance/trends/changeExplorer.tsx
@@ -196,7 +196,7 @@ function Header(props: HeaderProps) {
   } = props;
 
   const regression = trendChangeType === TrendChangeType.REGRESSION;
-  const next = getTransactionSummaryLink(
+  const transactionSummaryLink = getTransactionSummaryLink(
     trendView,
     transaction,
     projects,
@@ -214,18 +214,15 @@ function Header(props: HeaderProps) {
         <ChangeType regression={regression}>
           {regression ? t('Ongoing Regression') : t('Ongoing Improvement')}
         </ChangeType>
-        <div style={{display: 'flex', alignItems: 'center', marginBottom: space(3)}}>
-          <TransactionName style={{width: 'fit-content'}}>
-            {transaction.transaction}
-          </TransactionName>
-          <Button
-            style={{padding: space(0), height: 'min-content', minHeight: '0px'}}
+        <TransactionNameWrapper>
+          <TransactionName>{transaction.transaction}</TransactionName>
+          <ViewTransactionButton
             borderless
-            to={normalizeUrl(next)}
+            to={normalizeUrl(transactionSummaryLink)}
             icon={<IconOpen />}
             aria-label={t('View transaction summary')}
           />
-        </div>
+        </TransactionNameWrapper>
       </HeaderTextWrapper>
     </HeaderWrapper>
   );
@@ -289,6 +286,20 @@ const TransactionName = styled('h4')`
   margin-bottom: ${space(0)};
   ${p => p.theme.overflowEllipsis};
 `;
+
+const TransactionNameWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  margin-bottom: ${space(3)};
+  width: fit-content;
+`;
+
+const ViewTransactionButton = styled(Button)`
+  padding: ${space(0)};
+  height: min-content;
+  min-height: 0px;
+`;
+
 const InfoLabel = styled('strong')`
   color: ${p => p.theme.gray300};
 `;

--- a/static/app/views/performance/trends/changeExplorer.tsx
+++ b/static/app/views/performance/trends/changeExplorer.tsx
@@ -1,9 +1,9 @@
 import {Fragment} from 'react';
-import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 import moment from 'moment';
 
+import {Button} from 'sentry/components/button';
 import {getArbitraryRelativePeriod} from 'sentry/components/organizations/timeRangeSelector/utils';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {IconFire, IconOpen} from 'sentry/icons';
@@ -215,12 +215,15 @@ function Header(props: HeaderProps) {
           {regression ? t('Ongoing Regression') : t('Ongoing Improvement')}
         </ChangeType>
         <div style={{display: 'flex', alignItems: 'center', marginBottom: space(3)}}>
-          <TransactionName>{transaction.transaction}</TransactionName>
-          <IconOpen
-            onClick={e => {
-              e.stopPropagation();
-              browserHistory.push(normalizeUrl(next));
-            }}
+          <TransactionName style={{width: 'fit-content'}}>
+            {transaction.transaction}
+          </TransactionName>
+          <Button
+            style={{padding: space(0), height: 'min-content', minHeight: '0px'}}
+            borderless
+            to={normalizeUrl(next)}
+            icon={<IconOpen />}
+            aria-label={t('View transaction summary')}
           />
         </div>
       </HeaderTextWrapper>


### PR DESCRIPTION
Addressing the feedback that @udameli and @narsaynorath gave about having a link to the transaction summary from the performance change explorer. This adds a link at the bottom of the performance change explorer which directs users to the transaction summary with the trends graph displayed.

<img width="500" alt="Screenshot 2023-07-12 at 12 11 35 PM" src="https://github.com/getsentry/sentry/assets/72356613/cda93aea-e651-4b3c-96b0-8528b8757ebc">


EDIT: linked to transaction summary through open icon in header instead
<img width="500" alt="image" src="https://github.com/getsentry/sentry/assets/72356613/6e7d9d39-6ed7-4768-af33-0e3fc1f9832f">

