### PR TITLE
fix(functions): Switch to fingerprints when querying functions

### DIFF
--- a/static/app/views/profiling/landing/slowestFunctionsWidget.spec.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.spec.tsx
@@ -43,7 +43,7 @@ describe('SlowestFunctionsWidget', function () {
       match: [
         MockApiClient.matchQuery({
           dataset: 'profileFunctions',
-          field: ['project.id', 'package', 'function', 'count()', 'sum()'],
+          field: ['project.id', 'fingerprint', 'package', 'function', 'count()', 'sum()'],
         }),
       ],
     });
@@ -65,12 +65,14 @@ describe('SlowestFunctionsWidget', function () {
         data: [
           {
             'project.id': 1,
+            fingerprint: 123,
             package: 'foo',
             function: 'bar',
             'sum()': 150,
           },
           {
             'project.id': 1,
+            fingerprint: 456,
             package: 'baz',
             function: 'qux',
             'sum()': 100,
@@ -80,7 +82,7 @@ describe('SlowestFunctionsWidget', function () {
       match: [
         MockApiClient.matchQuery({
           dataset: 'profileFunctions',
-          field: ['project.id', 'package', 'function', 'count()', 'sum()'],
+          field: ['project.id', 'fingerprint', 'package', 'function', 'count()', 'sum()'],
         }),
       ],
     });
@@ -123,7 +125,7 @@ describe('SlowestFunctionsWidget', function () {
       match: [
         MockApiClient.matchQuery({
           dataset: 'profileFunctions',
-          query: 'project.id:1 package:foo function:bar',
+          query: 'project.id:1 fingerprint:123',
           field: ['transaction', 'count()', 'sum()', 'examples()'],
         }),
       ],
@@ -154,7 +156,7 @@ describe('SlowestFunctionsWidget', function () {
       match: [
         MockApiClient.matchQuery({
           dataset: 'profileFunctions',
-          query: 'project.id:1 package:baz function:qux',
+          query: 'project.id:1 fingerprint:456',
           field: ['transaction', 'count()', 'sum()', 'examples()'],
         }),
       ],

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -137,7 +137,7 @@ export function SlowestFunctionsWidget({
           </EmptyStateWarning>
         )}
         {hasFunctions && totalsQuery.isFetched && (
-          <Accordion>
+          <StyledAccordion>
             {(functionsQuery.data?.data ?? []).map((f, i) => {
               const projectEntry = totalsQuery.data?.data?.find(
                 row => row['project.id'] === f['project.id']
@@ -154,7 +154,7 @@ export function SlowestFunctionsWidget({
                 />
               );
             })}
-          </Accordion>
+          </StyledAccordion>
         )}
       </ContentContainer>
     </WidgetContainer>
@@ -190,8 +190,7 @@ function SlowestFunctionEntry({
     const conditions = new MutableSearch(query);
 
     conditions.setFilterValues('project.id', [String(func['project.id'])]);
-    conditions.setFilterValues('package', [String(func.package)]);
-    conditions.setFilterValues('function', [String(func.function)]);
+    conditions.setFilterValues('fingerprint', [String(func.fingerprint)]);
 
     return conditions.formatString();
   }, [func, query]);
@@ -305,6 +304,7 @@ function SlowestFunctionEntry({
 
 const functionsFields = [
   'project.id',
+  'fingerprint',
   'package',
   'function',
   'count()',
@@ -328,6 +328,11 @@ type FunctionTransactionField = (typeof functionTransactionsFields)[number];
 
 const StyledPagination = styled(Pagination)`
   margin: 0;
+`;
+
+const StyledAccordion = styled(Accordion)`
+  display: flex;
+  flex-direction: column;
 `;
 
 const StyledAccordionItem = styled(AccordionItem)`

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -190,6 +190,8 @@ function SlowestFunctionEntry({
     const conditions = new MutableSearch(query);
 
     conditions.setFilterValues('project.id', [String(func['project.id'])]);
+    // it is more efficient to filter on the fingerprint
+    // than it is to filter on the package + function
     conditions.setFilterValues('fingerprint', [String(func.fingerprint)]);
 
     return conditions.formatString();


### PR DESCRIPTION
It's more effectively to query for a function by it's fingerprint than to query by it's name.