### PR TITLE
Revert "ref(projects): Redirect post project transfer to project teams page"

### DIFF
--- a/static/app/views/acceptProjectTransfer/index.tsx
+++ b/static/app/views/acceptProjectTransfer/index.tsx
@@ -42,14 +42,8 @@ class AcceptProjectTransfer extends DeprecatedAsyncView<Props, State> {
       },
       success: () => {
         const orgSlug = formData.organization;
-        const projectSlug = this.state?.transferDetails?.project.slug;
-        if (projectSlug === null) {
-          this.props.router.push(normalizeUrl(`/organizations/${orgSlug}/projects/`));
-        } else {
-          this.props.router.push(
-            normalizeUrl(`/settings/${orgSlug}/projects/${projectSlug}/teams/`)
-          );
-        }
+
+        this.props.router.push(normalizeUrl(`/organizations/${orgSlug}/projects/`));
         addSuccessMessage(t('Project successfully transferred'));
       },
       error: error => {


### PR DESCRIPTION
Reverts getsentry/sentry#52925

Sadly it did not work, not sure why but it doesn't redirect to the new org so you just land on a page that says the project was not found (since it was transferred). 