### PR TITLE
style(auth): Improve spacing on OAuth connect

### DIFF
--- a/src/sentry/templates/sentry/login.html
+++ b/src/sentry/templates/sentry/login.html
@@ -7,10 +7,10 @@
 
 {% block auth_container %}
   {% if banner %}
-    <h2 class="m-t-1 m-l-1">{{ banner }}</h2>
+    <h2 class="m-t-1 m-l-1 m-b-0">{{ banner }}</h2>
   {% endif %}
 
-  <div class="auth-container border-bottom">
+  <div class="auth-container p-t-1 border-bottom">
     <h3>{% trans "Sign in to continue" %}</h3>
     <ul class="nav nav-tabs auth-toggle m-b-0">
       <li{% if op == "login" %} class="active"{% endif %}>

--- a/src/sentry/templates/sentry/login.html
+++ b/src/sentry/templates/sentry/login.html
@@ -7,7 +7,7 @@
 
 {% block auth_container %}
   {% if banner %}
-    <h4>{{ banner }}</h4>
+    <h4 class="m-t-1 m-l-1">{{ banner }}</h4>
   {% endif %}
 
   <div class="auth-container p-t-1 border-bottom">

--- a/src/sentry/templates/sentry/login.html
+++ b/src/sentry/templates/sentry/login.html
@@ -7,10 +7,10 @@
 
 {% block auth_container %}
   {% if banner %}
-    <h4 class="m-t-1 m-l-1">{{ banner }}</h4>
+    <h2 class="m-t-1 m-l-1">{{ banner }}</h2>
   {% endif %}
 
-  <div class="auth-container p-t-1 border-bottom">
+  <div class="auth-container border-bottom">
     <h3>{% trans "Sign in to continue" %}</h3>
     <ul class="nav nav-tabs auth-toggle m-b-0">
       <li{% if op == "login" %} class="active"{% endif %}>

--- a/static/less/misc.less
+++ b/static/less/misc.less
@@ -68,7 +68,6 @@
 .m-b-2 {
   margin-bottom: (@spacer-y * 1.5) !important;
 }
-
 .m-l-1 {
   margin-left: @spacer-x !important;
 }

--- a/static/less/misc.less
+++ b/static/less/misc.less
@@ -62,11 +62,16 @@
 .m-t-1 {
   margin-top: @spacer-y !important;
 }
+
 .m-b-1 {
   margin-bottom: @spacer-y !important;
 }
 .m-b-2 {
   margin-bottom: (@spacer-y * 1.5) !important;
+}
+
+.m-l-1 {
+  margin-left: @spacer-x !important;
 }
 
 // Padding

--- a/static/less/misc.less
+++ b/static/less/misc.less
@@ -62,7 +62,6 @@
 .m-t-1 {
   margin-top: @spacer-y !important;
 }
-
 .m-b-1 {
   margin-bottom: @spacer-y !important;
 }


### PR DESCRIPTION
Takes the OAuth connect application page from looking like this:

<img width="910" alt="Screenshot 2023-07-15 at 3 37 14 PM" src="https://github.com/getsentry/sentry/assets/26236981/e36c234d-d42e-4085-a778-baa660e8e669">

To looking like this:
<img width="1357" alt="Screenshot 2023-07-17 at 11 47 31 AM" src="https://github.com/getsentry/sentry/assets/26236981/286d9663-d752-47f9-9ee1-800b5ed37dcb">


Here the client application is World0. I think this looks fine? If we want an improved design lmk.