### PR TITLE
feat(hybrid-cloud): Add integration proxy to AWS Lambda client

### DIFF
--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -145,32 +145,39 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         self.log_extra["full_url"] = full_url
         headers = clean_outbound_headers(request.headers)
 
-        prepared_request = Request(
-            method=request.method,
-            url=full_url,
-            headers=headers,
-            data=request.body,
-        ).prepare()
-        # Third-party authentication headers will be added in client.authorize_request which runs
-        # in IntegrationProxyClient.finalize_request.
-        raw_response: Response = self.client._request(
-            request.method,
-            self.proxy_path,
-            allow_text=True,
-            prepared_request=prepared_request,
-            raw_response=True,
-        )
-        response = HttpResponse(
-            content=raw_response.content,
-            status=raw_response.status_code,
-            reason=raw_response.reason,
-            content_type=raw_response.headers.get("Content-Type"),
-            # XXX: Can be added in Django 3.2
-            # headers=raw_response.headers
-        )
-        valid_headers = clean_outbound_headers(raw_response.headers)
-        for header, value in valid_headers.items():
-            response[header] = value
+        if self.client.should_delegate():
+            response: HttpResponse = self.client.delegate(
+                request=request,
+                proxy_path=self.proxy_path,
+                headers=headers,
+            )
+        else:
+            prepared_request = Request(
+                method=request.method,
+                url=full_url,
+                headers=headers,
+                data=request.body,
+            ).prepare()
+            # Third-party authentication headers will be added in client.authorize_request which runs
+            # in IntegrationProxyClient.finalize_request.
+            raw_response: Response = self.client._request(
+                request.method,
+                self.proxy_path,
+                allow_text=True,
+                prepared_request=prepared_request,
+                raw_response=True,
+            )
+            response = HttpResponse(
+                content=raw_response.content,
+                status=raw_response.status_code,
+                reason=raw_response.reason,
+                content_type=raw_response.headers.get("Content-Type"),
+                # XXX: Can be added in Django 3.2
+                # headers=raw_response.headers
+            )
+            valid_headers = clean_outbound_headers(raw_response.headers)
+            for header, value in valid_headers.items():
+                response[header] = value
         metrics.incr("hc.integration_proxy.success")
         logger.info("proxy_success", extra=self.log_extra)
         return response

--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import Dict
+from urllib.parse import urljoin
 
 from django.http import Http404, HttpRequest, HttpResponse
 from requests import Request, Response
@@ -165,7 +166,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         if not self._should_operate(request):
             raise Http404
 
-        full_url = f"{self.client.base_url}/{self.proxy_path}"
+        full_url = urljoin(self.client.base_url, self.proxy_path)
         self.log_extra["full_url"] = full_url
         headers = clean_outbound_headers(request.headers)
 

--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -167,17 +167,14 @@ class InternalIntegrationProxyEndpoint(Endpoint):
                 prepared_request=prepared_request,
                 raw_response=True,
             )
+            clean_headers = clean_outbound_headers(raw_response.headers)
             response = HttpResponse(
                 content=raw_response.content,
                 status=raw_response.status_code,
                 reason=raw_response.reason,
-                content_type=raw_response.headers.get("Content-Type"),
-                # XXX: Can be added in Django 3.2
-                # headers=raw_response.headers
+                headers=clean_headers,
             )
-            valid_headers = clean_outbound_headers(raw_response.headers)
-            for header, value in valid_headers.items():
-                response[header] = value
+
         metrics.incr("hc.integration_proxy.success")
         logger.info("proxy_success", extra=self.log_extra)
         return response

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2598,7 +2598,7 @@ INTERNAL_URLS = [
     ),
     re_path(
         # If modifying, ensure PROXY_BASE_PATH is updated as well
-        r"^integration-proxy/\S+$",
+        r"^integration-proxy/\S*$",
         InternalIntegrationProxyEndpoint.as_view(),
         name="sentry-api-0-internal-integration-proxy",
     ),

--- a/src/sentry/integrations/aws_lambda/client.py
+++ b/src/sentry/integrations/aws_lambda/client.py
@@ -1,6 +1,16 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
 import boto3
+from django.http import HttpResponse, JsonResponse
+from rest_framework import serializers
 
 from sentry import options
+from sentry.services.hybrid_cloud.util import control_silo_function
+from sentry.shared_integrations.client.proxy import IntegrationProxyClient, get_proxy_url
+from sentry.silo.base import SiloMode
 from sentry.utils import json
 
 
@@ -8,6 +18,20 @@ class ConfigurationError(Exception):
     pass
 
 
+logger = logging.getLogger(__name__)
+
+
+class ExceptionSerializer(serializers.Serializer):
+    vars()["class"] = serializers.CharField(required=True)
+
+
+class ProxyResponseSerializer(serializers.Serializer):
+    function_name = serializers.CharField(required=True)
+    return_response = serializers.DictField(required=True)
+    exception = ExceptionSerializer(required=True, allow_null=True)
+
+
+@control_silo_function
 def gen_aws_client(account_number, region, aws_external_id, service_name="lambda"):
     """
     account_number - account number in AWS
@@ -70,3 +94,101 @@ def gen_aws_client(account_number, region, aws_external_id, service_name="lambda
         aws_session_token=credentials["SessionToken"],
     )
     return boto3_session.client(service_name=service_name, region_name=region)
+
+
+class AwsLambdaProxyClient(IntegrationProxyClient):
+    integration_name = "aws_lambda"
+    _client: Any | None = None
+
+    def __init__(
+        self,
+        org_integration_id: int | None,
+        account_number: str,
+        region: str,
+        aws_external_id: str,
+    ) -> None:
+        self.base_url = get_proxy_url()
+        self.account_number = account_number
+        self.region = region
+        self.aws_external_id = aws_external_id
+        super().__init__(org_integration_id=org_integration_id)
+
+    @property
+    def client(self):
+        if self._client:
+            return self._client
+
+        self._client = gen_aws_client(
+            account_number=self.account_number,
+            region=self.region,
+            aws_external_id=self.aws_external_id,
+        )
+        return self._client
+
+    def should_delegate(self) -> bool:
+        return True
+
+    def delegate(self, request, proxy_path: str, headers) -> HttpResponse:
+        payload = request.data
+        function_name = payload["function_name"]
+        args = payload["args"]
+        kwargs = payload["kwargs"]
+        boto3_func = getattr(self.client, function_name)
+        try:
+            result = boto3_func(*args, **kwargs)
+            return JsonResponse(
+                data={
+                    "function_name": function_name,
+                    "return_response": result,
+                    "exception": None,
+                },
+                status=200,
+            )
+        except Exception as err:
+            logger.info("boto3.client.exception", extra={"error": err})
+            return JsonResponse(
+                data={
+                    "function_name": function_name,
+                    "return_response": {},
+                    "exception": {"class": err.__class__.__name__},
+                },
+                status=400,
+            )
+
+    def __getattr__(self, func_name: str):
+        if SiloMode.get_current_mode() != SiloMode.REGION:
+
+            def boto3_func(*args, **kwargs):
+                func = getattr(self.client, func_name)
+                return func(*args, **kwargs)
+
+            return boto3_func
+
+        def boto3_proxy_func(*args, **kwargs):
+            # From the region silo, we create a request payload to the internal integration proxy endpoint.
+            payload = {
+                "args": list(args),
+                "kwargs": kwargs,
+                "function_name": func_name,
+            }
+
+            response = self.post("/", data=payload)
+            proxy_response = ProxyResponseSerializer(data=response)
+            if not proxy_response.is_valid():
+                raise Exception(f"Invalid response from calling: {func_name}")
+            validated_data = proxy_response.validated_data
+
+            function_name = validated_data["function_name"]
+            assert function_name == func_name
+
+            exception = validated_data["exception"]
+            if exception:
+                class_name = exception["class"]
+                lambda_client = self.client
+                exception_cls = getattr(lambda_client.exceptions, class_name)
+                raise exception_cls()
+
+            return_response = validated_data["return_response"]
+            return return_response
+
+        return boto3_proxy_func

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Mapping
 
 from django.conf import settings
+from django.http import HttpResponse
 from requests import PreparedRequest
 
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
@@ -51,6 +52,13 @@ def infer_org_integration(
     return org_integration_id
 
 
+def get_proxy_url() -> str:
+    control_address = getattr(settings, "SENTRY_CONTROL_ADDRESS", "")
+    control_address = control_address.rstrip("/")
+    proxy_base_path = PROXY_BASE_PATH.lstrip("/")
+    return f"{control_address}/{proxy_base_path}"
+
+
 class IntegrationProxyClient(ApiClient):
     """
     Universal Client to access third-party resources safely in Hybrid Cloud.
@@ -79,7 +87,7 @@ class IntegrationProxyClient(ApiClient):
 
         if is_region_silo and subnet_secret and control_address:
             self._should_proxy_to_control = True
-            self.proxy_url = f"{settings.SENTRY_CONTROL_ADDRESS}{PROXY_BASE_PATH}"
+            self.proxy_url = get_proxy_url()
 
         if in_test_environment() and not self._use_proxy_url_for_tests:
             logger.info("proxy_disabled_in_test_env")
@@ -131,3 +139,15 @@ class IntegrationProxyClient(ApiClient):
             },
         )
         return prepared_request
+
+    def should_delegate(self) -> bool:
+        return False
+
+    def delegate(self, request, proxy_path: str, headers) -> HttpResponse:
+        """
+        Rather than letting the internal integration proxy endpoint perform the 3rd-party API request, this method
+        perform the processing of that request whenever should_delegate() returns True.
+
+        This method should be implemented in cases when an integration uses a Python SDK API client (e.g. boto3).
+        """
+        raise NotImplementedError

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -145,7 +145,7 @@ class IntegrationProxyClient(ApiClient):
     def delegate(self, request, proxy_path: str, headers) -> HttpResponse:
         """
         Rather than letting the internal integration proxy endpoint perform the 3rd-party API request, this method
-        perform the processing of that request whenever should_delegate() returns True.
+        performs the processing of that request whenever should_delegate() returns True.
 
         This method should be implemented in cases when an integration uses a Python SDK API client (e.g. boto3).
         """

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -54,7 +54,7 @@ def infer_org_integration(
 
 
 def get_proxy_url() -> str:
-    control_address = settings.SENTRY_CONTROL_ADDRESS
+    control_address: str = settings.SENTRY_CONTROL_ADDRESS
     return urljoin(control_address, PROXY_BASE_PATH)
 
 

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -54,7 +54,7 @@ def infer_org_integration(
 
 
 def get_proxy_url() -> str:
-    control_address = getattr(settings, "SENTRY_CONTROL_ADDRESS", "")
+    control_address = settings.SENTRY_CONTROL_ADDRESS
     return urljoin(control_address, PROXY_BASE_PATH)
 
 

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any, Mapping
+from urllib.parse import urljoin
 
 from django.conf import settings
 from django.http import HttpResponse
@@ -54,9 +55,7 @@ def infer_org_integration(
 
 def get_proxy_url() -> str:
     control_address = getattr(settings, "SENTRY_CONTROL_ADDRESS", "")
-    control_address = control_address.rstrip("/")
-    proxy_base_path = PROXY_BASE_PATH.lstrip("/")
-    return f"{control_address}/{proxy_base_path}"
+    return urljoin(control_address, PROXY_BASE_PATH)
 
 
 class IntegrationProxyClient(ApiClient):

--- a/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
@@ -1,5 +1,9 @@
 from unittest.mock import MagicMock, patch
 
+import responses
+from django.test import override_settings
+from responses import matchers
+
 from sentry.integrations.aws_lambda.integration import AwsLambdaIntegration
 from sentry.models import Integration, ProjectKey
 from sentry.silo import SiloMode
@@ -39,8 +43,64 @@ class AbstractServerlessTest(APITestCase):
     def sentry_dsn(self):
         return ProjectKey.get_default(project=self.project).get_dsn(public=True)
 
+    def set_up_response_mocks(self, get_function_response, update_function_configuration_kwargs):
+        responses.add(
+            responses.POST,
+            "http://controlserver/api/0/internal/integration-proxy/",
+            match=[
+                matchers.header_matcher(
+                    {
+                        "Content-Type": "application/json",
+                        "X-Sentry-Subnet-Organization-Integration": str(self.org_integration.id),
+                    },
+                ),
+                matchers.json_params_matcher(
+                    {
+                        "args": [],
+                        "function_name": "get_function",
+                        "kwargs": {
+                            "FunctionName": get_function_response["Configuration"]["FunctionName"],
+                        },
+                    }
+                ),
+            ],
+            json={
+                "function_name": "get_function",
+                "return_response": get_function_response,
+                "exception": None,
+            },
+        )
+        responses.add(
+            responses.POST,
+            "http://controlserver/api/0/internal/integration-proxy/",
+            match=[
+                matchers.header_matcher(
+                    {
+                        "Content-Type": "application/json",
+                        "X-Sentry-Subnet-Organization-Integration": str(self.org_integration.id),
+                    },
+                ),
+                matchers.json_params_matcher(
+                    {
+                        "args": [],
+                        "function_name": "update_function_configuration",
+                        "kwargs": update_function_configuration_kwargs,
+                    }
+                ),
+            ],
+            json={
+                "function_name": "update_function_configuration",
+                "return_response": {},
+                "exception": None,
+            },
+        )
+
 
 @region_silo_test(stable=True)
+@override_settings(
+    SENTRY_SUBNET_SECRET="hush-hush-im-invisible",
+    SENTRY_CONTROL_ADDRESS="http://controlserver",
+)
 class OrganizationIntegrationServerlessFunctionsGetTest(AbstractServerlessTest):
     method = "get"
 
@@ -164,24 +224,49 @@ class OrganizationIntegrationServerlessFunctionsGetTest(AbstractServerlessTest):
 
 
 @region_silo_test(stable=True)
+@override_settings(
+    SENTRY_SUBNET_SECRET="hush-hush-im-invisible",
+    SENTRY_CONTROL_ADDRESS="http://controlserver",
+)
 class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest):
     method = "post"
 
+    @responses.activate
     @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
-    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    @patch("sentry.integrations.aws_lambda.client.gen_aws_client")
     def test_enable_node_layer(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
         mock_client = mock_gen_aws_client.return_value
 
-        mock_client.get_function = MagicMock(
-            return_value={
-                "Configuration": {
-                    "FunctionName": "lambdaD",
-                    "Runtime": "nodejs10.x",
-                    "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaD",
-                    "Layers": ["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
+        get_function_response = {
+            "Configuration": {
+                "FunctionName": "lambdaD",
+                "Runtime": "nodejs10.x",
+                "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaD",
+                "Layers": ["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
+            },
+        }
+
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            update_function_configuration_kwargs = {
+                "FunctionName": "lambdaD",
+                "Layers": [
+                    "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                    "arn:aws:lambda:us-east-2:1234:layer:my-layer:3",
+                ],
+                "Environment": {
+                    "Variables": {
+                        "NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto",
+                        "SENTRY_DSN": self.sentry_dsn,
+                        "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                    }
                 },
             }
-        )
+            self.set_up_response_mocks(
+                get_function_response=get_function_response,
+                update_function_configuration_kwargs=update_function_configuration_kwargs,
+            )
+
+        mock_client.get_function = MagicMock(return_value=get_function_response)
         mock_client.update_function_configuration = MagicMock()
         return_value = {
             "name": "lambdaD",
@@ -194,39 +279,64 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
 
         assert self.get_response(action="enable", target="lambdaD").data == return_value
 
-        mock_client.get_function.assert_called_with(FunctionName="lambdaD")
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            assert mock_client.get_function.call_count == 0
+            assert mock_client.update_function_configuration.call_count == 0
+        else:
+            mock_client.get_function.assert_called_with(FunctionName="lambdaD")
+            mock_client.update_function_configuration.assert_called_with(
+                FunctionName="lambdaD",
+                Layers=[
+                    "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                    "arn:aws:lambda:us-east-2:1234:layer:my-layer:3",
+                ],
+                Environment={
+                    "Variables": {
+                        "NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto",
+                        "SENTRY_DSN": self.sentry_dsn,
+                        "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                    }
+                },
+            )
 
-        mock_client.update_function_configuration.assert_called_with(
-            FunctionName="lambdaD",
-            Layers=[
-                "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
-                "arn:aws:lambda:us-east-2:1234:layer:my-layer:3",
-            ],
-            Environment={
-                "Variables": {
-                    "NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto",
-                    "SENTRY_DSN": self.sentry_dsn,
-                    "SENTRY_TRACES_SAMPLE_RATE": "1.0",
-                }
-            },
-        )
-
+    @responses.activate
     @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
-    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    @patch("sentry.integrations.aws_lambda.client.gen_aws_client")
     def test_enable_python_layer(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
         mock_client = mock_gen_aws_client.return_value
 
-        mock_client.get_function = MagicMock(
-            return_value={
-                "Configuration": {
-                    "FunctionName": "lambdaE",
-                    "Runtime": "python3.8",
-                    "Handler": "lambda_handler.test_handler",
-                    "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaE",
-                    "Layers": ["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
+        get_function_response = {
+            "Configuration": {
+                "FunctionName": "lambdaE",
+                "Runtime": "python3.8",
+                "Handler": "lambda_handler.test_handler",
+                "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaE",
+                "Layers": ["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
+            },
+        }
+
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            update_function_configuration_kwargs = {
+                "FunctionName": "lambdaE",
+                "Layers": [
+                    "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                    "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
+                ],
+                "Environment": {
+                    "Variables": {
+                        "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
+                        "SENTRY_DSN": self.sentry_dsn,
+                        "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                    }
                 },
+                "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
             }
-        )
+            self.set_up_response_mocks(
+                get_function_response=get_function_response,
+                update_function_configuration_kwargs=update_function_configuration_kwargs,
+            )
+
+        mock_client.get_function = MagicMock(return_value=get_function_response)
         mock_client.update_function_configuration = MagicMock()
         return_value = {
             "name": "lambdaE",
@@ -239,50 +349,65 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
 
         assert self.get_response(action="enable", target="lambdaE").data == return_value
 
-        mock_client.get_function.assert_called_with(FunctionName="lambdaE")
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            assert mock_client.get_function.call_count == 0
+            assert mock_client.update_function_configuration.call_count == 0
+        else:
+            mock_client.get_function.assert_called_with(FunctionName="lambdaE")
+            mock_client.update_function_configuration.assert_called_with(
+                FunctionName="lambdaE",
+                Layers=[
+                    "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                    "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
+                ],
+                Environment={
+                    "Variables": {
+                        "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
+                        "SENTRY_DSN": self.sentry_dsn,
+                        "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                    }
+                },
+                Handler="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+            )
 
-        mock_client.update_function_configuration.assert_called_with(
-            FunctionName="lambdaE",
-            Layers=[
-                "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
-                "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
-            ],
-            Environment={
-                "Variables": {
-                    "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
-                    "SENTRY_DSN": self.sentry_dsn,
-                    "SENTRY_TRACES_SAMPLE_RATE": "1.0",
-                }
-            },
-            Handler="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
-        )
-
+    @responses.activate
     @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
-    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    @patch("sentry.integrations.aws_lambda.client.gen_aws_client")
     def test_disable_node(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
         mock_client = mock_gen_aws_client.return_value
 
-        mock_client.get_function = MagicMock(
-            return_value={
-                "Configuration": {
-                    "FunctionName": "lambdaD",
-                    "Runtime": "nodejs10.x",
-                    "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaD",
-                    "Layers": [
-                        {"Arn": "arn:aws:lambda:us-east-2:1234:layer:something-else:2"},
-                        {"Arn": "arn:aws:lambda:us-east-2:1234:layer:my-layer:3"},
-                    ],
-                    "Environment": {
-                        "Variables": {
-                            "NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto",
-                            "SENTRY_DSN": self.sentry_dsn,
-                            "SENTRY_TRACES_SAMPLE_RATE": "1.0",
-                            "OTHER": "hi",
-                        }
-                    },
+        get_function_response = {
+            "Configuration": {
+                "FunctionName": "lambdaD",
+                "Runtime": "nodejs10.x",
+                "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaD",
+                "Layers": [
+                    {"Arn": "arn:aws:lambda:us-east-2:1234:layer:something-else:2"},
+                    {"Arn": "arn:aws:lambda:us-east-2:1234:layer:my-layer:3"},
+                ],
+                "Environment": {
+                    "Variables": {
+                        "NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto",
+                        "SENTRY_DSN": self.sentry_dsn,
+                        "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                        "OTHER": "hi",
+                    }
                 },
+            },
+        }
+
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            update_function_configuration_kwargs = {
+                "Environment": {"Variables": {"OTHER": "hi"}},
+                "FunctionName": "lambdaD",
+                "Layers": ["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
             }
-        )
+            self.set_up_response_mocks(
+                get_function_response=get_function_response,
+                update_function_configuration_kwargs=update_function_configuration_kwargs,
+            )
+
+        mock_client.get_function = MagicMock(return_value=get_function_response)
         mock_client.update_function_configuration = MagicMock()
         return_value = {
             "name": "lambdaD",
@@ -294,42 +419,58 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
         mock_get_serialized_lambda_function.return_value = return_value
 
         assert self.get_response(action="disable", target="lambdaD").data == return_value
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            assert mock_client.get_function.call_count == 0
+            assert mock_client.update_function_configuration.call_count == 0
+        else:
+            mock_client.get_function.assert_called_with(FunctionName="lambdaD")
 
-        mock_client.get_function.assert_called_with(FunctionName="lambdaD")
+            mock_client.update_function_configuration.assert_called_with(
+                FunctionName="lambdaD",
+                Layers=["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
+                Environment={"Variables": {"OTHER": "hi"}},
+            )
 
-        mock_client.update_function_configuration.assert_called_with(
-            FunctionName="lambdaD",
-            Layers=["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
-            Environment={"Variables": {"OTHER": "hi"}},
-        )
-
+    @responses.activate
     @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
-    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    @patch("sentry.integrations.aws_lambda.client.gen_aws_client")
     def test_disable_python(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
         mock_client = mock_gen_aws_client.return_value
 
-        mock_client.get_function = MagicMock(
-            return_value={
-                "Configuration": {
-                    "FunctionName": "lambdaF",
-                    "Runtime": "python3.6",
-                    "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaF",
-                    "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
-                    "Layers": [
-                        {"Arn": "arn:aws:lambda:us-east-2:1234:layer:something-else:2"},
-                        {"Arn": "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34"},
-                    ],
-                    "Environment": {
-                        "Variables": {
-                            "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
-                            "SENTRY_DSN": self.sentry_dsn,
-                            "SENTRY_TRACES_SAMPLE_RATE": "1.0",
-                            "OTHER": "hi",
-                        }
-                    },
+        get_function_response = {
+            "Configuration": {
+                "FunctionName": "lambdaF",
+                "Runtime": "python3.6",
+                "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaF",
+                "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+                "Layers": [
+                    {"Arn": "arn:aws:lambda:us-east-2:1234:layer:something-else:2"},
+                    {"Arn": "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34"},
+                ],
+                "Environment": {
+                    "Variables": {
+                        "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
+                        "SENTRY_DSN": self.sentry_dsn,
+                        "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                        "OTHER": "hi",
+                    }
                 },
+            },
+        }
+
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            update_function_configuration_kwargs = {
+                "FunctionName": "lambdaF",
+                "Layers": ["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
+                "Environment": {"Variables": {"OTHER": "hi"}},
+                "Handler": "lambda_handler.test_handler",
             }
-        )
+            self.set_up_response_mocks(
+                get_function_response=get_function_response,
+                update_function_configuration_kwargs=update_function_configuration_kwargs,
+            )
+
+        mock_client.get_function = MagicMock(return_value=get_function_response)
         mock_client.update_function_configuration = MagicMock()
         return_value = {
             "name": "lambdaF",
@@ -342,41 +483,59 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
 
         assert self.get_response(action="disable", target="lambdaF").data == return_value
 
-        mock_client.get_function.assert_called_with(FunctionName="lambdaF")
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            assert mock_client.get_function.call_count == 0
+            assert mock_client.update_function_configuration.call_count == 0
+        else:
+            mock_client.get_function.assert_called_with(FunctionName="lambdaF")
 
-        mock_client.update_function_configuration.assert_called_with(
-            FunctionName="lambdaF",
-            Layers=["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
-            Environment={"Variables": {"OTHER": "hi"}},
-            Handler="lambda_handler.test_handler",
-        )
+            mock_client.update_function_configuration.assert_called_with(
+                FunctionName="lambdaF",
+                Layers=["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
+                Environment={"Variables": {"OTHER": "hi"}},
+                Handler="lambda_handler.test_handler",
+            )
 
+    @responses.activate
     @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
-    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    @patch("sentry.integrations.aws_lambda.client.gen_aws_client")
     def test_update_node_version(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
         mock_client = mock_gen_aws_client.return_value
 
-        mock_client.get_function = MagicMock(
-            return_value={
-                "Configuration": {
-                    "FunctionName": "lambdaD",
-                    "Runtime": "nodejs10.x",
-                    "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaD",
-                    "Layers": [
-                        {"Arn": "arn:aws:lambda:us-east-2:1234:layer:something-else:2"},
-                        {"Arn": "arn:aws:lambda:us-east-2:1234:layer:my-layer:2"},
-                    ],
-                    "Environment": {
-                        "Variables": {
-                            "NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto",
-                            "SENTRY_DSN": self.sentry_dsn,
-                            "SENTRY_TRACES_SAMPLE_RATE": "1.0",
-                            "OTHER": "hi",
-                        }
-                    },
+        get_function_response = {
+            "Configuration": {
+                "FunctionName": "lambdaD",
+                "Runtime": "nodejs10.x",
+                "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaD",
+                "Layers": [
+                    {"Arn": "arn:aws:lambda:us-east-2:1234:layer:something-else:2"},
+                    {"Arn": "arn:aws:lambda:us-east-2:1234:layer:my-layer:2"},
+                ],
+                "Environment": {
+                    "Variables": {
+                        "NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto",
+                        "SENTRY_DSN": self.sentry_dsn,
+                        "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                        "OTHER": "hi",
+                    }
                 },
+            },
+        }
+
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            update_function_configuration_kwargs = {
+                "FunctionName": "lambdaD",
+                "Layers": [
+                    "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                    "arn:aws:lambda:us-east-2:1234:layer:my-layer:3",
+                ],
             }
-        )
+            self.set_up_response_mocks(
+                get_function_response=get_function_response,
+                update_function_configuration_kwargs=update_function_configuration_kwargs,
+            )
+
+        mock_client.get_function = MagicMock(return_value=get_function_response)
         mock_client.update_function_configuration = MagicMock()
         return_value = {
             "name": "lambdaD",
@@ -389,43 +548,62 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
 
         assert self.get_response(action="updateVersion", target="lambdaD").data == return_value
 
-        mock_client.get_function.assert_called_with(FunctionName="lambdaD")
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            assert mock_client.get_function.call_count == 0
+            assert mock_client.update_function_configuration.call_count == 0
+        else:
+            mock_client.get_function.assert_called_with(FunctionName="lambdaD")
 
-        mock_client.update_function_configuration.assert_called_with(
-            FunctionName="lambdaD",
-            Layers=[
-                "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
-                "arn:aws:lambda:us-east-2:1234:layer:my-layer:3",
-            ],
-        )
+            mock_client.update_function_configuration.assert_called_with(
+                # **update_function_configuration_kwargs
+                FunctionName="lambdaD",
+                Layers=[
+                    "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                    "arn:aws:lambda:us-east-2:1234:layer:my-layer:3",
+                ],
+            )
 
+    @responses.activate
     @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
-    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    @patch("sentry.integrations.aws_lambda.client.gen_aws_client")
     def test_update_python_version(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
         mock_client = mock_gen_aws_client.return_value
 
-        mock_client.get_function = MagicMock(
-            return_value={
-                "Configuration": {
-                    "FunctionName": "lambdaG",
-                    "Runtime": "python3.6",
-                    "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
-                    "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaG",
-                    "Layers": [
-                        {"Arn": "arn:aws:lambda:us-east-2:1234:layer:something-else:2"},
-                        {"Arn": "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:2"},
-                    ],
-                    "Environment": {
-                        "Variables": {
-                            "SENTRY_INITIAL_HANDLER": "lambda_test.lambda_handler",
-                            "SENTRY_DSN": self.sentry_dsn,
-                            "SENTRY_TRACES_SAMPLE_RATE": "1.0",
-                            "OTHER": "hi",
-                        }
-                    },
+        get_function_response = {
+            "Configuration": {
+                "FunctionName": "lambdaG",
+                "Runtime": "python3.6",
+                "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+                "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaG",
+                "Layers": [
+                    {"Arn": "arn:aws:lambda:us-east-2:1234:layer:something-else:2"},
+                    {"Arn": "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:2"},
+                ],
+                "Environment": {
+                    "Variables": {
+                        "SENTRY_INITIAL_HANDLER": "lambda_test.lambda_handler",
+                        "SENTRY_DSN": self.sentry_dsn,
+                        "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                        "OTHER": "hi",
+                    }
                 },
+            },
+        }
+
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            update_function_configuration_kwargs = {
+                "FunctionName": "lambdaG",
+                "Layers": [
+                    "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                    "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
+                ],
             }
-        )
+            self.set_up_response_mocks(
+                get_function_response=get_function_response,
+                update_function_configuration_kwargs=update_function_configuration_kwargs,
+            )
+
+        mock_client.get_function = MagicMock(return_value=get_function_response)
         mock_client.update_function_configuration = MagicMock()
         return_value = {
             "name": "lambdaG",
@@ -438,18 +616,23 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
 
         assert self.get_response(action="updateVersion", target="lambdaG").data == return_value
 
-        mock_client.get_function.assert_called_with(FunctionName="lambdaG")
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            assert mock_client.get_function.call_count == 0
+            assert mock_client.update_function_configuration.call_count == 0
+        else:
+            mock_client.get_function.assert_called_with(FunctionName="lambdaG")
 
-        mock_client.update_function_configuration.assert_called_with(
-            FunctionName="lambdaG",
-            Layers=[
-                "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
-                "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
-            ],
-        )
+            mock_client.update_function_configuration.assert_called_with(
+                FunctionName="lambdaG",
+                Layers=[
+                    "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                    "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
+                ],
+            )
 
+    @responses.activate
     @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
-    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    @patch("sentry.integrations.aws_lambda.client.gen_aws_client")
     def test_enable_python_layer_on_already_enabled(
         self, mock_gen_aws_client, mock_get_serialized_lambda_function
     ):
@@ -464,27 +647,48 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
         """
         mock_client = mock_gen_aws_client.return_value
 
-        mock_client.get_function = MagicMock(
-            return_value={
-                "Configuration": {
-                    "FunctionName": "lambdaZ",
-                    "Runtime": "python3.8",
-                    "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
-                    "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaZ",
-                    "Layers": [
-                        "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
-                        "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
-                    ],
-                    "Environment": {
-                        "Variables": {
-                            "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
-                            "SENTRY_DSN": self.sentry_dsn,
-                            "SENTRY_TRACES_SAMPLE_RATE": "1.0",
-                        }
-                    },
+        get_function_response = {
+            "Configuration": {
+                "FunctionName": "lambdaZ",
+                "Runtime": "python3.8",
+                "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+                "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaZ",
+                "Layers": [
+                    "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                    "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
+                ],
+                "Environment": {
+                    "Variables": {
+                        "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
+                        "SENTRY_DSN": self.sentry_dsn,
+                        "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                    }
                 },
+            },
+        }
+
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            update_function_configuration_kwargs = {
+                "FunctionName": "lambdaZ",
+                "Layers": [
+                    "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                    "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
+                ],
+                "Environment": {
+                    "Variables": {
+                        "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
+                        "SENTRY_DSN": self.sentry_dsn,
+                        "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                    }
+                },
+                "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
             }
-        )
+            self.set_up_response_mocks(
+                get_function_response=get_function_response,
+                update_function_configuration_kwargs=update_function_configuration_kwargs,
+            )
+
+        mock_client.get_function = MagicMock(return_value=get_function_response)
         mock_client.update_function_configuration = MagicMock()
         return_value = {
             "name": "lambdaZ",
@@ -497,20 +701,24 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
 
         assert self.get_response(action="enable", target="lambdaZ").data == return_value
 
-        mock_client.get_function.assert_called_with(FunctionName="lambdaZ")
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            assert mock_client.get_function.call_count == 0
+            assert mock_client.update_function_configuration.call_count == 0
+        else:
+            mock_client.get_function.assert_called_with(FunctionName="lambdaZ")
 
-        mock_client.update_function_configuration.assert_called_with(
-            FunctionName="lambdaZ",
-            Layers=[
-                "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
-                "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
-            ],
-            Environment={
-                "Variables": {
-                    "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
-                    "SENTRY_DSN": self.sentry_dsn,
-                    "SENTRY_TRACES_SAMPLE_RATE": "1.0",
-                }
-            },
-            Handler="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
-        )
+            mock_client.update_function_configuration.assert_called_with(
+                FunctionName="lambdaZ",
+                Layers=[
+                    "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                    "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
+                ],
+                Environment={
+                    "Variables": {
+                        "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
+                        "SENTRY_DSN": self.sentry_dsn,
+                        "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                    }
+                },
+                Handler="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+            )

--- a/tests/sentry/integrations/aws_lambda/test_client.py
+++ b/tests/sentry/integrations/aws_lambda/test_client.py
@@ -112,7 +112,7 @@ SENTRY_SUBNET_SECRET = "hush-hush-im-invisible"
 
 
 @override_settings(
-    SENTRY_SUBNET_SECRET="hush-hush-im-invisible",
+    SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET,
     SENTRY_CONTROL_ADDRESS="http://controlserver",
 )
 class AwsLambdaProxyApiClientTest(TestCase):

--- a/tests/sentry/integrations/aws_lambda/test_client.py
+++ b/tests/sentry/integrations/aws_lambda/test_client.py
@@ -1,8 +1,24 @@
+from typing import TypedDict
 from unittest.mock import MagicMock, patch
 
 import boto3
+import pytest
+import responses
+from django.test import override_settings
+from responses import matchers
+from rest_framework.decorators import api_view
+from rest_framework.test import APIRequestFactory
 
-from sentry.integrations.aws_lambda.client import gen_aws_client
+from sentry.integrations.aws_lambda import AwsLambdaIntegrationProvider
+from sentry.integrations.aws_lambda.client import AwsLambdaProxyClient, gen_aws_client
+from sentry.models import Integration
+from sentry.silo.base import SiloMode
+from sentry.silo.util import (
+    PROXY_BASE_PATH,
+    PROXY_OI_HEADER,
+    PROXY_SIGNATURE_HEADER,
+    encode_subnet_signature,
+)
 from sentry.testutils import TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
@@ -74,3 +90,263 @@ class AwsLambdaClientTest(TestCase):
         )
 
         mock_session.client.assert_called_once_with(service_name="lambda", region_name="us-west-1")
+
+
+def assert_proxy_request(request, is_proxy=True):
+    assert (PROXY_BASE_PATH in request.url) == is_proxy
+    assert (PROXY_OI_HEADER in request.headers) == is_proxy
+    assert (PROXY_SIGNATURE_HEADER in request.headers) == is_proxy
+    # AWS Lambda API does not require the Authorization header.
+    # The secret is instead passed in the body payload called routing_key/integration key
+    assert "Authorization" not in request.headers
+    if is_proxy:
+        assert request.headers[PROXY_OI_HEADER] is not None
+
+
+class SiloHttpHeaders(TypedDict, total=False):
+    HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION: str
+    HTTP_X_SENTRY_SUBNET_SIGNATURE: str
+
+
+SENTRY_SUBNET_SECRET = "hush-hush-im-invisible"
+
+
+@override_settings(
+    SENTRY_SUBNET_SECRET="hush-hush-im-invisible",
+    SENTRY_CONTROL_ADDRESS="http://controlserver",
+)
+class AwsLambdaProxyApiClientTest(TestCase):
+    provider = AwsLambdaIntegrationProvider
+
+    def setUp(self):
+        self.login_as(self.user)
+        self.account_number = "599817902985"
+        self.region = "us-east-2"
+        self.aws_external_id = "12-323"
+
+        self.integration = Integration.objects.create(
+            provider=self.provider.key,
+            name=f"{self.account_number} {self.region}",
+            external_id=f"{self.account_number}-{self.region}",
+            metadata={
+                "account_number": self.account_number,
+                "region": self.region,
+                "aws_external_id": self.aws_external_id,
+            },
+        )
+        self.integration.add_organization(self.organization, self.user)
+        self.installation = self.integration.get_installation(self.organization.id)
+
+    @patch("sentry.integrations.aws_lambda.client.gen_aws_client")
+    @responses.activate
+    def test_integration_proxy_is_active(self, mock_gen_aws_client):
+        expected_get_function_return = {
+            "Configuration": {
+                "FunctionName": "lambdaE",
+                "Runtime": "python3.8",
+                "Handler": "lambda_handler.test_handler",
+                "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaE",
+                "Layers": ["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
+            },
+        }
+
+        mock_client = mock_gen_aws_client.return_value
+        mock_client.get_function = MagicMock(return_value=expected_get_function_return)
+
+        class AwsLambdaProxyApiTestClient(AwsLambdaProxyClient):
+            _use_proxy_url_for_tests = True
+
+        responses.calls.reset()
+        with override_settings(SILO_MODE=SiloMode.MONOLITH):
+            client = AwsLambdaProxyApiTestClient(
+                org_integration_id=self.installation.org_integration.id,
+                account_number=self.account_number,
+                region=self.region,
+                aws_external_id=self.aws_external_id,
+            )
+            actual = client.get_function(FunctionName="lambdaE")
+            assert mock_client.get_function.call_count == 1
+            assert actual == expected_get_function_return
+            assert len(responses.calls) == 0
+
+        responses.calls.reset()
+        with override_settings(SILO_MODE=SiloMode.CONTROL):
+            mock_client.get_function.reset_mock()
+            assert mock_client.get_function.call_count == 0
+
+            client = AwsLambdaProxyApiTestClient(
+                org_integration_id=self.installation.org_integration.id,
+                account_number=self.account_number,
+                region=self.region,
+                aws_external_id=self.aws_external_id,
+            )
+            actual = client.get_function(FunctionName="lambdaE")
+            assert mock_client.get_function.call_count == 1
+            assert actual == expected_get_function_return
+            assert len(responses.calls) == 0
+
+        responses.calls.reset()
+        with override_settings(SILO_MODE=SiloMode.REGION):
+            responses.add(
+                responses.POST,
+                "http://controlserver/api/0/internal/integration-proxy/",
+                match=[
+                    matchers.header_matcher(
+                        {
+                            "Content-Type": "application/json",
+                            "X-Sentry-Subnet-Organization-Integration": str(
+                                self.installation.org_integration.id
+                            ),
+                        },
+                    ),
+                    matchers.json_params_matcher(
+                        {
+                            "args": [],
+                            "function_name": "get_function",
+                            "kwargs": {"FunctionName": "lambdaE"},
+                        }
+                    ),
+                ],
+                json={
+                    "function_name": "get_function",
+                    "return_response": expected_get_function_return,
+                    "exception": None,
+                },
+            )
+            mock_client.get_function.reset_mock()
+            assert mock_client.get_function.call_count == 0
+
+            client = AwsLambdaProxyApiTestClient(
+                org_integration_id=self.installation.org_integration.id,
+                account_number=self.account_number,
+                region=self.region,
+                aws_external_id=self.aws_external_id,
+            )
+            actual = client.get_function(FunctionName="lambdaE")
+            assert mock_client.get_function.call_count == 0
+            assert actual == expected_get_function_return
+            assert len(responses.calls) == 1
+            request = responses.calls[0].request
+            assert "http://controlserver/api/0/internal/integration-proxy/" == request.url
+            assert client.base_url and (client.base_url.lower() in request.url)
+            assert_proxy_request(request, is_proxy=True)
+
+    @patch("sentry.integrations.aws_lambda.client.gen_aws_client")
+    @responses.activate
+    def test_delegates_exception(self, mock_gen_aws_client):
+        class AWSOrganizationsNotInUseException(Exception):
+            pass
+
+        mock_client = mock_gen_aws_client.return_value
+        mock_client.get_function = MagicMock(side_effect=AWSOrganizationsNotInUseException())
+
+        class AwsLambdaProxyApiTestClient(AwsLambdaProxyClient):
+            _use_proxy_url_for_tests = True
+
+        responses.calls.reset()
+        with override_settings(SILO_MODE=SiloMode.CONTROL):
+            mock_client.get_function.reset_mock()
+            assert mock_client.get_function.call_count == 0
+
+            client = AwsLambdaProxyApiTestClient(
+                org_integration_id=self.installation.org_integration.id,
+                account_number=self.account_number,
+                region=self.region,
+                aws_external_id=self.aws_external_id,
+            )
+            assert client.should_delegate()
+            with pytest.raises(AWSOrganizationsNotInUseException):
+                client.get_function(FunctionName="lambdaE")
+                assert mock_client.get_function.call_count == 1
+                assert len(responses.calls) == 0
+
+            expected_proxy_payload = {
+                "args": ["hello"],
+                "kwargs": {"function_name": "lambdaE"},
+                "function_name": "get_function",
+            }
+            signature = encode_subnet_signature(
+                secret=SENTRY_SUBNET_SECRET,
+                path="",
+                identifier=str(self.installation.org_integration.id),
+                request_body=json.dumps(expected_proxy_payload).encode("utf-8"),
+            )
+            headers = SiloHttpHeaders(
+                HTTP_X_SENTRY_SUBNET_SIGNATURE=signature,
+                HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(
+                    self.installation.org_integration.id
+                ),
+            )
+            request = APIRequestFactory().post(
+                f"{PROXY_BASE_PATH}/", **headers, data=expected_proxy_payload, format="json"
+            )
+
+            @api_view(["GET", "POST"])
+            def view(request):
+                return request
+
+            response = view(request)
+            response.render()
+            request = response.renderer_context["request"]
+            proxy_response = client.delegate(request=request, proxy_path="", headers=headers)
+
+            actual_response_payload = json.loads(proxy_response.content)
+            assert actual_response_payload == {
+                "function_name": "get_function",
+                "return_response": {},
+                "exception": {"class": "AWSOrganizationsNotInUseException"},
+            }
+
+    @patch("sentry.integrations.aws_lambda.client.gen_aws_client")
+    @responses.activate
+    def test_wrapped_boto3_client_raises_exception(self, mock_gen_aws_client):
+        class AWSOrganizationsNotInUseException(Exception):
+            pass
+
+        mock_client = mock_gen_aws_client.return_value
+        mock_client.get_function = MagicMock()
+        mock_client.exceptions.AWSOrganizationsNotInUseException = AWSOrganizationsNotInUseException
+
+        class AwsLambdaProxyApiTestClient(AwsLambdaProxyClient):
+            _use_proxy_url_for_tests = True
+
+        responses.calls.reset()
+        with override_settings(SILO_MODE=SiloMode.REGION):
+
+            responses.add(
+                responses.POST,
+                "http://controlserver/api/0/internal/integration-proxy/",
+                match=[
+                    matchers.header_matcher(
+                        {
+                            "Content-Type": "application/json",
+                            "X-Sentry-Subnet-Organization-Integration": str(
+                                self.installation.org_integration.id
+                            ),
+                        },
+                    ),
+                    matchers.json_params_matcher(
+                        {
+                            "args": [],
+                            "function_name": "get_function",
+                            "kwargs": {"FunctionName": "lambdaE"},
+                        }
+                    ),
+                ],
+                json={
+                    "function_name": "get_function",
+                    "return_response": {},
+                    "exception": {"class": "AWSOrganizationsNotInUseException"},
+                },
+            )
+
+            client = AwsLambdaProxyApiTestClient(
+                org_integration_id=self.installation.org_integration.id,
+                account_number=self.account_number,
+                region=self.region,
+                aws_external_id=self.aws_external_id,
+            )
+            assert client.should_delegate()
+            with pytest.raises(client.client.exceptions.AWSOrganizationsNotInUseException):
+                client.get_function(FunctionName="lambdaE")
+            assert mock_client.get_function.call_count == 0


### PR DESCRIPTION
This PR introduces optional methods, `delegate()` and `should_delegate()`  on the `IntegrationProxyClient` class. 


If `should_delegate()` returns `True`, then `IntegrationProxyClient.delegate()` will be used to generate the http response at the internal Integration Proxy Endpoint (`InternalIntegrationProxyEndpoint`). This is an alternative to having the  Integration Proxy Endpoint making the API client calls on the `IntegrationProxyClient`'s behalf.

The AWS Lambda integration uses the `boto3` client (AWS's SDK) to make the API calls to AWS. We leverage `IntegrationProxyClient.delegate()` to make the `boto3` client calls at the control silo, and then generate the http response to be sent back to the region silo.

The `AwsLambdaProxyClient` class will handle generating the appropriate requests to the  internal Integration Proxy Endpoint at the region silo; and making calls to the `boto3` client at the control silo.