### PR TITLE
test: Fix TestIssueAssignedSentryFunctions

### DIFF
--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -441,7 +441,8 @@ class TestIssueAssignedSentryFunctions(APITestCase):
                 "email": self.assignee.email,
             }
         }
-        sub_data["user"] = serialize(self.user, UserSerializer())
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            sub_data["user"] = serialize(self.user, serializer=UserSerializer())
         delay.assert_called_once_with(
             self.sentryFunction.external_id,
             "issue.assigned",
@@ -465,7 +466,8 @@ class TestIssueAssignedSentryFunctions(APITestCase):
                 "id": self.assignee.id,
             }
         }
-        sub_data["user"] = serialize(self.user, UserSerializer())
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            sub_data["user"] = serialize(self.user, serializer=UserSerializer())
         delay.assert_called_once_with(
             self.sentryFunction.external_id,
             "issue.assigned",

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -412,8 +412,6 @@ class TestIssueAssigned(APITestCase):
         )
 
 
-@with_feature("organizations:sentry-functions")
-@patch("sentry.tasks.sentry_functions.send_sentry_function_webhook.delay")
 @region_silo_test(stable=True)
 class TestIssueAssignedSentryFunctions(APITestCase):
     def setUp(self):
@@ -431,6 +429,8 @@ class TestIssueAssignedSentryFunctions(APITestCase):
         self.issue = self.create_group(project=self.project)
         self.assignee = self.create_user(name="Bert", email="bert@example.com")
 
+    @with_feature("organizations:sentry-functions")
+    @patch("sentry.tasks.sentry_functions.send_sentry_function_webhook.delay")
     def test_after_issue_assigned(self, delay):
         GroupAssignee.objects.assign(self.issue, self.assignee, self.user)
         sub_data = {
@@ -449,6 +449,8 @@ class TestIssueAssignedSentryFunctions(APITestCase):
             sub_data,
         )
 
+    @with_feature("organizations:sentry-functions")
+    @patch("sentry.tasks.sentry_functions.send_sentry_function_webhook.delay")
     def test_after_issue_assigned_with_enhanced_privacy(self, delay):
         org = self.issue.project.organization
         org.flags.enhanced_privacy = True


### PR DESCRIPTION
Fix a problem with decorator placement that was causing Pytest not to pick up TestIssueAssignedSentryFunctions as a test case, and a previously undetected breakage.