### PR TITLE
feat(perf): Allow excluding span ops

### DIFF
--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -115,7 +115,10 @@ class OrganizationEventsSpansEndpointBase(OrganizationEventsV2EndpointBase):
 class SpansPerformanceSerializer(serializers.Serializer):
     field = ListField(child=serializers.CharField(), required=False, allow_null=True)
     query = serializers.CharField(required=False, allow_null=True)
-    spanOp = ListField(child=serializers.CharField(), required=False, allow_null=True, max_length=4)
+    spanOp = ListField(child=serializers.CharField(), required=False, allow_null=True, max_length=5)
+    excludeSpanOp = ListField(
+        child=serializers.CharField(), required=False, allow_null=True, max_length=5
+    )
     spanGroup = ListField(
         child=serializers.CharField(), required=False, allow_null=True, max_length=4
     )
@@ -157,6 +160,7 @@ class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsSpansEndpoint
         fields = serialized.get("field", [])
         query = serialized.get("query")
         span_ops = serialized.get("spanOp")
+        exclude_span_ops = serialized.get("excludeSpanOp")
         span_groups = serialized.get("spanGroup")
         min_exclusive_time = serialized.get("min_exclusive_time")
         max_exclusive_time = serialized.get("max_exclusive_time")
@@ -169,6 +173,7 @@ class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsSpansEndpoint
                 fields,
                 query,
                 span_ops,
+                exclude_span_ops,
                 span_groups,
                 direction,
                 orderby_column,
@@ -467,6 +472,7 @@ def query_suspect_span_groups(
     fields: List[str],
     query: Optional[str],
     span_ops: Optional[List[str]],
+    exclude_span_ops: Optional[List[str]],
     span_groups: Optional[List[str]],
     direction: str,
     orderby: str,
@@ -516,6 +522,15 @@ def query_suspect_span_groups(
                 builder.resolve_function("array_join(spans_op)"),
                 Op.IN,
                 Function("tuple", span_ops),
+            )
+        )
+
+    if exclude_span_ops:
+        extra_conditions.append(
+            Condition(
+                builder.resolve_function("array_join(spans_op)"),
+                Op.NOT_IN,
+                Function("tuple", exclude_span_ops),
             )
         )
 


### PR DESCRIPTION
### Summary
  We don't have a way currently to exclude span ops from "suspect spans" in the spans requests,
  this means sometimes suspect spans tab shows root spans (eg.
  http.server, pageload). The arrays that are used by suspect spans have
  no parent information, which would be the preferred way of checking
  this, but users might also set custom transactions they do care about
  the self-time for.

  This api changes allows us to send a small list of known root
  transaction op types from the frontend.

