### PR TITLE
feat(replays): Add --threads cli option to the ingest-replay-recordings consumer

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Mapping, Optional, Sequence
+from typing import List, Mapping, Optional, Sequence
 
 import click
 from arroyo.backends.abstract import Consumer
@@ -46,6 +46,13 @@ def multiprocessing_options(
             help="Maximum time (in milliseconds) to wait before flushing a batch.",
         ),
     ]
+
+
+def ingest_replay_recordings_options() -> List[click.Option]:
+    """Return a list of ingest-replay-recordings options."""
+    options = multiprocessing_options(default_max_batch_size=10)
+    options.append(click.Option(["--threads", "num_threads"], type=int, default=4))
+    return options
 
 
 _METRICS_INDEXER_OPTIONS = [
@@ -105,7 +112,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
     "ingest-replay-recordings": {
         "topic": settings.KAFKA_INGEST_REPLAYS_RECORDINGS,
         "strategy_factory": "sentry.replays.consumers.recording.ProcessReplayRecordingStrategyFactory",
-        "click_options": multiprocessing_options(default_max_batch_size=10),
+        "click_options": ingest_replay_recordings_options(),
     },
     "ingest-monitors": {
         "topic": settings.KAFKA_INGEST_MONITORS,

--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -47,6 +47,7 @@ class ProcessReplayRecordingStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
         max_batch_time: int,
         num_processes: int,
         output_block_size: int,
+        num_threads: int = 4,  # Defaults to 4 for self-hosted.
         force_synchronous: bool = False,  # Force synchronous runner (only used in test suite).
     ) -> None:
         # For information on configuring this consumer refer to this page:
@@ -55,6 +56,7 @@ class ProcessReplayRecordingStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
         self.max_batch_size = max_batch_size
         self.max_batch_time = max_batch_time
         self.num_processes = num_processes
+        self.num_threads = num_threads
         self.output_block_size = output_block_size
         self.use_processes = self.num_processes > 1
         self.force_synchronous = force_synchronous
@@ -85,7 +87,7 @@ class ProcessReplayRecordingStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
                 function=initialize_threaded_context,
                 next_step=RunTaskInThreads(
                     processing_function=process_message_threaded,
-                    concurrency=4,
+                    concurrency=self.num_threads,
                     max_pending_futures=50,
                     next_step=CommitOffsets(commit),
                 ),

--- a/tests/sentry/replays/consumers/test_recording.py
+++ b/tests/sentry/replays/consumers/test_recording.py
@@ -24,6 +24,7 @@ def test_multiprocessing_strategy():
     # multi-processing.
     factory = ProcessReplayRecordingStrategyFactory(
         num_processes=2,
+        num_threads=1,
         input_block_size=1,
         max_batch_size=1,
         max_batch_time=1,
@@ -44,6 +45,7 @@ class RecordingTestCaseMixin:
             max_batch_size=1,
             max_batch_time=1,
             num_processes=1,
+            num_threads=1,
             output_block_size=1,
             force_synchronous=self.force_synchronous,
         )


### PR DESCRIPTION
Adds a `--threads` CLI option to the ingest-replay-recordings consumer.