### PR TITLE
fix(starfish): Remove `sps()` data unit hack

### DIFF
--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -155,13 +155,9 @@ export function useWrappedDiscoverQuery<T>({
     },
   });
 
+  // TODO: useDiscoverQuery incorrectly states that it returns MetaType, but it
+  // does not!
   const meta = result.data?.meta as EventsMetaType | undefined;
-  if (meta) {
-    // TODO: Remove this hack when the backend returns `"rate"` as the data
-    // type for `sps()` and other rate fields!
-    meta.fields['sps()'] = 'rate';
-    meta.units['sps()'] = '1/second';
-  }
 
   const data =
     result.isLoading && initialData ? initialData : (result.data?.data as T | undefined);
@@ -169,7 +165,7 @@ export function useWrappedDiscoverQuery<T>({
   return {
     ...result,
     data,
-    meta, // TODO: useDiscoverQuery incorrectly states that it returns MetaType, but it does not!
+    meta,
   };
 }
 


### PR DESCRIPTION
As of #52991 the `meta` response from the server is correct, and the hack is not needed.
