### PR TITLE
ref(crons): Use darker colors for timeline marks

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/checkInTimeline.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/checkInTimeline.tsx
@@ -80,6 +80,7 @@ const JobTick = styled('div')<{
 }>`
   position: absolute;
   background: ${p => getColorsFromStatus(p.status, p.theme).tickColor};
+  opacity: 0.7;
   width: 4px;
   height: 14px;
   ${p =>

--- a/static/app/views/monitors/utils.tsx
+++ b/static/app/views/monitors/utils.tsx
@@ -76,10 +76,10 @@ export const statusToText: Record<CheckInStatus, string> = {
 
 export function getColorsFromStatus(status: CheckInStatus, theme: Theme) {
   const statusToColor: Record<CheckInStatus, {labelColor: string; tickColor: string}> = {
-    [CheckInStatus.ERROR]: {tickColor: theme.red200, labelColor: theme.red300},
-    [CheckInStatus.TIMEOUT]: {tickColor: theme.red200, labelColor: theme.red300},
-    [CheckInStatus.OK]: {tickColor: theme.green200, labelColor: theme.green300},
-    [CheckInStatus.MISSED]: {tickColor: theme.yellow200, labelColor: theme.yellow300},
+    [CheckInStatus.ERROR]: {tickColor: theme.red300, labelColor: theme.red400},
+    [CheckInStatus.TIMEOUT]: {tickColor: theme.red300, labelColor: theme.red400},
+    [CheckInStatus.OK]: {tickColor: theme.green300, labelColor: theme.green400},
+    [CheckInStatus.MISSED]: {tickColor: theme.yellow300, labelColor: theme.yellow400},
     [CheckInStatus.IN_PROGRESS]: {tickColor: theme.disabled, labelColor: theme.disabled},
   };
   return statusToColor[status];


### PR DESCRIPTION
**Before ——**
<img width="1589" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/080fa20c-2f4f-4d36-b903-eebf1210e4d5">


**After ——**
<img width="1589" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/f61affd6-a2cd-4ff5-af89-eeb8b4053b93">
