### PR TITLE
fix(escalating): Remove forecast does not exist error

### DIFF
--- a/src/sentry/issues/escalating_group_forecast.py
+++ b/src/sentry/issues/escalating_group_forecast.py
@@ -59,9 +59,6 @@ class EscalatingGroupForecast:
         results = nodestore.get(cls.build_storage_identifier(project_id, group_id))
         if results:
             return EscalatingGroupForecast.from_dict(results)
-        logger.exception(
-            f"Forecast does not exist for project id: {str(project_id)} group id: {str(group_id)}"
-        )
         generate_and_save_missing_forecasts.delay(group_id=group_id)
         return EscalatingGroupForecast(
             project_id=project_id,

--- a/tests/sentry/issues/test_ignored.py
+++ b/tests/sentry/issues/test_ignored.py
@@ -64,10 +64,8 @@ class HandleIgnoredTest(TestCase):
 class HandleArchiveUntilEscalating(TestCase):
     @patch("sentry.issues.forecasts.query_groups_past_counts", return_value={})
     @patch("sentry.issues.forecasts.generate_and_save_missing_forecasts.delay")
-    @patch("sentry.issues.escalating_group_forecast.logger")
     def test_archive_until_escalating_no_counts(
         self,
-        mock_logger: MagicMock,
         mock_generate_and_save_missing_forecasts: MagicMock,
         mock_query_groups_past_counts: MagicMock,
     ) -> None:
@@ -87,9 +85,6 @@ class HandleArchiveUntilEscalating(TestCase):
 
         fetched_forecast = EscalatingGroupForecast.fetch(self.group.project.id, self.group.id)
         assert fetched_forecast and fetched_forecast.forecast == ONE_EVENT_FORECAST
-        assert mock_logger.exception.call_args.args[0] == (
-            f"Forecast does not exist for project id: {self.group.project.id} group id: {str(self.group.id)}"
-        )
         assert mock_generate_and_save_missing_forecasts.call_count == 1
 
     @patch("sentry.issues.forecasts.query_groups_past_counts")

--- a/tests/sentry/tasks/test_weekly_escalating_forecast.py
+++ b/tests/sentry/tasks/test_weekly_escalating_forecast.py
@@ -25,12 +25,10 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
         return group_list
 
     @patch("sentry.issues.forecasts.generate_and_save_missing_forecasts.delay")
-    @patch("sentry.issues.escalating_group_forecast.logger")
     @patch("sentry.issues.escalating.query_groups_past_counts")
     def test_empty_escalating_forecast(
         self,
         mock_query_groups_past_counts: MagicMock,
-        mock_logger: MagicMock,
         mock_generate_and_save_missing_forecasts: MagicMock,
     ) -> None:
         """
@@ -46,9 +44,6 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
             group = group_list[0]
             fetched_forecast = EscalatingGroupForecast.fetch(group.project.id, group.id)
             assert fetched_forecast and fetched_forecast.forecast == ONE_EVENT_FORECAST
-            assert mock_logger.exception.call_args.args[0] == (
-                f"Forecast does not exist for project id: {group.project.id} group id: {group.id}"
-            )
         assert mock_generate_and_save_missing_forecasts.call_count == 1
 
     @patch("sentry.analytics.record")


### PR DESCRIPTION
Followup from this [PR](https://github.com/getsentry/sentry/pull/53088). 
I forgot to remove the error log if the forecast does not exist in nodestore. Since there is now a fallback for what to return from fetch if the forecast does not exist, the error is no longer needed.

fixes SENTRY-134Y