### PR TITLE
feat(hybrid-cloud): Add Bitbucket Server parser

### DIFF
--- a/src/sentry/middleware/integrations/integration_control.py
+++ b/src/sentry/middleware/integrations/integration_control.py
@@ -8,6 +8,7 @@ from sentry.silo import SiloMode
 
 from .parsers import (
     BitbucketRequestParser,
+    BitbucketServerRequestParser,
     GithubEnterpriseRequestParser,
     GithubRequestParser,
     GitlabRequestParser,
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 ACTIVE_PARSERS = [
     BitbucketRequestParser,
+    BitbucketServerRequestParser,
     GithubEnterpriseRequestParser,
     GithubRequestParser,
     GitlabRequestParser,

--- a/src/sentry/middleware/integrations/parsers/__init__.py
+++ b/src/sentry/middleware/integrations/parsers/__init__.py
@@ -1,4 +1,5 @@
 from .bitbucket import BitbucketRequestParser
+from .bitbucket_server import BitbucketServerRequestParser
 from .github import GithubRequestParser
 from .github_enterprise import GithubEnterpriseRequestParser
 from .gitlab import GitlabRequestParser
@@ -10,6 +11,7 @@ from .vsts import VstsRequestParser
 
 __all__ = (
     "BitbucketRequestParser",
+    "BitbucketServerRequestParser",
     "GithubRequestParser",
     "GitlabRequestParser",
     "JiraRequestParser",

--- a/src/sentry/middleware/integrations/parsers/bitbucket.py
+++ b/src/sentry/middleware/integrations/parsers/bitbucket.py
@@ -16,6 +16,9 @@ class BitbucketRequestParser(BaseRequestParser):
     webhook_identifier = WebhookProviderIdentifier.BITBUCKET
 
     def get_bitbucket_webhook_response(self):
+        """
+        Used for identifying regions from Bitbucket and Bitbucket Server webhooks
+        """
         # The organization is provided in the path, so we can skip inferring organizations
         # from the integration credentials
         organization_id = self.match.kwargs.get("organization_id")

--- a/src/sentry/middleware/integrations/parsers/bitbucket_server.py
+++ b/src/sentry/middleware/integrations/parsers/bitbucket_server.py
@@ -5,21 +5,18 @@ import logging
 from django.http import HttpResponse
 
 from sentry.integrations.bitbucket_server.webhook import BitbucketServerWebhookEndpoint
-from sentry.middleware.integrations.parsers.base import BaseRequestParser
+from sentry.middleware.integrations.parsers.bitbucket import BitbucketRequestParser
 from sentry.models.outbox import WebhookProviderIdentifier
 
 logger = logging.getLogger(__name__)
 
 
-class BitbucketServerRequestParser(BaseRequestParser):
+class BitbucketServerRequestParser(BitbucketRequestParser):
     provider = "bitbucket_server"
     webhook_identifier = WebhookProviderIdentifier.BITBUCKET_SERVER
-
-    def get_bitbucket_server_webhook_response(self):
-        pass
 
     def get_response(self) -> HttpResponse:
         view_class = self.match.func.view_class  # type: ignore
         if view_class == BitbucketServerWebhookEndpoint:
-            return self.get_bitbucket_server_webhook_response()
+            return self.get_bitbucket_webhook_response()
         return self.get_response_from_control_silo()

--- a/src/sentry/middleware/integrations/parsers/bitbucket_server.py
+++ b/src/sentry/middleware/integrations/parsers/bitbucket_server.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import logging
+
+from django.http import HttpResponse
+
+from sentry.integrations.bitbucket_server.webhook import BitbucketServerWebhookEndpoint
+from sentry.middleware.integrations.parsers.base import BaseRequestParser
+from sentry.models.outbox import WebhookProviderIdentifier
+
+logger = logging.getLogger(__name__)
+
+
+class BitbucketServerRequestParser(BaseRequestParser):
+    provider = "bitbucket_server"
+    webhook_identifier = WebhookProviderIdentifier.BITBUCKET_SERVER
+
+    def get_bitbucket_server_webhook_response(self):
+        pass
+
+    def get_response(self) -> HttpResponse:
+        view_class = self.match.func.view_class  # type: ignore
+        if view_class == BitbucketServerWebhookEndpoint:
+            return self.get_bitbucket_server_webhook_response()
+        return self.get_response_from_control_silo()

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -107,6 +107,7 @@ class WebhookProviderIdentifier(IntEnum):
     VSTS = 6
     JIRA_SERVER = 7
     GITHUB_ENTERPRISE = 8
+    BITBUCKET_SERVER = 9
 
 
 def _ensure_not_null(k: str, v: Any) -> Any:

--- a/tests/sentry/middleware/integrations/parsers/test_bitbucket_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_bitbucket_server.py
@@ -1,0 +1,68 @@
+from unittest import mock
+from unittest.mock import MagicMock
+
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+from django.urls import reverse
+
+from sentry.middleware.integrations.integration_control import IntegrationControlMiddleware
+from sentry.middleware.integrations.parsers.bitbucket_server import BitbucketServerRequestParser
+from sentry.models.outbox import WebhookProviderIdentifier
+from sentry.services.hybrid_cloud.organization_mapping.service import organization_mapping_service
+from sentry.silo.base import SiloMode
+from sentry.testutils import TestCase
+from sentry.testutils.outbox import assert_webhook_outboxes
+from sentry.testutils.region import override_regions
+from sentry.testutils.silo import control_silo_test
+from sentry.types.region import Region, RegionCategory
+
+
+@control_silo_test()
+class BitbucketServerRequestParserTest(TestCase):
+    get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
+    middleware = IntegrationControlMiddleware(get_response)
+    factory = RequestFactory()
+    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region_config = (region,)
+
+    def setUp(self):
+        super().setUp()
+        self.path = reverse(
+            "sentry-extensions-bitbucket-webhook", kwargs={"organization_id": self.organization.id}
+        )
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="bitbucketserver:1",
+            provider="bitbucket_server",
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_routing_webhook(self):
+        region_route = reverse(
+            "sentry-extensions-bitbucketserver-webhook",
+            kwargs={"organization_id": self.organization.id, "integration_id": self.integration.id},
+        )
+        request = self.factory.post(region_route)
+        parser = BitbucketServerRequestParser(request=request, response_handler=self.get_response)
+
+        # Missing region
+        organization_mapping_service.update(
+            organization_id=self.organization.id, update={"region_name": "eu"}
+        )
+        with mock.patch.object(
+            parser, "get_response_from_control_silo"
+        ) as get_response_from_control_silo:
+            parser.get_response()
+            assert get_response_from_control_silo.called
+
+        # Valid region
+        organization_mapping_service.update(
+            organization_id=self.organization.id, update={"region_name": "na"}
+        )
+        with override_regions(self.region_config):
+            parser.get_response()
+            assert_webhook_outboxes(
+                factory_request=request,
+                webhook_identifier=WebhookProviderIdentifier.BITBUCKET_SERVER,
+                region_names=[self.region.name],
+            )


### PR DESCRIPTION
There's only one endpoint for Bitbucket Server, and it contains the organization ID in it, so we can reuse the original Bitbucket code, which was a pleasant surprise.