### PR TITLE
fix(hc): Move OrganizationApiKeyIndexEndpoint to control silo

### DIFF
--- a/src/sentry/api/endpoints/organization_api_key_index.py
+++ b/src/sentry/api/endpoints/organization_api_key_index.py
@@ -3,19 +3,22 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
-from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.organization import OrganizationAdminPermission, OrganizationEndpoint
+from sentry.api.base import control_silo_endpoint
+from sentry.api.bases.organization import (
+    ControlSiloOrganizationEndpoint,
+    OrganizationAdminPermission,
+)
 from sentry.api.serializers import serialize
 from sentry.models import ApiKey
 
 DEFAULT_SCOPES = ["project:read", "event:read", "team:read", "org:read", "member:read"]
 
 
-@region_silo_endpoint
-class OrganizationApiKeyIndexEndpoint(OrganizationEndpoint):
+@control_silo_endpoint
+class OrganizationApiKeyIndexEndpoint(ControlSiloOrganizationEndpoint):
     permission_classes = (OrganizationAdminPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization_context, organization) -> Response:
         """
         List an Organization's API Keys
         ```````````````````````````````````
@@ -29,7 +32,7 @@ class OrganizationApiKeyIndexEndpoint(OrganizationEndpoint):
 
         return Response(serialize(queryset, request.user))
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization_context, organization) -> Response:
         """
         Create an Organization API Key
         ```````````````````````````````````

--- a/tests/sentry/api/endpoints/test_organization_api_key_index.py
+++ b/tests/sentry/api/endpoints/test_organization_api_key_index.py
@@ -1,8 +1,8 @@
 from sentry.testutils import APITestCase
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.silo import control_silo_test
 
 
-@region_silo_test
+@control_silo_test(stable=True)
 class OrganizationApiKeyIndex(APITestCase):
     endpoint = "sentry-api-0-organization-api-key-index"
 


### PR DESCRIPTION
The ApiKey model lives in the control silo.

#52776 took care of the details endpoint