### PR TITLE
feat(on-demand-metrics): Support count_if in rule conversion

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -97,15 +97,15 @@ class MetricsQueryBuilder(QueryBuilder):
     def _resolve_on_demand_spec(
         self, dataset: Optional[Dataset], selected_cols: List[Optional[str]], query: str
     ) -> Optional[OndemandMetricSpec]:
-        if not is_on_demand_query(dataset, query):
-            return None
-
         field = selected_cols[0] if selected_cols else None
         if not self.is_alerts_query or not field:
             return None
+
+        if not is_on_demand_query(dataset, field, query):
+            return None
+
         try:
             return OndemandMetricSpec(field, query)
-
         except Exception as e:
             sentry_sdk.capture_exception(e)
 

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -367,14 +367,14 @@ class OndemandMetricSpec:
         return condition
 
 
-def _convert_countif_filter(key: str, op: str, value: Any) -> RuleCondition:
+def _convert_countif_filter(key: str, op: str, value: str) -> RuleCondition:
     """Maps ``count_if`` arguments to a ``RuleCondition``."""
     assert op in _COUNTIF_TO_RELAY_OPERATORS, f"Unsupported `count_if` operator {op}"
 
     condition: RuleCondition = {
         "op": _COUNTIF_TO_RELAY_OPERATORS[op],
         "name": _map_field_name(key),
-        "value": value,  # TODO(ja): Value is not cast to the correct type
+        "value": fields.normalize_count_if_value({"column": key, "value": value}),
     }
 
     if op == "notEquals":

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -6,15 +6,13 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
 
 
-def create_alert(query: str):
-    snuba_query = SnubaQuery(
-        aggregate="p75(measurements.fp)", query=query, dataset=Dataset.PerformanceMetrics.value
-    )
-    return AlertRule(snuba_query=snuba_query)
-
-
 def test_empty_query():
-    alert = create_alert("")
+    snuba_query = SnubaQuery(
+        aggregate="p75(measurements.fp)",
+        query="transaction.duration:>=1000",
+        dataset=Dataset.PerformanceMetrics.value,
+    )
+    alert = AlertRule(snuba_query=snuba_query)
 
     assert convert_query_to_metric(alert.snuba_query) is None
 
@@ -28,119 +26,10 @@ def test_simple_query_count():
     alert = AlertRule(snuba_query=snuba_query)
 
     metric = convert_query_to_metric(alert.snuba_query)
-
-    expected = {
+    assert metric == {
         "category": "transaction",
         "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
         "field": None,
         "mri": "c:transactions/on_demand@none",
         "tags": [{"key": "query_hash", "value": ANY}],
     }
-
-    assert metric == expected
-
-
-def test_simple_query():
-    alert = create_alert("transaction.duration:>=1000")
-    metric = convert_query_to_metric(alert.snuba_query)
-
-    expected = {
-        "category": "transaction",
-        "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
-        "field": "event.measurements.fp",
-        "mri": "d:transactions/on_demand@none",
-        "tags": [{"key": "query_hash", "value": ANY}],
-    }
-
-    assert metric == expected
-
-
-def test_or_boolean_condition():
-    alert = create_alert("transaction.duration:>=100 OR transaction.duration:<1000")
-    metric = convert_query_to_metric(alert.snuba_query)
-
-    expected = {
-        "category": "transaction",
-        "condition": {
-            "inner": [
-                {"name": "event.duration", "op": "gte", "value": 100.0},
-                {"name": "event.duration", "op": "lt", "value": 1000.0},
-            ],
-            "op": "or",
-        },
-        "field": "event.measurements.fp",
-        "mri": "d:transactions/on_demand@none",
-        "tags": [{"key": "query_hash", "value": ANY}],
-    }
-
-    assert metric == expected
-
-
-def test_and_boolean_condition():
-    alert = create_alert("release:foo transaction.duration:<10s")
-    metric = convert_query_to_metric(alert.snuba_query)
-
-    expected = {
-        "category": "transaction",
-        "condition": {
-            "inner": [
-                {"name": "event.release", "op": "eq", "value": "foo"},
-                {"name": "event.duration", "op": "lt", "value": 10000.0},
-            ],
-            "op": "and",
-        },
-        "field": "event.measurements.fp",
-        "mri": "d:transactions/on_demand@none",
-        "tags": [{"key": "query_hash", "value": ANY}],
-    }
-
-    assert metric == expected
-
-
-def test_nested_conditions():
-    query = "(release:=a OR transaction.op:=b) transaction.duration:>1s"
-    metric = convert_query_to_metric(create_alert(query).snuba_query)
-
-    expected = {
-        "category": "transaction",
-        "condition": {
-            "op": "and",
-            "inner": [
-                {
-                    "op": "or",
-                    "inner": [
-                        {"name": "event.release", "op": "eq", "value": "a"},
-                        {"name": "event.contexts.trace.op", "op": "eq", "value": "b"},
-                    ],
-                },
-                {"name": "event.duration", "op": "gt", "value": 1000.0},
-            ],
-        },
-        "field": "event.measurements.fp",
-        "mri": "d:transactions/on_demand@none",
-        "tags": [{"key": "query_hash", "value": ANY}],
-    }
-
-    assert metric == expected
-
-
-def test_wildcard_condition():
-    # transaction.duration is required for convert_query_to_metric
-    alert = create_alert("release.version:1.* transaction.duration:1s")
-    metric = convert_query_to_metric(alert.snuba_query)
-
-    expected = {
-        "category": "transaction",
-        "condition": {
-            "op": "and",
-            "inner": [
-                {"name": "event.release.version.short", "op": "glob", "value": ["1.*"]},
-                {"name": "event.duration", "op": "eq", "value": 1000.0},
-            ],
-        },
-        "field": "event.measurements.fp",
-        "mri": "d:transactions/on_demand@none",
-        "tags": [{"key": "query_hash", "value": ANY}],
-    }
-
-    assert metric == expected

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -9,7 +9,7 @@ from sentry.snuba.models import SnubaQuery
 def test_empty_query():
     snuba_query = SnubaQuery(
         aggregate="p75(measurements.fp)",
-        query="transaction.duration:>=1000",
+        query="",
         dataset=Dataset.PerformanceMetrics.value,
     )
     alert = AlertRule(snuba_query=snuba_query)

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -1,12 +1,11 @@
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.metrics.extraction import is_on_demand_query
+from sentry.snuba.metrics.extraction import OndemandMetricSpec, is_on_demand_query
 
 
 def test_is_on_demand_query_wrong_dataset():
-    assert is_on_demand_query(Dataset.Transactions, "count()", "geo.city:=Vienna") is False
+    assert is_on_demand_query(Dataset.Transactions, "count()", "geo.city:Vienna") is False
     assert (
-        is_on_demand_query(Dataset.Metrics, "count()", "browser.version:=1 os.name:=android")
-        is False
+        is_on_demand_query(Dataset.Metrics, "count()", "browser.version:1 os.name:android") is False
     )
 
 
@@ -28,13 +27,13 @@ def test_is_on_demand_query_true():
     # transaction.duration is a non-standard field
     assert is_on_demand_query(dataset, "count()", "transaction.duration:>=1") is True
     # transaction.duration is a non-standard field
-    assert is_on_demand_query(dataset, "count()", "geo.city:=Vienna") is True
+    assert is_on_demand_query(dataset, "count()", "geo.city:Vienna") is True
     # os.name is a standard field, browser.version is not
-    assert is_on_demand_query(dataset, "count()", "browser.version:=1 os.name:=android") is True
+    assert is_on_demand_query(dataset, "count()", "browser.version:1 os.name:android") is True
     # os.version is not a standard field
     assert (
         is_on_demand_query(
-            dataset, "count()", "(release:=a OR transaction.op:=b) transaction.duration:>1s"
+            dataset, "count()", "(release:a OR transaction.op:b) transaction.duration:>1s"
         )
         is True
     )
@@ -44,11 +43,11 @@ def test_is_on_demand_query_false():
     dataset = Dataset.PerformanceMetrics
 
     assert is_on_demand_query(dataset, "count()", "") is False
-    assert is_on_demand_query(dataset, "count()", "environment:=dev") is False
-    assert is_on_demand_query(dataset, "count()", "release:=initial OR os.name:=android") is False
+    assert is_on_demand_query(dataset, "count()", "environment:dev") is False
+    assert is_on_demand_query(dataset, "count()", "release:initial OR os.name:android") is False
     assert (
         is_on_demand_query(
-            dataset, "count()", "(http.method:=POST OR http.status_code:=404) browser.name:=chrome"
+            dataset, "count()", "(http.method:POST OR http.status_code:404) browser.name:chrome"
         )
         is False
     )
@@ -59,3 +58,120 @@ def test_is_on_demand_query_countif():
 
     assert is_on_demand_query(dataset, "count_if(transaction.duration,equals,300)", "") is True
     assert is_on_demand_query(dataset, 'count_if(release,equals,"foo")', "") is False
+
+
+def test_spec_simple_query_count():
+    spec = OndemandMetricSpec("count()", "transaction.duration:>1s")
+
+    assert spec.metric_type == "c"
+    assert spec.field is None
+    assert spec.op == "sum"
+    assert spec.condition() == {"name": "event.duration", "op": "gt", "value": 1000.0}
+
+
+def test_spec_simple_query_distribution():
+    spec = OndemandMetricSpec("p75(measurements.fp)", "transaction.duration:>1s")
+
+    assert spec.metric_type == "d"
+    assert spec.field == "event.measurements.fp"
+    assert spec.op == "p75"
+    assert spec.condition() == {"name": "event.duration", "op": "gt", "value": 1000.0}
+
+
+def test_spec_or_condition():
+    spec = OndemandMetricSpec("count()", "transaction.duration:>=100 OR transaction.duration:<1000")
+
+    assert spec.condition() == {
+        "inner": [
+            {"name": "event.duration", "op": "gte", "value": 100.0},
+            {"name": "event.duration", "op": "lt", "value": 1000.0},
+        ],
+        "op": "or",
+    }
+
+
+def test_spec_and_condition():
+    spec = OndemandMetricSpec("count()", "release:foo transaction.duration:<10s")
+    assert spec.condition() == {
+        "inner": [
+            {"name": "event.release", "op": "eq", "value": "foo"},
+            {"name": "event.duration", "op": "lt", "value": 10000.0},
+        ],
+        "op": "and",
+    }
+
+
+def test_spec_nested_condition():
+    spec = OndemandMetricSpec("count()", "(release:a OR transaction.op:b) transaction.duration:>1s")
+    assert spec.condition() == {
+        "op": "and",
+        "inner": [
+            {
+                "op": "or",
+                "inner": [
+                    {"name": "event.release", "op": "eq", "value": "a"},
+                    {"name": "event.contexts.trace.op", "op": "eq", "value": "b"},
+                ],
+            },
+            {"name": "event.duration", "op": "gt", "value": 1000.0},
+        ],
+    }
+
+
+def test_spec_boolean_precedence():
+    spec = OndemandMetricSpec("count()", "release:a OR transaction.op:b transaction.duration:>1s")
+    assert spec.condition() == {
+        "op": "or",
+        "inner": [
+            {"name": "event.release", "op": "eq", "value": "a"},
+            {
+                "op": "and",
+                "inner": [
+                    {"name": "event.contexts.trace.op", "op": "eq", "value": "b"},
+                    {"name": "event.duration", "op": "gt", "value": 1000.0},
+                ],
+            },
+        ],
+    }
+
+
+def test_spec_wildcard():
+    spec = OndemandMetricSpec("count()", "release.version:1.*")
+    assert spec.condition() == {
+        "name": "event.release.version.short",
+        "op": "glob",
+        "value": ["1.*"],
+    }
+
+
+def test_spec_countif():
+    spec = OndemandMetricSpec("count_if(transaction.duration,equals,300)", "")
+
+    assert spec.metric_type == "c"
+    assert spec.field is None
+    assert spec.op == "sum"
+    assert spec.condition() == {
+        "name": "event.duration",
+        "op": "eq",
+        "value": 300.0,
+    }
+
+
+def test_spec_countif_with_query():
+    spec = OndemandMetricSpec(
+        "count_if(transaction.duration,equals,300)", "release:a OR transaction.op:b"
+    )
+
+    assert spec.condition() == {
+        "op": "and",
+        "inner": [
+            {
+                "op": "or",
+                "inner": [
+                    {"name": "event.release", "op": "eq", "value": "a"},
+                    {"name": "event.contexts.trace.op", "op": "eq", "value": "b"},
+                ],
+            },
+            {"name": "event.duration", "op": "eq", "value": 300.0},
+        ],
+    }

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -3,32 +3,39 @@ from sentry.snuba.metrics.extraction import is_on_demand_query
 
 
 def test_is_on_demand_query_wrong_dataset():
-    assert is_on_demand_query(Dataset.Transactions, "geo.city:=Vienna") is False
-    assert is_on_demand_query(Dataset.Metrics, "browser.version:=1 os.name:=android") is False
+    assert is_on_demand_query(Dataset.Transactions, "count()", "geo.city:=Vienna") is False
+    assert (
+        is_on_demand_query(Dataset.Metrics, "count()", "browser.version:=1 os.name:=android")
+        is False
+    )
 
 
 def test_is_on_demand_query_no_query():
-    assert is_on_demand_query(Dataset.PerformanceMetrics, "") is False
+    assert is_on_demand_query(Dataset.PerformanceMetrics, "count()", "") is False
 
 
 def test_is_on_demand_query_invalid_query():
-    assert is_on_demand_query(Dataset.PerformanceMetrics, "AND") is False
-    assert is_on_demand_query(Dataset.PerformanceMetrics, "(AND transaction.duration:>=1") is False
-    assert is_on_demand_query(Dataset.PerformanceMetrics, "transaction.duration:>=abc") is False
+    dataset = Dataset.PerformanceMetrics
+
+    assert is_on_demand_query(dataset, "count()", "AND") is False
+    assert is_on_demand_query(dataset, "count()", "(AND transaction.duration:>=1") is False
+    assert is_on_demand_query(dataset, "count()", "transaction.duration:>=abc") is False
 
 
 def test_is_on_demand_query_true():
     dataset = Dataset.PerformanceMetrics
 
     # transaction.duration is a non-standard field
-    assert is_on_demand_query(dataset, "transaction.duration:>=1") is True
+    assert is_on_demand_query(dataset, "count()", "transaction.duration:>=1") is True
     # transaction.duration is a non-standard field
-    assert is_on_demand_query(dataset, "geo.city:=Vienna") is True
+    assert is_on_demand_query(dataset, "count()", "geo.city:=Vienna") is True
     # os.name is a standard field, browser.version is not
-    assert is_on_demand_query(dataset, "browser.version:=1 os.name:=android") is True
+    assert is_on_demand_query(dataset, "count()", "browser.version:=1 os.name:=android") is True
     # os.version is not a standard field
     assert (
-        is_on_demand_query(dataset, "(release:=a OR transaction.op:=b) transaction.duration:>1s")
+        is_on_demand_query(
+            dataset, "count()", "(release:=a OR transaction.op:=b) transaction.duration:>1s"
+        )
         is True
     )
 
@@ -36,12 +43,19 @@ def test_is_on_demand_query_true():
 def test_is_on_demand_query_false():
     dataset = Dataset.PerformanceMetrics
 
-    assert is_on_demand_query(dataset, "") is False
-    assert is_on_demand_query(dataset, "environment:=dev") is False
-    assert is_on_demand_query(dataset, "release:=initial OR os.name:=android") is False
+    assert is_on_demand_query(dataset, "count()", "") is False
+    assert is_on_demand_query(dataset, "count()", "environment:=dev") is False
+    assert is_on_demand_query(dataset, "count()", "release:=initial OR os.name:=android") is False
     assert (
         is_on_demand_query(
-            dataset, "(http.method:=POST OR http.status_code:=404) browser.name:=chrome"
+            dataset, "count()", "(http.method:=POST OR http.status_code:=404) browser.name:=chrome"
         )
         is False
     )
+
+
+def test_is_on_demand_query_countif():
+    dataset = Dataset.PerformanceMetrics
+
+    assert is_on_demand_query(dataset, "count_if(transaction.duration,equals,300)", "") is True
+    assert is_on_demand_query(dataset, 'count_if(release,equals,"foo")', "") is False


### PR DESCRIPTION
Parses `count_if` conditions and converts them to a `RuleCondition`. The
condition is then merged with conditions from the query. Also adds
support for `count_if` to `is_on_demand_query`.

Tasks in this PR:
- [x] Allow `count_if` as aggregate function
- [x] Parse function args into a `RuleCondition`
- [x] Convert the value arg into the correct type
- [x] Merge query and aggregate conditions
- [x] Check the aggregate in `is_on_demand_query`

Closes #52504
