### PR TITLE
feat(crons): Show status labels next to environment names in timeline view

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -9,7 +9,7 @@ import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Monitor} from 'sentry/views/monitors/types';
 import {scheduleAsText} from 'sentry/views/monitors/utils';
-import {statusMap} from 'sentry/views/monitors/utils/constants';
+import {statusIconMap} from 'sentry/views/monitors/utils/constants';
 
 import {CheckInTimeline, CheckInTimelineProps} from './checkInTimeline';
 import {MonitorBucket} from './types';
@@ -34,15 +34,12 @@ export function TimelineTableRow({monitor, bucketedData, ...timelineProps}: Prop
     <TimelineRow key={monitor.id}>
       <MonitorDetails monitor={monitor} />
       <MonitorEnvContainer>
-        {environments.map(({name, status}) => {
-          const {Icon, color} = statusMap[status];
-          return (
-            <EnvWithStatus key={name}>
-              <MonitorEnvLabel>{name}</MonitorEnvLabel>
-              <Icon color={color} />
-            </EnvWithStatus>
-          );
-        })}
+        {environments.map(({name, status}) => (
+          <EnvWithStatus key={name}>
+            <MonitorEnvLabel>{name}</MonitorEnvLabel>
+            {statusIconMap[status]}
+          </EnvWithStatus>
+        ))}
         {!isExpanded && (
           <Button size="xs" onClick={() => setExpanded(true)}>
             {tct('Show [num] More', {

--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -9,6 +9,7 @@ import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Monitor} from 'sentry/views/monitors/types';
 import {scheduleAsText} from 'sentry/views/monitors/utils';
+import {statusMap} from 'sentry/views/monitors/utils/constants';
 
 import {CheckInTimeline, CheckInTimelineProps} from './checkInTimeline';
 import {MonitorBucket} from './types';
@@ -33,9 +34,15 @@ export function TimelineTableRow({monitor, bucketedData, ...timelineProps}: Prop
     <TimelineRow key={monitor.id}>
       <MonitorDetails monitor={monitor} />
       <MonitorEnvContainer>
-        {environments.map(({name}) => (
-          <MonitorEnvLabel key={name}>{name}</MonitorEnvLabel>
-        ))}
+        {environments.map(({name, status}) => {
+          const {Icon, color} = statusMap[status];
+          return (
+            <EnvWithStatus key={name}>
+              <MonitorEnvLabel>{name}</MonitorEnvLabel>
+              <Icon color={color} />
+            </EnvWithStatus>
+          );
+        })}
         {!isExpanded && (
           <Button size="xs" onClick={() => setExpanded(true)}>
             {tct('Show [num] More', {
@@ -120,10 +127,17 @@ const MonitorEnvContainer = styled('div')`
   text-align: right;
 `;
 
+const EnvWithStatus = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  align-items: center;
+`;
+
 const MonitorEnvLabel = styled('div')`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  flex: 1;
 `;
 
 const TimelineContainer = styled('div')`

--- a/static/app/views/monitors/utils/constants.tsx
+++ b/static/app/views/monitors/utils/constants.tsx
@@ -1,12 +1,4 @@
-import {
-  IconCheckmark,
-  IconExclamation,
-  IconFire,
-  IconPause,
-  IconTimer,
-} from 'sentry/icons';
-import {SVGIconProps} from 'sentry/icons/svgIcon';
-import {ColorOrAlias} from 'sentry/utils/theme';
+import {IconCheckmark, IconFire, IconPause, IconTimer, IconWarning} from 'sentry/icons';
 import {StatsBucket} from 'sentry/views/monitors/components/overviewTimeline/types';
 import {CheckInStatus, MonitorStatus} from 'sentry/views/monitors/types';
 
@@ -18,34 +10,11 @@ export const CHECKIN_STATUS_PRECEDENT = [
   CheckInStatus.ERROR,
 ] satisfies Array<keyof StatsBucket>;
 
-interface StatusData {
-  Icon: React.ComponentType<SVGIconProps>;
-  color: ColorOrAlias;
-}
-
-export const statusMap: Record<MonitorStatus, StatusData> = {
-  ok: {
-    Icon: IconCheckmark,
-    color: 'successText',
-  },
-  error: {
-    Icon: IconFire,
-    color: 'errorText',
-  },
-  timeout: {
-    Icon: IconFire,
-    color: 'errorText',
-  },
-  missed_checkin: {
-    Icon: IconExclamation,
-    color: 'warningText',
-  },
-  active: {
-    Icon: IconTimer,
-    color: 'subText',
-  },
-  disabled: {
-    Icon: (p: SVGIconProps) => <IconPause {...p} size="xs" />,
-    color: 'subText',
-  },
+export const statusIconMap: Record<MonitorStatus, React.ReactNode> = {
+  ok: <IconCheckmark color="successText" />,
+  error: <IconFire color="errorText" />,
+  timeout: <IconFire color="errorText" />,
+  missed_checkin: <IconWarning color="warningText" />,
+  active: <IconTimer color="subText" />,
+  disabled: <IconPause color="subText" size="xs" />,
 };


### PR DESCRIPTION
<img width="1258" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/60fa3b7b-dc91-40a5-a40e-08b912a935d5">
