### PR TITLE
ref(hc): Remove SiloMode conditional by splitting base class

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/interaction.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/interaction.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 
 from sentry import tsdb
 from sentry.api.base import StatsMixin, region_silo_endpoint
-from sentry.api.bases import SentryAppBaseEndpoint, SentryAppStatsPermission
+from sentry.api.bases import RegionSentryAppBaseEndpoint, SentryAppStatsPermission
 from sentry.api.bases.sentryapps import COMPONENT_TYPES
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.tsdb.base import TSDBModel
@@ -20,7 +20,7 @@ def get_component_interaction_key(sentry_app, component_type):
 
 
 @region_silo_endpoint
-class SentryAppInteractionEndpoint(SentryAppBaseEndpoint, StatsMixin):
+class SentryAppInteractionEndpoint(RegionSentryAppBaseEndpoint, StatsMixin):
     permission_classes = (SentryAppStatsPermission,)
 
     def get(self, request: Request, sentry_app) -> Response:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/requests.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/requests.py
@@ -6,7 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import SentryAppBaseEndpoint, SentryAppStatsPermission
+from sentry.api.bases import RegionSentryAppBaseEndpoint, SentryAppStatsPermission
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import RequestSerializer
 from sentry.models import Organization
@@ -39,7 +39,7 @@ class BufferedRequest:
 
 
 @region_silo_endpoint
-class SentryAppRequestsEndpoint(SentryAppBaseEndpoint):
+class SentryAppRequestsEndpoint(RegionSentryAppBaseEndpoint):
     permission_classes = (SentryAppStatsPermission,)
 
     def get(self, request: Request, sentry_app) -> Response:


### PR DESCRIPTION
Removing another SiloMode.get_current by explicitly splitting the base class for SentryApps.