### PR TITLE
fix(replays): Set max-width of progress to 100%

### DIFF
--- a/static/app/components/replays/progress.tsx
+++ b/static/app/components/replays/progress.tsx
@@ -24,6 +24,7 @@ export const Meter = styled('div')`
 export const Value = styled('span')<{
   style: {width: string} & CSSProperties;
 }>`
+  max-width: 100%;
   position: absolute;
   height: 100%;
   pointer-events: none;


### PR DESCRIPTION
Fixes #52304 by setting the max width of the progress to 100%.

I do find it odd that the context allows the `currentTime` to be be larger than `durationMs`, but this fix ensures that the progress will never appear wider than 100% (which I think is good to have regardless).