### PR TITLE
ref(replays): make mock replay more interesting

### DIFF
--- a/bin/mock-replay
+++ b/bin/mock-replay
@@ -19,10 +19,12 @@ from sentry.replays.models import ReplayRecordingSegment
 from sentry.replays.testutils import (
     mock_replay,
     mock_rrweb_div_helloworld,
+    mock_segment_click,
     mock_segment_console,
     mock_segment_fullsnapshot,
     mock_segment_init,
     mock_segment_nagivation,
+    mock_segment_rageclick,
 )
 
 
@@ -41,6 +43,31 @@ def create_recording(replay_id, project_id, timestamp):
         mock_segment_nagivation(timestamp + timedelta(seconds=1), hrefFrom="/", hrefTo="/home/"),
         mock_segment_nagivation(
             timestamp + timedelta(seconds=2), hrefFrom="/home/", hrefTo="/profile/"
+        ),
+        mock_segment_rageclick(
+            timestamp + timedelta(seconds=2),
+            "nav.app-65yvxw.e1upz5ks6[aria-label='Primary Navigation'] > div.app-1v175cc.e1upz5ks4",
+            "sidebar-item-performance",
+            "a",
+            24,
+        ),
+        mock_segment_click(
+            timestamp + timedelta(seconds=2),
+            "nav.app-65yvxw.e1upz5ks6[aria-label='Primary Navigation'] > div.app-1v175cc.e1upz5ks4",
+            "sidebar-item-performance",
+            "a",
+        ),
+        mock_segment_nagivation(
+            timestamp + timedelta(seconds=6),
+            hrefFrom="/profile/",
+            hrefTo="/performance/",
+        ),
+        mock_segment_rageclick(
+            timestamp + timedelta(seconds=6),
+            "nav.app-65yvxw.e1upz5ks6[aria-label='Primary Navigation'] > div.app-1v175cc.e1upz5ks4",
+            "sidebar-item-performance",
+            "a",
+            24,
         ),
     ]
     for (segment_id, segment) in enumerate(segments):
@@ -97,7 +124,7 @@ def main():
     project.add_team(team)
 
     replay_id = uuid.uuid4().hex
-    seq1_timestamp = datetime.now() - timedelta(seconds=22)
+    seq1_timestamp = datetime.now() - timedelta(seconds=15)
     seq2_timestamp = datetime.now() - timedelta(seconds=5)
 
     click.echo("Creating Replay events entries...")

--- a/src/sentry/replays/testutils.py
+++ b/src/sentry/replays/testutils.py
@@ -347,6 +347,51 @@ def mock_segment_nagivation(
     )
 
 
+def mock_segment_click(
+    timestamp: datetime.datetime, message: str, id: str, tagName: str
+) -> SegmentList:
+    return mock_segment_breadcrumb(
+        timestamp,
+        {
+            "timestamp": sec(timestamp),
+            "type": "default",
+            "category": "ui.click",
+            "message": message,
+            "data": {
+                "node": {
+                    "tagName": tagName,
+                    "attributes": {
+                        "id": id,
+                    },
+                }
+            },
+        },
+    )
+
+
+def mock_segment_rageclick(
+    timestamp: datetime.datetime, message: str, id: str, tagName: str, clickCount: int
+) -> SegmentList:
+    return mock_segment_breadcrumb(
+        timestamp,
+        {
+            "timestamp": sec(timestamp),  # sentry data inside rrweb is in seconds
+            "type": "default",
+            "category": "ui.multiClick",
+            "message": message,
+            "data": {
+                "node": {
+                    "tagName": tagName,
+                    "attributes": {
+                        "id": id,
+                    },
+                },
+                "clickCount": clickCount,
+            },
+        },
+    )
+
+
 __rrweb_id = 0
 
 


### PR DESCRIPTION
The `bin/mock-replay` script now features a slightly more interesting replay recording, with some mock rage click frames.
<img width="610" alt="Screenshot 2023-07-17 at 4 02 11 PM" src="https://github.com/getsentry/sentry/assets/56095982/8d933cea-0b0c-476d-ba93-74a05a37a889">

For simplicity, I added small methods that created rage click and click segments rather than importing and reading a large JSON file with a bunch of frames, since I figured that a few hardcoded rage click events would be good enough for demo purposes :o)