### PR TITLE
fix(perf): Add chart back to all transactions

### DIFF
--- a/static/app/views/performance/landing/views/allTransactionsView.tsx
+++ b/static/app/views/performance/landing/views/allTransactionsView.tsx
@@ -17,6 +17,7 @@ export function AllTransactionsView(props: BasePerformanceViewProps) {
     canUseMetricsData(props.organization)
   ) {
     doubleChartRowCharts.unshift(PerformanceWidgetSetting.MOST_CHANGED);
+    doubleChartRowCharts.unshift(PerformanceWidgetSetting.MOST_RELATED_ISSUES);
   } else {
     doubleChartRowCharts.unshift(PerformanceWidgetSetting.MOST_REGRESSED);
     doubleChartRowCharts.push(PerformanceWidgetSetting.MOST_IMPROVED);


### PR DESCRIPTION
We can't have a double chart row with only 1 allowed chart, adding back related issues for now
