### PR TITLE
ref(auth): Add security as a codeowner for auth files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,15 @@
 /src/sentry/api/authentication.py                        @getsentry/security @getsentry/enterprise
 /src/sentry/api/endpoints/auth*                          @getsentry/security @getsentry/enterprise
 /src/sentry/api/endpoints/user_permission*               @getsentry/security @getsentry/enterprise
+/src/sentry/web/frontend/auth_close.py                   @getsentry/security
+/src/sentry/web/frontend/auth_login.py                   @getsentry/security
+/src/sentry/web/frontend/auth_logout.py                  @getsentry/security
+/src/sentry/web/frontend/auth_organization_id_login.py   @getsentry/security
+/src/sentry/web/frontend/auth_organization_login.py      @getsentry/security
+/src/sentry/web/frontend/auth_provider_login.py          @getsentry/security
+/src/sentry/web/frontend/oauth_token.py                  @getsentry/security
+/src/sentry/web/frontend/oauth_authorize.py              @getsentry/security
+/src/sentry/web/frontend/openidtoken.py                  @getsentry/security
 
 ## Dev
 /.github/                                                @getsentry/owners-sentry-dev


### PR DESCRIPTION
We have a bunch of sensitive auth files living in our top level `web/frontend/` folder. This adds the security team as an owner for the relevant files. [Addresses comments in this PR](https://github.com/getsentry/sentry/pull/52556).

Note that I plan to reorganize our auth files in the future so we can move sensitive code into just a few main folders (and we won't have to specify ownership on a file-by-file basis.
