### PR TITLE
fix(starfish): fix no query results found in span sample list

### DIFF
--- a/static/app/views/starfish/queries/useSpanMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.tsx
@@ -43,7 +43,7 @@ export const useSpanMetrics = (
     referrer,
   });
 
-  return {...result, data: result?.data?.[0] ?? {}};
+  return {...result, data: result?.data?.[0] ?? {}, isEnabled: enabled};
 };
 
 function getEventView(

--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -53,7 +53,9 @@ export const useSpanSamples = (options: Options) => {
 
   const maxYValue = computeAxisMax([spanMetricsSeriesData?.[`p95(${SPAN_SELF_TIME})`]]);
 
-  return useQuery<SpanSample[]>({
+  const enabled = Boolean(groupId && transactionName && !isLoadingSeries);
+
+  const result = useQuery<SpanSample[]>({
     queryKey: [
       'span-samples',
       groupId,
@@ -82,7 +84,9 @@ export const useSpanSamples = (options: Options) => {
         .sort((a: SpanSample, b: SpanSample) => b[SPAN_SELF_TIME] - a[SPAN_SELF_TIME]);
     },
     refetchOnWindowFocus: false,
-    enabled: Boolean(groupId && transactionName && !isLoadingSeries),
+    enabled,
     initialData: [],
   });
+
+  return {...result, isEnabled: enabled};
 };

--- a/static/app/views/starfish/queries/useTransactions.tsx
+++ b/static/app/views/starfish/queries/useTransactions.tsx
@@ -51,11 +51,13 @@ export function useTransactions(eventIDs: string[], referrer = 'use-transactions
       isLoading: false,
       error: null,
       data: [],
+      isEnabled: enabled,
     };
   }
 
   return {
     ...response,
+    isEnabled: enabled,
     data,
   };
 }

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -45,6 +45,7 @@ function SampleTable({
   const {
     data: spans,
     isFetching: isFetchingSamples,
+    isEnabled: isSamplesEnabled,
     error: sampleError,
     refetch,
   } = useSpanSamples({
@@ -56,6 +57,7 @@ function SampleTable({
   const {
     data: transactions,
     isFetching: isFetchingTransactions,
+    isEnabled: isTransactionsEnabled,
     error: transactionError,
   } = useTransactions(
     spans.map(span => span['transaction.id']),
@@ -91,6 +93,8 @@ function SampleTable({
   const isLoading =
     isFetchingSpanMetrics ||
     isFetchingSamples ||
+    !isSamplesEnabled ||
+    !isTransactionsEnabled ||
     (!areNoSamples && isFetchingTransactions);
 
   if (sampleError || transactionError) {


### PR DESCRIPTION
There was a weird behaviour when clicking on a endpoint in the span/db/api module, where you'd see "No results found for your query" briefly, and then a few seconds later the loading bar would appear and load the span samples. 

Because we have a chain of dependent use Queries, you'd get to a point where one of them was was momentarily disabled, which means it was not in the `isFetching` state, which means the table would think that no query results were found. To fix this i'm just checking if the queries are enabled, if they aren't then we can assume there is either an error or we are waiting for the result of a dependent query.