### PR TITLE
feat(replays): add dead click and rage click columns to replay list

### DIFF
--- a/fixtures/js-stubs/replayList.ts
+++ b/fixtures/js-stubs/replayList.ts
@@ -15,6 +15,8 @@ export function ReplayList(
         name: 'Firefox',
         version: '111.0',
       },
+      count_dead_clicks: 0,
+      count_rage_clicks: 0,
       count_errors: 0,
       duration: duration(30000),
       finished_at: new Date('2022-09-15T06:54:00+00:00'),

--- a/static/app/components/replays/contextIcon.tsx
+++ b/static/app/components/replays/contextIcon.tsx
@@ -12,14 +12,14 @@ type Props = {
   name: string;
   version: undefined | string;
   className?: string;
-  hideVersion?: boolean;
+  showVersion?: boolean;
 };
 
 const LazyContextIcon = lazy(
   () => import('sentry/components/events/contextSummary/contextIcon')
 );
 
-const ContextIcon = styled(({className, name, version, hideVersion}: Props) => {
+const ContextIcon = styled(({className, name, version, showVersion}: Props) => {
   const icon = generateIconName(name, version);
 
   const title = (
@@ -35,7 +35,7 @@ const ContextIcon = styled(({className, name, version, hideVersion}: Props) => {
       <Suspense fallback={<LoadingMask />}>
         <LazyContextIcon name={icon} size="sm" />
       </Suspense>
-      {hideVersion ? undefined : version ? version : null}
+      {showVersion ? (version ? version : null) : undefined}
     </Tooltip>
   );
 })`

--- a/static/app/components/replays/contextIcon.tsx
+++ b/static/app/components/replays/contextIcon.tsx
@@ -12,13 +12,14 @@ type Props = {
   name: string;
   version: undefined | string;
   className?: string;
+  hideVersion?: boolean;
 };
 
 const LazyContextIcon = lazy(
   () => import('sentry/components/events/contextSummary/contextIcon')
 );
 
-const ContextIcon = styled(({className, name, version}: Props) => {
+const ContextIcon = styled(({className, name, version, hideVersion}: Props) => {
   const icon = generateIconName(name, version);
 
   const title = (
@@ -34,7 +35,7 @@ const ContextIcon = styled(({className, name, version}: Props) => {
       <Suspense fallback={<LoadingMask />}>
         <LazyContextIcon name={icon} size="sm" />
       </Suspense>
-      {version ? version : null}
+      {hideVersion ? undefined : version ? version : null}
     </Tooltip>
   );
 })`

--- a/static/app/components/replays/header/replayMetaData.tsx
+++ b/static/app/components/replays/header/replayMetaData.tsx
@@ -23,6 +23,7 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
         <ContextIcon
           name={replayRecord?.os.name ?? ''}
           version={replayRecord?.os.version ?? undefined}
+          showVersion
         />
       </KeyMetricData>
 
@@ -31,6 +32,7 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
         <ContextIcon
           name={replayRecord?.browser.name ?? ''}
           version={replayRecord?.browser.version ?? undefined}
+          showVersion
         />
       </KeyMetricData>
 

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -120,7 +120,9 @@ describe('GroupReplays', () => {
               field: [
                 'activity',
                 'browser',
+                'count_dead_clicks',
                 'count_errors',
+                'count_rage_clicks',
                 'duration',
                 'finished_at',
                 'id',

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -92,6 +92,29 @@ function ReplaysListTable({
 
   const hasReplayClick = conditions.getFilterKeys().some(k => k.startsWith('click.'));
 
+  const hasDeadRageCols = organization.features.includes(
+    'replay-rage-click-dead-click-columns'
+  );
+  const visibleCols = hasDeadRageCols
+    ? [
+        ReplayColumn.REPLAY,
+        ReplayColumn.OS,
+        ReplayColumn.BROWSER,
+        ReplayColumn.DURATION,
+        ReplayColumn.COUNT_ERRORS,
+        ReplayColumn.COUNT_DEAD_CLICKS,
+        ReplayColumn.COUNT_RAGE_CLICKS,
+        ReplayColumn.ACTIVITY,
+      ]
+    : [
+        ReplayColumn.REPLAY,
+        ReplayColumn.OS,
+        ReplayColumn.BROWSER,
+        ReplayColumn.DURATION,
+        ReplayColumn.COUNT_ERRORS,
+        ReplayColumn.ACTIVITY,
+      ];
+
   return (
     <Fragment>
       <ReplayTable
@@ -99,16 +122,7 @@ function ReplaysListTable({
         isFetching={isFetching}
         replays={replays}
         sort={eventView.sorts[0]}
-        visibleColumns={[
-          ReplayColumn.REPLAY,
-          ReplayColumn.OS,
-          ReplayColumn.BROWSER,
-          ReplayColumn.DURATION,
-          ReplayColumn.COUNT_ERRORS,
-          ReplayColumn.COUNT_DEAD_CLICKS,
-          ReplayColumn.COUNT_RAGE_CLICKS,
-          ReplayColumn.ACTIVITY,
-        ]}
+        visibleColumns={visibleCols}
         emptyMessage={
           allSelectedProjectsNeedUpdates && hasReplayClick ? (
             <Fragment>

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -105,6 +105,8 @@ function ReplaysListTable({
           ReplayColumn.BROWSER,
           ReplayColumn.DURATION,
           ReplayColumn.COUNT_ERRORS,
+          ReplayColumn.COUNT_DEAD_CLICKS,
+          ReplayColumn.COUNT_RAGE_CLICKS,
           ReplayColumn.ACTIVITY,
         ]}
         emptyMessage={

--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -31,7 +31,9 @@ function HeaderCell({column, sort}: Props) {
           sort={sort}
           fieldName="count_dead_clicks"
           label={t('Dead Clicks')}
-          tooltip={t('placeholder')}
+          tooltip={t(
+            'Dead clicks are slow clicks that are too slow and cause a timeout.'
+          )}
         />
       );
 
@@ -44,7 +46,9 @@ function HeaderCell({column, sort}: Props) {
           sort={sort}
           fieldName="count_rage_clicks"
           label={t('Rage Clicks')}
-          tooltip={t('placeholder')}
+          tooltip={t(
+            'Rage clicks occur when there are too many multi-clicks captured within a short period of time.'
+          )}
         />
       );
 

--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -31,6 +31,7 @@ function HeaderCell({column, sort}: Props) {
           sort={sort}
           fieldName="count_dead_clicks"
           label={t('Dead Clicks')}
+          tooltip={t('placeholder')}
         />
       );
 
@@ -43,6 +44,7 @@ function HeaderCell({column, sort}: Props) {
           sort={sort}
           fieldName="count_rage_clicks"
           label={t('Rage Clicks')}
+          tooltip={t('placeholder')}
         />
       );
 

--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -25,8 +25,26 @@ function HeaderCell({column, sort}: Props) {
     case ReplayColumn.BROWSER:
       return <SortableHeader sort={sort} fieldName="browser.name" label={t('Browser')} />;
 
+    case ReplayColumn.COUNT_DEAD_CLICKS:
+      return (
+        <SortableHeader
+          sort={sort}
+          fieldName="count_dead_clicks"
+          label={t('Dead Clicks')}
+        />
+      );
+
     case ReplayColumn.COUNT_ERRORS:
       return <SortableHeader sort={sort} fieldName="count_errors" label={t('Errors')} />;
+
+    case ReplayColumn.COUNT_RAGE_CLICKS:
+      return (
+        <SortableHeader
+          sort={sort}
+          fieldName="count_rage_clicks"
+          label={t('Rage Clicks')}
+        />
+      );
 
     case ReplayColumn.DURATION:
       return <SortableHeader sort={sort} fieldName="duration" label={t('Duration')} />;

--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -32,7 +32,7 @@ function HeaderCell({column, sort}: Props) {
           fieldName="count_dead_clicks"
           label={t('Dead Clicks')}
           tooltip={t(
-            'Dead clicks are slow clicks that are too slow and cause a timeout.'
+            'Dead clicks are user clicks that do not result in any page activity after 7 seconds.'
           )}
         />
       );
@@ -46,9 +46,7 @@ function HeaderCell({column, sort}: Props) {
           sort={sort}
           fieldName="count_rage_clicks"
           label={t('Rage Clicks')}
-          tooltip={t(
-            'Rage clicks occur when there are too many multi-clicks captured within a short period of time.'
-          )}
+          tooltip={t('A rage click is 5 dead clicks within 7 seconds.')}
         />
       );
 

--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -32,7 +32,7 @@ function HeaderCell({column, sort}: Props) {
           fieldName="count_dead_clicks"
           label={t('Dead Clicks')}
           tooltip={t(
-            'Dead clicks are user clicks that do not result in any page activity after 7 seconds.'
+            'A dead click is a user click that does not result in any page activity after 7 seconds.'
           )}
         />
       );
@@ -47,7 +47,7 @@ function HeaderCell({column, sort}: Props) {
           fieldName="count_rage_clicks"
           label={t('Rage Clicks')}
           tooltip={t(
-            'A rage click is 5 or more clicks on a dead element (no page activity after 7 seconds).'
+            'A rage click is 5 or more clicks on a dead element, which exhibits no page activity after 7 seconds.'
           )}
         />
       );

--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -46,7 +46,9 @@ function HeaderCell({column, sort}: Props) {
           sort={sort}
           fieldName="count_rage_clicks"
           label={t('Rage Clicks')}
-          tooltip={t('A rage click is 5 dead clicks within 7 seconds.')}
+          tooltip={t(
+            'A rage click is 5 or more clicks on a dead element (no page activity after 7 seconds).'
+          )}
         />
       );
 

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -15,9 +15,11 @@ import HeaderCell from 'sentry/views/replays/replayTable/headerCell';
 import {
   ActivityCell,
   BrowserCell,
+  DeadClickCountCell,
   DurationCell,
   ErrorCountCell,
   OSCell,
+  RageClickCountCell,
   ReplayCell,
   TransactionCell,
 } from 'sentry/views/replays/replayTable/tableCell';
@@ -92,8 +94,14 @@ function ReplayTable({
                 case ReplayColumn.BROWSER:
                   return <BrowserCell key="browser" replay={replay} />;
 
+                case ReplayColumn.COUNT_DEAD_CLICKS:
+                  return <DeadClickCountCell key="countDeadClicks" replay={replay} />;
+
                 case ReplayColumn.COUNT_ERRORS:
                   return <ErrorCountCell key="countErrors" replay={replay} />;
+
+                case ReplayColumn.COUNT_RAGE_CLICKS:
+                  return <RageClickCountCell key="countRageClicks" replay={replay} />;
 
                 case ReplayColumn.DURATION:
                   return <DurationCell key="duration" replay={replay} />;

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -190,7 +190,7 @@ export function OSCell({replay}: Props) {
       <ContextIcon
         name={name ?? ''}
         version={version && hasRoomForColumns ? version : undefined}
-        hideVersion
+        showVersion={false}
       />
     </Item>
   );
@@ -209,7 +209,7 @@ export function BrowserCell({replay}: Props) {
       <ContextIcon
         name={name ?? ''}
         version={version && hasRoomForColumns ? version : undefined}
-        hideVersion
+        showVersion={false}
       />
     </Item>
   );

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -190,6 +190,7 @@ export function OSCell({replay}: Props) {
       <ContextIcon
         name={name ?? ''}
         version={version && hasRoomForColumns ? version : undefined}
+        hideVersion
       />
     </Item>
   );
@@ -208,6 +209,7 @@ export function BrowserCell({replay}: Props) {
       <ContextIcon
         name={name ?? ''}
         version={version && hasRoomForColumns ? version : undefined}
+        hideVersion
       />
     </Item>
   );
@@ -220,6 +222,36 @@ export function DurationCell({replay}: Props) {
   return (
     <Item>
       <Time>{formatTime(replay.duration.asMilliseconds())}</Time>
+    </Item>
+  );
+}
+
+export function RageClickCountCell({replay}: Props) {
+  if (replay.is_archived) {
+    return <Item isArchived />;
+  }
+  return (
+    <Item data-test-id="replay-table-count-rage-clicks">
+      {replay.count_rage_clicks ? (
+        <Count>{replay.count_rage_clicks}</Count>
+      ) : (
+        <Count>0</Count>
+      )}
+    </Item>
+  );
+}
+
+export function DeadClickCountCell({replay}: Props) {
+  if (replay.is_archived) {
+    return <Item isArchived />;
+  }
+  return (
+    <Item data-test-id="replay-table-count-dead-clicks">
+      {replay.count_dead_clicks ? (
+        <Count>{replay.count_dead_clicks}</Count>
+      ) : (
+        <Count>0</Count>
+      )}
     </Item>
   );
 }

--- a/static/app/views/replays/replayTable/types.tsx
+++ b/static/app/views/replays/replayTable/types.tsx
@@ -1,7 +1,9 @@
 export enum ReplayColumn {
   ACTIVITY = 'activity',
   BROWSER = 'browser',
+  COUNT_DEAD_CLICKS = 'countDeadClicks',
   COUNT_ERRORS = 'countErrors',
+  COUNT_RAGE_CLICKS = 'countRageClicks',
   DURATION = 'duration',
   OS = 'os',
   REPLAY = 'replay',

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -116,7 +116,9 @@ export type ReplayListRecord = Pick<
   ReplayRecord,
   | 'activity'
   | 'browser'
+  | 'count_dead_clicks'
   | 'count_errors'
+  | 'count_rage_clicks'
   | 'duration'
   | 'finished_at'
   | 'id'
@@ -133,7 +135,9 @@ export const REPLAY_LIST_FIELDS: ReplayRecordNestedFieldName[] = [
   'activity',
   'browser.name',
   'browser.version',
+  'count_dead_clicks',
   'count_errors',
+  'count_rage_clicks',
   'duration',
   'finished_at',
   'id',


### PR DESCRIPTION
Closes #52980 by adding v0 dead click and rage click columns to the replay list table, with tooltips. Also, OS and browser version numbers are always hidden.

<img width="1224" alt="SCR-20230718-ovzo" src="https://github.com/getsentry/sentry/assets/56095982/45cd0376-787a-4067-970e-641b25753a8c">


<img width="1219" alt="SCR-20230718-owge" src="https://github.com/getsentry/sentry/assets/56095982/c67d3915-acb3-42b6-90cc-0adcb8e4e6b0">




