### PR TITLE
fix: Return more than one bundle containing a URL

### DIFF
--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -377,7 +377,7 @@ def get_artifact_bundles_containing_url(
         )
         .values_list("id", "date_added")
         .order_by("-date_last_modified", "-id")
-        .distinct("id", "date_added")[:MAX_BUNDLES_QUERY]
+        .distinct("date_last_modified", "id")[:MAX_BUNDLES_QUERY]
     )
 
 

--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -376,7 +376,8 @@ def get_artifact_bundles_containing_url(
             artifactbundleindex__url__icontains=url,
         )
         .values_list("id", "date_added")
-        .order_by("-date_last_modified", "-id")[:1]
+        .order_by("-date_last_modified", "-id")
+        .distinct("id", "date_added")[:MAX_BUNDLES_QUERY]
     )
 
 


### PR DESCRIPTION
Consider the following situation:
1. Symbolicator needs the bundle for release `foo`, dist `1` that contains `https://example.com/main.dart.js`.
2. URL search is not exact. Symbolicator asks the `artifact-lookup` endpoint for a bundle with release `foo`, dist `1`, URL `/main`.
3. There are two bundles for the release/dist. Bundle 1 contains `main.dart`, bundle 2 contains `main.dart.js`. It so happens that bundle 1 is newer.
4. Bundle 1 gets returned to Symbolicator.
5. The bundle Symbolicator got back doesn't contain the file it wanted.

We fix this by returning not just the first bundle that contains the URL, but up to `MAX_BUNDLES_QUERY` (=5) bundles.