### PR TITLE
ref(projects): Redirect post project transfer to project teams page

### DIFF
--- a/static/app/views/acceptProjectTransfer/index.tsx
+++ b/static/app/views/acceptProjectTransfer/index.tsx
@@ -42,10 +42,14 @@ class AcceptProjectTransfer extends DeprecatedAsyncView<Props, State> {
       },
       success: () => {
         const orgSlug = formData.organization;
-        const projectSlug = this.state.transferDetails.project.slug;
-        this.props.router.push(
-          normalizeUrl(`/settings/${orgSlug}/projects/${projectSlug}/teams/`)
-        );
+        const projectSlug = this.state?.transferDetails?.project.slug;
+        if (projectSlug === null) {
+          this.props.router.push(normalizeUrl(`/organizations/${orgSlug}/projects/`));
+        } else {
+          this.props.router.push(
+            normalizeUrl(`/settings/${orgSlug}/projects/${projectSlug}/teams/`)
+          );
+        }
         addSuccessMessage(t('Project successfully transferred'));
       },
       error: error => {

--- a/static/app/views/acceptProjectTransfer/index.tsx
+++ b/static/app/views/acceptProjectTransfer/index.tsx
@@ -42,8 +42,10 @@ class AcceptProjectTransfer extends DeprecatedAsyncView<Props, State> {
       },
       success: () => {
         const orgSlug = formData.organization;
-
-        this.props.router.push(normalizeUrl(`/organizations/${orgSlug}/projects/`));
+        const projectSlug = this.state.transferDetails.project.slug;
+        this.props.router.push(
+          normalizeUrl(`/settings/${orgSlug}/projects/${projectSlug}/teams/`)
+        );
         addSuccessMessage(t('Project successfully transferred'));
       },
       error: error => {


### PR DESCRIPTION
When a user approves transferring a project to a new organization the project isn't added to a team which results in confusion because the project doesn't show up on the projects page. The user needs to add the project to a team for it to show up in most places in the UI, so we should redirect them to the appropriate page to do so. 