### PR TITLE
fix(starfish): remove duplicated transaction method

### DIFF
--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -23,7 +23,6 @@ export type SpanTransactionMetrics = {
   'time_spent_percentage(local)': number;
   transaction: string;
   'transaction.method': string;
-  transactionMethod: string;
 };
 
 export const useSpanTransactionMetrics = (


### PR DESCRIPTION
transactionMethod isn't a field, we should use `transaction.method`