### PR TITLE
ref(stacktrace): Ensure frame labels stay aligned in Native

### DIFF
--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -410,7 +410,7 @@ const FileName = styled('span')`
 
 const RowHeader = styled('span')<{expandable: boolean; expanded: boolean}>`
   display: grid;
-  grid-template-columns: repeat(2, auto) 1fr repeat(2, auto);
+  grid-template-columns: repeat(2, auto) 1fr repeat(2, auto) ${space(2)};
   grid-template-rows: repeat(2, auto);
   align-items: center;
   align-content: center;
@@ -419,12 +419,9 @@ const RowHeader = styled('span')<{expandable: boolean; expanded: boolean}>`
   font-size: ${p => p.theme.codeFontSize};
   padding: ${space(1)};
   ${p => p.expandable && `cursor: pointer;`};
-  ${p =>
-    p.expandable && `grid-template-columns: repeat(2, auto) 1fr repeat(2, auto) 16px;`};
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: auto 150px 120px 4fr auto auto;
-    ${p => p.expandable && `grid-template-columns: auto 150px 120px 4fr auto auto 16px;`};
+    grid-template-columns: auto 150px 120px 4fr auto auto ${space(2)};
     padding: ${space(0.5)} ${space(1.5)};
     min-height: 32px;
   }


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/50695

When a native frame cannot be expanded, show an empty space there so that the right-aligned labels stay aligned.

<img width="240" alt="Screenshot 2023-07-18 at 10 27 18 AM" src="https://github.com/getsentry/sentry/assets/22582037/aa6f8f05-b21e-490b-a78b-0444298af8fb">
<img width="287" alt="Screenshot 2023-07-18 at 10 24 32 AM" src="https://github.com/getsentry/sentry/assets/22582037/ed74b299-a987-4066-88db-b967f8c2679f">