### PR TITLE
ref: Migrate from feature flag to option for recap servers

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -11,7 +11,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import audit_log, features
+from sentry import audit_log, features, options
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.decorators import sudo_required
@@ -332,27 +332,19 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
         return value
 
     def validate_recapServerUrl(self, value):
-        from sentry import features
-
-        project = self.context["project"]
-
         # Adding recapServerUrl is only allowed if recap server polling is enabled.
-        has_recap_server_enabled = features.has("projects:recap-server", project)
-
-        if not has_recap_server_enabled:
+        if self.context["project"].id not in options.get(
+            "processing.recap-server.enabled-projects", []
+        ):
             raise serializers.ValidationError("Project is not allowed to set recap server url")
 
         return value
 
     def validate_recapServerToken(self, value):
-        from sentry import features
-
-        project = self.context["project"]
-
         # Adding recapServerToken is only allowed if recap server polling is enabled.
-        has_recap_server_enabled = features.has("projects:recap-server", project)
-
-        if not has_recap_server_enabled:
+        if self.context["project"].id not in options.get(
+            "processing.recap-server.enabled-projects", []
+        ):
             raise serializers.ValidationError("Project is not allowed to set recap server token")
 
         return value

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1678,8 +1678,6 @@ SENTRY_FEATURES = {
     "projects:race-free-group-creation": True,
     # Enable functionality for rate-limiting events on projects.
     "projects:rate-limits": True,
-    # Enable functionality for recap server polling.
-    "projects:recap-server": False,
     # Enable functionality to trigger service hooks upon event ingestion.
     "projects:servicehooks": False,
     # Enable suspect resolutions feature

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -266,7 +266,6 @@ default_manager.add("projects:discard-groups", ProjectFeature, FeatureHandlerStr
 default_manager.add("projects:minidump", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:race-free-group-creation", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:rate-limits", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("projects:recap-server", ProjectFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("projects:servicehooks", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:similarity-indexing", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:similarity-view", ProjectFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -754,6 +754,14 @@ register(
     "processing.use-release-archives-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
 )  # unused
 
+# Controls the recap server feature availability for given projects.
+register(
+    "processing.recap-server.enabled-projects",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # All Relay options (statically authenticated Relays can be registered here)
 register("relay.static_auth", default={}, flags=FLAG_NOSTORE)
 

--- a/src/sentry/tasks/recap_servers.py
+++ b/src/sentry/tasks/recap_servers.py
@@ -3,7 +3,7 @@ import urllib.parse
 import uuid
 from typing import Any, Dict
 
-from sentry import features, http, options
+from sentry import http, options
 from sentry.datascrubbing import scrub_data
 from sentry.event_manager import EventManager
 from sentry.models import Project, ProjectOption
@@ -31,7 +31,6 @@ RECAP_SERVER_LATEST_ID = "sentry:recap_server_poll_id"
 logger = logging.getLogger(__name__)
 
 
-# TODO(recap): Add feature flag?
 @instrumented_task(
     name="sentry.tasks.poll_recap_servers",
     queue="recap_servers",
@@ -58,7 +57,7 @@ def poll_project_recap_server(project_id: int, **kwargs) -> None:
         logger.warning("Polled project do not exist", extra={"project_id": project_id})
         return
 
-    if not features.has("projects:recap-server", project):
+    if project_id not in options.get("processing.recap-server.enabled-projects", []):
         logger.info(
             "Recap server polling feature is not enabled for a given project",
             extra={"project_id": project_id},

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -32,6 +32,7 @@ from sentry.notifications.types import NotificationSettingOptionValues, Notifica
 from sentry.silo import unguarded_write
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
@@ -1004,7 +1005,7 @@ class ProjectUpdateTest(APITestCase):
     @mock.patch("sentry.tasks.recap_servers.poll_project_recap_server.delay")
     def test_recap_server(self, poll_project_recap_server):
         project = Project.objects.get(id=self.project.id)
-        with Feature({"projects:recap-server": True}):
+        with override_options({"processing.recap-server.enabled-projects": [self.project.id]}):
             resp = self.get_response(
                 self.org_slug, self.proj_slug, recapServerUrl="http://example.com"
             )
@@ -1022,7 +1023,7 @@ class ProjectUpdateTest(APITestCase):
     @mock.patch("sentry.tasks.recap_servers.poll_project_recap_server.delay")
     def test_recap_server_no_feature(self, poll_project_recap_server):
         project = Project.objects.get(id=self.project.id)
-        with Feature({"projects:recap-server": False}):
+        with override_options({"processing.recap-server.enabled-projects": []}):
             resp = self.get_response(
                 self.org_slug, self.proj_slug, recapServerUrl="http://example.com"
             )
@@ -1040,7 +1041,7 @@ class ProjectUpdateTest(APITestCase):
         project = Project.objects.get(id=self.project.id)
         project.update_option("sentry:recap_server_url", "http://example.com")
         project.update_option("sentry:recap_server_token", "wat")
-        with Feature({"projects:recap-server": True}):
+        with override_options({"processing.recap-server.enabled-projects": [self.project.id]}):
             resp = self.get_response(
                 self.org_slug, self.proj_slug, recapServerUrl="http://example.com"
             )
@@ -1060,7 +1061,7 @@ class ProjectUpdateTest(APITestCase):
         project = Project.objects.get(id=self.project.id)
         project.update_option("sentry:recap_server_url", "http://example.com")
         project.update_option("sentry:recap_server_token", "wat")
-        with Feature({"projects:recap-server": True}):
+        with override_options({"processing.recap-server.enabled-projects": [self.project.id]}):
             resp = self.get_response(self.org_slug, self.proj_slug, recapServerUrl="")
 
             assert resp.status_code == 200


### PR DESCRIPTION
This would be preferably configurable from the UI, but we do not support `Sequence` types there :(
Right now we'll have to ping ops for every single update.

Followup task: remove no. 415 from flagr

Closes https://github.com/getsentry/sentry/issues/52981