### PR TITLE
feat(starfish): Use skipLoadLastUsedEnvironment in Starfish pages

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -139,6 +139,12 @@ export type InitializeUrlStateParams = {
    * lead to very confusing behavior.
    */
   skipLoadLastUsed?: boolean;
+
+  /**
+   * Skip loading last used environment from local storage
+   * An example is Starfish, which doesn't support environments.
+   */
+  skipLoadLastUsedEnvironment?: boolean;
 };
 
 export function initializeUrlState({
@@ -147,6 +153,7 @@ export function initializeUrlState({
   router,
   memberProjects,
   skipLoadLastUsed,
+  skipLoadLastUsedEnvironment,
   shouldPersist = true,
   shouldForceProject,
   shouldEnforceSingleProject,
@@ -201,7 +208,11 @@ export function initializeUrlState({
       pageFilters.projects = storedState.project ?? [];
     }
 
-    if (!hasProjectOrEnvironmentInUrl && pinnedFilters.has('environments')) {
+    if (
+      !skipLoadLastUsedEnvironment &&
+      !hasProjectOrEnvironmentInUrl &&
+      pinnedFilters.has('environments')
+    ) {
       pageFilters.environments = storedState.environment ?? [];
     }
 

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -55,7 +55,12 @@ interface Props extends InitializeUrlStateProps {
  * The page filters container handles initialization of page filters for the
  * wrapped content. Children will not be rendered until the filters are ready.
  */
-function Container({skipLoadLastUsed, children, ...props}: Props) {
+function Container({
+  skipLoadLastUsed,
+  skipLoadLastUsedEnvironment,
+  children,
+  ...props
+}: Props) {
   const {
     forceProject,
     organization,
@@ -92,6 +97,7 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
       queryParams: location.query,
       router,
       skipLoadLastUsed,
+      skipLoadLastUsedEnvironment,
       memberProjects,
       defaultSelection,
       forceProject,

--- a/static/app/views/starfish/components/starfishPageFiltersContainer.tsx
+++ b/static/app/views/starfish/components/starfishPageFiltersContainer.tsx
@@ -1,0 +1,11 @@
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export function StarfishPageFiltersContainer({children}: Props) {
+  return (
+    <PageFiltersContainer skipLoadLastUsedEnvironment>{children}</PageFiltersContainer>
+  );
+}

--- a/static/app/views/starfish/modules/DBModule.tsx
+++ b/static/app/views/starfish/modules/DBModule.tsx
@@ -27,7 +27,7 @@ export default function DBModule() {
           <Layout.Body>
             <Layout.Main fullWidth>
               <PageErrorAlert />
-              <PageFiltersContainer>
+              <PageFiltersContainer skipLoadLastUsedEnvironment>
                 <SpansView moduleName={ModuleName.DB} />
               </PageFiltersContainer>
             </Layout.Main>

--- a/static/app/views/starfish/modules/DBModule.tsx
+++ b/static/app/views/starfish/modules/DBModule.tsx
@@ -1,5 +1,4 @@
 import * as Layout from 'sentry/components/layouts/thirds';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {
@@ -7,6 +6,7 @@ import {
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
 import useOrganization from 'sentry/utils/useOrganization';
+import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
 import {ModuleName} from 'sentry/views/starfish/types';
 import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 import SpansView from 'sentry/views/starfish/views/spans/spansView';
@@ -27,9 +27,9 @@ export default function DBModule() {
           <Layout.Body>
             <Layout.Main fullWidth>
               <PageErrorAlert />
-              <PageFiltersContainer skipLoadLastUsedEnvironment>
+              <StarfishPageFiltersContainer>
                 <SpansView moduleName={ModuleName.DB} />
-              </PageFiltersContainer>
+              </StarfishPageFiltersContainer>
             </Layout.Main>
           </Layout.Body>
         </PageErrorProvider>

--- a/static/app/views/starfish/views/definitionsView/index.tsx
+++ b/static/app/views/starfish/views/definitionsView/index.tsx
@@ -8,7 +8,7 @@ import {
 function DefinitionsView() {
   return (
     <Layout.Page>
-      <PageFiltersContainer>
+      <PageFiltersContainer skipLoadLastUsedEnvironment>
         <PageErrorProvider>
           <Layout.Header>
             <Layout.HeaderContent>

--- a/static/app/views/starfish/views/definitionsView/index.tsx
+++ b/static/app/views/starfish/views/definitionsView/index.tsx
@@ -1,14 +1,14 @@
 import * as Layout from 'sentry/components/layouts/thirds';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
+import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
 
 function DefinitionsView() {
   return (
     <Layout.Page>
-      <PageFiltersContainer skipLoadLastUsedEnvironment>
+      <StarfishPageFiltersContainer>
         <PageErrorProvider>
           <Layout.Header>
             <Layout.HeaderContent>
@@ -27,7 +27,7 @@ function DefinitionsView() {
             </Layout.Main>
           </Layout.Body>
         </PageErrorProvider>
-      </PageFiltersContainer>
+      </StarfishPageFiltersContainer>
     </Layout.Page>
   );
 }

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -5,7 +5,6 @@ import * as qs from 'query-string';
 
 import Breadcrumbs, {Crumb} from 'sentry/components/breadcrumbs';
 import * as Layout from 'sentry/components/layouts/thirds';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -25,6 +24,7 @@ import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/char
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
 import {SpanDescription} from 'sentry/views/starfish/components/spanDescription';
+import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
 import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
 import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
 import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
@@ -140,7 +140,7 @@ function SpanSummaryPage({params, location}: Props) {
   return (
     <SentryDocumentTitle title={title} orgSlug={organization.slug}>
       <Layout.Page>
-        <PageFiltersContainer skipLoadLastUsedEnvironment>
+        <StarfishPageFiltersContainer>
           <PageErrorProvider>
             <Layout.Header>
               <Layout.HeaderContent>
@@ -297,7 +297,7 @@ function SpanSummaryPage({params, location}: Props) {
               </Layout.Main>
             </Layout.Body>
           </PageErrorProvider>
-        </PageFiltersContainer>
+        </StarfishPageFiltersContainer>
       </Layout.Page>
     </SentryDocumentTitle>
   );

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -140,7 +140,7 @@ function SpanSummaryPage({params, location}: Props) {
   return (
     <SentryDocumentTitle title={title} orgSlug={organization.slug}>
       <Layout.Page>
-        <PageFiltersContainer>
+        <PageFiltersContainer skipLoadLastUsedEnvironment>
           <PageErrorProvider>
             <Layout.Header>
               <Layout.HeaderContent>

--- a/static/app/views/starfish/views/spans/index.tsx
+++ b/static/app/views/starfish/views/spans/index.tsx
@@ -1,11 +1,11 @@
 import * as Layout from 'sentry/components/layouts/thirds';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {t} from 'sentry/locale';
 import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
 import {useLocation} from 'sentry/utils/useLocation';
+import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
 import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
 
 import SpansView from './spansView';
@@ -40,9 +40,9 @@ export default function Spans() {
         <Layout.Body>
           <Layout.Main fullWidth>
             <PageErrorAlert />
-            <PageFiltersContainer skipLoadLastUsedEnvironment>
+            <StarfishPageFiltersContainer>
               <SpansView moduleName={moduleName} spanCategory={spanCategory} />
-            </PageFiltersContainer>
+            </StarfishPageFiltersContainer>
           </Layout.Main>
         </Layout.Body>
       </PageErrorProvider>

--- a/static/app/views/starfish/views/spans/index.tsx
+++ b/static/app/views/starfish/views/spans/index.tsx
@@ -40,7 +40,7 @@ export default function Spans() {
         <Layout.Body>
           <Layout.Main fullWidth>
             <PageErrorAlert />
-            <PageFiltersContainer>
+            <PageFiltersContainer skipLoadLastUsedEnvironment>
               <SpansView moduleName={moduleName} spanCategory={spanCategory} />
             </PageFiltersContainer>
           </Layout.Main>

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -9,7 +9,6 @@ import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {getInterval} from 'sentry/components/charts/utils';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {PerformanceLayoutBodyRow} from 'sentry/components/performance/layouts';
 import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -34,6 +33,7 @@ import {ERRORS_COLOR, P95_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/c
 import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
 import {TransactionSamplesTable} from 'sentry/views/starfish/components/samplesTable/transactionSamplesTable';
+import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
 import {ModuleName} from 'sentry/views/starfish/types';
 import formatThroughput from 'sentry/views/starfish/utils/chartValueFormatters/formatThroughput';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
@@ -290,7 +290,7 @@ export default function EndpointOverview() {
   useSynchronizeCharts();
 
   return (
-    <PageFiltersContainer skipLoadLastUsedEnvironment>
+    <StarfishPageFiltersContainer>
       <Layout.Page>
         <Layout.Header>
           <Layout.HeaderContent>
@@ -390,7 +390,7 @@ export default function EndpointOverview() {
           </Layout.Side>
         </Layout.Body>
       </Layout.Page>
-    </PageFiltersContainer>
+    </StarfishPageFiltersContainer>
   );
 }
 

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -290,7 +290,7 @@ export default function EndpointOverview() {
   useSynchronizeCharts();
 
   return (
-    <PageFiltersContainer>
+    <PageFiltersContainer skipLoadLastUsedEnvironment>
       <Layout.Page>
         <Layout.Header>
           <Layout.HeaderContent>

--- a/static/app/views/starfish/views/webServiceView/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/index.tsx
@@ -4,7 +4,6 @@ import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 
 import {loadOrganizationTags} from 'sentry/actionCreators/tags';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {PageFilters} from 'sentry/types';
@@ -13,6 +12,7 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
 import withPageFilters from 'sentry/utils/withPageFilters';
+import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
 
 import {generateWebServiceEventView} from '../../utils/generatePerformanceEventView';
 
@@ -52,7 +52,7 @@ function WebServiceView({selection, location, router}: Props) {
 
   return (
     <SentryDocumentTitle title={t('Service Overview')} orgSlug={organization.slug}>
-      <PageFiltersContainer skipLoadLastUsedEnvironment>
+      <StarfishPageFiltersContainer>
         <StarfishLanding
           router={router}
           eventView={eventView}
@@ -61,7 +61,7 @@ function WebServiceView({selection, location, router}: Props) {
           selection={selection}
           withStaticFilters={withStaticFilters}
         />
-      </PageFiltersContainer>
+      </StarfishPageFiltersContainer>
     </SentryDocumentTitle>
   );
 }

--- a/static/app/views/starfish/views/webServiceView/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/index.tsx
@@ -52,7 +52,7 @@ function WebServiceView({selection, location, router}: Props) {
 
   return (
     <SentryDocumentTitle title={t('Service Overview')} orgSlug={organization.slug}>
-      <PageFiltersContainer>
+      <PageFiltersContainer skipLoadLastUsedEnvironment>
         <StarfishLanding
           router={router}
           eventView={eventView}


### PR DESCRIPTION
Adds a skipLoadLastUsedEnvironment prop to pageFilter initialization so that it can be used in all Starfish pages. This is needed since Starfish pages dont currently support environment. This prop functions similarly to skipLoadLastUsed, except it only prevents loading the environment page filter from localStorage.