### PR TITLE
fix(source-map-debug): Remove user_agent alert 

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
@@ -84,20 +84,6 @@ function getErrorMessage(
           ),
         },
       ];
-    case SourceMapProcessingIssueType.MISSING_USER_AGENT:
-      return [
-        {
-          title: t('Sentry not part of release pipeline'),
-          desc: tct(
-            "Integrate Sentry into your release pipeline using  a tool like Webpack or the CLI. Your release must match what's set in your [init]. The value for this event is [version].",
-            {
-              init: sentryInit,
-              version: <code>{error.data.version}</code>,
-            }
-          ),
-          docsLink: defaultDocsLink,
-        },
-      ];
     case SourceMapProcessingIssueType.MISSING_SOURCEMAPS:
       return [
         {

--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.tsx
@@ -24,10 +24,6 @@ interface UnknownErrorDebugError extends BaseSourceMapDebugError {
 interface MissingReleaseDebugError extends BaseSourceMapDebugError {
   type: SourceMapProcessingIssueType.MISSING_RELEASE;
 }
-interface MissingUserAgentDebugError extends BaseSourceMapDebugError {
-  data: {version: string};
-  type: SourceMapProcessingIssueType.MISSING_USER_AGENT;
-}
 interface MissingSourcemapsDebugError extends BaseSourceMapDebugError {
   type: SourceMapProcessingIssueType.MISSING_SOURCEMAPS;
 }
@@ -57,7 +53,6 @@ interface NotPartOfPipelineError extends BaseSourceMapDebugError {
 export type SourceMapDebugError =
   | UnknownErrorDebugError
   | MissingReleaseDebugError
-  | MissingUserAgentDebugError
   | MissingSourcemapsDebugError
   | UrlNotValidDebugError
   | PartialMatchDebugError
@@ -73,7 +68,6 @@ export interface SourceMapDebugResponse {
 export enum SourceMapProcessingIssueType {
   UNKNOWN_ERROR = 'unknown_error',
   MISSING_RELEASE = 'no_release_on_event',
-  MISSING_USER_AGENT = 'no_user_agent_on_release',
   MISSING_SOURCEMAPS = 'no_sourcemaps_on_release',
   URL_NOT_VALID = 'url_not_valid',
   NO_URL_MATCH = 'no_url_match',


### PR DESCRIPTION
this pr removes the user_agent alert from the front end as we are removing it from the endpoint here (https://github.com/getsentry/sentry/pull/53172) 

Closes https://github.com/getsentry/sentry/issues/53168