### PR TITLE
Enable stack trace linking to Bitbucket and VSTS repos on the frontend

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -29,7 +29,7 @@ import {
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAnalyticsDataForEvent} from 'sentry/utils/events';
-import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
+import {getIntegrationIcon, getIntegrationSourceUrl} from 'sentry/utils/integrationUtil';
 import {promptIsDismissed} from 'sentry/utils/promptIsDismissed';
 import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -270,7 +270,11 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
       <StacktraceLinkWrapper>
         <OpenInLink
           onClick={onOpenLink}
-          href={`${match!.sourceUrl}#L${frame.lineNo}`}
+          href={getIntegrationSourceUrl(
+            match.config.provider.key,
+            match!.sourceUrl,
+            frame.lineNo
+          )}
           openInNewTab
         >
           <StyledIconWrapper>

--- a/static/app/utils/integrationUtil.spec.tsx
+++ b/static/app/utils/integrationUtil.spec.tsx
@@ -1,0 +1,34 @@
+import {getIntegrationSourceUrl} from 'sentry/utils/integrationUtil';
+
+describe('getIntegrationSourceUrl()', function () {
+  it('returns the correct url for Bitbucket', function () {
+    const result = getIntegrationSourceUrl('bitbucket', 'https://example.com', 10);
+    expect(result).toEqual('https://example.com#lines-10');
+  });
+
+  it('returns the correct url for Bitbucket Server', function () {
+    const result = getIntegrationSourceUrl('bitbucket_server', 'https://example.com', 10);
+    expect(result).toEqual('https://example.com#lines-10');
+  });
+
+  it('returns the correct url for GitHub', function () {
+    const result = getIntegrationSourceUrl('github', 'https://example.com', 10);
+    expect(result).toEqual('https://example.com#L10');
+  });
+
+  it('returns the correct url for GitHub Enterprise', function () {
+    const result = getIntegrationSourceUrl(
+      'github_enterprise',
+      'https://example.com',
+      10
+    );
+    expect(result).toEqual('https://example.com#L10');
+  });
+
+  it('returns the correct url for VSTS', function () {
+    const result = getIntegrationSourceUrl('vsts', 'https://example.com', 10);
+    expect(result).toEqual(
+      'https://example.com/?line=10&lineEnd=11&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents'
+    );
+  });
+});

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -211,6 +211,33 @@ export const getIntegrationIcon = (
   }
 };
 
+export const getIntegrationSourceUrl = (
+  integrationType: string,
+  sourceUrl: string,
+  lineNo: number | null
+) => {
+  switch (integrationType) {
+    case 'bitbucket':
+    case 'bitbucket_server':
+      return `${sourceUrl}#lines-${lineNo}`;
+    case 'vsts':
+      const url = new URL(sourceUrl);
+      if (lineNo) {
+        url.searchParams.set('line', lineNo.toString());
+        url.searchParams.set('lineEnd', (lineNo + 1).toString());
+        url.searchParams.set('lineStartColumn', '1');
+        url.searchParams.set('lineEndColumn', '1');
+        url.searchParams.set('lineStyle', 'plain');
+        url.searchParams.set('_a', 'contents');
+      }
+      return url.toString();
+    case 'github':
+    case 'github_enterprise':
+    default:
+      return `${sourceUrl}#L${lineNo}`;
+  }
+};
+
 export function getCodeOwnerIcon(
   provider: CodeOwner['provider'],
   iconSize: IconSize = 'md'


### PR DESCRIPTION
The frontend currently assumes GitHub or GitHub Enterprise for stack trace linking. This change extends support to include Bitbucket and VSTS version control systems.


Sample stack trace links:
1. Bitbucket: https://bitbucket.org/jianyuan/sentry-frontend-monitoring/src/master/src/components/App.js#lines-14
2. VSTS: https://jianyuanlee.visualstudio.com/_git/sentry%20frontend%20monitoring?path=/src/components/App.js&version=GBmaster&line=14&lineEnd=15&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents