### PR TITLE
feat(starfish): Add release selectors to mobile view

### DIFF
--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -1,0 +1,59 @@
+import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
+
+import {CompactSelect} from 'sentry/components/compactSelect';
+import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useReleases} from 'sentry/views/starfish/queries/useReleases';
+
+const ALL_RELEASES = {
+  value: '',
+  label: t('All Releases'),
+};
+
+type Props = {
+  selectorKey: string;
+  selectorName: string;
+};
+
+export function ReleaseSelector({selectorName, selectorKey}: Props) {
+  const {data, isLoading} = useReleases();
+  const location = useLocation();
+  let value =
+    decodeScalar(location.query[selectorKey]) ?? data?.[0]?.version ?? undefined;
+
+  if (!isLoading && !defined(value)) {
+    value = ALL_RELEASES.value;
+  }
+  return (
+    <StyledCompactSelect
+      triggerProps={{
+        prefix: selectorName,
+      }}
+      value={value}
+      options={[
+        ...(data ?? [ALL_RELEASES]).map(release => ({
+          value: release.version,
+          label: release.shortVersion ?? release.version,
+        })),
+      ]}
+      onChange={newValue => {
+        browserHistory.push({
+          ...location,
+          query: {
+            ...location.query,
+            [selectorKey]: newValue.value,
+          },
+        });
+      }}
+    />
+  );
+}
+
+const StyledCompactSelect = styled(CompactSelect)`
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    max-width: 300px;
+  }
+`;

--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -1,0 +1,25 @@
+import {Release} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+
+export function useReleases() {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const {environments, projects} = selection;
+
+  return useApiQuery<Release[]>(
+    [
+      `/organizations/${organization.slug}/releases/`,
+      {
+        query: {
+          sort: 'date',
+          project: projects,
+          per_page: 50,
+          environment: environments,
+        },
+      },
+    ],
+    {staleTime: Infinity}
+  );
+}

--- a/static/app/views/starfish/views/webServiceView/starfishLanding.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishLanding.tsx
@@ -15,6 +15,7 @@ import {
 } from 'sentry/utils/performance/contexts/pageError';
 import {STARFISH_TYPE_FOR_PROJECT} from 'sentry/views/starfish/allowedProjects';
 import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
+import {ReleaseSelector} from 'sentry/views/starfish/components/releaseSelector';
 import {StarfishProjectSelector} from 'sentry/views/starfish/components/starfishProjectSelector';
 import {StarfishType} from 'sentry/views/starfish/types';
 import {MobileStarfishView} from 'sentry/views/starfish/views/mobileServiceView';
@@ -37,15 +38,23 @@ export type BaseStarfishViewProps = {
 };
 
 export function StarfishLanding(props: Props) {
-  const pageFilters: React.ReactNode = (
-    <PageFilterBar condensed>
-      <StarfishProjectSelector />
-      <StarfishDatePicker />
-    </PageFilterBar>
-  );
-
   const project = props.selection.projects[0];
   const starfishType = STARFISH_TYPE_FOR_PROJECT[project] || StarfishType.BACKEND;
+
+  const pageFilters: React.ReactNode = (
+    <Fragment>
+      <PageFilterBar condensed>
+        <StarfishProjectSelector />
+        <StarfishDatePicker />
+      </PageFilterBar>
+      {starfishType === StarfishType.MOBILE && (
+        <PageFilterBar condensed>
+          <ReleaseSelector selectorKey="release1" selectorName={t('Release 1')} />
+          <ReleaseSelector selectorKey="release2" selectorName={t('Release 2')} />
+        </PageFilterBar>
+      )}
+    </Fragment>
+  );
 
   const getStarfishView = () => {
     switch (starfishType) {


### PR DESCRIPTION
Adds 2 release selectors to allow comparison. Right now,
selecting a release just pushes the release up to the url
and passes the release filter to the chart queries.

Still need to add a group by to get a multi-series and
plot the two distinct releases
![Screenshot 2023-07-19 at 11 22 22 AM](https://github.com/getsentry/sentry/assets/63818634/a3abdab1-6902-4682-83c7-e9b97f55682d)
