### PR TITLE
chore(starfish): Improve typing of `useSpansQuery`

### DIFF
--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -49,7 +49,7 @@ export const useSpanMetricsSeries = (
     yAxis.map(seriesName => {
       const series: Series = {
         seriesName,
-        data: result?.data.map(datum => ({
+        data: (result?.data ?? []).map(datum => ({
           value: datum[seriesName],
           name: datum.interval,
         })),

--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -163,7 +163,8 @@ export function useWrappedDiscoverQuery<T>({
     meta.units['sps()'] = '1/second';
   }
 
-  const data: T = result.isLoading && initialData ? initialData : result.data?.data;
+  const data =
+    result.isLoading && initialData ? initialData : (result.data?.data as T | undefined);
 
   return {
     ...result,

--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -32,7 +32,7 @@ export function useSpansQuery<T = any[]>({
   cursor?: string;
   enabled?: boolean;
   eventView?: EventView;
-  initialData?: any;
+  initialData?: T;
   limit?: number;
   referrer?: string;
 }) {
@@ -132,7 +132,7 @@ export function useWrappedDiscoverQuery<T>({
   eventView: EventView;
   cursor?: string;
   enabled?: boolean;
-  initialData?: any;
+  initialData?: T;
   limit?: number;
   referrer?: string;
 }) {

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -32,7 +32,7 @@ export function ActionSelector({
 
   const useHTTPActions = moduleName === ModuleName.HTTP;
 
-  const {data: actions} = useSpansQuery<[{'span.action': string}]>({
+  const {data: actions} = useSpansQuery<{'span.action': string}[]>({
     eventView,
     initialData: [],
     enabled: !useHTTPActions,

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -42,7 +42,7 @@ export function ActionSelector({
     ? HTTP_ACTION_OPTIONS
     : [
         {value: '', label: 'All'},
-        ...actions
+        ...(actions ?? [])
           .filter(datum => datum[SPAN_ACTION])
           .map(datum => ({
             value: datum[SPAN_ACTION],

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -37,7 +37,7 @@ export function DomainSelector({
 
   const options = [
     {value: '', label: 'All'},
-    ...domains.map(datum => ({
+    ...(domains ?? []).map(datum => ({
       value: datum['span.domain'],
       label: datum['span.domain'],
     })),

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -30,7 +30,7 @@ export function DomainSelector({
   const location = useLocation();
   const eventView = getEventView(location, moduleName, spanCategory);
 
-  const {data: domains} = useSpansQuery<[{'span.domain': string}]>({
+  const {data: domains} = useSpansQuery<{'span.domain': string}[]>({
     eventView,
     initialData: [],
   });

--- a/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
@@ -36,7 +36,7 @@ export function SpanOperationSelector({
 
   const options = [
     {value: '', label: 'All'},
-    ...operations.map(datum => ({
+    ...(operations ?? []).map(datum => ({
       value: datum[SPAN_OP],
       label: datum[SPAN_OP],
     })),

--- a/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
@@ -29,7 +29,7 @@ export function SpanOperationSelector({
   const location = useLocation();
   const eventView = getEventView(location, moduleName, spanCategory);
 
-  const {data: operations} = useSpansQuery<[{'span.op': string}]>({
+  const {data: operations} = useSpansQuery<{'span.op': string}[]>({
     eventView,
     initialData: [],
   });

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -90,7 +90,13 @@ function ThroughputChart({moduleName, filters}: ChartProps): JSX.Element {
   const eventView = getEventView(moduleName, pageFilters.selection, filters);
 
   const label = getSegmentLabel(moduleName);
-  const {isLoading, data} = useSpansQuery({
+  const {isLoading, data} = useSpansQuery<
+    {
+      interval: number;
+      'p95(span.self_time)': number;
+      'sps()': number;
+    }[]
+  >({
     eventView,
     initialData: [],
   });
@@ -101,7 +107,7 @@ function ThroughputChart({moduleName, filters}: ChartProps): JSX.Element {
 
     return {
       seriesName: label ?? 'Throughput',
-      data: groupData.map(datum => ({
+      data: (groupData ?? []).map(datum => ({
         value: datum['sps()'],
         name: datum.interval,
       })),
@@ -141,7 +147,13 @@ function DurationChart({moduleName, filters}: ChartProps): JSX.Element {
 
   const label = `p95(${SPAN_SELF_TIME})`;
 
-  const {isLoading, data} = useSpansQuery({
+  const {isLoading, data} = useSpansQuery<
+    {
+      interval: number;
+      'p95(span.self_time)': number;
+      'sps()': number;
+    }[]
+  >({
     eventView,
     initialData: [],
   });
@@ -152,7 +164,7 @@ function DurationChart({moduleName, filters}: ChartProps): JSX.Element {
 
     return {
       seriesName: label,
-      data: groupData.map(datum => ({
+      data: (groupData ?? []).map(datum => ({
         value: datum[`p95(${SPAN_SELF_TIME})`],
         name: datum.interval,
       })),

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -109,7 +109,7 @@ export default function SpansTable({
     <Fragment>
       <VisuallyCompleteWithData
         id="SpansTable"
-        hasData={data?.length > 0}
+        hasData={(data?.length ?? 0) > 0}
         isLoading={isLoading}
         disabled={shouldTrackVCD}
       >


### PR DESCRIPTION
Related to [Abhi's recent comment](https://github.com/getsentry/sentry/pull/52731#pullrequestreview-1526769790), _one_ of the reasons we're causing runtime errors is that our types are incorrect. This fixes _one_ spot, in which the response might be undefined, and we don't type is correctly. There's a lot more digging to do, but this already revealed some overly optimistic code.

## Changes

- `initialData` must match the returned type
    
    This was an oversight. It would make no sense to pass in `initialData`
    that doesn't match what we expect from the response.

- Improve typing of `useSpansQuery` responses
    
    Sometimes they can be undefined! We caused a lot of errors with
    incorrect types because we missed this.

