### PR TITLE
fix(starfish): Update starfishProjectSelector to force and save project selection to allowed project ids on load

### DIFF
--- a/static/app/views/starfish/components/starfishProjectSelector.tsx
+++ b/static/app/views/starfish/components/starfishProjectSelector.tsx
@@ -30,7 +30,14 @@ export function StarfishProjectSelector() {
     ) ?? projectOptions[0];
 
   const handleProjectChange = option =>
-    updateProjects([parseInt(option.value, 10)], router);
+    updateProjects([parseInt(option.value, 10)], router, {save: true});
+
+  if (
+    selection.projects.length > 1 ||
+    !allowedProjectIDs.includes(`${selection.projects[0]}`)
+  ) {
+    handleProjectChange(projectOptions[0]);
+  }
 
   return (
     <CompactSelect

--- a/static/app/views/starfish/index.tsx
+++ b/static/app/views/starfish/index.tsx
@@ -1,5 +1,3 @@
-import {useEffect} from 'react';
-
 import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -7,10 +5,7 @@ import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
-import {useLocation} from 'sentry/utils/useLocation';
-import useRouter from 'sentry/utils/useRouter';
 import withOrganization from 'sentry/utils/withOrganization';
-import {ALLOWED_PROJECT_IDS_FOR_ORG_SLUG} from 'sentry/views/starfish/allowedProjects';
 
 type Props = {
   children: React.ReactChildren;
@@ -20,24 +15,6 @@ type Props = {
 const queryClient = new QueryClient();
 
 function StarfishContainer({organization, children}: Props) {
-  const location = useLocation();
-  const router = useRouter();
-
-  useEffect(() => {
-    const allowedProjectIDs: string[] =
-      ALLOWED_PROJECT_IDS_FOR_ORG_SLUG[organization.slug] ?? [];
-    const requestedProjectID: string = Array.isArray(location?.query?.project)
-      ? location.query.project[0]
-      : location.query.project ?? '';
-
-    if (allowedProjectIDs.length > 0 && !allowedProjectIDs.includes(requestedProjectID)) {
-      router.replace({
-        pathname: location.pathname,
-        query: {...location.query, project: allowedProjectIDs[0]},
-      });
-    }
-  }, [router, location, organization]);
-
   return (
     <Feature
       hookName="feature-disabled:starfish-view"


### PR DESCRIPTION
Update starfishProjectSelector to force and save project selection to allowed project ids on load. This also fixes an issue where double clicking on a starfish link would reset the date selection to 14d because of directly doing a router.replace