### PR TITLE
fix(github-comments): feature toggle perms

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -348,7 +348,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
             help: t(
               'Allow Sentry to comment on pull requests about issues impacting your app.'
             ),
-            disabled: !hasIntegration || !hasOrgWrite,
+            disabled: !hasIntegration,
             disabledReason: t(
               'You must have a GitHub integration to enable this feature.'
             ),
@@ -370,7 +370,11 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
         initialData={initialData}
         onSubmitError={() => addErrorMessage('Unable to save change')}
       >
-        <JsonForm features={organization.features} forms={forms} />
+        <JsonForm
+          disabled={!hasOrgWrite}
+          features={organization.features}
+          forms={forms}
+        />
       </Form>
     );
   }


### PR DESCRIPTION
The only requirement for enabling/disabling the toggle should be whether the org has a GitHub integration. The requirement for editing the form overall should be whether the user has the `org:write` permission.