### PR TITLE
feat(helpful-event): Temporarily remove trace.sampled from sort

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -202,7 +202,6 @@ class EventOrdering(Enum):
         "-replayId",
         "-profile.id",
         "num_processing_errors",
-        "-trace.sampled",
         "-timestamp",
     ]
 


### PR DESCRIPTION
Due to the changes in https://github.com/getsentry/relay/pull/2290, `trace.sampled` is being applied more conservatively to events. With the current sorting logic, we may be selecting events FROM before the relay change because they were the only ones with `trace.sampled: true`.

Since we only check the last 7 days for the `/helpful` endpoint, we can add this line back in once the relay change is 7 days old.