### PR TITLE
fix(auth): Add OIDC signing token to prod

### DIFF
--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -116,15 +116,14 @@ class OAuthTokenView(View):
             return {"error": "invalid_grant", "reason": "invalid redirect URI"}
 
         token_data = {"token": ApiToken.from_grant(grant=grant)}
-        id_token = None
-        if grant.has_scope("openid"):
-            id_token = OpenIDToken(
+        if grant.has_scope("openid") and options.get("codecov.client-secret"):
+            open_id_token = OpenIDToken(
                 request.POST.get("client_id"),
                 grant.user_id,
                 options.get("codecov.client-secret"),
                 nonce=request.POST.get("nonce"),
             )
-            token_data["id_token"] = id_token.get_encrypted_id_token(grant=grant)
+            token_data["id_token"] = open_id_token.get_encrypted_id_token(grant=grant)
 
         return token_data
 

--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -124,7 +124,6 @@ class OAuthTokenView(View):
                 nonce=request.POST.get("nonce"),
             )
             token_data["id_token"] = open_id_token.get_encrypted_id_token(grant=grant)
-
         return token_data
 
     def get_refresh_token(self, request: Request, application: ApiApplication) -> dict:

--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -1,5 +1,4 @@
 import logging
-import secrets
 from typing import Optional
 
 from django.http import HttpRequest, HttpResponse
@@ -9,6 +8,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import View
 from rest_framework.request import Request
 
+from sentry import options
 from sentry.mediators import GrantTypes
 from sentry.models import ApiApplication, ApiApplicationStatus, ApiGrant, ApiToken
 from sentry.utils import json, metrics
@@ -121,8 +121,7 @@ class OAuthTokenView(View):
             id_token = OpenIDToken(
                 request.POST.get("client_id"),
                 grant.user_id,
-                # Encrypt with a random secret until we implement secure shared secrets in prod
-                secrets.token_urlsafe(),
+                options.get("codecov.client-secret"),
                 nonce=request.POST.get("nonce"),
             )
             token_data["id_token"] = id_token.get_encrypted_id_token(grant=grant)

--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -123,7 +123,7 @@ class OAuthTokenView(View):
                 options.get("codecov.client-secret"),
                 nonce=request.POST.get("nonce"),
             )
-            token_data["id_token"] = open_id_token.get_encrypted_id_token(grant=grant)
+            token_data["id_token"] = open_id_token.get_signed_id_token(grant=grant)
         return token_data
 
     def get_refresh_token(self, request: Request, application: ApiApplication) -> dict:

--- a/src/sentry/web/frontend/openidtoken.py
+++ b/src/sentry/web/frontend/openidtoken.py
@@ -36,7 +36,7 @@ class OpenIDToken:
         self.exp = exp if exp else default_expiration()
         self.iat = iat if iat else timezone.now()
 
-    def get_encrypted_id_token(self, grant: ApiGrant) -> str:
+    def get_signed_id_token(self, grant: ApiGrant) -> str:
         headers = {
             "alg": "HS256",
             "typ": "JWT",

--- a/tests/sentry/web/frontend/test_oauth_token.py
+++ b/tests/sentry/web/frontend/test_oauth_token.py
@@ -276,29 +276,30 @@ class OAuthTokenCodeTest(TestCase):
             redirect_uri="https://example.com",
             scope_list=["openid"],
         )
-        resp = self.client.post(
-            self.path,
-            {
-                "grant_type": "authorization_code",
-                "redirect_uri": self.application.get_default_redirect_uri(),
-                "code": open_id_grant.code,
-                "client_id": self.application.client_id,
-                "client_secret": self.client_secret,
-            },
-        )
-        assert resp.status_code == 200
+        with self.options({"codecov.client-secret": "signing_secret"}):
+            resp = self.client.post(
+                self.path,
+                {
+                    "grant_type": "authorization_code",
+                    "redirect_uri": self.application.get_default_redirect_uri(),
+                    "code": open_id_grant.code,
+                    "client_id": self.application.client_id,
+                    "client_secret": self.client_secret,
+                },
+            )
+            assert resp.status_code == 200
 
-        data = json.loads(resp.content)
-        token = ApiToken.objects.get(token=data["access_token"])
+            data = json.loads(resp.content)
+            token = ApiToken.objects.get(token=data["access_token"])
 
-        assert token.get_scopes() == ["openid"]
-        assert data["refresh_token"] == token.refresh_token
-        assert data["access_token"] == token.token
-        assert isinstance(data["expires_in"], int)
-        assert data["token_type"] == "bearer"
-        assert data["user"]["id"] == str(token.user_id)
+            assert token.get_scopes() == ["openid"]
+            assert data["refresh_token"] == token.refresh_token
+            assert data["access_token"] == token.token
+            assert isinstance(data["expires_in"], int)
+            assert data["token_type"] == "bearer"
+            assert data["user"]["id"] == str(token.user_id)
 
-        assert data["id_token"].count(".") == 2
+            assert data["id_token"].count(".") == 2
 
     def test_valid_params_id_token_additional_scopes(self):
         self.login_as(self.user)
@@ -308,29 +309,30 @@ class OAuthTokenCodeTest(TestCase):
             redirect_uri="https://example.com",
             scope_list=["openid", "profile", "email"],
         )
-        resp = self.client.post(
-            self.path,
-            {
-                "grant_type": "authorization_code",
-                "redirect_uri": self.application.get_default_redirect_uri(),
-                "code": open_id_grant.code,
-                "client_id": self.application.client_id,
-                "client_secret": self.client_secret,
-            },
-        )
-        assert resp.status_code == 200
+        with self.options({"codecov.client-secret": "signing_secret"}):
+            resp = self.client.post(
+                self.path,
+                {
+                    "grant_type": "authorization_code",
+                    "redirect_uri": self.application.get_default_redirect_uri(),
+                    "code": open_id_grant.code,
+                    "client_id": self.application.client_id,
+                    "client_secret": self.client_secret,
+                },
+            )
+            assert resp.status_code == 200
 
-        data = json.loads(resp.content)
-        token = ApiToken.objects.get(token=data["access_token"])
+            data = json.loads(resp.content)
+            token = ApiToken.objects.get(token=data["access_token"])
 
-        assert token.get_scopes() == ["openid", "profile", "email"]
-        assert data["refresh_token"] == token.refresh_token
-        assert data["access_token"] == token.token
-        assert isinstance(data["expires_in"], int)
-        assert data["token_type"] == "bearer"
-        assert data["user"]["id"] == str(token.user_id)
+            assert token.get_scopes() == ["openid", "profile", "email"]
+            assert data["refresh_token"] == token.refresh_token
+            assert data["access_token"] == token.token
+            assert isinstance(data["expires_in"], int)
+            assert data["token_type"] == "bearer"
+            assert data["user"]["id"] == str(token.user_id)
 
-        assert data["id_token"].count(".") == 2
+            assert data["id_token"].count(".") == 2
 
 
 @control_silo_test(stable=True)

--- a/tests/sentry/web/frontend/test_openidtoken.py
+++ b/tests/sentry/web/frontend/test_openidtoken.py
@@ -68,7 +68,7 @@ class OpenIDTokenTest(TestCase):
             "date_joined": str(grant_multiple_scopes.user.date_joined),
         }
 
-    def test_get_encrypted_id_token_no_scopes(self):
+    def test_get_signed_id_token_no_scopes(self):
         grant = ApiGrant.objects.create(
             user=self.user,
             application=self.application,
@@ -76,7 +76,7 @@ class OpenIDTokenTest(TestCase):
             scope_list=["openid"],
         )
         id_token = OpenIDToken("ex_client_id", self.user.id, "shared_secret", nonce="abcd")
-        encrypted_id_token = id_token.get_encrypted_id_token(grant)
+        encrypted_id_token = id_token.get_signed_id_token(grant)
         assert encrypted_id_token.count(".") == 2
 
         decrypted_id_token = jwt_utils.decode(
@@ -93,7 +93,7 @@ class OpenIDTokenTest(TestCase):
         assert decrypted_id_token["exp"] > current_timestamp
         assert decrypted_id_token["iat"] < current_timestamp
 
-    def test_get_encrypted_id_token_with_scopes(self):
+    def test_get_signed_id_token_with_scopes(self):
         grant = ApiGrant.objects.create(
             user=self.user,
             application=self.application,
@@ -101,7 +101,7 @@ class OpenIDTokenTest(TestCase):
             scope_list=["openid", "profile", "email"],
         )
         id_token = OpenIDToken("ex_client_id", self.user.id, "shared_secret", nonce="abcd")
-        encrypted_id_token = id_token.get_encrypted_id_token(grant)
+        encrypted_id_token = id_token.get_signed_id_token(grant)
         assert encrypted_id_token.count(".") == 2
 
         decrypted_id_token = jwt_utils.decode(


### PR DESCRIPTION
Signs our OIDC `id_token`s with a shared secret. Note that for now, all of our OIDC clients will use this. Since all of our OIDC clients == CodeCov this is fine, when we onboard more clients we likely want to switch to RS256 encryption for enhanced security.