### PR TITLE
chore(hybridcloud) Add query auditing utilities incrementally

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3608,3 +3608,6 @@ DEVSERVER_START_KAFKA_CONSUMERS: MutableSequence[str] = []
 # If set to True, buffer.incr will be spawned as background celery task. If false it's a direct call
 # to the buffer service.
 SENTRY_BUFFER_INCR_AS_CELERY_TASK = False
+
+# Feature flag to turn off role-swapping to help bridge getsentry transition.
+USE_ROLE_SWAPPING_IN_TESTS = True

--- a/src/sentry/testutils/asserts.py
+++ b/src/sentry/testutils/asserts.py
@@ -1,7 +1,5 @@
 from typing import Optional
 
-from sentry.models import AuditLogEntry, CommitFileChange
-
 
 def assert_mock_called_once_with_partial(mock, *args, **kwargs):
     """
@@ -16,10 +14,11 @@ def assert_mock_called_once_with_partial(mock, *args, **kwargs):
         assert m_kwargs[kwarg] == kwargs[kwarg], (m_kwargs[kwarg], kwargs[kwarg])
 
 
-commit_file_type_choices = {c[0] for c in CommitFileChange._meta.get_field("type").choices}
-
-
 def assert_commit_shape(commit):
+    from sentry.models import CommitFileChange
+
+    commit_file_type_choices = {c[0] for c in CommitFileChange._meta.get_field("type").choices}
+
     assert commit["id"]
     assert commit["repository"]
     assert commit["author_email"]
@@ -40,6 +39,8 @@ def assert_status_code(response, minimum: int, maximum: Optional[int] = None):
 
 
 def org_audit_log_exists(**kwargs):
+    from sentry.models import AuditLogEntry
+
     assert kwargs
     if "organization" in kwargs:
         kwargs["organization_id"] = kwargs.pop("organization").id
@@ -55,4 +56,6 @@ def assert_org_audit_log_does_not_exist(**kwargs):
 
 
 def delete_all_org_audit_logs():
+    from sentry.models import AuditLogEntry
+
     return AuditLogEntry.objects.all().delete()

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import functools
 import inspect
 import re
 import sys
+from collections import defaultdict
 from contextlib import contextmanager
 from typing import (
     Any,
@@ -34,6 +36,7 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 from sentry.deletions.base import BaseDeletionTask
 from sentry.models import Actor, NotificationSetting
 from sentry.silo import SiloMode
+from sentry.silo.patches.silo_aware_transaction_patch import determine_using_by_silo_mode
 from sentry.testutils.region import override_regions
 from sentry.types.region import Region, RegionCategory
 from sentry.utils.snowflake import SnowflakeIdMixin
@@ -267,7 +270,7 @@ _role_privileges_created: MutableMapping[str, bool] = {}
 
 def create_model_role_guards(app_config: Any, using: str, **kwargs: Any):
     global _role_created
-    if "pytest" not in sys.argv[0]:
+    if "pytest" not in sys.argv[0] or not settings.USE_ROLE_SWAPPING_IN_TESTS:
         return
 
     from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
@@ -338,6 +341,35 @@ def restrict_role(role: str, model: Any, revocation_type: str, using: str = "def
         connection.execute(f"REVOKE {revocation_type} ON public.{model._meta.db_table} FROM {role}")
 
 
+fence_re = re.compile(r"select\s*\'(?P<operation>start|end)_role_override", re.IGNORECASE)
+_fencing_counters: MutableMapping[str, int] = defaultdict(int)
+
+
+@contextlib.contextmanager
+def unguarded_write(using: str | None = None, *args: Any, **kwargs: Any):
+    """
+    Used to indicate that the wrapped block is safe to do
+    mutations on outbox backed records.
+    In production this context manager has no effect, but
+    in tests it emits 'fencing' queries that are audited at the
+    end of each test run by validate_protected_queries
+    """
+    if "pytest" not in sys.argv[0]:
+        yield
+        return
+
+    using = determine_using_by_silo_mode(using)
+    _fencing_counters[using] += 1
+
+    with get_connection(using).cursor() as conn:
+        fence_value = _fencing_counters[using]
+        conn.execute("SELECT %s", [f"start_role_override_{fence_value}"])
+        try:
+            yield
+        finally:
+            conn.execute("SELECT %s", [f"end_role_override_{fence_value}"])
+
+
 def protected_table(table: str, operation: str) -> re.Pattern:
     return re.compile(f'{operation}[^"]+"{table}"', re.IGNORECASE)
 
@@ -386,11 +418,11 @@ def validate_protected_queries(queries: Iterable[Dict[str, str]]) -> None:
                         "",
                         "Was not surrounded by role elevation queries, and could corrupt data if outboxes are not generated.",
                         "If you are confident that outboxes are being generated, wrap the "
-                        "operation that generates this query with the `in_test_psql_role_override` ",
+                        "operation that generates this query with the `unguarded_write()` ",
                         "context manager to resolve this failure. For example:",
                         "",
-                        "with in_test_psql_role_override():",
-                        "    membership.delete()",
+                        "with unguarded_write():",
+                        "    record.delete()",
                         "",
                         "Full query log:",
                         "",


### PR DESCRIPTION
I'm having a hard time getting #52673 to pass CI because of getsentry dependencies. These changes add the new helpers to adopt query auditing instead of role swapping without touching role. My plan now is to get these changes merged, then update getsentry to use query auditing and then update sentry and remove role swapping.