### PR TITLE
feat(starfish): Updates throughput titles depending on span op

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -41,7 +41,11 @@ import formatThroughput from 'sentry/views/starfish/utils/chartValueFormatters/f
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
-import {DataTitles} from 'sentry/views/starfish/views/spans/types';
+import {
+  DataTitles,
+  getThroughputChartTitle,
+  getThroughputTitle,
+} from 'sentry/views/starfish/views/spans/types';
 import {SampleList} from 'sentry/views/starfish/views/spanSummaryPage/sampleList';
 import {
   isAValidSort,
@@ -162,7 +166,7 @@ function SpanSummaryPage({params, location}: Props) {
                   <BlockContainer>
                     <Block title={t('Operation')}>{span?.[SPAN_OP]}</Block>
                     <Block
-                      title={t('Throughput')}
+                      title={getThroughputTitle(span?.[SPAN_OP])}
                       description={tct('Throughput of this [spanType] per second', {
                         spanType: spanDescriptionCardTitle,
                       })}
@@ -222,7 +226,7 @@ function SpanSummaryPage({params, location}: Props) {
                     </Block>
 
                     <Block>
-                      <ChartPanel title={DataTitles.throughput}>
+                      <ChartPanel title={getThroughputChartTitle(span?.[SPAN_OP])}>
                         <Chart
                           statsPeriod="24h"
                           height={140}

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -5,10 +5,10 @@ import DurationCell from 'sentry/views/starfish/components/tableCells/durationCe
 import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {SpanMetricsFields} from 'sentry/views/starfish/types';
-import {DataTitles} from 'sentry/views/starfish/views/spans/types';
+import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage';
 
-const {SPAN_SELF_TIME} = SpanMetricsFields;
+const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsFields;
 
 type Props = {
   groupId: string;
@@ -24,6 +24,7 @@ function SampleInfo(props: Props) {
     {group: groupId},
     {transactionName, 'transaction.method': transactionMethod},
     [
+      SPAN_OP,
       'sps()',
       `sum(${SPAN_SELF_TIME})`,
       `p95(${SPAN_SELF_TIME})`,
@@ -42,7 +43,7 @@ function SampleInfo(props: Props) {
 
   return (
     <BlockContainer>
-      <Block title={DataTitles.throughput}>
+      <Block title={getThroughputTitle(spanMetrics?.[SPAN_OP])}>
         <ThroughputCell
           containerProps={{style}}
           throughputPerSecond={spanMetrics?.['sps()']}

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -29,7 +29,9 @@ import {
 } from 'sentry/views/starfish/queries/useSpanTransactionMetrics';
 import {SpanMetricsFields} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
-import {DataTitles} from 'sentry/views/starfish/views/spans/types';
+import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
+
+const {SPAN_OP} = SpanMetricsFields;
 
 type Row = {
   metrics: SpanTransactionMetrics;
@@ -190,7 +192,7 @@ const getColumnOrder = (
   },
   {
     key: 'sps()',
-    name: DataTitles.throughput,
+    name: getThroughputTitle(span[SPAN_OP]),
     width: COL_WIDTH_UNDEFINED,
   },
   {

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -15,7 +15,10 @@ import formatThroughput from 'sentry/views/starfish/utils/chartValueFormatters/f
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {useErrorRateQuery as useErrorCountQuery} from 'sentry/views/starfish/views/spans/queries';
-import {DataTitles} from 'sentry/views/starfish/views/spans/types';
+import {
+  DataTitles,
+  getThroughputChartTitle,
+} from 'sentry/views/starfish/views/spans/types';
 import {NULL_SPAN_CATEGORY} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
 const {SPAN_SELF_TIME, SPAN_OP, SPAN_MODULE, SPAN_DESCRIPTION} = SpanMetricsFields;
@@ -60,7 +63,7 @@ export function SpanTimeCharts({moduleName, appliedFilters, spanCategory}: Props
     {Comp: (props: ChartProps) => JSX.Element; title: string}[]
   > = {
     [ModuleName.ALL]: [
-      {title: DataTitles.throughput, Comp: ThroughputChart},
+      {title: getThroughputChartTitle(moduleName), Comp: ThroughputChart},
       {title: DataTitles.p95, Comp: DurationChart},
     ],
     [ModuleName.DB]: [],

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -24,7 +24,7 @@ import {useSpanList} from 'sentry/views/starfish/queries/useSpanList';
 import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
-import {DataTitles} from 'sentry/views/starfish/views/spans/types';
+import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 
 type Row = {
   'http_error_count()': number;
@@ -249,7 +249,7 @@ function getColumns(
       : []),
     {
       key: 'sps()',
-      name: 'Throughput',
+      name: getThroughputTitle(moduleName),
       width: COL_WIDTH_UNDEFINED,
     },
     {

--- a/static/app/views/starfish/views/spans/types.tsx
+++ b/static/app/views/starfish/views/spans/types.tsx
@@ -45,3 +45,23 @@ export const getTooltip = (
   }
   return '';
 };
+
+export const getThroughputTitle = (spanOp?: string) => {
+  if (spanOp?.startsWith('db')) {
+    return t('Queries');
+  }
+  if (spanOp) {
+    return t('Requests');
+  }
+  return '--';
+};
+
+export const getThroughputChartTitle = (spanOp?: string) => {
+  if (spanOp?.startsWith('db')) {
+    return t('Queries Per Second');
+  }
+  if (spanOp) {
+    return t('Requests Per Second');
+  }
+  return '--';
+};


### PR DESCRIPTION
Updates throughput titles according to span op. `http` (and other generic) span ops will be labeled `Requests` and `Requests Per Second` (for charts). `db` span ops will be labeled `Queries` and `Queries Per Second` (for charts).