### PR TITLE
fix(dynamic-sampling) sliding-window-org mark the task as being run also if there was a TimeoutException

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window.py
@@ -98,9 +98,6 @@ def sliding_window() -> None:
                             adjust_base_sample_rate_of_projects_timer,
                         )
 
-            # Due to the synchronous nature of the sliding window, when we arrived here, we can confidently say that the
-            # execution of the sliding window was successful. We will keep this state for 1 hour.
-            mark_sliding_window_executed()
     except TimeoutException:
         set_extra("context-data", context.to_dict())
         log_task_timeout(context)
@@ -109,6 +106,13 @@ def sliding_window() -> None:
         set_extra("context-data", context.to_dict())
         capture_message("timing for sentry.dynamic_sampling.tasks.sliding_window")
         log_task_execution(context)
+    finally:
+        # TODO (RaduW) Hot fix, we need to see if this is indeed what we want to do, or we can mark the sliding window
+        #   as executed only when the task is successful.
+
+        # Due to the synchronous nature of the sliding window, when we arrived here, we can confidently say that the
+        # execution of the sliding window was successful. We will keep this state for 1 hour.
+        mark_sliding_window_executed()
 
 
 def adjust_base_sample_rates_of_projects(


### PR DESCRIPTION
This is a hotfix, for marking the sliding window org task as having been run also in the case of a TimeoutException.
We need this to adjust the sampling rate for orgs that have been processed despite the timeout