### PR TITLE
ref(getting-started-docs): Migrate Node doc to sentry main repo

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -29,6 +29,7 @@ export const migratedDocs = [
   'minidump',
   'native',
   'native-qt',
+  'node',
 ];
 
 type SdkDocumentationProps = {

--- a/static/app/gettingStartedDocs/node/node.spec.tsx
+++ b/static/app/gettingStartedDocs/node/node.spec.tsx
@@ -1,0 +1,20 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+
+import {GettingStartedWithNode, steps} from './node';
+
+describe('GettingStartedWithNode', function () {
+  it('all products are selected', function () {
+    const {container} = render(<GettingStartedWithNode dsn="test-dsn" />);
+
+    // Steps
+    for (const step of steps()) {
+      expect(
+        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
+      ).toBeInTheDocument();
+    }
+
+    expect(container).toSnapshot();
+  });
+});

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -84,30 +84,7 @@ npm install --save @sentry/node
   },
 ];
 
-export const nextSteps = [
-  {
-    id: 'profiling',
-    name: t('Profiling'),
-    description: t(
-      'Learn how to configure our Profiling integration and start profiling your code.'
-    ),
-    link: 'https://docs.sentry.io/platforms/node/profiling/',
-  },
-  {
-    id: 'performance-monitoring',
-    name: t('Performance Monitoring'),
-    description: t(
-      'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-    ),
-    link: 'https://docs.sentry.io/platforms/node/performance/',
-  },
-  {
-    id: 'source-maps',
-    name: t('Source Maps'),
-    description: t('Learn how to enable readable stack traces in your Sentry errors.'),
-    link: 'https://docs.sentry.io/platforms/node/sourcemaps/',
-  },
-];
+export const nextSteps = [];
 
 export function GettingStartedWithNode({dsn, ...props}: ModuleProps) {
   const sentryInitContent: string[] = [`dsn: "${dsn}",`, performanceOtherConfig];

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -84,17 +84,11 @@ npm install --save @sentry/node
   },
 ];
 
-export const nextSteps = [];
-
 export function GettingStartedWithNode({dsn, ...props}: ModuleProps) {
   const sentryInitContent: string[] = [`dsn: "${dsn}",`, performanceOtherConfig];
 
   return (
-    <Layout
-      steps={steps({sentryInitContent: sentryInitContent.join('\n')})}
-      nextSteps={nextSteps}
-      {...props}
-    />
+    <Layout steps={steps({sentryInitContent: sentryInitContent.join('\n')})} {...props} />
   );
 }
 

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -1,0 +1,124 @@
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
+import {t, tct} from 'sentry/locale';
+
+const performanceOtherConfig = `
+// Performance Monitoring
+tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!`;
+
+export const steps = ({
+  sentryInitContent,
+}: {
+  sentryInitContent?: string;
+} = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: t('Add the Sentry Node SDK as a dependency:'),
+    configurations: [
+      {
+        language: 'bash',
+        code: `
+# Using yarn
+yarn add @sentry/node
+
+# Using npm
+npm install --save @sentry/node
+        `,
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: (
+      <p>
+        {tct(
+          "Initialize Sentry as early as possible in your application's lifecycle, for example in your [code:index.ts/js] entry point:",
+          {code: <code />}
+        )}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        const Sentry = require("@sentry/node");
+        // or use ESM import statements
+        // import * as Sentry from '@sentry/node';
+
+        Sentry.init({
+          ${sentryInitContent}
+        });
+        `,
+      },
+    ],
+  },
+  getUploadSourceMapsStep('https://docs.sentry.io/platforms/node/sourcemaps/'),
+  {
+    type: StepType.VERIFY,
+    description: t(
+      "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        const transaction = Sentry.startTransaction({
+          op: "test",
+          name: "My First Test Transaction",
+        });
+
+        setTimeout(() => {
+          try {
+            foo();
+          } catch (e) {
+            Sentry.captureException(e);
+          } finally {
+            transaction.finish();
+          }
+        }, 99);
+        `,
+      },
+    ],
+  },
+];
+
+export const nextSteps = [
+  {
+    id: 'profiling',
+    name: t('Profiling'),
+    description: t(
+      'Learn how to configure our Profiling integration and start profiling your code.'
+    ),
+    link: 'https://docs.sentry.io/platforms/node/profiling/',
+  },
+  {
+    id: 'performance-monitoring',
+    name: t('Performance Monitoring'),
+    description: t(
+      'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
+    ),
+    link: 'https://docs.sentry.io/platforms/node/performance/',
+  },
+  {
+    id: 'source-maps',
+    name: t('Source Maps'),
+    description: t('Learn how to enable readable stack traces in your Sentry errors.'),
+    link: 'https://docs.sentry.io/platforms/node/sourcemaps/',
+  },
+];
+
+export function GettingStartedWithNode({dsn, ...props}: ModuleProps) {
+  const sentryInitContent: string[] = [`dsn: "${dsn}",`, performanceOtherConfig];
+
+  return (
+    <Layout
+      steps={steps({sentryInitContent: sentryInitContent.join('\n')})}
+      nextSteps={nextSteps}
+      {...props}
+    />
+  );
+}
+
+export default GettingStartedWithNode;


### PR DESCRIPTION
This PR represents the outcome of our chosen https://github.com/getsentry/sentry/pull/50169, aiming to enhance our getting started documentation in the Sentry repository using React.

It migrates the basic Node (no framework) onboarding/getting started doc to to the Sentry main repo
Decided to start with this one and base the other node framework docs migrations on it.

closes #52866  