### PR TITLE
feat(issues):  Add semver tag to release list

### DIFF
--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -41,7 +41,7 @@ interface RawVersion {
   raw: string;
 }
 
-interface SemverVerison extends RawVersion {
+export interface SemverVerison extends RawVersion {
   buildCode: string | null;
   components: number;
   major: number;

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -582,7 +582,7 @@ describe('ReleasesList', () => {
     expect(await screen.findByText('sentry@0.5.3')).toBeInTheDocument();
   });
 
-  it('renders if the version is using semver or not', async () => {
+  it('renders if the version is using semver or timestamp', async () => {
     const org = {...organization, features: ['issue-release-semver']};
     render(<ReleasesList {...props} organization={org} />, {
       context: routerContext,

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -17,6 +17,16 @@ import {ReleasesStatusOption} from 'sentry/views/releases/list/releasesStatusOpt
 
 describe('ReleasesList', () => {
   const {organization, routerContext, router, routerProps} = initializeOrg();
+  const semverVersionInfo = {
+    version: {
+      raw: '1.2.3',
+      major: 1,
+      minor: 2,
+      patch: 3,
+      buildCode: null,
+      components: 3,
+    },
+  };
 
   const props = {
     ...routerProps,
@@ -51,8 +61,14 @@ describe('ReleasesList', () => {
     endpointMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/releases/',
       body: [
-        TestStubs.Release({version: '1.0.0'}),
-        TestStubs.Release({version: '1.0.1'}),
+        TestStubs.Release({
+          version: '1.0.0',
+          versionInfo: {...semverVersionInfo, raw: '1.0.0'},
+        }),
+        TestStubs.Release({
+          version: '1.0.1',
+          versionInfo: {...semverVersionInfo, raw: '1.0.1'},
+        }),
         {
           ...TestStubs.Release({version: 'af4f231ec9a8'}),
           projects: [
@@ -564,5 +580,19 @@ describe('ReleasesList', () => {
     fireEvent.change(smartSearchBar, {target: {value: 'release.version:'}});
 
     expect(await screen.findByText('sentry@0.5.3')).toBeInTheDocument();
+  });
+
+  it('renders if the version is using semver or not', async () => {
+    const org = {...organization, features: ['issue-release-semver']};
+    render(<ReleasesList {...props} organization={org} />, {
+      context: routerContext,
+      organization: org,
+    });
+    const items = await screen.findAllByTestId('release-panel');
+
+    expect(items.length).toEqual(3);
+
+    expect(within(items.at(0)!).getByText('1.0.0')).toBeInTheDocument();
+    expect(within(items.at(0)!).getByText('(semver)')).toBeInTheDocument();
   });
 });

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -136,7 +136,7 @@ class ReleaseCard extends Component<Props> {
                   {versionInfo.package}
                 </TextOverflow>
               )}
-              {!organization.features.includes('issue-release-semver')
+              {organization.features.includes('issue-release-semver')
                 ? isVersionInfoSemver(versionInfo.version)
                   ? t('(semver)')
                   : t('(timestamp)')

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -17,6 +17,7 @@ import Version from 'sentry/components/version';
 import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization, PageFilters, Release} from 'sentry/types';
+import {isVersionInfoSemver} from 'sentry/views/releases/utils';
 
 import {ReleasesDisplayOption} from '../releasesDisplayOptions';
 import {ReleasesRequestRenderProps} from '../releasesRequest';
@@ -129,9 +130,18 @@ class ReleaseCard extends Component<Props> {
             )}
           </ReleaseInfoHeader>
           <ReleaseInfoSubheader>
-            {versionInfo?.package && (
-              <PackageName ellipsisDirection="left">{versionInfo.package}</PackageName>
-            )}
+            <PackageSemver>
+              {versionInfo?.package && (
+                <TextOverflow ellipsisDirection="left">
+                  {versionInfo.package}
+                </TextOverflow>
+              )}
+              {!organization.features.includes('issue-release-semver')
+                ? isVersionInfoSemver(versionInfo.version)
+                  ? t('(semver)')
+                  : t('(timestamp)')
+                : null}
+            </PackageSemver>
             <TimeSince date={lastDeploy?.dateFinished || dateCreated} />
             {lastDeploy?.dateFinished && ` \u007C ${lastDeploy.environment}`}
           </ReleaseInfoSubheader>
@@ -244,9 +254,12 @@ const ReleaseInfoSubheader = styled('div')`
   color: ${p => p.theme.gray400};
 `;
 
-const PackageName = styled(TextOverflow)`
+const PackageSemver = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   color: ${p => p.theme.textColor};
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
 `;
 
 const ReleaseProjects = styled('div')`

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -10,7 +10,7 @@ import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilte
 import {PAGE_URL_PARAM, URL_PARAM} from 'sentry/constants/pageFilters';
 import {desktop, mobile, PlatformKey} from 'sentry/data/platformCategories';
 import {t, tct} from 'sentry/locale';
-import {Release, ReleaseStatus} from 'sentry/types';
+import {Release, ReleaseStatus, SemverVerison, VersionInfo} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
@@ -244,4 +244,10 @@ export const isMobileRelease = (releaseProjectPlatform: PlatformKey) =>
 export function searchReleaseVersion(version: string): string {
   // Wrap with quotes and escape any quotes inside
   return `release:"${version.replace(/"/g, '\\"')}"`;
+}
+
+export function isVersionInfoSemver(
+  versionInfo: VersionInfo['version']
+): versionInfo is SemverVerison {
+  return versionInfo.hasOwnProperty('components');
 }


### PR DESCRIPTION
Displays if a release is using semver or timestamp in the release list

![image](https://github.com/getsentry/sentry/assets/1400464/a4375309-3ffb-4aa3-847b-175227c8ef08)
