### PR TITLE
ref(github-growth): check external id when creating repo

### DIFF
--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -150,9 +150,7 @@ class IntegrationRepositoryProvider:
                     organization_id=organization.id,
                     external_id=external_id,
                     integration_id=integration_id,
-                ).first()
-                if repo:
-                    repo.update(**repo_update_params)
+                ).update(**repo_update_params)
 
                 raise RepoExistsError
 

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -333,7 +333,10 @@ class OrganizationIntegrationRepositoriesCreateTest(APITestCase):
     )
     def test_floating_repo(self, mock_build_repository_config):
         repo = Repository.objects.create(
-            organization_id=self.org.id, name="getsentry/sentry", status=2
+            organization_id=self.org.id,
+            name="getsentry/sentry",
+            status=2,
+            external_id="my_external_id",
         )
         with patch.object(
             ExampleRepositoryProvider, "build_repository_config", return_value=self.repo_config_data

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -162,6 +162,7 @@ class PushEventWebhookTest(APITestCase):
             name="baxterthehacker/public-repo",
         )
         repo.status = ObjectStatus.HIDDEN
+        repo.external_id = "35129377"
         repo.save()
 
         self._setup_repo_test(project)
@@ -453,6 +454,7 @@ class PullRequestEventWebhook(APITestCase):
             name="baxterthehacker/public-repo",
         )
         repo.status = ObjectStatus.HIDDEN
+        repo.external_id = "35129377"
         repo.save()
 
         self._setup_repo_test(project)


### PR DESCRIPTION
We are removing the `organization + name` constraint on the `Repository` table (#53286) because we are allowing repos to be `hidden` and it's possible that the repo name will change during that time. We should be relying on `external_id` rather than the `name` field to ensure that repositories are unique per integration.

This applies to when we attempt to create a repo. If we are trying to create a repo and a repo with the same `external_id` exists, we should always overwrite the repo `name` to keep it updated.