### PR TITLE
fix(helpful-event): fix filtering on release.version query for helpful event

### DIFF
--- a/src/sentry/api/endpoints/group_event_details.py
+++ b/src/sentry/api/endpoints/group_event_details.py
@@ -50,9 +50,9 @@ def issue_search_query_to_conditions(
 
             if search_filter.key.name not in GroupSerializerSnuba.skip_snuba_fields:
                 filter_keys = {
-                    "organization_id": [group.project.organization.id],
+                    "organization_id": group.project.organization.id,
                     "project_id": [group.project.id],
-                    "environment_id": [env.id for env in environments],
+                    "environment": [env.name for env in environments],
                 }
                 legacy_condition, projects_to_filter, group_ids = format_search_filter(
                     search_filter, params=filter_keys
@@ -64,7 +64,8 @@ def issue_search_query_to_conditions(
                     new_condition = legacy_condition[0]
                 elif group_ids:
                     new_condition = convert_search_filter_to_snuba_query(
-                        search_filter, params=filter_keys
+                        search_filter,
+                        params=filter_keys,
                     )
 
                 if new_condition:


### PR DESCRIPTION
The bug was caused by us incorrectly passing in a list of organization IDs instead of a single organization_id. Also noticed we're incorrectly passing in `environment_id` instead of the correct `environment` filter key params, so went ahead and fixed that as well.

Resolves SENTRY-137B, SENTRY-1375