### PR TITLE
fix(replays): make title and issue links clickable

### DIFF
--- a/static/app/views/replays/detail/errorList/errorTableCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorTableCell.tsx
@@ -126,23 +126,45 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
       () => (
         <Cell {...columnProps}>
           <Text>
-            <ClassNames>
-              {({css}) => (
-                <QuickContextHovercard
-                  dataRow={{
-                    id: eventId,
-                    'project.name': projectSlug,
-                  }}
-                  contextType={ContextType.EVENT}
-                  organization={organization}
-                  containerClassName={css`
-                    display: inline;
-                  `}
-                >
-                  {title ?? EMPTY_CELL}
-                </QuickContextHovercard>
-              )}
-            </ClassNames>
+            {eventUrl ? (
+              <Link to={eventUrl}>
+                <ClassNames>
+                  {({css}) => (
+                    <QuickContextHovercard
+                      dataRow={{
+                        id: eventId,
+                        'project.name': projectSlug,
+                      }}
+                      contextType={ContextType.EVENT}
+                      organization={organization}
+                      containerClassName={css`
+                        display: inline;
+                      `}
+                    >
+                      {title ?? EMPTY_CELL}
+                    </QuickContextHovercard>
+                  )}
+                </ClassNames>
+              </Link>
+            ) : (
+              <ClassNames>
+                {({css}) => (
+                  <QuickContextHovercard
+                    dataRow={{
+                      id: eventId,
+                      'project.name': projectSlug,
+                    }}
+                    contextType={ContextType.EVENT}
+                    organization={organization}
+                    containerClassName={css`
+                      display: inline;
+                    `}
+                  >
+                    {title ?? EMPTY_CELL}
+                  </QuickContextHovercard>
+                )}
+              </ClassNames>
+            )}
           </Text>
         </Cell>
       ),
@@ -152,16 +174,31 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
             <AvatarWrapper>
               <Avatar project={project} size={16} />
             </AvatarWrapper>
-            <QuickContextHovercard
-              dataRow={{
-                'issue.id': groupId,
-                issue: groupShortId,
-              }}
-              contextType={ContextType.ISSUE}
-              organization={organization}
-            >
-              <span>{groupShortId}</span>
-            </QuickContextHovercard>
+            {eventUrl ? (
+              <Link to={eventUrl}>
+                <QuickContextHovercard
+                  dataRow={{
+                    'issue.id': groupId,
+                    issue: groupShortId,
+                  }}
+                  contextType={ContextType.ISSUE}
+                  organization={organization}
+                >
+                  <span>{groupShortId}</span>
+                </QuickContextHovercard>
+              </Link>
+            ) : (
+              <QuickContextHovercard
+                dataRow={{
+                  'issue.id': groupId,
+                  issue: groupShortId,
+                }}
+                contextType={ContextType.ISSUE}
+                organization={organization}
+              >
+                <span>{groupShortId}</span>
+              </QuickContextHovercard>
+            )}
           </Text>
         </Cell>
       ),


### PR DESCRIPTION
Fixes getsentry/team-replay#113 by making the Title and Issue links in replay clickable and linking to the event ID issue page.

Before:

https://github.com/getsentry/sentry/assets/187460/a39245b8-f13d-4acb-8dec-a92b8e2214a9



After:

https://github.com/getsentry/sentry/assets/187460/c6baf600-41e0-43ec-bbcc-6de163e49c4a


