### PR TITLE
Bust Symbolicator `list_files` cache on uploads

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -112,6 +112,7 @@ SENTRY_RULE_TASK_REDIS_CLUSTER = "default"
 SENTRY_TRANSACTION_NAMES_REDIS_CLUSTER = "default"
 SENTRY_WEBHOOK_LOG_REDIS_CLUSTER = "default"
 SENTRY_ARTIFACT_BUNDLES_INDEXING_REDIS_CLUSTER = "default"
+SENTRY_DEBUG_FILES_REDIS_CLUSTER = "default"
 
 # Hosts that are allowed to use system token authentication.
 # http://en.wikipedia.org/wiki/Reserved_IP_addresses

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -117,8 +117,12 @@ SOURCES_SCHEMA = {
     },
 }
 
-default_cluster = redis.redis_clusters.get("default")
 LAST_UPLOAD_TTL = 24 * 3600
+
+
+def _get_cluster():
+    cluster_key = settings.SENTRY_DEBUG_FILES_REDIS_CLUSTER
+    return redis.redis_clusters.get(cluster_key)
 
 
 def _last_upload_key(project_id: int) -> str:
@@ -127,11 +131,11 @@ def _last_upload_key(project_id: int) -> str:
 
 def record_last_upload(project: Project):
     timestamp = int(datetime.utcnow().timestamp() * 1000)
-    default_cluster.setex(_last_upload_key(project.id), LAST_UPLOAD_TTL, timestamp)
+    _get_cluster().setex(_last_upload_key(project.id), LAST_UPLOAD_TTL, timestamp)
 
 
 def get_last_upload(project_id: int):
-    return default_cluster.get(_last_upload_key(project_id))
+    return _get_cluster().get(_last_upload_key(project_id))
 
 
 class InvalidSourcesError(Exception):

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -168,6 +168,10 @@ def get_internal_source(project: Project):
     )
 
     if last_upload := get_last_upload(project.id):
+        # Adding a random query string parameter here makes sure that the
+        # Symbolicator-internal `list_files` cache that is querying this API
+        # is not being hit. This means that uploads will be immediately visible
+        # to Symbolicator, and not depending on its internal cache TTL.
         sentry_source_url += f"?_last_upload={last_upload}"
 
     return {

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -43,7 +43,6 @@ from sentry.db.models import (
     region_silo_only_model,
     sane_repr,
 )
-from sentry.lang.native.sources import record_last_upload
 from sentry.models.files.file import File
 from sentry.models.files.utils import clear_cached_files
 from sentry.reprocessing import bump_reprocessing_revision, resolve_processing_issue
@@ -599,6 +598,8 @@ def create_files_from_dif_zip(
     """Creates all missing debug files from the given zip file.  This
     returns a list of all files created.
     """
+    from sentry.lang.native.sources import record_last_upload
+
     scratchpad = tempfile.mkdtemp()
     try:
         safe_extract_zip(fileobj, scratchpad, strip_toplevel=False)

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -43,6 +43,7 @@ from sentry.db.models import (
     region_silo_only_model,
     sane_repr,
 )
+from sentry.lang.native.sources import record_last_upload
 from sentry.models.files.file import File
 from sentry.models.files.utils import clear_cached_files
 from sentry.reprocessing import bump_reprocessing_revision, resolve_processing_issue
@@ -615,6 +616,7 @@ def create_files_from_dif_zip(
         rv = create_debug_file_from_dif(to_create, project)
 
         # Uploading new dsysm changes the reprocessing revision
+        record_last_upload(project)
         bump_reprocessing_revision(project)
 
         return rv

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -185,6 +185,7 @@ def assemble_dif(project_id, name, checksum, chunks, debug_id=None, **kwargs):
     """
     Assembles uploaded chunks into a ``ProjectDebugFile``.
     """
+    from sentry.lang.native.sources import record_last_upload
     from sentry.models import BadDif, Project, debugfile
     from sentry.reprocessing import bump_reprocessing_revision
 
@@ -239,6 +240,7 @@ def assemble_dif(project_id, name, checksum, chunks, debug_id=None, **kwargs):
                 # and might resolve processing issues. If the file was not
                 # created, someone else has created it and will bump the
                 # revision instead.
+                record_last_upload(project)
                 bump_reprocessing_revision(project, use_buffer=True)
     except Exception:
         set_assemble_status(


### PR DESCRIPTION
Second try of #53049, now with a configurable redis cluster, and a companion PR: https://github.com/getsentry/getsentry/pull/11147

By attaching a random querystring parameter to the Sentry internal source, this will cause a cache miss in Symbolicators `list_files` cache, thus fetching and discovering the uploaded debug file immediately.

This is very similar to `bump_reprocessing_revision`, except it has a TTL. Also the code for `bump_reprocessing_revision` is overly complex for reasons I don’t understand so I don’t want to touch that.

I tested this with a local symbolicator that has caching turned on, see this comment:
https://github.com/getsentry/sentry/blob/3eae8087c6096c80aa64240e43bed670b3dfb6c5/tests/symbolicator/test_minidump_full.py#L156-L160