### PR TITLE
Stack trace linking for Bitbucket

### DIFF
--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import logging
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import parse_qs, urlparse, urlsplit
 
 from requests import PreparedRequest
@@ -11,6 +11,7 @@ from sentry.integrations.utils import get_query_hash
 from sentry.models import Repository
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.services.hybrid_cloud.util import control_silo_function
+from sentry.shared_integrations.client.base import BaseApiResponseX
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient, infer_org_integration
 from sentry.utils import jwt
 from sentry.utils.http import absolute_uri
@@ -176,7 +177,7 @@ class BitbucketApiClient(IntegrationProxyClient):
 
         return self.zip_commit_data(repo, commits)
 
-    def check_file(self, repo: Repository, path: str, version: str) -> Optional[str]:
+    def check_file(self, repo: Repository, path: str, version: str) -> BaseApiResponseX:
         return self.head_cached(
             path=BitbucketAPIPath.source.format(
                 repo=repo.name,

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -143,8 +143,23 @@ class BitbucketIntegration(IntegrationInstallation, BitbucketIssueBasicMixin, Re
     def reinstall(self):
         self.reinstall_repositories()
 
+    def source_url_matches(self, url: str) -> bool:
+        return url.startswith(f'https://{self.model.metadata["domain_name"]}') or url.startswith(
+            "https://bitbucket.org",
+        )
+
     def format_source_url(self, repo: Repository, filepath: str, branch: str) -> str:
         return f"https://bitbucket.org/{repo.name}/src/{branch}/{filepath}"
+
+    def extract_branch_from_source_url(self, repo: Repository, url: str) -> str:
+        url = url.replace(f"{repo.url}/src/", "")
+        branch, _, _ = url.partition("/")
+        return branch
+
+    def extract_source_path_from_source_url(self, repo: Repository, url: str) -> str:
+        url = url.replace(f"{repo.url}/src/", "")
+        _, _, source_path = url.partition("/")
+        return source_path
 
 
 class BitbucketIntegrationProvider(IntegrationProvider):

--- a/tests/sentry/integrations/bitbucket/test_client.py
+++ b/tests/sentry/integrations/bitbucket/test_client.py
@@ -1,12 +1,15 @@
 import re
 
 import jwt
+import pytest
 import responses
 from django.test import override_settings
 from requests import Request
 
 from sentry.integrations.bitbucket.client import BitbucketApiClient, BitbucketAPIPath
 from sentry.integrations.utils.atlassian_connect import get_query_hash
+from sentry.models import Repository
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import BaseTestCase, TestCase
@@ -43,6 +46,14 @@ class BitbucketApiClientTest(TestCase, BaseTestCase):
         self.install = self.integration.get_installation(self.organization.id)
         self.bitbucket_client: BitbucketApiClient = self.install.get_client()
 
+        self.repo = Repository.objects.create(
+            provider="bitbucket",
+            name="sentryuser/newsdiffs",
+            organization_id=self.organization.id,
+            config={"name": "sentryuser/newsdiffs"},
+            integration_id=self.integration.id,
+        )
+
     @freeze_time("2023-01-01 01:01:01")
     def test_authorize_request(self):
         method = "GET"
@@ -68,6 +79,50 @@ class BitbucketApiClientTest(TestCase, BaseTestCase):
             "qsh": get_query_hash(uri=path, method=method, query_params=params),
             "sub": self.integration.external_id,
         }
+
+    @responses.activate
+    def test_check_file(self):
+        path = "src/sentry/integrations/bitbucket/client.py"
+        version = "master"
+        url = f"https://api.bitbucket.org/2.0/repositories/{self.repo.name}/src/{version}/{path}"
+
+        responses.add(
+            method=responses.HEAD,
+            url=url,
+            json={"text": 200},
+        )
+
+        resp = self.bitbucket_client.check_file(self.repo, path, version)
+        assert resp.status_code == 200
+
+    @responses.activate
+    def test_check_no_file(self):
+        path = "src/santry/integrations/bitbucket/client.py"
+        version = "master"
+        url = f"https://api.bitbucket.org/2.0/repositories/{self.repo.name}/src/{version}/{path}"
+
+        responses.add(method=responses.HEAD, url=url, status=404)
+
+        with pytest.raises(ApiError):
+            self.bitbucket_client.check_file(self.repo, path, version)
+
+    @responses.activate
+    def test_get_stacktrace_link(self):
+        path = "/src/sentry/integrations/bitbucket/client.py"
+        version = "master"
+        url = f"https://api.bitbucket.org/2.0/repositories/{self.repo.name}/src/{version}/{path.lstrip('/')}"
+
+        responses.add(
+            method=responses.HEAD,
+            url=url,
+            json={"text": 200},
+        )
+
+        source_url = self.install.get_stacktrace_link(self.repo, path, "master", version)
+        assert (
+            source_url
+            == "https://bitbucket.org/sentryuser/newsdiffs/src/master/src/sentry/integrations/bitbucket/client.py"
+        )
 
     @responses.activate
     def test_integration_proxy_is_active(self):

--- a/tests/sentry/integrations/bitbucket/test_integration.py
+++ b/tests/sentry/integrations/bitbucket/test_integration.py
@@ -3,23 +3,28 @@ from urllib.parse import quote, urlencode
 import responses
 from django.urls import reverse
 
-from sentry.models import Integration
+from sentry.integrations.bitbucket import BitbucketIntegrationProvider
+from sentry.models import Integration, Repository
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test(stable=True)
 class BitbucketIntegrationTest(APITestCase):
+    provider = BitbucketIntegrationProvider
+
     def setUp(self):
         self.base_url = "https://api.bitbucket.org"
         self.shared_secret = "234567890"
         self.subject = "connect:1234567"
         self.integration = Integration.objects.create(
-            provider="bitbucket",
+            provider=self.provider.key,
             external_id=self.subject,
             name="sentryuser",
             metadata={
                 "base_url": self.base_url,
+                "domain_name": "bitbucket.org/Test-Organization",
                 "shared_secret": self.shared_secret,
                 "subject": self.subject,
             },
@@ -138,3 +143,62 @@ class BitbucketIntegrationTest(APITestCase):
             {"identifier": "sentryuser/stuff-2018", "name": "sentryuser/stuff-2018"},
             {"identifier": "sentryuser/stuff-2019", "name": "sentryuser/stuff-2019"},
         ]
+
+    @responses.activate
+    def test_source_url_matches(self):
+        installation = self.integration.get_installation(self.organization.id)
+
+        test_cases = [
+            (
+                "https://bitbucket.org/Test-Organization/sentry/src/master/src/sentry/integrations/bitbucket/integration.py",
+                True,
+            ),
+            (
+                "https://notbitbucket.org/Test-Organization/sentry/src/master/src/sentry/integrations/bitbucket/integration.py",
+                False,
+            ),
+            ("https://jianyuan.io", False),
+        ]
+        for source_url, matches in test_cases:
+            assert installation.source_url_matches(source_url) == matches
+
+    @responses.activate
+    def test_extract_branch_from_source_url(self):
+        installation = self.integration.get_installation(self.organization.id)
+        integration = Integration.objects.get(provider=self.provider.key)
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="Test-Organization/repo",
+                url="https://bitbucket.org/Test-Organization/repo",
+                provider="integrations:bitbucket",
+                external_id=123,
+                config={"name": "Test-Organization/repo"},
+                integration_id=integration.id,
+            )
+        source_url = "https://bitbucket.org/Test-Organization/repo/src/master/src/sentry/integrations/bitbucket/integration.py"
+
+        assert installation.extract_branch_from_source_url(repo, source_url) == "master"
+
+    @responses.activate
+    def test_extract_source_path_from_source_url(self):
+        installation = self.integration.get_installation(self.organization.id)
+        integration = Integration.objects.get(provider=self.provider.key)
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="Test-Organization/repo",
+                url="https://bitbucket.org/Test-Organization/repo",
+                provider="integrations:bitbucket",
+                external_id=123,
+                config={"name": "Test-Organization/repo"},
+                integration_id=integration.id,
+            )
+        source_url = "https://bitbucket.org/Test-Organization/repo/src/master/src/sentry/integrations/bitbucket/integration.py"
+
+        assert (
+            installation.extract_source_path_from_source_url(repo, source_url)
+            == "src/sentry/integrations/bitbucket/integration.py"
+        )


### PR DESCRIPTION
This PR enables Stack trace linking for Bitbucket.

Depends on https://github.com/getsentry/sentry/pull/53584