### PR TITLE
chore(hybridcloud) Move unguarded_write out of testutils

### DIFF
--- a/src/sentry/silo/__init__.py
+++ b/src/sentry/silo/__init__.py
@@ -1,1 +1,2 @@
 from .base import *  # NOQA
+from .safety import *  # NOQA

--- a/src/sentry/silo/safety.py
+++ b/src/sentry/silo/safety.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import contextlib
+import re
+import sys
+from collections import defaultdict
+from typing import Any, MutableMapping, Optional
+
+from django.db.transaction import get_connection
+
+from sentry.silo.patches.silo_aware_transaction_patch import determine_using_by_silo_mode
+
+_fence_re = re.compile(r"select\s*\'(?P<operation>start|end)_role_override", re.IGNORECASE)
+_fencing_counters: MutableMapping[str, int] = defaultdict(int)
+
+
+def match_fence_query(query: str) -> Optional[re.Match[str]]:
+    return _fence_re.match(query)
+
+
+@contextlib.contextmanager
+def unguarded_write(using: str | None = None, *args: Any, **kwargs: Any):
+    """
+    Used to indicate that the wrapped block is safe to do
+    mutations on outbox backed records.
+    In production this context manager has no effect, but
+    in tests it emits 'fencing' queries that are audited at the
+    end of each test run by:
+    sentry.testutils.silo.validate_protected_queries
+    This code can't be co-located with the auditing logic because
+    the testutils module cannot be used in production code.
+    """
+    if "pytest" not in sys.argv[0]:
+        yield
+        return
+
+    using = determine_using_by_silo_mode(using)
+    _fencing_counters[using] += 1
+
+    with get_connection(using).cursor() as conn:
+        fence_value = _fencing_counters[using]
+        conn.execute("SELECT %s", [f"start_role_override_{fence_value}"])
+        try:
+            yield
+        finally:
+            conn.execute("SELECT %s", [f"end_role_override_{fence_value}"])

--- a/src/sentry/testutils/asserts.py
+++ b/src/sentry/testutils/asserts.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from sentry.models import AuditLogEntry, CommitFileChange
+
 
 def assert_mock_called_once_with_partial(mock, *args, **kwargs):
     """
@@ -14,11 +16,10 @@ def assert_mock_called_once_with_partial(mock, *args, **kwargs):
         assert m_kwargs[kwarg] == kwargs[kwarg], (m_kwargs[kwarg], kwargs[kwarg])
 
 
+commit_file_type_choices = {c[0] for c in CommitFileChange._meta.get_field("type").choices}
+
+
 def assert_commit_shape(commit):
-    from sentry.models import CommitFileChange
-
-    commit_file_type_choices = {c[0] for c in CommitFileChange._meta.get_field("type").choices}
-
     assert commit["id"]
     assert commit["repository"]
     assert commit["author_email"]
@@ -39,8 +40,6 @@ def assert_status_code(response, minimum: int, maximum: Optional[int] = None):
 
 
 def org_audit_log_exists(**kwargs):
-    from sentry.models import AuditLogEntry
-
     assert kwargs
     if "organization" in kwargs:
         kwargs["organization_id"] = kwargs.pop("organization").id
@@ -56,6 +55,4 @@ def assert_org_audit_log_does_not_exist(**kwargs):
 
 
 def delete_all_org_audit_logs():
-    from sentry.models import AuditLogEntry
-
     return AuditLogEntry.objects.all().delete()


### PR DESCRIPTION
When opening the mulligan pull requests, I remembered that I'll also need to move the unguarded_write function out of testutils first, as I need to update getsentry before sentry.