### PR TITLE
fix(helpful-event): properly pass in a sequence of environment.names instead of sequence of Environment objects

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -687,7 +687,11 @@ class Group(Model):
             self,
             conditions,
         )
-        return maybe_event if maybe_event else self.get_latest_event_for_environments(environments)
+        return (
+            maybe_event
+            if maybe_event
+            else self.get_latest_event_for_environments([env.name for env in environments])
+        )
 
     def get_first_release(self) -> str | None:
         from sentry.models import Release


### PR DESCRIPTION
`get_latest_event_for_environments()` function takes in a sequence of environment names and not sequence of `Environment` objects. 

Resolves SENTRY-1378