### PR TITLE
feat(starfish): persist date selection on zoom

### DIFF
--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -63,6 +63,7 @@ type Props = {
   onZoom?: (period: Period) => void;
   period?: string | null;
   router?: InjectedRouter;
+  saveOnZoom?: boolean;
   showSlider?: boolean;
   start?: DateString;
   usePageDate?: boolean;
@@ -126,7 +127,7 @@ class ChartZoom extends Component<Props> {
    * Saves a callback function to be called after chart animation is completed
    */
   setPeriod = ({period, start, end}, saveHistory = false) => {
-    const {router, onZoom, usePageDate} = this.props;
+    const {router, onZoom, usePageDate, saveOnZoom} = this.props;
     const startFormatted = getDate(start);
     const endFormatted = getDate(end);
 
@@ -172,7 +173,8 @@ class ChartZoom extends Component<Props> {
               : startFormatted,
             end: endFormatted ? getUtcToLocalDateObject(endFormatted) : endFormatted,
           },
-          router
+          router,
+          {save: saveOnZoom}
         );
       }
 

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -376,6 +376,7 @@ function Chart({
     return (
       <ChartZoom
         router={router}
+        saveOnZoom
         period={statsPeriod}
         start={start}
         end={end}


### PR DESCRIPTION
This ensures that the date selection persists when you zoom in a chart. It fixes a bug where you would zoom into a chart, click a module, and the the date selection resets.