### PR TITLE
fix(replay): Do not force the error count tooltip to be visible

### DIFF
--- a/static/app/components/replays/header/errorCounts.tsx
+++ b/static/app/components/replays/header/errorCounts.tsx
@@ -68,7 +68,6 @@ export default function ErrorCounts({replayErrors, replayRecord}: Props) {
   const totalErrors = errorCountPerProject.reduce((acc, val) => acc + val.count, 0);
   return (
     <Tooltip
-      forceVisible
       title={
         <ColumnTooltipContent>
           {errorCountPerProject.map(({project, count}) => (


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/52837