### PR TITLE
ref(dynamic-sampling): Add total seconds field to TaskContext

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/task_context.py
+++ b/src/sentry/dynamic_sampling/tasks/task_context.py
@@ -79,7 +79,8 @@ class TaskContext:
     def to_dict(self) -> Dict[str, Any]:
         ret_val = {
             "taskName": self.name,
-            "numSeconds": self.num_seconds,
+            "maxSeconds": self.num_seconds,
+            "seconds": time.monotonic() - self.expiration_time + self.num_seconds,
         }
         if self.context_data is not None:
             ret_val["taskData"] = {k: v.to_dict() for k, v in self.context_data.items()}


### PR DESCRIPTION
This is a minor PR.
It adds to the total number of seconds elapsed from the TaskContext creation to the dictionary image of the TaskContext.