### PR TITLE
feat(backpressure): Add support for redis rb.Cluster client

### DIFF
--- a/src/sentry/processing/backpressure/monitor.py
+++ b/src/sentry/processing/backpressure/monitor.py
@@ -53,7 +53,10 @@ def load_service_definitions() -> Dict[str, Service]:
     services: Dict[str, Service] = {}
     for name, definition in settings.SENTRY_PROCESSING_SERVICES.items():
         if cluster_id := definition.get("redis"):
-            cluster = redis.redis_clusters.get(cluster_id)
+            _is_clsuter, cluster, _config = redis.get_dynamic_cluster_from_options(
+                setting=f"SENTRY_PROCESSING_SERVICES[{name}]",
+                config={"cluster": cluster_id},
+            )
             services[name] = Redis(cluster)
 
         elif rabbitmq_urls := definition.get("rabbitmq"):

--- a/tests/sentry/processing/backpressure/test_monitoring.py
+++ b/tests/sentry/processing/backpressure/test_monitoring.py
@@ -30,7 +30,9 @@ def test_loading_definitions() -> None:
 
 
 def test_check_redis_health() -> None:
-    cluster = redis.redis_clusters.get("default")
+    _, cluster, _ = redis.get_dynamic_cluster_from_options(
+        setting="tess", config={"cluster": "default"}
+    )
     services = {"redis": Redis(cluster)}
 
     with override_options(

--- a/tests/sentry/processing/backpressure/test_redis.py
+++ b/tests/sentry/processing/backpressure/test_redis.py
@@ -1,14 +1,17 @@
 from django.test.utils import override_settings
 
 from sentry.processing.backpressure.memory import iter_cluster_memory_usage
-from sentry.processing.backpressure.monitor import load_service_definitions
+from sentry.processing.backpressure.monitor import Redis, load_service_definitions
 
 
 def test_returns_some_usage() -> None:
     with override_settings(SENTRY_PROCESSING_SERVICES={"redis": {"redis": "default"}}):
         services = load_service_definitions()
 
-    usage = [usage for usage in iter_cluster_memory_usage(services["redis"].cluster)]
+    redis_service = services["redis"]
+    assert isinstance(redis_service, Redis)
+
+    usage = [usage for usage in iter_cluster_memory_usage(redis_service.cluster)]
     assert len(usage) > 0
     memory = usage[0]
     assert memory.used > 0

--- a/tests/sentry/processing/backpressure/test_redis.py
+++ b/tests/sentry/processing/backpressure/test_redis.py
@@ -1,11 +1,14 @@
+from django.test.utils import override_settings
+
 from sentry.processing.backpressure.memory import iter_cluster_memory_usage
-from sentry.utils import redis
+from sentry.processing.backpressure.monitor import load_service_definitions
 
 
 def test_returns_some_usage() -> None:
-    cluster = redis.redis_clusters.get("default")
+    with override_settings(SENTRY_PROCESSING_SERVICES={"redis": {"redis": "default"}}):
+        services = load_service_definitions()
 
-    usage = [usage for usage in iter_cluster_memory_usage(cluster)]
+    usage = [usage for usage in iter_cluster_memory_usage(services["redis"].cluster)]
     assert len(usage) > 0
     memory = usage[0]
     assert memory.used > 0


### PR DESCRIPTION
Adding support for `rb.Cluster` configurations because it's needed in production. Single instances will no longer use the simple client but will be treated as on node `rb.Cluster`.