### PR TITLE
ref(processing): Clarify parameters in `find_stacktraces_in_data`

### DIFF
--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -189,14 +189,14 @@ class StacktraceProcessor:
 def find_stacktraces_in_data(
     data: NodeData, include_raw: bool = False, include_empty_exceptions: bool = False
 ) -> list[StacktraceInfo]:
-    """Finds all stacktraces in a given data blob and returns it
-    together with some meta information.
+    """
+    Finds all stacktraces in a given data blob and returns them together with some meta information.
 
     If `include_raw` is True, then also raw stacktraces are included.
 
-    If `with_exceptions` is set to `True` then stacktraces of the exception
-    are always included and the `is_exception` flag is set on that stack
-    info object.
+    If `include_empty_exceptions` is set to `True` then null/empty stacktraces and stacktraces with
+    no or only null/empty frames are included (where they otherwise would not be), with the
+    `is_exception` flag is set on their `StacktraceInfo` object.
     """
     rv = []
 

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -200,9 +200,18 @@ def find_stacktraces_in_data(
     """
     rv = []
 
-    def _append_stacktrace(stacktrace, container, is_exception: bool = False) -> None:
+    def _append_stacktrace(
+        stacktrace: Any,
+        container: Any,
+        is_exception: bool = False,
+        include_empty_exceptions: bool = False,
+    ) -> None:
         frames = _safe_get_frames(stacktrace)
-        if not is_exception and (not stacktrace or not frames):
+
+        if is_exception and include_empty_exceptions:
+            # win-fast bypass of null/empty check
+            pass
+        elif not stacktrace or not frames:
             return
 
         platforms = _get_frames_metadata(frames, data.get("platform", "unknown"))
@@ -217,7 +226,12 @@ def find_stacktraces_in_data(
 
     # Look for stacktraces under the key `exception`
     for exc in get_path(data, "exception", "values", filter=True, default=()):
-        _append_stacktrace(exc.get("stacktrace"), exc, is_exception=include_empty_exceptions)
+        _append_stacktrace(
+            exc.get("stacktrace"),
+            exc,
+            is_exception=True,
+            include_empty_exceptions=include_empty_exceptions,
+        )
 
     # Look for stacktraces under the key `stacktrace`
     _append_stacktrace(data.get("stacktrace"), None)

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -204,7 +204,7 @@ def find_stacktraces_in_data(
         stacktrace: Any,
         # The entry in `exception.values` or `threads.values` containing the `stacktrace` attribute,
         # or None for top-level stacktraces
-        container: Any,
+        container: Any = None,
         # Whether or not the container is from `exception.values`
         is_exception: bool = False,
         # Prevent skipping empty/null stacktraces from `exception.values` (other empty/null
@@ -233,23 +233,23 @@ def find_stacktraces_in_data(
     for exc in get_path(data, "exception", "values", filter=True, default=()):
         _append_stacktrace(
             exc.get("stacktrace"),
-            exc,
+            container=exc,
             is_exception=True,
             include_empty_exceptions=include_empty_exceptions,
         )
 
     # Look for stacktraces under the key `stacktrace`
-    _append_stacktrace(data.get("stacktrace"), None)
+    _append_stacktrace(data.get("stacktrace"))
 
     # The native family includes stacktraces under threads
     for thread in get_path(data, "threads", "values", filter=True, default=()):
-        _append_stacktrace(thread.get("stacktrace"), thread)
+        _append_stacktrace(thread.get("stacktrace"), container=thread)
 
     if include_raw:
         # Iterate over a copy of rv, otherwise, it will infinitely append to itself
         for info in rv[:]:
             if info.container is not None:
-                _append_stacktrace(info.container.get("raw_stacktrace"), info.container)
+                _append_stacktrace(info.container.get("raw_stacktrace"), container=info.container)
 
     return rv
 

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -187,7 +187,7 @@ class StacktraceProcessor:
 
 
 def find_stacktraces_in_data(
-    data: NodeData, include_raw: bool = False, with_exceptions: bool = False
+    data: NodeData, include_raw: bool = False, include_empty_exceptions: bool = False
 ) -> list[StacktraceInfo]:
     """Finds all stacktraces in a given data blob and returns it
     together with some meta information.
@@ -217,7 +217,7 @@ def find_stacktraces_in_data(
 
     # Look for stacktraces under the key `exception`
     for exc in get_path(data, "exception", "values", filter=True, default=()):
-        _append_stacktrace(exc.get("stacktrace"), exc, is_exception=with_exceptions)
+        _append_stacktrace(exc.get("stacktrace"), exc, is_exception=include_empty_exceptions)
 
     # Look for stacktraces under the key `stacktrace`
     _append_stacktrace(data.get("stacktrace"), None)
@@ -333,7 +333,7 @@ def _update_frame(frame: dict[str, Any], platform: Optional[str]) -> None:
 def should_process_for_stacktraces(data):
     from sentry.plugins.base import plugins
 
-    infos = find_stacktraces_in_data(data, with_exceptions=True)
+    infos = find_stacktraces_in_data(data, include_empty_exceptions=True)
     platforms: set[str] = set()
     for info in infos:
         platforms.update(info.platforms or ())
@@ -532,7 +532,7 @@ def dedup_errors(errors):
 
 
 def process_stacktraces(data, make_processors=None, set_raw_stacktrace=True):
-    infos = find_stacktraces_in_data(data, with_exceptions=True)
+    infos = find_stacktraces_in_data(data, include_empty_exceptions=True)
     if make_processors is None:
         processors = get_processors_for_stacktraces(data, infos)
     else:

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -249,6 +249,9 @@ def find_stacktraces_in_data(
         # Iterate over a copy of rv, otherwise, it will infinitely append to itself
         for info in rv[:]:
             if info.container is not None:
+                # We don't set `is_exception` to `True` here, even if `info.is_exception` is set,
+                # because otherwise we'd end up processing each exception container twice in
+                # `process_stacktraces`
                 _append_stacktrace(info.container.get("raw_stacktrace"), container=info.container)
 
     return rv

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -202,8 +202,13 @@ def find_stacktraces_in_data(
 
     def _append_stacktrace(
         stacktrace: Any,
+        # The entry in `exception.values` or `threads.values` containing the `stacktrace` attribute,
+        # or None for top-level stacktraces
         container: Any,
+        # Whether or not the container is from `exception.values`
         is_exception: bool = False,
+        # Prevent skipping empty/null stacktraces from `exception.values` (other empty/null
+        # stacktraces are always skipped)
         include_empty_exceptions: bool = False,
     ) -> None:
         frames = _safe_get_frames(stacktrace)

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -146,7 +146,8 @@ class JavaScriptStacktraceProcessorTest(TestCase):
         }
 
         stacktrace_infos = [
-            stacktrace for stacktrace in find_stacktraces_in_data(data, with_exceptions=True)
+            stacktrace
+            for stacktrace in find_stacktraces_in_data(data, include_empty_exceptions=True)
         ]
         processor = JavaScriptStacktraceProcessor(
             data={"release": release.version, "dist": "foo", "timestamp": 123.4},
@@ -201,7 +202,8 @@ class JavaScriptStacktraceProcessorTest(TestCase):
         }
 
         stacktrace_infos = [
-            stacktrace for stacktrace in find_stacktraces_in_data(data, with_exceptions=True)
+            stacktrace
+            for stacktrace in find_stacktraces_in_data(data, include_empty_exceptions=True)
         ]
 
         processor = JavaScriptStacktraceProcessor(

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -118,7 +118,6 @@ class JavaScriptStacktraceProcessorTest(TestCase):
         release = self.create_release(project=project, version="12.31.12")
 
         data = {
-            "is_exception": True,
             "platform": "javascript",
             "project": project.id,
             "exception": {
@@ -167,7 +166,6 @@ class JavaScriptStacktraceProcessorTest(TestCase):
         release = self.create_release(project=project, version="12.31.12")
 
         data = {
-            "is_exception": True,
             "platform": "javascript",
             "project": project.id,
             "exception": {

--- a/tests/sentry/test_stacktraces.py
+++ b/tests/sentry/test_stacktraces.py
@@ -144,7 +144,7 @@ class FindStacktracesTest(TestCase):
             },
         }
 
-        infos = find_stacktraces_in_data(data, with_exceptions=True)
+        infos = find_stacktraces_in_data(data, include_empty_exceptions=True)
         assert len(infos) == 4
         assert sum(1 for x in infos if x.stacktrace) == 3
         assert sum(1 for x in infos if x.is_exception) == 4


### PR DESCRIPTION
This is a small refactor of `find_stacktraces_in_data`, mainly for the purpose of clearing up confusion about the `with_exceptions` parameter and how it's used. I actually thought there was a bug, for two reasons: 

 - We  don't check the `with_exceptions` value before including entries from `exception.values`. (Seems like if `with_exceptions` is false, we should skip including those entries entirely.)
 - We use the `with_exception` value for those entries' `is_exception` flag, even when `with_exceptions` is `False` (meaning we're turning exception stacktraces into `StacktraceInfo` objects whose `is_exception` flag is set to `False`, which is just factually untrue).

But I dug into the parameter's origin, and I learned from [the PR which introduced it](https://github.com/getsentry/sentry/pull/15795) that, as they say, it's not a bug, it's a feature. Its actual purpose is to force us not to skip individual `exception.values` _entries_, even when they have null or empty stacktraces or stacktraces which contain only null or empty values, so that we still make `StacktraceInfo` objects out of their containers.

To clear up this confusion, a few changes were made:

- Rename `with_exceptions` to `include_empty_exceptions`.
- Add `include_empty_exceptions` as a separate parameter in `find_stacktraces_in_data`'s helper function, `_append_stacktrace`, so that `is_exception` can be set to `True` for all entries in `exception.values`. (This has no practical effect, since it was already `True` in [the one place it matters](https://github.com/getsentry/sentry/blob/75fb8f2a06a79b039e1ed53b934ade85e89dfa14/src/sentry/stacktraces/processing.py#L522): `process_stacktraces`, so that the Java processor can have access to the empty exception objects. That said, if we do ever decide to use it, now it will at least be correct data.)
- Fix docstrings and comments to explain the purpose of the renamed parameter.

Also, in my investigation into whether or not correcting the `is_exception` value on some `StacktraceInfo` instances would break anything, I came across two tests which included `is_exception` values in a spot they never show up IRL, being passed to functions which never check them. They have now been removed.