### PR TITLE
feat(hybrid-cloud): Create parser for Github Enterprise

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -42,8 +42,8 @@ from .repository import GitHubRepositoryProvider
 logger = logging.getLogger("sentry.webhooks")
 
 
-def get_github_external_id(event: Mapping[str, Any], host: str | None = None) -> str:
-    external_id = event.get("installation", {}).get("id")
+def get_github_external_id(event: Mapping[str, Any], host: str | None = None) -> str | None:
+    external_id: str | None = event.get("installation", {}).get("id")
     return f"{host}:{external_id}" if host else external_id
 
 

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -42,6 +42,11 @@ from .repository import GitHubRepositoryProvider
 logger = logging.getLogger("sentry.webhooks")
 
 
+def get_github_external_id(event: Mapping[str, Any], host: str | None = None) -> str:
+    external_id = event.get("installation", {}).get("id")
+    return f"{host}:{external_id}" if host else external_id
+
+
 class Webhook:
     provider = "github"
 
@@ -56,9 +61,7 @@ class Webhook:
         raise NotImplementedError
 
     def __call__(self, event: Mapping[str, Any], host: str | None = None) -> None:
-        external_id = event.get("installation", {}).get("id")
-        if host:
-            external_id = f"{host}:{external_id}"
+        external_id = get_github_external_id(event=event, host=host)
 
         integration, installs = integration_service.get_organization_contexts(
             external_id=external_id, provider=self.provider

--- a/src/sentry/integrations/github_enterprise/urls.py
+++ b/src/sentry/integrations/github_enterprise/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     re_path(
         r"^webhook/$",
         GitHubEnterpriseWebhookEndpoint.as_view(),
+        name="sentry-integration-github-enterprise-webhook",
     )
 ]

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -14,6 +14,7 @@ from sentry.integrations.github.webhook import (
     InstallationEventWebhook,
     PullRequestEventWebhook,
     PushEventWebhook,
+    get_github_external_id,
 )
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.utils import json
@@ -27,12 +28,18 @@ from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 
 
+def get_host(request: Request):
+    # XXX: There's lots of customers that are giving us an IP rather than a host name
+    # Use HTTP_X_REAL_IP in a follow up PR (#42405)
+    return request.META["HTTP_X_GITHUB_ENTERPRISE_HOST"]
+
+
 def get_installation_metadata(event, host):
     if not host:
         return
-
+    external_id = get_github_external_id(event=event, host=host)
     integration = integration_service.get_integration(
-        external_id="{}:{}".format(host, event["installation"]["id"]),
+        external_id=external_id,
         provider="github_enterprise",
     )
     if integration is None:
@@ -111,9 +118,7 @@ class GitHubEnterpriseWebhookBase(Endpoint):
         with configure_scope() as scope:
             meta = request.META
             try:
-                # XXX: There's lost of customers that are giving us an IP rather than a host name
-                # Use HTTP_X_REAL_IP in a follow up PR
-                host = meta["HTTP_X_GITHUB_ENTERPRISE_HOST"]
+                host = get_host(request=request)
             except KeyError:
                 logger.warning("github_enterprise.webhook.missing-enterprise-host")
                 logger.exception("Missing enterprise host.")

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -28,10 +28,10 @@ from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 
 
-def get_host(request: Request):
+def get_host(request: Request) -> str | None:
     # XXX: There's lots of customers that are giving us an IP rather than a host name
     # Use HTTP_X_REAL_IP in a follow up PR (#42405)
-    return request.META["HTTP_X_GITHUB_ENTERPRISE_HOST"]
+    return request.META.get("HTTP_X_GITHUB_ENTERPRISE_HOST")
 
 
 def get_installation_metadata(event, host):
@@ -117,9 +117,8 @@ class GitHubEnterpriseWebhookBase(Endpoint):
         clear_tags_and_context()
         with configure_scope() as scope:
             meta = request.META
-            try:
-                host = get_host(request=request)
-            except KeyError:
+            host = get_host(request=request)
+            if not host:
                 logger.warning("github_enterprise.webhook.missing-enterprise-host")
                 logger.exception("Missing enterprise host.")
                 return HttpResponse(status=400)

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -4,7 +4,7 @@ import hashlib
 import hmac
 import logging
 
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -28,7 +28,7 @@ from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 
 
-def get_host(request: Request) -> str | None:
+def get_host(request: HttpRequest) -> str | None:
     # XXX: There's lots of customers that are giving us an IP rather than a host name
     # Use HTTP_X_REAL_IP in a follow up PR (#42405)
     return request.META.get("HTTP_X_GITHUB_ENTERPRISE_HOST")

--- a/src/sentry/middleware/integrations/integration_control.py
+++ b/src/sentry/middleware/integrations/integration_control.py
@@ -8,6 +8,7 @@ from sentry.silo import SiloMode
 
 from .parsers import (
     BitbucketRequestParser,
+    GithubEnterpriseRequestParser,
     GithubRequestParser,
     GitlabRequestParser,
     JiraRequestParser,
@@ -21,13 +22,14 @@ from .parsers.base import BaseRequestParser
 logger = logging.getLogger(__name__)
 
 ACTIVE_PARSERS = [
+    BitbucketRequestParser,
+    GithubEnterpriseRequestParser,
     GithubRequestParser,
     GitlabRequestParser,
     JiraRequestParser,
     JiraServerRequestParser,
-    SlackRequestParser,
     MsTeamsRequestParser,
-    BitbucketRequestParser,
+    SlackRequestParser,
     VstsRequestParser,
 ]
 

--- a/src/sentry/middleware/integrations/parsers/__init__.py
+++ b/src/sentry/middleware/integrations/parsers/__init__.py
@@ -1,5 +1,6 @@
 from .bitbucket import BitbucketRequestParser
 from .github import GithubRequestParser
+from .github_enterprise import GithubEnterpriseRequestParser
 from .gitlab import GitlabRequestParser
 from .jira import JiraRequestParser
 from .jira_server import JiraServerRequestParser
@@ -13,6 +14,7 @@ __all__ = (
     "GitlabRequestParser",
     "JiraRequestParser",
     "JiraServerRequestParser",
+    "GithubEnterpriseRequestParser",
     "MsTeamsRequestParser",
     "SlackRequestParser",
     "VstsRequestParser",

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -31,6 +31,8 @@ class GithubRequestParser(BaseRequestParser):
         except json.JSONDecodeError:
             return None
         external_id = self._get_external_id(event=event)
+        if not external_id:
+            return None
         return Integration.objects.filter(external_id=external_id, provider=self.provider).first()
 
     def get_response(self):

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -18,7 +18,7 @@ class GithubRequestParser(BaseRequestParser):
     provider = EXTERNAL_PROVIDERS[ExternalProviders.GITHUB]
     webhook_identifier = WebhookProviderIdentifier.GITHUB
 
-    def _get_external_id(self, event: Mapping[str, Any]) -> str:
+    def _get_external_id(self, event: Mapping[str, Any]) -> str | None:
         """Overridden in GithubEnterpriseRequestParser"""
         return get_github_external_id(event)
 

--- a/src/sentry/middleware/integrations/parsers/github_enterprise.py
+++ b/src/sentry/middleware/integrations/parsers/github_enterprise.py
@@ -15,5 +15,8 @@ class GithubEnterpriseRequestParser(GithubRequestParser):
     provider = "github_enterprise"
     webhook_identifier = WebhookProviderIdentifier.GITHUB_ENTERPRISE
 
-    def _get_external_id(self, event: Mapping[str, Any]) -> str:
+    def _get_external_id(self, event: Mapping[str, Any]) -> str | None:
+        host = get_host(request=self.request)
+        if not host:
+            return None
         return get_github_external_id(event=event, host=get_host(request=self.request))

--- a/src/sentry/middleware/integrations/parsers/github_enterprise.py
+++ b/src/sentry/middleware/integrations/parsers/github_enterprise.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 import logging
+from typing import Any, Mapping
 
-from sentry.middleware.integrations.parsers.base import BaseRequestParser
+from sentry.integrations.github.webhook import get_github_external_id
+from sentry.integrations.github_enterprise.webhook import get_host
+from sentry.middleware.integrations.parsers.github import GithubRequestParser
 from sentry.models.outbox import WebhookProviderIdentifier
 
 logger = logging.getLogger(__name__)
 
 
-class GithubEnterpriseRequestParser(BaseRequestParser):
+class GithubEnterpriseRequestParser(GithubRequestParser):
     provider = "github_enterprise"
     webhook_identifier = WebhookProviderIdentifier.GITHUB_ENTERPRISE
+
+    def _get_external_id(self, event: Mapping[str, Any]) -> str:
+        return get_github_external_id(event=event, host=get_host(request=self.request))

--- a/src/sentry/middleware/integrations/parsers/github_enterprise.py
+++ b/src/sentry/middleware/integrations/parsers/github_enterprise.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import logging
+
+from sentry.middleware.integrations.parsers.base import BaseRequestParser
+from sentry.models.outbox import WebhookProviderIdentifier
+
+logger = logging.getLogger(__name__)
+
+
+class GithubEnterpriseRequestParser(BaseRequestParser):
+    provider = "github_enterprise"
+    webhook_identifier = WebhookProviderIdentifier.GITHUB_ENTERPRISE

--- a/src/sentry/middleware/integrations/parsers/github_enterprise.py
+++ b/src/sentry/middleware/integrations/parsers/github_enterprise.py
@@ -19,4 +19,4 @@ class GithubEnterpriseRequestParser(GithubRequestParser):
         host = get_host(request=self.request)
         if not host:
             return None
-        return get_github_external_id(event=event, host=get_host(request=self.request))
+        return get_github_external_id(event=event, host=host)

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -107,6 +107,7 @@ class WebhookProviderIdentifier(IntEnum):
     BITBUCKET = 5
     VSTS = 6
     JIRA_SERVER = 7
+    GITHUB_ENTERPRISE = 8
 
 
 def _ensure_not_null(k: str, v: Any) -> Any:

--- a/tests/sentry/middleware/integrations/parsers/test_github_enterprise.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github_enterprise.py
@@ -92,7 +92,7 @@ class GithubEnterpriseRequestParserTest(TestCase):
             self.path,
             data={"installation": {"id": self.external_identifier}},
             content_type="application/json",
-            **{"HTTP_X_GITHUB_ENTERPRISE_HOST": self.external_host},
+            HTTP_X_GITHUB_ENTERPRISE_HOST=self.external_host,
         )
         parser = GithubEnterpriseRequestParser(request=request, response_handler=self.get_response)
         integration = parser.get_integration_from_request()

--- a/tests/sentry/middleware/integrations/parsers/test_github_enterprise.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github_enterprise.py
@@ -1,0 +1,134 @@
+from typing import Any
+from unittest import mock
+from unittest.mock import MagicMock
+
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+from django.urls import reverse
+
+from sentry.middleware.integrations.integration_control import IntegrationControlMiddleware
+from sentry.middleware.integrations.parsers.github_enterprise import GithubEnterpriseRequestParser
+from sentry.models.outbox import (
+    ControlOutbox,
+    OutboxCategory,
+    OutboxScope,
+    WebhookProviderIdentifier,
+)
+from sentry.silo.base import SiloMode
+from sentry.testutils import TestCase
+from sentry.testutils.silo import control_silo_test
+from sentry.types.region import Region, RegionCategory
+
+
+@control_silo_test(stable=True)
+class GithubEnterpriseRequestParserTest(TestCase):
+    get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
+    middleware = IntegrationControlMiddleware(get_response)
+    factory = RequestFactory()
+    path = reverse("sentry-integration-github-enterprise-webhook")
+    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    external_host = "12.345.678.901"
+    external_identifier = "github_enterprise:1"
+    external_id = f"{external_host}:{external_identifier}"
+
+    def setUp(self):
+        super().setUp()
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id=self.external_id,
+            provider="github_enterprise",
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_invalid_webhook(self):
+        request = self.factory.post(
+            self.path, data=b"invalid-data", content_type="application/x-www-form-urlencoded"
+        )
+        parser = GithubEnterpriseRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+        assert response.status_code == 200
+        assert response.content == b"no-error"
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_routing_properly(self):
+        request = self.factory.post(self.path, data={}, content_type="application/json")
+        parser = GithubEnterpriseRequestParser(request=request, response_handler=self.get_response)
+
+        # No regions identified
+        with mock.patch.object(
+            parser, "get_response_from_outbox_creation"
+        ) as get_response_from_outbox_creation, mock.patch.object(
+            parser, "get_response_from_control_silo"
+        ) as get_response_from_control_silo, mock.patch.object(
+            parser, "get_regions_from_organizations", return_value=[]
+        ):
+            parser.get_response()
+            assert get_response_from_control_silo.called
+            assert not get_response_from_outbox_creation.called
+
+        # Regions found
+        with mock.patch.object(
+            parser, "get_response_from_outbox_creation"
+        ) as get_response_from_outbox_creation, mock.patch.object(
+            parser, "get_regions_from_organizations", return_value=[self.region]
+        ):
+            parser.get_response()
+            assert get_response_from_outbox_creation.called
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_get_integration_from_request(self):
+        # No host header
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": self.external_identifier}},
+            content_type="application/json",
+        )
+        parser = GithubEnterpriseRequestParser(request=request, response_handler=self.get_response)
+        integration = parser.get_integration_from_request()
+        assert integration is None
+
+        # With host header
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": self.external_identifier}},
+            content_type="application/json",
+            **{"HTTP_X_GITHUB_ENTERPRISE_HOST": self.external_host},
+        )
+        parser = GithubEnterpriseRequestParser(request=request, response_handler=self.get_response)
+        integration = parser.get_integration_from_request()
+        assert integration == self.integration
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_webhook_outbox_creation(self):
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": self.external_identifier}},
+            content_type="application/json",
+        )
+        parser = GithubEnterpriseRequestParser(request=request, response_handler=self.get_response)
+
+        assert ControlOutbox.objects.count() == 0
+        with mock.patch.object(
+            parser, "get_regions_from_organizations", return_value=[self.region]
+        ):
+            parser.get_response()
+
+            assert ControlOutbox.objects.count() == 1
+            outbox = ControlOutbox.objects.first()
+            expected_payload: Any = {
+                "method": "POST",
+                "path": self.path,
+                "uri": f"http://testserver{self.path}",
+                "headers": {
+                    "Cookie": "",
+                    "Content-Length": "47",
+                    "Content-Type": "application/json",
+                },
+                "body": request.body.decode(encoding="utf-8"),
+            }
+            assert outbox.payload == expected_payload
+            assert outbox.shard_scope == OutboxScope.WEBHOOK_SCOPE
+            assert outbox.shard_identifier == WebhookProviderIdentifier.GITHUB_ENTERPRISE
+            assert outbox.category == OutboxCategory.WEBHOOK_PROXY
+            assert outbox.region_name == self.region.name
+            assert outbox.payload == expected_payload


### PR DESCRIPTION
This PR adds the Github Enterprise request parser. This parser is nearly identical to the regular Github one, so it actually inherits it and makes a few changes to the 'external_id' code. I also modified the code at the webhook application code so they would refer to the same method of getting an integration and we wouldn't introduce any drift by accident.