### PR TITLE
fix(starfish): Add empty state and error state for project selector

### DIFF
--- a/static/app/views/starfish/components/starfishProjectSelector.tsx
+++ b/static/app/views/starfish/components/starfishProjectSelector.tsx
@@ -1,6 +1,7 @@
 import {updateProjects} from 'sentry/actionCreators/pageFilters';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import {t} from 'sentry/locale';
 import {Project} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -9,10 +10,24 @@ import useRouter from 'sentry/utils/useRouter';
 import {ALLOWED_PROJECT_IDS_FOR_ORG_SLUG} from 'sentry/views/starfish/allowedProjects';
 
 export function StarfishProjectSelector() {
-  const {projects} = useProjects();
+  const {projects, initiallyLoaded: projectsLoaded, fetchError} = useProjects();
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const router = useRouter();
+
+  if (!projectsLoaded) {
+    return (
+      <CompactSelect
+        disabled
+        options={[{label: t('Loading\u2026'), value: 'loading'}]}
+        defaultValue="loading"
+      />
+    );
+  }
+
+  if (fetchError) {
+    throw new Error('Failed to fetch projects');
+  }
 
   const allowedProjectIDs: string[] =
     ALLOWED_PROJECT_IDS_FOR_ORG_SLUG[organization.slug] ?? [];
@@ -34,6 +49,7 @@ export function StarfishProjectSelector() {
 
   return (
     <CompactSelect
+      disabled={!projectsLoaded}
       menuWidth={250}
       options={projectOptions}
       defaultValue={selectedOption?.value}

--- a/static/app/views/starfish/components/starfishProjectSelector.tsx
+++ b/static/app/views/starfish/components/starfishProjectSelector.tsx
@@ -49,7 +49,6 @@ export function StarfishProjectSelector() {
 
   return (
     <CompactSelect
-      disabled={!projectsLoaded}
       menuWidth={250}
       options={projectOptions}
       defaultValue={selectedOption?.value}


### PR DESCRIPTION
There was a bug that was sometimes causing the project selector to default to 'None'. This was because we were not confirming that the projects were loaded before setting the default option in the component. 

This PR fixes this by checking that the projects are loaded first, otherwise it will display a disabled dropdown that says "Loading...". 

Also adds error handling, will throw an error if projects fail to load.