### PR TITLE
feat(perf-detector-threshold-configuration) Passing is_dry_run for all detections.

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -504,10 +504,8 @@ def report_metrics_for_detectors(
     detected_tags = {
         "sdk_name": sdk_name,
         "is_early_adopter": organization.flags.early_adopter.is_set,
+        "is_dry_run": is_dry_run,
     }
-
-    if is_dry_run:
-        detected_tags["is_dry_run"] = True
 
     event_integrations = event.get("sdk", {}).get("integrations", []) or []
 


### PR DESCRIPTION
- We are dry running detection of performance issue detection with lowered thresholds to evaluate the noise.  
- Currently the "is_dry_run" tag for metrics is only set to True for the dry run detections.
- It's hard to compare between regular detections and dry_run detections. 
- Therefore, added "is_dry_run" = False, tag to regular detection. 