### PR TITLE
fix(getting-started-docs): Fix code in tct duplicating last translation

### DIFF
--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -69,9 +69,10 @@ export const steps = ({
       <InstallDescription>
         <p>
           {tct(
-            "To use Sentry with your Angular application, you'll need [code:@sentry/angular-ivy] or [code:@sentry/angular], Sentry’s Browser Angular SDKs:",
+            "To use Sentry with your Angular application, you'll need [sentryAngularIvyCode:@sentry/angular-ivy] or [sentryAngularCode:@sentry/angular], Sentry’s Browser Angular SDKs:",
             {
-              code: <code />,
+              sentryAngularIvyCode: <code />,
+              sentryAngularCode: <code />,
             }
           )}
         </p>

--- a/static/app/gettingStartedDocs/javascript/ember.tsx
+++ b/static/app/gettingStartedDocs/javascript/ember.tsx
@@ -55,9 +55,10 @@ ember install @sentry/ember
     description: (
       <p>
         {tct(
-          'You should [code:init] the Sentry SDK as soon as possible during your application load up in [code:app.js], before initializing Ember:',
+          'You should [initCode:init] the Sentry SDK as soon as possible during your application load up in [appCode:app.js], before initializing Ember:',
           {
-            code: <code />,
+            initCode: <code />,
+            appCode: <code />,
           }
         )}
       </p>

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -67,9 +67,10 @@ npm install --save @sentry/gatsby
         description: (
           <p>
             {tct(
-              'Register the [code:@sentry/gatsby] plugin in your Gatsby configuration file (typically [code:gatsby-config.js]).',
+              'Register the [sentryGatsbyCode:@sentry/gatsby] plugin in your Gatsby configuration file (typically [gatsbyConfigCode:gatsby-config.js]).',
               {
-                code: <code />,
+                sentryGatsbyCode: <code />,
+                gatsbyConfigCode: <code />,
               }
             )}
           </p>

--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -63,9 +63,11 @@ export const steps = ({
         <List symbol="bullet">
           <ListItem>
             {tct(
-              'Create [code:sentry.client.config.js] and [code:sentry.server.config.js] with the default [code:Sentry.init].',
+              'Create [sentryClientCode:sentry.client.config.js] and [sentryServerCode:sentry.server.config.js] with the default [sentryInitCode:Sentry.init].',
               {
-                code: <code />,
+                sentryClientCode: <code />,
+                sentryServerCode: <code />,
+                sentryInitCode: <code />,
               }
             )}
           </ListItem>
@@ -99,9 +101,10 @@ export const steps = ({
             <strong>{t('Configure the Sentry SDK:')}</strong>
             <p>
               {tct(
-                'Install Sentry’s Next.js SDK using either [code:yarn] or [code:npm]:',
+                'Install Sentry’s Next.js SDK using either [yarnCode:yarn] or [npmCode:npm]:',
                 {
-                  code: <code />,
+                  yarnCode: <code />,
+                  npmCode: <code />,
                 }
               )}
             </p>

--- a/static/app/gettingStartedDocs/javascript/sveltekit.tsx
+++ b/static/app/gettingStartedDocs/javascript/sveltekit.tsx
@@ -58,9 +58,11 @@ export const steps = ({
         <List symbol="bullet">
           <ListItem>
             {tct(
-              'Create or update [code:src/hooks.client.js] and [code:src/hooks.server.js] with the default [code:Sentry.init] call and SvelteKit hooks handlers.',
+              'Create or update [hookClientCode:src/hooks.client.js] and [hookServerCode:src/hooks.server.js] with the default [sentryInitCode:Sentry.init] call and SvelteKit hooks handlers.',
               {
-                code: <code />,
+                hookClientCode: <code />,
+                hookServerCode: <code />,
+                sentryInitCode: <code />,
               }
             )}
           </ListItem>
@@ -74,9 +76,10 @@ export const steps = ({
           </ListItem>
           <ListItem>
             {tct(
-              'Create [code:.sentryclirc] and [code:sentry.properties] files with configuration for sentry-cli (which is used when automatically uploading source maps).',
+              'Create [sentryClircCode:.sentryclirc] and [sentryPropertiesCode:sentry.properties] files with configuration for sentry-cli (which is used when automatically uploading source maps).',
               {
-                code: <code />,
+                sentryClircCode: <code />,
+                sentryPropertiesCode: <code />,
               }
             )}
           </ListItem>
@@ -97,8 +100,8 @@ export const steps = ({
             <strong>{t('Configure the Sentry SDK:')}</strong>
             <p>
               {tct(
-                'To configure the Sentry SDK, edit the [code:Sentry.init] options in [code:hooks.(client|server).(js|ts)]:',
-                {code: <code />}
+                'To configure the Sentry SDK, edit the [sentryInitCode:Sentry.init] options in [hooksCode:hooks.(client|server).(js|ts)]:',
+                {hooksCode: <code />, sentryInitCode: <code />}
               )}
             </p>
           </Fragment>


### PR DESCRIPTION
We will have to investigate why this is happening, but this PR fixes this issue for the getting started docs by creating a separate property for the strings.

**Before:**

<img width="848" alt="image" src="https://github.com/getsentry/sentry/assets/29228205/718dfe05-33fd-4b62-892b-fbf9e992faf2">
<img width="512" alt="image" src="https://github.com/getsentry/sentry/assets/29228205/782d5100-f671-40f3-a00a-77e4da4a9165">

**After:**

<img width="853" alt="image" src="https://github.com/getsentry/sentry/assets/29228205/f7fcd8ee-eac5-4add-8c8e-145858fa9a3f">
<img width="1259" alt="image" src="https://github.com/getsentry/sentry/assets/29228205/8f2b8954-807c-4d95-8fe2-f0ebec1c9f56">
