### PR TITLE
ref(ui): Change wording of stacktrace order in user settings

### DIFF
--- a/static/app/data/forms/accountPreferences.tsx
+++ b/static/app/data/forms/accountPreferences.tsx
@@ -54,9 +54,9 @@ const formGroups: JsonFormObject[] = [
         type: 'select',
         required: false,
         options: [
-          {value: -1, label: t('Default (let Sentry decide)')},
-          {value: 1, label: t('Most recent call last')},
-          {value: 2, label: t('Most recent call first')},
+          {value: -1, label: t('Default')},
+          {value: 1, label: t('Oldest')},
+          {value: 2, label: t('Newest')},
         ],
         label: t('Stack Trace Order'),
         help: t('Choose the default ordering of frames in stack traces'),


### PR DESCRIPTION
Closes #50697

Update sort order wording in user settings to match issue details

Before: 
<img width="555" alt="Screenshot 2023-07-14 at 9 46 50 AM" src="https://github.com/getsentry/sentry/assets/22582037/d61e854a-91d9-4641-bfed-d97f38ef4647">
After:
<img width="555" alt="Screenshot 2023-07-14 at 9 45 25 AM" src="https://github.com/getsentry/sentry/assets/22582037/8aba23a8-049e-4bac-bd31-9678895cd04c">

