### PR TITLE
ref(sort): Change betterPriority to priority

### DIFF
--- a/static/app/components/modals/savedSearchModal/createSavedSearchModal.spec.tsx
+++ b/static/app/components/modals/savedSearchModal/createSavedSearchModal.spec.tsx
@@ -92,7 +92,7 @@ describe('CreateSavedSearchModal', function () {
           data: {
             name: 'new search name',
             query: 'is:resolved',
-            sort: IssueSortOptions.BETTER_PRIORITY,
+            sort: IssueSortOptions.PRIORITY,
             type: 0,
             visibility: SavedSearchVisibility.OWNER,
           },

--- a/static/app/components/modals/savedSearchModal/createSavedSearchModal.tsx
+++ b/static/app/components/modals/savedSearchModal/createSavedSearchModal.tsx
@@ -22,7 +22,7 @@ function validateSortOption({sort}: {sort?: string}) {
   const sortOptions = [
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    IssueSortOptions.BETTER_PRIORITY,
+    IssueSortOptions.PRIORITY,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/components/modals/savedSearchModal/editSavedSearchModal.spec.tsx
+++ b/static/app/components/modals/savedSearchModal/editSavedSearchModal.spec.tsx
@@ -56,7 +56,7 @@ describe('EditSavedSearchModal', function () {
         id: 'saved-search-id',
         name: 'test',
         query: 'is:unresolved browser:firefox',
-        sort: IssueSortOptions.BETTER_PRIORITY,
+        sort: IssueSortOptions.PRIORITY,
         visibility: SavedSearchVisibility.OWNER,
       },
     });
@@ -97,7 +97,7 @@ describe('EditSavedSearchModal', function () {
         id: 'saved-search-id',
         name: 'test',
         query: 'is:unresolved browser:firefox',
-        sort: IssueSortOptions.BETTER_PRIORITY,
+        sort: IssueSortOptions.PRIORITY,
         visibility: SavedSearchVisibility.OWNER,
       },
     });

--- a/static/app/components/modals/savedSearchModal/savedSearchModalContent.tsx
+++ b/static/app/components/modals/savedSearchModal/savedSearchModalContent.tsx
@@ -23,7 +23,7 @@ export function SavedSearchModalContent({organization}: SavedSearchModalContentP
   const sortOptions = [
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    IssueSortOptions.BETTER_PRIORITY,
+    IssueSortOptions.PRIORITY,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -73,7 +73,7 @@ function getTableSortOptions(_organization: Organization, _widgetQuery: WidgetQu
   const sortOptions = [
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    IssueSortOptions.BETTER_PRIORITY,
+    IssueSortOptions.PRIORITY,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/dashboards/widgetBuilder/issueWidget/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/issueWidget/utils.tsx
@@ -30,7 +30,7 @@ export const ISSUE_WIDGET_SORT_OPTIONS = [
   IssueSortOptions.DATE,
   IssueSortOptions.NEW,
   IssueSortOptions.FREQ,
-  IssueSortOptions.BETTER_PRIORITY,
+  IssueSortOptions.PRIORITY,
   IssueSortOptions.USER,
 ];
 

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -19,7 +19,7 @@ function getSortTooltip(key: IssueSortOptions) {
       return t('When issue was flagged for review.');
     case IssueSortOptions.NEW:
       return t('First time the issue occurred.');
-    case IssueSortOptions.BETTER_PRIORITY:
+    case IssueSortOptions.PRIORITY:
       return t('Recent issues trending upward.');
     case IssueSortOptions.FREQ:
       return t('Number of events.');
@@ -37,7 +37,7 @@ function IssueListSortOptions({onSelect, sort, query}: Props) {
     ...(FOR_REVIEW_QUERIES.includes(query || '') ? [IssueSortOptions.INBOX] : []),
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
-    IssueSortOptions.BETTER_PRIORITY,
+    IssueSortOptions.PRIORITY,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -174,7 +174,7 @@ export type QueryCounts = Partial<Record<Query, QueryCount>>;
 export enum IssueSortOptions {
   DATE = 'date',
   NEW = 'new',
-  BETTER_PRIORITY = 'betterPriority',
+  PRIORITY = 'priority',
   FREQ = 'freq',
   USER = 'user',
   INBOX = 'inbox',
@@ -190,7 +190,7 @@ export function getSortLabel(key: string) {
   switch (key) {
     case IssueSortOptions.NEW:
       return t('First Seen');
-    case IssueSortOptions.BETTER_PRIORITY:
+    case IssueSortOptions.PRIORITY:
       return t('Priority');
     case IssueSortOptions.FREQ:
       return t('Events');


### PR DESCRIPTION
Change references to the new priority sort to just "priority" for simplicity and to prevent more saved searches being created with the sort string "betterPriority".

After this is merged we'll run a migration to make all saved searches for priority sort the same (https://github.com/getsentry/sentry/pull/52909) and then finish by cleaning up the backend to only accept "priority" (right now it treats betterPriority and priority the same". 

Step 1: This PR
Step 2: Migration https://github.com/getsentry/sentry/pull/52909
Step 3: Backend PR https://github.com/getsentry/sentry/pull/52915