### PR TITLE
feat(github-growth): activate hidden repo in create_repository

### DIFF
--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -18,6 +18,7 @@ from sentry.models import Integration, Repository
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.signals import repo_linked
+from sentry.utils import metrics
 
 
 class RepoExistsError(APIException):
@@ -86,23 +87,25 @@ class IntegrationRepositoryProvider:
         external_id = result.get("external_id")
 
         repo_update_params = {
-            "external_id": result.get("external_id"),
+            "external_id": external_id,
             "url": result.get("url"),
             "config": result.get("config") or {},
             "provider": self.id,
             "integration_id": integration_id,
         }
 
-        # first check if there is an existing repository with an integration that matches
+        # first check if there is an existing hidden repository with an integration that matches
         existing_repo = Repository.objects.filter(
             organization_id=organization.id,
             name=result["name"],
             integration_id=integration_id,
             external_id=external_id,
+            status=ObjectStatus.HIDDEN,
         ).first()
         if existing_repo:
             existing_repo.status = ObjectStatus.ACTIVE
             existing_repo.save()
+            metrics.incr("in")
             return result, existing_repo
 
         # then check if there is a repository without an integration that matches

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -105,7 +105,7 @@ class IntegrationRepositoryProvider:
         if existing_repo:
             existing_repo.status = ObjectStatus.ACTIVE
             existing_repo.save()
-            metrics.incr("in")
+            metrics.incr("sentry.integration_repo_provider.repo_relink")
             return result, existing_repo
 
         # then check if there is a repository without an integration that matches


### PR DESCRIPTION
When we attempt to create a new repository, we will check if the repo already exists but has `status=ObjectStatus.HIDDEN`, and if it does exist we will set `status=ObjectStatus.ACTIVE`.

Given the way we wrote automatic repository linking, we will not re-link the hidden repo automatically. TL;DR all repos are added automatically, and subsequently users will be able to delete (aka hide) repos at their discretion. The GitHub webhook ignores hidden repos and we create new `Repository` objects only if they don't exist. (see #52756)

For ER-1721