### PR TITLE
fix(discord): Do not attempt to set up Discord integration without credentials

### DIFF
--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -132,10 +132,9 @@ class DiscordIntegrationProvider(IntegrationProvider):
         return guild_name
 
     def get_bot_install_url(self):
-        application_id = options.get("discord.application-id")
         setup_url = absolute_uri("extensions/discord/setup/")
 
-        return f"https://discord.com/api/oauth2/authorize?client_id={application_id}&permissions={self.bot_permissions}&redirect_uri={setup_url}&response_type=code&scope={' '.join(self.oauth_scopes)}"
+        return f"https://discord.com/api/oauth2/authorize?client_id={self.application_id}&permissions={self.bot_permissions}&redirect_uri={setup_url}&response_type=code&scope={' '.join(self.oauth_scopes)}"
 
     def setup(self) -> None:
         if self._credentials_exist():

--- a/src/sentry/integrations/discord/requests/base.py
+++ b/src/sentry/integrations/discord/requests/base.py
@@ -109,6 +109,7 @@ class DiscordRequest:
         logger.error(key, extra={**self.logging_data})
 
     def is_ping(self) -> bool:
+        # TODO: Make these constants an enum like DISCORD_REQUEST_TYPE.PING
         return self._data.get("type", 0) == 1
 
     def is_command(self) -> bool:

--- a/tests/sentry/integrations/discord/test_integration.py
+++ b/tests/sentry/integrations/discord/test_integration.py
@@ -17,9 +17,11 @@ class DiscordIntegrationTest(IntegrationTestCase):
     def setUp(self):
         super().setUp()
         self.application_id = "application-id"
+        self.public_key = "public-key"
         self.bot_token = "bot-token"
         options.set("discord.application-id", self.application_id)
         options.set("discord.bot-token", self.bot_token)
+        options.set("discord.public-key", self.public_key)
 
     def assert_setup_flow(
         self,


### PR DESCRIPTION
Currently everyone is probably seeing errors in their development environment because this thing is trying to update commands without any credentials. A better solution may come later, but this works for now.
