### PR TITLE
Unquote `abs_path` before processing

### DIFF
--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -808,13 +808,13 @@ class TestJavascriptIntegration(RelayStoreHelper):
         ]:
             with open(get_fixture_path(file), "rb") as f:
                 headers = {"sourcemap": name + ".map"} if name.endswith(".js") else {}
-                file = File.objects.create(name=name, type="release.file", headers=headers)
-                file.putfile(f)
+                file_obj = File.objects.create(name=name, type="release.file", headers=headers)
+                file_obj.putfile(f)
             ReleaseFile.objects.create(
                 name=name,
                 release_id=release.id,
                 organization_id=project.organization_id,
-                file=file,
+                file=file_obj,
             )
 
         data = {

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -795,6 +795,70 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
     @requires_symbolicator
     @pytest.mark.symbolicator
+    def test_urlencoded_files(self, process_with_symbolicator):
+        if not process_with_symbolicator:
+            return
+        project = self.project
+        release = Release.objects.create(organization_id=project.organization_id, version="abc")
+        release.add_project(project)
+
+        for file, name in [
+            ("file.min.js", "~/_next/static/chunks/pages/foo/[bar]-1234.js"),
+            ("file.wc.sourcemap.js", "~/_next/static/chunks/pages/foo/[bar]-1234.js.map"),
+        ]:
+            with open(get_fixture_path(file), "rb") as f:
+                headers = {"sourcemap": name + ".map"} if name.endswith(".js") else {}
+                file = File.objects.create(name=name, type="release.file", headers=headers)
+                file.putfile(f)
+            ReleaseFile.objects.create(
+                name=name,
+                release_id=release.id,
+                organization_id=project.organization_id,
+                file=file,
+            )
+
+        data = {
+            "timestamp": self.min_ago,
+            "message": "hello",
+            "platform": "javascript",
+            "release": "abc",
+            "exception": {
+                "values": [
+                    {
+                        "type": "Error",
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "abs_path": "app:///_next/static/chunks/pages/foo/%5Bbar%5D-1234.js",
+                                    "lineno": 1,
+                                    "colno": 79,
+                                }
+                            ]
+                        },
+                    }
+                ]
+            },
+        }
+
+        event = self.post_and_retrieve_event(data)
+
+        assert "errors" not in event.data
+
+        exception = event.interfaces["exception"]
+        frame_list = exception.values[0].stacktrace.frames
+
+        assert len(frame_list) == 1
+        frame = frame_list[0]
+        assert frame.data["resolved_with"] == "release-old"
+        assert frame.data["symbolicated"]
+
+        assert frame.function == "multiply"
+        assert frame.filename == "file2.js"
+        assert frame.lineno == 3
+        assert frame.colno == 2
+
+    @requires_symbolicator
+    @pytest.mark.symbolicator
     def test_indexed_sourcemap_source_expansion(self, process_with_symbolicator):
         self.project.update_option("sentry:scrape_javascript", False)
         release = Release.objects.create(


### PR DESCRIPTION
We have observed customers that have special characters in their file name, and the SDK reports those as url-encoded urls. We need to decode this before we go into processing, so we query for and find the correct uploaded files.
