### PR TITLE
fix(metrics): on demand metric deduplication

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -58,7 +58,7 @@ def get_metric_extraction_config(project: Project) -> Optional[MetricExtractionC
         .select_related("snuba_query")
     )
 
-    metrics = get_metric_specs(alerts)
+    metrics = _get_metric_specs(alerts)
 
     if not metrics:
         return None

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, List, Optional, Sequence, Tuple, TypedDict, Union, cast
+from typing import Any, Dict, List, Optional, Sequence, Tuple, TypedDict, Union, cast
 
 from sentry import features
 from sentry.api.endpoints.project_transaction_threshold import DEFAULT_THRESHOLD
@@ -58,10 +58,7 @@ def get_metric_extraction_config(project: Project) -> Optional[MetricExtractionC
         .select_related("snuba_query")
     )
 
-    metrics: List[MetricSpec] = []
-    for alert in alerts:
-        if metric := convert_query_to_metric(alert.snuba_query):
-            metrics.append(metric)
+    metrics = get_metric_specs(alerts)
 
     if not metrics:
         return None
@@ -76,7 +73,19 @@ def get_metric_extraction_config(project: Project) -> Optional[MetricExtractionC
     }
 
 
-def convert_query_to_metric(snuba_query: SnubaQuery) -> Optional[MetricSpec]:
+def get_metric_specs(alert_rules: Sequence[AlertRule]) -> Sequence[MetricSpec]:
+    # We use a dict so that we can deduplicate metrics with the same query.
+    metrics: Dict[str, MetricSpec] = dict()
+
+    for alert in alert_rules:
+        query_hash, metric = convert_query_to_metric(alert.snuba_query)
+        if query_hash and metric:
+            metrics[query_hash] = metric
+
+    return list(metrics.values())
+
+
+def convert_query_to_metric(snuba_query: SnubaQuery) -> Optional[Tuple[str, MetricSpec]]:
     """
     If the passed snuba_query is a valid query for on-demand metric extraction,
     returns a MetricSpec for the query. Otherwise, returns None.
@@ -86,13 +95,14 @@ def convert_query_to_metric(snuba_query: SnubaQuery) -> Optional[MetricSpec]:
             return None
 
         spec = OndemandMetricSpec(snuba_query.aggregate, snuba_query.query)
+        query_hash = spec.query_hash()
 
-        return {
+        return query_hash, {
             "category": DataCategory.TRANSACTION.api_name(),
             "mri": spec.mri,
             "field": spec.field,
             "condition": spec.condition(),
-            "tags": [{"key": QUERY_HASH_KEY, "value": spec.query_hash()}],
+            "tags": [{"key": QUERY_HASH_KEY, "value": query_hash}],
         }
     except Exception as e:
         logger.error(e, exc_info=True)

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -73,7 +73,7 @@ def get_metric_extraction_config(project: Project) -> Optional[MetricExtractionC
     }
 
 
-def get_metric_specs(alert_rules: Sequence[AlertRule]) -> List[MetricSpec]:
+def _get_metric_specs(alert_rules: Sequence[AlertRule]) -> List[MetricSpec]:
     # We use a dict so that we can deduplicate metrics with the same query.
     metrics: Dict[str, MetricSpec] = {}
 

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -78,10 +78,8 @@ def get_metric_specs(alert_rules: Sequence[AlertRule]) -> List[MetricSpec]:
     metrics: Dict[str, MetricSpec] = {}
 
     for alert in alert_rules:
-        result = convert_query_to_metric(alert.snuba_query)
-        if result:
-            query_hash, spec = result
-            metrics[query_hash] = spec
+        if result := convert_query_to_metric(alert.snuba_query):
+            metrics[result[0]] = result[1]
 
     return [spec for spec in metrics.values()]
 

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -73,16 +73,17 @@ def get_metric_extraction_config(project: Project) -> Optional[MetricExtractionC
     }
 
 
-def get_metric_specs(alert_rules: Sequence[AlertRule]) -> Sequence[MetricSpec]:
+def get_metric_specs(alert_rules: Sequence[AlertRule]) -> List[MetricSpec]:
     # We use a dict so that we can deduplicate metrics with the same query.
-    metrics: Dict[str, MetricSpec] = dict()
+    metrics: Dict[str, MetricSpec] = {}
 
     for alert in alert_rules:
-        query_hash, metric = convert_query_to_metric(alert.snuba_query)
-        if query_hash and metric:
-            metrics[query_hash] = metric
+        result = convert_query_to_metric(alert.snuba_query)
+        if result:
+            query_hash, spec = result
+            metrics[query_hash] = spec
 
-    return list(metrics.values())
+    return [spec for spec in metrics.values()]
 
 
 def convert_query_to_metric(snuba_query: SnubaQuery) -> Optional[Tuple[str, MetricSpec]]:

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -1,7 +1,7 @@
 from unittest.mock import ANY
 
+import sentry.relay.config.metric_extraction as extraction
 from sentry.incidents.models import AlertRule
-from sentry.relay.config.metric_extraction import convert_query_to_metric, get_metric_specs
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
 
@@ -18,13 +18,13 @@ def create_alert(query: str) -> AlertRule:
 def test_empty_query():
     alert = create_alert("")
 
-    assert convert_query_to_metric(alert.snuba_query) is None
+    assert extraction.convert_query_to_metric(alert.snuba_query) is None
 
 
 def test_simple_query_count():
     alert = create_alert("transaction.duration:>=1000")
 
-    metric = convert_query_to_metric(alert.snuba_query)
+    metric = extraction.convert_query_to_metric(alert.snuba_query)
 
     assert metric
     assert metric[1] == {
@@ -37,13 +37,13 @@ def test_simple_query_count():
 
 
 def test_get_metric_specs_empty():
-    assert len(get_metric_specs([])) == 0
+    assert len(extraction._get_metric_specs([])) == 0
 
 
 def test_get_metric_specs_single():
     alert = create_alert("transaction.duration:>=1000")
 
-    specs = get_metric_specs([alert])
+    specs = extraction._get_metric_specs([alert])
 
     assert len(specs) == 1
     assert specs[0] == {
@@ -59,7 +59,7 @@ def test_get_metric_specs_multiple():
     alert_1 = create_alert("transaction.duration:>=1")
     alert_2 = create_alert("transaction.duration:>=2")
 
-    specs = get_metric_specs([alert_1, alert_2])
+    specs = extraction._get_metric_specs([alert_1, alert_2])
 
     assert len(specs) == 2
 
@@ -74,7 +74,7 @@ def test_get_metric_specs_multiple_duplicated():
     alert_2 = create_alert("transaction.duration:>=1000")
     alert_3 = create_alert("transaction.duration:>=1000")
 
-    specs = get_metric_specs([alert_1, alert_2, alert_3])
+    specs = extraction._get_metric_specs([alert_1, alert_2, alert_3])
 
     assert len(specs) == 1
     assert specs[0] == {

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -1,32 +1,81 @@
 from unittest.mock import ANY
 
 from sentry.incidents.models import AlertRule
-from sentry.relay.config.metric_extraction import convert_query_to_metric
+from sentry.relay.config.metric_extraction import convert_query_to_metric, get_metric_specs
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
 
 
-def test_empty_query():
+def create_alert(query: str) -> AlertRule:
     snuba_query = SnubaQuery(
-        aggregate="p75(measurements.fp)",
-        query="",
+        aggregate="count()",
+        query=query,
         dataset=Dataset.PerformanceMetrics.value,
     )
-    alert = AlertRule(snuba_query=snuba_query)
+    return AlertRule(snuba_query=snuba_query)
+
+
+def test_empty_query():
+    alert = create_alert("")
 
     assert convert_query_to_metric(alert.snuba_query) is None
 
 
 def test_simple_query_count():
-    snuba_query = SnubaQuery(
-        aggregate="count()",
-        query="transaction.duration:>=1000",
-        dataset=Dataset.PerformanceMetrics.value,
-    )
-    alert = AlertRule(snuba_query=snuba_query)
+    alert = create_alert("transaction.duration:>=1000")
 
-    metric = convert_query_to_metric(alert.snuba_query)
+    _, metric = convert_query_to_metric(alert.snuba_query)
     assert metric == {
+        "category": "transaction",
+        "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
+        "field": None,
+        "mri": "c:transactions/on_demand@none",
+        "tags": [{"key": "query_hash", "value": ANY}],
+    }
+
+
+def test_get_metric_specs_empty():
+    assert len(get_metric_specs([])) == 0
+
+
+def test_get_metric_specs_single():
+    alert = create_alert("transaction.duration:>=1000")
+
+    specs = get_metric_specs([alert])
+
+    assert len(specs) == 1
+    assert specs[0] == {
+        "category": "transaction",
+        "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
+        "field": None,
+        "mri": "c:transactions/on_demand@none",
+        "tags": [{"key": "query_hash", "value": ANY}],
+    }
+
+
+def test_get_metric_specs_multiple():
+    alert_1 = create_alert("transaction.duration:>=1")
+    alert_2 = create_alert("transaction.duration:>=2")
+
+    specs = get_metric_specs([alert_1, alert_2])
+
+    assert len(specs) == 2
+
+    first_hash = specs[0]["tags"][0]["value"]
+    second_hash = specs[1]["tags"][0]["value"]
+
+    assert first_hash != second_hash
+
+
+def test_get_metric_specs_multiple_duplicated():
+    alert_1 = create_alert("transaction.duration:>=1000")
+    alert_2 = create_alert("transaction.duration:>=1000")
+    alert_3 = create_alert("transaction.duration:>=1000")
+
+    specs = get_metric_specs([alert_1, alert_2, alert_3])
+
+    assert len(specs) == 1
+    assert specs[0] == {
         "category": "transaction",
         "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
         "field": None,

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -25,6 +25,8 @@ def test_simple_query_count():
     alert = create_alert("transaction.duration:>=1000")
 
     metric = convert_query_to_metric(alert.snuba_query)
+
+    assert metric
     assert metric[1] == {
         "category": "transaction",
         "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -24,8 +24,8 @@ def test_empty_query():
 def test_simple_query_count():
     alert = create_alert("transaction.duration:>=1000")
 
-    _, metric = convert_query_to_metric(alert.snuba_query)
-    assert metric == {
+    metric = convert_query_to_metric(alert.snuba_query)
+    assert metric[1] == {
         "category": "transaction",
         "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
         "field": None,


### PR DESCRIPTION
Closes [Fix duplicated metric data on query_hash collision](https://github.com/getsentry/sentry/issues/52957)