### PR TITLE
ref(sort): Remove priority and betterpriority flags

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -1,6 +1,6 @@
 import functools
 from datetime import datetime, timedelta
-from typing import Any, List, Mapping, Optional, Sequence, Type, TypeVar
+from typing import Any, List, Mapping, Optional, Sequence
 
 from django.utils import timezone
 from rest_framework.exceptions import ParseError, PermissionDenied
@@ -38,11 +38,7 @@ from sentry.models import (
 )
 from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.search.snuba.backend import assigned_or_suggested_filter
-from sentry.search.snuba.executors import (
-    DEFAULT_PRIORITY_WEIGHTS,
-    PrioritySortWeights,
-    get_search_filter,
-)
+from sentry.search.snuba.executors import get_search_filter
 from sentry.snuba import discover
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.cursors import Cursor, CursorResult
@@ -164,57 +160,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         },
     }
 
-    @staticmethod
-    def build_better_priority_sort_kwargs(request: Request) -> Mapping[str, PrioritySortWeights]:
-        """
-        Temporary function to be used while developing the new priority sort. Parses the query params in the request.
-
-        :param logLevel: the weight (number from 0 to 10) to apply for events
-        :param hasStacktrace: the weight (number from 0 to 3) to apply for error events with stacktraces or not
-        :param eventHalflifeHours: each multiple of eventHalflifeHours halves the contribution score of an event
-        :param v2: boolean to switch between using v1 or v2 priority sort
-        :param norm: boolean to switch between normalizing the individual contribution scores to [0, 1] or not
-        """
-
-        R = TypeVar("R")
-
-        def _coerce(val: Optional[str], func: Type[R], default: R) -> R:
-            if func == bool:
-                func = lambda x: str(x).lower() == "true"
-
-            return func(val) if val is not None else default
-
-        # XXX(CEO): these default values are based on sort E
-        return {
-            "better_priority": {
-                "log_level": _coerce(
-                    request.GET.get("logLevel"), int, DEFAULT_PRIORITY_WEIGHTS["log_level"]
-                ),
-                "has_stacktrace": _coerce(
-                    request.GET.get("hasStacktrace"),
-                    int,
-                    DEFAULT_PRIORITY_WEIGHTS["has_stacktrace"],
-                ),
-                "relative_volume": _coerce(
-                    request.GET.get("relativeVolume"),
-                    int,
-                    DEFAULT_PRIORITY_WEIGHTS["relative_volume"],
-                ),
-                "event_halflife_hours": _coerce(
-                    request.GET.get("eventHalflifeHours"),
-                    int,
-                    DEFAULT_PRIORITY_WEIGHTS["event_halflife_hours"],
-                ),
-                "issue_halflife_hours": _coerce(
-                    request.GET.get("issueHalflifeHours"),
-                    int,
-                    DEFAULT_PRIORITY_WEIGHTS["issue_halflife_hours"],
-                ),
-                "v2": _coerce(request.GET.get("v2"), bool, DEFAULT_PRIORITY_WEIGHTS["v2"]),
-                "norm": _coerce(request.GET.get("norm"), bool, DEFAULT_PRIORITY_WEIGHTS["norm"]),
-            }
-        }
-
     def _search(
         self, request: Request, organization, projects, environments, extra_query_kwargs=None
     ):
@@ -225,9 +170,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             if extra_query_kwargs is not None:
                 assert "environment" not in extra_query_kwargs
                 query_kwargs.update(extra_query_kwargs)
-
-            if query_kwargs["sort_by"] == "betterPriority":
-                query_kwargs["aggregate_kwargs"] = self.build_better_priority_sort_kwargs(request)
 
             query_kwargs["environments"] = environments if environments else None
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1473,8 +1473,6 @@ SENTRY_FEATURES = {
     "organizations:issue-details-replay-event": False,
     # Enable sorting Issue detail events by 'most helpful'
     "organizations:issue-details-most-helpful-event": False,
-    # Enable better priority sort algorithm.
-    "organizations:issue-list-better-priority-sort": False,
     # Adds the ttid & ttfd vitals to the frontend
     "organizations:mobile-vitals": False,
     # Display CPU and memory metrics in transactions with profiles

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -93,7 +93,6 @@ default_manager.add("organizations:issue-alert-fallback-targeting", Organization
 default_manager.add("organizations:issue-details-replay-event", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-details-most-helpful-event", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-details-tag-improvements", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:issue-list-better-priority-sort", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-platform", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-use-cdc-primary", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -114,7 +114,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(group.id)
 
-    @with_feature("organizations:issue-list-better-priority-sort")
     def test_sort_by_better_priority(self):
         group = self.store_event(
             data={

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -365,20 +365,19 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         assert list(results) == [self.group1, self.group2]
 
     def test_better_priority_sort(self):
-        with self.feature("organizations:issue-list-better-priority-sort"):
-            weights: PrioritySortWeights = {
-                "log_level": 5,
-                "has_stacktrace": 5,
-                "relative_volume": 1,
-                "event_halflife_hours": 4,
-                "issue_halflife_hours": 24 * 7,
-                "v2": False,
-                "norm": False,
-            }
-            results = self.make_query(
-                sort_by="betterPriority",
-                aggregate_kwargs=weights,
-            )
+        weights: PrioritySortWeights = {
+            "log_level": 5,
+            "has_stacktrace": 5,
+            "relative_volume": 1,
+            "event_halflife_hours": 4,
+            "issue_halflife_hours": 24 * 7,
+            "v2": False,
+            "norm": False,
+        }
+        results = self.make_query(
+            sort_by="betterPriority",
+            aggregate_kwargs=weights,
+        )
         assert list(results) == [self.group2, self.group1]
 
     def test_sort_with_environment(self):
@@ -2631,21 +2630,20 @@ class EventsBetterPriorityTest(SharedSnubaTest, OccurrenceTestMixin):
         # datetime(2017, 9, 6, 0, 0)
         old_event.data["timestamp"] = 1504656000.0
 
-        with self.feature("organizations:issue-list-better-priority-sort"):
-            weights: PrioritySortWeights = {
-                "log_level": 0,
-                "has_stacktrace": 0,
-                "relative_volume": 1,
-                "event_halflife_hours": 4,
-                "issue_halflife_hours": 24 * 7,
-                "v2": False,
-                "norm": False,
-            }
-            results = self.make_query(
-                sort_by="betterPriority",
-                projects=[new_project],
-                aggregate_kwargs=weights,
-            )
+        weights: PrioritySortWeights = {
+            "log_level": 0,
+            "has_stacktrace": 0,
+            "relative_volume": 1,
+            "event_halflife_hours": 4,
+            "issue_halflife_hours": 24 * 7,
+            "v2": False,
+            "norm": False,
+        }
+        results = self.make_query(
+            sort_by="betterPriority",
+            projects=[new_project],
+            aggregate_kwargs=weights,
+        )
         recent_group = Group.objects.get(id=recent_event.group.id)
         old_group = Group.objects.get(id=old_event.group.id)
         assert list(results) == [recent_group, old_group]
@@ -2682,21 +2680,20 @@ class EventsBetterPriorityTest(SharedSnubaTest, OccurrenceTestMixin):
         # datetime(2017, 9, 6, 0, 0)
         old_event.data["timestamp"] = 1504656000.0
 
-        with self.feature("organizations:issue-list-better-priority-sort"):
-            weights: PrioritySortWeights = {
-                "log_level": 0,
-                "has_stacktrace": 0,
-                "relative_volume": 1,
-                "event_halflife_hours": 4,
-                "issue_halflife_hours": 24 * 7,
-                "v2": True,
-                "norm": False,
-            }
-            results = self.make_query(
-                sort_by="betterPriority",
-                projects=[new_project],
-                aggregate_kwargs=weights,
-            )
+        weights: PrioritySortWeights = {
+            "log_level": 0,
+            "has_stacktrace": 0,
+            "relative_volume": 1,
+            "event_halflife_hours": 4,
+            "issue_halflife_hours": 24 * 7,
+            "v2": True,
+            "norm": False,
+        }
+        results = self.make_query(
+            sort_by="betterPriority",
+            projects=[new_project],
+            aggregate_kwargs=weights,
+        )
         recent_group = Group.objects.get(id=recent_event.group.id)
         old_group = Group.objects.get(id=old_event.group.id)
         assert list(results) == [recent_group, old_group]
@@ -2981,7 +2978,6 @@ class EventsBetterPriorityTest(SharedSnubaTest, OccurrenceTestMixin):
             [
                 "organizations:issue-platform",
                 ProfileFileIOGroupType.build_visible_feature_name(),
-                "organizations:issue-list-better-priority-sort",
             ]
         ):
             results = query_executor.snuba_search(

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -359,7 +359,7 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         assert list(results) == [self.group1, self.group2]
 
         results = self.make_query(sort_by="priority")
-        assert list(results) == [self.group1, self.group2]
+        assert list(results) == [self.group2, self.group1]
 
         results = self.make_query(sort_by="user")
         assert list(results) == [self.group1, self.group2]
@@ -660,7 +660,7 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             project_id=self.project.id,
         )
         results = self.make_query(search_filter_query="priority:%s" % priority, sort_by="priority")
-        assert list(results) == [self.group1, self.group2]
+        assert list(results) == [self.group2, self.group1]
 
     def test_search_tag_overlapping_with_internal_fields(self):
         # Using a tag of email overlaps with the promoted user.email column in events.
@@ -2282,7 +2282,11 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         assert list(results) == [self.group1, self.group_p2, self.group2]
 
         results = self.make_query([self.project, self.project2], sort_by="priority")
-        assert list(results) == [self.group1, self.group2, self.group_p2]
+        assert list(results) == [
+            self.group_p2,
+            self.group2,
+            self.group1,
+        ]
 
         results = self.make_query([self.project, self.project2], sort_by="user")
         assert list(results) == [self.group1, self.group2, self.group_p2]


### PR DESCRIPTION
Remove feature flag / references for better priority sort as it's in GA. This also routes the "priority" sort to use "betterPriority" temporarily while I clean up references on the front end. 

Front end PR must be merged first: https://github.com/getsentry/sentry/pull/52769