### PR TITLE
fix(starfish): span sample back button behaviour

### DIFF
--- a/static/app/views/starfish/components/detailPanel.tsx
+++ b/static/app/views/starfish/components/detailPanel.tsx
@@ -27,6 +27,8 @@ export default function Detail({children, detailKey, onClose}: DetailProps) {
   useEffect(() => {
     if (detailKey) {
       setState({collapsed: false});
+    } else {
+      setState({collapsed: true});
     }
   }, [detailKey]);
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -34,7 +34,7 @@ export function SampleList({groupId, transactionName, transactionMethod}: Props)
         onClose={() => {
           router.push({
             pathname: router.location.pathname,
-            query: omit(router.location.query, 'transaction'),
+            query: omit(router.location.query, 'transaction', 'transactionMethod'),
           });
         }}
       >


### PR DESCRIPTION
Fixes a bug where clicking the browser back button when the span samples page is open leads to a `undefined` span samples page.