### PR TITLE
fix: delete not working on memcached

### DIFF
--- a/src/sentry/monkey/__init__.py
+++ b/src/sentry/monkey/__init__.py
@@ -28,10 +28,12 @@ def patch_celery_imgcat():
 def patch_memcached():
     # Fixes a bug in Django 3.2
     from django.core.cache.backends.memcached import MemcachedCache
+
     def fixed_delete(self, key, version=None):
         key = self.make_key(key, version=version)
         self.validate_key(key)
         return bool(self._cache.delete(key))
+
     MemcachedCache.delete = fixed_delete
 
 

--- a/src/sentry/monkey/__init__.py
+++ b/src/sentry/monkey/__init__.py
@@ -27,7 +27,10 @@ def patch_celery_imgcat():
 
 def patch_memcached():
     # Fixes a bug in Django 3.2
-    from django.core.cache.backends.memcached import MemcachedCache
+    try:
+        from django.core.cache.backends.memcached import MemcachedCache
+    except ImportError:
+        return
 
     def fixed_delete(self, key, version=None):
         key = self.make_key(key, version=version)

--- a/src/sentry/monkey/__init__.py
+++ b/src/sentry/monkey/__init__.py
@@ -37,7 +37,7 @@ def patch_memcached():
         self.validate_key(key)
         return bool(self._cache.delete(key))
 
-    MemcachedCache.delete = fixed_delete
+    MemcachedCache.delete = fixed_delete  # type: ignore[method-assign]
 
 
 patch_celery_imgcat()

--- a/src/sentry/monkey/__init__.py
+++ b/src/sentry/monkey/__init__.py
@@ -25,5 +25,16 @@ def patch_celery_imgcat():
     term.imgcat = lambda *a, **kw: b""
 
 
+def patch_memcached():
+    # Fixes a bug in Django 3.2
+    from django.core.cache.backends.memcached import MemcachedCache
+    def fixed_delete(self, key, version=None):
+        key = self.make_key(key, version=version)
+        self.validate_key(key)
+        return bool(self._cache.delete(key))
+    MemcachedCache.delete = fixed_delete
+
+
 patch_celery_imgcat()
 patch_pickle_loaders()
+patch_memcached()


### PR DESCRIPTION
This works around a bug with memcached in Django. The cache implementation bypasses the original methods in 3.2 which breaks with our version of the client.

This restores the direct delete calling from 2.2