### PR TITLE
fix(replays): fix bin/mock-replays script

### DIFF
--- a/bin/mock-replay
+++ b/bin/mock-replay
@@ -14,7 +14,7 @@ import click
 import requests
 from django.conf import settings
 
-from sentry.models import File, Organization, Project
+from sentry.models import File, Organization, Project, Team
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.replays.testutils import (
     mock_replay,
@@ -64,7 +64,7 @@ def make_filename(filename: str) -> str:
 
 
 def main():
-    project_name = "Replay Test"
+    project_name = "Replay Test Project"
 
     if settings.SENTRY_SINGLE_ORGANIZATION:
         org = Organization.get_default()
@@ -74,13 +74,21 @@ def main():
         org, _ = Organization.objects.get_or_create(slug="default")
 
     click.echo(f"  > Mocking project {project_name}")
+
+    team, _ = Team.objects.get_or_create(
+        organization=org, slug="sentry", defaults={"name": "Sentry"}
+    )
+
     project, _ = Project.objects.get_or_create(
         name=project_name,
         defaults={
             "organization": org,
             "flags": Project.flags.has_replays,
         },
+        platform="javascript",
     )
+
+    project.add_team(team)
 
     replay_id = uuid.uuid4().hex
     seq1_timestamp = datetime.now() - timedelta(seconds=22)

--- a/bin/mock-replay
+++ b/bin/mock-replay
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
+from io import BytesIO
+from zlib import compress
+
 from sentry.runner import configure
+from sentry.utils.json import dumps_htmlsafe
 
 configure()
-import datetime
 import pathlib
 import uuid
+from datetime import datetime, timedelta
 
 import click
 import requests
@@ -12,7 +16,14 @@ from django.conf import settings
 
 from sentry.models import File, Organization, Project
 from sentry.replays.models import ReplayRecordingSegment
-from sentry.replays.testutils import mock_replay
+from sentry.replays.testutils import (
+    mock_replay,
+    mock_rrweb_div_helloworld,
+    mock_segment_console,
+    mock_segment_fullsnapshot,
+    mock_segment_init,
+    mock_segment_nagivation,
+)
 
 
 def store_replay(replay):
@@ -22,16 +33,28 @@ def store_replay(replay):
     assert response.status_code == 200
 
 
-def create_recording_segment(replay_id, project_id, filename, segment_id):
-    with open(filename, "rb") as f:
-        file = File.objects.create(name=filename, type="application/octet-stream")
-        file.putfile(f)
+def create_recording(replay_id, project_id, timestamp):
+    segments = [
+        mock_segment_init(timestamp),
+        mock_segment_fullsnapshot(timestamp, [mock_rrweb_div_helloworld()]),
+        mock_segment_console(timestamp),
+        mock_segment_nagivation(timestamp + timedelta(seconds=1), hrefFrom="/", hrefTo="/home/"),
+        mock_segment_nagivation(
+            timestamp + timedelta(seconds=2), hrefFrom="/home/", hrefTo="/profile/"
+        ),
+    ]
+    for (segment_id, segment) in enumerate(segments):
+        store_replay_segments(replay_id, project_id, segment_id, segment)
 
+
+def store_replay_segments(replay_id: str, project_id: str, segment_id: int, segment):
+    f = File.objects.create(name="rr:{segment_id}", type="replay.recording")
+    f.putfile(BytesIO(compress(dumps_htmlsafe(segment).encode())))
     ReplayRecordingSegment.objects.create(
-        replay_id=replay_id.replace("-", ""),
+        replay_id=replay_id,
         project_id=project_id,
         segment_id=segment_id,
-        file_id=file.id,
+        file_id=f.id,
     )
 
 
@@ -60,16 +83,15 @@ def main():
     )
 
     replay_id = uuid.uuid4().hex
-    seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=22)
-    seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=5)
+    seq1_timestamp = datetime.now() - timedelta(seconds=22)
+    seq2_timestamp = datetime.now() - timedelta(seconds=5)
 
-    click.echo("Creating Clickhouse entries...")
+    click.echo("Creating Replay events entries...")
     store_replay(mock_replay(seq1_timestamp, project.id, replay_id, segment_id=0))
     store_replay(mock_replay(seq2_timestamp, project.id, replay_id, segment_id=1))
 
-    click.echo("Creating Postgres entries...")
-    create_recording_segment(replay_id, project.id, make_filename("rrweb-1658770770892.json"), 0)
-    create_recording_segment(replay_id, project.id, make_filename("rrweb-1658770772903.json"), 1)
+    click.echo("Creating Replay recording entries...")
+    create_recording(replay_id, project.id, seq1_timestamp)
 
 
 if __name__ == "__main__":

--- a/bin/mock-replay
+++ b/bin/mock-replay
@@ -66,6 +66,12 @@ def make_filename(filename: str) -> str:
 def main():
     project_name = "Replay Test Project"
 
+    if not settings.SENTRY_FEATURES["organizations:session-replay"]:
+        click.echo(
+            'Session Replays is currently turned off! \nTo enable, add the following line to your local sentry.conf.py file: \nSENTRY_FEATURES["organizations:session-replay"] = True'
+        )
+        exit()
+
     if settings.SENTRY_SINGLE_ORGANIZATION:
         org = Organization.get_default()
         click.echo(f"Mocking org {org.name}")


### PR DESCRIPTION
Closes getsentry/team-replay#115

bin/mock-replays script now runs successfully locally so you can see an empty replay in your local environment upon running `sentry devserver`