### PR TITLE
fix(starfish): Filter out empty actions from dropdown

### DIFF
--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -41,10 +41,12 @@ export function ActionSelector({
     ? HTTP_ACTION_OPTIONS
     : [
         {value: '', label: 'All'},
-        ...actions.map(datum => ({
-          value: datum[SPAN_ACTION],
-          label: datum[SPAN_ACTION],
-        })),
+        ...actions
+          .filter(datum => datum[SPAN_ACTION])
+          .map(datum => ({
+            value: datum[SPAN_ACTION],
+            label: datum[SPAN_ACTION],
+          })),
       ];
 
   return (


### PR DESCRIPTION
Removes this empty option from the Action dropdown selector (on the generic span view) by filtering out items that don't have the `span.action` field


Fixes this:

![image](https://github.com/getsentry/sentry/assets/16740047/1f47cccc-525c-4c65-9db3-e1033ace338b)
