### PR TITLE
feat(github-growth): replace delete repo with hide repo on config page

### DIFF
--- a/static/app/actionCreators/integrations.tsx
+++ b/static/app/actionCreators/integrations.tsx
@@ -112,9 +112,9 @@ export function cancelDeleteRepository(
 /**
  * Delete a repository by setting its status to hidden.
  *
- * @param {Object} client ApiClient
- * @param {String} orgId Organization Slug
- * @param {String} repositoryId Repository ID
+ * @param client ApiClient
+ * @param orgId Organization Slug
+ * @param repositoryId Repository ID
  */
 export function hideRepository(client: Client, orgId: string, repositoryId: string) {
   addLoadingMessage();

--- a/static/app/actionCreators/integrations.tsx
+++ b/static/app/actionCreators/integrations.tsx
@@ -109,6 +109,29 @@ export function cancelDeleteRepository(
   return promise;
 }
 
+/**
+ * Delete a repository by setting its status to hidden.
+ *
+ * @param {Object} client ApiClient
+ * @param {String} orgId Organization Slug
+ * @param {String} repositoryId Repository ID
+ */
+export function hideRepository(client: Client, orgId: string, repositoryId: string) {
+  addLoadingMessage();
+  const promise = client.requestPromise(
+    `/organizations/${orgId}/repos/${repositoryId}/`,
+    {
+      method: 'PUT',
+      data: {status: 'hidden'},
+    }
+  );
+  promise.then(
+    () => clearIndicators(),
+    () => addErrorMessage(t('Unable to delete repository.'))
+  );
+  return promise;
+}
+
 function applyRepositoryAddComplete(promise: Promise<Repository>) {
   promise.then(
     (repo: Repository) => {

--- a/static/app/components/repositoryRow.spec.tsx
+++ b/static/app/components/repositoryRow.spec.tsx
@@ -115,12 +115,12 @@ describe('RepositoryRow', function () {
       access: ['org:integrations'],
     });
 
-    it('sends api request on delete', async function () {
+    it('sends api request to hide upon clicking delete', async function () {
       const deleteRepo = MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/repos/${repository.id}/`,
-        method: 'DELETE',
+        method: 'PUT',
         statusCode: 204,
-        body: {},
+        body: {status: 'hidden'},
       });
 
       render(

--- a/static/app/components/repositoryRow.tsx
+++ b/static/app/components/repositoryRow.tsx
@@ -1,10 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {
-  cancelDeleteRepository,
-  deleteRepository,
-} from 'sentry/actionCreators/integrations';
+import {cancelDeleteRepository, hideRepository} from 'sentry/actionCreators/integrations';
 import {openModal} from 'sentry/actionCreators/modal';
 import {Client} from 'sentry/api';
 import Access from 'sentry/components/acl/access';
@@ -69,7 +66,7 @@ function RepositoryRow({
     );
 
   const deleteRepo = () =>
-    deleteRepository(api, orgId, repository.id).then(
+    hideRepository(api, orgId, repository.id).then(
       data => {
         if (onRepositoryChange) {
           onRepositoryChange(data);


### PR DESCRIPTION
Instead of deleting a repo, clicking the trash icon will now set the repo status to `HIDDEN`.

Requires #53018 in order to maintain the behavior of cascading deletions now that we are hiding the repo instead of fully deleting it.