### PR TITLE
fix(stacktrace processing): Fix in-app detection for `Array.forEach` frames

### DIFF
--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -173,6 +173,11 @@ class StacktraceProcessor:
         """
         return False
 
+    def postproces_step(self, processed_frames, raw_frames, errors):
+        """Make any necessary adjustments after the full stacktrace has been processed, but before
+        it's returned."""
+        return (processed_frames, raw_frames, errors)
+
 
 def find_stacktraces_in_data(data, include_raw=False, with_exceptions=False):
     """Finds all stacktraces in a given data blob and returns it
@@ -559,6 +564,12 @@ def process_stacktraces(data, make_processors=None, set_raw_stacktrace=True):
                     processing_task, stacktrace_info, processable_frames
                 )
                 if new_frames is not None:
+                    # Make any necessary list-minute adjustments. Note: This assumes
+                    # all frames use the same processor.
+                    new_frames, new_raw_frames, errors = processable_frames[
+                        0
+                    ].processor.postprocess_step(new_frames, new_raw_frames, errors)
+
                     stacktrace_info.stacktrace["frames"] = new_frames
                     changed = True
                     span.set_data("data_changed", True)


### PR DESCRIPTION
There are places in JS stacktraces where we incorrectly label `Array.forEach` frames as `in_app`, even though they're just the anonymous callbacks to `forEach` calls in non-in-app code. (For more detail, see https://github.com/getsentry/sentry/issues/53007.) This fixes that by considering the previous frame's `in_app` value when setting the final `in_app` value for an `Array.forEach` frame. 

Because there was no place in the `StacktraceProcessor` class where an entire processed stacktrace could be acted on at once, I added a `postprocess_step` method to match the `preprocess_step` method. By default, it's a no-op on the processed frames, the raw frames, and the list of errors. In the JS processor, it now runs through the frames for a final time and adjusts `Array.forEach` frames' `in_app` values based on the previous frame's values.*

\*Though it doesn't make a ton of sense, I've occasionally seen stacktraces which start with such a frame. In that case, in order to avoid an `IndexError`, the next frame is used instead of the previous one.

--------------

TODO: 
- [ ] Fix failing tests
- [ ] Write new tests