### PR TITLE
feat(github-growth): allow hiding repos

### DIFF
--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -54,7 +54,7 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
         if result.get("status"):
             if result["status"] in ("visible", "active"):
                 update_kwargs["status"] = ObjectStatus.ACTIVE
-            elif result["status"] in ("hidden"):
+            elif result["status"] == "hidden":
                 update_kwargs["status"] = ObjectStatus.HIDDEN
             else:
                 raise NotImplementedError

--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -20,6 +20,7 @@ class RepositorySerializer(serializers.Serializer):
             # XXX(dcramer): these are aliased, and we prefer 'active' over 'visible'
             ("visible", "visible"),
             ("active", "active"),
+            ("hidden", "hidden"),
         )
     )
     name = serializers.CharField(required=False)
@@ -53,6 +54,8 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
         if result.get("status"):
             if result["status"] in ("visible", "active"):
                 update_kwargs["status"] = ObjectStatus.ACTIVE
+            elif result["status"] in ("hidden"):
+                update_kwargs["status"] = ObjectStatus.HIDDEN
             else:
                 raise NotImplementedError
         if result.get("integrationId"):

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -247,6 +247,26 @@ class OrganizationRepositoryDeleteTest(APITestCase):
             organization_id=org.id, key=repo.build_pending_deletion_key()
         ).exists()
 
+    def test_put_hide_repo(self):
+        self.login_as(user=self.user)
+
+        org = self.create_organization(owner=self.user, name="baz")
+
+        repo = Repository.objects.create(
+            name="uuid-name",
+            external_id="uuid-external-id",
+            organization_id=org.id,
+            status=ObjectStatus.ACTIVE,
+        )
+
+        url = reverse("sentry-api-0-organization-repository-details", args=[org.slug, repo.id])
+        response = self.client.put(url, data={"status": "hidden"})
+
+        assert response.status_code == 200
+
+        repo = Repository.objects.get(id=repo.id)
+        assert repo.status == ObjectStatus.HIDDEN
+
     def test_put_cancel_deletion_duplicate_exists(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
Allow setting a `Repository` object's status to `ObjectStatus.HIDDEN`.

For ER-1718