### PR TITLE
feat(function): Link before/after examples in function trends

### DIFF
--- a/static/app/utils/profiling/hooks/types.tsx
+++ b/static/app/utils/profiling/hooks/types.tsx
@@ -30,8 +30,6 @@ export type FunctionTrend = {
   breakpoint: number;
   change: TrendType;
   'count()': number;
-  'examples()': string[];
-  // fingerprint: number; DO NOT use this yet
   function: string;
   package: string;
   project: string;
@@ -39,6 +37,7 @@ export type FunctionTrend = {
   trend_difference: number;
   trend_percentage: number;
   unweighted_p_value: number;
+  worst: FunctionExample[];
 };
 
 type EpochTime = number;
@@ -50,3 +49,5 @@ type FunctionTrendStats = {
   end: number;
   start: number;
 };
+
+type FunctionExample = [EpochTime, string];


### PR DESCRIPTION
As an incremental improvement, we want to link a before/after example that can be viewed and manually compared.