### PR TITLE
feat(starfish): Remove span operation selector and column from specific modules

### DIFF
--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -207,12 +207,16 @@ function getColumns(moduleName: ModuleName, transaction?: string): Column[] {
 
   const domain = getDomainHeader(moduleName);
 
-  const order: Column[] = [
-    {
-      key: SPAN_OP,
-      name: 'Operation',
-      width: 120,
-    },
+  const order = [
+    // We don't show the operation selector in specific modules, so there's no
+    // point having that column
+    [ModuleName.ALL, ModuleName.NONE].includes(moduleName)
+      ? {
+          key: SPAN_OP,
+          name: 'Operation',
+          width: 120,
+        }
+      : undefined,
     {
       key: SPAN_DESCRIPTION,
       name: description,
@@ -277,7 +281,7 @@ function getColumns(moduleName: ModuleName, transaction?: string): Column[] {
     });
   }
 
-  return order;
+  return order.filter((item): item is NonNullable<Column> => Boolean(item));
 }
 
 export function isAValidSort(sort: Sort): sort is ValidSort {

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -69,11 +69,16 @@ export default function SpansView(props: Props) {
         />
       </PaddedContainer>
       <FilterOptionsContainer>
-        <SpanOperationSelector
-          moduleName={moduleName}
-          value={appliedFilters[SPAN_OP] || ''}
-          spanCategory={props.spanCategory}
-        />
+        {/* Specific modules like Database and API only show _one_ kind of span
+        op based on how we group them. So, the operation selector is pointless
+        there. */}
+        {[ModuleName.ALL, ModuleName.NONE].includes(moduleName) && (
+          <SpanOperationSelector
+            moduleName={moduleName}
+            value={appliedFilters[SPAN_OP] || ''}
+            spanCategory={props.spanCategory}
+          />
+        )}
 
         <ActionSelector
           moduleName={moduleName}

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -40,6 +40,8 @@ type Query = {
 };
 
 export default function SpansView(props: Props) {
+  const moduleName = props.moduleName ?? ModuleName.ALL;
+
   const location = useLocation<Query>();
   const appliedFilters = pick(location.query, [
     SPAN_ACTION,
@@ -61,26 +63,26 @@ export default function SpansView(props: Props) {
 
       <PaddedContainer>
         <SpanTimeCharts
-          moduleName={props.moduleName || ModuleName.ALL}
+          moduleName={moduleName}
           appliedFilters={appliedFilters}
           spanCategory={props.spanCategory}
         />
       </PaddedContainer>
       <FilterOptionsContainer>
         <SpanOperationSelector
-          moduleName={props.moduleName}
+          moduleName={moduleName}
           value={appliedFilters[SPAN_OP] || ''}
           spanCategory={props.spanCategory}
         />
 
         <ActionSelector
-          moduleName={props.moduleName}
+          moduleName={moduleName}
           value={appliedFilters[SPAN_ACTION] || ''}
           spanCategory={props.spanCategory}
         />
 
         <DomainSelector
-          moduleName={props.moduleName}
+          moduleName={moduleName}
           value={appliedFilters[SPAN_DOMAIN] || ''}
           spanCategory={props.spanCategory}
         />
@@ -88,7 +90,7 @@ export default function SpansView(props: Props) {
 
       <PaddedContainer>
         <SpansTable
-          moduleName={props.moduleName || ModuleName.ALL}
+          moduleName={moduleName}
           spanCategory={props.spanCategory}
           sort={sort}
           limit={LIMIT}


### PR DESCRIPTION
The Database and API modules only show spans of _one_ `operation` respectively, so there's no point having either a span op selector, nor a span op column. Hide 'em.
