### PR TITLE
fix(source-map-debug): Remove user agent check

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -111,12 +111,6 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
             except (SourceMapException, Release.DoesNotExist):
                 return self._create_response(issue=SourceMapProcessingIssue.MISSING_RELEASE)
 
-            user_agent = release.user_agent
-            if not user_agent:
-                return self._create_response(
-                    issue=SourceMapProcessingIssue.MISSING_USER_AGENT,
-                    data={"version": release.version, "filename": filename},
-                )
             num_artifacts = release.count_artifacts()
 
             if num_artifacts == 0:

--- a/src/sentry/models/sourcemapprocessingissue.py
+++ b/src/sentry/models/sourcemapprocessingissue.py
@@ -7,7 +7,6 @@ class SourceMapProcessingIssue:
     # Generic errors
     UNKNOWN_ERROR = "unknown_error"
     MISSING_RELEASE = "no_release_on_event"
-    MISSING_USER_AGENT = "no_user_agent_on_release"
     MISSING_SOURCEMAPS = "no_sourcemaps_on_release"
     URL_NOT_VALID = "url_not_valid"
     NO_URL_MATCH = "no_url_match"
@@ -19,7 +18,6 @@ class SourceMapProcessingIssue:
     _messages = {
         UNKNOWN_ERROR: "Unknown error",
         MISSING_RELEASE: "The event is missing a release",
-        MISSING_USER_AGENT: "The release is missing a user agent",
         MISSING_SOURCEMAPS: "The release is missing source maps",
         URL_NOT_VALID: "The absolute path url is not valid",
         NO_URL_MATCH: "The absolute path url does not match any source maps",

--- a/tests/sentry/api/endpoints/test_source_map_debug.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug.py
@@ -191,49 +191,6 @@ class SourceMapDebugEndpointTestCase(APITestCase):
         assert error["type"] == "no_release_on_event"
         assert error["message"] == "The event is missing a release"
 
-    def test_release_has_no_user_agent(self):
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "release": "my-release",
-                "exception": {
-                    "values": [
-                        {
-                            "type": "Error",
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "abs_path": "https://app.example.com/static/js/main.fa8fe19f.js",
-                                        "filename": "/static/js/main.fa8fe19f.js",
-                                        "lineno": 1,
-                                        "colno": 39,
-                                    }
-                                ]
-                            },
-                        },
-                    ]
-                },
-            },
-            project_id=self.project.id,
-        )
-        Release.objects.get(organization=self.organization, version=event.release)
-
-        resp = self.get_success_response(
-            self.organization.slug,
-            self.project.slug,
-            event.event_id,
-            frame_idx=0,
-            exception_idx=0,
-        )
-
-        error = resp.data["errors"][0]
-        assert error["type"] == "no_user_agent_on_release"
-        assert error["message"] == "The release is missing a user agent"
-        assert error["data"] == {
-            "version": "my-release",
-            "filename": "/static/js/main.fa8fe19f.js",
-        }
-
     def test_release_has_no_artifacts(self):
         event = self.store_event(
             data={

--- a/tests/sentry/api/endpoints/test_source_map_debug.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug.py
@@ -703,8 +703,8 @@ class SourceMapDebugEndpointTestCase(APITestCase):
         )
 
         error = resp.data["errors"][0]
-        assert error["type"] == "no_user_agent_on_release"
-        assert error["message"] == "The release is missing a user agent"
+        assert error["type"] == "no_sourcemaps_on_release"
+        assert error["message"] == "The release is missing source maps"
 
     def test_remix_up_to_date(self):
         event = self.store_event(
@@ -744,8 +744,8 @@ class SourceMapDebugEndpointTestCase(APITestCase):
         )
 
         error = resp.data["errors"][0]
-        assert error["type"] == "no_user_agent_on_release"
-        assert error["message"] == "The release is missing a user agent"
+        assert error["type"] == "no_sourcemaps_on_release"
+        assert error["message"] == "The release is missing source maps"
 
     def test_not_part_of_pipeline(self):
         event = self.store_event(


### PR DESCRIPTION
this pr removes the check for `user_agent` from the source map debug endpoint. Since we are checking the number of artifacts already, this check is redundant. 

Closes https://github.com/getsentry/sentry/issues/53164