### PR TITLE
feat(github-growth): manually cascade delete after hiding repo

### DIFF
--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -89,6 +89,8 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
                 ):
                     repo.reset_pending_deletion_field_names()
                     repo.delete_pending_deletion_option()
+                elif repo.status == ObjectStatus.HIDDEN and old_status != repo.status:
+                    repo.cascade_delete_on_hide()
 
         return Response(serialize(repo, request.user))
 

--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -12,6 +12,7 @@ from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.models import Commit, Integration, Repository, ScheduledDeletion
 from sentry.services.hybrid_cloud import coerce_id_from
+from sentry.tasks.repository import repository_cascade_delete_on_hide
 
 
 class RepositorySerializer(serializers.Serializer):
@@ -90,7 +91,7 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
                     repo.reset_pending_deletion_field_names()
                     repo.delete_pending_deletion_option()
                 elif repo.status == ObjectStatus.HIDDEN and old_status != repo.status:
-                    repo.cascade_delete_on_hide()
+                    repository_cascade_delete_on_hide.apply_async(kwargs={"repo_id": repo.id})
 
         return Response(serialize(repo, request.user))
 

--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -8,6 +8,27 @@ from sentry.utils.query import bulk_delete_objects
 _leaf_re = re.compile(r"^(UserReport|Event|Group)(.+)")
 
 
+def delete_children(manager, relations, transaction_id=None, actor_id=None):
+    # Ideally this runs through the deletion manager
+    for relation in relations:
+        task = manager.get(
+            transaction_id=transaction_id,
+            actor_id=actor_id,
+            task=relation.task,
+            **relation.params,
+        )
+
+        # If we want smaller tasks then this also has to return when has_more is true.
+        # This could significant increase the number of tasks we spawn. Get better estimates
+        # by collecting metrics.
+        has_more = True
+        while has_more:
+            has_more = task.chunk()
+            if has_more:
+                metrics.incr("deletions.should_spawn", tags={"task": type(task).__name__})
+    return False
+
+
 class BaseRelation:
     def __init__(self, params, task):
         self.task = task
@@ -126,24 +147,7 @@ class BaseDeletionTask:
             self.delete_instance(instance)
 
     def delete_children(self, relations):
-        # Ideally this runs through the deletion manager
-        for relation in relations:
-            task = self.manager.get(
-                transaction_id=self.transaction_id,
-                actor_id=self.actor_id,
-                task=relation.task,
-                **relation.params,
-            )
-
-            # If we want smaller tasks then this also has to return when has_more is true.
-            # This could significant increase the number of tasks we spawn. Get better estimates
-            # by collecting metrics.
-            has_more = True
-            while has_more:
-                has_more = task.chunk()
-                if has_more:
-                    metrics.incr("deletions.should_spawn", tags={"task": type(task).__name__})
-        return False
+        return delete_children(self.manager, relations, self.transaction_id, self.actor_id)
 
     def mark_deletion_in_progress(self, instance_list):
         pass

--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -8,7 +8,7 @@ from sentry.utils.query import bulk_delete_objects
 _leaf_re = re.compile(r"^(UserReport|Event|Group)(.+)")
 
 
-def delete_children(manager, relations, transaction_id=None, actor_id=None):
+def _delete_children(manager, relations, transaction_id=None, actor_id=None):
     # Ideally this runs through the deletion manager
     for relation in relations:
         task = manager.get(
@@ -147,7 +147,7 @@ class BaseDeletionTask:
             self.delete_instance(instance)
 
     def delete_children(self, relations):
-        return delete_children(self.manager, relations, self.transaction_id, self.actor_id)
+        return _delete_children(self.manager, relations, self.transaction_id, self.actor_id)
 
     def mark_deletion_in_progress(self, instance_list):
         pass

--- a/src/sentry/deletions/defaults/repository.py
+++ b/src/sentry/deletions/defaults/repository.py
@@ -4,6 +4,16 @@ from sentry.signals import pending_delete
 from ..base import ModelDeletionTask, ModelRelation
 
 
+def get_repository_child_relations(instance):
+    from sentry.models import Commit, PullRequest, RepositoryProjectPathConfig
+
+    return [
+        ModelRelation(Commit, {"repository_id": instance.id}),
+        ModelRelation(PullRequest, {"repository_id": instance.id}),
+        ModelRelation(RepositoryProjectPathConfig, {"repository_id": instance.id}),
+    ]
+
+
 class RepositoryDeletionTask(ModelDeletionTask):
     def should_proceed(self, instance):
         """
@@ -12,13 +22,7 @@ class RepositoryDeletionTask(ModelDeletionTask):
         return instance.status in {ObjectStatus.PENDING_DELETION, ObjectStatus.DELETION_IN_PROGRESS}
 
     def get_child_relations(self, instance):
-        from sentry.models import Commit, PullRequest, RepositoryProjectPathConfig
-
-        return [
-            ModelRelation(Commit, {"repository_id": instance.id}),
-            ModelRelation(PullRequest, {"repository_id": instance.id}),
-            ModelRelation(RepositoryProjectPathConfig, {"repository_id": instance.id}),
-        ]
+        return get_repository_child_relations(instance)
 
     def delete_instance(self, instance):
         # TODO child_relations should also send pending_delete so we

--- a/src/sentry/deletions/defaults/repository.py
+++ b/src/sentry/deletions/defaults/repository.py
@@ -4,7 +4,7 @@ from sentry.signals import pending_delete
 from ..base import ModelDeletionTask, ModelRelation
 
 
-def get_repository_child_relations(instance):
+def _get_repository_child_relations(instance):
     from sentry.models import Commit, PullRequest, RepositoryProjectPathConfig
 
     return [
@@ -22,7 +22,7 @@ class RepositoryDeletionTask(ModelDeletionTask):
         return instance.status in {ObjectStatus.PENDING_DELETION, ObjectStatus.DELETION_IN_PROGRESS}
 
     def get_child_relations(self, instance):
-        return get_repository_child_relations(instance)
+        return _get_repository_child_relations(instance)
 
     def delete_instance(self, instance):
         # TODO child_relations should also send pending_delete so we

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -14,12 +14,8 @@ from sentry.db.models import (
     region_silo_only_model,
     sane_repr,
 )
-from sentry.models.commit import Commit
-from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
-from sentry.models.pullrequest import PullRequest
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.signals import pending_delete
-from sentry.utils import metrics
 
 
 @region_silo_only_model
@@ -106,40 +102,21 @@ class Repository(Model, PendingDeletionMixin):
             return
 
         from sentry.deletions import default_manager
-        from sentry.deletions.base import ModelRelation
-
-        def _delete_children(relations: list[ModelRelation]) -> bool:
-            for relation in relations:
-                task = default_manager.get(
-                    transaction_id=None,
-                    actor_id=None,
-                    task=relation.task,
-                    **relation.params,
-                )
-
-                has_more = True
-                while has_more:
-                    has_more = task.chunk()
-                    if has_more:
-                        metrics.incr("deletions.should_spawn", tags={"task": type(task).__name__})
-            return False
+        from sentry.deletions.base import delete_children
+        from sentry.deletions.defaults.repository import get_repository_child_relations
 
         has_more = True
 
         while has_more:
             # get child relations
-            child_relations = [
-                ModelRelation(Commit, {"repository_id": self.id}),
-                ModelRelation(PullRequest, {"repository_id": self.id}),
-                ModelRelation(RepositoryProjectPathConfig, {"repository_id": self.id}),
-            ]
+            child_relations = get_repository_child_relations(self)
             # extend relations
             child_relations = child_relations + [
                 rel(self) for rel in default_manager.dependencies[Repository]
             ]
             # no need to filter relations; delete them
             if child_relations:
-                has_more = _delete_children(child_relations)
+                has_more = delete_children(manager=default_manager, relations=child_relations)
 
 
 def on_delete(instance, actor: RpcUser | None = None, **kwargs):

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -102,21 +102,21 @@ class Repository(Model, PendingDeletionMixin):
             return
 
         from sentry.deletions import default_manager
-        from sentry.deletions.base import delete_children
-        from sentry.deletions.defaults.repository import get_repository_child_relations
+        from sentry.deletions.base import _delete_children
+        from sentry.deletions.defaults.repository import _get_repository_child_relations
 
         has_more = True
 
         while has_more:
             # get child relations
-            child_relations = get_repository_child_relations(self)
+            child_relations = _get_repository_child_relations(self)
             # extend relations
             child_relations = child_relations + [
                 rel(self) for rel in default_manager.dependencies[Repository]
             ]
             # no need to filter relations; delete them
             if child_relations:
-                has_more = delete_children(manager=default_manager, relations=child_relations)
+                has_more = _delete_children(manager=default_manager, relations=child_relations)
 
 
 def on_delete(instance, actor: RpcUser | None = None, **kwargs):

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -94,12 +94,10 @@ class Repository(Model, PendingDeletionMixin):
         return super().reset_pending_deletion_field_names(["config"])
 
     def cascade_delete_on_hide(self) -> None:
-        # Manually cause a deletion cascade after setting a repo's status
+        # Manually cause a deletion cascade.
+        # This should be called after setting a repo's status
         # to ObjectStatus.HIDDEN.
         # References RepositoryDeletionTask and BaseDeletionTask logic.
-
-        if self.status != ObjectStatus.HIDDEN:
-            return
 
         from sentry.deletions import default_manager
         from sentry.deletions.base import _delete_children

--- a/src/sentry/tasks/repository.py
+++ b/src/sentry/tasks/repository.py
@@ -5,9 +5,7 @@ from sentry.models.repository import Repository
 from sentry.tasks.base import instrumented_task
 
 
-@instrumented_task(
-    name="sentry.models.repository_cascade_delete_on_hide",
-)
+@instrumented_task(name="sentry.models.repository_cascade_delete_on_hide", acks_late=True)
 def repository_cascade_delete_on_hide(repo_id: int) -> None:
     # Manually cause a deletion cascade.
     # This should be called after setting a repo's status

--- a/src/sentry/tasks/repository.py
+++ b/src/sentry/tasks/repository.py
@@ -1,0 +1,33 @@
+from sentry.deletions import default_manager
+from sentry.deletions.base import _delete_children
+from sentry.deletions.defaults.repository import _get_repository_child_relations
+from sentry.models.repository import Repository
+from sentry.tasks.base import instrumented_task
+
+
+@instrumented_task(
+    name="sentry.models.repository_cascade_delete_on_hide",
+)
+def repository_cascade_delete_on_hide(repo_id: int) -> None:
+    # Manually cause a deletion cascade.
+    # This should be called after setting a repo's status
+    # to ObjectStatus.HIDDEN.
+    # References RepositoryDeletionTask and BaseDeletionTask logic.
+
+    try:
+        repo = Repository.objects.get(id=repo_id)
+    except Repository.DoesNotExist:
+        return
+
+    has_more = True
+
+    while has_more:
+        # get child relations
+        child_relations = _get_repository_child_relations(repo)
+        # extend relations
+        child_relations = child_relations + [
+            rel(repo) for rel in default_manager.dependencies[Repository]
+        ]
+        # no need to filter relations; delete them
+        if child_relations:
+            has_more = _delete_children(manager=default_manager, relations=child_relations)

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -267,6 +267,25 @@ class OrganizationRepositoryDeleteTest(APITestCase):
         repo = Repository.objects.get(id=repo.id)
         assert repo.status == ObjectStatus.HIDDEN
 
+    def test_put_hide_repo_with_commits(self):
+        self.login_as(user=self.user)
+
+        org = self.create_organization(owner=self.user, name="baz")
+        repo = Repository.objects.create(
+            name="example", organization_id=org.id, external_id="abc123"
+        )
+        Commit.objects.create(repository_id=repo.id, key="a" * 40, organization_id=org.id)
+
+        url = reverse("sentry-api-0-organization-repository-details", args=[org.slug, repo.id])
+
+        with self.tasks():
+            response = self.client.put(url, data={"status": "hidden"})
+            assert response.status_code == 200
+
+        repo = Repository.objects.get(id=repo.id)
+        assert repo.status == ObjectStatus.HIDDEN
+        assert len(Commit.objects.filter(repository_id=repo.id)) == 0
+
     def test_put_cancel_deletion_duplicate_exists(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
We are replacing the behavior of deleting a `Repository` with setting its status to `HIDDEN`. We do this to track the repo so we don't re-install it in the future when the user has explicitly removed it.

When a user deletes a `Repository`, a deletion cascade happens. For the case of changing its status to `HIDDEN`, this needs to be done manually because we want to retain the previous behavior of "deleting" a repo (deleting commit data, etc).

A repo's status is updated through `PUT OrganizationRepositoryDetailsEndpoint`. This updates attributes of a `Repository` object through a call to `repo.update()`, but `update()` doesn't send the `pre_save` or `post_save` Django signal since [it is converted directly into a SQL statement](https://docs.djangoproject.com/en/dev/topics/db/queries/#updating-multiple-objects-at-once) and doesn't call `save()`.

Instead we can have an async task that does the deleting. This mimics the deletion cascade logic but doesn't actually delete the parent object at the end.

For ER-1736