### PR TITLE
feat(functions): Include examples in functions trends timeseries

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -150,6 +150,7 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
                     top_events={"data": chunk},
                     result_key_order=["project.id", "fingerprint"],
                 )
+
                 results.update(formatted_results)
 
             return results
@@ -161,15 +162,17 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
             trends_request = {
                 "data": {
                     k: {
-                        "data": v["data"],
-                        "data_start": v["start"],
-                        "data_end": v["end"],
+                        "data": v[data["function"]]["data"],
+                        "data_start": v[data["function"]]["start"],
+                        "data_end": v[data["function"]]["end"],
                         # We want to use the first 20% of the data as historical data
                         # to help filter out false positives.
                         # This means if there is a change in the first 20%, it will
                         # not be detected as a breakpoint.
-                        "request_start": v["data"][len(v["data"]) // 5][0],
-                        "request_end": v["end"],
+                        "request_start": v[data["function"]]["data"][
+                            len(v[data["function"]]["data"]) // 5
+                        ][0],
+                        "request_end": v[data["function"]]["end"],
                     }
                     for k, v in stats_data.items()
                 },
@@ -185,6 +188,7 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
             get_event_stats,
             top_events=FUNCTIONS_PER_QUERY,
             query_column=data["function"],
+            additional_query_column="worst()",
             params=params,
             query=data.get("query"),
         )
@@ -230,7 +234,14 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
                 # hence the name of the key, but it can be adapted to work
                 # for functions as well.
                 key = f"{result['project']},{result['transaction']}"
-                formatted_result = {"stats": stats_data[key]}
+                formatted_result = {
+                    "stats": stats_data[key][data["function"]],
+                    "worst": [
+                        (ts, data[0]["count"])
+                        for (ts, data) in stats_data[key]["worst()"]["data"]
+                        if data[0]["count"]  # filter out entries without an example
+                    ],
+                }
                 formatted_result.update(
                     {
                         k: result[k]

--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -112,7 +112,7 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
             transform_alias_to_input_format=True,
         )
 
-        def get_event_stats(columns, query, params, _rollup, zerofill_results, _comparison_delta):
+        def get_event_stats(_columns, query, params, _rollup, zerofill_results, _comparison_delta):
             rollup = get_rollup_from_range(params["end"] - params["start"])
 
             chunks = [
@@ -129,7 +129,10 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
                     other=False,
                     query=query,
                     selected_columns=["project.id", "fingerprint"],
-                    timeseries_columns=columns,
+                    # It's possible to override the columns via
+                    # the `yAxis` qs. So we explicitly ignore the
+                    # columns, and hard code in the columns we want.
+                    timeseries_columns=[data["function"], "worst()"],
                     skip_tag_resolution=True,
                 )
                 for chunk in chunks

--- a/src/sentry/search/events/datasets/profile_functions.py
+++ b/src/sentry/search/events/datasets/profile_functions.py
@@ -247,6 +247,22 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                     default_result_type="integer",
                 ),
                 SnQLFunction(
+                    "worst",
+                    snql_aggregate=lambda _, alias: Function(
+                        "replaceAll",
+                        [
+                            Function(
+                                "toString",
+                                [Function("argMaxMerge", [SnQLColumn("worst")])],
+                            ),
+                            "-",
+                            "",
+                        ],
+                        alias,
+                    ),
+                    default_result_type="string",  # TODO: support array type
+                ),
+                SnQLFunction(
                     "examples",
                     snql_aggregate=lambda _, alias: Function(
                         "arrayMap",

--- a/tests/sentry/api/endpoints/test_organization_profiling_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_functions.py
@@ -217,6 +217,8 @@ class OrganizationProfilingFunctionTrendsEndpointTest(ProfilesSnubaTestCase):
         assert results
         trend_percentages = [data["trend_percentage"] for data in results]
         assert trend_percentages == [10.0, 5.0]
+        for data in results:
+            assert isinstance(data["worst"], list)
 
     @mock.patch("sentry.api.endpoints.organization_profiling_functions.trends_query")
     def test_improvement(self, mock_trends_query):
@@ -296,6 +298,8 @@ class OrganizationProfilingFunctionTrendsEndpointTest(ProfilesSnubaTestCase):
         assert results
         trend_percentages = [data["trend_percentage"] for data in results]
         assert trend_percentages == [0.1, 0.2]
+        for data in results:
+            assert isinstance(data["worst"], list)
 
 
 def test_get_rollup_from_range_max_buckets():


### PR DESCRIPTION
A simple list of examples isn't very meaningful in this context. We want a list of examples that can be associated with a timestamp. This adds a timeseries that includes up to 1 example profile per bucket in the roll up so that we can pick out examples at various points in time.