### PR TITLE
fix(starfish): App crash if data not loaded

### DIFF
--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -109,7 +109,7 @@ export default function SpansTable({
     <Fragment>
       <VisuallyCompleteWithData
         id="SpansTable"
-        hasData={data.length > 0}
+        hasData={data?.length > 0}
         isLoading={isLoading}
         disabled={shouldTrackVCD}
       >


### PR DESCRIPTION
Fixes an occasional crash in Starfish that was caused by not using optional chaining on `data` in the VCD component 

![image](https://github.com/getsentry/sentry/assets/16740047/763bd2ae-f971-4680-8cea-048737c9b953)
