### PR TITLE
ref(backup): Use a more exact datetime serializer

### DIFF
--- a/fixtures/backup/datetime-formatting.json
+++ b/fixtures/backup/datetime-formatting.json
@@ -1,0 +1,20 @@
+[
+  {
+    "model": "sites.site",
+    "pk": 1,
+    "fields": {
+      "domain": "example.com",
+      "name": "example.com"
+    }
+  },
+  {
+    "model": "sentry.option",
+    "pk": 1,
+    "fields": {
+      "key": "sentry:latest_version",
+      "last_updated": "2023-06-22T00:00:00.000Z",
+      "last_updated_by": "unknown",
+      "value": "\"23.6.1\""
+    }
+  }
+]

--- a/fixtures/backup/fresh-install.json
+++ b/fixtures/backup/fresh-install.json
@@ -166,7 +166,7 @@
   "pk": 1,
   "fields": {
     "date_updated": "2023-06-22T23:00:00.123Z",
-    "date_added": "2023-06-22T22:59:57.073Z",
+    "date_added": "2023-06-22T22:59:57.000Z",
     "user": [
       "testing@example.com"
     ],

--- a/tests/sentry/backup/test_correctness.py
+++ b/tests/sentry/backup/test_correctness.py
@@ -40,3 +40,8 @@ def test_bad_fresh_install_validation(tmp_path):
     with pytest.raises(ValidationError) as excinfo:
         import_export_then_validate(tmp_path, "fresh-install.json")
     assert len(excinfo.value.info.findings) == 2
+
+
+@django_db_all(transaction=True, reset_sequences=True)
+def test_datetime_formatting(tmp_path):
+    import_export_then_validate(tmp_path, "datetime-formatting.json")


### PR DESCRIPTION
The default DjangoJSONEncoder inherits from the odd behavior of Python's own `isoformat` serializer: it includes milliseconds in the output in all cases EXCEPT those where the value of the milliseconds are `.000`, in which case it removes them completely. This makes it difficult and flaky to do simple string comparison between two dates. Instead, a new wrapper class is introduced to ensure that we always retain the milliseconds on all date serializations.