### PR TITLE
ref(alerts): Remove mute metric alerts flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1313,8 +1313,6 @@ SENTRY_FEATURES = {
     "organizations:change-alerts": True,
     # Enable alerting based on crash free sessions/users
     "organizations:crash-rate-alerts": True,
-    # Enable the mute metric alerts feature
-    "organizations:mute-metric-alerts": False,
     # Enable the Commit Context feature
     "organizations:commit-context": False,
     # Enable creating organizations within sentry (if SENTRY_SINGLE_ORGANIZATION

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -71,7 +71,6 @@ default_manager.add("organizations:api-keys", OrganizationFeature, FeatureHandle
 default_manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:auto-repo-linking", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:crash-rate-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:mute-metric-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:crons-issue-platform", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:crons-timeline-listing-page", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:customer-domains", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -266,11 +266,9 @@ def generate_incident_trigger_email_context(
         query="referrer=alert_email",
     )
 
-    snooze_alert = False
     snooze_alert_url = None
-    if features.has("organizations:mute-metric-alerts", organization):
-        snooze_alert = True
-        snooze_alert_url = alert_link + "&" + urlencode({"mute": "1"})
+    snooze_alert = True
+    snooze_alert_url = alert_link + "&" + urlencode({"mute": "1"})
 
     return {
         "link": alert_link,

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -217,7 +217,6 @@ class EmailActionHandlerGetTargetsTest(TestCase):
 
 @freeze_time()
 class EmailActionHandlerGenerateEmailContextTest(TestCase):
-    @with_feature("organizations:mute-metric-alerts")
     def test_simple(self):
         trigger_status = TriggerStatus.ACTIVE
         incident = self.create_incident()


### PR DESCRIPTION
Remove the feature flag and usages of it since the feature is in GA now. This must be merged after the [front end PR](https://github.com/getsentry/sentry/pull/52822) and the [getsentry PR](https://github.com/getsentry/getsentry/pull/11117).