### PR TITLE
fix(ts): Add types for semver release version info

### DIFF
--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -37,11 +37,24 @@ export type Deploy = {
   version: string;
 };
 
+interface RawVersion {
+  raw: string;
+}
+
+interface SemverVerison extends RawVersion {
+  buildCode: string | null;
+  components: number;
+  major: number | null;
+  minor: number | null;
+  patch: number | null;
+  pre: string | null;
+}
+
 export type VersionInfo = {
   buildHash: string | null;
   description: string;
   package: string | null;
-  version: {raw: string};
+  version: RawVersion | SemverVerison;
 };
 
 export interface BaseRelease {

--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -44,9 +44,9 @@ interface RawVersion {
 interface SemverVerison extends RawVersion {
   buildCode: string | null;
   components: number;
-  major: number | null;
-  minor: number | null;
-  patch: number | null;
+  major: number;
+  minor: number;
+  patch: number;
   pre: string | null;
 }
 


### PR DESCRIPTION
Adds the correct type when the release is using semver.

semver `versionInfo` example https://sentry.sentry.io/api/0/organizations/sentry/releases/io.sentry.mobile.app%401.0.4%2B25/?adoptionStages=1&project=5645511&statsPeriod=14d

