### PR TITLE
fix(github-comment): add github comment task referrer

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -419,6 +419,7 @@ class Referrer(Enum):
     GETSENTRY_PROMOTION_MOBILE_PERFORMANCE_ADOPTION_CHECK_ELIGIBLE = (
         "getsentry.promotion.mobile_performance_adoption.check_eligible"
     )
+    GITHUB_PR_COMMENT_BOT = "tasks.github_comment"
     GROUP_FILTER_BY_EVENT_ID = "group.filter_by_event_id"
     GROUP_GET_LATEST = "Group.get_latest"
     GROUP_UNHANDLED_FLAG = "group.unhandled-flag"

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -20,6 +20,7 @@ from sentry.models.pullrequest import PullRequestComment
 from sentry.models.repository import Repository
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions.base import ApiError
+from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.commit_context import DEBOUNCE_PR_COMMENT_CACHE_KEY
 from sentry.types.referrer_ids import GITHUB_PR_BOT_REFERRER
@@ -117,7 +118,7 @@ def get_top_5_issues_by_count(issue_list: List[int], project: Project) -> List[i
             .set_limit(5)
         ),
     )
-    return raw_snql_query(request, referrer="tasks.github_comment")["data"]
+    return raw_snql_query(request, referrer=Referrer.GITHUB_PR_COMMENT_BOT.value)["data"]
 
 
 def get_comment_contents(issue_list: List[int]) -> List[PullRequestIssue]:


### PR DESCRIPTION
Fixes this warning
![image](https://github.com/getsentry/sentry/assets/70817427/d6d8cea0-1386-471a-a562-4d3887d26bc2)
