### PR TITLE
fix(helpful-event): Prevent event from being refetched when using All Events tab

### DIFF
--- a/static/app/views/issueDetails/groupEvents.tsx
+++ b/static/app/views/issueDetails/groupEvents.tsx
@@ -30,7 +30,7 @@ function GroupEvents({params, location, group}: Props) {
 
   const {groupId} = params;
 
-  useCleanQueryParamsOnRouteLeave({fieldsToClean: ['cursor']});
+  useCleanQueryParamsOnRouteLeave({fieldsToClean: ['cursor', 'query']});
 
   const handleSearch = useCallback(
     (query: string) =>


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/52738
Fixes SENTRY-131D

`useApiQuery` refetches whenever its query key changes. Since the `query` part of the URL can change when you search in the "All Events" tab, this was causing refetches of the helpful event. This does two things to prevent that from occurring:

1. Disables the event details query when we are not on the details tab
2. Clears `query` from the query string when navigating away from the All Events tab