### PR TITLE
ref(getting-started-docs): Migrate AWS Lambda doc to sentry main rep

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -67,6 +67,7 @@ export const migratedDocs = [
   'ruby-rack',
   'kotlin',
   'node',
+  'node-awslambda',
   'node-azurefunctions',
   'node-gcpfunctions',
   'node-express',

--- a/static/app/gettingStartedDocs/node/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.spec.tsx
@@ -5,7 +5,7 @@ import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {GettingStartedWithAwsLambda, steps} from './awslambda';
 
 describe('GettingStartedWithAwsLambda', function () {
-  it('all products are selected', function () {
+  it('renders doc correctly', function () {
     const {container} = render(<GettingStartedWithAwsLambda dsn="test-dsn" />);
 
     // Steps

--- a/static/app/gettingStartedDocs/node/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.spec.tsx
@@ -1,0 +1,20 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+
+import {GettingStartedWithAwsLambda, steps} from './awslambda';
+
+describe('GettingStartedWithAwsLambda', function () {
+  it('all products are selected', function () {
+    const {container} = render(<GettingStartedWithAwsLambda dsn="test-dsn" />);
+
+    // Steps
+    for (const step of steps()) {
+      expect(
+        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
+      ).toBeInTheDocument();
+    }
+
+    expect(container).toSnapshot();
+  });
+});

--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -1,0 +1,85 @@
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
+import {t, tct} from 'sentry/locale';
+
+const performanceOtherConfig = `
+// Performance Monitoring
+tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!`;
+
+export const steps = ({
+  sentryInitContent,
+}: {
+  sentryInitContent?: string;
+} = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: t('Add the Sentry Node SDK as a dependency:'),
+    configurations: [
+      {
+        language: 'bash',
+        code: `
+# Using yarn
+yarn add @sentry/serverless
+
+# Using npm
+npm install --save @sentry/serverless
+        `,
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: (
+      <p>
+        {tct("Wrap your lambda handler with Sentry's [code:wraphandler] function:", {
+          code: <code />,
+        })}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        const Sentry = require("@sentry/serverless");
+
+        Sentry.AWSLambda.init({
+          ${sentryInitContent},
+        });
+
+        exports.handler = Sentry.AWSLambda.wrapHandler(async (event, context) => {
+          // Your handler code
+        });
+        `,
+      },
+    ],
+  },
+  getUploadSourceMapsStep('https://docs.sentry.io/platforms/node/sourcemaps/'),
+  {
+    type: StepType.VERIFY,
+    description: t(
+      "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        exports.handler = Sentry.AWSLambda.wrapHandler(async (event, context) => {
+          throw new Error("This should show up in Sentry!")
+        });
+        `,
+      },
+    ],
+  },
+];
+
+export function GettingStartedWithAwsLambda({dsn, ...props}: ModuleProps) {
+  const sentryInitContent: string[] = [`dsn: "${dsn}",`, performanceOtherConfig];
+
+  return (
+    <Layout steps={steps({sentryInitContent: sentryInitContent.join('\n')})} {...props} />
+  );
+}
+
+export default GettingStartedWithAwsLambda;

--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -2,7 +2,17 @@ import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDo
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
+import {PlatformKey} from 'sentry/data/platformCategories';
 import {t, tct} from 'sentry/locale';
+import {Organization} from 'sentry/types';
+
+type StepProps = {
+  newOrg: boolean;
+  organization: Organization;
+  platformKey: PlatformKey;
+  projectId: string;
+  sentryInitContent: string;
+};
 
 const performanceOtherConfig = `
 // Performance Monitoring
@@ -10,9 +20,8 @@ tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production
 
 export const steps = ({
   sentryInitContent,
-}: {
-  sentryInitContent?: string;
-} = {}): LayoutProps['steps'] => [
+  ...props
+}: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
     description: t('Add the Sentry Serverless SDK as a dependency:'),
@@ -55,7 +64,10 @@ npm install --save @sentry/serverless
       },
     ],
   },
-  getUploadSourceMapsStep('https://docs.sentry.io/platforms/node/sourcemaps/'),
+  getUploadSourceMapsStep({
+    guideLink: 'https://docs.sentry.io/platforms/node/sourcemaps/',
+    ...props,
+  }),
   {
     type: StepType.VERIFY,
     description: t(
@@ -74,11 +86,27 @@ npm install --save @sentry/serverless
   },
 ];
 
-export function GettingStartedWithAwsLambda({dsn, ...props}: ModuleProps) {
+export function GettingStartedWithAwsLambda({
+  dsn,
+  organization,
+  newOrg,
+  platformKey,
+  projectId,
+}: ModuleProps) {
   const sentryInitContent: string[] = [`dsn: "${dsn}",`, performanceOtherConfig];
 
   return (
-    <Layout steps={steps({sentryInitContent: sentryInitContent.join('\n')})} {...props} />
+    <Layout
+      steps={steps({
+        sentryInitContent: sentryInitContent.join('\n'),
+        organization,
+        newOrg,
+        platformKey,
+        projectId,
+      })}
+      newOrg={newOrg}
+      platformKey={platformKey}
+    />
   );
 }
 

--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -15,7 +15,7 @@ export const steps = ({
 } = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: t('Add the Sentry Node SDK as a dependency:'),
+    description: t('Add the Sentry Serverless SDK as a dependency:'),
     configurations: [
       {
         language: 'bash',


### PR DESCRIPTION
This PR represents the outcome of our chosen https://github.com/getsentry/sentry/pull/50169, aiming to enhance our getting started documentation in the Sentry repository using React.

It migrates the Node AWS Lambda onboarding/getting started to to the Sentry main repo

closes #52192 