### PR TITLE
fix: Fix autoassignment test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1003,7 +1003,6 @@ module = [
     "tests.sentry.api.endpoints.notifications.test_notification_actions_index",
     "tests.sentry.api.endpoints.test_event_attachment_details",
     "tests.sentry.api.endpoints.test_organization_metrics",
-    "tests.sentry.api.endpoints.test_project_ownership",
     "tests.sentry.api.helpers.test_group_index",
     "tests.sentry.api.serializers.test_alert_rule",
     "tests.sentry.api.serializers.test_event",

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -455,7 +455,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
             project_id=self.project.id,
             last_seen__gte=timezone.now() - timedelta(seconds=ISSUE_OWNERS_DEBOUNCE_DURATION),
         )
-        assert groups is not None
+        assert groups
         auto_assignment_cache_keys = [
             GroupOwner.get_autoassigned_owner_cache_key(
                 group.id, self.project.id, auto_assignment_types

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -468,7 +468,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         ]
         # Assert the cache is set
         for cache_key in auto_assignment_cache_keys:
-            assert cache.get(cache_key) is not False
+            assert cache.get(cache_key) is not None
 
         # Turn auto assignment off
         self.client.put(self.path, {"autoAssignment": "Turn off Auto-Assignment"})


### PR DESCRIPTION
The queryset was empty in this [test](https://github.com/getsentry/sentry/blob/4bd6934f1b3f947043ef93b1dd35a11b1e9927cf/tests/sentry/api/endpoints/test_project_ownership.py#L404), which was not properly testing the autoassignment behaviour and caused mypy problems. This PR fixes this test