### PR TITLE
feat(starfish): Add unit and types for rates

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -293,6 +293,13 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             elif value in DURATION_UNITS:
                 units[key] = value
                 meta[key] = "duration"
+            elif value == "rate":
+                if key in ["eps()", "sps()", "tps()"]:
+                    units[key] = "1/second"
+                elif key in ["epm()", "spm()", "tpm()"]:
+                    units[key] = "1/minute"
+                else:
+                    units[key] = None
             elif value == "duration":
                 units[key] = "millisecond"
             else:

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -95,7 +95,16 @@ FUNCTION_PATTERN = re.compile(
 
 DURATION_PATTERN = re.compile(r"(\d+\.?\d?)(\D{1,3})")
 
-RESULT_TYPES = {"duration", "string", "number", "integer", "percentage", "percent_change", "date"}
+RESULT_TYPES = {
+    "duration",
+    "string",
+    "number",
+    "integer",
+    "percentage",
+    "percent_change",
+    "date",
+    "rate",
+}
 # event_search normalizes to bytes
 # based on https://getsentry.github.io/relay/relay_metrics/enum.InformationUnit.html
 SIZE_UNITS = {

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -623,7 +623,7 @@ class DiscoverDatasetConfig(DatasetConfig):
                         "divide", [Function("count", []), args["interval"]], alias
                     ),
                     optional_args=[IntervalDefault("interval", 1, None)],
-                    default_result_type="number",
+                    default_result_type="rate",
                 ),
                 SnQLFunction(
                     "epm",
@@ -633,7 +633,7 @@ class DiscoverDatasetConfig(DatasetConfig):
                         alias,
                     ),
                     optional_args=[IntervalDefault("interval", 1, None)],
-                    default_result_type="number",
+                    default_result_type="rate",
                 ),
                 SnQLFunction(
                     "compare_numeric_aggregate",

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -530,7 +530,7 @@ class MetricsDatasetConfig(DatasetConfig):
                     "epm",
                     snql_distribution=self._resolve_epm,
                     optional_args=[fields.IntervalDefault("interval", 1, None)],
-                    default_result_type="number",
+                    default_result_type="rate",
                 ),
                 fields.MetricsFunction(
                     "floored_epm",
@@ -573,13 +573,13 @@ class MetricsDatasetConfig(DatasetConfig):
                         alias,
                     ),
                     optional_args=[fields.IntervalDefault("interval", 1, None)],
-                    default_result_type="number",
+                    default_result_type="rate",
                 ),
                 fields.MetricsFunction(
                     "eps",
                     snql_distribution=self._resolve_eps,
                     optional_args=[fields.IntervalDefault("interval", 1, None)],
-                    default_result_type="number",
+                    default_result_type="rate",
                 ),
                 fields.MetricsFunction(
                     "failure_count",

--- a/src/sentry/search/events/datasets/metrics_layer.py
+++ b/src/sentry/search/events/datasets/metrics_layer.py
@@ -366,7 +366,7 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
                         alias,
                     ),
                     optional_args=[fields.IntervalDefault("interval", 1, None)],
-                    default_result_type="number",
+                    default_result_type="rate",
                 ),
                 fields.MetricsFunction(
                     "eps",
@@ -380,7 +380,7 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
                         alias,
                     ),
                     optional_args=[fields.IntervalDefault("interval", 1, None)],
-                    default_result_type="number",
+                    default_result_type="rate",
                 ),
                 fields.MetricsFunction(
                     "failure_count",

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -155,7 +155,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
                         "divide", [Function("count", []), args["interval"]], alias
                     ),
                     optional_args=[IntervalDefault("interval", 1, None)],
-                    default_result_type="number",
+                    default_result_type="rate",
                 ),
                 SnQLFunction(
                     "epm",
@@ -165,7 +165,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
                         alias,
                     ),
                     optional_args=[IntervalDefault("interval", 1, None)],
-                    default_result_type="number",
+                    default_result_type="rate",
                 ),
             ]
         }

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -84,13 +84,13 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     "epm",
                     snql_distribution=self._resolve_epm,
                     optional_args=[fields.IntervalDefault("interval", 1, None)],
-                    default_result_type="number",
+                    default_result_type="rate",
                 ),
                 fields.MetricsFunction(
                     "eps",
                     snql_distribution=self._resolve_eps,
                     optional_args=[fields.IntervalDefault("interval", 1, None)],
-                    default_result_type="number",
+                    default_result_type="rate",
                 ),
                 fields.MetricsFunction(
                     "count",

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -2521,6 +2521,9 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         assert data[0]["epm()"] == 0.5
         assert data[1]["transaction"] == event2.transaction
         assert data[1]["epm()"] == 0.5
+        meta = response.data["meta"]
+        assert meta["fields"]["epm()"] == "rate"
+        assert meta["units"]["epm()"] == "1/minute"
 
     def test_nonexistent_fields(self):
         self.store_event(

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -161,7 +161,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert meta["isMetricsData"]
         assert field_meta["project.name"] == "string"
         assert field_meta["environment"] == "string"
-        assert field_meta["epm()"] == "number"
+        assert field_meta["epm()"] == "rate"
 
     def test_project_id(self):
         self.store_transaction_metric(
@@ -190,7 +190,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert meta["isMetricsData"]
         assert field_meta["project_id"] == "integer"
         assert field_meta["environment"] == "string"
-        assert field_meta["epm()"] == "number"
+        assert field_meta["epm()"] == "rate"
 
     def test_project_dot_id(self):
         self.store_transaction_metric(
@@ -219,7 +219,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert meta["isMetricsData"]
         assert field_meta["project.id"] == "integer"
         assert field_meta["environment"] == "string"
-        assert field_meta["epm()"] == "number"
+        assert field_meta["epm()"] == "rate"
 
     def test_title_alias(self):
         """title is an alias to transaction name"""
@@ -500,6 +500,9 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             assert field_meta["user_misery()"] == "number"
             assert field_meta["failure_rate()"] == "percentage"
             assert field_meta["failure_count()"] == "integer"
+            assert field_meta["tpm()"] == "rate"
+
+            assert meta["units"]["tpm()"] == "1/minute"
 
     def test_user_misery_and_team_key_sort(self):
         self.store_transaction_metric(

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -194,6 +194,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert len(data) == 1
         assert data[0]["eps()"] == 0.01
         assert data[0]["sps()"] == 0.01
+        assert meta["fields"]["eps()"] == "rate"
+        assert meta["fields"]["sps()"] == "rate"
+        assert meta["units"]["eps()"] == "1/second"
+        assert meta["units"]["sps()"] == "1/second"
         assert meta["dataset"] == "spansMetrics"
 
     def test_epm(self):
@@ -218,6 +222,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert len(data) == 1
         assert data[0]["epm()"] == 0.6
         assert data[0]["spm()"] == 0.6
+        assert meta["fields"]["epm()"] == "rate"
+        assert meta["fields"]["spm()"] == "rate"
+        assert meta["units"]["epm()"] == "1/minute"
+        assert meta["units"]["spm()"] == "1/minute"
         assert meta["dataset"] == "spansMetrics"
 
     def test_time_spent_percentage(self):


### PR DESCRIPTION
- This adds a `rate` type for epm and eps
- This adds a `1/minute` and `1/second` unit for epm and eps respectively