### PR TITLE
fix(alerts): on demand metric flag

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -183,7 +183,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
             allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
             sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
 
-        use_on_demand_metrics = request.GET.get("useOnDemandMetrics")
+        use_on_demand_metrics = request.GET.get("useOnDemandMetrics") == "true"
 
         def get_event_stats(
             query_columns: Sequence[str],


### PR DESCRIPTION
Fixes standard metric alert chart being treated as on-demand metric charts