### PR TITLE
ref(auth): Refactor auth_login.py

### DIFF
--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -67,7 +67,133 @@ additional_context = AdditionalContext()
 class AuthLoginView(BaseView):
     auth_required = False
 
-    def get_auth_provider(self, organization_slug):
+    @never_cache
+    def handle(self, request: Request, *args, **kwargs) -> Response:
+        return super().handle(request, *args, **kwargs)
+
+    def get(self, request: Request) -> Response:
+        next_uri = self.get_next_uri(request)
+        if request.user.is_authenticated:
+            return self.redirect_authenticated_user(request, next_uri=next_uri)
+
+        request.session.set_test_cookie()
+
+        # we always reset the state on GET so you don't end up at an odd location
+        initiate_login(request, next_uri)
+
+        # Single org mode -- send them to the org-specific handler
+        if settings.SENTRY_SINGLE_ORGANIZATION:
+            return self.redirect_to_org_specific_login()
+
+        session_expired = "session_expired" in request.COOKIES
+        if session_expired:
+            messages.add_message(request, messages.WARNING, WARN_SESSION_EXPIRED)
+
+        default_context = self.get_default_context(request=request)
+
+        if self.requires_sso_login_redirect(request=request):
+            response = self.get_sso_redirect(request=request)
+        elif self.can_register(request):
+            response = self.get_registration_page(request=request, context=default_context)
+        else:
+            response = self.get_login_page(request=request, context=default_context)
+
+        if session_expired:
+            response.delete_cookie("session_expired")
+
+        return response
+
+    def redirect_authenticated_user(self, request: Request, next_uri):
+        """If an authenticated user sends a GET request to AuthLoginView, we redirect them forwards in the auth process."""
+        if is_valid_redirect(next_uri, allowed_hosts=(request.get_host(),)):
+            return self.redirect(next_uri)
+        return self.redirect_to_org(request)
+
+    def redirect_to_org_specific_login(self):
+        """If Sentry is in single org mode this redirects users to their specific handler."""
+        org = Organization.get_default()
+        next_uri = reverse("sentry-auth-organization", args=[org.slug])
+        return HttpResponseRedirect(next_uri)
+
+    def requires_sso_login_redirect(self, request: Request) -> bool:
+        non_sso_urls = [
+            reverse("sentry-auth-organization", args=[request.subdomain]),
+            reverse("sentry-register"),
+        ]
+        return (
+            request.subdomain
+            and self.check_if_org_exists(request)
+            and request.path_info not in non_sso_urls
+        )
+
+    def get_sso_redirect(self, request: Request):
+        """Returns a redirect response that will take a user to SSO login."""
+        url_prefix = generate_organization_url(
+            reverse("sentry-auth-organization", args=[request.subdomain])
+        )
+        absolute_url = absolute_uri(
+            reverse("sentry-auth-organization", args=[request.subdomain]), url_prefix=url_prefix
+        )
+        url = f"{absolute_url}?{request.GET.urlencode()}"
+        return HttpResponseRedirect(url)
+
+    def get_registration_page(self, request: Request, context: dict) -> Response:
+        """Returns the standard registration page."""
+        register_form = self.get_register_form(
+            request, initial={"username": request.session.get("invite_email", "")}
+        )
+        context.update(
+            {
+                "op": "register",
+                "CAN_REGISTER": True,
+                "register_form": register_form,
+            }
+        )
+        return self.respond("sentry/login.html", context)
+
+    def get_login_page(self, request: Request, context: dict) -> Response:
+        """Returns the standard login page."""
+        op = request.GET.get("op") if request.GET.get("op") == "sso" else "login"
+        login_form = AuthenticationForm(request)
+        context.update(
+            {
+                "op": op,
+                "login_form": login_form,
+            }
+        )
+        return self.respond("sentry/login.html", context)
+
+    def post(self, request: Request, **kwargs) -> Response:
+        op = request.POST.get("op")
+        if op == "sso" and request.POST.get("organization"):
+            return self.redirect_post_to_sso(request=request)
+
+        default_context = self.get_default_context(request=request, **kwargs)
+        organization = kwargs.pop("organization", None)
+
+        if self.can_register(request):
+            return self.handle_register_form_submit(
+                request=request, context=default_context, organization=organization
+            )
+        else:
+            return self.handle_login_form_submit(
+                request=request, context=default_context, organization=organization
+            )
+
+    def redirect_post_to_sso(self, request: Request) -> Response:
+        """If the post call comes from the SSO tab, redirect the user to SSO login next steps."""
+        auth_provider = self.get_auth_providerif_exists(request.POST["organization"])
+        if auth_provider:
+            next_uri = reverse("sentry-auth-organization", args=[request.POST["organization"]])
+        else:
+            # Redirect to the org login route
+            next_uri = request.get_full_path()
+            messages.add_message(request, messages.ERROR, ERR_NO_SSO)
+
+        return HttpResponseRedirect(next_uri)
+
+    def get_auth_provider_if_exists(self, organization_slug):
+        """Returns the auth provider for the given org, or None if there isn't one."""
         try:
             organization = Organization.objects.get(
                 slug=organization_slug, status=OrganizationStatus.ACTIVE
@@ -82,11 +208,29 @@ class AuthLoginView(BaseView):
 
         return auth_provider
 
-    def get_login_form(self, request: Request):
-        op = request.POST.get("op")
-        return AuthenticationForm(request, request.POST if op == "login" else None)
+    def handle_register_form_submit(self, request: Request, context, organization):
+        """Validates a completed register form, redirecting to the next
+        step or returning the form with its errors displayed."""
 
-    def get_register_form(self, request: Request, initial=None):
+        register_form = self.get_register_form(
+            request, initial={"username": request.session.get("invite_email", "")}
+        )
+        if register_form.is_valid():
+            return self.redirect_to_next_register_step(
+                request=request, register_form=register_form, organization=organization
+            )
+        else:
+            context.update(
+                {
+                    "op": "register",
+                    "register_form": register_form,
+                    "CAN_REGISTER": True,
+                }
+            )
+            self.respond("sentry/login.html", context)
+
+    def get_register_form(self, request: Request, initial):
+        """Extracts the register form from a request, then formats and returns it."""
         op = request.POST.get("op")
         return RegistrationForm(
             request.POST if op == "register" else None,
@@ -95,8 +239,194 @@ class AuthLoginView(BaseView):
             auto_id="id_registration_%s",
         )
 
-    def can_register(self, request: Request):
+    def redirect_to_next_register_step(self, request: Request, register_form, organization):
+        """Given a valid register form, redirects the user to their next step."""
+
+        user = register_form.save()
+        user.send_confirm_emails(is_new_user=True)
+        user_signup.send_robust(sender=self, user=user, source="register-form", referrer="in-app")
+
+        # HACK: grab whatever the first backend is and assume it works
+        user.backend = settings.AUTHENTICATION_BACKENDS[0]
+        self._handle_login(request, user, organization)
+
+        # can_register should only allow a single registration
+        request.session.pop("can_register", None)
+        request.session.pop("invite_email", None)
+
+        # Attempt to directly accept any pending invites
+        invite_helper = ApiInviteHelper.from_session(
+            request=request,
+        )
+
+        # In single org mode, associate the user to the only organization.
+        #
+        # XXX: Only do this if there isn't a pending invitation. The user
+        # may need to configure 2FA in which case, we don't want to make
+        # the association for them.
+        if settings.SENTRY_SINGLE_ORGANIZATION and not invite_helper:
+            self.add_user_to_organization(user)
+
+        if invite_helper and invite_helper.valid_request:
+            return self.accept_invite_and_redirect_to_org(
+                request=request, invite_helper=invite_helper
+            )
+
+        return self.redirect(self.get_post_register_url(request))
+
+    def add_user_to_organization(self, user) -> None:
+        """Adds a user to their default organization as a member."""
+        organization = Organization.get_default()
+        organization_service.add_organization_member(
+            organization_id=organization.id,
+            default_org_role=organization.default_role,
+            user_id=user.id,
+        )
+
+    def accept_invite_and_redirect_to_org(self, request: Request, invite_helper):
+        """Accepts an invite on behalf of a user and redirects them to their org login"""
+        invite_helper.accept_invite()
+        organization_slug = invite_helper.invite_context.organization.slug
+        self.determine_active_organization(request, organization_slug)
+        response = self.redirect_to_org(request)
+        remove_invite_details_from_session(request)
+        return response
+
+    def get_post_register_url(self, request: Request):
+        """Gets the redirect URL for a successfully submitted register form."""
+        base_url = auth.get_login_redirect(request)
+        params = {"frontend_events": json.dumps({"event_name": "Sign Up"})}
+        return add_params_to_url(base_url, params)
+
+    def get_next_uri(self, request: Request):
+        next_uri_fallback = None
+        if request.session.get("_next") is not None:
+            next_uri_fallback = request.session.pop("_next")
+        return request.GET.get(REDIRECT_FIELD_NAME, next_uri_fallback)
+
+    def handle_login_form_submit(self, request: Request, context: dict, **kwargs):
+        op = request.POST.get("op")
+        organization = kwargs.pop("organization", None)
+        login_form = AuthenticationForm(request, request.POST if op == "login" else None)
+
+        if self.is_ratelimited_login_attempt(request=request, login_form=login_form, op=op):
+            return self.get_ratelimited_login_form(request, login_form, op)
+        elif login_form.is_valid():
+            return self.redirect_to_next_login_step(
+                request=request, login_form=login_form, organization=organization
+            )
+        context.update({"login_form": login_form, "op": op or login})
+        return self.respond("sentry/login.html", context)
+
+    def is_ratelimited_login_attempt(self, request: Request, login_form, op: str):
+        """Returns true if a user is attempting to login but is currently ratelimited."""
+        from sentry import ratelimits as ratelimiter
+        from sentry.utils.hashlib import md5_text
+
+        attempted_login = (
+            op == "login" and request.POST.get("username") and request.POST.get("password")
+        )
+
+        return attempted_login and ratelimiter.is_limited(
+            "auth:login:username:{}".format(
+                md5_text(login_form.clean_username(request.POST["username"])).hexdigest()
+            ),
+            limit=5,
+            window=60,  # 5 per minute should be enough for anyone
+        )
+
+    def get_ratelimited_login_form(self, request: Request, login_form, op: str):
+        """Returns a login form with ratelimited errors displayed."""
+        login_form.errors["__all__"] = [
+            "You have made too many login attempts. Please try again later."
+        ]
+        metrics.incr("login.attempt", instance="rate_limited", skip_internal=True, sample_rate=1.0)
+
+        context = {
+            "op": op or "login",
+            "login_form": login_form,
+        }
+
+        context.update(additional_context.run_callbacks(request))
+        return self.respond("sentry/login.html", context)
+
+    def redirect_to_next_login_step(self, request: Request, login_form, organization, **kwargs):
+        """Called when a user submits a valid login form and must be redirected to
+        the next step in their auth process"""
+        user = login_form.get_user()
+
+        self._handle_login(request, user, organization)
+        metrics.incr("login.attempt", instance="success", skip_internal=True, sample_rate=1.0)
+
+        if not user.is_active:
+            return self.redirect(reverse("sentry-reactivate-account"))
+        if organization:
+            self.refresh_organization_status(request, user, organization)
+        # On login, redirect to onboarding
+        if self.active_organization:
+            if features.has(
+                "organizations:customer-domains",
+                self.active_organization.organization,
+                actor=user,
+            ):
+                setattr(request, "subdomain", self.active_organization.organization.slug)
+        return self.redirect(get_login_redirect(request))
+
+    def _handle_login(self, request: Request, user, organization: Optional[Organization]):
+        login(request, user, organization_id=coerce_id_from(organization))
+        self.determine_active_organization(request)
+
+    def refresh_organization_status(self, request: Request, user, organization) -> None:
+        """I'm not really sure what this does actually."""
+        # Refresh the organization we fetched prior to login in order to check its login state.
+        org_context = organization_service.get_organization_by_slug(
+            user_id=request.user.id,
+            slug=organization.slug,
+            only_visible=False,
+        )
+        if org_context:
+            if org_context.member and request.user and not is_active_superuser(request):
+                auth.set_active_org(request, org_context.organization.slug)
+
+            if settings.SENTRY_SINGLE_ORGANIZATION:
+                om = organization_service.check_membership_by_email(
+                    organization_id=org_context.organization.id, email=user.email
+                )
+
+                if om is None:
+                    om = organization_service.check_membership_by_id(
+                        organization_id=org_context.organization.id, user_id=user.id
+                    )
+                if om is None or om.user_id is None:
+                    request.session.pop("_next", None)
+
+    def check_if_org_exists(self, request: Request) -> bool:
+        """Returns True iff the organization passed in a request exists."""
+        return bool(
+            organization_service.check_organization_by_slug(
+                slug=request.subdomain, only_visible=True
+            )
+        )
+
+    def can_register(self, request: Request) -> bool:
+        """Returns True if a user is eligible to register.
+        Users are eligible to register if they are arriving at this page via an invite link"""
         return bool(has_user_registration() or request.session.get("can_register"))
+
+    def get_default_context(self, request: Request, **kwargs):
+        organization = kwargs.pop("organization", None)
+        default_context = {
+            "server_hostname": get_server_hostname(),
+            "login_form": None,
+            "organization": kwargs.pop("organization", None),
+            "register_form": None,
+            "CAN_REGISTER": False,
+            "join_request_link": self.get_join_request_link(organization),
+            "show_login_banner": settings.SHOW_LOGIN_BANNER,
+            "banner_choice": randint(0, 1),  # 2 possible banners
+        }
+        default_context.update(additional_context.run_callbacks(request))
+        return default_context
 
     def get_join_request_link(self, organization):
         if not organization:
@@ -109,25 +439,8 @@ class AuthLoginView(BaseView):
 
         return reverse("sentry-join-request", args=[organization.slug])
 
-    def get_next_uri(self, request: Request):
-        next_uri_fallback = None
-        if request.session.get("_next") is not None:
-            next_uri_fallback = request.session.pop("_next")
-        return request.GET.get(REDIRECT_FIELD_NAME, next_uri_fallback)
-
-    def get_post_register_url(self, request: Request):
-        base_url = auth.get_login_redirect(request)
-        params = {"frontend_events": json.dumps({"event_name": "Sign Up"})}
-        return add_params_to_url(base_url, params)
-
-    def respond_login(self, request: Request, context, **kwargs):
-        return self.respond("sentry/login.html", context)
-
-    def _handle_login(self, request: Request, user, organization: Optional[Organization]):
-        login(request, user, organization_id=coerce_id_from(organization))
-        self.determine_active_organization(request)
-
     def handle_basic_auth(self, request: Request, **kwargs):
+        """Legacy handler that handles GET and POST requests for registration and login."""
         op = request.POST.get("op")
         organization = kwargs.pop("organization", None)
 
@@ -296,57 +609,5 @@ class AuthLoginView(BaseView):
         context.update(additional_context.run_callbacks(request))
         return self.respond_login(request, context, **kwargs)
 
-    def handle_authenticated(self, request: Request):
-        next_uri = self.get_next_uri(request)
-        if is_valid_redirect(next_uri, allowed_hosts=(request.get_host(),)):
-            return self.redirect(next_uri)
-        return self.redirect_to_org(request)
-
-    @never_cache
-    def handle(self, request: Request, *args, **kwargs) -> Response:
-        return super().handle(request, *args, **kwargs)
-
-    # XXX(dcramer): OAuth provider hooks this view
-    def get(self, request: Request, **kwargs) -> Response:
-        next_uri = self.get_next_uri(request)
-        if request.user.is_authenticated:
-            return self.handle_authenticated(request)
-
-        request.session.set_test_cookie()
-
-        # we always reset the state on GET so you don't end up at an odd location
-        initiate_login(request, next_uri)
-
-        # Single org mode -- send them to the org-specific handler
-        if settings.SENTRY_SINGLE_ORGANIZATION:
-            org = organization_service.get_default_organization()
-            next_uri = reverse("sentry-auth-organization", args=[org.slug])
-            return HttpResponseRedirect(next_uri)
-
-        session_expired = "session_expired" in request.COOKIES
-        if session_expired:
-            messages.add_message(request, messages.WARNING, WARN_SESSION_EXPIRED)
-
-        response = self.handle_basic_auth(request, **kwargs)
-
-        if session_expired:
-            response.delete_cookie("session_expired")
-
-        return response
-
-    # XXX(dcramer): OAuth provider hooks this view
-    def post(self, request: Request, **kwargs) -> Response:
-        op = request.POST.get("op")
-        if op == "sso" and request.POST.get("organization"):
-            # if post is from "Single Sign On tab"
-            auth_provider = self.get_auth_provider(request.POST["organization"])
-            if auth_provider:
-                next_uri = reverse("sentry-auth-organization", args=[request.POST["organization"]])
-            else:
-                # Redirect to the org login route
-                next_uri = request.get_full_path()
-                messages.add_message(request, messages.ERROR, ERR_NO_SSO)
-
-            return HttpResponseRedirect(next_uri)
-
-        return self.handle_basic_auth(request, **kwargs)
+    def respond_login(self, request: Request, context, **kwargs):
+        return self.respond("sentry/login.html", context)

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -166,7 +166,7 @@ class AuthLoginView(BaseView):
         """
         context = self.get_default_context(request=request)
 
-        register_form = self.get_register_form(
+        register_form = self.initialize_register_form(
             request=request, initial={"username": request.session.get("invite_email", "")}
         )
         context.update(
@@ -247,7 +247,7 @@ class AuthLoginView(BaseView):
         """
         context = self.get_default_context(request=request, **kwargs)
 
-        register_form = self.get_register_form(
+        register_form = self.initialize_register_form(
             request=request, initial={"username": request.session.get("invite_email", "")}
         )
         if register_form.is_valid():
@@ -266,7 +266,7 @@ class AuthLoginView(BaseView):
             )
             return self.respond_login(request=request, context=context, **kwargs)
 
-    def get_register_form(self, request: Request, initial: dict) -> RegistrationForm:
+    def initialize_register_form(self, request: Request, initial: dict) -> RegistrationForm:
         """
         Extracts the register form from a request, then formats and returns it.
         """
@@ -574,7 +574,7 @@ class AuthLoginView(BaseView):
         # login_form either validated on post or renders form fields for GET
         login_form = self.get_login_form(request)
         if can_register:
-            register_form = self.get_register_form(
+            register_form = self.initialize_register_form(
                 request, initial={"username": request.session.get("invite_email", "")}
             )
         else:

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -641,7 +641,7 @@ class AuthLoginView(BaseView):
         context.update(additional_context.run_callbacks(request))
         return self.respond_login(request, context, **kwargs)
 
-    def respond_login(self, context, **kwargs):
+    def respond_login(self, request: Request, context: dict, **kwargs):
         """Finds and returns the login template -> useful because it's overloaded by subclasses."""
         return self.respond("sentry/login.html", context, **kwargs)
 

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -401,6 +401,7 @@ class BaseView(View, OrganizationMixin):
         default_context = self.default_context
         if context:
             default_context.update(context)
+
         return render_to_response(template, default_context, self.request, status=status)
 
     def redirect(self, url: str, headers: Mapping[str, str] | None = None) -> HttpResponse:

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -401,7 +401,6 @@ class BaseView(View, OrganizationMixin):
         default_context = self.default_context
         if context:
             default_context.update(context)
-
         return render_to_response(template, default_context, self.request, status=status)
 
     def redirect(self, url: str, headers: Mapping[str, str] | None = None) -> HttpResponse:

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -472,6 +472,7 @@ class AuthLoginCustomerDomainTest(TestCase):
             HTTP_HOST=f"{self.organization.slug}.testserver",
             follow=True,
         )
+
         assert resp.status_code == 200
         assert resp.redirect_chain == [("http://baz.testserver/auth/login/baz/", 302)]
         self.assertTemplateUsed("sentry/organization-login.html")
@@ -506,7 +507,7 @@ class AuthLoginCustomerDomainTest(TestCase):
             SERVER_NAME="albertos-apples.testserver",
             follow=True,
         )
-        # assert self.path == "hello world"
+
         assert resp.status_code == 200
         assert resp.redirect_chain == [
             ("http://albertos-apples.testserver/auth/login/", 302),

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -468,7 +468,6 @@ class AuthLoginCustomerDomainTest(TestCase):
             HTTP_HOST=f"{self.organization.slug}.testserver",
             follow=True,
         )
-
         assert resp.status_code == 200
         assert resp.redirect_chain == [("http://baz.testserver/auth/login/baz/", 302)]
         self.assertTemplateUsed("sentry/organization-login.html")
@@ -503,6 +502,7 @@ class AuthLoginCustomerDomainTest(TestCase):
             SERVER_NAME="albertos-apples.testserver",
             follow=True,
         )
+        # assert self.path == "hello world"
         assert resp.status_code == 200
         assert resp.redirect_chain == [
             ("http://albertos-apples.testserver/auth/login/", 302),

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -462,6 +462,10 @@ class AuthLoginCustomerDomainTest(TestCase):
     def path(self):
         return reverse("sentry-login")
 
+    def setUp(self):
+        super().setUp()
+        options.set("auth.allow-registration", False)
+
     def test_renders_correct_template_existent_org(self):
         resp = self.client.get(
             self.path,


### PR DESCRIPTION
Refactors `auth_login.py` and splits the mega `handle_basic_auth()` function into many smaller components.

**Why?** Auth is a consistently troublesome part of the codebase to work in. Seemingly small changes can have major side effects that are hard to predict and diagnose. Because auth code is brittle and hard to change, it's a limiting factor for projects that involve it (for example, the recent Fly.io work, or the updates we made to refresh tokens).  This change falls into a larger group of refactors/redesigns that the enterprise team is making in order to improve auth so we can:
- Ship code faster
- Add new functionality to Sentry auth without worrying so much about things breaking
- Lower the barrier to entry for working on auth code/flatten the related learning curve
- Change auth-related code confidently
- Avoid strange bugs in corner cases
- Trace errors and their causes more effectively

The goal here is to have the `auth_login.py` functionality be broken into small, predictable methods/functions with narrow scope that are easy to understand and easier to work with/change. The file is meant to be read like a top-down narrative, where, as you go deeper into the file, you descend layers of abstraction. Note that all of the main methods for `GET` come above the methods for `POST`, and then the shared methods/common utils are at the bottom.

Also note I left in the old `handle_basic_auth` function because some subclasses rely on it, after this I intend to switch those over and get rid of that too.

I know this is a sensitive file and I want to be careful in how we do this, if you notice any behavior that is untested, or can think of corner cases, please let me know and I can test for them.