### PR TITLE
ref(hc): Force transaction.on_commit using= param

### DIFF
--- a/src/sentry/data_export/models.py
+++ b/src/sentry/data_export/models.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from django.db import models, transaction
+from django.db import models, router, transaction
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_str
@@ -82,7 +82,7 @@ class ExportedData(Model):
         current_time = timezone.now()
         expire_time = current_time + expiration
         self.update(file_id=file.id, date_finished=current_time, date_expired=expire_time)
-        transaction.on_commit(lambda: self.email_success())
+        transaction.on_commit(lambda: self.email_success(), router.db_for_write(ExportedData))
 
     def email_success(self):
         from sentry.utils.email import MessageBuilder

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -998,7 +998,8 @@ def trigger_incident_triggers(incident):
                         project_id=project.id,
                         method="resolve",
                         new_status=IncidentStatus.CLOSED.value,
-                    ).delay
+                    ).delay,
+                    router.db_for_write(AlertRuleTrigger),
                 )
 
 

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -701,7 +701,8 @@ class SubscriptionProcessor:
                     method=method,
                     new_status=new_status,
                     metric_value=metric_value,
-                ).delay
+                ).delay,
+                router.db_for_write(AlertRule),
             )
 
     def handle_incident_severity_update(self) -> None:

--- a/src/sentry/models/commitfilechange.py
+++ b/src/sentry/models/commitfilechange.py
@@ -1,6 +1,6 @@
 from typing import Any, Iterable
 
-from django.db import models, transaction
+from django.db import models, router, transaction
 from django.db.models.signals import post_save
 
 from sentry.db.models import (
@@ -62,7 +62,7 @@ def process_resource_change(instance, **kwargs):
                 kwargs={"commit_id": instance.commit_id}, countdown=60 * 5
             )
 
-    transaction.on_commit(_spawn_task)
+    transaction.on_commit(_spawn_task, router.db_for_write(CommitFileChange))
 
 
 post_save.connect(

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Dict
 
 from django.conf import settings
-from django.db import models, transaction
+from django.db import models, router, transaction
 from django.utils import timezone
 
 from sentry.db.models import (
@@ -79,7 +79,8 @@ class GroupAssigneeManager(BaseManager):
             transaction.on_commit(
                 lambda: issue_assigned.send_robust(
                     project=group.project, group=group, user=acting_user, sender=self.__class__
-                )
+                ),
+                router.db_for_write(GroupAssignee),
             )
             data = {
                 "assignee": str(assigned_to.id),

--- a/src/sentry/models/integrations/external_actor.py
+++ b/src/sentry/models/integrations/external_actor.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db import models, transaction
+from django.db import models, router, transaction
 from django.db.models.signals import post_delete, post_save
 
 from sentry.db.models import (
@@ -77,7 +77,7 @@ def process_resource_change(instance, **kwargs):
         except (Organization.DoesNotExist, Project.DoesNotExist):
             pass
 
-    transaction.on_commit(_spawn_task)
+    transaction.on_commit(_spawn_task, router.db_for_write(Project))
 
 
 post_save.connect(

--- a/src/sentry/models/integrations/repository_project_path_config.py
+++ b/src/sentry/models/integrations/repository_project_path_config.py
@@ -1,4 +1,4 @@
-from django.db import models, transaction
+from django.db import models, router, transaction
 from django.db.models.signals import post_save
 
 from sentry.db.models import (
@@ -71,8 +71,8 @@ def process_resource_change(instance, **kwargs):
         cache_keys = [f"process-commit-context-{group_id}" for group_id in group_ids]
         cache.delete_many(cache_keys)
 
-    transaction.on_commit(_spawn_update_schema_task)
-    transaction.on_commit(_clear_commit_context_cache)
+    transaction.on_commit(_spawn_update_schema_task, router.db_for_write(type(instance)))
+    transaction.on_commit(_clear_commit_context_cache, router.db_for_write(type(instance)))
 
 
 post_save.connect(

--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Sequence
 
-from django.db import transaction
+from django.db import router, transaction
 from django.db.models.signals import post_delete, post_save
 
 from sentry.constants import ObjectStatus
@@ -68,7 +68,7 @@ def process_resource_change(instance, **kwargs):
         except (Project.DoesNotExist, Organization.DoesNotExist):
             pass
 
-    transaction.on_commit(_spawn_task)
+    transaction.on_commit(_spawn_task, router.db_for_write(ProjectTeam))
 
 
 post_save.connect(

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -118,7 +118,7 @@ class TeamManager(BaseManager):
             except (Organization.DoesNotExist, Project.DoesNotExist):
                 pass
 
-        transaction.on_commit(_spawn_task)
+        transaction.on_commit(_spawn_task, router.db_for_write(Team))
 
 
 # TODO(dcramer): pull in enum library

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Set, Union
 
-from django.db import transaction
+from django.db import router, transaction
 from django.utils import timezone
 from rest_framework.request import Request
 
@@ -24,7 +24,8 @@ def signal_first_checkin(project: Project, monitor: Monitor):
         transaction.on_commit(
             lambda: first_cron_checkin_received.send_robust(
                 project=project, monitor_id=str(monitor.guid), sender=Project
-            )
+            ),
+            router.db_for_write(Project),
         )
 
 

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -49,7 +49,10 @@ def resolve_group_resolutions(instance, created, **kwargs):
     if not created:
         return
 
-    transaction.on_commit(lambda: clear_expired_resolutions.delay(release_id=instance.id))
+    transaction.on_commit(
+        lambda: clear_expired_resolutions.delay(release_id=instance.id),
+        router.db_for_write(Release),
+    )
 
 
 def remove_resolved_link(link):

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -551,5 +551,6 @@ class OnCommitBackedOrganizationSignalService(OrganizationSignalService):
                 organization_id=organization_id,
                 signal=_signal,
                 args=args,
-            )
+            ),
+            router.db_for_write(Organization),
         )

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -2,7 +2,7 @@ import logging
 import time
 
 import sentry_sdk
-from django.db import transaction
+from django.db import router, transaction
 
 from sentry.models.organization import Organization
 from sentry.relay import projectconfig_cache, projectconfig_debounce_cache
@@ -270,6 +270,8 @@ def schedule_invalidate_project_config(
         slight delay to increase the likelihood of deduplicating invalidations but you can
         tweak this, like e.g. the :func:`invalidate_all` task does.
     """
+    from sentry.models import Project
+
     with sentry_sdk.start_span(
         op="relay.projectconfig_cache.invalidation.schedule_after_db_transaction",
     ):
@@ -283,7 +285,8 @@ def schedule_invalidate_project_config(
                 project_id=project_id,
                 public_key=public_key,
                 countdown=countdown,
-            )
+            ),
+            router.db_for_write(Project),
         )
 
 

--- a/tests/sentry/db/test_transactions.py
+++ b/tests/sentry/db/test_transactions.py
@@ -99,16 +99,16 @@ class CaseMixin:
     def test_transaction_on_commit(self):
         def do_assertions():
             calls = []
-            transaction.on_commit(lambda: calls.append("a"))
+            transaction.on_commit(lambda: calls.append("a"), "default")
 
             with transaction.atomic("default"):
                 with transaction.atomic("default"):
                     with pytest.raises(AssertionError):
                         with transaction.atomic("default"):
-                            transaction.on_commit(lambda: calls.append("no go"))
+                            transaction.on_commit(lambda: calls.append("no go"), "default")
                             raise AssertionError("Oh no!")
-                    transaction.on_commit(lambda: calls.append("b"))
-                transaction.on_commit(lambda: calls.append("c"))
+                    transaction.on_commit(lambda: calls.append("b"), "default")
+                transaction.on_commit(lambda: calls.append("c"), "default")
                 assert calls == ["a"]
 
             assert calls == ["a", "b", "c"]


### PR DESCRIPTION
As part of hybrid cloud, we need to make sure every database interaction specifies the precise using= it touches.