### PR TITLE
ref(getting-started-docs): Add docs for node/koa

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -71,6 +71,7 @@ export const migratedDocs = [
   'node-azurefunctions',
   'node-gcpfunctions',
   'node-express',
+  'node-koa',
   'electron',
   'elixir',
 ];

--- a/static/app/gettingStartedDocs/node/koa.spec.tsx
+++ b/static/app/gettingStartedDocs/node/koa.spec.tsx
@@ -1,0 +1,20 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+
+import {GettingStartedWithKoa, steps} from './koa';
+
+describe('GettingStartedWithKoa', function () {
+  it('all products are selected', function () {
+    const {container} = render(<GettingStartedWithKoa dsn="test-dsn" />);
+
+    // Steps
+    for (const step of steps()) {
+      expect(
+        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
+      ).toBeInTheDocument();
+    }
+
+    expect(container).toSnapshot();
+  });
+});

--- a/static/app/gettingStartedDocs/node/koa.tsx
+++ b/static/app/gettingStartedDocs/node/koa.tsx
@@ -1,0 +1,181 @@
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
+import {t, tct} from 'sentry/locale';
+
+const performanceIntegrations: string[] = [
+  `// Automatically instrument Node.js libraries and frameworks
+  ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),`,
+];
+
+const performanceOtherConfig = `// Performance Monitoring
+tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!`;
+
+export const steps = ({
+  sentryInitContent,
+}: {
+  sentryInitContent?: string;
+} = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: t('Add the Sentry Node SDK as a dependency:'),
+    configurations: [
+      {
+        language: 'bash',
+        code: `
+# Using yarn
+yarn add @sentry/node @sentry/utils
+
+# Using npm
+npm install --save @sentry/node @sentry/utils
+        `,
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: (
+      <p>
+        {tct(
+          "Initialize Sentry as early as possible in your application's lifecycle, for example in your [code:index.ts/js] entry point:",
+          {code: <code />}
+        )}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        const Sentry = require("@sentry/node");
+        const { stripUrlQueryAndFragment } = require("@sentry/utils");
+        const Koa = require("koa");
+        const app = new Koa();
+
+        Sentry.init({
+          ${sentryInitContent},
+        });
+
+        const requestHandler = (ctx, next) => {
+          return new Promise((resolve, reject) => {
+            Sentry.runWithAsyncContext(async () => {
+              const hub = Sentry.getCurrentHub();
+              hub.configureScope((scope) =>
+                scope.addEventProcessor((event) =>
+                  Sentry.addRequestDataToEvent(event, ctx.request, {
+                    include: {
+                      user: false,
+                    },
+                  })
+                )
+              );
+
+              try {
+                await next();
+              } catch (err) {
+                reject(err);
+              }
+              resolve();
+            });
+          });
+        };
+
+        // this tracing middleware creates a transaction per request
+        const tracingMiddleWare = async (ctx, next) => {
+          const reqMethod = (ctx.method || "").toUpperCase();
+          const reqUrl = ctx.url && stripUrlQueryAndFragment(ctx.url);
+
+          // connect to trace of upstream app
+          let traceparentData;
+          if (ctx.request.get("sentry-trace")) {
+            traceparentData = Sentry.extractTraceparentData(
+              ctx.request.get("sentry-trace")
+            );
+          }
+
+          const transaction = Sentry.startTransaction({
+            name: \`\${reqMethod} \${reqUrl}\`,
+            op: "http.server",
+            ...traceparentData,
+          });
+
+          ctx.__sentry_transaction = transaction;
+
+          // We put the transaction on the scope so users can attach children to it
+          Sentry.getCurrentHub().configureScope((scope) => {
+            scope.setSpan(transaction);
+          });
+
+          ctx.res.on("finish", () => {
+            // Push \`transaction.finish\` to the next event loop so open spans have a chance to finish before the transaction closes
+            setImmediate(() => {
+              // if using koa router, a nicer way to capture transaction using the matched route
+              if (ctx._matchedRoute) {
+                const mountPath = ctx.mountPath || "";
+                transaction.setName(\`\${reqMethod} \${mountPath}\${ctx._matchedRoute}\`);
+              }
+              transaction.setHttpStatus(ctx.status);
+              transaction.finish();
+            });
+          });
+
+          await next();
+        };
+
+        app.use(requestHandler);
+        app.use(tracingMiddleWare);
+
+        // usual error handler
+        app.on("error", (err, ctx) => {
+          Sentry.withScope((scope) => {
+            scope.addEventProcessor((event) => {
+              return Sentry.addRequestDataToEvent(event, ctx.request);
+            });
+            Sentry.captureException(err);
+          });
+        });
+
+        app.listen(3000);
+        `,
+      },
+    ],
+  },
+  getUploadSourceMapsStep('https://docs.sentry.io/platforms/node/guides/koa/sourcemaps'),
+  {
+    type: StepType.VERIFY,
+    description: t(
+      "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        app.get("/debug-sentry", function mainHandler(req, res) {
+          throw new Error("My first Sentry error!");
+        });
+        `,
+      },
+    ],
+  },
+];
+
+export function GettingStartedWithKoa({dsn, ...props}: ModuleProps) {
+  let sentryInitContent: string[] = [`dsn: "${dsn}",`];
+
+  const integrations = [...performanceIntegrations];
+  const otherConfigs = [performanceOtherConfig];
+
+  if (integrations.length > 0) {
+    sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
+  }
+
+  if (otherConfigs.length > 0) {
+    sentryInitContent = sentryInitContent.concat(otherConfigs);
+  }
+
+  return (
+    <Layout steps={steps({sentryInitContent: sentryInitContent.join('\n')})} {...props} />
+  );
+}
+
+export default GettingStartedWithKoa;

--- a/static/app/gettingStartedDocs/node/koa.tsx
+++ b/static/app/gettingStartedDocs/node/koa.tsx
@@ -140,7 +140,7 @@ npm install --save @sentry/node @sentry/utils
       },
     ],
   },
-  getUploadSourceMapsStep('https://docs.sentry.io/platforms/node/guides/koa/sourcemaps'),
+  getUploadSourceMapsStep('https://docs.sentry.io/platforms/node/guides/koa/sourcemaps/'),
   {
     type: StepType.VERIFY,
     description: t(

--- a/static/app/gettingStartedDocs/node/koa.tsx
+++ b/static/app/gettingStartedDocs/node/koa.tsx
@@ -2,7 +2,17 @@ import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDo
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
+import {PlatformKey} from 'sentry/data/platformCategories';
 import {t, tct} from 'sentry/locale';
+import {Organization} from 'sentry/types';
+
+type StepProps = {
+  newOrg: boolean;
+  organization: Organization;
+  platformKey: PlatformKey;
+  projectId: string;
+  sentryInitContent: string;
+};
 
 const performanceIntegrations: string[] = [
   `// Automatically instrument Node.js libraries and frameworks
@@ -14,9 +24,8 @@ tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production
 
 export const steps = ({
   sentryInitContent,
-}: {
-  sentryInitContent?: string;
-} = {}): LayoutProps['steps'] => [
+  ...props
+}: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
     description: t('Add the Sentry Node SDK as a dependency:'),
@@ -140,7 +149,10 @@ npm install --save @sentry/node @sentry/utils
       },
     ],
   },
-  getUploadSourceMapsStep('https://docs.sentry.io/platforms/node/guides/koa/sourcemaps/'),
+  getUploadSourceMapsStep({
+    guideLink: 'https://docs.sentry.io/platforms/node/guides/koa/sourcemaps/',
+    ...props,
+  }),
   {
     type: StepType.VERIFY,
     description: t(
@@ -159,7 +171,13 @@ npm install --save @sentry/node @sentry/utils
   },
 ];
 
-export function GettingStartedWithKoa({dsn, ...props}: ModuleProps) {
+export function GettingStartedWithKoa({
+  dsn,
+  organization,
+  newOrg,
+  platformKey,
+  projectId,
+}: ModuleProps) {
   let sentryInitContent: string[] = [`dsn: "${dsn}",`];
 
   const integrations = [...performanceIntegrations];
@@ -174,7 +192,17 @@ export function GettingStartedWithKoa({dsn, ...props}: ModuleProps) {
   }
 
   return (
-    <Layout steps={steps({sentryInitContent: sentryInitContent.join('\n')})} {...props} />
+    <Layout
+      steps={steps({
+        sentryInitContent: sentryInitContent.join('\n'),
+        organization,
+        newOrg,
+        platformKey,
+        projectId,
+      })}
+      newOrg={newOrg}
+      platformKey={platformKey}
+    />
   );
 }
 

--- a/static/app/gettingStartedDocs/node/koa.tsx
+++ b/static/app/gettingStartedDocs/node/koa.tsx
@@ -109,7 +109,7 @@ npm install --save @sentry/node @sentry/utils
           ctx.res.on("finish", () => {
             // Push \`transaction.finish\` to the next event loop so open spans have a chance to finish before the transaction closes
             setImmediate(() => {
-              // if using koa router, a nicer way to capture transaction using the matched route
+              // if you're using koa router, set the matched route as transaction name
               if (ctx._matchedRoute) {
                 const mountPath = ctx.mountPath || "";
                 transaction.setName(\`\${reqMethod} \${mountPath}\${ctx._matchedRoute}\`);

--- a/static/app/gettingStartedDocs/node/koa.tsx
+++ b/static/app/gettingStartedDocs/node/koa.tsx
@@ -150,7 +150,7 @@ npm install --save @sentry/node @sentry/utils
       {
         language: 'javascript',
         code: `
-        app.get("/debug-sentry", function mainHandler(req, res) {
+        app.use(async function () {
           throw new Error("My first Sentry error!");
         });
         `,


### PR DESCRIPTION
closes(https://github.com/getsentry/sentry/issues/52195)

# Result

![screencapture-sentry-tutorial-localhost-7999-projects-javascript-u3-getting-started-2023-07-20-12_26_30 (1)](https://github.com/getsentry/sentry/assets/7096858/06c48d77-017d-44b7-ade1-f86441f373ac)


# IC Support

Please verify this is correct for Koa:

- [x] Intro for "Configure SDK"

> ![Screenshot 2023-07-20 at 12 19 30](https://github.com/getsentry/sentry/assets/7096858/138b60b8-20bb-4a31-95a6-9a982a4907ff)

- [x] Verify section (there was none in the docs) 
> ![Screenshot 2023-07-20 at 12 20 01](https://github.com/getsentry/sentry/assets/7096858/e26582ae-fb26-4da6-89af-5935dfd5dce0)

- [x] Error handler setup was copied from perf. instructions, but it differs from only errors

> ![Screenshot 2023-07-20 at 12 22 20](https://github.com/getsentry/sentry/assets/7096858/9b947104-354c-43f2-b48f-27d26eebe185)

vs. 

> ![Screenshot 2023-07-20 at 12 23 21](https://github.com/getsentry/sentry/assets/7096858/80d665a0-c915-40d9-892f-800026494a5c)
