### PR TITLE
ref(search): time postgres-only vs non-postgres-only searches

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -926,6 +926,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                 actor=actor,
                 aggregate_kwargs=aggregate_kwargs,
             )
+            metrics.timing("snuba.search.num_snuba_results", len(snuba_groups))
             count = len(snuba_groups)
             more_results = count >= limit and (offset + limit) < total
             offset += len(snuba_groups)
@@ -993,6 +994,8 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             # cursor, then it's worth allowing them to go back a page to check for
             # more results.
             paginator_results.prev.has_results = True
+
+        metrics.timing("snuba.search.num_chunks", num_chunks)
 
         groups = Group.objects.in_bulk(paginator_results.results)
         paginator_results.results = [groups[k] for k in paginator_results.results if k in groups]

--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -252,7 +252,7 @@ def build_cursor(
     cursor: Cursor | None = None,
     hits: int | None = None,
     max_hits: int | None = None,
-    on_results: None | OnResultCallable[T] = None,
+    on_results: OnResultCallable[T] | None = None,
 ) -> CursorResult[T | JSONData]:
     if cursor is None:
         cursor = Cursor(0, 0, 0)


### PR DESCRIPTION
Add some metrics to track query times for search when we hit snuba vs when we avoid snuba.