### PR TITLE
ref(rule): Allow migration to be re-run

### DIFF
--- a/src/sentry/migrations/0507_delete_pending_deletion_rules.py
+++ b/src/sentry/migrations/0507_delete_pending_deletion_rules.py
@@ -24,12 +24,12 @@ def schedule(cls, instance, days=30):
     model = type(instance)
     model_name = model.__name__
     cls.objects.update_or_create(
+        app_label=instance._meta.app_label,
+        model_name=model_name,
         object_id=instance.pk,
-        data={},
-        actor_id=None,
         defaults={
-            "app_label": instance._meta.app_label,
-            "model_name": model_name,
+            "actor_id": None,
+            "data": {},
             "date_scheduled": timezone.now() + timedelta(days=days, hours=0),
         },
     )

--- a/src/sentry/migrations/0507_delete_pending_deletion_rules.py
+++ b/src/sentry/migrations/0507_delete_pending_deletion_rules.py
@@ -24,12 +24,14 @@ def schedule(cls, instance, days=30):
     model = type(instance)
     model_name = model.__name__
     cls.objects.update_or_create(
-        app_label=instance._meta.app_label,
-        model_name=model_name,
         object_id=instance.pk,
-        date_scheduled=timezone.now() + timedelta(days=days, hours=0),
         data={},
         actor_id=None,
+        defaults={
+            "app_label": instance._meta.app_label,
+            "model_name": model_name,
+            "date_scheduled": timezone.now() + timedelta(days=days, hours=0),
+        },
     )
 
 


### PR DESCRIPTION
Use `defaults` so we can re-run the migration since it got killed.