### PR TITLE
feat(grouping): Add metrics for issue merging and unmerging

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Any, Dict, Mapping, MutableMapping, Sequence
+from urllib.parse import urlparse
 
 import rest_framework
 from django.db import IntegrityError, transaction
@@ -649,6 +651,27 @@ def update_groups(
         # don't allow merging cross project
         if len(projects) > 1:
             return Response({"detail": "Merging across multiple projects is not supported"})
+
+        referer = urlparse(request.META.get("HTTP_REFERER", "")).path
+        issue_stream_regex = r"^(\/organizations\/[^\/]+)?\/issues\/$"
+        similar_issues_tab_regex = r"^(\/organizations\/[^\/]+)?\/issues\/\d+\/similar\/$"
+
+        metrics.incr(
+            "grouping.merge_issues",
+            sample_rate=1.0,
+            tags={
+                # We assume that if someone's merging groups, they're from the same platform
+                "platform": group_list[0].platform or "unknown",
+                # TODO: It's probably cleaner to just send this value from the front end
+                "referer": (
+                    "issue stream"
+                    if re.search(issue_stream_regex, referer)
+                    else "similar issues tab"
+                    if re.search(similar_issues_tab_regex, referer)
+                    else "unknown"
+                ),
+            },
+        )
 
         result["merge"] = handle_merge(group_list, project_lookup, acting_user)
 

--- a/tests/sentry/api/endpoints/test_group_hashes.py
+++ b/tests/sentry/api/endpoints/test_group_hashes.py
@@ -1,4 +1,5 @@
 import copy
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 from sentry.eventstream.snuba import SnubaEventStream
@@ -94,7 +95,7 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
     def test_unmerge(self):
         self.login_as(user=self.user)
 
-        group = self.create_group()
+        group = self.create_group(platform="javascript")
 
         hashes = [
             GroupHash.objects.create(project=group.project, group=group, hash=hash)
@@ -108,5 +109,12 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
             ]
         )
 
-        response = self.client.delete(url, format="json")
-        assert response.status_code == 202, response.content
+        with patch("sentry.api.endpoints.group_hashes.metrics.incr") as mock_metrics_incr:
+            response = self.client.delete(url, format="json")
+
+            assert response.status_code == 202, response.content
+            mock_metrics_incr.assert_any_call(
+                "grouping.unmerge_issues",
+                sample_rate=1.0,
+                tags={"platform": "javascript"},
+            )

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from django.http import QueryDict
@@ -262,6 +262,102 @@ class UpdateGroupsTest(TestCase):
         assert group.substatus == GroupSubStatus.UNTIL_ESCALATING
         assert send_robust.called
         assert not GroupInbox.objects.filter(group=group).exists()
+
+
+class MergeGroupsTest(TestCase):
+    @patch("sentry.api.helpers.group_index.update.handle_merge")
+    def test_simple(self, mock_handle_merge: MagicMock):
+        group_ids = [self.create_group().id, self.create_group().id]
+        project = self.project
+
+        request = self.make_request(method="PUT")
+        request.user = self.user
+        request.data = {"merge": 1}
+        request.GET = {"id": group_ids, "project": [project.id]}
+
+        update_groups(request, group_ids, [project], self.organization.id, search_fn=Mock())
+
+        call_args = mock_handle_merge.call_args.args
+
+        assert len(call_args) == 3
+        # Have to convert to ids because first argument is a queryset
+        assert [group.id for group in call_args[0]] == group_ids
+        assert call_args[1] == {project.id: project}
+        assert call_args[2] == self.user
+
+    @patch("sentry.api.helpers.group_index.update.handle_merge")
+    def test_multiple_projects(self, mock_handle_merge: MagicMock):
+        project1 = self.create_project()
+        project2 = self.create_project()
+        projects = [project1, project2]
+        project_ids = [project.id for project in projects]
+
+        group_ids = [
+            self.create_group(project1).id,
+            self.create_group(project2).id,
+        ]
+
+        request = self.make_request(method="PUT")
+        request.user = self.user
+        request.data = {"merge": 1}
+        request.GET = {"id": group_ids, "project": project_ids}
+
+        response = update_groups(
+            request, group_ids, projects, self.organization.id, search_fn=Mock()
+        )
+
+        assert response.data == {"detail": "Merging across multiple projects is not supported"}
+        assert mock_handle_merge.call_count == 0
+
+    def test_metrics(self):
+        for referer, expected_referer_tag in [
+            ("https://sentry.io/organizations/dogsaregreat/issues/", "issue stream"),
+            ("https://dogsaregreat.sentry.io/issues/", "issue stream"),
+            (
+                "https://sentry.io/organizations/dogsaregreat/issues/12311121/similar/",
+                "similar issues tab",
+            ),
+            (
+                "https://dogsaregreat.sentry.io/issues/12311121/similar/",
+                "similar issues tab",
+            ),
+            (
+                "https://sentry.io/organizations/dogsaregreat/some/other/path/",
+                "unknown",
+            ),
+            (
+                "https://dogsaregreat.sentry.io/some/other/path/",
+                "unknown",
+            ),
+            (
+                "",
+                "unknown",
+            ),
+        ]:
+
+            group_ids = [
+                self.create_group(platform="javascript").id,
+                self.create_group(platform="javascript").id,
+            ]
+            project = self.project
+
+            request = self.make_request(method="PUT")
+            request.user = self.user
+            request.data = {"merge": 1}
+            request.GET = {"id": group_ids, "project": [project.id]}
+            request.META = {"HTTP_REFERER": referer}
+
+            with patch("sentry.api.helpers.group_index.update.metrics.incr") as mock_metrics_incr:
+                update_groups(request, group_ids, [project], self.organization.id, search_fn=Mock())
+
+                mock_metrics_incr.assert_any_call(
+                    "grouping.merge_issues",
+                    sample_rate=1.0,
+                    tags={
+                        "platform": "javascript",
+                        "referer": expected_referer_tag,
+                    },
+                )
 
 
 class TestHandleIsSubscribed(TestCase):


### PR DESCRIPTION
This adds DataDog metrics for instances of issues being merged and unmerged. Both metrics include the issues' platform, and the merge metric additionally includes referer (since you can merge from either the issue stream or the Similar Issues tab). A few missing merge-related tests were also added.

Note: I was originally going to include the number of issues being merged as extra data for the merging metric, but it occurred to me that people are more likely to merge in new issues as they appear rather than wait and merge all the issues at once, so I removed it. We can revisit this later if necessary.

Ref: https://github.com/getsentry/sentry/issues/52920
Ref: https://github.com/getsentry/sentry/issues/52922