### PR TITLE
fix(hc): Move OrganizationApiKeyDetailsEndpoint to control silo

### DIFF
--- a/src/sentry/api/endpoints/organization_api_key_details.py
+++ b/src/sentry/api/endpoints/organization_api_key_details.py
@@ -3,8 +3,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
-from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.organization import OrganizationAdminPermission, OrganizationEndpoint
+from sentry.api.base import control_silo_endpoint
+from sentry.api.bases.organization import (
+    ControlSiloOrganizationEndpoint,
+    OrganizationAdminPermission,
+)
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.models import ApiKey
@@ -16,11 +19,11 @@ class ApiKeySerializer(serializers.ModelSerializer):
         fields = ("label", "scope_list", "allowed_origins")
 
 
-@region_silo_endpoint
-class OrganizationApiKeyDetailsEndpoint(OrganizationEndpoint):
+@control_silo_endpoint
+class OrganizationApiKeyDetailsEndpoint(ControlSiloOrganizationEndpoint):
     permission_classes = (OrganizationAdminPermission,)
 
-    def get(self, request: Request, organization, api_key_id) -> Response:
+    def get(self, request: Request, organization_context, organization, api_key_id) -> Response:
         """
         Retrieves API Key details
         `````````````````````````
@@ -37,7 +40,7 @@ class OrganizationApiKeyDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serialize(api_key, request.user))
 
-    def put(self, request: Request, organization, api_key_id) -> Response:
+    def put(self, request: Request, organization_context, organization, api_key_id) -> Response:
         """
         Update an API Key
         `````````````````
@@ -73,7 +76,7 @@ class OrganizationApiKeyDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request: Request, organization, api_key_id) -> Response:
+    def delete(self, request: Request, organization_context, organization, api_key_id) -> Response:
         """
         Deletes an API Key
         ``````````````````

--- a/tests/sentry/api/endpoints/test_organization_api_key_details.py
+++ b/tests/sentry/api/endpoints/test_organization_api_key_details.py
@@ -1,6 +1,6 @@
 from sentry.models import ApiKey
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.silo import control_silo_test
 
 DEFAULT_SCOPES = ["project:read", "event:read", "team:read", "org:read", "member:read"]
 
@@ -16,7 +16,7 @@ class OrganizationApiKeyDetailsBase(APITestCase):
         )
 
 
-@region_silo_test
+@control_silo_test(stable=True)
 class OrganizationApiKeyDetails(OrganizationApiKeyDetailsBase):
     def test_api_key_no_exist(self):
         self.get_error_response(self.organization.slug, 123456, status_code=404)
@@ -26,7 +26,7 @@ class OrganizationApiKeyDetails(OrganizationApiKeyDetailsBase):
         assert response.data.get("id") == str(self.api_key.id)
 
 
-@region_silo_test
+@control_silo_test(stable=True)
 class OrganizationApiKeyDetailsPut(OrganizationApiKeyDetailsBase):
     method = "put"
 
@@ -40,7 +40,7 @@ class OrganizationApiKeyDetailsPut(OrganizationApiKeyDetailsBase):
         assert api_key.allowed_origins == "sentry.io"
 
 
-@region_silo_test
+@control_silo_test(stable=True)
 class OrganizationApiKeyDetailsDelete(OrganizationApiKeyDetailsBase):
     method = "delete"
 


### PR DESCRIPTION
The [ApiKey model lives in the control silo](https://github.com/getsentry/sentry/blob/6ef66a3/src/sentry/models/apikey.py#L26-L27).