### PR TITLE
ref(hc): Force transaction.atomic calls to specify using=

### DIFF
--- a/src/sentry/api/endpoints/group_hashes_split.py
+++ b/src/sentry/api/endpoints/group_hashes_split.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Any, Dict, List, Optional, Sequence
 
 import sentry_sdk
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 from snuba_sdk import Request as SnubaRequest
@@ -204,7 +204,7 @@ def _unsplit_group(group: Group, hash: str, hierarchical_hashes: Optional[Sequen
         if grouphash.group_id == group.id:
             grouphash_to_delete = grouphash
 
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(GroupHash)):
         if grouphash_to_unsplit is not None:
             grouphash_to_unsplit.state = GroupHash.State.UNLOCKED
             grouphash_to_unsplit.save()

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -1,6 +1,6 @@
 from typing import Any, Mapping, MutableMapping
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -192,7 +192,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             return Response({"non_field_errors": [str(e)]}, status=400)
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(GroupLink)):
                 GroupLink.objects.create(
                     group_id=group.id,
                     project_id=group.project_id,
@@ -256,7 +256,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         )
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(GroupLink)):
                 GroupLink.objects.create(
                     group_id=group.id,
                     project_id=group.project_id,
@@ -318,7 +318,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         except ExternalIssue.DoesNotExist:
             return Response(status=404)
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(GroupLink)):
             GroupLink.objects.get_group_issues(group, external_issue_id).delete()
 
             # check if other groups reference this external issue

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -1,4 +1,4 @@
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -118,7 +118,7 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
 
         if is_approved:
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
                     omt = OrganizationMemberTeam.objects.create(
                         organizationmember=access_request.member, team=access_request.team
                     )

--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -1,5 +1,5 @@
 import sentry_sdk
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import F
 from django.utils import timezone
 from rest_framework.request import Request
@@ -125,7 +125,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(DashboardTombstone)):
                 serializer.save()
                 if tombstone:
                     DashboardTombstone.objects.get_or_create(

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -1,6 +1,6 @@
 import re
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import Case, IntegerField, When
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -154,7 +154,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             return Response(serializer.errors, status=400)
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(Dashboard)):
                 dashboard = serializer.save()
             return Response(serialize(dashboard, request.user), status=201)
         except IntegrityError:

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import Count, Q, Sum
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -216,7 +216,7 @@ class OrganizationIndexEndpoint(Endpoint):
 
             try:
 
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(Organization)):
                     org = create_organization_with_outbox_message(
                         create_options={"name": result["name"], "slug": result.get("slug")}
                     )

--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple
 
 from django.conf import settings
-from django.db import transaction
+from django.db import router, transaction
 from django.db.models import F, Q
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -267,7 +267,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
             )
             return Response({"detail": ERR_RATE_LIMITED}, status=429)
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(OrganizationMember)):
             # remove any invitation requests for this email before inviting
             existing_invite = OrganizationMember.objects.filter(
                 Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)

--- a/src/sentry/api/endpoints/organization_member/requests/invite/index.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/index.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import router, transaction
 from django.db.models import Q
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -74,7 +74,9 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
 
         result = serializer.validated_data
 
-        with outbox_context(transaction.atomic(), flush=False):
+        with outbox_context(
+            transaction.atomic(router.db_for_write(OrganizationMember)), flush=False
+        ):
             om = OrganizationMember.objects.create(
                 organization_id=organization.id,
                 role=result["role"] or organization.default_role,

--- a/src/sentry/api/endpoints/organization_projects_experiment.py
+++ b/src/sentry/api/endpoints/organization_projects_experiment.py
@@ -3,7 +3,7 @@ import random
 import string
 from email.headerregistry import Address
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.utils.text import slugify
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 from rest_framework.request import Request
@@ -113,7 +113,7 @@ class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
         default_team_slug = suffixed_team_slug
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(Team)):
                 team = Team.objects.create(
                     name=default_team_slug,
                     slug=default_team_slug,

--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -81,7 +81,7 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
 
         if update_kwargs:
             old_status = repo.status
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(Repository)):
                 repo.update(**update_kwargs)
                 if (
                     old_status == ObjectStatus.PENDING_DELETION
@@ -101,7 +101,7 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
         except Repository.DoesNotExist:
             raise ResourceDoesNotExist
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(Repository)):
             updated = Repository.objects.filter(
                 id=repo.id, status__in=[ObjectStatus.ACTIVE, ObjectStatus.DISABLED]
             ).update(status=ObjectStatus.PENDING_DELETION)

--- a/src/sentry/api/endpoints/organization_slugs.py
+++ b/src/sentry/api/endpoints/organization_slugs.py
@@ -1,5 +1,5 @@
 from django.core.validators import ValidationError, validate_slug
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -38,7 +38,7 @@ class SlugsUpdateEndpoint(OrganizationEndpoint):
 
         rv = {}
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(Project)):
             projects = {}
 
             # Clear out all slugs first so that we can move them

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import OpenApiResponse, extend_schema
@@ -184,7 +184,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
             result = serializer.validated_data
 
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(Team)):
                     team = Team.objects.create(
                         name=result.get("name") or result["slug"],
                         slug=result.get("slug"),

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from itertools import chain
 from uuid import uuid4
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
@@ -527,7 +527,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
 
         if result.get("isBookmarked"):
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(ProjectBookmark)):
                     ProjectBookmark.objects.create(project_id=project.id, user_id=request.user.id)
             except IntegrityError:
                 pass

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -125,7 +125,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
                     owner_id = owner.id
 
                 try:
-                    with transaction.atomic():
+                    with transaction.atomic(router.db_for_write(Release)):
                         release, created = (
                             Release.objects.create(
                                 organization_id=project.organization_id,

--- a/src/sentry/api/endpoints/project_servicehook_details.py
+++ b/src/sentry/api/endpoints/project_servicehook_details.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -75,7 +75,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
         elif result.get("isActive") is False:
             updates["status"] = ObjectStatus.DISABLED
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(ServiceHook)):
             hook.update(**updates)
 
             self.create_audit_entry(
@@ -108,7 +108,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
         except ServiceHook.DoesNotExist:
             raise ResourceDoesNotExist
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(ServiceHook)):
             hook.delete()
 
             self.create_audit_entry(

--- a/src/sentry/api/endpoints/project_transaction_threshold.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -82,7 +82,7 @@ class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
 
         data = serializer.validated_data
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(ProjectTransactionThreshold)):
             try:
                 project_threshold = ProjectTransactionThreshold.objects.get(
                     project=project,

--- a/src/sentry/api/endpoints/project_transaction_threshold_override.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold_override.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework import serializers, status
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
@@ -106,7 +106,7 @@ class ProjectTransactionThresholdOverrideEndpoint(OrganizationEventsV2EndpointBa
 
         data = serializer.validated_data
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(ProjectTransactionThresholdOverride)):
             (
                 transaction_threshold,
                 created,

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -1,6 +1,6 @@
 import calendar
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from django.http import HttpResponse
 from django.utils import timezone
@@ -101,7 +101,7 @@ class PromptsActivityEndpoint(Endpoint):
             data["dismissed_ts"] = now
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(PromptsActivity)):
                 PromptsActivity.objects.create_or_update(
                     feature=feature, user_id=request.user.id, values={"data": data}, **fields
                 )

--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any
 
 from django.conf import settings
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -95,7 +95,7 @@ class SystemOptionsEndpoint(Endpoint):
                 )
 
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(type(option))):
                     if not (option.flags & options.FLAG_ALLOW_EMPTY) and not v:
                         options.delete(k)
                     else:

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -147,9 +147,9 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         result = serializer.validated_data
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(Project)):
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(Project)):
                     project = Project.objects.create(
                         name=result["name"],
                         slug=result.get("slug"),

--- a/src/sentry/api/serializers/rest_framework/doc_integration.py
+++ b/src/sentry/api/serializers/rest_framework/doc_integration.py
@@ -1,6 +1,6 @@
 from typing import Any, MutableMapping
 
-from django.db import transaction
+from django.db import router, transaction
 from django.utils.text import slugify
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 from rest_framework import serializers
@@ -60,7 +60,7 @@ class DocIntegrationSerializer(Serializer):
     def create(self, validated_data: MutableMapping[str, Any]) -> DocIntegration:
         slug = self._generate_slug(validated_data["name"])
         features = validated_data.pop("features") if validated_data.get("features") else []
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(DocIntegration)):
             doc_integration = DocIntegration.objects.create(slug=slug, **validated_data)
             IntegrationFeature.objects.bulk_create(
                 [

--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Tuple, TypedDict
 
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework import serializers
 
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
@@ -272,7 +272,7 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
             organization_id=self.context["organization"].id,
             **validated_data,
         )
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(NotificationAction)):
             action.save()
             action.projects.set(projects)
         return action
@@ -285,7 +285,7 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
         for key, value in validated_data.items():
             setattr(instance, key, value)
         instance.type = service_type
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(NotificationAction)):
             instance.save()
             instance.projects.set(projects)
         return instance

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -10,7 +10,7 @@ import sentry_sdk
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import AnonymousUser
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import F
 from django.http import HttpResponseRedirect
 from django.http.request import HttpRequest
@@ -626,7 +626,7 @@ class AuthIdentityHandler:
             user.update(flags=F("flags").bitor(User.flags.newsletter_consent_prompt))
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(AuthIdentity)):
                 auth_identity = AuthIdentity.objects.create(
                     auth_provider=self.auth_provider,
                     user=user,

--- a/src/sentry/db/mixin.py
+++ b/src/sentry/db/mixin.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, FrozenSet
 from uuid import uuid4
 
-from django.db import transaction
+from django.db import router, transaction
 
 from sentry.db.models.manager import M
 from sentry.models import OrganizationOption
@@ -46,7 +46,7 @@ class PendingDeletionMixin:
         if extra_fields_to_save:
             fields = list(fields) + extra_fields_to_save
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(type(self))):
             self.save(update_fields=fields)
             OrganizationOption.objects.update_or_create(
                 organization_id=self.organization_id,

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -57,7 +57,7 @@ class KeyTransactionEndpoint(KeyTransactionBase):
 
         project = self.get_project(request, organization)
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(ProjectTeam)):
             serializer = serializers.TeamKeyTransactionSerializer(
                 data=request.data,
                 context={

--- a/src/sentry/discover/models.py
+++ b/src/sentry/discover/models.py
@@ -1,4 +1,4 @@
-from django.db import models, transaction
+from django.db import models, router, transaction
 from django.db.models import Q, UniqueConstraint
 from django.utils import timezone
 
@@ -67,7 +67,7 @@ class DiscoverSavedQuery(Model):
     __repr__ = sane_repr("organization_id", "created_by_id", "name")
 
     def set_projects(self, project_ids):
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(DiscoverSavedQueryProject)):
             DiscoverSavedQueryProject.objects.filter(discover_saved_query=self).exclude(
                 project__in=project_ids
             ).delete()

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
-from django.db import transaction
+from django.db import router, transaction
 from django.db.models.signals import post_save
 from django.utils import timezone
 from snuba_sdk import Column, Condition, Limit, Op
@@ -104,7 +104,7 @@ def create_incident(
     if date_detected is None:
         date_detected = date_started
 
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(Incident)):
         incident = Incident.objects.create(
             organization=organization,
             detection_uuid=detection_uuid,
@@ -156,7 +156,7 @@ def update_incident_status(
     if incident.status == status.value:
         # If the status isn't actually changing just no-op.
         return incident
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(Incident)):
         create_incident_activity(
             incident,
             IncidentActivityType.STATUS_CHANGE,
@@ -226,7 +226,7 @@ def set_incident_seen(incident, user=None):
     return False
 
 
-@transaction.atomic
+@transaction.atomic(router.db_for_write(Incident))
 def create_incident_activity(
     incident,
     activity_type,
@@ -508,7 +508,7 @@ def create_alert_rule(
     elif owner and isinstance(owner, Actor):
         actor = owner
 
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(SnubaQuery)):
         snuba_query = create_snuba_query(
             query_type,
             dataset,
@@ -569,7 +569,7 @@ def create_alert_rule(
 def snapshot_alert_rule(alert_rule, user=None):
     # Creates an archived alert_rule using the same properties as the passed rule
     # It will also resolve any incidents attached to this rule.
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(AlertRuleActivity)):
         triggers = AlertRuleTrigger.objects.filter(alert_rule=alert_rule)
         incidents = Incident.objects.filter(alert_rule=alert_rule)
         snuba_query_snapshot = deepcopy(alert_rule.snuba_query)
@@ -697,7 +697,7 @@ def update_alert_rule(
         updated_query_fields["resolution"] = timedelta(minutes=resolution)
         updated_fields["comparison_delta"] = comparison_delta
 
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(AlertRuleActivity)):
         incidents = Incident.objects.filter(alert_rule=alert_rule).exists()
         if incidents:
             snapshot_alert_rule(alert_rule, user)
@@ -816,7 +816,7 @@ def subscribe_projects_to_alert_rule(alert_rule, projects):
 def enable_alert_rule(alert_rule):
     if alert_rule.status != AlertRuleStatus.DISABLED.value:
         return
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(AlertRule)):
         alert_rule.update(status=AlertRuleStatus.PENDING.value)
         bulk_enable_snuba_subscriptions(alert_rule.snuba_query.subscriptions.all())
 
@@ -824,7 +824,7 @@ def enable_alert_rule(alert_rule):
 def disable_alert_rule(alert_rule):
     if alert_rule.status != AlertRuleStatus.PENDING.value:
         return
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(AlertRule)):
         alert_rule.update(status=AlertRuleStatus.DISABLED.value)
         bulk_disable_snuba_subscriptions(alert_rule.snuba_query.subscriptions.all())
 
@@ -837,7 +837,7 @@ def delete_alert_rule(alert_rule, user=None, ip_address=None):
     if alert_rule.status == AlertRuleStatus.SNAPSHOT.value:
         raise AlreadyDeletedError()
 
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(AlertRuleActivity)):
         if user:
             create_audit_entry_from_user(
                 user,
@@ -896,7 +896,7 @@ def create_alert_rule_trigger(alert_rule, label, alert_threshold, excluded_proje
     if excluded_projects:
         excluded_subs = get_subscriptions_from_alert_rule(alert_rule, excluded_projects)
 
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(AlertRuleTrigger)):
         trigger = AlertRuleTrigger.objects.create(
             alert_rule=alert_rule, label=label, alert_threshold=alert_threshold
         )
@@ -950,7 +950,7 @@ def update_alert_rule_trigger(trigger, label=None, alert_threshold=None, exclude
         ]
         new_subs = [sub for sub in excluded_subs if sub.id not in existing_sub_ids]
 
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(AlertRuleTrigger)):
         if updated_fields:
             trigger.update(**updated_fields)
 
@@ -984,7 +984,7 @@ def trigger_incident_triggers(incident):
     incident_triggers = IncidentTrigger.objects.filter(incident=incident)
     triggers = get_triggers_for_alert_rule(incident.alert_rule)
     actions = deduplicate_trigger_actions(triggers=triggers)
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(AlertRuleTrigger)):
         for trigger in incident_triggers:
             trigger.status = TriggerStatus.RESOLVED.value
             trigger.save()

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -3,7 +3,7 @@ import operator
 from datetime import timedelta
 
 from django.conf import settings
-from django.db import transaction
+from django.db import router, transaction
 from django.utils import timezone
 from rest_framework import serializers
 from snuba_sdk import Column, Condition, Function, Limit, Op
@@ -406,7 +406,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             raise serializers.ValidationError(
                 f"You may not exceed {settings.MAX_QUERY_SUBSCRIPTIONS_PER_ORG} metric alerts per organization"
             )
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(AlertRule)):
             triggers = validated_data.pop("triggers")
             alert_rule = create_alert_rule(
                 user=self.context.get("user", None),
@@ -421,7 +421,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         triggers = validated_data.pop("triggers")
         if "id" in validated_data:
             validated_data.pop("id")
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(AlertRule)):
             alert_rule = update_alert_rule(
                 instance,
                 user=self.context.get("user", None),

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Sequence, Tuple, TypeVar, cast
 
 from django.conf import settings
-from django.db import transaction
+from django.db import router, transaction
 from snuba_sdk import Column, Condition, Limit, Op
 
 from sentry import features
@@ -484,7 +484,7 @@ class SubscriptionProcessor:
             AlertRuleThresholdType(self.alert_rule.threshold_type)
         ]
         fired_incident_triggers = []
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(AlertRule)):
             for trigger in self.triggers:
                 if alert_operator(
                     aggregation_value, trigger.alert_threshold

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -2,7 +2,7 @@ import ipaddress
 import logging
 
 from dateutil.parser import parse as parse_date
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.http import Http404, HttpResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -90,7 +90,7 @@ class PushEventWebhook(Webhook):
                 else:
                     author = authors[author_email]
                 try:
-                    with transaction.atomic():
+                    with transaction.atomic(router.db_for_write(Commit)):
 
                         Commit.objects.create(
                             repository_id=repo.id,

--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.http import Http404, HttpResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -85,7 +85,7 @@ class PushEventWebhook(Webhook):
                 else:
                     author = authors[author_email]
                 try:
-                    with transaction.atomic():
+                    with transaction.atomic(router.db_for_write(Commit)):
 
                         Commit.objects.create(
                             repository_id=repo.id,

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Mapping, Tuple
 
 from dateutil.parser import parse as parse_date
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.http import Http404, HttpResponse
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare
@@ -185,7 +185,7 @@ class PushEventWebhook(Webhook):
             try:
                 if author is not None:
                     author.preload_users()
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(Commit)):
                     Commit.objects.create(
                         repository_id=repo.id,
                         organization_id=organization.id,

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping, Optional, Tuple, TypedDict, cast
 
 import sentry_sdk
 from django.conf import settings
-from django.db import transaction
+from django.db import router, transaction
 
 from sentry import eventstream
 from sentry.constants import LOG_LEVELS_MAP
@@ -180,7 +180,9 @@ def save_issue_from_occurrence(
             "issues.save_issue_from_occurrence.transaction",
             tags={"platform": event.platform or "unknown", "type": occurrence.type.type_id},
             sample_rate=1.0,
-        ) as metric_tags, transaction.atomic():
+        ) as metric_tags, transaction.atomic(
+            router.db_for_write(GroupHash)
+        ):
             group, is_new = _save_grouphash_and_group(
                 project, event, new_grouphash, **cast(Mapping[str, Any], issue_kwargs)
             )

--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List
 import jsonschema
 import requests
 import sentry_sdk
-from django.db import transaction
+from django.db import router, transaction
 
 from sentry.lang.native.sources import APP_STORE_CONNECT_SCHEMA, secret_fields
 from sentry.models import Project
@@ -198,7 +198,7 @@ class AppStoreConnectConfig:
         :raises ValueError: if an ``appStoreConnect`` source already exists but the ID does not
            match
         """
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(Project)):
             all_sources_raw = project.get_option(SYMBOL_SOURCES_PROP_NAME)
             all_sources = json.loads(all_sources_raw) if all_sources_raw else []
             for i, source in enumerate(all_sources):

--- a/src/sentry/mediators/alert_rule_actions/creator.py
+++ b/src/sentry/mediators/alert_rule_actions/creator.py
@@ -1,3 +1,5 @@
+from django.db import router
+
 from sentry.coreapi import APIError
 from sentry.mediators.external_requests.alert_rule_action_requester import (
     AlertRuleActionRequester,
@@ -11,6 +13,7 @@ from sentry.utils.cache import memoize
 
 
 class AlertRuleActionCreator(Mediator):
+    using = router.db_for_write(SentryAppComponent)
     install = Param(SentryAppInstallation)
     fields = Param(object, default=[])  # array of dicts
 

--- a/src/sentry/mediators/external_issues/creator.py
+++ b/src/sentry/mediators/external_issues/creator.py
@@ -1,5 +1,7 @@
 from html import escape
 
+from django.db import router
+
 from sentry.mediators.mediator import Mediator
 from sentry.mediators.param import Param
 from sentry.models import PlatformExternalIssue
@@ -13,6 +15,7 @@ class Creator(Mediator):
     web_url = Param(str)
     project = Param(str)
     identifier = Param(str)
+    using = router.db_for_write(PlatformExternalIssue)
 
     def call(self):
         self._create_external_issue()

--- a/src/sentry/mediators/external_issues/issue_link_creator.py
+++ b/src/sentry/mediators/external_issues/issue_link_creator.py
@@ -1,8 +1,11 @@
+from django.db import router
+
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.external_issues.creator import Creator
 from sentry.mediators.external_requests.issue_link_requester import IssueLinkRequester
 from sentry.mediators.mediator import Mediator
 from sentry.mediators.param import Param
+from sentry.models import PlatformExternalIssue
 from sentry.models.group import Group
 from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation
 from sentry.services.hybrid_cloud.user import RpcUser
@@ -16,6 +19,7 @@ class IssueLinkCreator(Mediator):
     fields = Param(object)
     uri = Param(str)
     user = Param(RpcUser)
+    using = router.db_for_write(PlatformExternalIssue)
 
     def call(self):
         self._verify_action()

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -3,6 +3,7 @@ from typing import TypedDict
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
+from django.db import router
 from requests import RequestException
 from requests.models import Response
 
@@ -34,6 +35,7 @@ class AlertRuleActionRequester(Mediator):
     uri = Param(str)
     fields = Param(list, required=False, default=[])
     http_method = Param(str, required=False, default="POST")
+    using = router.db_for_write(SentryAppInstallation)
 
     def call(self):
         return self._make_request()

--- a/src/sentry/mediators/external_requests/issue_link_requester.py
+++ b/src/sentry/mediators/external_requests/issue_link_requester.py
@@ -5,6 +5,8 @@ from typing import Any
 from urllib.parse import urlparse
 from uuid import uuid4
 
+from django.db import router
+
 from sentry.coreapi import APIError
 from sentry.http import safe_urlread
 from sentry.mediators.external_requests.util import send_and_save_sentry_app_request, validate
@@ -55,6 +57,7 @@ class IssueLinkRequester(Mediator):
     fields = Param(dict)
     user = Param(RpcUser)
     action = Param(str)
+    using = router.db_for_write(Group)
 
     def call(self):
         return self._make_request()

--- a/src/sentry/mediators/external_requests/select_requester.py
+++ b/src/sentry/mediators/external_requests/select_requester.py
@@ -29,6 +29,7 @@ class SelectRequester(Mediator):
     uri = Param(str)
     query = Param(str, required=False)
     dependent_data = Param(str, required=False)
+    using = None
 
     def call(self):
         return self._make_request()

--- a/src/sentry/mediators/plugins/migrator.py
+++ b/src/sentry/mediators/plugins/migrator.py
@@ -1,3 +1,5 @@
+from django.db import router
+
 from sentry.mediators.mediator import Mediator
 from sentry.mediators.param import Param
 from sentry.models import Repository
@@ -10,6 +12,7 @@ from sentry.utils.cache import memoize
 class Migrator(Mediator):
     integration = Param(Integration)
     organization = Param(RpcOrganization)
+    using = router.db_for_write(Integration)
 
     def call(self):
         for project in self.projects:

--- a/src/sentry/mediators/project_rules/creator.py
+++ b/src/sentry/mediators/project_rules/creator.py
@@ -1,3 +1,4 @@
+from django.db import router
 from rest_framework.request import Request
 
 from sentry.mediators.mediator import Mediator
@@ -16,6 +17,7 @@ class Creator(Mediator):
     conditions = Param(list)
     frequency = Param(int)
     request = Param(Request, required=False)
+    using = router.db_for_write(Project)
 
     def call(self):
         self.rule = self._create_rule()

--- a/src/sentry/mediators/project_rules/updater.py
+++ b/src/sentry/mediators/project_rules/updater.py
@@ -1,3 +1,4 @@
+from django.db import router
 from rest_framework.request import Request
 
 from sentry.mediators.mediator import Mediator
@@ -17,6 +18,7 @@ class Updater(Mediator):
     conditions = Param(list, required=False)
     frequency = Param(int, required=False)
     request = Param(Request, required=False)
+    using = router.db_for_write(Project)
 
     def call(self):
         self._update_name()

--- a/src/sentry/mediators/sentry_app_installations/installation_notifier.py
+++ b/src/sentry/mediators/sentry_app_installations/installation_notifier.py
@@ -1,3 +1,5 @@
+from django.db import router
+
 from sentry.api.serializers import AppPlatformEvent, SentryAppInstallationSerializer, serialize
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.mediator import Mediator
@@ -11,6 +13,7 @@ class InstallationNotifier(Mediator):
     install = Param(SentryAppInstallation)
     user = Param(User)
     action = Param(str)
+    using = router.db_for_write(SentryAppInstallation)
 
     def call(self):
         self._verify_action()

--- a/src/sentry/mediators/sentry_app_installations/updater.py
+++ b/src/sentry/mediators/sentry_app_installations/updater.py
@@ -1,3 +1,5 @@
+from django.db import router
+
 from sentry import analytics
 from sentry.constants import SentryAppInstallationStatus
 from sentry.mediators.mediator import Mediator
@@ -9,6 +11,7 @@ from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation
 class Updater(Mediator):
     sentry_app_installation = Param(RpcSentryAppInstallation)
     status = Param(str, required=False)
+    using = router.db_for_write(SentryAppInstallation)
 
     def call(self):
         self._update_status()

--- a/src/sentry/mediators/token_exchange/grant_exchanger.py
+++ b/src/sentry/mediators/token_exchange/grant_exchanger.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytz
+from django.db import router
 
 from sentry import analytics
 from sentry.coreapi import APIUnauthorized
@@ -23,6 +24,7 @@ class GrantExchanger(Mediator):
     code = Param(str)
     client_id = Param(str)
     user = Param(User)
+    using = router.db_for_write(User)
 
     def call(self):
         self._validate()

--- a/src/sentry/mediators/token_exchange/refresher.py
+++ b/src/sentry/mediators/token_exchange/refresher.py
@@ -1,3 +1,5 @@
+from django.db import router
+
 from sentry import analytics
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.mediator import Mediator
@@ -19,6 +21,7 @@ class Refresher(Mediator):
     refresh_token = Param(str)
     client_id = Param(str)
     user = Param(User)
+    using = router.db_for_write(User)
 
     def call(self):
         self._validate()

--- a/src/sentry/mediators/token_exchange/validator.py
+++ b/src/sentry/mediators/token_exchange/validator.py
@@ -1,3 +1,5 @@
+from django.db import router
+
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.mediator import Mediator
 from sentry.mediators.param import Param
@@ -14,6 +16,7 @@ class Validator(Mediator):
     install = Param(RpcSentryAppInstallation)
     client_id = Param(str)
     user = Param(User)
+    using = router.db_for_write(User)
 
     def call(self):
         self._validate_is_sentry_app_making_request()

--- a/src/sentry/migrations/0349_issue_alert_fallback.py
+++ b/src/sentry/migrations/0349_issue_alert_fallback.py
@@ -40,7 +40,7 @@ def set_issue_alert_fallback(rule, fallthrough_choice):
 
 
 def migrate_project_ownership_to_issue_alert_fallback(project, ProjectOwnership, Rule):
-    with transaction.atomic():
+    with transaction.atomic("default"):
         # Determine whether this project has a fallback setting.
         fallthrough_choice = None
         try:

--- a/src/sentry/migrations/0403_backfill_actors.py
+++ b/src/sentry/migrations/0403_backfill_actors.py
@@ -16,7 +16,7 @@ def backfill_actors(apps, schema_editor):
     def get_actor_id_for_user(user):
         if user.actor_id:
             return user.actor_id
-        with transaction.atomic():
+        with transaction.atomic("default"):
             actors_for_user = Actor.objects.filter(type=1, user_id=user.id).all()
             if len(actors_for_user) > 0:
                 actor = actors_for_user[0]

--- a/src/sentry/migrations/0415_backfill_actor_team_and_user.py
+++ b/src/sentry/migrations/0415_backfill_actor_team_and_user.py
@@ -14,7 +14,7 @@ def backfill_actors(apps, schema_editor):
     def get_actor_id_for_user(user):
         if user.actor_id:
             return user.actor_id
-        with transaction.atomic():
+        with transaction.atomic("default"):
             actors_for_user = Actor.objects.filter(type=1, user_id=user.id).all()
             if len(actors_for_user) > 0:
                 actor = actors_for_user[0]

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, List, Optional, Sequence, Type, Union, cast
 
 import sentry_sdk
 from django.conf import settings
-from django.db import IntegrityError, models, transaction
+from django.db import IntegrityError, models, router, transaction
 from django.db.models.signals import post_save
 from rest_framework import serializers
 
@@ -122,7 +122,7 @@ def get_actor_for_user(user: Union[int, "User", RpcUser]) -> "Actor":
     else:
         user_id = user.id
     try:
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(Actor)):
             actor, _ = Actor.objects.get_or_create(type=ACTOR_TYPES["user"], user_id=user_id)
     except IntegrityError as err:
         # Likely a race condition. Long term these need to be eliminated.

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 import petname
-from django.db import models, transaction
+from django.db import models, router, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -75,7 +75,7 @@ class ApiApplication(Model):
 
         # There is no foreign key relationship so we have to manually cascade.
         NotificationSetting.objects.remove_for_project(self)
-        with outbox_context(transaction.atomic(), flush=False):
+        with outbox_context(transaction.atomic(router.db_for_write(ApiApplication)), flush=False):
             for outbox in self.outboxes_for_update():
                 outbox.save()
             return super().delete(**kwargs)

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 from uuid import uuid4
 
-from django.db import models, transaction
+from django.db import models, router, transaction
 from django.utils import timezone
 from django.utils.encoding import force_str
 
@@ -52,7 +52,7 @@ class ApiToken(Model, HasApiScopes):
 
     @classmethod
     def from_grant(cls, grant):
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(cls)):
             return cls.objects.create(
                 application=grant.application, user=grant.user, scope_list=grant.get_scopes()
             )

--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -1,7 +1,7 @@
 import re
 from urllib.parse import unquote
 
-from django.db import IntegrityError, models, transaction
+from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
 from sentry.constants import ENVIRONMENT_NAME_MAX_LENGTH, ENVIRONMENT_NAME_PATTERN
@@ -106,7 +106,7 @@ class Environment(Model):
 
         if cache.get(cache_key) is None:
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(EnvironmentProject)):
                     EnvironmentProject.objects.create(
                         project=project, environment=self, is_hidden=is_hidden
                     )

--- a/src/sentry/models/featureadoption.py
+++ b/src/sentry/models/featureadoption.py
@@ -2,7 +2,7 @@ import logging
 from typing import cast
 
 from django.conf import settings
-from django.db import IntegrityError, models, transaction
+from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
 from sentry.adoption import manager
@@ -205,7 +205,7 @@ class FeatureAdoptionManager(BaseManager):
             )
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(FeatureAdoption)):
                 self.bulk_create(features)
         except IntegrityError:
             # This can occur if redis somehow loses the set of complete features and

--- a/src/sentry/models/grouprelease.py
+++ b/src/sentry/models/grouprelease.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.db import IntegrityError, models, transaction
+from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
 from sentry.db.models import (
@@ -51,7 +51,7 @@ class GroupRelease(Model):
         instance = cache.get(cache_key)
         if instance is None:
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(cls)):
                     instance, created = (
                         cls.objects.create(
                             release_id=release.id,

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Iterable, Optional, Sequence, Union
 
 from django.conf import settings
-from django.db import IntegrityError, models, transaction
+from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
 from sentry.db.models import (
@@ -39,7 +39,7 @@ class GroupSubscriptionManager(BaseManager):
         unsubscribed.
         """
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(GroupSubscription)):
                 self.create(
                     user_id=user.id,
                     group=group,
@@ -104,7 +104,7 @@ class GroupSubscriptionManager(BaseManager):
             ]
 
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(GroupSubscription)):
                     self.bulk_create(subscriptions)
                     return True
             except IntegrityError as e:

--- a/src/sentry/models/integrations/organization_integration.py
+++ b/src/sentry/models/integrations/organization_integration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List
 
-from django.db import models, transaction
+from django.db import models, router, transaction
 
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
@@ -50,7 +50,9 @@ class OrganizationIntegration(DefaultFieldsModel):
         ]
 
     def delete(self, *args, **kwds):
-        with outbox_context(transaction.atomic(), flush=False):
+        with outbox_context(
+            transaction.atomic(router.db_for_write(OrganizationIntegration)), flush=False
+        ):
             for outbox in self.outboxes_for_update():
                 outbox.save()
             super().delete(*args, **kwds)

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -4,7 +4,7 @@ import uuid
 from itertools import chain
 from typing import TYPE_CHECKING, Any, List
 
-from django.db import models, transaction
+from django.db import models, router, transaction
 from django.db.models import OuterRef, QuerySet, Subquery
 from django.utils import timezone
 
@@ -170,7 +170,9 @@ class SentryAppInstallation(ParanoidModel):
         return super().save(*args, **kwargs)
 
     def delete(self, **kwargs):
-        with outbox_context(transaction.atomic(), flush=False):
+        with outbox_context(
+            transaction.atomic(router.db_for_write(SentryAppInstallation)), flush=False
+        ):
             for outbox in self.outboxes_for_update():
                 outbox.save()
             return super().delete(**kwargs)

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -263,7 +263,7 @@ class Organization(Model, OptionMixin, OrganizationAbsoluteUrlMixin, SnowflakeId
     #  properly to the control silo.
     @override
     def update(self, *args, **kwargs):
-        with outbox_context(transaction.atomic()):
+        with outbox_context(transaction.atomic(router.db_for_write(Organization))):
             results = super().update(*args, **kwargs)
             Organization.outbox_for_update(self.id).save()
             return results
@@ -281,7 +281,7 @@ class Organization(Model, OptionMixin, OrganizationAbsoluteUrlMixin, SnowflakeId
         # There is no foreign key relationship so we have to manually cascade.
         NotificationSetting.objects.remove_for_organization(self)
 
-        with outbox_context(transaction.atomic(), flush=False):
+        with outbox_context(transaction.atomic(router.db_for_write(Organization)), flush=False):
             Organization.outbox_for_update(self.id).save()
             return super().delete(**kwargs)
 

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from django.conf import settings
 from django.core.cache import cache
-from django.db import IntegrityError, models, transaction
+from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
 from sentry.db.models import (
@@ -63,7 +63,7 @@ class OrganizationOnboardingTaskManager(BaseManager):
         cache_key = f"organizationonboardingtask:{organization_id}:{task}"
         if cache.get(cache_key) is None:
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(OrganizationOnboardingTask)):
                     self.create(organization_id=organization_id, task=task, **kwargs)
                     return True
             except IntegrityError:

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -9,7 +9,7 @@ from uuid import uuid1
 
 import sentry_sdk
 from django.conf import settings
-from django.db import IntegrityError, models, transaction
+from django.db import IntegrityError, models, router, transaction
 from django.db.models import QuerySet
 from django.db.models.signals import pre_delete
 from django.utils import timezone
@@ -341,7 +341,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
         self.organization = organization
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(Project)):
                 self.update(organization=organization)
         except IntegrityError:
             slugify_instance(self, self.name, organization=organization, max_length=50)
@@ -451,7 +451,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
         from sentry.models.projectteam import ProjectTeam
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(ProjectTeam)):
                 ProjectTeam.objects.create(project=self, team=team)
         except IntegrityError:
             return False
@@ -499,7 +499,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
 
         project = Project.objects.get(id=project_id)
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(Project)):
                 for model in model_list:
                     # remove all previous project settings
                     model.objects.filter(project_id=self.id).delete()
@@ -546,7 +546,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
 
         # There is no foreign key relationship so we have to manually cascade.
         NotificationSetting.objects.remove_for_project(self)
-        with outbox_context(transaction.atomic()):
+        with outbox_context(transaction.atomic(router.db_for_write(Project))):
             Project.outbox_for_update(self.id, self.organization_id).save()
             return super().delete(**kwargs)
 

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -237,7 +237,7 @@ class Team(Model, SnowflakeIdMixin):
         from sentry.models.projectteam import ProjectTeam
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(Team)):
                 self.update(organization=organization)
         except IntegrityError:
             # likely this means a team already exists, let's try to coerce to
@@ -278,7 +278,7 @@ class Team(Model, SnowflakeIdMixin):
                 continue
 
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
                     OrganizationMemberTeam.objects.create(
                         team=new_team, organizationmember=new_member
                     )
@@ -295,7 +295,7 @@ class Team(Model, SnowflakeIdMixin):
             # we use a cursor here to avoid automatic cascading of relations
             # in Django
             try:
-                with outbox_context(transaction.atomic(), flush=False):
+                with outbox_context(transaction.atomic(router.db_for_write(Team)), flush=False):
                     cursor.execute("DELETE FROM sentry_team WHERE id = %s", [self.id])
                     self.outbox_for_update().save()
                     cursor.execute("DELETE FROM sentry_actor WHERE team_id = %s", [new_team.id])
@@ -303,7 +303,7 @@ class Team(Model, SnowflakeIdMixin):
                 cursor.close()
 
             # Change whatever new_team's actor is to the one from the old team.
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(Team)):
                 Actor.objects.filter(id=self.actor_id).update(team_id=new_team.id)
                 new_team.actor_id = self.actor_id
                 new_team.save()
@@ -334,7 +334,7 @@ class Team(Model, SnowflakeIdMixin):
         from sentry.models import ExternalActor
 
         # There is no foreign key relationship so we have to manually delete the ExternalActors
-        with outbox_context(transaction.atomic()):
+        with outbox_context(transaction.atomic(router.db_for_write(ExternalActor))):
             ExternalActor.objects.filter(actor_id=self.actor_id).delete()
             self.outbox_for_update().save()
 

--- a/src/sentry/models/tombstone.py
+++ b/src/sentry/models/tombstone.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Type
 
-from django.db import IntegrityError, models, transaction
+from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
 from sentry.db.models import (
@@ -45,7 +45,7 @@ class TombstoneBase(Model):
     @classmethod
     def record_delete(cls, table_name: str, identifier: int):
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(cls)):
                 cls.objects.create(table_name=table_name, object_identifier=identifier)
         except IntegrityError:
             pass

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -10,7 +10,7 @@ from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import Commit, Message, Partition
 from django.conf import settings
-from django.db import transaction
+from django.db import router, transaction
 from django.utils.text import slugify
 
 from sentry import ratelimits
@@ -221,7 +221,7 @@ def _process_message(wrapper: Dict) -> None:
         return
 
     try:
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(Monitor)):
             monitor_config = params.pop("monitor_config", None)
 
             params["duration"] = (

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.db import transaction
+from django.db import router, transaction
 from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
@@ -115,7 +115,7 @@ class MonitorIngestCheckInDetailsEndpoint(MonitorIngestEndpoint):
             checkin.monitor_environment = monitor_environment
             checkin.save()
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(MonitorEnvironment)):
             checkin.update(**params)
 
             if checkin.status == CheckInStatus.ERROR:

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from django.db import transaction
+from django.db import router, transaction
 from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import Throttled
@@ -146,7 +146,7 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
                 detail="Rate limited, please send no more than 5 checkins per minute per monitor"
             )
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(Monitor)):
             monitor_data = result.get("monitor")
             create_monitor = monitor_data and not monitor
             update_monitor = monitor_data and monitor

--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.db import transaction
+from django.db import router, transaction
 from django.utils.crypto import get_random_string
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
@@ -162,7 +162,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
         Delete a monitor or monitor environments.
         """
         environment_names = request.query_params.getlist("environment")
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(MonitorEnvironment)):
             if environment_names:
                 monitor_objects = (
                     MonitorEnvironment.objects.filter(

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -97,6 +97,7 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
         team_id: Optional[int] = None,
     ) -> None:
         """Save a NotificationSettings row."""
+        from sentry.models.notificationsetting import NotificationSetting
 
         defaults = {"value": value.value}
         with configure_scope() as scope:

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -13,7 +13,7 @@ from typing import (
     Union,
 )
 
-from django.db import transaction
+from django.db import router, transaction
 from django.db.models import Q, QuerySet
 
 from sentry import analytics
@@ -100,7 +100,7 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
 
         defaults = {"value": value.value}
         with configure_scope() as scope:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(NotificationSetting)):
                 setting, created = self.get_or_create(
                     provider=provider.value,
                     type=type.value,

--- a/src/sentry/onboarding_tasks/backends/organization_onboarding_task.py
+++ b/src/sentry/onboarding_tasks/backends/organization_onboarding_task.py
@@ -1,4 +1,4 @@
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from django.utils import timezone
 
@@ -35,7 +35,7 @@ class OrganizationOnboardingTaskBackend(OnboardingTaskBackend):
         )
         if completed >= OrganizationOnboardingTask.REQUIRED_ONBOARDING_TASKS:
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(OrganizationOption)):
                     OrganizationOption.objects.create(
                         organization_id=organization_id,
                         key="onboarding:complete",

--- a/src/sentry/plugins/interfaces/releasehook.py
+++ b/src/sentry/plugins/interfaces/releasehook.py
@@ -1,6 +1,6 @@
 __all__ = ["ReleaseHook"]
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -19,7 +19,7 @@ class ReleaseHook:
             raise HookValidationError("Invalid release version: %s" % version)
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(Release)):
                 release = Release.objects.create(
                     version=version, organization_id=self.project.organization_id, **values
                 )
@@ -45,7 +45,7 @@ class ReleaseHook:
 
         project = self.project
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(Release)):
                 release = Release.objects.create(
                     organization_id=project.organization_id, version=version
                 )
@@ -64,7 +64,7 @@ class ReleaseHook:
 
         values.setdefault("date_released", timezone.now())
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(Release)):
                 release = Release.objects.create(
                     version=version, organization_id=self.project.organization_id, **values
                 )

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, MutableMapping
 
 from dateutil.parser import parse as parse_date
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.utils import timezone
 from rest_framework.exceptions import APIException
 from rest_framework.request import Request
@@ -112,7 +112,7 @@ class IntegrationRepositoryProvider:
             repo.save()
         else:
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(Repository)):
                     repo = Repository.objects.create(
                         organization_id=organization.id, name=result["name"], **repo_update_params
                     )

--- a/src/sentry/plugins/providers/repository.py
+++ b/src/sentry/plugins/providers/repository.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.urls import reverse
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -66,7 +66,7 @@ class RepositoryProvider(ProviderMixin):
             return Response({"errors": {"__all__": str(e)}}, status=400)
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(Repository)):
                 repo = Repository.objects.create(
                     organization_id=organization.id,
                     name=result["name"],

--- a/src/sentry/receivers/email.py
+++ b/src/sentry/receivers/email.py
@@ -1,4 +1,4 @@
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models.signals import post_delete, post_save
 
 from sentry.models import Email, UserEmail
@@ -7,7 +7,7 @@ from sentry.models import Email, UserEmail
 def create_email(instance, created, **kwargs):
     if created:
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(Email)):
                 Email.objects.create(email=instance.email)
         except IntegrityError:
             pass

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -89,6 +89,7 @@ from typing import Any, Dict, List, Literal, Sequence, Tuple, Union
 import redis
 import sentry_sdk
 from django.conf import settings
+from django.db import router
 
 from sentry import eventstore, models, nodestore, options
 from sentry.attachments import CachedAttachment, attachment_cache
@@ -593,7 +594,7 @@ def start_group_reprocessing(
 ):
     from django.db import transaction
 
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(models.Group)):
         group = models.Group.objects.get(id=group_id)
         original_status = group.status
         original_substatus = group.substatus

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -12,7 +12,7 @@ from django.apps import apps
 from django.core import management, serializers
 from django.core.serializers import serialize
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db import IntegrityError, connection, router, transaction
+from django.db import IntegrityError, connection, transaction
 
 from sentry.runner.decorators import configuration
 from sentry.utils.json import JSONData, JSONEncoder, better_default_encoder
@@ -227,22 +227,23 @@ def validate(
 def import_(src):
     """CLI command wrapping the `exec_import` functionality."""
 
-    for obj in serializers.deserialize("json", src, stream=True, use_natural_keys=True):
-        try:
-            with transaction.atomic(router.db_for_write(type(obj))):
+    try:
+        # Import / export only works in monolith mode with a consolidated db.
+        with transaction.atomic("default"):
+            for obj in serializers.deserialize("json", src, stream=True, use_natural_keys=True):
                 if obj.object._meta.app_label not in EXCLUDED_APPS:
                     obj.save()
-        # For all database integrity errors, let's warn users to follow our
-        # recommended backup/restore workflow before reraising exception. Most of
-        # these errors come from restoring on a different version of Sentry or not restoring
-        # on a clean install.
-        except IntegrityError as e:
-            warningText = ">> Are you restoring from a backup of the same version of Sentry?\n>> Are you restoring onto a clean database?\n>> If so then this IntegrityError might be our fault, you can open an issue here:\n>> https://github.com/getsentry/sentry/issues/new/choose"
-            click.echo(
-                warningText,
-                err=True,
-            )
-            raise (e)
+    # For all database integrity errors, let's warn users to follow our
+    # recommended backup/restore workflow before reraising exception. Most of
+    # these errors come from restoring on a different version of Sentry or not restoring
+    # on a clean install.
+    except IntegrityError as e:
+        warningText = ">> Are you restoring from a backup of the same version of Sentry?\n>> Are you restoring onto a clean database?\n>> If so then this IntegrityError might be our fault, you can open an issue here:\n>> https://github.com/getsentry/sentry/issues/new/choose"
+        click.echo(
+            warningText,
+            err=True,
+        )
+        raise (e)
 
     sequence_reset_sql = StringIO()
 

--- a/src/sentry/runner/commands/permissions.py
+++ b/src/sentry/runner/commands/permissions.py
@@ -1,4 +1,5 @@
 import click
+from django.db import router
 
 from sentry.runner.decorators import configuration
 
@@ -35,7 +36,7 @@ def add(user, permission):
     user = user_param_to_user(user)
 
     try:
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(UserPermission)):
             UserPermission.objects.create(user=user, permission=permission)
     except IntegrityError:
         click.echo(f"Permission already exists for `{user.username}`")

--- a/src/sentry/runner/commands/repair.py
+++ b/src/sentry/runner/commands/repair.py
@@ -17,7 +17,7 @@ class RollbackLocally(Exception):
 @contextmanager
 def catchable_atomic():
     try:
-        with transaction.atomic():
+        with transaction.atomic("default"):
             yield
     except RollbackLocally:
         pass

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Union
 
 import sentry_sdk
 from django.conf import settings
-from django.db import transaction
+from django.db import router, transaction
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema, extend_schema_field, inline_serializer
 from rest_framework import serializers
@@ -167,7 +167,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         audit_data = member.get_audit_log_data()
         if member.is_only_owner():
             raise PermissionDenied(detail=ERR_ONLY_OWNER)
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(OrganizationMember)):
             member.delete()
             self.create_audit_entry(
                 request=request,
@@ -505,7 +505,7 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
                 raise SCIMApiError(detail=json.dumps(serializer.errors))
 
             result = serializer.validated_data
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(OrganizationMember)):
                 member_query = OrganizationMember.objects.filter(
                     organization=organization, email=result["email"], role=result["role"]
                 )

--- a/src/sentry/sentry_apps/components.py
+++ b/src/sentry/sentry_apps/components.py
@@ -4,7 +4,6 @@ import dataclasses
 from typing import Any, List, Mapping, MutableMapping
 from urllib.parse import urlparse, urlunparse
 
-from django.db import transaction
 from django.utils.encoding import force_str
 from django.utils.http import urlencode
 
@@ -22,13 +21,12 @@ class SentryAppComponentPreparer:
     values: List[Mapping[str, Any]] = dataclasses.field(default_factory=list)
 
     def run(self) -> None:
-        with transaction.atomic():
-            if self.component.type == "issue-link":
-                self._prepare_issue_link()
-            elif self.component.type == "stacktrace-link":
-                self._prepare_stacktrace_link()
-            elif self.component.type == "alert-rule-action":
-                self._prepare_alert_rule_action()
+        if self.component.type == "issue-link":
+            self._prepare_issue_link()
+        elif self.component.type == "stacktrace-link":
+            self._prepare_stacktrace_link()
+        elif self.component.type == "alert-rule-action":
+            self._prepare_alert_rule_action()
 
     def _prepare_stacktrace_link(self) -> None:
         schema = self.component.schema

--- a/src/sentry/sentry_apps/installations.py
+++ b/src/sentry/sentry_apps/installations.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 from functools import cached_property
 
-from django.db import transaction
+from django.db import router, transaction
 from rest_framework.request import Request
 
 from sentry import analytics, audit_log
@@ -30,7 +30,7 @@ class SentryAppInstallationTokenCreator:
     generate_audit: bool = False
 
     def run(self, user: User, request: Request | None = None) -> ApiToken:
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(ApiToken)):
             self._check_token_limit()
             api_token = self._create_api_token()
             self._create_sentry_app_installation_token(api_token=api_token)
@@ -102,7 +102,7 @@ class SentryAppInstallationCreator:
     notify: bool = True
 
     def run(self, *, user: User, request: Request | None) -> SentryAppInstallation:
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(ApiGrant)):
             api_grant = self._create_api_grant()
             install = self._create_install(api_grant=api_grant)
             self.audit(request=request)

--- a/src/sentry/services/hybrid_cloud/hook/impl.py
+++ b/src/sentry/services/hybrid_cloud/hook/impl.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from django.db import transaction
+from django.db import router, transaction
 
 from sentry import deletions
 from sentry.models import ServiceHook
@@ -19,8 +19,8 @@ class DatabaseBackedHookService(HookService):
         webhook_url: Optional[str] = None,
         events: List[str],
     ) -> List[RpcServiceHook]:
-        hooks = ServiceHook.objects.filter(application_id=application_id)
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(ServiceHook)):
+            hooks = ServiceHook.objects.filter(application_id=application_id)
             if webhook_url:
                 for hook in hooks:
                     hook.url = webhook_url
@@ -43,7 +43,7 @@ class DatabaseBackedHookService(HookService):
         url: str = "",
     ) -> RpcServiceHook:
         # nullable for sentry apps
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(ServiceHook)):
             project_id: Optional[int] = project_ids[0] if project_ids else None
 
             hook = ServiceHook.objects.create(

--- a/src/sentry/services/hybrid_cloud/notifications/impl.py
+++ b/src/sentry/services/hybrid_cloud/notifications/impl.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Callable, List, Mapping, Optional, Sequence
 
-from django.db import transaction
+from django.db import router, transaction
 from django.db.models import Q, QuerySet
 
 from sentry.api.serializers.base import Serializer
@@ -70,7 +70,7 @@ class DatabaseBackedNotificationsService(NotificationsService):
         external_provider: ExternalProviders,
         user_id: int,
     ) -> None:
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(NotificationSetting)):
             for notification_type, setting_option in notification_type_to_value_map.items():
                 self.update_settings(
                     external_provider=external_provider,

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -228,7 +228,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         organization_id: int,
         user_id: int,
     ) -> Optional[RpcOrganizationMember]:
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(OrganizationMember)):
             try:
                 org_member = OrganizationMember.objects.get(
                     user_id=user_id, organization_id=organization_id
@@ -290,7 +290,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
             else:
                 raise TypeError(f"Invalid value received for update_flags: {name}={value!r}")
 
-        with outbox_context(transaction.atomic()):
+        with outbox_context(transaction.atomic(router.db_for_write(Organization))):
             Organization.objects.filter(id=organization_id).update(flags=updates)
             Organization.outbox_for_update(org_id=organization_id).save()
 
@@ -322,7 +322,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         if invite_status is None:
             invite_status = InviteStatus.APPROVED.value
 
-        with outbox_context(transaction.atomic()):
+        with outbox_context(transaction.atomic(router.db_for_write(OrganizationMember))):
             org_member: Optional[OrganizationMember] = None
             if user_id is not None:
                 org_member = OrganizationMember.objects.filter(
@@ -406,7 +406,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         return serialize_rpc_organization(org)
 
     def remove_user(self, *, organization_id: int, user_id: int) -> Optional[RpcOrganizationMember]:
-        with outbox_context(transaction.atomic()):
+        with outbox_context(transaction.atomic(router.db_for_write(OrganizationMember))):
             try:
                 org_member = OrganizationMember.objects.get(
                     organization_id=organization_id, user_id=user_id
@@ -451,7 +451,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
 
         for team in from_member.teams.all():
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
                     OrganizationMemberTeam.objects.create(organizationmember=to_member, team=team)
             except IntegrityError:
                 pass
@@ -470,7 +470,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
                 user_id=from_user_id, project__organization_id=organization_id
             ):
                 try:
-                    with transaction.atomic():
+                    with transaction.atomic(router.db_for_write(model)):
                         obj.update(user_id=to_user_id)
                 except IntegrityError:
                     pass

--- a/src/sentry/tasks/deletion/scheduled.py
+++ b/src/sentry/tasks/deletion/scheduled.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Iterable, Tuple, Type
 
 import sentry_sdk
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import transaction
+from django.db import router, transaction
 from django.utils import timezone
 
 from sentry.exceptions import DeleteAborted
@@ -57,7 +57,7 @@ def run_scheduled_deletions():
             in_progress=False, date_scheduled__lte=timezone.now()
         )
         for item in queryset:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(deletion_orm)):
                 affected = deletion_orm.objects.filter(
                     id=item.id,
                     in_progress=False,

--- a/src/sentry/tasks/integrations/migrate_issues.py
+++ b/src/sentry/tasks/integrations/migrate_issues.py
@@ -1,4 +1,4 @@
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 
 from sentry.models import (
     ExternalIssue,
@@ -49,7 +49,7 @@ def migrate_issues(integration_id: int, organization_id: int) -> None:
                 key=plugin_issue.value,
             )
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(GroupLink)):
                     GroupLink.objects.create(
                         group_id=plugin_issue.group_id,
                         project_id=project.id,

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -152,7 +152,7 @@ def merge_groups(
 
             previous_group_id = group.id
 
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(GroupRedirect)):
                 GroupRedirect.create_for_group(group, new_group)
                 group.delete()
             delete_logger.info(

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -2,7 +2,7 @@ import time
 
 import sentry_sdk
 from django.conf import settings
-from django.db import transaction
+from django.db import router, transaction
 
 from sentry import eventstore, eventstream, nodestore
 from sentry.eventstore.models import Event
@@ -225,7 +225,7 @@ def handle_remaining_events(
 def finish_reprocessing(project_id, group_id):
     from sentry.models import Activity, Group, GroupRedirect
 
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(Group)):
         group = Group.objects.get(id=group_id)
 
         # While we migrated all associated models at the beginning of

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from functools import reduce
 from typing import Any, Mapping, Optional, Tuple
 
-from django.db import transaction
+from django.db import router, transaction
 
 from sentry import eventstore, similarity, tsdb
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS_MAP
@@ -438,7 +438,7 @@ def repair_denormalizations(caches, project, events):
 
 
 def lock_hashes(project_id, source_id, fingerprints):
-    with transaction.atomic():
+    with transaction.atomic(router.db_for_write(GroupHash)):
         eligible_hashes = list(
             GroupHash.objects.filter(
                 project_id=project_id, group_id=source_id, hash__in=fingerprints

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -15,7 +15,7 @@ import petname
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.files.base import ContentFile
-from django.db import transaction
+from django.db import router, transaction
 from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.text import slugify
@@ -371,7 +371,7 @@ class Factories:
         if not organization and teams:
             organization = teams[0].organization
 
-        with transaction.atomic():
+        with transaction.atomic(router.db_for_write(Project)):
             project = Project.objects.create(organization=organization, **kwargs)
             if teams:
                 for team in teams:

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -22,7 +22,7 @@ def safe_execute(func, *args, **kwargs):
     try:
         if _with_transaction:
             with sentry_sdk.start_span(op="db.safe_execute", description="transaction.atomic"):
-                with transaction.atomic(), django_test_transaction_water_mark():
+                with transaction.atomic("default"), django_test_transaction_water_mark():
                     result = func(*args, **kwargs)
         else:
             result = func(*args, **kwargs)

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -4,7 +4,7 @@ from functools import partial, update_wrapper
 from django.contrib import messages
 from django.contrib.auth import authenticate
 from django.contrib.auth import login as login_user
-from django.db import transaction
+from django.db import router, transaction
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.template.context_processors import csrf
 from django.urls import reverse
@@ -13,7 +13,7 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_http_methods
 
-from sentry.models import LostPasswordHash, NotificationSetting, Project, UserEmail
+from sentry.models import LostPasswordHash, NotificationSetting, Project, User, UserEmail
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.security import capture_security_activity
 from sentry.services.hybrid_cloud.lost_password_hash import lost_password_hash_service
@@ -109,7 +109,7 @@ def recover_confirm(request, user_id, hash, mode="recover"):
     if request.method == "POST":
         form = ChangePasswordRecoverForm(request.POST)
         if form.is_valid():
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(User)):
                 user.set_password(form.cleaned_data["password"])
                 user.refresh_session_nonce(request)
                 user.save()

--- a/src/sentry/web/frontend/oauth_authorize.py
+++ b/src/sentry/web/frontend/oauth_authorize.py
@@ -2,7 +2,7 @@ import logging
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from django.conf import settings
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
 from django.utils.safestring import mark_safe
@@ -270,7 +270,7 @@ class OAuthAuthorizeView(AuthLoginView):
 
     def approve(self, request: HttpRequest, application, **params):
         try:
-            with transaction.atomic():
+            with transaction.atomic(router.db_for_write(ApiAuthorization)):
                 ApiAuthorization.objects.create(
                     application=application, user_id=request.user.id, scope_list=params["scopes"]
                 )

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -2,7 +2,7 @@ import ipaddress
 import logging
 
 from dateutil.parser import parse as parse_date
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.http import Http404, HttpResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -62,7 +62,7 @@ class PushEventWebhook(Webhook):
                 else:
                     author = authors[author_email]
                 try:
-                    with transaction.atomic():
+                    with transaction.atomic(router.db_for_write(Commit)):
 
                         Commit.objects.create(
                             repository_id=repo.id,

--- a/src/sentry_plugins/github/webhooks/events/installation.py
+++ b/src/sentry_plugins/github/webhooks/events/installation.py
@@ -1,4 +1,4 @@
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 
 from sentry.models import Integration
 
@@ -13,7 +13,7 @@ class InstallationEventWebhook(Webhook):
         # TODO(jess): handle uninstalls
         if action == "created":
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(Integration)):
                     Integration.objects.create(
                         provider="github_apps",
                         external_id=installation["id"],

--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -1,7 +1,7 @@
 import logging
 
 from dateutil.parser import parse as parse_date
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.http import Http404
 from django.utils import timezone
 
@@ -90,7 +90,9 @@ class PushEventWebhook(Webhook):
                                     gh_username_cache[gh_username] = author_email
                                     if commit_author is not None:
                                         try:
-                                            with transaction.atomic():
+                                            with transaction.atomic(
+                                                router.db_for_write(CommitAuthor)
+                                            ):
                                                 commit_author.update(
                                                     email=author_email, external_id=external_id
                                                 )
@@ -124,7 +126,7 @@ class PushEventWebhook(Webhook):
 
                 if update_kwargs:
                     try:
-                        with transaction.atomic():
+                        with transaction.atomic(router.db_for_write(CommitAuthor)):
                             author.update(**update_kwargs)
                     except IntegrityError:
                         pass
@@ -132,7 +134,7 @@ class PushEventWebhook(Webhook):
                 author = authors[author_email]
 
             try:
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(Commit)):
                     c = Commit.objects.create(
                         repository_id=repo.id,
                         organization_id=organization_id,

--- a/tests/sentry/db/test_transactions.py
+++ b/tests/sentry/db/test_transactions.py
@@ -17,15 +17,15 @@ class CaseMixin:
             in_test_assert_no_transaction("Not, in transaction, should not fail")
 
             with pytest.raises(AssertionError):
-                with transaction.atomic():
+                with transaction.atomic("default"):
                     in_test_assert_no_transaction("In transaction, should assert")
 
-            with transaction.atomic():
+            with transaction.atomic("default"):
                 with in_test_hide_transaction_boundary():
                     in_test_assert_no_transaction("Guarded, should not assert")
 
         do_assertions()
-        with transaction.atomic(), django_test_transaction_water_mark():
+        with transaction.atomic("default"), django_test_transaction_water_mark():
             do_assertions()
 
     def test_transaction_on_commit(self):
@@ -33,10 +33,10 @@ class CaseMixin:
             calls = []
             transaction.on_commit(lambda: calls.append("a"))
 
-            with transaction.atomic():
-                with transaction.atomic():
+            with transaction.atomic("default"):
+                with transaction.atomic("default"):
                     with pytest.raises(AssertionError):
-                        with transaction.atomic():
+                        with transaction.atomic("default"):
                             transaction.on_commit(lambda: calls.append("no go"))
                             raise AssertionError("Oh no!")
                     transaction.on_commit(lambda: calls.append("b"))
@@ -46,7 +46,7 @@ class CaseMixin:
             assert calls == ["a", "b", "c"]
 
         do_assertions()
-        with transaction.atomic(), django_test_transaction_water_mark():
+        with transaction.atomic("default"), django_test_transaction_water_mark():
             do_assertions()
 
 

--- a/tests/sentry/discover/test_models.py
+++ b/tests/sentry/discover/test_models.py
@@ -1,5 +1,5 @@
 import pytest
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryProject
 from sentry.models import User
@@ -82,14 +82,20 @@ class DiscoverSavedQueryTest(TestCase):
             created_by_id=self.user.id,
         )
 
-        with pytest.raises(IntegrityError), transaction.atomic():
+        with pytest.raises(IntegrityError), transaction.atomic(
+            router.db_for_write(DiscoverSavedQueryProject)
+        ):
             new_query.update(is_homepage=True)
 
-        with pytest.raises(IntegrityError), transaction.atomic():
+        with pytest.raises(IntegrityError), transaction.atomic(
+            router.db_for_write(DiscoverSavedQueryProject)
+        ):
             new_query.is_homepage = True
             new_query.save()
 
-        with pytest.raises(IntegrityError), transaction.atomic():
+        with pytest.raises(IntegrityError), transaction.atomic(
+            router.db_for_write(DiscoverSavedQueryProject)
+        ):
             DiscoverSavedQuery.objects.filter(id=new_query.id).update(is_homepage=True)
 
     def test_user_can_have_homepage_query_in_multiple_orgs(self):

--- a/tests/sentry/event_manager/test_save_aggregate.py
+++ b/tests/sentry/event_manager/test_save_aggregate.py
@@ -34,7 +34,7 @@ def test_group_creation_race(monkeypatch, default_project, is_race_free):
         class FakeTransactionModule:
             @staticmethod
             @contextlib.contextmanager
-            def atomic():
+            def atomic(*args, **kwds):
                 yield
 
         # Disable transaction isolation just within event manager, but not in

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from django.core.cache import cache
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.utils import timezone
 from freezegun import freeze_time
 
@@ -316,7 +316,7 @@ class IncidentCreationTest(TestCase):
                 # This incident will take the identifier we already fetched and
                 # use it, which will cause the database to throw an integrity
                 # error.
-                with transaction.atomic():
+                with transaction.atomic(router.db_for_write(Incident)):
                     incident = Incident.objects.create(
                         self.organization,
                         status=IncidentStatus.OPEN.value,

--- a/tests/sentry/mediators/test_mediator.py
+++ b/tests/sentry/mediators/test_mediator.py
@@ -3,6 +3,7 @@ import types
 from unittest.mock import PropertyMock, patch
 
 import pytest
+from django.db import router
 
 from sentry.mediators.mediator import Mediator
 from sentry.mediators.param import Param
@@ -21,6 +22,7 @@ class MockMediator(Mediator):
     user = Param(dict)
     name = Param(str, default=lambda self: self.user["name"])
     age = Param(int, required=False)
+    using = router.db_for_write(User)
 
     def call(self):
         with self.log():


### PR DESCRIPTION
In anticipation of enforcing a runtime check that `using=` must be specified for all transaction.atomic and transaction.get_connection calls, we add a value to all sentry callsites.