### PR TITLE
fix(issues): Prevent escaping of `[me, none]` style tags

### DIFF
--- a/static/app/components/smartSearchBar/utils.spec.tsx
+++ b/static/app/components/smartSearchBar/utils.spec.tsx
@@ -1,5 +1,6 @@
 import {
   addSpace,
+  escapeTagValue,
   filterKeysFromQuery,
   getTagItemsFromKeys,
   removeSpace,
@@ -250,5 +251,18 @@ describe('filterKeysFromQuery', () => {
         'unresolved'
       )
     ).toMatchObject([FieldKey.IS]);
+  });
+});
+
+describe('escapeTagValue()', () => {
+  it('wraps tags containing quotes in quotes', () => {
+    expect(escapeTagValue('foo"bar')).toBe('"foo\\"bar"');
+  });
+  it('wraps tags containing spaces in quotes', () => {
+    expect(escapeTagValue('foo bar')).toBe('"foo bar"');
+  });
+  it('does not escape tags in array style', () => {
+    expect(escapeTagValue('[me, none]')).toBe('[me, none]');
+    expect(escapeTagValue('[me, my_teams, none]')).toBe('[me, my_teams, none]');
   });
 });

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -695,7 +695,8 @@ export function getAutoCompleteGroupForInvalidWildcard(searchText: string) {
 
 export function escapeTagValue(value: string): string {
   // Wrap in quotes if there is a space
-  return value.includes(' ') || value.includes('"')
+  const isArrayTag = value.startsWith('[') && value.endsWith(']') && value.includes(',');
+  return (value.includes(' ') || value.includes('"')) && !isArrayTag
     ? `"${value.replace(/"/g, '\\"')}"`
     : value;
 }


### PR DESCRIPTION
prevents this
![image](https://github.com/getsentry/sentry/assets/1400464/8f397976-c7c5-4d1e-b5c0-15d6c16c18d6)
