### PR TITLE
ref(sort): Clean up priority/better priority

### DIFF
--- a/static/app/components/modals/savedSearchModal/createSavedSearchModal.spec.tsx
+++ b/static/app/components/modals/savedSearchModal/createSavedSearchModal.spec.tsx
@@ -92,7 +92,7 @@ describe('CreateSavedSearchModal', function () {
           data: {
             name: 'new search name',
             query: 'is:resolved',
-            sort: IssueSortOptions.PRIORITY,
+            sort: IssueSortOptions.BETTER_PRIORITY,
             type: 0,
             visibility: SavedSearchVisibility.OWNER,
           },

--- a/static/app/components/modals/savedSearchModal/createSavedSearchModal.tsx
+++ b/static/app/components/modals/savedSearchModal/createSavedSearchModal.tsx
@@ -18,22 +18,11 @@ interface CreateSavedSearchModalProps extends ModalRenderProps {
   sort?: string;
 }
 
-function validateSortOption({
-  sort,
-  organization,
-}: {
-  organization: Organization;
-  sort?: string;
-}) {
-  const hasBetterPrioritySort = organization.features.includes(
-    'issue-list-better-priority-sort'
-  );
+function validateSortOption({sort}: {sort?: string}) {
   const sortOptions = [
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    ...(hasBetterPrioritySort
-      ? [IssueSortOptions.BETTER_PRIORITY]
-      : [IssueSortOptions.PRIORITY]), // show better priority for EA orgs
+    IssueSortOptions.BETTER_PRIORITY,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];
@@ -59,7 +48,7 @@ export function CreateSavedSearchModal({
   const initialData = {
     name: '',
     query,
-    sort: validateSortOption({sort, organization}),
+    sort: validateSortOption({sort}),
     visibility: SavedSearchVisibility.OWNER,
   };
 

--- a/static/app/components/modals/savedSearchModal/editSavedSearchModal.spec.tsx
+++ b/static/app/components/modals/savedSearchModal/editSavedSearchModal.spec.tsx
@@ -56,7 +56,7 @@ describe('EditSavedSearchModal', function () {
         id: 'saved-search-id',
         name: 'test',
         query: 'is:unresolved browser:firefox',
-        sort: IssueSortOptions.PRIORITY,
+        sort: IssueSortOptions.BETTER_PRIORITY,
         visibility: SavedSearchVisibility.OWNER,
       },
     });
@@ -97,7 +97,7 @@ describe('EditSavedSearchModal', function () {
         id: 'saved-search-id',
         name: 'test',
         query: 'is:unresolved browser:firefox',
-        sort: IssueSortOptions.PRIORITY,
+        sort: IssueSortOptions.BETTER_PRIORITY,
         visibility: SavedSearchVisibility.OWNER,
       },
     });

--- a/static/app/components/modals/savedSearchModal/savedSearchModalContent.tsx
+++ b/static/app/components/modals/savedSearchModal/savedSearchModalContent.tsx
@@ -19,16 +19,11 @@ const SELECT_FIELD_VISIBILITY_OPTIONS = [
 
 export function SavedSearchModalContent({organization}: SavedSearchModalContentProps) {
   const canChangeVisibility = organization.access.includes('org:write');
-  const hasBetterPrioritySort = organization.features.includes(
-    'issue-list-better-priority-sort'
-  );
 
   const sortOptions = [
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    ...(hasBetterPrioritySort
-      ? [IssueSortOptions.BETTER_PRIORITY]
-      : [IssueSortOptions.PRIORITY]), // show better priority for EA orgs
+    IssueSortOptions.BETTER_PRIORITY,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -70,15 +70,10 @@ function disableSortOptions(_widgetQuery: WidgetQuery) {
 }
 
 function getTableSortOptions(_organization: Organization, _widgetQuery: WidgetQuery) {
-  const hasBetterPrioritySort = organization.features.includes(
-    'issue-list-better-priority-sort'
-  );
   const sortOptions = [
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    ...(hasBetterPrioritySort
-      ? [IssueSortOptions.BETTER_PRIORITY]
-      : [IssueSortOptions.PRIORITY]), // show better priority for EA orgs
+    IssueSortOptions.BETTER_PRIORITY,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -69,16 +69,11 @@ function disableSortOptions(_widgetQuery: WidgetQuery) {
   };
 }
 
-function getTableSortOptions(organization: Organization, _widgetQuery: WidgetQuery) {
-  const hasBetterPrioritySort = organization.features.includes(
-    'issue-list-better-priority-sort'
-  );
+function getTableSortOptions(_widgetQuery: WidgetQuery) {
   const sortOptions = [
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    ...(hasBetterPrioritySort
-      ? [IssueSortOptions.BETTER_PRIORITY]
-      : [IssueSortOptions.PRIORITY]), // show better priority for EA orgs
+    IssueSortOptions.BETTER_PRIORITY,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -69,11 +69,16 @@ function disableSortOptions(_widgetQuery: WidgetQuery) {
   };
 }
 
-function getTableSortOptions(_widgetQuery: WidgetQuery) {
+function getTableSortOptions(_organization: Organization, _widgetQuery: WidgetQuery) {
+  const hasBetterPrioritySort = organization.features.includes(
+    'issue-list-better-priority-sort'
+  );
   const sortOptions = [
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    IssueSortOptions.BETTER_PRIORITY,
+    ...(hasBetterPrioritySort
+      ? [IssueSortOptions.BETTER_PRIORITY]
+      : [IssueSortOptions.PRIORITY]), // show better priority for EA orgs
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/dashboards/widgetBuilder/issueWidget/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/issueWidget/utils.tsx
@@ -30,7 +30,7 @@ export const ISSUE_WIDGET_SORT_OPTIONS = [
   IssueSortOptions.DATE,
   IssueSortOptions.NEW,
   IssueSortOptions.FREQ,
-  IssueSortOptions.PRIORITY,
+  IssueSortOptions.BETTER_PRIORITY,
   IssueSortOptions.USER,
 ];
 

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -230,8 +230,7 @@ function WidgetBuilder({
           orderby:
             defaultWidgetQuery.orderby ||
             (datasetConfig.getTableSortOptions
-              ? datasetConfig.getTableSortOptions(organization, defaultWidgetQuery)[0]
-                  .value
+              ? datasetConfig.getTableSortOptions(defaultWidgetQuery)[0].value
               : ''),
         },
       ];

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -230,7 +230,8 @@ function WidgetBuilder({
           orderby:
             defaultWidgetQuery.orderby ||
             (datasetConfig.getTableSortOptions
-              ? datasetConfig.getTableSortOptions(defaultWidgetQuery)[0].value
+              ? datasetConfig.getTableSortOptions(organization, defaultWidgetQuery)[0]
+                  .value
               : ''),
         },
       ];

--- a/static/app/views/dashboards/widgetBuilder/widgetLibrary/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetLibrary/index.tsx
@@ -31,7 +31,7 @@ export function WidgetLibrary({
   organization,
 }: Props) {
   const theme = useTheme();
-  let defaultWidgets = getTopNConvertedDefaultWidgets(organization);
+  let defaultWidgets = getTopNConvertedDefaultWidgets();
   if (!organization.features.includes('dashboards-rh-widget')) {
     defaultWidgets = defaultWidgets.filter(
       widget => !(widget.widgetType === WidgetType.RELEASE)

--- a/static/app/views/dashboards/widgetLibrary/data.tsx
+++ b/static/app/views/dashboards/widgetLibrary/data.tsx
@@ -1,5 +1,4 @@
 import {t} from 'sentry/locale';
-import {Organization} from 'sentry/types';
 import {TOP_N} from 'sentry/utils/discover/types';
 
 import {DisplayType, Widget, WidgetType} from '../types';
@@ -8,7 +7,7 @@ export type WidgetTemplate = Widget & {
   description: string;
 };
 
-export const getDefaultWidgets = (organization: Organization) => {
+export const getDefaultWidgets = () => {
   return [
     {
       id: 'duration-distribution',
@@ -167,9 +166,7 @@ export const getDefaultWidgets = (organization: Organization) => {
           fields: ['issue', 'assignee', 'events', 'title'],
           aggregates: [],
           columns: ['issue', 'assignee', 'events', 'title'],
-          orderby: organization.features.includes('issue-list-better-priority-sort')
-            ? 'betterPriority'
-            : 'date',
+          orderby: 'date',
         },
       ],
     },
@@ -212,10 +209,8 @@ export const getDefaultWidgets = (organization: Organization) => {
   ];
 };
 
-export function getTopNConvertedDefaultWidgets(
-  organization: Organization
-): Readonly<Array<WidgetTemplate>> {
-  return getDefaultWidgets(organization).map(widget => {
+export function getTopNConvertedDefaultWidgets(): Readonly<Array<WidgetTemplate>> {
+  return getDefaultWidgets().map(widget => {
     if (widget.displayType === DisplayType.TOP_N) {
       return {
         ...widget,

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -1,7 +1,6 @@
 import {CompactSelect} from 'sentry/components/compactSelect';
 import {IconSort} from 'sentry/icons/iconSort';
 import {t} from 'sentry/locale';
-import useOrganization from 'sentry/utils/useOrganization';
 import {
   FOR_REVIEW_QUERIES,
   getSortLabel,
@@ -20,8 +19,6 @@ function getSortTooltip(key: IssueSortOptions) {
       return t('When issue was flagged for review.');
     case IssueSortOptions.NEW:
       return t('First time the issue occurred.');
-    case IssueSortOptions.PRIORITY:
-      return t('Recent issues trending upward.');
     case IssueSortOptions.BETTER_PRIORITY:
       return t('Recent issues trending upward.');
     case IssueSortOptions.FREQ:
@@ -35,18 +32,12 @@ function getSortTooltip(key: IssueSortOptions) {
 }
 
 function IssueListSortOptions({onSelect, sort, query}: Props) {
-  const organization = useOrganization();
-  const hasBetterPrioritySort = organization.features.includes(
-    'issue-list-better-priority-sort'
-  );
   const sortKey = sort || IssueSortOptions.DATE;
   const sortKeys = [
     ...(FOR_REVIEW_QUERIES.includes(query || '') ? [IssueSortOptions.INBOX] : []),
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    ...(hasBetterPrioritySort
-      ? [IssueSortOptions.BETTER_PRIORITY]
-      : [IssueSortOptions.PRIORITY]), // show better priority for EA orgs
+    IssueSortOptions.BETTER_PRIORITY,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -143,16 +143,6 @@ type StatEndpointParams = Omit<EndpointParams, 'cursor' | 'page'> & {
   expand?: string | string[];
 };
 
-type BetterPriorityEndpointParams = Partial<EndpointParams> & {
-  eventHalflifeHours?: number;
-  hasStacktrace?: number;
-  issueHalflifeHours?: number;
-  logLevel?: number;
-  norm?: boolean;
-  relativeVolume?: number;
-  v2?: boolean;
-};
-
 class IssueListOverview extends Component<Props, State> {
   state: State = this.getInitialState();
 
@@ -335,29 +325,6 @@ class IssueListOverview extends Component<Props, State> {
       : DEFAULT_GRAPH_STATS_PERIOD;
   }
 
-  getBetterPriorityParams(): BetterPriorityEndpointParams {
-    const query = this.props.location.query ?? {};
-    const {
-      eventHalflifeHours,
-      hasStacktrace,
-      issueHalflifeHours,
-      logLevel,
-      norm,
-      v2,
-      relativeVolume,
-    } = query;
-
-    return {
-      eventHalflifeHours,
-      hasStacktrace,
-      issueHalflifeHours,
-      logLevel,
-      norm,
-      v2,
-      relativeVolume,
-    };
-  }
-
   getEndpointParams = (): EndpointParams => {
     const {selection} = this.props;
 
@@ -389,10 +356,8 @@ class IssueListOverview extends Component<Props, State> {
       params.groupStatsPeriod = groupStatsPeriod;
     }
 
-    const mergedParams = {...params, ...this.getBetterPriorityParams()};
-
     // only include defined values.
-    return pickBy(mergedParams, v => defined(v)) as EndpointParams;
+    return pickBy(params, v => defined(v)) as EndpointParams;
   };
 
   getSelectedProjectIds = (): string[] => {
@@ -886,7 +851,7 @@ class IssueListOverview extends Component<Props, State> {
   }
 
   transitionTo = (
-    newParams: Partial<EndpointParams> | Partial<BetterPriorityEndpointParams> = {},
+    newParams: Partial<EndpointParams> = {},
     savedSearch: (SavedSearch & {projectId?: number}) | null = this.props.savedSearch
   ) => {
     const query = {

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -174,7 +174,6 @@ export type QueryCounts = Partial<Record<Query, QueryCount>>;
 export enum IssueSortOptions {
   DATE = 'date',
   NEW = 'new',
-  PRIORITY = 'priority',
   BETTER_PRIORITY = 'betterPriority',
   FREQ = 'freq',
   USER = 'user',
@@ -191,8 +190,6 @@ export function getSortLabel(key: string) {
   switch (key) {
     case IssueSortOptions.NEW:
       return t('First Seen');
-    case IssueSortOptions.PRIORITY:
-      return t('Priority');
     case IssueSortOptions.BETTER_PRIORITY:
       return t('Priority');
     case IssueSortOptions.FREQ:


### PR DESCRIPTION
Remove checks for the feature flag and any code written specifically to use the feature flag, as well as remove references to the old priority sort. We do have 310 saved searches using the old priority so if they use it it will show "None" in the sort dropdown temporarily, but I checked in Redash and nobody's default search is set to it. 

Backend PR to follow: https://github.com/getsentry/sentry/pull/52770