### PR TITLE
fix(hybrid-cloud): auth attach identity unsets idp:provisioned flag

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -296,7 +296,12 @@ class DatabaseBackedOrganizationService(OrganizationService):
 
     @staticmethod
     def _deserialize_member_flags(flags: RpcOrganizationMemberFlags) -> int:
-        return flags_to_bits(flags.sso__linked, flags.sso__invalid, flags.member_limit__restricted)
+        return flags_to_bits(
+            flags.sso__linked,
+            flags.sso__invalid,
+            flags.member_limit__restricted,
+            flags.idp__provisioned,
+        )
 
     def add_organization_member(
         self,

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -301,6 +301,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
             flags.sso__invalid,
             flags.member_limit__restricted,
             flags.idp__provisioned,
+            flags.idp__role_restricted,
         )
 
     def add_organization_member(

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -82,6 +82,7 @@ class RpcOrganizationMemberFlags(RpcModel):
     sso__invalid: bool = False
     member_limit__restricted: bool = False
     idp__provisioned: bool = False
+    idp__role_restricted: bool = False
 
     def __getattr__(self, item: str) -> bool:
         from sentry.services.hybrid_cloud.organization.serial import escape_flag_name

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -81,6 +81,7 @@ class RpcOrganizationMemberFlags(RpcModel):
     sso__linked: bool = False
     sso__invalid: bool = False
     member_limit__restricted: bool = False
+    idp__provisioned: bool = False
 
     def __getattr__(self, item: str) -> bool:
         from sentry.services.hybrid_cloud.organization.serial import escape_flag_name

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django.contrib.auth.models import AnonymousUser
+from django.db import models
 from django.test import Client, RequestFactory
 
 from sentry import audit_log
@@ -20,7 +21,7 @@ from sentry.models import (
     UserEmail,
 )
 from sentry.services.hybrid_cloud.organization.serial import serialize_rpc_organization
-from sentry.silo import SiloMode
+from sentry.silo import SiloMode, unguarded_write
 from sentry.testutils import TestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -273,14 +274,20 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
         )
 
     @mock.patch("sentry.auth.helper.messages")
-    def test_new_identity_with_existing_om_idp_provisioned(self, mock_messages):
+    def test_new_identity_with_existing_om_idp_flags(self, mock_messages):
         user = self.set_up_user()
         with assume_test_silo_mode(SiloMode.REGION):
             existing_om = OrganizationMember.objects.create(
                 user_id=user.id,
                 organization=self.organization,
-                flags=OrganizationMember.flags["idp:provisioned"],
             )
+            with unguarded_write():
+                existing_om.update(
+                    flags=models.F("flags")
+                    .bitor(OrganizationMember.flags["idp:provisioned"])
+                    .bitor(OrganizationMember.flags["idp:role-restricted"])
+                )
+                existing_om.save()
 
         auth_identity = self.handler.handle_attach_identity()
         assert auth_identity.ident == self.identity["id"]
@@ -290,6 +297,7 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
             persisted_om = OrganizationMember.objects.get(id=existing_om.id)
             assert getattr(persisted_om.flags, "sso:linked")
             assert getattr(persisted_om.flags, "idp:provisioned")
+            assert getattr(persisted_om.flags, "idp:role-restricted")
             assert not getattr(persisted_om.flags, "sso:invalid")
 
         mock_messages.add_message.assert_called_with(

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -273,13 +273,12 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
         )
 
     @mock.patch("sentry.auth.helper.messages")
-    def test_new_identity_with_existing_om_invited_idp_provisioned(self, mock_messages):
+    def test_new_identity_with_existing_om_idp_provisioned(self, mock_messages):
         user = self.set_up_user()
         with assume_test_silo_mode(SiloMode.REGION):
             existing_om = OrganizationMember.objects.create(
                 user_id=user.id,
                 organization=self.organization,
-                invite_status=InviteStatus.APPROVED.value,
                 flags=OrganizationMember.flags["idp:provisioned"],
             )
 


### PR DESCRIPTION
Add `idp__provisioned` and `idp__role_restricted` as flags in `RpcOrganizationMemberFlags`.

When a user is invited to an organization through an IdP, we set the `idp:provisioned` flag (and possibly the `idp:role-restricted` flag) on the `OrganizationMember` object. When a user accepts the invitation we link their Sentry membership to the account created in the IdP, but we were not correctly keeping the idp flags set for the Sentry `OrganizationMember` and these members were removable from the Sentry organization (when they shouldn't be).