### PR TITLE
ref(metrics) Add the transactions http_error_rate function to metrics layer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,9 @@
 /src/sentry/tagstore/snuba/                              @getsentry/owners-snuba
 /src/sentry/sentry_metrics/                              @getsentry/owners-snuba
 /tests/sentry/sentry_metrics/                            @getsentry/owners-snuba
+/src/sentry/snuba/metrics/                               @getsentry/owners-snuba @getsentry/telemetry-experience
+/src/sentry/snuba/metrics/query.py                       @getsentry/owners-snuba @getsentry/telemetry-experience
+/src/sentry/search/events/datasets/metrics_layer.py      @getsentry/owners-snuba
 
 ## Event Ingestion
 /src/sentry/attachments/                                 @getsentry/owners-ingest
@@ -387,13 +390,11 @@ yarn.lock                                                @getsentry/owners-js-de
 
 
 ## Telemetry Experience
-/src/sentry/snuba/metrics/                                                       @getsentry/telemetry-experience
 /src/sentry/api/endpoints/organization_metrics.py                                @getsentry/telemetry-experience
 /src/sentry/api/endpoints/organization_sessions.py                               @getsentry/telemetry-experience
 /src/sentry/api/endpoints/project_dynamic_sampling.py                            @getsentry/telemetry-experience
 /src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py          @getsentry/telemetry-experience
 /src/sentry/dynamic_sampling/                                                    @getsentry/telemetry-experience
-/src/sentry/snuba/metrics/query.py                                               @getsentry/telemetry-experience
 /src/sentry/release_health/metrics_sessions_v2.py                                @getsentry/telemetry-experience
 /tests/sentry/api/endpoints/test_organization_metric_data.py                     @getsentry/telemetry-experience
 /tests/sentry/api/endpoints/test_organization_metric_details.py                  @getsentry/telemetry-experience

--- a/src/sentry/search/events/datasets/metrics_layer.py
+++ b/src/sentry/search/events/datasets/metrics_layer.py
@@ -397,6 +397,20 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
                     default_result_type="percentage",
                 ),
                 fields.MetricsFunction(
+                    "http_error_count",
+                    snql_metric_layer=lambda args, alias: AliasedExpression(
+                        Column(TransactionMRI.HTTP_ERROR_COUNT.value), alias
+                    ),
+                    default_result_type="integer",
+                ),
+                fields.MetricsFunction(
+                    "http_error_rate",
+                    snql_metric_layer=lambda args, alias: AliasedExpression(
+                        Column(TransactionMRI.HTTP_ERROR_RATE.value), alias
+                    ),
+                    default_result_type="percentage",
+                ),
+                fields.MetricsFunction(
                     "histogram",
                     required_args=[fields.MetricArg("column")],
                     snql_metric_layer=self._resolve_histogram_function,

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -55,6 +55,7 @@ from sentry.snuba.metrics.fields.snql import (
     failure_count_transaction,
     foreground_anr_users,
     histogram_snql_factory,
+    http_error_count_transaction,
     max_timestamp,
     min_timestamp,
     miserable_users,
@@ -1545,6 +1546,25 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             unit="transactions",
             snql=lambda failure_count, tx_count, project_ids, org_id, metric_ids, alias=None: division_float(
                 failure_count, tx_count, alias=alias
+            ),
+        ),
+        SingularEntityDerivedMetric(
+            metric_mri=TransactionMRI.HTTP_ERROR_COUNT.value,
+            metrics=[TransactionMRI.DURATION.value],
+            unit="transactions",
+            snql=lambda project_ids, org_id, metric_ids, alias=None: http_error_count_transaction(
+                org_id, metric_ids=metric_ids, alias=alias
+            ),
+        ),
+        SingularEntityDerivedMetric(
+            metric_mri=TransactionMRI.HTTP_ERROR_RATE.value,
+            metrics=[
+                TransactionMRI.HTTP_ERROR_COUNT.value,
+                TransactionMRI.ALL.value,
+            ],
+            unit="transactions",
+            snql=lambda http_error_count, tx_count, project_ids, org_id, metric_ids, alias=None: division_float(
+                http_error_count, tx_count, alias=alias
             ),
         ),
         SingularEntityDerivedMetric(

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -124,6 +124,8 @@ class TransactionMRI(Enum):
     ALL_USER = "e:transactions/user.all@none"
     USER_MISERY = "e:transactions/user_misery@ratio"
     TEAM_KEY_TRANSACTION = "e:transactions/team_key_transaction@none"
+    HTTP_ERROR_COUNT = "e:transactions/http_error_count@none"
+    HTTP_ERROR_RATE = "e:transactions/http_error_rate@ratio"
 
     # Spans (might be moved to their own namespace soon)
     SPAN_USER = "s:transactions/span.user@none"

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -94,6 +94,7 @@ class TransactionMetricKey(Enum):
     USER_MISERY = "transaction.user_misery"
     FAILURE_COUNT = "transaction.failure_count"
     TEAM_KEY_TRANSACTION = "transactions.team_key_transaction"
+    HTTP_ERROR_RATE = "transaction.http_error_rate"
 
     # Span metrics.
     # NOTE: These might be moved to their own namespace soon.
@@ -113,6 +114,7 @@ class TransactionTagsKey(Enum):
 
     TRANSACTION_STATUS = "transaction.status"
     TRANSACTION_SATISFACTION = "satisfaction"
+    TRANSACTION_HTTP_STATUS_CODE = "http.status_code"
 
 
 class TransactionStatusTagValue(Enum):

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2214,8 +2214,4 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
 
     @pytest.mark.xfail(reason="Not supported")
     def test_time_spent(self):
-        super().test_custom_measurement_size_filtering()
-
-    @pytest.mark.xfail(reason="Not supported")
-    def test_http_error_rate(self):
-        super().test_having_condition()
+        super().test_time_spent()


### PR DESCRIPTION
This adds the transactions version of `http_error_rate()` to the metrics layer,
so it can be queried with the metrics builder.

Also update the CODEOWNERS so the search team gets notified of these PRs and
can also comment on them.