### PR TITLE
fix(replays): display unique frame colors in prioritized order

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -97,16 +97,26 @@ function Event({
     }
   `;
 
-  // If we have more than 3 events we want to make sure of showing all the different colors that we have
+  // We want to make sure of showing all the different colors that we have
   const uniqueColors = uniq(frames.map(getColor));
 
   // We just need to stack up to 3 times
-  const frameCount = Math.min(frames.length, 3);
+  const frameCount = Math.min(uniqueColors.length, 3);
+
+  // Sort the frame colors by color priority
+  // Priority order: red300, yellow300, green300, purple300, gray300
+  const sortedUniqueColors: Color[] = uniqueColors.sort(function (x, y) {
+    const colorOrder = ['red300', 'yellow300', 'green300', 'purple300', 'gray300'];
+    function getColorPos(c: Color) {
+      return colorOrder.indexOf(c);
+    }
+    return getColorPos(x) - getColorPos(y);
+  });
 
   return (
     <IconPosition style={{marginLeft: `${markerWidth / 2}px`}}>
       <IconNodeTooltip title={title} overlayStyle={overlayStyle} isHoverable>
-        <IconNode colors={uniqueColors} frameCount={frameCount} />
+        <IconNode colors={sortedUniqueColors} frameCount={frameCount} />
       </IconNodeTooltip>
     </IconPosition>
   );

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -97,7 +97,7 @@ function Event({
     }
   `;
 
-  // We want to make sure of showing all the different colors that we have
+  // We want to show the full variety of colors available.
   const uniqueColors = uniq(frames.map(getColor));
 
   // We just need to stack up to 3 times
@@ -106,7 +106,13 @@ function Event({
   // Sort the frame colors by color priority
   // Priority order: red300, yellow300, green300, purple300, gray300
   const sortedUniqueColors = uniqueColors.sort(function (x, y) {
-    const colorOrder: Color[] = ['red300', 'yellow300', 'green300', 'purple300', 'gray300'];
+    const colorOrder: Color[] = [
+      'red300',
+      'yellow300',
+      'green300',
+      'purple300',
+      'gray300',
+    ];
     function getColorPos(c: Color) {
       return colorOrder.indexOf(c);
     }

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -105,8 +105,8 @@ function Event({
 
   // Sort the frame colors by color priority
   // Priority order: red300, yellow300, green300, purple300, gray300
-  const sortedUniqueColors: Color[] = uniqueColors.sort(function (x, y) {
-    const colorOrder = ['red300', 'yellow300', 'green300', 'purple300', 'gray300'];
+  const sortedUniqueColors = uniqueColors.sort(function (x, y) {
+    const colorOrder: Color[] = ['red300', 'yellow300', 'green300', 'purple300', 'gray300'];
     function getColorPos(c: Color) {
       return colorOrder.indexOf(c);
     }


### PR DESCRIPTION
Fixes #50308 by displaying the frame colors in the replays timeline in a prioritized order, and only displaying unique colors (e.g. not displaying 2 rings of green, only displaying 1 ring of green).

Before prioritization:
<img width="569" alt="Screenshot 2023-07-13 at 1 49 51 PM" src="https://github.com/getsentry/sentry/assets/56095982/b65e7b7c-5eca-47ef-8626-a261cf8e345b">
Colors are not sorted by priority, leading the red color to be hidden.

After prioritization:
<img width="352" alt="Screenshot 2023-07-13 at 1 49 31 PM" src="https://github.com/getsentry/sentry/assets/56095982/34f98f32-4a78-4c6b-ba9d-e5b9d712a18c">
Red is now the outermost ring.

Before only displaying unique colors:
<img width="541" alt="Screenshot 2023-07-13 at 1 50 02 PM" src="https://github.com/getsentry/sentry/assets/56095982/a940c606-b451-406f-9a62-a58485930167">
Bubble size is larger.

After only displaying unique colors:
<img width="386" alt="Screenshot 2023-07-13 at 1 49 45 PM" src="https://github.com/getsentry/sentry/assets/56095982/d5b5acb7-8446-4b3b-8edb-b710daada731">
Bubble size is smaller because only unique colors are displayed.
