### PR TITLE
Hook up Bundle Index to JS Symbolication

### DIFF
--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -19,7 +19,7 @@ from sentry.debug_files.artifact_bundles import (
 )
 from sentry.lang.native.sources import get_internal_artifact_lookup_source_url
 from sentry.models import ArtifactBundle, Distribution, Project, Release, ReleaseFile
-from sentry.models.artifactbundle import NULL_STRING
+from sentry.models.artifactbundle import NULL_STRING, ArtifactBundleFlatFileIndex
 from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.api")
@@ -38,7 +38,7 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
         split = download_id.split("/")
         if len(split) < 2:
             raise Http404
-        ty, ty_id = split
+        ty, ty_id, *_rest = split
 
         rate_limited = ratelimits.is_limited(
             project=project,
@@ -72,10 +72,20 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
                 .first()
             )
             metrics.incr("sourcemaps.download.release_file")
+        elif ty == "bundle_index":
+            file = (
+                ArtifactBundleFlatFileIndex.objects.filter(id=ty_id, project_id=project.id)
+                .select_related("flat_file_index")
+                .first()
+            )
+            metrics.incr("sourcemaps.download.flat_file_index")
 
         if file is None:
             raise Http404
-        file = file.file
+        if isinstance(file, ArtifactBundleFlatFileIndex):
+            file = file.flat_file_index
+        else:
+            file = file.file
 
         try:
             fp = file.getfile()

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import base64
 import logging
+import random
 import sys
 from copy import deepcopy
 from datetime import datetime
-from typing import Tuple
+from typing import Optional, Tuple
 
 import jsonschema
 import sentry_sdk
@@ -207,8 +208,11 @@ def get_internal_artifact_lookup_source_url(project: Project):
 
 
 def get_bundle_index_urls(
-    project: Project, release: str | None, dist: str | None
-) -> Tuple[str | None, str | None]:
+    project: Project, release: Optional[str], dist: Optional[str]
+) -> Tuple[Optional[str], Optional[str]]:
+    if options.get("symbolicator.sourcemaps-bundle-index-sample-rate") <= random.random():
+        return (None, None)
+
     base_url = get_internal_artifact_lookup_source_url(project)
 
     def make_download_url(bundle: ArtifactBundleFlatFileIndex):

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import base64
 import logging
 import sys
 from copy import deepcopy
 from datetime import datetime
+from typing import Tuple
 
 import jsonschema
 import sentry_sdk
@@ -11,6 +14,7 @@ from django.urls import reverse
 
 from sentry import features, options
 from sentry.auth.system import get_system_token
+from sentry.models.artifactbundle import NULL_STRING, ArtifactBundleFlatFileIndex
 from sentry.models.project import Project
 from sentry.utils import json, redis, safe
 
@@ -200,6 +204,38 @@ def get_internal_artifact_lookup_source_url(project: Project):
             },
         ),
     )
+
+
+def get_bundle_index_urls(
+    project: Project, release: str | None, dist: str | None
+) -> Tuple[str | None, str | None]:
+    base_url = get_internal_artifact_lookup_source_url(project)
+
+    def make_download_url(bundle: ArtifactBundleFlatFileIndex):
+        timestamp = int(bundle.date_added.timestamp() * 1000)
+        # NOTE: The `download` query-parameter is both used by symbolicator as a cache key,
+        # and it is also used as the the download key for the artifact-lookup API.
+        # The artifact-lookup API will ignore the additional timestamp on download.
+
+        return f"{base_url}?download=bundle_index/{bundle.id}/{timestamp}"
+
+    # We query the empty release/dist which is a marker for the debug-id index,
+    # as well as the normal release index if we have a release.
+    debug_id_index = ArtifactBundleFlatFileIndex.objects.filter(
+        project_id=project.id, release_name=NULL_STRING, dist_name=NULL_STRING
+    ).first()
+    if debug_id_index:
+        debug_id_index = make_download_url(debug_id_index)
+
+    url_index = None
+    if release:
+        url_index = ArtifactBundleFlatFileIndex.objects.filter(
+            project_id=project.id, release_name=release, dist_name=dist or NULL_STRING
+        ).first()
+    if url_index:
+        url_index = make_download_url(url_index)
+
+    return debug_id_index, url_index
 
 
 def get_internal_artifact_lookup_source(project: Project):

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -14,6 +14,7 @@ from requests.exceptions import RequestException
 from sentry import options
 from sentry.cache import default_cache
 from sentry.lang.native.sources import (
+    get_bundle_index_urls,
     get_internal_artifact_lookup_source,
     sources_for_symbolication,
 )
@@ -179,6 +180,12 @@ class Symbolicator:
             "modules": modules,
             "options": {"apply_source_context": apply_source_context},
         }
+
+        debug_id_index, url_index = get_bundle_index_urls(self.project, release, dist)
+        if debug_id_index:
+            json["debug_id_index"] = debug_id_index
+        if url_index:
+            json["url_index"] = url_index
 
         if release is not None:
             json["release"] = release

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -566,6 +566,10 @@ register(
 register(
     "symbolicator.sourcemaps-processing-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
+# Query and supply Bundle Indexes to Symbolicator SourceMap processing
+register(
+    "symbolicator.sourcemaps-bundle-index-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
 
 # Normalization after processors
 register("store.normalize-after-processing", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)  # unused

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -26,6 +26,7 @@ from sentry.tasks.assemble import assemble_artifacts
 from sentry.testutils import RelayStoreHelper
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.skips import requires_symbolicator
 from sentry.utils import json
 
@@ -3078,6 +3079,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
     @requires_symbolicator
     @pytest.mark.symbolicator
     @with_feature("organizations:sourcemaps-bundle-flat-file-indexing")
+    @override_options({"symbolicator.sourcemaps-bundle-index-sample-rate": 1.0})
     def test_bundle_index(self, process_with_symbolicator):
         if not process_with_symbolicator:
             return


### PR DESCRIPTION
Based on top of https://github.com/getsentry/sentry/pull/53505

This sends new `debug_id_index` and `url_index` download links to Symbolicator which will use those to fetch artifact bundles based on the index.

Also adds support to download the bundle index via the `artifact-lookup?download` API.