### PR TITLE
feat(github-growth): list hidden org integration repos

### DIFF
--- a/src/sentry/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/api/endpoints/organization_integration_repos.py
@@ -48,7 +48,7 @@ class OrganizationIntegrationReposEndpoint(RegionOrganizationIntegrationBaseEndp
         installed_repos = Repository.objects.filter(integration_id=integration.id).exclude(
             status=ObjectStatus.HIDDEN
         )
-        external_names = {hidden_repo.name for hidden_repo in installed_repos}
+        repo_names = {installed_repo.name for installed_repo in installed_repos}
 
         install = integration_service.get_installation(
             integration=integration, organization_id=organization.id
@@ -67,7 +67,7 @@ class OrganizationIntegrationReposEndpoint(RegionOrganizationIntegrationBaseEndp
                     defaultBranch=repo.get("default_branch"),
                 )
                 for repo in repositories
-                if repo["identifier"] not in external_names
+                if repo["identifier"] not in repo_names
             ]
             context = {"repos": serializedRepositories, "searchable": install.repo_search}
             return self.respond(context)

--- a/src/sentry/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/api/endpoints/organization_integration_repos.py
@@ -9,6 +9,7 @@ from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.integrations.mixins import RepositoryMixin
 from sentry.models import Organization
+from sentry.models.repository import Repository
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import IntegrationError
 
@@ -44,6 +45,11 @@ class OrganizationIntegrationReposEndpoint(RegionOrganizationIntegrationBaseEndp
             context = {"repos": []}
             return self.respond(context)
 
+        installed_repos = Repository.objects.filter(integration_id=integration.id).exclude(
+            status=ObjectStatus.HIDDEN
+        )
+        external_names = {hidden_repo.name for hidden_repo in installed_repos}
+
         install = integration_service.get_installation(
             integration=integration, organization_id=organization.id
         )
@@ -61,6 +67,7 @@ class OrganizationIntegrationReposEndpoint(RegionOrganizationIntegrationBaseEndp
                     defaultBranch=repo.get("default_branch"),
                 )
                 for repo in repositories
+                if repo["identifier"] not in external_names
             ]
             context = {"repos": serializedRepositories, "searchable": install.repo_search}
             return self.respond(context)


### PR DESCRIPTION
When fetching the available repos for an integration for an org, we should list the hidden repos because those are the ones that can be installed.

For ER-1720