### PR TITLE
fix: Centralize and robustify test mode detection

### DIFF
--- a/src/sentry/db/postgres/transactions.py
+++ b/src/sentry/db/postgres/transactions.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import contextlib
-import sys
 import threading
 
 from django.conf import settings
 from django.db import connections, transaction
+
+from sentry.utils.env import in_test_environment
 
 
 @contextlib.contextmanager
@@ -19,7 +20,7 @@ def django_test_transaction_water_mark(using: str | None = None):
 
     This method has no effect in production.
     """
-    if "pytest" not in sys.argv[0]:
+    if not in_test_environment():
         yield
         return
 
@@ -61,7 +62,7 @@ def in_test_hide_transaction_boundary():
     In tests, it hides 'in_test_assert_no_transaction' invocations against problematic code paths.
     Using this function is a huge code smell, often masking some other code smell, but not always possible to avoid.
     """
-    if "pytest" not in sys.argv[0]:
+    if not in_test_environment():
         yield
         return
 
@@ -82,7 +83,7 @@ def in_test_assert_no_transaction(msg: str):
     execution time can have cause major performance issues by holding transactional resources open for long periods
     of time.
     """
-    if "pytest" not in sys.argv[0] or not in_test_transaction_enforcement.enabled:
+    if not in_test_environment() or not in_test_transaction_enforcement.enabled:
         return
 
     from sentry.testutils import hybrid_cloud

--- a/src/sentry/db/router.py
+++ b/src/sentry/db/router.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 from typing import Iterable, Optional
 
 from django.apps import apps
@@ -10,6 +9,7 @@ from django.utils.connection import ConnectionDoesNotExist
 
 from sentry.db.models.base import Model, ModelSiloLimit
 from sentry.silo.base import SiloLimit, SiloMode
+from sentry.utils.env import in_test_environment
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ class SiloRouter:
             self.__is_simulated = False
 
     def use_simulated(self, value: bool):
-        if "pytest" not in sys.argv[0]:
+        if not in_test_environment():
             raise ValueError("Cannot mutate simulation mode outside of tests")
         self.__is_simulated = value
 
@@ -97,7 +97,7 @@ class SiloRouter:
 
         # If we're in tests raise an error, otherwise return 'no decision'
         # so that django skips migration operations that won't work.
-        if "pytest" in sys.argv[0]:
+        if in_test_environment():
             raise SiloConnectionUnavailableError(
                 f"Cannot resolve table {table} in {silo_modes}. "
                 f"Application silo mode is {active_mode} and simulated silos are not enabled."

--- a/src/sentry/services/hybrid_cloud/util.py
+++ b/src/sentry/services/hybrid_cloud/util.py
@@ -1,7 +1,7 @@
-import sys
 from typing import Any, Callable, Iterable
 
 from sentry.silo.base import SiloLimit, SiloMode
+from sentry.utils.env import in_test_environment
 
 
 def flags_to_bits(*flag_values: bool) -> int:
@@ -19,7 +19,7 @@ class FunctionSiloLimit(SiloLimit):
         current_mode: SiloMode,
         available_modes: Iterable[SiloMode],
     ) -> Callable[..., Any]:
-        if "pytest" in sys.argv[0]:
+        if in_test_environment():
             mode_str = ", ".join(str(m) for m in available_modes)
             message = (
                 f"Called {original_method.__name__} in "

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 from typing import Any, Mapping
 
 from django.conf import settings
@@ -20,6 +19,7 @@ from sentry.silo.util import (
     encode_subnet_signature,
     trim_leading_slashes,
 )
+from sentry.utils.env import in_test_environment
 
 logger = logging.getLogger(__name__)
 
@@ -76,13 +76,12 @@ class IntegrationProxyClient(ApiClient):
         is_region_silo = SiloMode.get_current_mode() == SiloMode.REGION
         subnet_secret = getattr(settings, "SENTRY_SUBNET_SECRET", None)
         control_address = getattr(settings, "SENTRY_CONTROL_ADDRESS", None)
-        is_test_environment = "pytest" in sys.argv[0]
 
         if is_region_silo and subnet_secret and control_address:
             self._should_proxy_to_control = True
             self.proxy_url = f"{settings.SENTRY_CONTROL_ADDRESS}{PROXY_BASE_PATH}"
 
-        if is_test_environment and not self._use_proxy_url_for_tests:
+        if in_test_environment() and not self._use_proxy_url_for_tests:
             logger.info("proxy_disabled_in_test_env")
             self.proxy_url = self.base_url
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import enum
 import functools
 import logging
-import sys
 from typing import Any, Callable, List, Tuple, Union
 
 from django.dispatch.dispatcher import NO_RECEIVERS, Signal
+
+from sentry.utils.env import in_test_environment
 
 Receiver = Callable[[], Any]
 
@@ -91,7 +92,7 @@ class BetterSignal(Signal):
             try:
                 response = receiver(signal=self, sender=sender, **named)
             except Exception as err:
-                if "pytest" in sys.argv[0]:
+                if in_test_environment():
                     if (
                         _receivers_that_raise is _AllReceivers.ALL
                         or receiver in _receivers_that_raise

--- a/src/sentry/silo/base.py
+++ b/src/sentry/silo/base.py
@@ -4,12 +4,13 @@ import abc
 import contextlib
 import functools
 import itertools
-import sys
 import threading
 from enum import Enum
 from typing import Any, Callable, Generator, Iterable
 
 from django.conf import settings
+
+from sentry.utils.env import in_test_environment
 
 
 class SiloMode(Enum):
@@ -49,7 +50,7 @@ class SiloMode(Enum):
         cases unless the exit_single_process_silo_context is explicitly embedded, ensuring that this single process
         silo mode simulates the boundaries explicitly between what would be separate processes in deployment.
         """
-        if "pytest" in sys.argv[0]:
+        if in_test_environment():
             assert (
                 single_process_silo_mode_state.mode is None
             ), "Re-entrant invariant broken! Use exit_single_process_silo_context to explicit pass 'fake' RPC boundaries."

--- a/src/sentry/silo/safety.py
+++ b/src/sentry/silo/safety.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import re
-import sys
 from collections import defaultdict
 from typing import Any, MutableMapping, Optional
 
@@ -11,6 +10,7 @@ from django.db.transaction import get_connection
 from sentry.silo.patches.silo_aware_transaction_patch import (
     validate_transaction_using_for_silo_mode,
 )
+from sentry.utils.env import in_test_environment
 
 _fence_re = re.compile(r"select\s*\'(?P<operation>start|end)_role_override", re.IGNORECASE)
 _fencing_counters: MutableMapping[str, int] = defaultdict(int)
@@ -35,7 +35,7 @@ def unguarded_write(using: str, *args: Any, **kwargs: Any):
     This code can't be co-located with the auditing logic because
     the testutils module cannot be used in production code.
     """
-    if "pytest" not in sys.argv[0]:
+    if not in_test_environment():
         yield
         return
 

--- a/src/sentry/tasks/deletion/scheduled.py
+++ b/src/sentry/tasks/deletion/scheduled.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from datetime import timedelta
 from typing import TYPE_CHECKING, Iterable, Tuple, Type
 
@@ -12,6 +11,7 @@ from sentry.exceptions import DeleteAborted
 from sentry.signals import pending_delete
 from sentry.silo import SiloMode
 from sentry.tasks.base import instrumented_task, retry
+from sentry.utils.env import in_test_environment
 
 logger = logging.getLogger("sentry.deletions.api")
 
@@ -153,5 +153,5 @@ def run_deletion(deletion_id, first_pass=True, silo_mode="CONTROL"):
             },
         )
         sentry_sdk.capture_exception(err)
-        if "pytest" in sys.argv[0]:
+        if in_test_environment():
             raise err

--- a/src/sentry/utils/env.py
+++ b/src/sentry/utils/env.py
@@ -1,0 +1,5 @@
+import sys
+
+
+def in_test_environment():
+    return "pytest" in sys.argv[0] or "vscode" in sys.argv[0]


### PR DESCRIPTION
PR #52605 broke VSCode Test Explorer's debug mode for certain tests (at least those which require flushing the database, perhaps more). This change centralizes the functionality that the previous one altered in a single utility function, and checks for `vscode` in the path of the calling binary as an alternate mechanism for deciding "am I in test mode or not?" This is sufficient to re-enable normal debugging behavior.