### PR TITLE
fix(helpful-event): fix querying for title for helpful event

### DIFF
--- a/src/sentry/api/endpoints/group_event_details.py
+++ b/src/sentry/api/endpoints/group_event_details.py
@@ -32,9 +32,7 @@ def issue_search_query_to_conditions(
     from sentry.utils.snuba import resolve_column, resolve_conditions
 
     dataset = (
-        Dataset.Events
-        if group.issue_category == GroupCategory.ERROR.value
-        else Dataset.IssuePlatform
+        Dataset.Events if group.issue_category == GroupCategory.ERROR else Dataset.IssuePlatform
     )
 
     # syntactically correct search filters

--- a/tests/sentry/api/endpoints/test_group_event_details.py
+++ b/tests/sentry/api/endpoints/test_group_event_details.py
@@ -370,6 +370,7 @@ class GroupEventDetailsHelpfulEndpointTest(
             },
         )
 
+        assert group_info is not None
         url = f"/api/0/issues/{group_info.group.id}/events/helpful/"
         response = self.client.get(url, {"query": f'title:"{issue_title}"'}, format="json")
 


### PR DESCRIPTION
We were improperly mapping the dataset resulting in all calls with `query` string filtering on the `IssuePlatform` dataset.

Resolves SENTRY-1379