### PR TITLE
fix(scim): email was not not within an array for filters

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -399,7 +399,7 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         ).order_by("email", "id")
         if query_params["filter"]:
             filtered_users = user_service.get_many_by_email(
-                emails=query_params["filter"],
+                emails=[query_params["filter"]],
                 organization_id=organization.id,
                 is_verified=False,
             )

--- a/tests/sentry/api/endpoints/test_scim_user_index.py
+++ b/tests/sentry/api/endpoints/test_scim_user_index.py
@@ -302,6 +302,7 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
 
     def test_get_members_no_filter__invited(self):
         member = self.create_member(organization=self.organization, email="test.user@okta.local")
+        admin = OrganizationMember.objects.get(organization=self.organization, user_id=self.user.id)
         url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
         response = self.client.get(f"{url}?startIndex=1&count=100")
         correct_get_data = {
@@ -322,7 +323,7 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
                 },
                 {
                     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
-                    "id": "1",
+                    "id": str(admin.id),
                     "userName": self.user.username,
                     "emails": [{"primary": True, "value": self.user.email, "type": "work"}],
                     "name": {"familyName": "N/A", "givenName": "N/A"},
@@ -338,6 +339,7 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
     def test_get_members_no_filter__approved(self):
         user = self.create_user(email="test.user@okta.local")
         member = self.create_member(organization=self.organization, user=user)
+        admin = OrganizationMember.objects.get(organization=self.organization, user_id=self.user.id)
         url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
         response = self.client.get(f"{url}?startIndex=1&count=100")
         correct_get_data = {
@@ -348,7 +350,7 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
             "Resources": [
                 {
                     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
-                    "id": "1",
+                    "id": str(admin.id),
                     "userName": self.user.username,
                     "emails": [{"primary": True, "value": self.user.email, "type": "work"}],
                     "name": {"familyName": "N/A", "givenName": "N/A"},
@@ -405,6 +407,7 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
         response = self.client.get(
             f"{url}?startIndex=1&count=100&filter=userName%20eq%20%22TEST.USER%40okta.local%22"
         )
+
         correct_get_data = {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
             "totalResults": 1,

--- a/tests/sentry/api/endpoints/test_scim_user_index.py
+++ b/tests/sentry/api/endpoints/test_scim_user_index.py
@@ -273,8 +273,107 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
             "detail": "Invalid organization role.",
         }
 
-    def test_users_get_populated(self):
+    def test_get_members_with_filter__invited(self):
         member = self.create_member(organization=self.organization, email="test.user@okta.local")
+        url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
+        response = self.client.get(
+            f"{url}?startIndex=1&count=100&filter=userName%20eq%20%22test.user%40okta.local%22"
+        )
+        correct_get_data = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+            "totalResults": 1,
+            "startIndex": 1,
+            "itemsPerPage": 1,
+            "Resources": [
+                {
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+                    "id": str(member.id),
+                    "userName": "test.user@okta.local",
+                    "emails": [{"primary": True, "value": "test.user@okta.local", "type": "work"}],
+                    "name": {"familyName": "N/A", "givenName": "N/A"},
+                    "active": True,
+                    "meta": {"resourceType": "User"},
+                    "sentryOrgRole": self.organization.default_role,
+                }
+            ],
+        }
+        assert response.status_code == 200, response.content
+        assert response.data == correct_get_data
+
+    def test_get_members_no_filter__invited(self):
+        member = self.create_member(organization=self.organization, email="test.user@okta.local")
+        url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
+        response = self.client.get(f"{url}?startIndex=1&count=100")
+        correct_get_data = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+            "totalResults": 2,
+            "startIndex": 1,
+            "itemsPerPage": 2,
+            "Resources": [
+                {
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+                    "id": str(member.id),
+                    "userName": "test.user@okta.local",
+                    "emails": [{"primary": True, "value": "test.user@okta.local", "type": "work"}],
+                    "name": {"familyName": "N/A", "givenName": "N/A"},
+                    "active": True,
+                    "meta": {"resourceType": "User"},
+                    "sentryOrgRole": self.organization.default_role,
+                },
+                {
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+                    "id": "1",
+                    "userName": self.user.username,
+                    "emails": [{"primary": True, "value": self.user.email, "type": "work"}],
+                    "name": {"familyName": "N/A", "givenName": "N/A"},
+                    "active": True,
+                    "meta": {"resourceType": "User"},
+                    "sentryOrgRole": "owner",
+                },
+            ],
+        }
+        assert response.status_code == 200, response.content
+        assert response.data == correct_get_data
+
+    def test_get_members_no_filter__approved(self):
+        user = self.create_user(email="test.user@okta.local")
+        member = self.create_member(organization=self.organization, user=user)
+        url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
+        response = self.client.get(f"{url}?startIndex=1&count=100")
+        correct_get_data = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+            "totalResults": 2,
+            "startIndex": 1,
+            "itemsPerPage": 2,
+            "Resources": [
+                {
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+                    "id": "1",
+                    "userName": self.user.username,
+                    "emails": [{"primary": True, "value": self.user.email, "type": "work"}],
+                    "name": {"familyName": "N/A", "givenName": "N/A"},
+                    "active": True,
+                    "meta": {"resourceType": "User"},
+                    "sentryOrgRole": "owner",
+                },
+                {
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+                    "id": str(member.id),
+                    "userName": "test.user@okta.local",
+                    "emails": [{"primary": True, "value": "test.user@okta.local", "type": "work"}],
+                    "name": {"familyName": "N/A", "givenName": "N/A"},
+                    "active": True,
+                    "meta": {"resourceType": "User"},
+                    "sentryOrgRole": self.organization.default_role,
+                },
+            ],
+        }
+        assert response.status_code == 200, response.content
+        assert response.data == correct_get_data
+
+    def test_get_members_with_filter__approved(self):
+        user = self.create_user(email="test.user@okta.local")
+        member = self.create_member(organization=self.organization, user=user)
         url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
         response = self.client.get(
             f"{url}?startIndex=1&count=100&filter=userName%20eq%20%22test.user%40okta.local%22"


### PR DESCRIPTION
The user_service email filter expects an array of emails, but the filter was providing a single email. Also I added a few tests to improve coverage
