### PR TITLE
fix(starfish): None project if pagefilters not ready

### DIFF
--- a/static/app/views/starfish/components/starfishProjectSelector.tsx
+++ b/static/app/views/starfish/components/starfishProjectSelector.tsx
@@ -12,10 +12,10 @@ import {ALLOWED_PROJECT_IDS_FOR_ORG_SLUG} from 'sentry/views/starfish/allowedPro
 export function StarfishProjectSelector() {
   const {projects, initiallyLoaded: projectsLoaded, fetchError} = useProjects();
   const organization = useOrganization();
-  const {selection} = usePageFilters();
+  const {selection, isReady} = usePageFilters();
   const router = useRouter();
 
-  if (!projectsLoaded) {
+  if (!projectsLoaded || !isReady) {
     return (
       <CompactSelect
         disabled


### PR DESCRIPTION
Another attempt at fixing the 'None' project bug by checking if pagefilters are ready first.