### PR TITLE
feat(replays): add feature flagged dead and rage click columns to replays list

### DIFF
--- a/fixtures/js-stubs/replayList.ts
+++ b/fixtures/js-stubs/replayList.ts
@@ -15,6 +15,8 @@ export function ReplayList(
         name: 'Firefox',
         version: '111.0',
       },
+      count_dead_clicks: 0,
+      count_rage_clicks: 0,
       count_errors: 0,
       duration: duration(30000),
       finished_at: new Date('2022-09-15T06:54:00+00:00'),

--- a/static/app/components/replays/contextIcon.tsx
+++ b/static/app/components/replays/contextIcon.tsx
@@ -12,13 +12,14 @@ type Props = {
   name: string;
   version: undefined | string;
   className?: string;
+  showVersion?: boolean;
 };
 
 const LazyContextIcon = lazy(
   () => import('sentry/components/events/contextSummary/contextIcon')
 );
 
-const ContextIcon = styled(({className, name, version}: Props) => {
+const ContextIcon = styled(({className, name, version, showVersion}: Props) => {
   const icon = generateIconName(name, version);
 
   const title = (
@@ -34,7 +35,7 @@ const ContextIcon = styled(({className, name, version}: Props) => {
       <Suspense fallback={<LoadingMask />}>
         <LazyContextIcon name={icon} size="sm" />
       </Suspense>
-      {version ? version : null}
+      {showVersion ? (version ? version : null) : undefined}
     </Tooltip>
   );
 })`

--- a/static/app/components/replays/header/replayMetaData.tsx
+++ b/static/app/components/replays/header/replayMetaData.tsx
@@ -23,6 +23,7 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
         <ContextIcon
           name={replayRecord?.os.name ?? ''}
           version={replayRecord?.os.version ?? undefined}
+          showVersion
         />
       </KeyMetricData>
 
@@ -31,6 +32,7 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
         <ContextIcon
           name={replayRecord?.browser.name ?? ''}
           version={replayRecord?.browser.version ?? undefined}
+          showVersion
         />
       </KeyMetricData>
 

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -120,9 +120,7 @@ describe('GroupReplays', () => {
               field: [
                 'activity',
                 'browser',
-                'count_dead_clicks',
                 'count_errors',
-                'count_rage_clicks',
                 'duration',
                 'finished_at',
                 'id',

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -120,7 +120,9 @@ describe('GroupReplays', () => {
               field: [
                 'activity',
                 'browser',
+                'count_dead_clicks',
                 'count_errors',
+                'count_rage_clicks',
                 'duration',
                 'finished_at',
                 'id',

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -54,15 +54,13 @@ function useReplayFromIssue({
       id: '',
       name: '',
       version: 2,
-      fields: getReplayListFields(
-        organization.features.includes('replay-rage-click-dead-click-columns')
-      ),
+      fields: getReplayListFields(organization),
       query: `id:[${String(replayIds)}]`,
       range: '14d',
       projects: [],
       orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
     });
-  }, [location.query.sort, replayIds, organization.features]);
+  }, [location.query.sort, replayIds, organization]);
 
   useCleanQueryParamsOnRouteLeave({fieldsToClean: ['cursor']});
   useEffect(() => {

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -20,9 +20,6 @@ function useReplayFromIssue({
   location: Location;
   organization: Organization;
 }) {
-  const hasDeadRageCols = organization.features.includes(
-    'replay-rage-click-dead-click-columns'
-  );
   const api = useApi();
 
   const [replayIds, setReplayIds] = useState<string[]>();
@@ -57,13 +54,15 @@ function useReplayFromIssue({
       id: '',
       name: '',
       version: 2,
-      fields: getReplayListFields(hasDeadRageCols),
+      fields: getReplayListFields(
+        organization.features.includes('replay-rage-click-dead-click-columns')
+      ),
       query: `id:[${String(replayIds)}]`,
       range: '14d',
       projects: [],
       orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
     });
-  }, [location.query.sort, replayIds, hasDeadRageCols]);
+  }, [location.query.sort, replayIds, organization.features]);
 
   useCleanQueryParamsOnRouteLeave({fieldsToClean: ['cursor']});
   useEffect(() => {

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -9,7 +9,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {DEFAULT_SORT} from 'sentry/utils/replays/fetchReplayList';
 import useApi from 'sentry/utils/useApi';
 import useCleanQueryParamsOnRouteLeave from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
-import {REPLAY_LIST_FIELDS} from 'sentry/views/replays/types';
+import {getReplayListFields} from 'sentry/views/replays/types';
 
 function useReplayFromIssue({
   group,
@@ -20,6 +20,9 @@ function useReplayFromIssue({
   location: Location;
   organization: Organization;
 }) {
+  const hasDeadRageCols = organization.features.includes(
+    'replay-rage-click-dead-click-columns'
+  );
   const api = useApi();
 
   const [replayIds, setReplayIds] = useState<string[]>();
@@ -54,13 +57,13 @@ function useReplayFromIssue({
       id: '',
       name: '',
       version: 2,
-      fields: REPLAY_LIST_FIELDS,
+      fields: getReplayListFields(hasDeadRageCols),
       query: `id:[${String(replayIds)}]`,
       range: '14d',
       projects: [],
       orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
     });
-  }, [location.query.sort, replayIds]);
+  }, [location.query.sort, replayIds, hasDeadRageCols]);
 
   useCleanQueryParamsOnRouteLeave({fieldsToClean: ['cursor']});
   useEffect(() => {

--- a/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
@@ -48,10 +48,6 @@ function useReplaysFromTransaction({
 }: Options): Return {
   const api = useApi();
 
-  const hasDeadRageCols = organization.features.includes(
-    'replay-rage-click-dead-click-columns'
-  );
-
   const [response, setResponse] = useState<{
     events: EventSpanData[];
     pageLinks: null | string;
@@ -91,12 +87,14 @@ function useReplaysFromTransaction({
       id: '',
       name: '',
       version: 2,
-      fields: getReplayListFields(hasDeadRageCols),
+      fields: getReplayListFields(
+        organization.features.includes('replay-rage-click-dead-click-columns')
+      ),
       projects: [],
       query: `id:[${String(response.replayIds)}]`,
       orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
     });
-  }, [location.query.sort, response.replayIds, hasDeadRageCols]);
+  }, [location.query.sort, response.replayIds, organization.features]);
 
   useEffect(() => {
     fetchReplayIds();

--- a/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
@@ -9,7 +9,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {DEFAULT_SORT} from 'sentry/utils/replays/fetchReplayList';
 import useApi from 'sentry/utils/useApi';
 import type {ReplayListLocationQuery} from 'sentry/views/replays/types';
-import {REPLAY_LIST_FIELDS} from 'sentry/views/replays/types';
+import {getReplayListFields} from 'sentry/views/replays/types';
 
 type Options = {
   location: Location;
@@ -48,6 +48,10 @@ function useReplaysFromTransaction({
 }: Options): Return {
   const api = useApi();
 
+  const hasDeadRageCols = organization.features.includes(
+    'replay-rage-click-dead-click-columns'
+  );
+
   const [response, setResponse] = useState<{
     events: EventSpanData[];
     pageLinks: null | string;
@@ -82,16 +86,17 @@ function useReplaysFromTransaction({
     if (!response.replayIds) {
       return null;
     }
+
     return EventView.fromSavedQuery({
       id: '',
       name: '',
       version: 2,
-      fields: REPLAY_LIST_FIELDS,
+      fields: getReplayListFields(hasDeadRageCols),
       projects: [],
       query: `id:[${String(response.replayIds)}]`,
       orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
     });
-  }, [location.query.sort, response.replayIds]);
+  }, [location.query.sort, response.replayIds, hasDeadRageCols]);
 
   useEffect(() => {
     fetchReplayIds();

--- a/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
@@ -87,14 +87,12 @@ function useReplaysFromTransaction({
       id: '',
       name: '',
       version: 2,
-      fields: getReplayListFields(
-        organization.features.includes('replay-rage-click-dead-click-columns')
-      ),
+      fields: getReplayListFields(organization),
       projects: [],
       query: `id:[${String(response.replayIds)}]`,
       orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
     });
-  }, [location.query.sort, response.replayIds, organization.features]);
+  }, [location.query.sort, response.replayIds, organization]);
 
   useEffect(() => {
     fetchReplayIds();

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -92,6 +92,29 @@ function ReplaysListTable({
 
   const hasReplayClick = conditions.getFilterKeys().some(k => k.startsWith('click.'));
 
+  const hasDeadRageCols = organization.features.includes(
+    'replay-rage-click-dead-click-columns'
+  );
+  const visibleCols = hasDeadRageCols
+    ? [
+        ReplayColumn.REPLAY,
+        ReplayColumn.OS,
+        ReplayColumn.BROWSER,
+        ReplayColumn.DURATION,
+        ReplayColumn.COUNT_ERRORS,
+        ReplayColumn.COUNT_DEAD_CLICKS,
+        ReplayColumn.COUNT_RAGE_CLICKS,
+        ReplayColumn.ACTIVITY,
+      ]
+    : [
+        ReplayColumn.REPLAY,
+        ReplayColumn.OS,
+        ReplayColumn.BROWSER,
+        ReplayColumn.DURATION,
+        ReplayColumn.COUNT_ERRORS,
+        ReplayColumn.ACTIVITY,
+      ];
+
   return (
     <Fragment>
       <ReplayTable
@@ -99,14 +122,7 @@ function ReplaysListTable({
         isFetching={isFetching}
         replays={replays}
         sort={eventView.sorts[0]}
-        visibleColumns={[
-          ReplayColumn.REPLAY,
-          ReplayColumn.OS,
-          ReplayColumn.BROWSER,
-          ReplayColumn.DURATION,
-          ReplayColumn.COUNT_ERRORS,
-          ReplayColumn.ACTIVITY,
-        ]}
+        visibleColumns={visibleCols}
         emptyMessage={
           allSelectedProjectsNeedUpdates && hasReplayClick ? (
             <Fragment>

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -21,11 +21,14 @@ import ReplayOnboardingPanel from 'sentry/views/replays/list/replayOnboardingPan
 import ReplayTable from 'sentry/views/replays/replayTable';
 import {ReplayColumn} from 'sentry/views/replays/replayTable/types';
 import type {ReplayListLocationQuery} from 'sentry/views/replays/types';
-import {REPLAY_LIST_FIELDS} from 'sentry/views/replays/types';
+import {getReplayListFields} from 'sentry/views/replays/types';
 
 function ReplaysList() {
   const location = useLocation<ReplayListLocationQuery>();
   const organization = useOrganization();
+  const hasDeadRageCols = organization.features.includes(
+    'replay-rage-click-dead-click-columns'
+  );
 
   const eventView = useMemo(() => {
     const query = decodeScalar(location.query.query, '');
@@ -36,14 +39,14 @@ function ReplaysList() {
         id: '',
         name: '',
         version: 2,
-        fields: REPLAY_LIST_FIELDS,
+        fields: getReplayListFields(hasDeadRageCols),
         projects: [],
         query: conditions.formatString(),
         orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
       },
       location
     );
-  }, [location]);
+  }, [location, hasDeadRageCols]);
 
   const hasSessionReplay = organization.features.includes('session-replay');
   const {hasSentOneReplay, fetching} = useHaveSelectedProjectsSentAnyReplayEvents();

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -26,9 +26,6 @@ import {getReplayListFields} from 'sentry/views/replays/types';
 function ReplaysList() {
   const location = useLocation<ReplayListLocationQuery>();
   const organization = useOrganization();
-  const hasDeadRageCols = organization.features.includes(
-    'replay-rage-click-dead-click-columns'
-  );
 
   const eventView = useMemo(() => {
     const query = decodeScalar(location.query.query, '');
@@ -39,14 +36,16 @@ function ReplaysList() {
         id: '',
         name: '',
         version: 2,
-        fields: getReplayListFields(hasDeadRageCols),
+        fields: getReplayListFields(
+          organization.features.includes('replay-rage-click-dead-click-columns')
+        ),
         projects: [],
         query: conditions.formatString(),
         orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
       },
       location
     );
-  }, [location, hasDeadRageCols]);
+  }, [location, organization.features]);
 
   const hasSessionReplay = organization.features.includes('session-replay');
   const {hasSentOneReplay, fetching} = useHaveSelectedProjectsSentAnyReplayEvents();

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -36,16 +36,14 @@ function ReplaysList() {
         id: '',
         name: '',
         version: 2,
-        fields: getReplayListFields(
-          organization.features.includes('replay-rage-click-dead-click-columns')
-        ),
+        fields: getReplayListFields(organization),
         projects: [],
         query: conditions.formatString(),
         orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
       },
       location
     );
-  }, [location, organization.features]);
+  }, [location, organization]);
 
   const hasSessionReplay = organization.features.includes('session-replay');
   const {hasSentOneReplay, fetching} = useHaveSelectedProjectsSentAnyReplayEvents();

--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -25,8 +25,32 @@ function HeaderCell({column, sort}: Props) {
     case ReplayColumn.BROWSER:
       return <SortableHeader sort={sort} fieldName="browser.name" label={t('Browser')} />;
 
+    case ReplayColumn.COUNT_DEAD_CLICKS:
+      return (
+        <SortableHeader
+          sort={sort}
+          fieldName="count_dead_clicks"
+          label={t('Dead Clicks')}
+          tooltip={t(
+            'A dead click is a user click that does not result in any page activity after 7 seconds.'
+          )}
+        />
+      );
+
     case ReplayColumn.COUNT_ERRORS:
       return <SortableHeader sort={sort} fieldName="count_errors" label={t('Errors')} />;
+
+    case ReplayColumn.COUNT_RAGE_CLICKS:
+      return (
+        <SortableHeader
+          sort={sort}
+          fieldName="count_rage_clicks"
+          label={t('Rage Clicks')}
+          tooltip={t(
+            'A rage click is 5 or more clicks on a dead element, which exhibits no page activity after 7 seconds.'
+          )}
+        />
+      );
 
     case ReplayColumn.DURATION:
       return <SortableHeader sort={sort} fieldName="duration" label={t('Duration')} />;

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -15,9 +15,11 @@ import HeaderCell from 'sentry/views/replays/replayTable/headerCell';
 import {
   ActivityCell,
   BrowserCell,
+  DeadClickCountCell,
   DurationCell,
   ErrorCountCell,
   OSCell,
+  RageClickCountCell,
   ReplayCell,
   TransactionCell,
 } from 'sentry/views/replays/replayTable/tableCell';
@@ -92,8 +94,14 @@ function ReplayTable({
                 case ReplayColumn.BROWSER:
                   return <BrowserCell key="browser" replay={replay} />;
 
+                case ReplayColumn.COUNT_DEAD_CLICKS:
+                  return <DeadClickCountCell key="countDeadClicks" replay={replay} />;
+
                 case ReplayColumn.COUNT_ERRORS:
                   return <ErrorCountCell key="countErrors" replay={replay} />;
+
+                case ReplayColumn.COUNT_RAGE_CLICKS:
+                  return <RageClickCountCell key="countRageClicks" replay={replay} />;
 
                 case ReplayColumn.DURATION:
                   return <DurationCell key="duration" replay={replay} />;

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -190,6 +190,7 @@ export function OSCell({replay}: Props) {
       <ContextIcon
         name={name ?? ''}
         version={version && hasRoomForColumns ? version : undefined}
+        showVersion={false}
       />
     </Item>
   );
@@ -208,6 +209,7 @@ export function BrowserCell({replay}: Props) {
       <ContextIcon
         name={name ?? ''}
         version={version && hasRoomForColumns ? version : undefined}
+        showVersion={false}
       />
     </Item>
   );
@@ -220,6 +222,36 @@ export function DurationCell({replay}: Props) {
   return (
     <Item>
       <Time>{formatTime(replay.duration.asMilliseconds())}</Time>
+    </Item>
+  );
+}
+
+export function RageClickCountCell({replay}: Props) {
+  if (replay.is_archived) {
+    return <Item isArchived />;
+  }
+  return (
+    <Item data-test-id="replay-table-count-rage-clicks">
+      {replay.count_rage_clicks ? (
+        <Count>{replay.count_rage_clicks}</Count>
+      ) : (
+        <Count>0</Count>
+      )}
+    </Item>
+  );
+}
+
+export function DeadClickCountCell({replay}: Props) {
+  if (replay.is_archived) {
+    return <Item isArchived />;
+  }
+  return (
+    <Item data-test-id="replay-table-count-dead-clicks">
+      {replay.count_dead_clicks ? (
+        <Count>{replay.count_dead_clicks}</Count>
+      ) : (
+        <Count>0</Count>
+      )}
     </Item>
   );
 }

--- a/static/app/views/replays/replayTable/types.tsx
+++ b/static/app/views/replays/replayTable/types.tsx
@@ -1,7 +1,9 @@
 export enum ReplayColumn {
   ACTIVITY = 'activity',
   BROWSER = 'browser',
+  COUNT_DEAD_CLICKS = 'countDeadClicks',
   COUNT_ERRORS = 'countErrors',
+  COUNT_RAGE_CLICKS = 'countRageClicks',
   DURATION = 'duration',
   OS = 'os',
   REPLAY = 'replay',

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -116,7 +116,9 @@ export type ReplayListRecord = Pick<
   ReplayRecord,
   | 'activity'
   | 'browser'
+  // | 'count_dead_clicks'
   | 'count_errors'
+  //  | 'count_rage_clicks'
   | 'duration'
   | 'finished_at'
   | 'id'
@@ -133,7 +135,9 @@ export const REPLAY_LIST_FIELDS: ReplayRecordNestedFieldName[] = [
   'activity',
   'browser.name',
   'browser.version',
+  //  'count_dead_clicks',
   'count_errors',
+  // 'count_rage_clicks',
   'duration',
   'finished_at',
   'id',

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -15,17 +15,9 @@ export type ReplayRecord = {
     version: null | string;
   };
   /**
-   * The number of dead clicks associated with the replay.
-   */
-  count_dead_clicks: number;
-  /**
    * The number of errors associated with the replay.
    */
   count_errors: number;
-  /**
-   * The number of rage clicks associated with the replay.
-   */
-  count_rage_clicks: number;
   /**
    * The number of segments that make up the replay.
    */
@@ -86,6 +78,14 @@ export type ReplayRecord = {
     ip: null | string;
     username: null | string;
   };
+  /**
+   * The number of dead clicks associated with the replay.
+   */
+  count_dead_clicks?: number;
+  /**
+   * The number of rage clicks associated with the replay.
+   */
+  count_rage_clicks?: number;
 };
 
 // The ReplayRecord fields, but with nested fields represented as `foo.bar`.
@@ -111,14 +111,53 @@ export type ReplayListLocationQuery = {
   utc?: 'true' | 'false';
 };
 
+// Sync with ReplayListRecord above
+export function getReplayListFields(hasDeadRageCols) {
+  return hasDeadRageCols
+    ? [
+        'activity',
+        'browser.name',
+        'browser.version',
+        'count_dead_clicks',
+        'count_errors',
+        'count_rage_clicks',
+        'duration',
+        'finished_at',
+        'id',
+        'is_archived',
+        'os.name',
+        'os.version',
+        'project_id',
+        'started_at',
+        'urls',
+        'user',
+      ]
+    : [
+        'activity',
+        'browser.name',
+        'browser.version',
+        'count_errors',
+        'duration',
+        'finished_at',
+        'id',
+        'is_archived',
+        'os.name',
+        'os.version',
+        'project_id',
+        'started_at',
+        'urls',
+        'user',
+      ];
+}
+
 // Sync with REPLAY_LIST_FIELDS below
 export type ReplayListRecord = Pick<
   ReplayRecord,
   | 'activity'
   | 'browser'
-  // | 'count_dead_clicks'
+  | 'count_dead_clicks'
   | 'count_errors'
-  //  | 'count_rage_clicks'
+  | 'count_rage_clicks'
   | 'duration'
   | 'finished_at'
   | 'id'
@@ -129,26 +168,6 @@ export type ReplayListRecord = Pick<
   | 'urls'
   | 'user'
 >;
-
-// Sync with ReplayListRecord above
-export const REPLAY_LIST_FIELDS: ReplayRecordNestedFieldName[] = [
-  'activity',
-  'browser.name',
-  'browser.version',
-  //  'count_dead_clicks',
-  'count_errors',
-  // 'count_rage_clicks',
-  'duration',
-  'finished_at',
-  'id',
-  'is_archived',
-  'os.name',
-  'os.version',
-  'project_id',
-  'started_at',
-  'urls',
-  'user',
-];
 
 export type ReplaySegment = {
   dateAdded: string;

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -1,6 +1,7 @@
 import type {eventWithTime} from '@sentry-internal/rrweb/typings/types';
 import type {Duration} from 'moment';
 
+import {Organization} from 'sentry/types';
 import type {RawCrumb} from 'sentry/types/breadcrumbs';
 
 // Keep this in sync with the backend blueprint
@@ -112,7 +113,10 @@ export type ReplayListLocationQuery = {
 };
 
 // Sync with ReplayListRecord above
-export function getReplayListFields(hasDeadRageCols) {
+export function getReplayListFields(organization: Organization) {
+  const hasDeadRageCols = organization.features.includes(
+    'replay-rage-click-dead-click-columns'
+  );
   return hasDeadRageCols
     ? [
         'activity',


### PR DESCRIPTION
Updated reverted PR (https://github.com/getsentry/sentry/pull/53116) to add feature flagging to protect the data fetching of `count_dead_clicks` and `count_rage_clicks` 