### PR TITLE
feat(starfish): Add span module field alias

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -42,6 +42,7 @@ TRACE_PARENT_SPAN_ALIAS = "trace.parent_span"
 HTTP_STATUS_CODE_ALIAS = "http.status_code"
 DEVICE_CLASS_ALIAS = "device.class"
 TOTAL_SPAN_DURATION_ALIAS = "total.span_duration"
+SPAN_MODULE_ALIAS = "span.module"
 
 
 class ThresholdDict(TypedDict):

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -29,7 +29,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
 
     @property
     def field_alias_converter(self) -> Mapping[str, Callable[[str], SelectType]]:
-        return {}
+        return {constants.SPAN_MODULE_ALIAS: self._resolve_span_module}
 
     def resolve_metric(self, value: str) -> int:
         metric_id = self.builder.resolve_metric_index(constants.SPAN_METRICS_MAP.get(value, value))
@@ -343,6 +343,26 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                 function_converter[alias] = function_converter[name].alias_as(alias)
 
         return function_converter
+
+    def _resolve_span_module(self, alias: str) -> SelectType:
+        return Function(
+            "transform",
+            [
+                self.builder.column("span.category"),
+                [
+                    "cache",
+                    "db",
+                    "http",
+                ],
+                [
+                    "cache",
+                    "db",
+                    "http",
+                ],
+                "other",
+            ],
+            alias,
+        )
 
     # Query Functions
     def _resolve_count_if(

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -500,3 +500,53 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[0]["p50(span.self_time)"] == 100
         assert meta["dataset"] == "spansMetrics"
         assert meta["fields"]["p50(span.self_time)"] == "duration"
+
+    def test_span_module(self):
+        self.store_span_metric(
+            1,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"span.category": "http"},
+        )
+        self.store_span_metric(
+            3,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"span.category": "db"},
+        )
+        self.store_span_metric(
+            5,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"span.category": "foobar"},
+        )
+        self.store_span_metric(
+            7,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"span.category": "cache"},
+        )
+        response = self.do_request(
+            {
+                "field": ["span.module", "p50(span.self_time)"],
+                "query": "",
+                "orderby": ["-p50(span.self_time)"],
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 4
+        assert data[0]["p50(span.self_time)"] == 7
+        assert data[0]["span.module"] == "cache"
+        assert data[1]["p50(span.self_time)"] == 5
+        assert data[1]["span.module"] == "other"
+        assert data[2]["p50(span.self_time)"] == 3
+        assert data[2]["span.module"] == "db"
+        assert data[3]["p50(span.self_time)"] == 1
+        assert data[3]["span.module"] == "http"
+        assert meta["dataset"] == "spansMetrics"
+        assert meta["fields"]["p50(span.self_time)"] == "duration"


### PR DESCRIPTION
- Move span.module to be a field alias instead so we no longer need the span.module tag anymore
- This adds a span.module "other", instead of the empty string we have now
- The categories are 1:1 to the modules for now