### PR TITLE
chore(vscode): Update some configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Gemfile.lock
 *.iml
 .pytest_cache/
 .vscode/tags
+.vscode/bookmarks.json
 coverage.xml
 junit.xml
 *.codestyle.xml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,7 +59,8 @@
       "django": true,
       "env": {
         "SENTRY_MODEL_MANIFEST_FILE_PATH": "./model-manifest.json"
-      }
+      },
+      "justMyCode": false
     }
   ]
 }


### PR DESCRIPTION
We make two changes:
1. Ignore the settings file from the popular bookmarks plugin, as we probably don't want bookmarks shared between users.
2. Disable the default `true` `justMyCode` setting in the `pytest` launch config. This allows dependencies, like DRF and Django core for example, to be indexed and available for breakpointing during debugger runs.