### PR TITLE
feat(replay): Render the replay currentTime & hoverTime inside the performance waterfall

### DIFF
--- a/static/app/components/performance/waterfall/row.tsx
+++ b/static/app/components/performance/waterfall/row.tsx
@@ -87,6 +87,7 @@ const RowIndicatorBar = styled('div')`
   height: 100%;
   position: absolute;
   top: 0;
+  transform: translateX(-50%);
   width: 1px;
   z-index: 1;
 `;

--- a/static/app/components/performance/waterfall/row.tsx
+++ b/static/app/components/performance/waterfall/row.tsx
@@ -2,7 +2,10 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {ROW_HEIGHT} from 'sentry/components/performance/waterfall/constants';
-import {getBackgroundColor} from 'sentry/components/performance/waterfall/utils';
+import {
+  getBackgroundColor,
+  toPercent,
+} from 'sentry/components/performance/waterfall/utils';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 
 interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -70,10 +73,10 @@ export function RowReplayTimeIndicators() {
 
   return (
     <Fragment>
-      <RowIndicatorBar style={{left: `${(currentTime / durationMs) * 100}%`}} />
+      <RowIndicatorBar style={{left: toPercent(currentTime / durationMs)}} />
       {currentHoverTime !== undefined ? (
         <RowHoverIndicatorBar
-          style={{left: `${(currentHoverTime / durationMs) * 100}%`}}
+          style={{transform: toPercent(currentHoverTime / durationMs)}}
         />
       ) : null}
     </Fragment>

--- a/static/app/components/performance/waterfall/row.tsx
+++ b/static/app/components/performance/waterfall/row.tsx
@@ -75,9 +75,7 @@ export function RowReplayTimeIndicators() {
     <Fragment>
       <RowIndicatorBar style={{left: toPercent(currentTime / durationMs)}} />
       {currentHoverTime !== undefined ? (
-        <RowHoverIndicatorBar
-          style={{transform: toPercent(currentHoverTime / durationMs)}}
-        />
+        <RowHoverIndicatorBar style={{left: toPercent(currentHoverTime / durationMs)}} />
       ) : null}
     </Fragment>
   );

--- a/static/app/components/performance/waterfall/row.tsx
+++ b/static/app/components/performance/waterfall/row.tsx
@@ -1,7 +1,9 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {ROW_HEIGHT} from 'sentry/components/performance/waterfall/constants';
 import {getBackgroundColor} from 'sentry/components/performance/waterfall/utils';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
 
 interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
   cursor?: 'pointer' | 'default';
@@ -56,4 +58,39 @@ export const RowCell = styled('div')<RowCellProps>`
   color: ${p => (p.showDetail ? p.theme.background : 'inherit')};
   display: flex;
   align-items: center;
+`;
+
+export function RowReplayTimeIndicators() {
+  const {currentTime, currentHoverTime, replay} = useReplayContext();
+  const durationMs = replay?.getDurationMs();
+
+  if (!replay || !durationMs) {
+    return null;
+  }
+
+  return (
+    <Fragment>
+      <RowIndicatorBar style={{left: `${(currentTime / durationMs) * 100}%`}} />
+      {currentHoverTime !== undefined ? (
+        <RowHoverIndicatorBar
+          style={{left: `${(currentHoverTime / durationMs) * 100}%`}}
+        />
+      ) : null}
+    </Fragment>
+  );
+}
+
+const RowIndicatorBar = styled('div')`
+  background: ${p => p.theme.purple300};
+  content: '';
+  display: block;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  width: 1px;
+  z-index: 1;
+`;
+
+const RowHoverIndicatorBar = styled(RowIndicatorBar)`
+  background: ${p => p.theme.purple200};
 `;

--- a/static/app/views/performance/traceDetails/transactionBar.tsx
+++ b/static/app/views/performance/traceDetails/transactionBar.tsx
@@ -19,6 +19,7 @@ import {
   Row,
   RowCell,
   RowCellContainer,
+  RowReplayTimeIndicators,
 } from 'sentry/components/performance/waterfall/row';
 import {DurationPill, RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {
@@ -546,6 +547,7 @@ class TransactionBar extends Component<Props, State> {
           showDetail={showDetail}
           onClick={this.toggleDisplayDetail}
         >
+          <RowReplayTimeIndicators />
           <GuideAnchor target="trace_view_guide_row_details" disabled={!hasGuideAnchor}>
             {this.renderRectangle()}
             {this.renderMeasurements()}


### PR DESCRIPTION
Render a purple vertical bar to represent the current replay time. Also, when hovering, render another bar to represent the point in time where the mouse cursor is.

<img width="617" alt="SCR-20230714-jazb" src="https://github.com/getsentry/sentry/assets/187460/20602a76-b101-44a5-af5e-c5b5bb2f1c84">



We're calling `useReplayContext` on each trace row. When there is no context provider the default values will be fetched. Mainly this include `replay === null` which will short-circuit everything and return null from the component.

Fixes https://github.com/getsentry/sentry/issues/51938