### PR TITLE
ref(hc): Remove unnecessary silo conditional around UserIP.log

### DIFF
--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -45,8 +45,7 @@ def get_user(request):
                 )
                 user = AnonymousUser()
             else:
-                if SiloMode.get_current_mode() == SiloMode.MONOLITH:
-                    UserIP.log(user, request.META["REMOTE_ADDR"])
+                UserIP.log(user, request.META["REMOTE_ADDR"])
         request._cached_user = user
     return request._cached_user
 


### PR DESCRIPTION
Very very very small change.

Removing conditional paths in our silo logic.  `UserIP.log` under the hood uses `log_service` which is silo complaint, so removing this is a no-op in practice but removes more conditional code paths.