### PR TITLE
chore(github-comments): add success/fail metrics for comment task

### DIFF
--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -311,10 +311,9 @@ def github_comment_reactions():
 
             if e.code == 404:
                 metrics.incr("github_pr_comment.comment_reactions.not_found_error")
-                continue
-
-            metrics.incr("github_pr_comment.comment_reactions.api_error")
-            sentry_sdk.capture_exception(e)
+            else:
+                metrics.incr("github_pr_comment.comment_reactions.api_error")
+                sentry_sdk.capture_exception(e)
             continue
 
         metrics.incr("github_pr_comment.comment_reactions.success")

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -309,6 +309,12 @@ def github_comment_reactions():
                 metrics.incr("github_pr_comment.comment_reactions.rate_limited_error")
                 break
 
+            if e.code == 404:
+                metrics.incr("github_pr_comment.comment_reactions.not_found_error")
+                continue
+
             metrics.incr("github_pr_comment.comment_reactions.api_error")
             sentry_sdk.capture_exception(e)
             continue
+
+        metrics.incr("github_pr_comment.comment_reactions.success")

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -630,8 +630,9 @@ class TestCommentReactionsTask(GithubCommentTestCase):
         self.expired_pr.save()
 
     @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @responses.activate
-    def test_comment_reactions_task(self, get_jwt):
+    def test_comment_reactions_task(self, mock_metrics, get_jwt):
         old_comment = PullRequestComment.objects.create(
             external_id="1",
             pull_request=self.expired_pr,
@@ -668,6 +669,8 @@ class TestCommentReactionsTask(GithubCommentTestCase):
         stored_reactions = comment_reactions["reactions"]
         del stored_reactions["url"]
         assert self.comment.reactions == stored_reactions
+
+        mock_metrics.incr.assert_called_with("github_pr_comment.comment_reactions.success")
 
     @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
@@ -769,3 +772,25 @@ class TestCommentReactionsTask(GithubCommentTestCase):
         mock_metrics.incr.assert_called_with(
             "github_pr_comment.comment_reactions.rate_limited_error"
         )
+
+    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.tasks.integrations.github.pr_comment.metrics")
+    @responses.activate
+    def test_comment_reactions_task_api_error_404(self, mock_metrics, get_jwt):
+        responses.add(
+            responses.POST,
+            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
+            json={"token": self.access_token, "expires_at": self.expires_at},
+        )
+        responses.add(
+            responses.GET,
+            self.base_url + "/repos/getsentry/sentry/issues/comments/2",
+            status=404,
+            json={},
+        )
+
+        github_comment_reactions()
+
+        self.comment.refresh_from_db()
+        assert self.comment.reactions is None
+        mock_metrics.incr.assert_called_with("github_pr_comment.comment_reactions.not_found_error")


### PR DESCRIPTION
If getting the comment returns a 404 (the comment doesn't exist), emit a metric and continue in the loop rather than capture the exception. Also emit a metric if the GET succeeds.

For ER-1745