### PR TITLE
feat(issues): Add semver information to release sidebar

### DIFF
--- a/fixtures/js-stubs/release.js
+++ b/fixtures/js-stubs/release.js
@@ -24,6 +24,7 @@ export function Release(params, healthParams) {
         minor: 2,
         buildCode: null,
         patch: 0,
+        components: 3,
       },
       description: '1.2.0',
       package: 'sentry-android-shop',

--- a/fixtures/js-stubs/releaseMeta.js
+++ b/fixtures/js-stubs/releaseMeta.js
@@ -1,0 +1,38 @@
+export function ReleaseMeta(params) {
+  const project = TestStubs.Project();
+  return {
+    version: 'sentry-android-shop@1.2.0',
+    versionInfo: {
+      package: 'sentry-android-shop',
+      version: {
+        raw: '1.2.0',
+        major: 1,
+        minor: 2,
+        patch: 0,
+        pre: null,
+        buildCode: null,
+        components: 3,
+      },
+      description: '1.2.0',
+      buildHash: null,
+    },
+    projects: [
+      {
+        id: project.id,
+        slug: project.slug,
+        name: project.name,
+        newGroups: 0,
+        platform: project.platform,
+        platforms: ['javascript'],
+      },
+    ],
+    newGroups: 0,
+    deployCount: 1,
+    commitCount: 2,
+    released: '2020-03-23T01:02:30Z',
+    commitFilesChanged: 17,
+    releaseFileCount: 1662,
+    isArtifactBundle: false,
+    ...params,
+  };
+}

--- a/fixtures/js-stubs/releaseMeta.ts
+++ b/fixtures/js-stubs/releaseMeta.ts
@@ -1,4 +1,6 @@
-export function ReleaseMeta(params) {
+import type {ReleaseMeta as ReleaseMetaType} from 'sentry/types';
+
+export function ReleaseMeta(params: Partial<ReleaseMetaType>): ReleaseMetaType {
   const project = TestStubs.Project();
   return {
     version: 'sentry-android-shop@1.2.0',

--- a/fixtures/js-stubs/types.tsx
+++ b/fixtures/js-stubs/types.tsx
@@ -1,4 +1,4 @@
-import {EntryException} from 'sentry/types';
+import {EntryException, ReleaseMeta} from 'sentry/types';
 import type {
   ReplayListRecord,
   ReplayRecord,
@@ -123,6 +123,7 @@ type TestStubFixtures = {
   PublishedApps: SimpleStub;
   PullRequest: OverridableStub;
   Release: (params?: any, healthParams?: any) => any;
+  ReleaseMeta: OverridableStub<ReleaseMeta>;
   Replay: typeof Replay;
   ReplayError: OverridableStub;
   ReplayList: OverridableStubList<ReplayListRecord>;

--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -122,13 +122,13 @@ export type CurrentRelease = {
 };
 
 export type ReleaseProject = {
-  hasHealthData: boolean;
   id: number;
   name: string;
   newGroups: number;
   platform: PlatformKey;
   platforms: PlatformKey[];
   slug: string;
+  hasHealthData?: boolean;
   healthData?: Health;
 };
 
@@ -137,6 +137,7 @@ export type ReleaseMeta = {
   commitFilesChanged: number;
   deployCount: number;
   isArtifactBundle: boolean;
+  newGroups: number;
   projects: ReleaseProject[];
   releaseFileCount: number;
   released: string;

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -599,7 +599,6 @@ class ReleaseOverview extends DeprecatedAsyncView<Props> {
                           <ProjectReleaseDetails
                             release={release}
                             releaseMeta={releaseMeta}
-                            orgSlug={organization.slug}
                             projectSlug={project.slug}
                           />
                           {commitCount > 0 && (

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.spec.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.spec.tsx
@@ -1,0 +1,21 @@
+import {render} from 'sentry-test/reactTestingLibrary';
+
+import ProjectReleaseDetails from './projectReleaseDetails';
+
+describe('ProjectReleaseDetails', () => {
+  it('should dislay if the release is using semver', () => {
+    const organization = TestStubs.Organization({features: ['issue-release-semver']});
+    const release = TestStubs.Release();
+    const releaseMeta = TestStubs.ReleaseMeta();
+    const {container} = render(
+      <ProjectReleaseDetails
+        projectSlug="project-slug"
+        release={release}
+        releaseMeta={releaseMeta}
+      />,
+      {organization}
+    );
+
+    expect(container).toHaveTextContent('SemverYes');
+  });
+});

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -9,16 +9,19 @@ import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
 import Version from 'sentry/components/version';
 import {t, tn} from 'sentry/locale';
-import {ReleaseMeta, ReleaseWithHealth} from 'sentry/types';
+import type {ReleaseMeta, ReleaseWithHealth} from 'sentry/types';
+import useOrganization from 'sentry/utils/useOrganization';
+import {isVersionInfoSemver} from 'sentry/views/releases/utils';
 
 type Props = {
-  orgSlug: string;
   projectSlug: string;
   release: ReleaseWithHealth;
   releaseMeta: ReleaseMeta;
 };
 
-function ProjectReleaseDetails({release, releaseMeta, orgSlug, projectSlug}: Props) {
+function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
+  const organization = useOrganization();
+  const orgSlug = organization.slug;
   const {version, versionInfo, dateCreated, firstEvent, lastEvent} = release;
   const {releaseFileCount, isArtifactBundle} = releaseMeta;
 
@@ -35,6 +38,12 @@ function ProjectReleaseDetails({release, releaseMeta, orgSlug, projectSlug}: Pro
             keyName={t('Version')}
             value={<Version version={version} anchor={false} />}
           />
+          {organization.features.includes('issue-release-semver') ? (
+            <KeyValueTableRow
+              keyName={t('Semver')}
+              value={isVersionInfoSemver(versionInfo.version) ? t('Yes') : t('No')}
+            />
+          ) : null}
           <KeyValueTableRow
             keyName={t('Package')}
             value={


### PR DESCRIPTION
Says if a release is using semver
![image](https://github.com/getsentry/sentry/assets/1400464/4a65efd9-aff2-47f0-8023-3ed1be5b01d2)
