### PR TITLE
Log explicit errors for `FileBlob`s suddenly disappearing

### DIFF
--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import mmap
 import os
 import tempfile
@@ -10,7 +11,7 @@ from typing import ClassVar, Type
 
 from django.core.files.base import ContentFile
 from django.core.files.base import File as FileObj
-from django.db import models, router, transaction
+from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
 from sentry.celery import SentryTask
@@ -19,6 +20,8 @@ from sentry.models.files.abstractfileblob import AbstractFileBlob
 from sentry.models.files.utils import DEFAULT_BLOB_SIZE, AssembleChecksumMismatch, nooplogger
 from sentry.utils import metrics
 from sentry.utils.db import atomic_transaction
+
+logger = logging.getLogger(__name__)
 
 
 class ChunkedFileBlobIndexWrapper:
@@ -309,16 +312,31 @@ class AbstractFile(Model):
                 router.db_for_write(self.FILE_BLOB_INDEX_MODEL),
             )
         ):
-            file_blobs = self.FILE_BLOB_MODEL.objects.filter(id__in=file_blob_ids).all()
+            try:
+                file_blobs = self.FILE_BLOB_MODEL.objects.filter(id__in=file_blob_ids).all()
 
-            # Ensure blobs are in the order and duplication as provided
-            blobs_by_id = {blob.id: blob for blob in file_blobs}
-            file_blobs = [blobs_by_id[blob_id] for blob_id in file_blob_ids]
+                # Ensure blobs are in the order and duplication as provided
+                blobs_by_id = {blob.id: blob for blob in file_blobs}
+                file_blobs = [blobs_by_id[blob_id] for blob_id in file_blob_ids]
+            except Exception:
+                # Most likely a `KeyError` like `SENTRY-11QP` because an `id` in
+                # `file_blob_ids` does suddenly not exist anymore
+                logger.error("`FileBlob` disappeared during `assemble_file`", exc_info=True)
+                raise
 
             new_checksum = sha1(b"")
             offset = 0
             for blob in file_blobs:
-                self.FILE_BLOB_INDEX_MODEL.objects.create(file=self, blob=blob, offset=offset)
+                try:
+                    self.FILE_BLOB_INDEX_MODEL.objects.create(file=self, blob=blob, offset=offset)
+                except IntegrityError:
+                    # Most likely a `ForeignKeyViolation` like `SENTRY-11P5`, because
+                    # the blob we want to link does not exist anymore
+                    logger.error(
+                        "`FileBlob` disappeared trying to link `FileBlobIndex`", exc_info=True
+                    )
+                    raise
+
                 with blob.getfile() as blobfile:
                     for chunk in blobfile.chunks():
                         new_checksum.update(chunk)

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -85,6 +85,19 @@ def assemble_file(
     # Load all FileBlobs from db since we can be sure here we already own all chunks need to build the file.
     file_blobs = FileBlob.objects.filter(checksum__in=chunks).values_list("id", "checksum", "size")
 
+    # Reject all files that exceed the maximum allowed size for this organization.
+    file_size = sum(x[2] for x in file_blobs)
+    if file_size > get_max_file_size(organization):
+        set_assemble_status(
+            task,
+            org_or_project.id,
+            checksum,
+            ChunkFileState.ERROR,
+            detail="File exceeds maximum size",
+        )
+
+        return None
+
     # Sanity check. In case not all blobs exist at this point we have a race condition.
     if {x[1] for x in file_blobs} != set(chunks):
         # Most likely a previous check to `find_missing_chunks` or similar
@@ -98,19 +111,6 @@ def assemble_file(
             checksum,
             ChunkFileState.ERROR,
             detail="Not all chunks available for assembling",
-        )
-
-        return None
-
-    # Reject all files that exceed the maximum allowed size for this organization.
-    file_size = sum(x[2] for x in file_blobs)
-    if file_size > get_max_file_size(organization):
-        set_assemble_status(
-            task,
-            org_or_project.id,
-            checksum,
-            ChunkFileState.ERROR,
-            detail="File exceeds maximum size",
         )
 
         return None


### PR DESCRIPTION
We have had Sentry errors for two of the exceptions that happen due to this.

This will now log an explicit error so these failures can be searched for more easily. It also adds another log for a sanity check that will also trigger when `FileBlob`s suddenly disappear.