### PR TITLE
ref(getting-started-docs): Migrate php doc to sentry main repo

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -21,6 +21,7 @@ export const migratedDocs = [
   'python-django',
   'react-native',
   'java-spring-boot',
+  'php',
   'php-laravel',
   'native',
   'go',

--- a/static/app/gettingStartedDocs/php/php.spec.tsx
+++ b/static/app/gettingStartedDocs/php/php.spec.tsx
@@ -1,0 +1,20 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+
+import {GettingStartedWithPHP, steps} from './php';
+
+describe('GettingStartedWithPHP', function () {
+  it('renders doc correctly', function () {
+    const {container} = render(<GettingStartedWithPHP dsn="test-dsn" />);
+
+    // Steps
+    for (const step of steps()) {
+      expect(
+        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
+      ).toBeInTheDocument();
+    }
+
+    expect(container).toSnapshot();
+  });
+});

--- a/static/app/gettingStartedDocs/php/php.tsx
+++ b/static/app/gettingStartedDocs/php/php.tsx
@@ -1,0 +1,75 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {t, tct} from 'sentry/locale';
+
+// Configuration Start
+export const steps = ({
+  dsn,
+}: {
+  dsn?: string;
+} = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: (
+      <p>
+        {tct(
+          'To install the PHP SDK, you need to be using Composer in your project. For more details about Composer, see the [composerDocumentationLink:Composer documentation].',
+          {
+            composerDocumentationLink: (
+              <ExternalLink href="https://getcomposer.org/doc/" />
+            ),
+          }
+        )}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'bash',
+        code: 'composer require sentry/sdk',
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: t(
+      'To capture all errors, even the one during the startup of your application, you should initialize the Sentry PHP SDK as soon as possible.'
+    ),
+    configurations: [
+      {
+        language: 'php',
+        code: `\Sentry\init(['dsn' => '${dsn}' ]);`,
+      },
+    ],
+  },
+  {
+    type: StepType.VERIFY,
+    description: t(
+      'In PHP you can either capture a caught exception or capture the last error with captureLastError.'
+    ),
+    configurations: [
+      {
+        language: 'php',
+        code: `
+try {
+  $this->functionFailsForSure();
+} catch (\Throwable $exception) {
+  \Sentry\captureException($exception);
+}
+
+// OR
+
+\Sentry\captureLastError();
+        `,
+      },
+    ],
+  },
+];
+// Configuration End
+
+export function GettingStartedWithPHP({dsn, ...props}: ModuleProps) {
+  return <Layout steps={steps({dsn})} {...props} />;
+}
+
+export default GettingStartedWithPHP;


### PR DESCRIPTION
This PR represents the outcome of our chosen https://github.com/getsentry/sentry/pull/50169, aiming to enhance our getting started documentation in the Sentry repository using React.

It successfully migrates the php doc to our main Sentry repository.

closes: https://github.com/getsentry/sentry/issues/52188