### PR TITLE
ref(replays): update links to remove project slug

### DIFF
--- a/static/app/components/events/eventReplay/replayPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.spec.tsx
@@ -25,7 +25,7 @@ const mockEvent = {
 };
 
 const mockButtonHref =
-  '/organizations/sentry-emerging-tech/replays/761104e184c64d439ee1014b72b4d83b/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&t=62&t_main=console';
+  '/replays/761104e184c64d439ee1014b72b4d83b/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&t=62&t_main=console';
 
 // Mock screenfull library
 jest.mock('screenfull', () => ({

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -99,7 +99,7 @@ function ReplayPreview({orgSlug, replaySlug, event, onClickOpenReplay}: Props) {
   }
 
   const fullReplayUrl = {
-    pathname: `/organizations/${orgSlug}/replays/${replayId}/`,
+    pathname: `/replays/${replayId}/`,
     query: {
       referrer: getRouteStringFromRoutes(routes),
       t_main: 'console',

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -293,10 +293,7 @@ describe('GroupReplays', () => {
               finished_at: new Date('2022-09-15T06:54:00+00:00'),
               id: '346789a703f6454384f1de473b8b9fcc',
               started_at: new Date('2022-09-15T06:50:00+00:00'),
-              urls: [
-                'https://dev.getsentry.net:7999/organizations/sentry-emerging-tech/replays/',
-                '/organizations/sentry-emerging-tech/replays/?project=2',
-              ],
+              urls: ['https://dev.getsentry.net:7999/replays/', '/replays/?project=2'],
             },
             {
               ...TestStubs.ReplayList()[0],

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -339,13 +339,13 @@ describe('GroupReplays', () => {
       // Expect the first row to have the correct href
       expect(screen.getAllByRole('link', {name: 'testDisplayName'})[0]).toHaveAttribute(
         'href',
-        `/organizations/org-slug/replays/project-slug:${REPLAY_ID_1}/?${expectedQuery}`
+        `/replays/project-slug:${REPLAY_ID_1}/?${expectedQuery}`
       );
 
       // Expect the second row to have the correct href
       expect(screen.getAllByRole('link', {name: 'testDisplayName'})[1]).toHaveAttribute(
         'href',
-        `/organizations/org-slug/replays/project-slug:${REPLAY_ID_2}/?${expectedQuery}`
+        `/replays/project-slug:${REPLAY_ID_2}/?${expectedQuery}`
       );
 
       // Expect the first row to have the correct duration

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -339,13 +339,13 @@ describe('GroupReplays', () => {
       // Expect the first row to have the correct href
       expect(screen.getAllByRole('link', {name: 'testDisplayName'})[0]).toHaveAttribute(
         'href',
-        `/replays/project-slug:${REPLAY_ID_1}/?${expectedQuery}`
+        `/replays/${REPLAY_ID_1}/?${expectedQuery}`
       );
 
       // Expect the second row to have the correct href
       expect(screen.getAllByRole('link', {name: 'testDisplayName'})[1]).toHaveAttribute(
         'href',
-        `/replays/project-slug:${REPLAY_ID_2}/?${expectedQuery}`
+        `/replays/${REPLAY_ID_2}/?${expectedQuery}`
       );
 
       // Expect the first row to have the correct duration

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -204,7 +204,10 @@ describe('TransactionReplays', () => {
             finished_at: new Date('2022-09-15T06:54:00+00:00'),
             id: '346789a703f6454384f1de473b8b9fcc',
             started_at: new Date('2022-09-15T06:50:00+00:00'),
-            urls: ['https://dev.getsentry.net:7999/replays/', '/replays/?project=2'],
+            urls: [
+              'https://dev.getsentry.net:7999/organizations/sentry-emerging-tech/replays/',
+              '/organizations/sentry-emerging-tech/replays/?project=2',
+            ],
           },
           {
             ...TestStubs.ReplayList()[0],
@@ -244,13 +247,13 @@ describe('TransactionReplays', () => {
     // Expect the first row to have the correct href
     expect(screen.getAllByRole('link', {name: 'testDisplayName'})[0]).toHaveAttribute(
       'href',
-      `/organizations/org-slug/replays/project-slug:346789a703f6454384f1de473b8b9fcc/?${expectedQuery}`
+      `/replays/project-slug:346789a703f6454384f1de473b8b9fcc/?${expectedQuery}`
     );
 
     // Expect the second row to have the correct href
     expect(screen.getAllByRole('link', {name: 'testDisplayName'})[1]).toHaveAttribute(
       'href',
-      `/organizations/org-slug/replays/project-slug:b05dae9b6be54d21a4d5ad9f8f02b780/?${expectedQuery}`
+      `/replays/project-slug:b05dae9b6be54d21a4d5ad9f8f02b780/?${expectedQuery}`
     );
 
     // Expect the first row to have the correct duration

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -247,13 +247,13 @@ describe('TransactionReplays', () => {
     // Expect the first row to have the correct href
     expect(screen.getAllByRole('link', {name: 'testDisplayName'})[0]).toHaveAttribute(
       'href',
-      `/replays/project-slug:346789a703f6454384f1de473b8b9fcc/?${expectedQuery}`
+      `/replays/346789a703f6454384f1de473b8b9fcc/?${expectedQuery}`
     );
 
     // Expect the second row to have the correct href
     expect(screen.getAllByRole('link', {name: 'testDisplayName'})[1]).toHaveAttribute(
       'href',
-      `/replays/project-slug:b05dae9b6be54d21a4d5ad9f8f02b780/?${expectedQuery}`
+      `/replays/b05dae9b6be54d21a4d5ad9f8f02b780/?${expectedQuery}`
     );
 
     // Expect the first row to have the correct duration

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -204,10 +204,7 @@ describe('TransactionReplays', () => {
             finished_at: new Date('2022-09-15T06:54:00+00:00'),
             id: '346789a703f6454384f1de473b8b9fcc',
             started_at: new Date('2022-09-15T06:50:00+00:00'),
-            urls: [
-              'https://dev.getsentry.net:7999/organizations/sentry-emerging-tech/replays/',
-              '/organizations/sentry-emerging-tech/replays/?project=2',
-            ],
+            urls: ['https://dev.getsentry.net:7999/replays/', '/replays/?project=2'],
           },
           {
             ...TestStubs.ReplayList()[0],

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -175,7 +175,7 @@ export function generateReplayLink(routes: PlainRoute<any>[]) {
   const referrer = getRouteStringFromRoutes(routes);
 
   return (
-    organization: Organization,
+    _: Organization,
     tableRow: TableDataRow,
     _query: Query | undefined
   ): LocationDescriptor => {
@@ -186,7 +186,7 @@ export function generateReplayLink(routes: PlainRoute<any>[]) {
 
     if (!tableRow.timestamp) {
       return {
-        pathname: `/organizations/${organization.slug}/replays/${replayId}/`,
+        pathname: `/replays/${replayId}/`,
         query: {
           referrer,
         },
@@ -199,7 +199,7 @@ export function generateReplayLink(routes: PlainRoute<any>[]) {
       : undefined;
 
     return {
-      pathname: `/organizations/${organization.slug}/replays/${replayId}/`,
+      pathname: `/replays/${replayId}/`,
       query: {
         event_t: transactionStartTimestamp,
         referrer,

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -56,7 +56,7 @@ export function ReplayCell({
   const project = projects.find(p => p.id === replay.project_id);
 
   const replayDetails = {
-    pathname: `/organizations/${organization.slug}/replays/${project?.slug}:${replay.id}/`,
+    pathname: `/replays/${replay.id}/`,
     query: {
       referrer,
       ...eventView.generateQueryStringObject(),


### PR DESCRIPTION
Closes #51541 by updating all links to replays to remove any instances of organization slug, project slug, etc. 

Checked the following:
- [x] issue details
- [x] issue replays tab
- [x] transaction summary
- [x] transaction replays tab
- [x] discover event detail
- [x] discover home
- [x] replay list page