### PR TITLE
ref(getting-started-docs): Migrate flask doc to sentry main repo

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -19,6 +19,7 @@ export const migratedDocs = [
   'javascript-nextjs',
   'javascript',
   'python-django',
+  'python-flask',
   'react-native',
   'java-spring-boot',
   'php-laravel',

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -70,9 +70,7 @@ sentry_sdk.init(
     configurations: [
       {
         language: 'python',
-        description: t(
-          'Visiting this route will trigger an error that will be captured by Sentry.'
-        ),
+
         code: `
 from django.urls import path
 
@@ -86,6 +84,9 @@ def trigger_error(request):
         `,
       },
     ],
+    additionalInfo: t(
+      'Visiting this route will trigger an error that will be captured by Sentry.'
+    ),
   },
 ];
 // Configuration End

--- a/static/app/gettingStartedDocs/python/flask.spec.tsx
+++ b/static/app/gettingStartedDocs/python/flask.spec.tsx
@@ -1,0 +1,20 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+
+import {GettingStartedWithFlask, steps} from './flask';
+
+describe('GettingStartedWithDjango', function () {
+  it('renders doc correctly', function () {
+    const {container} = render(<GettingStartedWithFlask dsn="test-dsn" />);
+
+    // Steps
+    for (const step of steps()) {
+      expect(
+        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
+      ).toBeInTheDocument();
+    }
+
+    expect(container).toSnapshot();
+  });
+});

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -1,0 +1,105 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {t, tct} from 'sentry/locale';
+
+// Configuration Start
+export const steps = ({
+  dsn,
+}: {
+  dsn?: string;
+} = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: (
+      <p>
+        {tct(
+          'The Flask integration adds support for the [flaskWebFrameworkLink:Flask Web Framework].',
+          {
+            flaskWebFrameworkLink: (
+              <ExternalLink href="https://flask.palletsprojects.com/en/2.3.x/" />
+            ),
+          }
+        )}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'bash',
+        description: (
+          <p>
+            {tct('Install [code:sentry-sdk] from PyPI with the [code:flask] extra:', {
+              code: <code />,
+            })}
+          </p>
+        ),
+        code: "pip install --upgrade 'sentry-sdk[flask]'",
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: t(
+      'To configure the SDK, initialize it with the integration before or after your app has been initialized:'
+    ),
+    configurations: [
+      {
+        language: 'python',
+        code: `
+import sentry_sdk
+from flask import Flask
+from sentry_sdk.integrations.flask import FlaskIntegration
+
+sentry_sdk.init(
+    dsn="${dsn}",
+    integrations=[
+        FlaskIntegration(),
+    ],
+
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    # We recommend adjusting this value in production.
+    traces_sample_rate=1.0
+)
+
+app = Flask(__name__)
+        `,
+      },
+    ],
+    additionalInfo: (
+      <p>
+        {tct(
+          'The above configuration captures both error and performance data. To reduce the volume of performance data captured, change [code:traces_sample_rate] to a value between 0 and 1.',
+          {code: <code />}
+        )}
+      </p>
+    ),
+  },
+  {
+    type: StepType.VERIFY,
+    description: t(
+      'You can easily verify your Sentry installation by creating a route that triggers an error:'
+    ),
+    configurations: [
+      {
+        language: 'python',
+        code: `
+@app.route('/debug-sentry')
+def trigger_error():
+  division_by_zero = 1 / 0
+        `,
+      },
+    ],
+    additionalInfo: t(
+      'Visiting this route will trigger an error that will be captured by Sentry.'
+    ),
+  },
+];
+// Configuration End
+
+export function GettingStartedWithFlask({dsn, ...props}: ModuleProps) {
+  return <Layout steps={steps({dsn})} {...props} />;
+}
+
+export default GettingStartedWithFlask;


### PR DESCRIPTION
This PR represents the outcome of our chosen https://github.com/getsentry/sentry/pull/50169, aiming to enhance our getting started documentation in the Sentry repository using React.

It successfully migrates the python-flask doc to our main Sentry repository.

closes: https://github.com/getsentry/sentry/issues/52169