### PR TITLE
feat(auth): Allow users to rotate client secrets

### DIFF
--- a/static/app/views/settings/account/apiApplications/details.spec.tsx
+++ b/static/app/views/settings/account/apiApplications/details.spec.tsx
@@ -1,5 +1,10 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
 
 import ApiApplicationDetails from 'sentry/views/settings/account/apiApplications/details';
 
@@ -42,16 +47,16 @@ describe('ApiApplications', function () {
     expect(screen.getByDisplayValue('1234')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Example App Name')).toBeInTheDocument();
 
-    expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Homepage')).toBeInTheDocument();
-    expect(screen.getByText('Privacy Policy')).toBeInTheDocument();
-    expect(screen.getByText('Terms of Service')).toBeInTheDocument();
-    expect(screen.getByText('Authorized Redirect URIs')).toBeInTheDocument();
-    expect(screen.getByText('Authorized JavaScript Origins')).toBeInTheDocument();
-    expect(screen.getByText('Client ID')).toBeInTheDocument();
-    expect(screen.getByText('Client Secret')).toBeInTheDocument();
-    expect(screen.getByText('Authorization URL')).toBeInTheDocument();
-    expect(screen.getByText('Token URL')).toBeInTheDocument();
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Homepage')).toBeInTheDocument();
+    expect(screen.getByLabelText('Privacy Policy')).toBeInTheDocument();
+    expect(screen.getByLabelText('Terms of Service')).toBeInTheDocument();
+    expect(screen.getByLabelText('Authorized Redirect URIs')).toBeInTheDocument();
+    expect(screen.getByLabelText('Authorized JavaScript Origins')).toBeInTheDocument();
+    expect(screen.getByLabelText('Client ID')).toBeInTheDocument();
+    expect(screen.getByLabelText('Client Secret')).toBeInTheDocument();
+    expect(screen.getByLabelText('Authorization URL')).toBeInTheDocument();
+    expect(screen.getByLabelText('Token URL')).toBeInTheDocument();
   });
 
   it('handles client secret rotation', async function () {
@@ -71,7 +76,6 @@ describe('ApiApplications', function () {
         termsUrl: ['http://example.com/terms'],
       },
     });
-
     const rotateSecretApiCall = MockApiClient.addMockResponse({
       method: 'POST',
       url: '/api-applications/abcd/rotate-secret/',
@@ -92,12 +96,20 @@ describe('ApiApplications', function () {
         }}
       />
     );
+    renderGlobalModal();
 
     expect(screen.getByText('hidden')).toBeInTheDocument();
     expect(
       screen.getByRole('button', {name: 'Rotate client secret'})
     ).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', {name: 'Rotate client secret'}));
+
+    expect(
+      screen.getByText('This will be the only time your client secret is visible!')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Rotated Client Secret')).toBeInTheDocument();
+    expect(screen.getByText('Your client secret is:')).toBeInTheDocument();
+    expect(screen.getByText('newSecret!')).toBeInTheDocument();
 
     expect(rotateSecretApiCall).toHaveBeenCalledTimes(1);
   });

--- a/static/app/views/settings/account/apiApplications/details.tsx
+++ b/static/app/views/settings/account/apiApplications/details.tsx
@@ -28,7 +28,7 @@ type State = {
 class ApiApplicationsDetails extends DeprecatedAsyncView<Props, State> {
   rotateClientSecret = async () => {
     try {
-      const rotate_response = await this.api.requestPromise(
+      const rotateResponse = await this.api.requestPromise(
         `/api-applications/${this.props.params.appId}/rotate-secret/`,
         {
           method: 'POST',
@@ -40,7 +40,7 @@ class ApiApplicationsDetails extends DeprecatedAsyncView<Props, State> {
           <Header>{t('New Client Secret (ONE TIME ONLY)')}</Header>
           <Body>
             <p>
-              <b>Your client secret is:</b> {rotate_response.client_secret}
+              <b>Your client secret is:</b> {rotateResponse.clientSecret}
             </p>
           </Body>
         </Fragment>
@@ -105,7 +105,7 @@ class ApiApplicationsDetails extends DeprecatedAsyncView<Props, State> {
                       <StyledSpan>
                         <em>hidden</em>
                       </StyledSpan>
-                      <StyledButton onClick={this.rotateClientSecret}>
+                      <StyledButton onClick={this.rotateClientSecret} priority="danger">
                         Rotate client secret
                       </StyledButton>
                     </ClientSecretDiv>

--- a/static/app/views/settings/account/apiApplications/details.tsx
+++ b/static/app/views/settings/account/apiApplications/details.tsx
@@ -106,9 +106,7 @@ class ApiApplicationsDetails extends DeprecatedAsyncView<Props, State> {
                     </TextCopyInput>
                   ) : (
                     <ClientSecret>
-                      <StyledSpan>
-                        <em>hidden</em>
-                      </StyledSpan>
+                      <HiddenSecret>{t('hidden')}</HiddenSecret>
                       <Button
                         size="md"
                         onClick={this.rotateClientSecret}
@@ -136,8 +134,9 @@ class ApiApplicationsDetails extends DeprecatedAsyncView<Props, State> {
   }
 }
 
-const StyledSpan = styled('span')`
+const HiddenSecret = styled('span')`
   width: 100px;
+  font-style: italic;
 `;
 
 const ClientSecret = styled('div')`

--- a/static/app/views/settings/account/apiApplications/details.tsx
+++ b/static/app/views/settings/account/apiApplications/details.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
 import Button from 'sentry/components/actions/button';
+import {Alert} from 'sentry/components/alert';
 import Form from 'sentry/components/forms/form';
 import FormField from 'sentry/components/forms/formField';
 import JsonForm from 'sentry/components/forms/jsonForm';
@@ -32,15 +33,18 @@ class ApiApplicationsDetails extends DeprecatedAsyncView<Props, State> {
         `/api-applications/${this.props.params.appId}/rotate-secret/`,
         {
           method: 'POST',
-          data: {},
         }
       );
       openModal(({Body, Header}) => (
         <Fragment>
-          <Header>{t('New Client Secret (ONE TIME ONLY)')}</Header>
+          <Header>{t('Rotated Client Secret')}</Header>
           <Body>
+            <Alert type="info" showIcon>
+              {t('This will be the only time your client secret is visible!')}
+            </Alert>
             <p>
-              <b>Your client secret is:</b> {rotateResponse.clientSecret}
+              {t('Your client secret is:')}
+              <code>{rotateResponse.clientSecret}</code>
             </p>
           </Body>
         </Fragment>
@@ -101,14 +105,18 @@ class ApiApplicationsDetails extends DeprecatedAsyncView<Props, State> {
                       {getDynamicText({value, fixed: 'CI_CLIENT_SECRET'})}
                     </TextCopyInput>
                   ) : (
-                    <ClientSecretDiv>
+                    <ClientSecret>
                       <StyledSpan>
                         <em>hidden</em>
                       </StyledSpan>
-                      <StyledButton onClick={this.rotateClientSecret} priority="danger">
+                      <Button
+                        size="md"
+                        onClick={this.rotateClientSecret}
+                        priority="danger"
+                      >
                         Rotate client secret
-                      </StyledButton>
-                    </ClientSecretDiv>
+                      </Button>
+                    </ClientSecret>
                   )
                 }
               </FormField>
@@ -128,17 +136,14 @@ class ApiApplicationsDetails extends DeprecatedAsyncView<Props, State> {
   }
 }
 
-const StyledButton = styled(Button)`
-  width: 150px;
-`;
-
 const StyledSpan = styled('span')`
   width: 100px;
 `;
 
-const ClientSecretDiv = styled('div')`
+const ClientSecret = styled('div')`
   display: flex;
   justify-content: right;
+  align-items: center;
   margin-right: 0;
 `;
 


### PR DESCRIPTION
Allows users to navigate to -> `settings/account/api/applications/<app_id>` and rotate their client secret. Very basic UI, could probably use some love, and some tests, rushing this out as a fix to [this flaw](https://github.com/getsentry/sentry/pull/52953). Relies on the backend endpoint being created, which is addressed in [this PR](https://github.com/getsentry/sentry/pull/53124)


https://github.com/getsentry/sentry/assets/26236981/94deb2d4-7538-4773-af3b-0b378cf23b50


