### PR TITLE
feat(issue-details): Render the event replay in its own separate section

### DIFF
--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -94,7 +94,7 @@ export function EventDataSection({
   return (
     <DataSection ref={scrollToSection} className={className || ''} {...props}>
       {title && (
-        <SectionHeader id={type}>
+        <SectionHeader id={type} data-test-id={`event-section-${type}`}>
           <Title>
             {showPermalink ? (
               <Permalink className="permalink">

--- a/static/app/components/events/eventEntries.spec.tsx
+++ b/static/app/components/events/eventEntries.spec.tsx
@@ -1,0 +1,54 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {EventEntries} from 'sentry/components/events/eventEntries';
+
+describe('EventEntries', function () {
+  const defaultProps = {
+    organization: TestStubs.Organization(),
+    project: TestStubs.Project(),
+    event: TestStubs.Event(),
+    location: TestStubs.location(),
+  };
+
+  beforeEach(function () {
+    const project = TestStubs.Project({platform: 'javascript'});
+
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/events/1/grouping-info/',
+    });
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/events/1/committers/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project],
+    });
+  });
+
+  it('renders the replay section in the correct place', async function () {
+    render(
+      <EventEntries
+        {...defaultProps}
+        event={TestStubs.Event({
+          entries: [TestStubs.EventEntry(), TestStubs.EventEntryDebugMeta()],
+          contexts: {
+            replay_id: 1,
+          },
+        })}
+      />,
+      {organization: TestStubs.Organization({features: ['session-replay']})}
+    );
+
+    await screen.findByText(/message/i);
+
+    const sections = screen.getAllByTestId(/event-section/);
+
+    expect(sections).toHaveLength(5); //  event tags + 3 entries + event grouping
+
+    // Replay should be after message but before images loaded
+    expect(sections[1]).toHaveTextContent(/message/i);
+    expect(sections[2]).toHaveTextContent(/replay/i);
+    expect(sections[3]).toHaveTextContent(/images loaded/i);
+  });
+});

--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -97,9 +97,6 @@ function EventEntryContent({
           data={entry.data}
           organization={organization as Organization}
           event={event}
-          isShare={isShare}
-          projectSlug={projectSlug}
-          group={group}
         />
       );
 

--- a/static/app/components/events/eventReplay/eventReplaySection.tsx
+++ b/static/app/components/events/eventReplay/eventReplaySection.tsx
@@ -1,0 +1,12 @@
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {t} from 'sentry/locale';
+
+type EventReplaySectionProps = {children: JSX.Element};
+
+export function EventReplaySection({children}: EventReplaySectionProps) {
+  return (
+    <EventDataSection type="replay" title={t('Replay')}>
+      {children}
+    </EventDataSection>
+  );
+}

--- a/static/app/components/events/eventReplay/eventReplaySection.tsx
+++ b/static/app/components/events/eventReplay/eventReplaySection.tsx
@@ -5,7 +5,7 @@ type EventReplaySectionProps = {children: JSX.Element};
 
 export function EventReplaySection({children}: EventReplaySectionProps) {
   return (
-    <EventDataSection type="replay" title={t('Replay')}>
+    <EventDataSection type="replay" title={t('Session Replay')}>
       {children}
     </EventDataSection>
   );

--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -1,40 +1,33 @@
 import {useCallback} from 'react';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import {EventReplaySection} from 'sentry/components/events/eventReplay/eventReplaySection';
 import LazyLoad from 'sentry/components/lazyLoad';
-import {Group, Organization} from 'sentry/types';
+import {Group} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAnalyticsDataForEvent, getAnalyticsDataForGroup} from 'sentry/utils/events';
+import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import {useHasOrganizationSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
 import {projectCanLinkToReplay} from 'sentry/utils/replays/projectSupportsReplay';
+import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
 
 type Props = {
   event: Event;
-  organization: Organization;
   projectSlug: string;
-  replayId: undefined | string;
   group?: Group;
 };
 
-export default function EventReplay({
-  replayId,
-  organization,
-  projectSlug,
-  event,
-  group,
-}: Props) {
-  const hasReplaysFeature = organization.features.includes('session-replay');
+function EventReplayContent({projectSlug, event, group}: Props) {
+  const organization = useOrganization();
   const {hasOrgSentReplays, fetching} = useHasOrganizationSentAnyReplayEvents();
+  const replayId = getReplayIdFromEvent(event);
 
   const onboardingPanel = useCallback(() => import('./replayInlineOnboardingPanel'), []);
   const replayPreview = useCallback(() => import('./replayPreview'), []);
 
-  const project = useProjectFromSlug({organization, projectSlug});
-  const isReplayRelated = projectCanLinkToReplay(project);
-
-  if (!hasReplaysFeature || fetching || !isReplayRelated) {
+  if (fetching) {
     return null;
   }
 
@@ -51,20 +44,35 @@ export default function EventReplay({
   }
 
   return (
-    <ErrorBoundary mini>
-      <LazyLoad
-        component={replayPreview}
-        replaySlug={`${projectSlug}:${replayId}`}
-        orgSlug={organization.slug}
-        event={event}
-        onClickOpenReplay={() => {
-          trackAnalytics('issue_details.open_replay_details_clicked', {
-            ...getAnalyticsDataForEvent(event),
-            ...getAnalyticsDataForGroup(group),
-            organization,
-          });
-        }}
-      />
-    </ErrorBoundary>
+    <EventReplaySection>
+      <ErrorBoundary mini>
+        <LazyLoad
+          component={replayPreview}
+          replaySlug={`${projectSlug}:${replayId}`}
+          orgSlug={organization.slug}
+          event={event}
+          onClickOpenReplay={() => {
+            trackAnalytics('issue_details.open_replay_details_clicked', {
+              ...getAnalyticsDataForEvent(event),
+              ...getAnalyticsDataForGroup(group),
+              organization,
+            });
+          }}
+        />
+      </ErrorBoundary>
+    </EventReplaySection>
   );
+}
+
+export default function EventReplay({projectSlug, event, group}: Props) {
+  const organization = useOrganization();
+  const hasReplaysFeature = organization.features.includes('session-replay');
+  const project = useProjectFromSlug({organization, projectSlug});
+  const isReplayRelated = projectCanLinkToReplay(project);
+
+  if (!hasReplaysFeature || !isReplayRelated) {
+    return null;
+  }
+
+  return <EventReplayContent {...{projectSlug, event, group}} />;
 }

--- a/static/app/components/events/eventReplay/replayInlineOnboardingPanel.tsx
+++ b/static/app/components/events/eventReplay/replayInlineOnboardingPanel.tsx
@@ -5,6 +5,7 @@ import replaysInlineOnboarding from 'sentry-images/spot/replay-inline-onboarding
 
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
+import {EventReplaySection} from 'sentry/components/events/eventReplay/eventReplaySection';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import localStorage from 'sentry/utils/localStorage';
@@ -42,42 +43,44 @@ export default function ReplayInlineOnboardingPanel() {
   }
 
   return (
-    <StyledOnboardingPanel>
-      <div>
-        <Heading>{t('Configure Session Replay')}</Heading>
-        <Content>
-          {t(
-            'Playback your app to identify the root cause of errors and latency issues.'
-          )}
-        </Content>
-        <ButtonList>
-          <Button onClick={activateSidebar} priority="primary" size="sm">
-            {t('Get Started')}
-          </Button>
-          <ButtonBar merged>
-            <Button
-              size="sm"
-              onClick={() => {
-                setHideUntilTime(SNOOZE_TIME);
-                setIsHidden(true);
-              }}
-            >
-              {t('Snooze')}
+    <EventReplaySection>
+      <StyledOnboardingPanel>
+        <div>
+          <Heading>{t('Configure Session Replay')}</Heading>
+          <Content>
+            {t(
+              'Playback your app to identify the root cause of errors and latency issues.'
+            )}
+          </Content>
+          <ButtonList>
+            <Button onClick={activateSidebar} priority="primary" size="sm">
+              {t('Get Started')}
             </Button>
-            <Button
-              size="sm"
-              onClick={() => {
-                setHideUntilTime(DISMISS_TIME);
-                setIsHidden(true);
-              }}
-            >
-              {t('Dismiss')}
-            </Button>
-          </ButtonBar>
-        </ButtonList>
-      </div>
-      <Illustration src={replaysInlineOnboarding} width={220} height={112} alt="" />
-    </StyledOnboardingPanel>
+            <ButtonBar merged>
+              <Button
+                size="sm"
+                onClick={() => {
+                  setHideUntilTime(SNOOZE_TIME);
+                  setIsHidden(true);
+                }}
+              >
+                {t('Snooze')}
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => {
+                  setHideUntilTime(DISMISS_TIME);
+                  setIsHidden(true);
+                }}
+              >
+                {t('Dismiss')}
+              </Button>
+            </ButtonBar>
+          </ButtonList>
+        </div>
+        <Illustration src={replaysInlineOnboarding} width={220} height={112} alt="" />
+      </StyledOnboardingPanel>
+    </EventReplaySection>
   );
 }
 

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -33,8 +33,9 @@ function ReplayPreview({orgSlug, replaySlug, event, onClickOpenReplay}: Props) {
     replaySlug,
   });
 
-  const eventTimestamp = event.dateCreated
-    ? Math.floor(new Date(event.dateCreated).getTime() / 1000) * 1000
+  const timeOfEvent = event.dateCreated ?? event.dateReceived;
+  const eventTimestamp = timeOfEvent
+    ? Math.floor(new Date(timeOfEvent).getTime() / 1000) * 1000
     : 0;
 
   const startTimestampMs = replayRecord?.started_at.getTime() ?? 0;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -1,16 +1,8 @@
-import selectEvent from 'react-select-event';
-
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {Breadcrumbs} from 'sentry/components/events/interfaces/breadcrumbs';
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
-import {
-  useHasOrganizationSentAnyReplayEvents,
-  useReplayOnboardingSidebarPanel,
-} from 'sentry/utils/replays/hooks/useReplayOnboarding';
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
-import ReplayReader from 'sentry/utils/replays/replayReader';
 import useProjects from 'sentry/utils/useProjects';
 
 jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
@@ -26,44 +18,12 @@ jest.mock('screenfull', () => ({
   off: jest.fn(),
 }));
 
-const mockReplay = ReplayReader.factory({
-  replayRecord: TestStubs.ReplayRecord({}),
-  errors: [],
-  attachments: TestStubs.ReplaySegmentInit({}),
-});
-
-const mockUseReplayReader = useReplayReader as jest.MockedFunction<
-  typeof useReplayReader
->;
-
-mockUseReplayReader.mockImplementation(() => {
-  return {
-    attachments: [],
-    errors: [],
-    fetchError: undefined,
-    fetching: false,
-    onRetry: jest.fn(),
-    projectSlug: TestStubs.Project().slug,
-    replay: mockReplay,
-    replayId: TestStubs.ReplayRecord({}).id,
-    replayRecord: TestStubs.ReplayRecord(),
-  };
-});
+jest.mock('sentry/utils/useProjects');
 
 describe('Breadcrumbs', () => {
   let props: React.ComponentProps<typeof Breadcrumbs>;
 
   const MockUseProjects = useProjects as jest.MockedFunction<typeof useProjects>;
-
-  const MockUseReplayOnboardingSidebarPanel =
-    useReplayOnboardingSidebarPanel as jest.MockedFunction<
-      typeof useReplayOnboardingSidebarPanel
-    >;
-
-  const MockUseHasOrganizationSentAnyReplayEvents =
-    useHasOrganizationSentAnyReplayEvents as jest.MockedFunction<
-      typeof useHasOrganizationSentAnyReplayEvents
-    >;
 
   beforeEach(() => {
     const project = TestStubs.Project({platform: 'javascript'});
@@ -77,18 +37,9 @@ describe('Breadcrumbs', () => {
       placeholders: [],
       projects: [project],
     });
-    MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
-      hasOrgSentReplays: false,
-      fetching: false,
-    });
-    MockUseReplayOnboardingSidebarPanel.mockReturnValue({
-      activateSidebar: jest.fn(),
-    });
 
     props = {
       organization: TestStubs.Organization(),
-      projectSlug: 'project-slug',
-      isShare: false,
       event: TestStubs.Event({entries: [], projectID: project.id}),
       data: {
         values: [
@@ -277,166 +228,6 @@ describe('Breadcrumbs', () => {
         'href',
         '/organizations/org-slug/performance/project-slug:abcdabcdabcdabcdabcdabcdabcdabcd/?referrer=breadcrumbs'
       );
-    });
-  });
-
-  describe('replay', () => {
-    it('should render the replay inline onboarding component when replays are enabled and the project supports replay', async function () {
-      MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
-        hasOrgSentReplays: false,
-        fetching: false,
-      });
-      MockUseReplayOnboardingSidebarPanel.mockReturnValue({
-        activateSidebar: jest.fn(),
-      });
-      const {container} = render(
-        <Breadcrumbs
-          {...props}
-          event={TestStubs.Event({
-            entries: [],
-            tags: [],
-            platform: 'javascript',
-          })}
-          organization={TestStubs.Organization({
-            features: ['session-replay'],
-          })}
-        />
-      );
-
-      expect(await screen.findByText('Configure Session Replay')).toBeInTheDocument();
-      expect(container).toSnapshot();
-    });
-
-    it('should not render the replay inline onboarding component when the project is not JS', async function () {
-      MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
-        hasOrgSentReplays: false,
-        fetching: false,
-      });
-      MockUseReplayOnboardingSidebarPanel.mockReturnValue({
-        activateSidebar: jest.fn(),
-      });
-      const {container} = render(
-        <Breadcrumbs
-          {...props}
-          event={TestStubs.Event({
-            entries: [],
-            tags: [],
-          })}
-          organization={TestStubs.Organization({
-            features: ['session-replay'],
-          })}
-        />
-      );
-
-      expect(
-        await screen.queryByText('Configure Session Replay')
-      ).not.toBeInTheDocument();
-      expect(await screen.queryByTestId('player-container')).not.toBeInTheDocument();
-      expect(container).toSnapshot();
-    });
-
-    it('should render a replay when there is a replayId from tags', async function () {
-      MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
-        hasOrgSentReplays: true,
-        fetching: false,
-      });
-      MockUseReplayOnboardingSidebarPanel.mockReturnValue({
-        activateSidebar: jest.fn(),
-      });
-      const {container} = render(
-        <Breadcrumbs
-          {...props}
-          event={TestStubs.Event({
-            entries: [],
-            tags: [{key: 'replayId', value: '761104e184c64d439ee1014b72b4d83b'}],
-            platform: 'javascript',
-          })}
-          organization={TestStubs.Organization({
-            features: ['session-replay'],
-          })}
-        />
-      );
-
-      expect(await screen.findByTestId('player-container')).toBeInTheDocument();
-      expect(container).toSnapshot();
-    });
-
-    it('should render a replay when there is a replay_id from contexts', async function () {
-      MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
-        hasOrgSentReplays: true,
-        fetching: false,
-      });
-      MockUseReplayOnboardingSidebarPanel.mockReturnValue({
-        activateSidebar: jest.fn(),
-      });
-      const {container} = render(
-        <Breadcrumbs
-          {...props}
-          event={TestStubs.Event({
-            entries: [],
-            tags: [],
-            contexts: {
-              replay: {
-                replay_id: '761104e184c64d439ee1014b72b4d83b',
-              },
-            },
-            platform: 'javascript',
-          })}
-          organization={TestStubs.Organization({
-            features: ['session-replay'],
-          })}
-        />
-      );
-
-      expect(await screen.findByTestId('player-container')).toBeInTheDocument();
-      expect(container).toSnapshot();
-    });
-
-    it('can change the sort', async function () {
-      render(
-        <Breadcrumbs
-          {...props}
-          data={{
-            values: [
-              {
-                message: 'sup',
-                category: 'default',
-                level: BreadcrumbLevelType.WARNING,
-                type: BreadcrumbType.INFO,
-              },
-              {
-                message: 'hey',
-                category: 'error',
-                level: BreadcrumbLevelType.INFO,
-                type: BreadcrumbType.INFO,
-              },
-              {
-                message: 'hello',
-                category: 'default',
-                level: BreadcrumbLevelType.WARNING,
-                type: BreadcrumbType.INFO,
-              },
-            ],
-          }}
-        />
-      );
-      const breadcrumbsBefore = screen.getAllByTestId(/crumb/i);
-      expect(breadcrumbsBefore).toHaveLength(4); // Virtual exception crumb added to 3 in props
-
-      // Should be sorted newest -> oldest by default
-      expect(within(breadcrumbsBefore[0]).getByText(/exception/i)).toBeInTheDocument();
-      expect(within(breadcrumbsBefore[1]).getByText('hello')).toBeInTheDocument();
-      expect(within(breadcrumbsBefore[2]).getByText('hey')).toBeInTheDocument();
-      expect(within(breadcrumbsBefore[3]).getByText('sup')).toBeInTheDocument();
-
-      await selectEvent.select(screen.getByText(/newest/i), /oldest/i);
-
-      // Now should be sorted oldest -> newest
-      const breadcrumbsAfter = screen.getAllByTestId(/crumb/i);
-      expect(within(breadcrumbsAfter[0]).getByText('sup')).toBeInTheDocument();
-      expect(within(breadcrumbsAfter[1]).getByText('hey')).toBeInTheDocument();
-      expect(within(breadcrumbsAfter[2]).getByText('hello')).toBeInTheDocument();
-      expect(within(breadcrumbsAfter[3]).getByText(/exception/i)).toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useState} from 'react';
+import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
@@ -12,16 +12,14 @@ import {
 } from 'sentry/components/compactSelect';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
-import EventReplay from 'sentry/components/events/eventReplay';
 import {BreadcrumbWithMeta} from 'sentry/components/events/interfaces/breadcrumbs/types';
 import {IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Group, Organization} from 'sentry/types';
+import {Organization} from 'sentry/types';
 import {BreadcrumbLevelType, RawCrumb} from 'sentry/types/breadcrumbs';
 import {EntryType, Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
-import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
 import SearchBarAction from '../searchBarAction';
@@ -39,9 +37,6 @@ type Props = {
   };
   event: Event;
   organization: Organization;
-  projectSlug: string;
-  group?: Group;
-  isShare?: boolean;
 };
 
 enum BreadcrumbSort {
@@ -56,14 +51,7 @@ const sortOptions = [
   {label: t('Oldest'), value: BreadcrumbSort.OLDEST},
 ];
 
-function BreadcrumbsContainer({
-  data,
-  event,
-  organization,
-  projectSlug,
-  isShare,
-  group,
-}: Props) {
+function BreadcrumbsContainer({data, event, organization}: Props) {
   const [searchTerm, setSearchTerm] = useState('');
   const [filterSelections, setFilterSelections] = useState<SelectOption<string>[]>([]);
   const [displayRelativeTime, setDisplayRelativeTime] = useState(false);
@@ -296,11 +284,8 @@ function BreadcrumbsContainer({
     };
   }
 
-  const replayId = getReplayIdFromEvent(event);
-  const showReplay = !isShare && organization.features.includes('session-replay');
-
   const actions = (
-    <SearchAndSortWrapper isFullWidth={showReplay}>
+    <SearchAndSortWrapper>
       <SearchBarAction
         placeholder={t('Search breadcrumbs')}
         onChange={setSearchTerm}
@@ -327,20 +312,8 @@ function BreadcrumbsContainer({
     <EventDataSection
       type={EntryType.BREADCRUMBS}
       title={t('Breadcrumbs')}
-      actions={!showReplay ? actions : null}
+      actions={actions}
     >
-      {showReplay ? (
-        <Fragment>
-          <EventReplay
-            organization={organization}
-            replayId={replayId}
-            projectSlug={projectSlug}
-            event={event}
-            group={group}
-          />
-          {actions}
-        </Fragment>
-      ) : null}
       <ErrorBoundary>
         <GuideAnchor target="breadcrumbs" position="bottom">
           <Breadcrumbs
@@ -361,7 +334,7 @@ function BreadcrumbsContainer({
 
 export {BreadcrumbsContainer as Breadcrumbs};
 
-const SearchAndSortWrapper = styled('div')<{isFullWidth?: boolean}>`
+const SearchAndSortWrapper = styled('div')`
   display: grid;
   grid-template-columns: 1fr auto;
   gap: ${space(1)};
@@ -369,8 +342,6 @@ const SearchAndSortWrapper = styled('div')<{isFullWidth?: boolean}>`
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     grid-template-columns: 1fr;
   }
-
-  margin-bottom: ${p => (p.isFullWidth ? space(1) : 0)};
 `;
 
 const LevelWrap = styled('span')`

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -258,6 +258,10 @@ const mockGroupApis = (
     url: '/organizations/org-slug/users/',
     body: [],
   });
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/projects/',
+    body: [project],
+  });
 
   MockApiClient.addMockResponse({
     url: `/customers/org-slug/policies/`,

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -11,6 +11,7 @@ import {EventEntry} from 'sentry/components/events/eventEntry';
 import {EventErrors} from 'sentry/components/events/eventErrors';
 import {EventEvidence} from 'sentry/components/events/eventEvidence';
 import {EventExtraData} from 'sentry/components/events/eventExtraData';
+import EventReplay from 'sentry/components/events/eventReplay';
 import {EventSdk} from 'sentry/components/events/eventSdk';
 import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScreenshot';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
@@ -120,6 +121,7 @@ function GroupEventDetailsContent({
           projectSlug={project.slug}
         />
       )}
+      <EventReplay event={event} group={group} projectSlug={project.slug} />
       <GroupEventEntry entryType={EntryType.HPKP} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.CSP} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.EXPECTCT} {...eventEntryProps} />


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/46162

The moves the event replay out of the breadcrumbs section and into its own. Because performance issues can lack breadcrumbs, we needed to do this in order to display replays in all issue types.

The work here does the following:

- Moves the replay rendering logic from `interfaces/breadcrumbs/index.tsx` to `events/eventReplay/index.tsx`
- Renders `EventReplay` inside of `GroupEventDetailsContent`, which adds it to the issue details page
- Renders `EventReplay` inside of `EventEntries`, which adds it to the event views in discover and performance
- Makes a small change to the logic inside `ReplayPreview` so that the initial timestamp falls back to `event.dateReceived` if `date.eventCreated` does not exist (transaction events do not have a `dateCreated`).

![CleanShot 2023-07-18 at 16 03 29](https://github.com/getsentry/sentry/assets/10888943/5e556abc-588f-4bab-aa15-c5c34ded79bf)
