### PR TITLE
feat(hybrid-cloud): Add statuses param to get_organization_integrations

### DIFF
--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -164,6 +164,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         organization_id: int | None = None,
         organization_ids: Optional[List[int]] = None,
         status: int | None = None,
+        statuses: List[int] | None = None,
         providers: List[str] | None = None,
         has_grace_period: bool | None = None,
         limit: int | None = None,
@@ -178,7 +179,9 @@ class DatabaseBackedIntegrationService(IntegrationService):
         if organization_ids is not None:
             oi_kwargs["organization_id__in"] = organization_ids
         if status is not None:
-            oi_kwargs["status"] = status
+            statuses = [status]
+        if statuses is not None:
+            oi_kwargs["status__in"] = statuses
         if providers is not None:
             oi_kwargs["integration__provider__in"] = providers
         if has_grace_period is not None:

--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -109,6 +109,7 @@ class IntegrationService(RpcService):
         organization_id: Optional[int] = None,
         organization_ids: Optional[List[int]] = None,
         status: Optional[int] = None,
+        statuses: Optional[List[int]] = None,
         providers: Optional[List[str]] = None,
         has_grace_period: Optional[bool] = None,
         limit: Optional[int] = None,

--- a/tests/sentry/hybrid_cloud/test_integration.py
+++ b/tests/sentry/hybrid_cloud/test_integration.py
@@ -212,6 +212,15 @@ class OrganizationIntegrationServiceTest(BaseIntegrationServiceTest):
         )
         self.verify_result(result=result, expected=[self.org_integration1, self.org_integration3])
 
+        result = integration_service.get_organization_integrations(
+            organization_id=self.organization.id,
+            statuses=[ObjectStatus.ACTIVE, ObjectStatus.PENDING_DELETION],
+        )
+        self.verify_result(
+            result=result,
+            expected=[self.org_integration1, self.org_integration2, self.org_integration3],
+        )
+
         # by Integration attributes
         result = integration_service.get_organization_integrations(
             organization_id=self.organization.id,


### PR DESCRIPTION
In the Discord integration I want to grab all organization integrations with one of two statuses and this addition will make this task slightly more efficient. 😄 