### PR TITLE
feat(perf-detector-threshold-configuration) Detector dry runs and new thresholds for extended detectors.

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
@@ -183,6 +183,12 @@ class ConsecutiveHTTPSpanDetectorExtended(ConsecutiveHTTPSpanDetector):
             "consecutive_count_threshold"
         )
 
+        exceeds_span_duration_threshold = all(
+            get_span_duration(span).total_seconds() * 1000
+            >= self.settings.get("span_duration_threshold")
+            for span in self.consecutive_http_spans
+        )
+
         exceeds_min_time_saved_duration = False
         if self.consecutive_http_spans:
             exceeds_min_time_saved_duration = self._calculate_time_saved() >= self.settings.get(
@@ -201,6 +207,7 @@ class ConsecutiveHTTPSpanDetectorExtended(ConsecutiveHTTPSpanDetector):
             exceeds_count_threshold
             and subceeds_duration_between_spans_threshold
             and exceeds_min_time_saved_duration
+            and exceeds_span_duration_threshold
         ):
             self._store_performance_problem()
 

--- a/tests/sentry/utils/performance_issues/test_consecutive_http_detector_extended.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_http_detector_extended.py
@@ -134,7 +134,7 @@ class ConsecutiveHTTPSpansDetectorExtendedTest(TestCase):
         spans = [
             create_span(
                 "http.client", 500, "GET /api/0/organizations/endpoint1", "hash1"
-            ),  # spans with low durations, but min_time_saved exceeds threshold
+            ),  # all thresholds are exceeded.
             create_span("http.client", 500, "GET /api/0/organizations/endpoint2", "hash2"),
             create_span("http.client", 500, "GET /api/0/organizations/endpoint3", "hash3"),
             create_span("http.client", 500, "GET /api/0/organizations/endpoint4", "hash4"),
@@ -149,11 +149,11 @@ class ConsecutiveHTTPSpansDetectorExtendedTest(TestCase):
 
         spans = [
             create_span(
-                "http.client", 400, "GET /api/0/organizations/endpoint1", "hash1"
-            ),  # spans with low durations, but min_time_saved is same as above
-            create_span("http.client", 400, "GET /api/0/organizations/endpoint2", "hash2"),
-            create_span("http.client", 400, "GET /api/0/organizations/endpoint3", "hash3"),
-            create_span("http.client", 400, "GET /api/0/organizations/endpoint4", "hash4"),
+                "http.client", 500, "GET /api/0/organizations/endpoint1", "hash1"
+            ),  # some spans with low durations, all other thresholds are exceeded.
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint2", "hash2"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint3", "hash3"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint4", "hash4"),
             create_span("http.client", 400, "GET /api/0/organizations/endpoint5", "hash5"),
             create_span("http.client", 400, "GET /api/0/organizations/endpoint5", "hash5"),
         ]

--- a/tests/sentry/utils/performance_issues/test_consecutive_http_detector_extended.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_http_detector_extended.py
@@ -101,9 +101,9 @@ class ConsecutiveHTTPSpansDetectorExtendedTest(TestCase):
 
         assert len(problems) == 1
 
-        spans = [  # min time saved by parallelizing is 40ms
-            create_span("http.client", 20, "GET /api/0/organizations/endpoint1", "hash1"),
-            create_span("http.client", 20, "GET /api/0/organizations/endpoint2", "hash2"),
+        spans = [  # min time saved by parallelizing is 1s
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint1", "hash1"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint2", "hash2"),
             create_span("http.client", 1000, "GET /api/0/organizations/endpoint3", "hash3"),
         ]
         spans = [
@@ -130,20 +130,51 @@ class ConsecutiveHTTPSpansDetectorExtendedTest(TestCase):
         problems = self.find_problems(create_event(spans))
         assert problems == []
 
+    def test_does_not_detect_consecutive_http_issue_with_low_duration_spans(self):
+        spans = [
+            create_span(
+                "http.client", 500, "GET /api/0/organizations/endpoint1", "hash1"
+            ),  # spans with low durations, but min_time_saved exceeds threshold
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint2", "hash2"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint3", "hash3"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint4", "hash4"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint5", "hash5"),
+        ]
+        spans = [
+            modify_span_start(span, 1000 * spans.index(span)) for span in spans
+        ]  # ensure spans don't overlap
+        problems = self.find_problems(create_event(spans))
+
+        assert len(problems) == 1
+
+        spans = [
+            create_span(
+                "http.client", 400, "GET /api/0/organizations/endpoint1", "hash1"
+            ),  # spans with low durations, but min_time_saved is same as above
+            create_span("http.client", 400, "GET /api/0/organizations/endpoint2", "hash2"),
+            create_span("http.client", 400, "GET /api/0/organizations/endpoint3", "hash3"),
+            create_span("http.client", 400, "GET /api/0/organizations/endpoint4", "hash4"),
+            create_span("http.client", 400, "GET /api/0/organizations/endpoint5", "hash5"),
+            create_span("http.client", 400, "GET /api/0/organizations/endpoint5", "hash5"),
+        ]
+        spans = [
+            modify_span_start(span, 1000 * spans.index(span)) for span in spans
+        ]  # ensure spans don't overlap
+        problems = self.find_problems(create_event(spans))
+
+        assert problems == []
+
     def test_detects_consecutive_http_issue_with_low_duration_spans(self):
         spans = [
             create_span(
-                "http.client", 300, "GET /api/0/organizations/endpoint1", "hash1"
+                "http.client", 500, "GET /api/0/organizations/endpoint1", "hash1"
             ),  # spans with low durations, but min_time_saved
             create_span(
-                "http.client", 300, "GET /api/0/organizations/endpoint2", "hash2"
+                "http.client", 500, "GET /api/0/organizations/endpoint2", "hash2"
             ),  # exceeds threshold
-            create_span("http.client", 300, "GET /api/0/organizations/endpoint3", "hash3"),
-            create_span("http.client", 300, "GET /api/0/organizations/endpoint4", "hash4"),
-            create_span("http.client", 300, "GET /api/0/organizations/endpoint5", "hash5"),
-            create_span("http.client", 300, "GET /api/0/organizations/endpoint6", "hash6"),
-            create_span("http.client", 300, "GET /api/0/organizations/endpoint7", "hash7"),
-            create_span("http.client", 300, "GET /api/0/organizations/endpoint8", "hash8"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint3", "hash3"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint4", "hash4"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint5", "hash5"),
         ]
         spans = [
             modify_span_start(span, 1000 * spans.index(span)) for span in spans

--- a/tests/sentry/utils/performance_issues/test_consecutive_http_detector_extended.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_http_detector_extended.py
@@ -130,6 +130,40 @@ class ConsecutiveHTTPSpansDetectorExtendedTest(TestCase):
         problems = self.find_problems(create_event(spans))
         assert problems == []
 
+    def test_detects_consecutive_http_issue_with_trailing_low_duration_span(self):
+        spans = [
+            create_span(
+                "http.client", 500, "GET /api/0/organizations/endpoint1", "hash1"
+            ),  # all thresholds are exceeded.
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint2", "hash2"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint3", "hash3"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint4", "hash4"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint5", "hash5"),
+        ]
+        spans = [
+            modify_span_start(span, 1000 * spans.index(span)) for span in spans
+        ]  # ensure spans don't overlap
+        problems = self.find_problems(create_event(spans))
+
+        assert len(problems) == 1
+
+        spans = [
+            create_span(
+                "http.client", 500, "GET /api/0/organizations/endpoint1", "hash1"
+            ),  # some spans with low durations, all other thresholds are exceeded.
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint2", "hash2"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint3", "hash3"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint4", "hash4"),
+            create_span("http.client", 500, "GET /api/0/organizations/endpoint5", "hash5"),
+            create_span("http.client", 400, "GET /api/0/organizations/endpoint6", "hash6"),
+        ]
+        spans = [
+            modify_span_start(span, 1000 * spans.index(span)) for span in spans
+        ]  # ensure spans don't overlap
+        problems = self.find_problems(create_event(spans))
+
+        assert len(problems) == 1
+
     def test_does_not_detect_consecutive_http_issue_with_low_duration_spans(self):
         spans = [
             create_span(

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -413,7 +413,7 @@ class PerformanceDetectionTest(TestCase):
 
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock, self.project)
 
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 7
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 12
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
@@ -472,7 +472,7 @@ class PerformanceDetectionTest(TestCase):
             for call in incr_mock.mock_calls
             if call.args[0] == "performance.performance_issue.detected"
         ]
-        assert len(detection_calls) == 1
+        assert len(detection_calls) == 2
         tags = detection_calls[0].kwargs["tags"]
 
         assert tags["uncompressed_assets"]


### PR DESCRIPTION
1.  Added min span duration threshold to extended Consecutive HTTP span detector. With default of 500ms.
2. Reduced total duration threshold of extended N+1 API Calls issue to 300ms.
3. Added dry runs for the following:

- **N+1 db**: Dry run detection with 50ms total duration threshold.
- **Large HTTP Payload**: Dry run detection with 300kb size threshold.
- **Uncompressed asset**: Dry run detection with default duration of  300ms.

