### PR TITLE
fix(auth): Require client secret in /token

### DIFF
--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -114,7 +114,6 @@ class OAuthTokenView(View):
 
         if not refresh_token_code:
             return {"error": "invalid_request"}
-        self.error(request, "invalid_request")
 
         # TODO(dcramer): support scope
         if scope:

--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import secrets
 from typing import Union
@@ -58,15 +57,11 @@ class OAuthTokenView(View):
         except ApiApplication.DoesNotExist:
             return self.error(request, "invalid_client", "invalid client_id")
 
-        # date that we started requiring client secrets
-        cutoff_date = datetime.datetime(2023, 7, 16).time()
-
-        if application.date_added.time() > cutoff_date:
-            client_secret = request.POST.get("client_secret")
-            if not client_secret:
-                return self.error(request, "missing client_secret")
-            elif client_secret != application.client_secret:
-                return self.error(request, "invalid client_secret")
+        client_secret = request.POST.get("client_secret")
+        if not client_secret:
+            return self.error(request, "missing client_secret")
+        elif client_secret != application.client_secret:
+            return self.error(request, "invalid client_secret")
 
         if grant_type == GrantTypes.AUTHORIZATION:
             token_data = self.get_access_tokens(request=request, application=application)

--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -1,6 +1,6 @@
 import logging
 import secrets
-from typing import Union
+from typing import Optional
 
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
@@ -130,7 +130,7 @@ class OAuthTokenView(View):
         return {"token": refresh_token}
 
     def process_token_details(
-        self, token: ApiToken, id_token: Union[OpenIDToken, None] = None
+        self, token: ApiToken, id_token: Optional[OpenIDToken] = None
     ) -> HttpResponse:
         token_information = {
             "access_token": token.token,

--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -1,11 +1,14 @@
+import datetime
 import logging
 import secrets
+from typing import Union
 
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import View
+from rest_framework.request import Request
 
 from sentry.mediators import GrantTypes
 from sentry.models import ApiApplication, ApiApplicationStatus, ApiGrant, ApiToken
@@ -42,21 +45,25 @@ class OAuthTokenView(View):
 
     @never_cache
     def post(self, request: HttpRequest) -> HttpResponse:
+        client_details = self._get_client_details_if_valid_request(request=request)
+
+        if not isinstance(client_details, dict):
+            return client_details  # client_details contains an error response.
+
+        if client_details["grant_type"] == GrantTypes.AUTHORIZATION:
+            return self._get_access_tokens(
+                request=request, application=client_details["application"]
+            )
+        return self._get_refresh_token(request, application=client_details["application"])
+
+    def _get_client_details_if_valid_request(self, request: Request) -> Union[dict, HttpResponse]:
+        """Returns the client's ID and associated ApiApplication if they provided the correct client secret."""
         grant_type = request.POST.get("grant_type")
         client_id = request.POST.get("client_id")
         if not client_id:
             return self.error(request, "invalid_client", "missing client_id")
-        if grant_type == GrantTypes.AUTHORIZATION:
-            return self._get_access_tokens(request, client_id)
-        elif grant_type == GrantTypes.REFRESH:
-            return self._get_refresh_token(request, client_id)
-        else:
+        if grant_type not in [GrantTypes.AUTHORIZATION, GrantTypes.REFRESH]:
             return self.error(request, "unsupported_grant_type")
-
-    def _get_access_tokens(self, request, client_id):
-        redirect_uri = request.POST.get("redirect_uri")
-        code = request.POST.get("code")
-
         try:
             application = ApiApplication.objects.get(
                 client_id=client_id, status=ApiApplicationStatus.active
@@ -64,6 +71,20 @@ class OAuthTokenView(View):
         except ApiApplication.DoesNotExist:
             return self.error(request, "invalid_client", "invalid client_id")
 
+        # date that we started requiring client secrets
+        cutoff_date = datetime.datetime(2023, 7, 16).astimezone()
+
+        if application.date_added > cutoff_date:
+            client_secret = request.POST.get("client_secret")
+            if not client_secret:
+                return self.error(request, "missing client_secret")
+            elif client_secret != application.client_secret:
+                return self.error(request, "invalid client_secret")
+
+        return {"client_id": client_id, "grant_type": grant_type, "application": application}
+
+    def _get_access_tokens(self, request: Request, application: ApiApplication) -> HttpResponse:
+        code = request.POST.get("code")
         try:
             grant = ApiGrant.objects.get(application=application, code=code)
         except ApiGrant.DoesNotExist:
@@ -72,16 +93,17 @@ class OAuthTokenView(View):
         if grant.is_expired():
             return self.error(request, "invalid_grant", "grant expired")
 
+        redirect_uri = request.POST.get("redirect_uri")
         if not redirect_uri:
             redirect_uri = application.get_default_redirect_uri()
         elif grant.redirect_uri != redirect_uri:
             return self.error(request, "invalid_grant", "invalid redirect_uri")
 
-        access_token = ApiToken.from_grant(grant)
-        id_token = self._get_open_id_token(grant, request)
-        return self._process_token_details(access_token, id_token)
+        access_token = ApiToken.from_grant(grant=grant)
+        id_token = self._get_open_id_token(request=request, grant=grant)
+        return self._process_token_details(token=access_token, id_token=id_token)
 
-    def _get_open_id_token(self, grant, request):
+    def _get_open_id_token(self, request: Request, grant: ApiGrant) -> Union[OpenIDToken, None]:
         if grant.has_scope("openid"):
             open_id_token = OpenIDToken(
                 request.POST.get("client_id"),
@@ -93,11 +115,11 @@ class OAuthTokenView(View):
             return open_id_token.get_encrypted_id_token(grant=grant)
         return None
 
-    def _get_refresh_token(self, request, client_id):
-        refresh_token = request.POST.get("refresh_token")
+    def _get_refresh_token(self, request: Request, application: ApiApplication) -> HttpResponse:
+        refresh_token_code = request.POST.get("refresh_token")
         scope = request.POST.get("scope")
 
-        if not refresh_token:
+        if not refresh_token_code:
             return self.error(request, "invalid_request")
 
         # TODO(dcramer): support scope
@@ -105,22 +127,19 @@ class OAuthTokenView(View):
             return self.error(request, "invalid_request")
 
         try:
-            application = ApiApplication.objects.get(
-                client_id=client_id, status=ApiApplicationStatus.active
+            refresh_token = ApiToken.objects.get(
+                application=application, refresh_token=refresh_token_code
             )
-        except ApiApplication.DoesNotExist:
-            return self.error(request, "invalid_client", "invalid client_id")
-
-        try:
-            token = ApiToken.objects.get(application=application, refresh_token=refresh_token)
         except ApiToken.DoesNotExist:
             return self.error(request, "invalid_grant", "invalid refresh token")
 
-        token.refresh()
+        refresh_token.refresh()
 
-        return self._process_token_details(token)
+        return self._process_token_details(token=refresh_token)
 
-    def _process_token_details(self, token, id_token=None):
+    def _process_token_details(
+        self, token: ApiToken, id_token: Union[OpenIDToken, None] = None
+    ) -> HttpResponse:
         token_information = {
             "access_token": token.token,
             "refresh_token": token.refresh_token,

--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -49,12 +49,14 @@ class OAuthTokenView(View):
         client_secret = request.POST.get("client_secret")
 
         if not client_id:
-            return self.error(request, "invalid_client", "missing client_id")
+            return self.error(request=request, name="missing_client_id", reason="missing client_id")
         if not client_secret:
-            return self.error(request, "missing client_secret")
+            return self.error(
+                request=request, name="missing_client_secret", reason="missing client_secret"
+            )
 
         if grant_type not in [GrantTypes.AUTHORIZATION, GrantTypes.REFRESH]:
-            return self.error(request, "unsupported_grant_type")
+            return self.error(request=request, name="unsupported_grant_type")
 
         try:
             application = ApiApplication.objects.get(
@@ -62,7 +64,10 @@ class OAuthTokenView(View):
             )
         except ApiApplication.DoesNotExist:
             return self.error(
-                request, "invalid_credentials", "invalid client_id or client_secret", status=401
+                request=request,
+                name="invalid_credentials",
+                reason="invalid client_id or client_secret",
+                status=401,
             )
 
         if grant_type == GrantTypes.AUTHORIZATION:

--- a/tests/sentry/web/frontend/test_oauth_token.py
+++ b/tests/sentry/web/frontend/test_oauth_token.py
@@ -24,7 +24,7 @@ class OAuthTokenTest(TestCase):
     def test_missing_grant_type(self):
         self.login_as(self.user)
 
-        resp = self.client.post(self.path, {"client_id": "abcd"})
+        resp = self.client.post(self.path, {"client_id": "abcd", "client_secret": "abcd"})
 
         assert resp.status_code == 400
         assert json.loads(resp.content) == {"error": "unsupported_grant_type"}
@@ -32,7 +32,9 @@ class OAuthTokenTest(TestCase):
     def test_invalid_grant_type(self):
         self.login_as(self.user)
 
-        resp = self.client.post(self.path, {"grant_type": "foo", "client_id": "abcd"})
+        resp = self.client.post(
+            self.path, {"grant_type": "foo", "client_id": "abcd", "client_secret": "abcd"}
+        )
 
         assert resp.status_code == 400
         assert json.loads(resp.content) == {"error": "unsupported_grant_type"}
@@ -72,7 +74,6 @@ class OAuthTokenCodeTest(TestCase):
 
     def test_invalid_client_id(self):
         self.login_as(self.user)
-
         resp = self.client.post(
             self.path,
             {
@@ -83,9 +84,8 @@ class OAuthTokenCodeTest(TestCase):
                 "client_secret": self.client_secret,
             },
         )
-
-        assert resp.status_code == 400
-        assert json.loads(resp.content) == {"error": "invalid_client"}
+        assert resp.status_code == 401
+        assert json.loads(resp.content) == {"error": "invalid_credentials"}
 
     def test_missing_client_secret(self):
         self.login_as(self.user)
@@ -117,8 +117,8 @@ class OAuthTokenCodeTest(TestCase):
             },
         )
 
-        assert resp.status_code == 400
-        assert json.loads(resp.content) == {"error": "invalid client_secret"}
+        assert resp.status_code == 401
+        assert json.loads(resp.content) == {"error": "invalid_credentials"}
 
     def test_missing_code(self):
         self.login_as(self.user)
@@ -381,8 +381,8 @@ class OAuthTokenRefreshTokenTest(TestCase):
             },
         )
 
-        assert resp.status_code == 400
-        assert json.loads(resp.content) == {"error": "invalid_client"}
+        assert resp.status_code == 401
+        assert json.loads(resp.content) == {"error": "invalid_credentials"}
 
     def test_missing_refresh_token(self):
         self.login_as(self.user)

--- a/tests/sentry/web/frontend/test_oauth_token.py
+++ b/tests/sentry/web/frontend/test_oauth_token.py
@@ -70,7 +70,7 @@ class OAuthTokenCodeTest(TestCase):
         )
 
         assert resp.status_code == 400
-        assert json.loads(resp.content) == {"error": "invalid_client"}
+        assert json.loads(resp.content) == {"error": "missing_client_id"}
 
     def test_invalid_client_id(self):
         self.login_as(self.user)
@@ -101,7 +101,7 @@ class OAuthTokenCodeTest(TestCase):
         )
 
         assert resp.status_code == 400
-        assert json.loads(resp.content) == {"error": "missing client_secret"}
+        assert json.loads(resp.content) == {"error": "missing_client_secret"}
 
     def test_invalid_client_secret(self):
         self.login_as(self.user)
@@ -366,7 +366,7 @@ class OAuthTokenRefreshTokenTest(TestCase):
         )
 
         assert resp.status_code == 400
-        assert json.loads(resp.content) == {"error": "invalid_client"}
+        assert json.loads(resp.content) == {"error": "missing_client_id"}
 
     def test_invalid_client_id(self):
         self.login_as(self.user)

--- a/tests/sentry/web/frontend/test_oauth_token.py
+++ b/tests/sentry/web/frontend/test_oauth_token.py
@@ -1,4 +1,3 @@
-import datetime
 from functools import cached_property
 
 from django.utils import timezone
@@ -262,41 +261,6 @@ class OAuthTokenCodeTest(TestCase):
         assert token.application == self.application
         assert token.user == self.grant.user
         assert token.get_scopes() == self.grant.get_scopes()
-
-        assert data["access_token"] == token.token
-        assert data["refresh_token"] == token.refresh_token
-        assert isinstance(data["expires_in"], int)
-        assert data["token_type"] == "bearer"
-        assert data["user"]["id"] == str(token.user_id)
-
-    def test_old_application_no_secret(self):
-        """Tests that applications created before we
-        required client secret still work without the client secret."""
-        old_application = ApiApplication.objects.create(
-            owner=self.user,
-            redirect_uris="https://example.com",
-            date_added=datetime.datetime(2023, 6, 15).astimezone(),
-        )
-        grant = ApiGrant.objects.create(
-            user=self.user, application=old_application, redirect_uri="https://example.com"
-        )
-        resp = self.client.post(
-            self.path,
-            {
-                "grant_type": "authorization_code",
-                "redirect_uri": old_application.get_default_redirect_uri(),
-                "code": grant.code,
-                "client_id": old_application.client_id,
-            },
-        )
-
-        assert resp.status_code == 200
-        data = json.loads(resp.content)
-
-        token = ApiToken.objects.get(token=data["access_token"])
-        assert token.application == old_application
-        assert token.user == grant.user
-        assert token.get_scopes() == grant.get_scopes()
 
         assert data["access_token"] == token.token
         assert data["refresh_token"] == token.refresh_token


### PR DESCRIPTION
Sooo it looks to me like the OAuth provider we've been running for ~6 years doesn't actually require a client secret to be passed to the `/token` endpoint. This is, obviously, not great.

This PR requires the client secret to be passed in and validates it, _so long as the application was created after July 16th, 2023_. I did this to preserve backwards compatibility, but if we want to break backwards compatibility here in favor of security - let me know and I can remove the date-checking logic.

Also - if I'm missing something here please let me know, I assumed originally that credentials were being validated in one of the base views with something like `ClientIdSecretAuthentication` ([source](https://github.com/getsentry/sentry/blob/17433defa2b99c98166f7e491653fccef24a4975/src/sentry/api/authentication.py#L159)) but I don't think anything of that sort is happening.