### PR TITLE
ref(replays): adjust replay list columns

### DIFF
--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -101,9 +101,9 @@ function ReplaysListTable({
         ReplayColumn.OS,
         ReplayColumn.BROWSER,
         ReplayColumn.DURATION,
-        ReplayColumn.COUNT_ERRORS,
         ReplayColumn.COUNT_DEAD_CLICKS,
         ReplayColumn.COUNT_RAGE_CLICKS,
+        ReplayColumn.COUNT_ERRORS,
         ReplayColumn.ACTIVITY,
       ]
     : [


### PR DESCRIPTION
Fixes #53283 - column order is now Dead | Rage | Error

<img width="1229" alt="SCR-20230720-jvhv" src="https://github.com/getsentry/sentry/assets/56095982/8a24618e-5fc8-4a4c-b709-dfd012367882">
