### PR TITLE
ref(api): Create basic auth header helper function

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import os
 import random
+from base64 import b64encode
 from binascii import hexlify
 from datetime import datetime
 from hashlib import sha1
@@ -1509,6 +1510,11 @@ class Factories:
         action.save()
 
         return action
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.REGION)
+    def create_basic_auth_header(username: str, password: str = "") -> str:
+        return b"Basic " + b64encode(f"{username}:{password}".encode())
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1512,7 +1512,6 @@ class Factories:
         return action
 
     @staticmethod
-    @assume_test_silo_mode(SiloMode.REGION)
     def create_basic_auth_header(username: str, password: str = "") -> str:
         return b"Basic " + b64encode(f"{username}:{password}".encode())
 

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -444,6 +444,9 @@ class Fixtures:
     def create_organization_mapping(self, *args, **kwargs):
         return Factories.create_org_mapping(*args, **kwargs)
 
+    def create_basic_auth_header(self, *args, **kwargs):
+        return Factories.create_basic_auth_header(*args, **kwargs)
+
     def snooze_rule(self, *args, **kwargs):
         return Factories.snooze_rule(*args, **kwargs)
 

--- a/tests/sentry/api/endpoints/test_auth.py
+++ b/tests/sentry/api/endpoints/test_auth.py
@@ -1,5 +1,3 @@
-import base64
-
 from django.urls import reverse
 
 from sentry.testutils import APITestCase
@@ -13,10 +11,12 @@ class LoginTest(APITestCase):
         user.set_password("test")
         user.save()
 
-        auth_header = b"Basic " + base64.b64encode(b"a@example.com:test")
-
         url = reverse("sentry-api-0-auth")
-        response = self.client.post(url, format="json", HTTP_AUTHORIZATION=auth_header)
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=self.create_basic_auth_header("a@example.com", "test"),
+        )
 
         assert response.status_code == 200, response.content
 

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -1,4 +1,3 @@
-from base64 import b64encode
 from datetime import datetime, timedelta, timezone
 from unittest import mock
 from urllib.parse import urlencode
@@ -38,7 +37,7 @@ class AuthLoginEndpointTest(APITestCase):
         user = self.create_user("foo@example.com")
         response = self.client.post(
             self.path,
-            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{user.username}:admin".encode()),
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(user.username, "admin"),
         )
         assert response.status_code == 200
         assert response.data["id"] == str(user.id)
@@ -47,7 +46,7 @@ class AuthLoginEndpointTest(APITestCase):
         user = self.create_user("foo@example.com")
         response = self.client.post(
             self.path,
-            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{user.username}:foobar".encode()),
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(user.username, "foobar"),
         )
         assert response.status_code == 401
 

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -1,4 +1,3 @@
-from base64 import b64encode
 from datetime import timedelta
 from unittest import mock
 
@@ -436,7 +435,7 @@ class GroupUpdateTest(APITestCase):
             url,
             data={"assignedTo": self.user.id},
             format="json",
-            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{api_key.key}:".encode()),
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
         )
         assert response.status_code == 200, response.content
         assert GroupAssignee.objects.filter(group=group, user_id=self.user.id).exists()

--- a/tests/sentry/api/endpoints/test_index.py
+++ b/tests/sentry/api/endpoints/test_index.py
@@ -1,5 +1,3 @@
-from base64 import b64encode
-
 from django.urls import reverse
 
 from sentry.models import ApiKey, ApiToken
@@ -29,7 +27,8 @@ class ApiIndexTest(APITestCase):
         key = ApiKey.objects.create(organization_id=org.id)
         url = reverse("sentry-api-index")
         response = self.client.get(
-            url, HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{key.key}:".encode())
+            url,
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(key.key),
         )
         assert response.status_code == 200
         assert response.data["version"] == "0"

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -1,5 +1,3 @@
-from base64 import b64encode
-
 from django.urls import reverse
 
 from sentry.models import ApiKey
@@ -29,7 +27,7 @@ class OrganizationProjectsTestBase(APITestCase):
         path = reverse(self.endpoint, args=[self.organization.slug])
         response = self.client.get(
             path,
-            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{key.key}:".encode()),
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(key.key),
         )
         self.check_valid_response(response, [project])
 

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1,5 +1,4 @@
 import unittest
-from base64 import b64encode
 from datetime import datetime, timedelta
 from functools import cached_property
 from unittest.mock import patch
@@ -1633,7 +1632,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         response = self.client.post(
             url,
             data={"version": "1.2.1", "projects": [project1.slug]},
-            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{bad_api_key.key}:".encode()),
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(bad_api_key.key),
         )
         assert response.status_code == 403
 
@@ -1645,7 +1644,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         response = self.client.post(
             url,
             data={"version": "1.2.1", "projects": [project1.slug]},
-            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{wrong_org_api_key.key}:".encode()),
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(wrong_org_api_key.key),
         )
         assert response.status_code == 403
 
@@ -1657,7 +1656,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         response = self.client.post(
             url,
             data={"version": "1.2.1", "projects": [project1.slug]},
-            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{good_api_key.key}:".encode()),
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(good_api_key.key),
         )
         assert response.status_code == 201, response.content
 

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -1,4 +1,3 @@
-import base64
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -115,9 +114,7 @@ class EndpointTest(APITestCase):
 
         request = self.make_request(method="GET")
         request.META["HTTP_ORIGIN"] = "http://example.com"
-        request.META["HTTP_AUTHORIZATION"] = b"Basic " + base64.b64encode(
-            apikey.key.encode("utf-8")
-        )
+        request.META["HTTP_AUTHORIZATION"] = self.create_basic_auth_header(apikey.key)
 
         response = _dummy_endpoint(request)
         response.render()
@@ -141,9 +138,7 @@ class EndpointTest(APITestCase):
 
         request = self.make_request(method="GET")
         request.META["HTTP_ORIGIN"] = "http://acme.example.com"
-        request.META["HTTP_AUTHORIZATION"] = b"Basic " + base64.b64encode(
-            apikey.key.encode("utf-8")
-        )
+        request.META["HTTP_AUTHORIZATION"] = self.create_basic_auth_header(apikey.key)
 
         response = _dummy_endpoint(request)
         response.render()
@@ -167,9 +162,7 @@ class EndpointTest(APITestCase):
         for http_origin in ["http://acme.example.com", "http://fakeacme.com"]:
             request = self.make_request(method="GET")
             request.META["HTTP_ORIGIN"] = http_origin
-            request.META["HTTP_AUTHORIZATION"] = b"Basic " + base64.b64encode(
-                apikey.key.encode("utf-8")
-            )
+            request.META["HTTP_AUTHORIZATION"] = self.create_basic_auth_header(apikey.key)
 
             response = _dummy_endpoint(request)
             response.render()

--- a/tests/sentry/middleware/test_auth.py
+++ b/tests/sentry/middleware/test_auth.py
@@ -1,4 +1,3 @@
-import base64
 from functools import cached_property
 from unittest.mock import patch
 
@@ -114,9 +113,7 @@ class AuthenticationMiddlewareTestCase(TestCase):
                 organization_id=self.organization.id, allowed_origins="*"
             )
             request = self.make_request(method="GET")
-            request.META["HTTP_AUTHORIZATION"] = b"Basic " + base64.b64encode(
-                apikey.key.encode("utf-8")
-            )
+            request.META["HTTP_AUTHORIZATION"] = self.create_basic_auth_header(apikey.key)
 
         self.middleware.process_request(request)
         # ApiKey is tied to an organization not user

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -1,6 +1,5 @@
 import math
 import uuid
-from base64 import b64encode
 from datetime import timedelta
 from unittest import mock
 
@@ -123,7 +122,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
             url,
             query,
             format="json",
-            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{api_key.key}:".encode()),
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
         )
 
         assert response.status_code == 200, response.content
@@ -4219,7 +4218,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
                 url,
                 query,
                 format="json",
-                HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{api_key.key}:".encode()),
+                HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
             )
 
         _, kwargs = mock.call_args


### PR DESCRIPTION
Formatting a basic auth header is long and annoying to type out so create util function to handle instead