### PR TITLE
fix(metric-layer): Temporarily disable on starfish

### DIFF
--- a/src/sentry/snuba/spans_metrics.py
+++ b/src/sentry/snuba/spans_metrics.py
@@ -91,7 +91,6 @@ def timeseries_query(
         selected_columns=selected_columns,
         functions_acl=functions_acl,
         allow_metric_aggregates=allow_metric_aggregates,
-        use_metrics_layer=use_metrics_layer,
         groupby=groupby,
     )
     result = metrics_query.run_query(referrer)


### PR DESCRIPTION
- Removes the metrics layer from starfish (specifically events-stats, it wasn't on for events) So that we can enable the feature flag for sentry without breaking starfish too