### PR TITLE
ref(metrics): Move MQB query transformer

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -755,10 +755,10 @@ class MetricsQueryBuilder(QueryBuilder):
 
     def run_query(self, referrer: str, use_cache: bool = False) -> Any:
         if self.use_metrics_layer or self._on_demand_spec:
-            from sentry.snuba.metrics.datasource import get_series
-            from sentry.snuba.metrics.mqb_query_transformer import (
+            from sentry.search.events.builder.mqb_query_transformer import (
                 transform_mqb_query_to_metrics_query,
             )
+            from sentry.snuba.metrics.datasource import get_series
 
             try:
                 with sentry_sdk.start_span(op="metric_layer", description="transform_query"):
@@ -955,10 +955,10 @@ class AlertMetricsQueryBuilder(MetricsQueryBuilder):
         """
 
         if self.use_metrics_layer or self._on_demand_spec:
-            from sentry.snuba.metrics import SnubaQueryBuilder
-            from sentry.snuba.metrics.mqb_query_transformer import (
+            from sentry.search.events.builder.mqb_query_transformer import (
                 transform_mqb_query_to_metrics_query,
             )
+            from sentry.snuba.metrics import SnubaQueryBuilder
 
             snuba_request = self.get_metrics_layer_snql_query()
 
@@ -1181,10 +1181,10 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
 
     def run_query(self, referrer: str, use_cache: bool = False) -> Any:
         if self.use_metrics_layer:
-            from sentry.snuba.metrics.datasource import get_series
-            from sentry.snuba.metrics.mqb_query_transformer import (
+            from sentry.search.events.builder.mqb_query_transformer import (
                 transform_mqb_query_to_metrics_query,
             )
+            from sentry.snuba.metrics.datasource import get_series
 
             snuba_query = self.get_snql_query()[0].query
             try:

--- a/src/sentry/search/events/builder/mqb_query_transformer.py
+++ b/src/sentry/search/events/builder/mqb_query_transformer.py
@@ -1,24 +1,25 @@
 import inspect
 from typing import Set
 
-from snuba_sdk import AliasedExpression, Column, Condition, Function, Granularity, Op
-from snuba_sdk.query import Query
+from snuba_sdk import AliasedExpression, Column, Condition, Function, Granularity, Op, Query
 
 from sentry.api.utils import InvalidParams
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics import (
+    DERIVED_OPS,
     FIELD_ALIAS_MAPPINGS,
     FILTERABLE_TAGS,
+    FUNCTION_ALLOWLIST,
     OPERATIONS,
     DerivedMetricException,
+    MetricConditionField,
+    MetricField,
+    MetricGroupByField,
+    MetricOrderByField,
+    MetricsQuery,
     TransactionMRI,
+    metric_object_factory,
 )
-from sentry.snuba.metrics.fields.base import DERIVED_OPS, metric_object_factory
-from sentry.snuba.metrics.query import MetricConditionField, MetricField, MetricGroupByField
-from sentry.snuba.metrics.query import MetricOrderByField
-from sentry.snuba.metrics.query import MetricOrderByField as MetricOrderBy
-from sentry.snuba.metrics.query import MetricsQuery
-from sentry.snuba.metrics.query_builder import FUNCTION_ALLOWLIST
 
 TEAM_KEY_TRANSACTION_OP = "team_key_transaction"
 
@@ -248,7 +249,7 @@ def _transform_orderby(query_orderby):
             except DerivedMetricException as e:
                 raise MQBQueryTransformationException(e)
 
-            metric_order_by = MetricOrderBy(
+            metric_order_by = MetricOrderByField(
                 field=transformed_field, direction=orderby_field.direction
             )
 

--- a/tests/sentry/search/events/builder/test_mqb_query_transformer.py
+++ b/tests/sentry/search/events/builder/test_mqb_query_transformer.py
@@ -11,6 +11,10 @@ from snuba_sdk.function import Function
 from snuba_sdk.orderby import Direction, OrderBy
 from snuba_sdk.query import Query
 
+from sentry.search.events.builder.mqb_query_transformer import (
+    MQBQueryTransformationException,
+    transform_mqb_query_to_metrics_query,
+)
 from sentry.snuba.metrics import (
     MetricConditionField,
     MetricField,
@@ -18,10 +22,6 @@ from sentry.snuba.metrics import (
     MetricOrderByField,
     MetricsQuery,
     TransactionMRI,
-)
-from sentry.snuba.metrics.mqb_query_transformer import (
-    MQBQueryTransformationException,
-    transform_mqb_query_to_metrics_query,
 )
 
 """


### PR DESCRIPTION
Moves the MQB query transformer from `sentry.snuba.metrics` to
`sentry.search.events.builder`, since this functionality is part of event
search and is tightly coupled to a SnQL query emitted by the event search query
builders.

