### PR TITLE
fix(notifications): replay_id link bug squashing

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -241,12 +241,12 @@ def get_oldest_or_latest_event_for_environments(
 def get_replay_count_for_group(group: Group) -> int:
     events = eventstore.backend.get_events(
         filter=eventstore.Filter(
-            conditions=[["replayId", "!=", None]],
+            conditions=[["replay_id", "IS NOT NULL", None]],
             project_ids=[group.project_id],
             group_ids=[group.id],
         ),
         limit=1,
-        orderby=EventOrdering.MOST_HELPFUL,
+        orderby=EventOrdering.MOST_HELPFUL.value,
         referrer="Group.get_replay_count_for_group",
         dataset=Dataset.Events,
         tenant_ids={"organization_id": group.project.organization_id},
@@ -620,7 +620,7 @@ class Group(Model):
         return self.get_status() == GroupStatus.RESOLVED
 
     def has_replays(self):
-        return get_replay_count_for_group(self) > 0
+        return len(get_replay_count_for_group(self)) > 0
 
     def get_status(self):
         # XXX(dcramer): GroupSerializer reimplements this logic

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -251,7 +251,7 @@ def get_replay_count_for_group(group: Group) -> int:
         dataset=Dataset.Events,
         tenant_ids={"organization_id": group.project.organization_id},
     )
-    return events
+    return len(events)
 
 
 def get_helpful_event_for_environments(
@@ -620,7 +620,7 @@ class Group(Model):
         return self.get_status() == GroupStatus.RESOLVED
 
     def has_replays(self):
-        return len(get_replay_count_for_group(self)) > 0
+        return get_replay_count_for_group(self) > 0
 
     def get_status(self):
         # XXX(dcramer): GroupSerializer reimplements this logic

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -127,7 +127,6 @@ class DigestNotification(ProjectNotification):
     ) -> MutableMapping[str, Any]:
         has_session_replay = features.has("organizations:session-replay", organization)
         show_replay_link = features.has("organizations:session-replay-issue-emails", organization)
-
         return {
             **get_digest_as_context(digest),
             "has_alert_integration": has_alert_integration(project),

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -423,17 +423,20 @@ def send_activity_notification(notification: ActivityNotification | UserReportNo
 
 
 def get_replay_id(event: Event | GroupEvent) -> str | None:
-    tags_replay_id = event.get_tag("replayId")
+    replay_id = event.data.get("contexts", {}).get("replay", {}).get("replay_id", {})
     if (
         isinstance(event, GroupEvent)
         and event.occurrence is not None
         and event.occurrence.evidence_data
     ):
-        evidence_replay_id = event.occurrence.evidence_data.get("replayId", "")
+        evidence_replay_id = (
+            event.occurrence.evidence_data.get("contexts", {}).get("replay", {}).get("replay_id")
+        )
+
         if evidence_replay_id:
             return evidence_replay_id
 
-    return tags_replay_id
+    return replay_id
 
 
 @dataclass

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -641,10 +641,11 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
         organization = project.organization
         event = self.store_event(
             data={
+                "contexts": {"replay": {"replay_id": "46eb3948be25448abd53fe36b5891ff2"}},
                 "message": "Kaboom!",
                 "platform": "python",
                 "timestamp": iso_format(before_now(seconds=1)),
-                "tags": [("level", "error"), ("replayId", "123456789")],
+                "tags": [("level", "error")],
                 "request": {"url": "example.com"},
             },
             project_id=project.id,
@@ -1216,6 +1217,43 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest):
 
         message = mail.outbox[0]
         assert "List-ID" in message.message()
+
+    @mock.patch.object(mail_adapter, "notify", side_effect=mail_adapter.notify, autospec=True)
+    def test_notify_digest_replay_id(self, notify):
+        project = self.project
+        timestamp = iso_format(before_now(minutes=1))
+        event = self.store_event(
+            data={
+                "timestamp": timestamp,
+                "fingerprint": ["group-1"],
+                "contexts": {"replay": {"replay_id": "46eb3948be25448abd53fe36b5891ff2"}},
+            },
+            project_id=project.id,
+        )
+        event2 = self.store_event(
+            data={
+                "timestamp": timestamp,
+                "fingerprint": ["group-2"],
+                "contexts": {"replay": {"replay_id": "46eb3948be25448abd53fe36b5891ff2"}},
+            },
+            project_id=project.id,
+        )
+
+        rule = project.rule_set.all()[0]
+        ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
+        digest = build_digest(
+            project, (event_to_record(event, (rule,)), event_to_record(event2, (rule,)))
+        )[0]
+
+        features = ["organizations:session-replay", "organizations:session-replay-issue-emails"]
+        with self.feature(features), self.tasks():
+            self.adapter.notify_digest(project, digest, ActionTargetType.ISSUE_OWNERS)
+
+        assert notify.call_count == 0
+        assert len(mail.outbox) == 1
+
+        message = mail.outbox[0]
+        assert "View Replays" in message.message().as_string()
 
     @mock.patch.object(mail_adapter, "notify", side_effect=mail_adapter.notify, autospec=True)
     def test_dont_notify_digest_snoozed(self, notify):


### PR DESCRIPTION
- some small tweaks to how we access `replay_id` in the event. `replayId` only exists as a tag to search in snuba, so it is not on the data to pull from nodestore.
- fixes some issues in `has_replays` and `get_replay_count_for_group`. I'm not sure why these errors weren't bubbled up anywhere, but there is now test coverage for their behavior via the added test `test_notify_digest_replay_id`.

