### PR TITLE
fix(dynamic-sampling): Make timing out tasks finish quicker

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -158,7 +158,7 @@ def boost_low_volume_transactions() -> None:
         raise
     else:
         set_extra("context-data", context.to_dict())
-        capture_message("sentry.dynamic_sampling.tasks.boost_low_volume_transactions")
+        capture_message("timing for sentry.dynamic_sampling.tasks.boost_low_volume_transactions")
         log_task_execution(context)
 
 

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -1,3 +1,5 @@
+import time
+
 from sentry_sdk import capture_message, set_extra
 from snuba_sdk import Granularity
 
@@ -88,11 +90,15 @@ def recalibrate_orgs() -> None:
         raise
     else:
         set_extra("context-data", context.to_dict())
-        capture_message("timing for sentry.dynamic_sampling.tasks.boost_low_volume_projects")
+        capture_message("timing for sentry.dynamic_sampling.tasks.recalibrate_orgs")
         log_task_execution(context)
 
 
 def recalibrate_org(org_volume: OrganizationDataVolume, context: TaskContext, timer: Timer) -> None:
+
+    if time.monotonic() > context.expiration_time:
+        raise TimeoutException(context)
+
     with timer:
         # We check if the organization volume is valid for recalibration, otherwise it doesn't make sense to run the
         # recalibration.
@@ -158,7 +164,7 @@ def recalibrate_org(org_volume: OrganizationDataVolume, context: TaskContext, ti
             "set_adjusted_factor", {"org_id": org_volume.org_id}, orgs_to_check(org_volume)
         )
 
-    name = recalibrate_orgs.__name__
+    name = recalibrate_org.__name__
     state = context.get_function_state(name)
     state.num_orgs += 1
     state.num_iterations += 1

--- a/src/sentry/dynamic_sampling/tasks/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window.py
@@ -107,7 +107,7 @@ def sliding_window() -> None:
         raise
     else:
         set_extra("context-data", context.to_dict())
-        capture_message("sentry.dynamic_sampling.tasks.sliding_window")
+        capture_message("timing for sentry.dynamic_sampling.tasks.sliding_window")
         log_task_execution(context)
 
 
@@ -122,6 +122,9 @@ def adjust_base_sample_rates_of_projects(
     Adjusts the base sample rate per project by computing the sliding window sample rate, considering the total
     volume of root transactions started from each project in the org.
     """
+    if time.monotonic() > context.expiration_time:
+        raise TimeoutException(context)
+
     with timer:
         projects_with_rebalanced_sample_rate = []
 

--- a/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
@@ -1,3 +1,4 @@
+import time
 from datetime import timedelta
 
 from sentry_sdk import capture_message, set_extra
@@ -71,7 +72,7 @@ def sliding_window_org() -> None:
         raise
     else:
         set_extra("context-data", context.to_dict())
-        capture_message("sentry.dynamic_sampling.tasks.sliding_window_org")
+        capture_message("timing for sentry.dynamic_sampling.tasks.sliding_window_org")
         log_task_execution(context)
 
 
@@ -81,6 +82,9 @@ def adjust_base_sample_rate_of_org(
     """
     Adjusts the base sample rate per org by considering its volume and how it fits w.r.t. to the sampling tiers.
     """
+    if time.monotonic() > context.expiration_time:
+        raise TimeoutException(context)
+
     with timer:
         sample_rate = compute_guarded_sliding_window_sample_rate(
             org_id, None, total_root_count, window_size


### PR DESCRIPTION
This PR fixes recalibrate-orgs, sliding-window and sliding-window-orgs task timeout detection.
Previously timeout was checked before each batch was fetched from the database.
This is too slow, now it is also checked before each organisation is processed.

Additionally this fixes some minor logging errors ( bad/non consistent names were used). 