### PR TITLE
fix(starfish): Fix WSV bug where Other module is added when it does not exist

### DIFF
--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -136,7 +136,7 @@ export function SpanGroupBreakdownContainer({transaction, transactionMethod}: Pr
       });
     }
 
-    if (otherValue > 0) {
+    if (otherValue > 0 && OTHER_SPAN_GROUP_MODULE in topData) {
       transformedData.push({
         cumulativeTime: otherValue,
         group: {


### PR DESCRIPTION
Fixes JAVASCRIPT-2MX2

We were manually transforming the data to include the 'Other' module, even when it doesn't exist. It doesn't exist in Snuba, and so we were trying to access missing data which caused a crash in the frontend