### PR TITLE
fix(dynamic-sampling) Increase dynamic-sampling task timeouts

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1070,18 +1070,18 @@ CELERYBEAT_SCHEDULE_REGION = {
     },
     "dynamic-sampling-boost-low-volume-projects": {
         "task": "sentry.dynamic_sampling.tasks.boost_low_volume_projects",
-        # Run every 5 minutes
-        "schedule": crontab(minute="*/5"),
+        # Run every 10 minutes
+        "schedule": crontab(minute="*/10"),
     },
     "dynamic-sampling-boost-low-volume-transactions": {
         "task": "sentry.dynamic_sampling.tasks.boost_low_volume_transactions",
-        # Run every 5 minutes
-        "schedule": crontab(minute="*/5"),
+        # Run every 10 minutes
+        "schedule": crontab(minute="*/10"),
     },
     "dynamic-sampling-recalibrate-orgs": {
         "task": "sentry.dynamic_sampling.tasks.recalibrate_orgs",
-        # Run every 5 minutes
-        "schedule": crontab(minute="*/5"),
+        # Run every 10 minutes
+        "schedule": crontab(minute="*/10"),
     },
     "dynamic-sampling-sliding-window-org": {
         "task": "sentry.dynamic_sampling.tasks.sliding_window_org",
@@ -1119,8 +1119,8 @@ CELERYBEAT_SCHEDULE_REGION = {
     },
     "dynamic-sampling-collect-orgs": {
         "task": "sentry.dynamic_sampling.tasks.collect_orgs",
-        # Run every 5 minutes
-        "schedule": crontab(minute="*/5"),
+        # Run every 20 minutes
+        "schedule": crontab(minute="*/20"),
     },
 }
 

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -43,7 +43,7 @@ from sentry.dynamic_sampling.tasks.constants import (
     CHUNK_SIZE,
     DEFAULT_REDIS_CACHE_KEY_TTL,
     MAX_PROJECTS_PER_QUERY,
-    MAX_SECONDS,
+    MAX_TASK_SECONDS,
     MAX_TRANSACTIONS_PER_PROJECT,
 )
 from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
@@ -76,7 +76,9 @@ from sentry.utils.snuba import raw_snql_query
 )
 @dynamic_sampling_task
 def boost_low_volume_projects() -> None:
-    context = TaskContext("sentry.dynamic_sampling.tasks.boost_low_volume_projects", MAX_SECONDS)
+    context = TaskContext(
+        "sentry.dynamic_sampling.tasks.boost_low_volume_projects", MAX_TASK_SECONDS
+    )
     fetch_projects_timer = Timer()
 
     try:

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -32,7 +32,7 @@ from sentry.dynamic_sampling.tasks.constants import (
     CHUNK_SIZE,
     DEFAULT_REDIS_CACHE_KEY_TTL,
     MAX_PROJECTS_PER_QUERY,
-    MAX_SECONDS,
+    MAX_TASK_SECONDS,
 )
 from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
     get_boost_low_volume_projects_sample_rate,
@@ -105,7 +105,7 @@ def boost_low_volume_transactions() -> None:
     )
 
     context = TaskContext(
-        "sentry.dynamic_sampling.tasks.boost_low_volume_transactions", MAX_SECONDS
+        "sentry.dynamic_sampling.tasks.boost_low_volume_transactions", MAX_TASK_SECONDS
     )
 
     # create global timers for the internal iterators since they are created multiple times,
@@ -292,6 +292,8 @@ class FetchProjectTransactionTotals:
         self._ensure_log_state()
         assert self.log_state is not None
 
+        self.log_state.num_iterations += 1
+
         if not self._cache_empty():
             return self._get_from_cache()
 
@@ -447,7 +449,10 @@ class FetchProjectTransactionVolumes:
     def __iter__(self):
         return self
 
-    def __next__(self):
+    def __next__(self) -> ProjectTransactions:
+        self._ensure_log_state()
+
+        self.log_state.num_iterations += 1
 
         if self.max_transactions == 0:
             # the user is not interested in transactions of this type, return nothing.
@@ -506,12 +511,16 @@ class FetchProjectTransactionVolumes:
                 request,
                 referrer=Referrer.DYNAMIC_SAMPLING_COUNTERS_FETCH_PROJECTS_WITH_COUNT_PER_TRANSACTION.value,
             )["data"]
+
             count = len(data)
             self.has_more_results = count > CHUNK_SIZE
             self.offset += CHUNK_SIZE
 
             if self.has_more_results:
                 data = data[:-1]
+
+            self.log_state.num_rows_total += count
+            self.log_state.num_db_calls += 1
 
             self._add_results_to_cache(data)
 
@@ -522,6 +531,8 @@ class FetchProjectTransactionVolumes:
         transaction_counts: List[Tuple[str, float]] = []
         current_org_id: Optional[int] = None
         current_proj_id: Optional[int] = None
+
+        self._ensure_log_state()
 
         for row in data:
             proj_id = row["project_id"]
@@ -543,6 +554,11 @@ class FetchProjectTransactionVolumes:
                             "total_num_classes": None,
                         }
                     )
+                    if current_proj_id != proj_id:
+                        self.log_state.num_projects += 1
+                    if current_org_id != org_id:
+                        self.log_state.num_orgs += 1
+
                 transaction_counts = []
                 current_org_id = org_id
                 current_proj_id = proj_id

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -450,7 +450,9 @@ class FetchProjectTransactionVolumes:
         return self
 
     def __next__(self) -> ProjectTransactions:
+
         self._ensure_log_state()
+        assert self.log_state is not None
 
         self.log_state.num_iterations += 1
 
@@ -533,6 +535,7 @@ class FetchProjectTransactionVolumes:
         current_proj_id: Optional[int] = None
 
         self._ensure_log_state()
+        assert self.log_state is not None
 
         for row in data:
             proj_id = row["project_id"]

--- a/src/sentry/dynamic_sampling/tasks/collect_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/collect_orgs.py
@@ -2,7 +2,7 @@ from sentry_sdk import capture_message, set_extra
 
 from sentry import options
 from sentry.dynamic_sampling.tasks.common import GetActiveOrgs, TimedIterator, TimeoutException
-from sentry.dynamic_sampling.tasks.constants import MAX_PROJECTS_PER_QUERY, MAX_SECONDS
+from sentry.dynamic_sampling.tasks.constants import MAX_PROJECTS_PER_QUERY, MAX_TASK_SECONDS
 from sentry.dynamic_sampling.tasks.logging import log_task_execution, log_task_timeout
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task
@@ -24,7 +24,7 @@ def collect_orgs() -> None:
     if not enabled:
         return
 
-    context = TaskContext("sentry.dynamic-sampling.tasks.collect_orgs", MAX_SECONDS)
+    context = TaskContext("sentry.dynamic-sampling.tasks.collect_orgs", MAX_TASK_SECONDS)
     iterator_name = GetActiveOrgs.__name__
     try:
         for orgs in TimedIterator(

--- a/src/sentry/dynamic_sampling/tasks/constants.py
+++ b/src/sentry/dynamic_sampling/tasks/constants.py
@@ -16,6 +16,10 @@ MAX_REBALANCE_FACTOR = 10
 
 # Parameters to bound the execution time of queries in Snuba.
 MAX_SECONDS = 60
+
+# The maximum time a dynamic sampling task can run.
+MAX_TASK_SECONDS = 7 * 60  # 7 minutes
+
 # Snuba's limit is 10000, and we fetch CHUNK_SIZE + 1.
 CHUNK_SIZE = 9998
 

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -11,7 +11,7 @@ from sentry.dynamic_sampling.tasks.common import (
 from sentry.dynamic_sampling.tasks.constants import (
     CHUNK_SIZE,
     MAX_REBALANCE_FACTOR,
-    MAX_SECONDS,
+    MAX_TASK_SECONDS,
     MIN_REBALANCE_FACTOR,
     RECALIBRATE_ORGS_QUERY_INTERVAL,
 )
@@ -59,7 +59,7 @@ def orgs_to_check(org_volume: OrganizationDataVolume):
 )
 @dynamic_sampling_task
 def recalibrate_orgs() -> None:
-    context = TaskContext("sentry.dynamic_sampling.tasks.recalibrate_orgs", MAX_SECONDS)
+    context = TaskContext("sentry.dynamic_sampling.tasks.recalibrate_orgs", MAX_TASK_SECONDS)
     recalibrate_org_timer = Timer()
 
     try:

--- a/src/sentry/dynamic_sampling/tasks/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window.py
@@ -30,6 +30,7 @@ from sentry.dynamic_sampling.tasks.constants import (
     DEFAULT_REDIS_CACHE_KEY_TTL,
     MAX_PROJECTS_PER_QUERY,
     MAX_SECONDS,
+    MAX_TASK_SECONDS,
 )
 from sentry.dynamic_sampling.tasks.helpers.sliding_window import (
     SLIDING_WINDOW_CALCULATION_ERROR,
@@ -64,7 +65,7 @@ from sentry.utils.snuba import raw_snql_query
 )
 @dynamic_sampling_task
 def sliding_window() -> None:
-    context = TaskContext("sentry.dynamic_sampling.tasks.sliding_window", MAX_SECONDS)
+    context = TaskContext("sentry.dynamic_sampling.tasks.sliding_window", MAX_TASK_SECONDS)
     adjust_base_sample_rate_of_projects_timer = Timer()
 
     window_size = get_sliding_window_size()

--- a/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
@@ -12,7 +12,7 @@ from sentry.dynamic_sampling.tasks.common import (
 from sentry.dynamic_sampling.tasks.constants import (
     CHUNK_SIZE,
     DEFAULT_REDIS_CACHE_KEY_TTL,
-    MAX_SECONDS,
+    MAX_TASK_SECONDS,
 )
 from sentry.dynamic_sampling.tasks.helpers.sliding_window import (
     generate_sliding_window_org_cache_key,
@@ -35,7 +35,7 @@ from sentry.tasks.base import instrumented_task
 )
 @dynamic_sampling_task
 def sliding_window_org() -> None:
-    context = TaskContext("sentry.dynamic_sampling.tasks.sliding_window_org", MAX_SECONDS)
+    context = TaskContext("sentry.dynamic_sampling.tasks.sliding_window_org", MAX_TASK_SECONDS)
     adjust_base_sample_rate_of_org_timer = Timer()
 
     window_size = get_sliding_window_size()


### PR DESCRIPTION
This PR increases the timeout for dynamic sampling tasks to 7 minutes (total running time).
It also changes the frequency they are run at from 5 minutes to 10 minutes ( 20 minutes for CollectOrgs)