### PR TITLE
ref(sort): Replace betterPriority with priority

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -46,7 +46,6 @@ SORT_OPTIONS = {
     "date": _("Last Seen"),
     "new": _("First Seen"),
     "freq": _("Frequency"),
-    "better_priority": _("Better Priority"),
 }
 
 SEARCH_SORT_OPTIONS = {

--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -18,7 +18,6 @@ class SortOptions:
     FREQ = "freq"
     USER = "user"
     INBOX = "inbox"
-    BETTER_PRIORITY = "betterPriority"
 
     @classmethod
     def as_choices(cls):
@@ -29,7 +28,6 @@ class SortOptions:
             (cls.FREQ, _("Events")),
             (cls.USER, _("Users")),
             (cls.INBOX, _("Date Added")),
-            (cls.BETTER_PRIORITY, _("Better Priority")),
         )
 
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -76,7 +76,7 @@ DEFAULT_PRIORITY_WEIGHTS: PrioritySortWeights = {
 
 
 @dataclass
-class BetterPriorityParams:
+class PriorityParams:
     # (event or issue age_hours) / (event or issue halflife hours)
     # any event or issue age that is greater than max_pow times the half-life hours will get clipped
     max_pow: int
@@ -238,7 +238,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         end: datetime,
         having: Sequence[Sequence[Any]],
         aggregate_kwargs: Optional[PrioritySortWeights] = None,
-        replace_better_priority_aggregation: Optional[bool] = False,
+        replace_priority_aggregation: Optional[bool] = False,
     ) -> list[Any]:
         extra_aggregations = self.dependency_aggregations.get(sort_field, [])
         required_aggregations = set([sort_field, "total"] + extra_aggregations)
@@ -249,8 +249,8 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         aggregations = []
         for alias in required_aggregations:
             aggregation = self.aggregation_defs[alias]
-            if replace_better_priority_aggregation and alias in ["priority", "better_priority"]:
-                aggregation = self.aggregation_defs["better_priority_issue_platform"]
+            if replace_priority_aggregation and alias == "priority":
+                aggregation = self.aggregation_defs["priority_issue_platform"]
             if callable(aggregation):
                 if aggregate_kwargs:
                     aggregation = aggregation(start, end, aggregate_kwargs.get(alias, {}))
@@ -302,10 +302,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                 else:
                     conditions.append(converted_filter)
 
-        if (
-            sort_field in ["priority", "better_priority"]
-            and group_category is not GroupCategory.ERROR.value
-        ):
+        if sort_field == "priority" and group_category is not GroupCategory.ERROR.value:
             aggregations = self._prepare_aggregations(
                 sort_field, start, end, having, aggregate_kwargs, True
             )
@@ -503,13 +500,13 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         return sort_by in self.sort_strategies.keys()
 
 
-def better_priority_aggregation(
+def priority_aggregation(
     start: datetime,
     end: datetime,
     aggregate_kwargs: PrioritySortWeights,
 ) -> Sequence[str]:
-    return better_priority_aggregation_impl(
-        BetterPriorityParams(
+    return priority_aggregation_impl(
+        PriorityParams(
             max_pow=16,
             min_score=0.01,
             event_age_weight=1,
@@ -529,13 +526,13 @@ def better_priority_aggregation(
     )
 
 
-def better_priority_issue_platform_aggregation(
+def priority_issue_platform_aggregation(
     start: datetime,
     end: datetime,
     aggregate_kwargs: PrioritySortWeights,
 ) -> Sequence[str]:
-    return better_priority_aggregation_impl(
-        BetterPriorityParams(
+    return priority_aggregation_impl(
+        PriorityParams(
             max_pow=16,
             min_score=0.01,
             event_age_weight=1,
@@ -555,8 +552,8 @@ def better_priority_issue_platform_aggregation(
     )
 
 
-def better_priority_aggregation_impl(
-    params: BetterPriorityParams,
+def priority_aggregation_impl(
+    params: PriorityParams,
     timestamp_column: str,
     use_stacktrace: bool,
     start: datetime,
@@ -695,24 +692,22 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         "date": "last_seen",
         "freq": "times_seen",
         "new": "first_seen",
-        "priority": "better_priority",
+        "priority": "priority",
         "user": "user_count",
         # We don't need a corresponding snuba field here, since this sort only happens
         # in Postgres
         "inbox": "",
-        "betterPriority": "better_priority",
     }
 
     aggregation_defs = {
         "times_seen": ["count()", ""],
         "first_seen": ["multiply(toUInt64(min(timestamp)), 1000)", ""],
         "last_seen": ["multiply(toUInt64(max(timestamp)), 1000)", ""],
-        "priority": better_priority_aggregation,
+        "priority": priority_aggregation,
         # Only makes sense with WITH TOTALS, returns 1 for an individual group.
         "total": ["uniq", ISSUE_FIELD_NAME],
         "user_count": ["uniq", "tags[sentry:user]"],
-        "better_priority": better_priority_aggregation,
-        "better_priority_issue_platform": better_priority_issue_platform_aggregation,
+        "priority_issue_platform": priority_issue_platform_aggregation,
     }
 
     @property

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -114,7 +114,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(group.id)
 
-    def test_sort_by_better_priority(self):
+    def test_sort_by_priority(self):
         group = self.store_event(
             data={
                 "timestamp": iso_format(before_now(seconds=10)),
@@ -164,7 +164,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         }
 
         response = self.get_success_response(
-            sort="betterPriority",
+            sort="priority",
             query="is:unresolved",
             limit=25,
             start=iso_format(before_now(days=1)),


### PR DESCRIPTION
Now that the betterPriority sort is out and has replaced the old priority, just rename everything to priority for simplicity.

Step 1: FE PR: https://github.com/getsentry/sentry/pull/52910
Step 2: Migration: https://github.com/getsentry/sentry/pull/52909
Step 3: This PR!