### PR TITLE
fix(replay): Fix DeadClick/Rage click rendering so we can differentiate them

### DIFF
--- a/static/app/utils/replays/frame.tsx
+++ b/static/app/utils/replays/frame.tsx
@@ -15,7 +15,7 @@ import type {
   SlowClickFrame,
   SpanFrame,
 } from 'sentry/utils/replays/types';
-import {isDeadClick, isRageClick} from 'sentry/utils/replays/types';
+import {isDeadClick, isDeadRageClick, isRageClick} from 'sentry/utils/replays/types';
 import type {Color} from 'sentry/utils/theme';
 
 export function getColor(frame: ReplayFrame): Color {
@@ -129,7 +129,11 @@ export function getTitle(frame: ReplayFrame): ReactNode {
       case 'navigation':
         return 'Navigation';
       case 'ui.slowClickDetected':
-        return isDeadClick(frame as SlowClickFrame) ? 'Dead Click' : 'Slow Click';
+        return isDeadRageClick(frame as SlowClickFrame)
+          ? 'Rage Click'
+          : isDeadClick(frame as SlowClickFrame)
+          ? 'Dead Click'
+          : 'Slow Click';
       case 'ui.multiClick':
         return isRageClick(frame as MultiClickFrame) ? 'Rage Click' : 'Multi Click';
       case 'replay.mutations':

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -32,7 +32,7 @@ import type {
   SlowClickFrame,
   SpanFrame,
 } from 'sentry/utils/replays/types';
-import {isDeadClick} from 'sentry/utils/replays/types';
+import {isDeadClick, isDeadRageClick} from 'sentry/utils/replays/types';
 import type {
   NetworkSpan,
   RecordingEvent,
@@ -255,7 +255,8 @@ export default class ReplayReader {
             frame.category
           ) ||
           (frame.category === 'ui.slowClickDetected' &&
-            isDeadClick(frame as SlowClickFrame))
+            (isDeadClick(frame as SlowClickFrame) ||
+              isDeadRageClick(frame as SlowClickFrame)))
         // Hiding all ui.multiClick (multi or rage clicks)
       ),
       ...this._sortedSpanFrames.filter(frame =>

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -27,11 +27,12 @@ import type {
   BreadcrumbFrame,
   ErrorFrame,
   MemoryFrame,
-  MultiClickFrame,
   OptionFrame,
   RecordingFrame,
+  SlowClickFrame,
   SpanFrame,
 } from 'sentry/utils/replays/types';
+import {isDeadClick} from 'sentry/utils/replays/types';
 import type {
   NetworkSpan,
   RecordingEvent,
@@ -250,15 +251,12 @@ export default class ReplayReader {
     [
       ...this._sortedBreadcrumbFrames.filter(
         frame =>
-          [
-            'replay.init',
-            'ui.click',
-            'replay.mutations',
-            'ui.slowClickDetected',
-            'navigation',
-          ].includes(frame.category) ||
-          (frame.category === 'ui.multiClick' &&
-            (frame as MultiClickFrame).data.clickCount >= 3)
+          ['navigation', 'replay.init', 'replay.mutations', 'ui.click'].includes(
+            frame.category
+          ) ||
+          (frame.category === 'ui.slowClickDetected' &&
+            isDeadClick(frame as SlowClickFrame))
+        // Hiding all ui.multiClick (multi or rage clicks)
       ),
       ...this._sortedSpanFrames.filter(frame =>
         ['navigation.navigate', 'navigation.reload', 'navigation.back_forward'].includes(

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -86,7 +86,7 @@ export function isDeadClick(frame: SlowClickFrame) {
 }
 
 export function isRageClick(frame: MultiClickFrame) {
-  return (frame as MultiClickFrame).data.clickCount >= 3;
+  return (frame as MultiClickFrame).data.clickCount >= 5;
 }
 
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -75,10 +75,18 @@ export function isErrorFrame(frame: ReplayFrame | undefined): frame is ErrorFram
   return Boolean(frame && 'category' in frame && frame.category === 'issue');
 }
 
-export function frameOpOrCategory(frame: ReplayFrame) {
+export function getFrameOpOrCategory(frame: ReplayFrame) {
   const val = ('op' in frame && frame.op) || ('category' in frame && frame.category);
   invariant(val, 'Frame has no category or op');
   return val;
+}
+
+export function isDeadClick(frame: SlowClickFrame) {
+  return (frame as SlowClickFrame).data.endReason === 'timeout';
+}
+
+export function isRageClick(frame: MultiClickFrame) {
+  return (frame as MultiClickFrame).data.clickCount >= 3;
 }
 
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -82,11 +82,17 @@ export function getFrameOpOrCategory(frame: ReplayFrame) {
 }
 
 export function isDeadClick(frame: SlowClickFrame) {
-  return (frame as SlowClickFrame).data.endReason === 'timeout';
+  return frame.data.endReason === 'timeout';
+}
+
+export function isDeadRageClick(frame: SlowClickFrame) {
+  return Boolean(
+    isDeadClick(frame) && frame.data.clickCount && frame.data.clickCount >= 5
+  );
 }
 
 export function isRageClick(frame: MultiClickFrame) {
-  return (frame as MultiClickFrame).data.clickCount >= 5;
+  return frame.data.clickCount >= 5;
 }
 
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;

--- a/static/app/views/replays/detail/domMutations/useDomFilters.tsx
+++ b/static/app/views/replays/detail/domMutations/useDomFilters.tsx
@@ -4,7 +4,7 @@ import uniq from 'lodash/uniq';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import useFiltersInLocationQuery from 'sentry/utils/replays/hooks/useFiltersInLocationQuery';
-import {frameOpOrCategory} from 'sentry/utils/replays/types';
+import {getFrameOpOrCategory} from 'sentry/utils/replays/types';
 import {filterItems} from 'sentry/views/replays/detail/utils';
 
 export type FilterFields = {
@@ -39,7 +39,7 @@ function typeToLabel(val: string): string {
 
 const FILTERS = {
   type: (item: Extraction, type: string[]) =>
-    type.length === 0 || type.includes(frameOpOrCategory(item.frame)),
+    type.length === 0 || type.includes(getFrameOpOrCategory(item.frame)),
   searchTerm: (item: Extraction, searchTerm: string) =>
     JSON.stringify(item.html).toLowerCase().includes(searchTerm),
 };
@@ -65,7 +65,7 @@ function useDomFilters({actions}: Options): Return {
 
   const getMutationsTypes = useCallback(
     () =>
-      uniq(actions.map(mutation => frameOpOrCategory(mutation.frame)).concat(type))
+      uniq(actions.map(mutation => getFrameOpOrCategory(mutation.frame)).concat(type))
         .sort()
         .map(value => ({value, label: typeToLabel(value)})),
     [actions, type]


### PR DESCRIPTION
If* slowClicks/deadClicks/mutliClicks/rageclicks were rendered, they would be yellow or red, and have appropriate titles in the Timeline and Breadcrumbs sections of Replay Details page.

But actually we filter out everything inside ReplayReader, and will only show Dead Clicks in the ui


Relates to https://github.com/getsentry/sentry/pull/53116
Relates to https://github.com/getsentry/sentry/pull/53140