### PR TITLE
feat(perf): Add http/1.1 overhead detector

### DIFF
--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -91,6 +91,7 @@ class ProjectPerformanceIssueSettingsSerializer(serializers.Serializer):
     consecutive_db_queries_detection_enabled = serializers.BooleanField(required=False)
     large_render_blocking_asset_detection_enabled = serializers.BooleanField(required=False)
     slow_db_queries_detection_enabled = serializers.BooleanField(required=False)
+    http_overhead_detection_enabled = serializers.BooleanField(required=False)
 
 
 @region_silo_endpoint

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -133,6 +133,7 @@ default_manager.add("organizations:performance-db-main-thread-detector", Organiz
 default_manager.add("organizations:performance-n-plus-one-api-calls-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-issues-compressed-assets-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-issues-render-blocking-assets-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:performance-issues-render-blocking-assets-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-issues-m-n-plus-one-db-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-issues-dev", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:project-performance-settings-admin", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -133,7 +133,7 @@ default_manager.add("organizations:performance-db-main-thread-detector", Organiz
 default_manager.add("organizations:performance-n-plus-one-api-calls-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-issues-compressed-assets-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-issues-render-blocking-assets-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:performance-issues-render-blocking-assets-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:performance-issues-http-overhead-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-issues-m-n-plus-one-db-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-issues-dev", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:project-performance-settings-admin", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -290,9 +290,15 @@ class PerformanceLargeHTTPPayloadGroupType(PerformanceGroupTypeDefaults, GroupTy
     category = GroupCategory.PERFORMANCE.value
 
 
+@dataclass(frozen=True)
+class PerformanceHTTPOverheadGroupType(PerformanceGroupTypeDefaults, GroupType):
+    type_id = 1016
+    slug = "performance_http_overhead"
+    description = "HTTP/1.1 Overhead"
+    category = GroupCategory.PERFORMANCE.value
+
+
 # 2000 was ProfileBlockingFunctionMainThreadType
-
-
 @dataclass(frozen=True)
 class ProfileFileIOGroupType(GroupType):
     type_id = 2001

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1203,6 +1203,20 @@ register(
 register(
     "performance.issues.m_n_plus_one_db.ga-rollout", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
+register(
+    "performance.issues.http_overhead.problem-creation",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "performance.issues.http_overhead.la-rollout", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+register(
+    "performance.issues.http_overhead.ea-rollout", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+register(
+    "performance.issues.http_overhead.ga-rollout", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
 
 
 # System-wide options for default performance detection settings for any org opted into the performance-issues-ingest feature. Meant for rollout.
@@ -1282,6 +1296,11 @@ register(
 register(
     "performance.issues.consecutive_db.min_time_saved_threshold",
     default=100,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)  # ms
+register(
+    "performance.issues.http_overhead.http_request_delay_threshold",
+    default=500,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )  # ms
 

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -113,6 +113,7 @@ DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS = {
     "consecutive_db_queries_detection_enabled": True,
     "large_render_blocking_asset_detection_enabled": True,
     "slow_db_queries_detection_enabled": True,
+    "http_overhead_detection_enabled": True,
 }
 
 # A dict containing all the specific detection thresholds and rates.

--- a/src/sentry/utils/performance_issues/detectors/__init__.py
+++ b/src/sentry/utils/performance_issues/detectors/__init__.py
@@ -1,5 +1,6 @@
 from .consecutive_db_detector import ConsecutiveDBSpanDetector  # NOQA
 from .consecutive_http_detector import ConsecutiveHTTPSpanDetector  # NOQA
+from .http_overhead_detector import HTTPOverheadDetector  # NOQA
 from .io_main_thread_detector import DBMainThreadDetector, FileIOMainThreadDetector  # NOQA
 from .large_payload_detector import LargeHTTPPayloadDetector  # NOQA
 from .mn_plus_one_db_span_detector import MNPlusOneDBSpanDetector  # NOQA

--- a/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import timedelta
-
 from sentry import features
 from sentry.issues.grouptype import PerformanceConsecutiveHTTPQueriesGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
@@ -16,6 +14,7 @@ from sentry.utils.safe import get_path
 from ..base import (
     DetectorType,
     PerformanceDetector,
+    does_overlap_previous_span,
     fingerprint_http_spans,
     get_duration_between_spans,
     get_notification_attachment_body,
@@ -128,12 +127,8 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
     def _overlaps_last_span(self, span: Span) -> bool:
         if len(self.consecutive_http_spans) == 0:
             return False
-
         last_span = self.consecutive_http_spans[-1]
-
-        last_span_ends = timedelta(seconds=last_span.get("timestamp", 0))
-        current_span_begins = timedelta(seconds=span.get("start_timestamp", 0))
-        return last_span_ends > current_span_begins
+        return does_overlap_previous_span(last_span, span)
 
     def _reset_variables(self) -> None:
         self.consecutive_http_spans = []

--- a/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
@@ -134,7 +134,7 @@ class HTTPOverheadDetector(PerformanceDetector):
         location_spans = [indicator.span for indicator in indicators]
         meets_min_queued = any(
             indicator.queue_depth >= 5 for indicator in indicators
-        ) # Browsers queue past 4-6 connections.
+        )  # Browsers queue past 4-6 connections.
         exceeds_delay_threshold = any(indicator.delay > delay_threshold for indicator in indicators)
 
         if not exceeds_delay_threshold or not meets_min_queued or not location_spans:

--- a/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import urllib.parse
+from dataclasses import dataclass
+from typing import Optional
+
+from sentry import features
+from sentry.issues.grouptype import PerformanceHTTPOverheadGroupType
+from sentry.issues.issue_occurrence import IssueEvidence
+from sentry.models import Organization, Project
+
+from ..base import (
+    DetectorType,
+    PerformanceDetector,
+    does_overlap_previous_span,
+    get_notification_attachment_body,
+    get_span_evidence_value,
+)
+from ..performance_problem import PerformanceProblem
+from ..types import Span
+
+
+@dataclass
+class ProblemIndicator:
+    """
+    Keep span data that will be used to store the problem together.
+    Has a monotonic queue depth to know if spans hit the parallel limit without walking all spans again.
+    """
+
+    span: Span
+    delay: float
+    queue_depth: int = 0
+
+
+class HTTPOverheadDetector(PerformanceDetector):
+    """
+    Detect HTTP/1.1 overhead in http spans outside of response time for that endpoint using
+    Browser reporting of PerformanceNavigationTiming. Parent-child span hierarchy
+    is ignored as there is an external limit (browser http/1.1 request limit) solely based on time.
+
+      [-------- transaction -----------]
+        [0] https://service.io/api/book/1      - request delay ~0ms
+        ----[1] https://service.io/api/book/2  - request delay ~0ms
+        ----[2] https://service.io/api/book/3  - request delay ~0ms
+        ...
+        ----[5] https://service.io/api/book/6  - request delay 400ms - Hit ~6 connection limit.
+        ----[6] https://service.io/api/book/7  - request delay 600ms - Over threshold, triggers detection.
+        ...
+    """
+
+    __slots__ = "stored_problems"
+
+    type: DetectorType = DetectorType.HTTP_OVERHEAD
+    settings_key = DetectorType.HTTP_OVERHEAD
+
+    def init(self):
+        self.stored_problems: dict[str, PerformanceProblem] = {}
+        self.location_to_indicators = {}
+
+    def visit_span(self, span: Span) -> None:
+        span_data = span.get("data", {})
+        if not self._is_span_eligible(span) or not span_data:
+            return
+
+        url = span_data.get("url", "")
+        span_start = span.get("start_timestamp", 0) * 1000
+        request_start = span_data.get("http.request.request_start", 0) * 1000
+
+        if not url or not span_start or not request_start:
+            return
+
+        if url.startswith("/"):
+            location = "/"
+        else:
+            parsed_url = urllib.parse.urlparse(url)
+            location = parsed_url.netloc
+
+        if not location:
+            return
+
+        if location not in self.location_to_indicators:
+            self.location_to_indicators[location] = []
+
+        request_delay = request_start - span_start
+
+        if request_delay < 0:
+            # shouldn't be possible, but these values are browser reported
+            return
+
+        indicators = self.location_to_indicators[location]
+        recent_beginning_of_chain = next(
+            filter(lambda i: i.queue_depth == 0, reversed(indicators)), None
+        )
+        recent_end_of_chain = indicators[-1] if indicators else None
+
+        if not recent_beginning_of_chain:
+            self.location_to_indicators[location] += [ProblemIndicator(span, request_delay, 0)]
+            return
+
+        previous_delay = recent_beginning_of_chain.delay
+        previous_span = recent_beginning_of_chain.span
+        previous_monotonic = recent_end_of_chain.queue_depth if recent_end_of_chain else 0
+
+        is_overlapping = does_overlap_previous_span(previous_span, span)
+        new_monotonic = (
+            previous_monotonic + 1 if request_delay >= previous_delay and is_overlapping else 0
+        )
+
+        self.location_to_indicators[location] += [
+            ProblemIndicator(span, request_delay, new_monotonic)
+        ]
+
+    def _is_span_eligible(self, span: Span) -> None:
+        span_op = span.get("op", None)
+        span_data = span.get("data", {})
+        if not span_data:
+            return False
+        protocol_version = span_data.get("network.protocol.version", None)
+
+        if not span_op or not span_op == "http.client" or not protocol_version == "1.1":
+            return False
+        return True
+
+    def _store_performance_problem(self, location: str) -> None:
+        delay_threshold = self.settings.get("http_request_delay_threshold")
+
+        # This isn't a threshold, it reduces noise in offending spans.
+        indicators = [
+            indicator
+            for indicator in self.location_to_indicators[location]
+            if indicator.delay > 100
+        ]
+
+        location_spans = [indicator.span for indicator in indicators]
+        meets_min_queued = any(
+            indicator.queue_depth >= 5 for indicator in indicators
+        ) # Browsers queue past 4-6 connections.
+        exceeds_delay_threshold = any(indicator.delay > delay_threshold for indicator in indicators)
+
+        if not exceeds_delay_threshold or not meets_min_queued or not location_spans:
+            return
+
+        fingerprint = f"1-{PerformanceHTTPOverheadGroupType.type_id}-{location}"
+        example_span = location_spans[0]
+        desc: str = example_span.get("description", None)
+
+        location_span_ids = [span.get("span_id", None) for span in location_spans]
+
+        self.stored_problems[fingerprint] = PerformanceProblem(
+            fingerprint,
+            "http",
+            desc=desc,
+            type=PerformanceHTTPOverheadGroupType,
+            cause_span_ids=[],
+            parent_span_ids=None,
+            offender_span_ids=location_span_ids,
+            evidence_data={
+                "parent_span_ids": [],
+                "cause_span_ids": [],
+                "offender_span_ids": location_span_ids,
+                "op": "http",
+                "transaction_name": self._event.get("transaction", ""),
+                "repeating_spans": get_span_evidence_value(example_span),
+                "repeating_spans_compact": get_span_evidence_value(example_span, include_op=False),
+                "num_repeating_spans": str(len(location_spans)),
+            },
+            evidence_display=[
+                IssueEvidence(
+                    name="Offending Spans",
+                    value=get_notification_attachment_body(
+                        "http",
+                        desc,
+                    ),
+                    important=True,
+                )
+            ],
+        )
+
+    def on_complete(self) -> None:
+        for location in self.location_to_indicators:
+            self._store_performance_problem(location)
+
+    def is_creation_allowed_for_organization(self, organization: Optional[Organization]) -> bool:
+        return features.has(
+            "organizations:performance-issues-http-overhead-detector",
+            organization,
+            actor=None,
+        )
+
+    def is_creation_allowed_for_project(self, project: Project) -> bool:
+        return self.settings["detection_enabled"]

--- a/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import urllib.parse
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import Optional
 
@@ -55,7 +56,7 @@ class HTTPOverheadDetector(PerformanceDetector):
 
     def init(self):
         self.stored_problems: dict[str, PerformanceProblem] = {}
-        self.location_to_indicators = {}
+        self.location_to_indicators = defaultdict(list)
 
     def visit_span(self, span: Span) -> None:
         span_data = span.get("data", {})
@@ -77,9 +78,6 @@ class HTTPOverheadDetector(PerformanceDetector):
 
         if not location:
             return
-
-        if location not in self.location_to_indicators:
-            self.location_to_indicators[location] = []
 
         request_delay = request_start - span_start
 

--- a/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
@@ -50,7 +50,7 @@ class HTTPOverheadDetector(PerformanceDetector):
 
     __slots__ = "stored_problems"
 
-    type: DetectorType = DetectorType.HTTP_OVERHEAD
+    type = DetectorType.HTTP_OVERHEAD
     settings_key = DetectorType.HTTP_OVERHEAD
 
     def init(self):
@@ -110,7 +110,7 @@ class HTTPOverheadDetector(PerformanceDetector):
             ProblemIndicator(span, request_delay, new_monotonic)
         ]
 
-    def _is_span_eligible(self, span: Span) -> None:
+    def _is_span_eligible(self, span: Span) -> bool:
         span_op = span.get("op", None)
         span_data = span.get("data", {})
         if not span_data:

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -28,6 +28,7 @@ from .detectors import (
     ConsecutiveHTTPSpanDetector,
     DBMainThreadDetector,
     FileIOMainThreadDetector,
+    HTTPOverheadDetector,
     LargeHTTPPayloadDetector,
     MNPlusOneDBSpanDetector,
     NPlusOneAPICallsDetector,
@@ -179,6 +180,9 @@ def get_merged_settings(project_id: Optional[int] = None) -> Dict[str | Any, Any
         "consecutive_db_min_time_saved_threshold": options.get(
             "performance.issues.consecutive_db.min_time_saved_threshold"
         ),
+        "http_request_delay_threshold": options.get(
+            "performance.issues.http_overhead.http_request_delay_threshold"
+        ),
     }
 
     default_project_settings = (
@@ -305,6 +309,10 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
             "payload_size_threshold": settings["large_http_payload_size_threshold"],
             "detection_enabled": settings["large_http_payload_detection_enabled"],
         },
+        DetectorType.HTTP_OVERHEAD: {
+            "http_request_delay_threshold": settings["http_request_delay_threshold"],
+            "detection_enabled": settings["http_overhead_detection_enabled"],
+        },
     }
 
 
@@ -330,6 +338,7 @@ def _detect_performance_problems(
         MNPlusOneDBSpanDetector(detection_settings, data),
         UncompressedAssetSpanDetector(detection_settings, data),
         LargeHTTPPayloadDetector(detection_settings, data),
+        HTTPOverheadDetector(detection_settings, data),
     ]
 
     for detector in detectors:

--- a/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
+++ b/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sentry.issues.grouptype import PerformanceHTTPOverheadGroupType
+from sentry.testutils import TestCase
+from sentry.testutils.performance_issues.event_generators import (
+    PROJECT_ID,
+    create_span,
+    modify_span_start,
+)
+from sentry.testutils.silo import region_silo_test
+from sentry.utils.performance_issues.detectors.http_overhead_detector import HTTPOverheadDetector
+from sentry.utils.performance_issues.performance_detection import (
+    get_detection_settings,
+    run_detector_on_data,
+)
+from sentry.utils.performance_issues.performance_problem import PerformanceProblem
+
+
+def overhead_span(duration: float, request_start: float, url: str) -> dict[str, Any]:
+    return modify_span_start(
+        create_span(
+            "http.client",
+            desc=url,
+            duration=duration,
+            data={
+                "url": url,
+                "network.protocol.version": "1.1",
+                "http.request.request_start": request_start / 1000.0,
+            },
+        ),
+        1,
+    )
+
+
+def _valid_http_overhead_event(url: str) -> dict[str, Any]:
+    return {
+        "event_id": "a" * 16,
+        "project": PROJECT_ID,
+        "spans": [
+            overhead_span(1000, 100, url),
+            overhead_span(1000, 200, url),
+            overhead_span(1000, 300, url),
+            overhead_span(1000, 400, url),
+            overhead_span(1000, 500, url),
+            overhead_span(1000, 600, url),
+        ],
+        "contexts": {
+            "trace": {
+                "span_id": "c" * 16,
+            }
+        },
+        "transaction": url,
+    }
+
+
+def find_problems(settings, event: dict[str, Any]) -> list[PerformanceProblem]:
+    detector = HTTPOverheadDetector(settings, event)
+    run_detector_on_data(detector, event)
+    return list(detector.stored_problems.values())
+
+
+@region_silo_test
+@pytest.mark.django_db
+class HTTPOverheadDetectorTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._settings = get_detection_settings()
+
+    def find_problems(self, event):
+        return find_problems(self._settings, event)
+
+    def test_detects_http_overhead(self):
+        event = _valid_http_overhead_event("/api/endpoint/123")
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1016-/",
+                op="http",
+                desc="/api/endpoint/123",
+                type=PerformanceHTTPOverheadGroupType,
+                parent_span_ids=None,
+                cause_span_ids=[],
+                offender_span_ids=[
+                    "bbbbbbbbbbbbbbbb",
+                    "bbbbbbbbbbbbbbbb",
+                    "bbbbbbbbbbbbbbbb",
+                    "bbbbbbbbbbbbbbbb",
+                    "bbbbbbbbbbbbbbbb",
+                ],
+                evidence_data={
+                    "op": "http",
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": [
+                        "bbbbbbbbbbbbbbbb",
+                        "bbbbbbbbbbbbbbbb",
+                        "bbbbbbbbbbbbbbbb",
+                        "bbbbbbbbbbbbbbbb",
+                        "bbbbbbbbbbbbbbbb",
+                    ],
+                },
+                evidence_display=[],
+            )
+        ]
+
+    def test_does_not_detect_overlap_limit(self):
+        event = _valid_http_overhead_event("/api/endpoint/123")
+
+        event["spans"] = event["spans"][:5]
+        assert self.find_problems(event) == []
+
+    def test_does_not_detect_under_delay_threshold(self):
+        url = "/api/endpoint/123"
+        event = _valid_http_overhead_event(url)
+
+        event["spans"] = [
+            overhead_span(1000, 1, url),
+            overhead_span(1000, 2, url),
+            overhead_span(1000, 3, url),
+            overhead_span(1000, 4, url),
+            overhead_span(1000, 5, url),
+            overhead_span(1000, 501, url),  # Request start is at 1ms.
+        ]
+        assert self.find_problems(event) == []
+
+    def test_detect_non_http_1_1(self):
+        url = "/api/endpoint/123"
+        event = _valid_http_overhead_event(url)
+
+        trigger_span = overhead_span(1000, 502, url)
+        event["spans"] = [
+            overhead_span(1000, 1, url),
+            overhead_span(1000, 2, url),
+            overhead_span(1000, 3, url),
+            overhead_span(1000, 4, url),
+            overhead_span(1000, 5, url),
+            trigger_span,
+        ]
+
+        assert len(self.find_problems(event)) == 1
+        trigger_span["data"]["network.protocol.version"] = "h3"
+
+        assert len(self.find_problems(event)) == 0
+
+    def test_detect_other_location(self):
+        url = "https://example.com/api/endpoint/123"
+        event = _valid_http_overhead_event(url)
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1016-example.com",
+                op="http",
+                desc="/api/endpoint/123",
+                type=PerformanceHTTPOverheadGroupType,
+                parent_span_ids=None,
+                cause_span_ids=[],
+                offender_span_ids=[
+                    "bbbbbbbbbbbbbbbb",
+                    "bbbbbbbbbbbbbbbb",
+                    "bbbbbbbbbbbbbbbb",
+                    "bbbbbbbbbbbbbbbb",
+                    "bbbbbbbbbbbbbbbb",
+                ],
+                evidence_data={
+                    "op": "http",
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": [
+                        "bbbbbbbbbbbbbbbb",
+                        "bbbbbbbbbbbbbbbb",
+                        "bbbbbbbbbbbbbbbb",
+                        "bbbbbbbbbbbbbbbb",
+                        "bbbbbbbbbbbbbbbb",
+                    ],
+                },
+                evidence_display=[],
+            )
+        ]

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -467,32 +467,19 @@ class PerformanceDetectionTest(TestCase):
             )
             in incr_mock.mock_calls
         )
-        assert (
-            call(
-                "performance.performance_issue.detected",
-                instance="True",
-                tags={
-                    "sdk_name": "sentry.javascript.react",
-                    "consecutive_db": False,
-                    "large_http_payload": False,
-                    "consecutive_http": False,
-                    "consecutive_http_ext": False,
-                    "slow_db_query": False,
-                    "render_blocking_assets": False,
-                    "n_plus_one_db": False,
-                    "n_plus_one_db_ext": False,
-                    "file_io_main_thread": False,
-                    "db_main_thread": False,
-                    "n_plus_one_api_calls": False,
-                    "n_plus_one_api_calls_ext": False,
-                    "m_n_plus_one_db": False,
-                    "uncompressed_assets": True,
-                    "browser_name": "Chrome",
-                    "is_early_adopter": False,
-                },
-            )
-            in incr_mock.mock_calls
-        )
+        detection_calls = [call for call in incr_mock.mock_calls if call.args[0] == "performance.performance_issue.detected"]
+        assert len(detection_calls) == 1
+        tags = detection_calls[0].kwargs["tags"]
+
+        assert tags["uncompressed_assets"]
+        assert tags["sdk_name"] == "sentry.javascript.react"
+        assert not tags["is_early_adopter"]
+        assert tags["browser_name"] == "Chrome"
+
+        # Ensure all other detections are set to false in tags
+        pre_checked_keys = ["sdk_name", "is_early_adopter", "browser_name", "uncompressed_assets"]
+        assert not any([v for k, v in tags.items() if k not in pre_checked_keys])
+
 
 
 @region_silo_test

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -467,7 +467,11 @@ class PerformanceDetectionTest(TestCase):
             )
             in incr_mock.mock_calls
         )
-        detection_calls = [call for call in incr_mock.mock_calls if call.args[0] == "performance.performance_issue.detected"]
+        detection_calls = [
+            call
+            for call in incr_mock.mock_calls
+            if call.args[0] == "performance.performance_issue.detected"
+        ]
         assert len(detection_calls) == 1
         tags = detection_calls[0].kwargs["tags"]
 
@@ -479,7 +483,6 @@ class PerformanceDetectionTest(TestCase):
         # Ensure all other detections are set to false in tags
         pre_checked_keys = ["sdk_name", "is_early_adopter", "browser_name", "uncompressed_assets"]
         assert not any([v for k, v in tags.items() if k not in pre_checked_keys])
-
 
 
 @region_silo_test


### PR DESCRIPTION
### Summary
Adds a new detector (flags aren't going to be flipped until after audit). 

Servers using http/1.1 might be causing queueing behaviour on the browser when the connections reach a certain amount. This detector roughly detects overlapping spans against the same location (connections are limited per host), assuming that queue depth is causing monotonically increasing requestStart. 

#### Other
- We'll likely need to change the network timing (`requestStart`) this currently targets, but sdk needs to be cut before that.
- Our sdk collects absolute paths, so we skip url parsing in that case and use location '/'
- Didn't want to have `/1.1` in filenames or enums so change the file/vars to `http overhead`. 
- We'll try a `500` delay threshold for now, meaning the peak of the increasing times should be 500ms. I've found existing  real events that fire on this.

