### PR TITLE
ref(alerts): Remove mute alerts feature flag

### DIFF
--- a/static/app/views/alerts/rules/metric/details/header.tsx
+++ b/static/app/views/alerts/rules/metric/details/header.tsx
@@ -53,7 +53,6 @@ function DetailsHeader({
     },
   };
 
-  const hasSnoozeFeature = organization.features.includes('mute-metric-alerts');
   const isSnoozed = rule?.snooze ?? false;
 
   return (
@@ -79,7 +78,7 @@ function DetailsHeader({
       </Layout.HeaderContent>
       <Layout.HeaderActions>
         <ButtonBar gap={1}>
-          {hasSnoozeFeature && rule && project && (
+          {rule && project && (
             <Access access={['alerts:write']}>
               {({hasAccess}) => (
                 <SnoozeAlert

--- a/static/app/views/alerts/rules/metric/details/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.spec.tsx
@@ -124,9 +124,7 @@ describe('MetricAlertDetails', () => {
   });
 
   it('renders mute button for metric alert', async () => {
-    const {routerContext, organization, router} = initializeOrg({
-      organization: {features: ['mute-metric-alerts']},
-    });
+    const {routerContext, organization, router} = initializeOrg();
     const incident = TestStubs.Incident();
     const rule = TestStubs.MetricRule({
       projects: [project.slug],


### PR DESCRIPTION
Remove usages of the mute metric alerts feature flag now that it's in GA.

Back end PR: https://github.com/getsentry/sentry/pull/52823