### PR TITLE
feat(github-growth): add repos from within github webhook

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -29,7 +29,7 @@ from sentry.services.hybrid_cloud.integration.model import (
 from sentry.services.hybrid_cloud.integration.service import integration_service
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.utils import json
+from sentry.utils import json, metrics
 from sentry.utils.json import JSONData
 
 from .repository import GitHubRepositoryProvider
@@ -101,9 +101,10 @@ class Webhook:
                     "identifier": event.get("repository", {}).get("full_name", None),
                 }
 
-                for org in list(orgs.values()):
+                for org in orgs.values():
                     if features.has("organizations:auto-repo-linking", org):
                         provider.create_repository(config, org)
+                        metrics.incr("github.webhook.create_repository")
 
                 repos = repos.all()
 

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -98,7 +98,7 @@ class Webhook:
                 organization_id__in=orgs.keys(),
                 provider=f"integrations:{self.provider}",
                 external_id=str(event["repository"]["id"]),
-            ).exclude(status=ObjectStatus.HIDDEN)
+            )
 
             if not repos.exists():
                 provider = get_integration_repository_provider(integration)
@@ -115,7 +115,7 @@ class Webhook:
 
                 repos = repos.all()
 
-            for repo in repos:
+            for repo in repos.exclude(status=ObjectStatus.HIDDEN):
                 self._handle(integration, event, orgs[repo.organization_id], repo)
 
     def update_repo_data(self, repo: Repository, event: Mapping[str, Any]) -> None:

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -18,16 +18,8 @@ from sentry import features, options
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.utils.scope import clear_tags_and_context
-from sentry.models import (
-    Commit,
-    CommitAuthor,
-    CommitFileChange,
-    Organization,
-    PullRequest,
-    Repository,
-)
+from sentry.models import Commit, CommitAuthor, Organization, PullRequest, Repository
 from sentry.models.commitfilechange import CommitFileChange
-from sentry.plugins.base import bindings
 from sentry.plugins.providers.integration_repository import get_integration_repository_provider
 from sentry.services.hybrid_cloud.identity.service import identity_service
 from sentry.services.hybrid_cloud.integration.model import (

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -97,7 +97,7 @@ class Webhook:
                 organization_id__in=orgs.keys(),
                 provider=f"integrations:{self.provider}",
                 external_id=str(event["repository"]["id"]),
-            )
+            ).exclude(status=ObjectStatus.HIDDEN)
 
             if not repos.exists():
                 binding_key = "integration-repository.provider"
@@ -114,7 +114,9 @@ class Webhook:
                 for org in list(orgs.values()):
                     provider.create_repository(config, org)
 
-                repos = Repository.objects.filter(external_id=config["external_id"])
+                repos = Repository.objects.filter(external_id=config["external_id"]).exclude(
+                    status=ObjectStatus.HIDDEN
+                )
 
             for repo in repos:
                 self._handle(integration, event, orgs[repo.organization_id], repo)

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -14,7 +14,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 
-from sentry import options
+from sentry import features, options
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.utils.scope import clear_tags_and_context
@@ -112,7 +112,8 @@ class Webhook:
                 }
 
                 for org in list(orgs.values()):
-                    provider.create_repository(config, org)
+                    if features.has("organizations:auto-repo-linking", org):
+                        provider.create_repository(config, org)
 
                 repos = Repository.objects.filter(external_id=config["external_id"]).exclude(
                     status=ObjectStatus.HIDDEN

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -18,8 +18,16 @@ from sentry import options
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.utils.scope import clear_tags_and_context
-from sentry.models import Commit, CommitAuthor, Organization, PullRequest, Repository
+from sentry.models import (
+    Commit,
+    CommitAuthor,
+    CommitFileChange,
+    Organization,
+    PullRequest,
+    Repository,
+)
 from sentry.models.commitfilechange import CommitFileChange
+from sentry.plugins.base import bindings
 from sentry.services.hybrid_cloud.identity.service import identity_service
 from sentry.services.hybrid_cloud.integration.model import (
     RpcIntegration,
@@ -90,6 +98,24 @@ class Webhook:
                 provider=f"integrations:{self.provider}",
                 external_id=str(event["repository"]["id"]),
             )
+
+            if not repos.exists():
+                binding_key = "integration-repository.provider"
+                provider_key = "integrations:" + integration.provider
+                provider_cls = bindings.get(binding_key).get(provider_key)
+                provider = provider_cls(id=provider_key)
+
+                config = {
+                    "integration_id": integration.id,
+                    "external_id": str(event["repository"]["id"]),
+                    "identifier": event.get("repository", {}).get("full_name", None),
+                }
+
+                for org in list(orgs.values()):
+                    provider.create_repository(config, org)
+
+                repos = Repository.objects.filter(external_id=config["external_id"])
+
             for repo in repos:
                 self._handle(integration, event, orgs[repo.organization_id], repo)
 

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -15,6 +15,7 @@ from sentry.constants import ObjectStatus
 from sentry.models import Commit, CommitAuthor, GroupLink, Integration, PullRequest, Repository
 from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
@@ -138,7 +139,83 @@ class PushEventWebhookTest(APITestCase):
         assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
 
     @patch("sentry.integrations.github.client.get_jwt")
+    def test_auto_linking_missing_feature_flag(self, mock_get_jwt):
+        mock_get_jwt.return_value = ""
+
+        project = self.project  # force creation
+
+        url = "/extensions/github/webhook/"
+
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
+
+        options.set("github-app.webhook-secret", secret)
+
+        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.create(
+                external_id="12345",
+                provider="github",
+                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
+            )
+            integration.add_organization(project.organization, self.user)
+
+        response = self.client.post(
+            path=url,
+            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_HUB_SIGNATURE="sha1=56a3df597e02adbc17fb617502c70e19d96a6136",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+
+        assert response.status_code == 204
+
+        repos = Repository.objects.all()
+        assert len(repos) == 0
+
+    @with_feature("organizations:auto-repo-linking")
+    @patch("sentry.integrations.github.client.get_jwt")
     def test_creates_missing_repo(self, mock_get_jwt):
+        mock_get_jwt.return_value = ""
+
+        project = self.project  # force creation
+
+        url = "/extensions/github/webhook/"
+
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
+
+        options.set("github-app.webhook-secret", secret)
+
+        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.create(
+                external_id="12345",
+                provider="github",
+                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
+            )
+            integration.add_organization(project.organization, self.user)
+
+        response = self.client.post(
+            path=url,
+            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_HUB_SIGNATURE="sha1=56a3df597e02adbc17fb617502c70e19d96a6136",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+
+        assert response.status_code == 204
+
+        repos = Repository.objects.all()
+        assert len(repos) == 1
+        assert repos[0].organization_id == project.organization.id
+        assert repos[0].external_id == "35129377"
+        assert repos[0].provider == "integrations:github"
+        assert repos[0].name == "baxterthehacker/public-repo"
+
+    @with_feature("organizations:auto-repo-linking")
+    @patch("sentry.integrations.github.client.get_jwt")
+    def test_ignores_hidden_repo(self, mock_get_jwt):
         mock_get_jwt.return_value = ""
 
         project = self.project  # force creation
@@ -179,45 +256,6 @@ class PushEventWebhookTest(APITestCase):
         repos = Repository.objects.all()
         assert len(repos) == 1
         assert repos[0] == repo
-
-    @patch("sentry.integrations.github.client.get_jwt")
-    def test_ignores_hidden_repo(self, mock_get_jwt):
-        mock_get_jwt.return_value = ""
-
-        project = self.project  # force creation
-
-        url = "/extensions/github/webhook/"
-
-        secret = "b3002c3e321d4b7880360d397db2ccfd"
-
-        options.set("github-app.webhook-secret", secret)
-
-        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
-                external_id="12345",
-                provider="github",
-                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
-            )
-            integration.add_organization(project.organization, self.user)
-
-        response = self.client.post(
-            path=url,
-            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="push",
-            HTTP_X_HUB_SIGNATURE="sha1=56a3df597e02adbc17fb617502c70e19d96a6136",
-            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
-        )
-
-        assert response.status_code == 204
-
-        repos = Repository.objects.all()
-        assert len(repos) == 1
-        assert repos[0].organization_id == project.organization.id
-        assert repos[0].external_id == "35129377"
-        assert repos[0].provider == "integrations:github"
-        assert repos[0].name == "baxterthehacker/public-repo"
 
     def test_anonymous_lookup(self):
         project = self.project  # force creation
@@ -360,6 +398,7 @@ class PushEventWebhookTest(APITestCase):
         )
         assert len(commit_list) == 0
 
+    @with_feature("organizations:auto-repo-linking")
     @patch("sentry.integrations.github.client.get_jwt")
     def test_multiple_orgs_creates_missing_repos(self, mock_get_jwt):
         mock_get_jwt.return_value = ""
@@ -461,6 +500,37 @@ class PullRequestEventWebhook(APITestCase):
 
         self.assert_group_link(group, pr)
 
+    def test_auto_linking_missing_feature_flag(self):
+        project = self.project  # force creation
+        url = "/extensions/github/webhook/"
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
+        options.set("github-app.webhook-secret", secret)
+
+        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.create(
+                provider="github",
+                external_id="12345",
+                name="octocat",
+                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
+            )
+            integration.add_organization(project.organization, self.user)
+
+        response = self.client.post(
+            path=url,
+            data=PULL_REQUEST_OPENED_EVENT_EXAMPLE,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="pull_request",
+            HTTP_X_HUB_SIGNATURE="sha1=bc7ce12fc1058a35bf99355e6fc0e6da72c35de3",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+
+        assert response.status_code == 204
+
+        repos = Repository.objects.all()
+        assert len(repos) == 0
+
+    @with_feature("organizations:auto-repo-linking")
     def test_creates_missing_repo(self):
         project = self.project  # force creation
         url = "/extensions/github/webhook/"
@@ -495,6 +565,7 @@ class PullRequestEventWebhook(APITestCase):
         assert repos[0].provider == "integrations:github"
         assert repos[0].name == "baxterthehacker/public-repo"
 
+    @with_feature("organizations:auto-repo-linking")
     def test_ignores_hidden_repo(self):
         project = self.project  # force creation
         url = "/extensions/github/webhook/"
@@ -534,6 +605,7 @@ class PullRequestEventWebhook(APITestCase):
         assert len(repos) == 1
         assert repos[0] == repo
 
+    @with_feature("organizations:auto-repo-linking")
     def test_multiple_orgs_creates_missing_repo(self):
         project = self.project  # force creation
         url = "/extensions/github/webhook/"

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -81,7 +81,8 @@ class PushEventWebhookTest(APITestCase):
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
         with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
+            integration = self.create_integration(
+                organization=self.organization,
                 external_id="12345",
                 provider="github",
                 metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
@@ -199,13 +200,13 @@ class PushEventWebhookTest(APITestCase):
 
         project = self.project  # force creation
 
-        repo = Repository.objects.create(
-            organization_id=project.organization.id,
-            external_id="35129377",
+        repo = self.create_repo(
+            project=project,
             provider="integrations:github",
             name="baxterthehacker/public-repo",
-            status=ObjectStatus.HIDDEN,
         )
+        repo.status = ObjectStatus.HIDDEN
+        repo.save()
 
         self._setup_repo_test(project)
 
@@ -312,9 +313,8 @@ class PushEventWebhookTest(APITestCase):
         org2 = self.create_organization()
         project2 = self.create_project(organization=org2, name="bar")
 
-        Repository.objects.create(
-            organization_id=project2.organization.id,
-            external_id="77",
+        self.create_repo(
+            project=project2,
             provider="integrations:github",
             name="another/repo",
         )
@@ -505,13 +505,14 @@ class PullRequestEventWebhook(APITestCase):
     def test_ignores_hidden_repo(self):
         project = self.project  # force creation
 
-        repo = Repository.objects.create(
-            organization_id=project.organization.id,
-            external_id="35129377",
+        repo = self.create_repo(
+            project=project,
             provider="integrations:github",
             name="baxterthehacker/public-repo",
-            status=ObjectStatus.HIDDEN,
         )
+        repo.status = ObjectStatus.HIDDEN
+        repo.save()
+
         self._setup_repo_test(project)
 
         repos = Repository.objects.all()

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -72,6 +72,33 @@ class WebhookTest(APITestCase):
 class PushEventWebhookTest(APITestCase):
     base_url = "https://api.github.com"
 
+    def _setup_repo_test(self, project):
+        url = "/extensions/github/webhook/"
+
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
+
+        options.set("github-app.webhook-secret", secret)
+
+        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.create(
+                external_id="12345",
+                provider="github",
+                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
+            )
+            integration.add_organization(project.organization, self.user)
+
+        response = self.client.post(
+            path=url,
+            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_HUB_SIGNATURE="sha1=56a3df597e02adbc17fb617502c70e19d96a6136",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+
+        assert response.status_code == 204
+
     @patch("sentry.integrations.github.client.get_jwt")
     def test_simple(self, mock_get_jwt):
         mock_get_jwt.return_value = ""
@@ -144,31 +171,7 @@ class PushEventWebhookTest(APITestCase):
 
         project = self.project  # force creation
 
-        url = "/extensions/github/webhook/"
-
-        secret = "b3002c3e321d4b7880360d397db2ccfd"
-
-        options.set("github-app.webhook-secret", secret)
-
-        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
-                external_id="12345",
-                provider="github",
-                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
-            )
-            integration.add_organization(project.organization, self.user)
-
-        response = self.client.post(
-            path=url,
-            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="push",
-            HTTP_X_HUB_SIGNATURE="sha1=56a3df597e02adbc17fb617502c70e19d96a6136",
-            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
-        )
-
-        assert response.status_code == 204
+        self._setup_repo_test(project)
 
         repos = Repository.objects.all()
         assert len(repos) == 0
@@ -180,31 +183,7 @@ class PushEventWebhookTest(APITestCase):
 
         project = self.project  # force creation
 
-        url = "/extensions/github/webhook/"
-
-        secret = "b3002c3e321d4b7880360d397db2ccfd"
-
-        options.set("github-app.webhook-secret", secret)
-
-        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
-                external_id="12345",
-                provider="github",
-                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
-            )
-            integration.add_organization(project.organization, self.user)
-
-        response = self.client.post(
-            path=url,
-            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="push",
-            HTTP_X_HUB_SIGNATURE="sha1=56a3df597e02adbc17fb617502c70e19d96a6136",
-            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
-        )
-
-        assert response.status_code == 204
+        self._setup_repo_test(project)
 
         repos = Repository.objects.all()
         assert len(repos) == 1
@@ -220,11 +199,6 @@ class PushEventWebhookTest(APITestCase):
 
         project = self.project  # force creation
 
-        url = "/extensions/github/webhook/"
-
-        secret = "b3002c3e321d4b7880360d397db2ccfd"
-
-        options.set("github-app.webhook-secret", secret)
         repo = Repository.objects.create(
             organization_id=project.organization.id,
             external_id="35129377",
@@ -233,25 +207,7 @@ class PushEventWebhookTest(APITestCase):
             status=ObjectStatus.HIDDEN,
         )
 
-        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
-                external_id="12345",
-                provider="github",
-                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
-            )
-            integration.add_organization(project.organization, self.user)
-
-        response = self.client.post(
-            path=url,
-            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="push",
-            HTTP_X_HUB_SIGNATURE="sha1=56a3df597e02adbc17fb617502c70e19d96a6136",
-            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
-        )
-
-        assert response.status_code == 204
+        self._setup_repo_test(project)
 
         repos = Repository.objects.all()
         assert len(repos) == 1
@@ -447,6 +403,32 @@ class PushEventWebhookTest(APITestCase):
 
 @region_silo_test(stable=True)
 class PullRequestEventWebhook(APITestCase):
+    def _setup_repo_test(self, project):
+        url = "/extensions/github/webhook/"
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
+        options.set("github-app.webhook-secret", secret)
+
+        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.create(
+                provider="github",
+                external_id="12345",
+                name="octocat",
+                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
+            )
+            integration.add_organization(project.organization, self.user)
+
+        response = self.client.post(
+            path=url,
+            data=PULL_REQUEST_OPENED_EVENT_EXAMPLE,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="pull_request",
+            HTTP_X_HUB_SIGNATURE="sha1=bc7ce12fc1058a35bf99355e6fc0e6da72c35de3",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+
+        assert response.status_code == 204
+
     def test_opened(self):
         project = self.project  # force creation
         group = self.create_group(project=project, short_id=7)
@@ -502,30 +484,7 @@ class PullRequestEventWebhook(APITestCase):
 
     def test_auto_linking_missing_feature_flag(self):
         project = self.project  # force creation
-        url = "/extensions/github/webhook/"
-        secret = "b3002c3e321d4b7880360d397db2ccfd"
-        options.set("github-app.webhook-secret", secret)
-
-        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
-                provider="github",
-                external_id="12345",
-                name="octocat",
-                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
-            )
-            integration.add_organization(project.organization, self.user)
-
-        response = self.client.post(
-            path=url,
-            data=PULL_REQUEST_OPENED_EVENT_EXAMPLE,
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="pull_request",
-            HTTP_X_HUB_SIGNATURE="sha1=bc7ce12fc1058a35bf99355e6fc0e6da72c35de3",
-            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
-        )
-
-        assert response.status_code == 204
+        self._setup_repo_test(project)
 
         repos = Repository.objects.all()
         assert len(repos) == 0
@@ -533,30 +492,7 @@ class PullRequestEventWebhook(APITestCase):
     @with_feature("organizations:auto-repo-linking")
     def test_creates_missing_repo(self):
         project = self.project  # force creation
-        url = "/extensions/github/webhook/"
-        secret = "b3002c3e321d4b7880360d397db2ccfd"
-        options.set("github-app.webhook-secret", secret)
-
-        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
-                provider="github",
-                external_id="12345",
-                name="octocat",
-                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
-            )
-            integration.add_organization(project.organization, self.user)
-
-        response = self.client.post(
-            path=url,
-            data=PULL_REQUEST_OPENED_EVENT_EXAMPLE,
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="pull_request",
-            HTTP_X_HUB_SIGNATURE="sha1=bc7ce12fc1058a35bf99355e6fc0e6da72c35de3",
-            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
-        )
-
-        assert response.status_code == 204
+        self._setup_repo_test(project)
 
         repos = Repository.objects.all()
         assert len(repos) == 1
@@ -568,19 +504,6 @@ class PullRequestEventWebhook(APITestCase):
     @with_feature("organizations:auto-repo-linking")
     def test_ignores_hidden_repo(self):
         project = self.project  # force creation
-        url = "/extensions/github/webhook/"
-        secret = "b3002c3e321d4b7880360d397db2ccfd"
-        options.set("github-app.webhook-secret", secret)
-
-        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
-                provider="github",
-                external_id="12345",
-                name="octocat",
-                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
-            )
-            integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,
@@ -589,17 +512,7 @@ class PullRequestEventWebhook(APITestCase):
             name="baxterthehacker/public-repo",
             status=ObjectStatus.HIDDEN,
         )
-
-        response = self.client.post(
-            path=url,
-            data=PULL_REQUEST_OPENED_EVENT_EXAMPLE,
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="pull_request",
-            HTTP_X_HUB_SIGNATURE="sha1=bc7ce12fc1058a35bf99355e6fc0e6da72c35de3",
-            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
-        )
-
-        assert response.status_code == 204
+        self._setup_repo_test(project)
 
         repos = Repository.objects.all()
         assert len(repos) == 1


### PR DESCRIPTION
For GitHub we have custom webhooks for `Push` events and `PullRequest` events. If at any time we encounter a repo that is mentioned but not installed (i.e. no corresponding `Repository` row), then we create the `Repository` object(s) for the organization(s) associated with the installation.

For ER-1716