### PR TITLE
ref(getting-started-docs): Migrate rust doc to sentry main repo

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -22,6 +22,7 @@ export const migratedDocs = [
   'react-native',
   'java-spring-boot',
   'php-laravel',
+  'rust',
 ];
 
 type SdkDocumentationProps = {

--- a/static/app/gettingStartedDocs/rust/rust.spec.tsx
+++ b/static/app/gettingStartedDocs/rust/rust.spec.tsx
@@ -1,0 +1,20 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+
+import {GettingStartedWithRust, steps} from './rust';
+
+describe('GettingStartedWithRust', function () {
+  it('all products are selected', function () {
+    const {container} = render(<GettingStartedWithRust dsn="test-dsn" />);
+
+    // Steps
+    for (const step of steps()) {
+      expect(
+        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
+      ).toBeInTheDocument();
+    }
+
+    expect(container).toSnapshot();
+  });
+});

--- a/static/app/gettingStartedDocs/rust/rust.tsx
+++ b/static/app/gettingStartedDocs/rust/rust.tsx
@@ -1,0 +1,83 @@
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {t, tct} from 'sentry/locale';
+
+// Configuration Start
+export const steps = ({
+  dsn,
+}: {
+  dsn?: string;
+} = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: (
+      <p>
+        {tct(
+          'To add Sentry to your Rust project you just need to add a new dependency to your [code:Cargo.toml]:',
+          {code: <code />}
+        )}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'toml',
+        code: `
+[dependencies]
+sentry = "0.31.5"
+        `,
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: (
+      <p>
+        {tct(
+          '[code:Sentry.init()] will return you a guard that when freed, will prevent process exit until all events have been sent (within a timeout):',
+          {code: <code />}
+        )}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'rust',
+        code: `
+let _guard = sentry::init(("${dsn}", sentry::ClientOptions {
+  release: sentry::release_name!(),
+  ..Default::default()
+}));
+        `,
+      },
+    ],
+  },
+  {
+    type: StepType.VERIFY,
+    description: t(
+      'The quickest way to verify Sentry in your Rust application is to cause a panic:'
+    ),
+    configurations: [
+      {
+        language: 'rust',
+        code: `
+fn main() {
+  let _guard = sentry::init(("${dsn}", sentry::ClientOptions {
+    release: sentry::release_name!(),
+    ..Default::default()
+  }));
+
+  // Sentry will capture this
+  panic!("Everything is on fire!");
+}
+        `,
+      },
+    ],
+  },
+];
+// Configuration End
+
+export function GettingStartedWithRust({dsn, ...props}: ModuleProps) {
+  return <Layout steps={steps({dsn})} {...props} />;
+}
+
+export default GettingStartedWithRust;


### PR DESCRIPTION
This PR represents the outcome of our chosen https://github.com/getsentry/sentry/pull/50169, aiming to enhance our getting started documentation in the Sentry repository using React.

It successfully migrates the rust to our main Sentry repository.

closes: https://github.com/getsentry/sentry/issues/52161