### PR TITLE
ref(getting-started-docs): Migrate GCPFunctions doc to sentry main repo

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -57,6 +57,7 @@ export const migratedDocs = [
   'ruby-rack',
   'kotlin',
   'node',
+  'node-gcpfunctions',
   'node-express',
   'electron',
   'elixir',

--- a/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
@@ -1,0 +1,20 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+
+import {GettingStartedWithGCPFunctions, steps} from './gcpfunctions';
+
+describe('GettingStartedWithGCPFunctions', function () {
+  it('all products are selected', function () {
+    const {container} = render(<GettingStartedWithGCPFunctions dsn="test-dsn" />);
+
+    // Steps
+    for (const step of steps()) {
+      expect(
+        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
+      ).toBeInTheDocument();
+    }
+
+    expect(container).toSnapshot();
+  });
+});

--- a/static/app/gettingStartedDocs/node/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.tsx
@@ -1,0 +1,154 @@
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
+import {t, tct} from 'sentry/locale';
+
+const performanceOtherConfig = `// Performance Monitoring
+tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!`;
+
+export const steps = ({
+  sentryInitContent,
+}: {
+  sentryInitContent?: string;
+} = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: (
+      <p>
+        {tct(
+          'Add the Sentry Serverless SDK as a dependency to your [code:package.json]:',
+          {code: <code />}
+        )}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'json',
+        code: `
+dependencies: {
+  //...
+  "@sentry/serverless": "^7"
+}
+        `,
+      },
+    ],
+  },
+  {
+    title: t('Configure SDK for Http Functions'),
+    description: (
+      <p>
+        {tct('Use [code:wrapHttpFunction] to wrap your http function:', {
+          code: <code />,
+        })}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        const Sentry = require("@sentry/serverless");
+
+        Sentry.GCPFunction.init({
+          ${sentryInitContent}
+        });
+
+        exports.helloHttp = Sentry.GCPFunction.wrapHttpFunction((req, res) => {
+          /* Your function code */
+        });
+        `,
+      },
+    ],
+  },
+  {
+    title: t('Configure SDK for Background Functions'),
+    description: (
+      <p>
+        {tct('Use [code:wrapEventFunction] to wrap your background function:', {
+          code: <code />,
+        })}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        const Sentry = require("@sentry/serverless");
+
+        Sentry.GCPFunction.init({
+          ${sentryInitContent}
+        });
+
+        exports.helloEvents = Sentry.GCPFunction.wrapEventFunction(
+          (data, context, callback) => {
+            /* Your function code */
+          }
+        );
+        `,
+      },
+    ],
+  },
+  {
+    title: t('Configure SDK for CloudEvent Functions'),
+    description: (
+      <p>
+        {tct('Use [code:wrapCloudEventFunction] to wrap your CloudEvent function:', {
+          code: <code />,
+        })}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        const Sentry = require("@sentry/serverless");
+
+        Sentry.GCPFunction.init({
+          ${sentryInitContent}
+        });
+
+        exports.helloEvents = Sentry.GCPFunction.wrapCloudEventFunction(
+          (context, callback) => {
+            /* Your function code */
+          }
+        );
+        `,
+      },
+    ],
+  },
+  getUploadSourceMapsStep(
+    'https://docs.sentry.io/platforms/node/guides/express/sourcemaps/'
+  ),
+  {
+    type: StepType.VERIFY,
+    description: t(
+      "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        exports.helloHttp = Sentry.GCPFunction.wrapHttpFunction((req, res) => {
+          throw new Error("oh, hello there!");
+        });
+        `,
+      },
+    ],
+  },
+];
+
+export function GettingStartedWithGCPFunctions({dsn, ...props}: ModuleProps) {
+  let sentryInitContent: string[] = [`dsn: "${dsn}",`];
+
+  const otherConfigs = [performanceOtherConfig];
+
+  if (otherConfigs.length > 0) {
+    sentryInitContent = sentryInitContent.concat(otherConfigs);
+  }
+
+  return (
+    <Layout steps={steps({sentryInitContent: sentryInitContent.join('\n')})} {...props} />
+  );
+}
+
+export default GettingStartedWithGCPFunctions;


### PR DESCRIPTION
This PR represents the outcome of our chosen https://github.com/getsentry/sentry/pull/50169, aiming to enhance our getting started documentation in the Sentry repository using React.

It migrates the Node GCP Functions onboarding/getting started to to the Sentry main repo

closes #52193  