### PR TITLE
perf(crons): Introduce maximimum timeout_at value

### DIFF
--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -22,7 +22,7 @@ TIMEOUT = 30
 
 # hard maximum runtime for a monitor, in minutes
 # current limit is 14 days
-MAX_TIMEOUT = 20_160
+MAX_TIMEOUT = 40_320
 
 # This is the MAXIMUM number of MONITOR this job will check.
 #

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("sentry")
 TIMEOUT = 30
 
 # hard maximum runtime for a monitor, in minutes
-# current limit is 14 days
+# current limit is 28 days
 MAX_TIMEOUT = 40_320
 
 # This is the MAXIMUM number of MONITOR this job will check.

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -21,7 +21,8 @@ logger = logging.getLogger("sentry")
 TIMEOUT = 30
 
 # hard maximum runtime for a monitor, in minutes
-MAX_TIMEOUT = 720
+# current limit is 14 days
+MAX_TIMEOUT = 20_160
 
 # This is the MAXIMUM number of MONITOR this job will check.
 #

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -20,6 +20,9 @@ logger = logging.getLogger("sentry")
 # default maximum runtime for a monitor, in minutes
 TIMEOUT = 30
 
+# hard maximum runtime for a monitor, in minutes
+MAX_TIMEOUT = 720
+
 # This is the MAXIMUM number of MONITOR this job will check.
 #
 # NOTE: We should keep an eye on this as we have more and more usage of

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -14,7 +14,7 @@ from sentry.models.project import Project
 from sentry.signals import first_cron_checkin_received, first_cron_monitor_created
 
 from .models import CheckInStatus, Monitor, MonitorCheckIn
-from .tasks import TIMEOUT
+from .tasks import MAX_TIMEOUT, TIMEOUT
 
 
 def signal_first_checkin(project: Project, monitor: Monitor):
@@ -42,7 +42,7 @@ def get_timeout_at(
 ) -> Optional[datetime]:
     if status == CheckInStatus.IN_PROGRESS:
         return date_added.replace(second=0, microsecond=0) + timedelta(
-            minutes=(monitor_config or {}).get("max_runtime") or TIMEOUT
+            minutes=min(((monitor_config or {}).get("max_runtime") or TIMEOUT), MAX_TIMEOUT)
         )
 
     return None

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -18,6 +18,7 @@ from sentry.monitors.models import (
     MonitorType,
     ScheduleType,
 )
+from sentry.monitors.tasks import MAX_TIMEOUT
 
 MONITOR_TYPES = {"cron_job": MonitorType.CRON_JOB}
 
@@ -98,6 +99,7 @@ class ConfigValidator(serializers.Serializer):
         default=None,
         help_text="How long (in minutes) is the checkin allowed to run for in CheckInStatus.IN_PROGRESS before it is considered failed.",
         min_value=1,
+        max_value=MAX_TIMEOUT,
     )
 
     timezone = serializers.ChoiceField(


### PR DESCRIPTION
Adds maximum `timeout_at` value to prevent check-ins from staying in_progress too long