### PR TITLE
Instrument a couple of assemble-related functions

### DIFF
--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -99,7 +99,7 @@ def index_artifact_bundles_for_release(
             # debounce this in case there is a persistent error?
 
 
-@sentry_sdk.trace
+@sentry_sdk.tracing.trace
 def _index_urls_in_bundle(
     organization_id: int,
     artifact_bundle: ArtifactBundle,

--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -99,6 +99,7 @@ def index_artifact_bundles_for_release(
             # debounce this in case there is a persistent error?
 
 
+@sentry_sdk.trace
 def _index_urls_in_bundle(
     organization_id: int,
     artifact_bundle: ArtifactBundle,

--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -9,6 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 from hashlib import sha1
 from typing import ClassVar, Type
 
+import sentry_sdk
 from django.core.files.base import ContentFile
 from django.core.files.base import File as FileObj
 from django.db import IntegrityError, models, router, transaction
@@ -269,6 +270,7 @@ class AbstractFile(Model):
                 except Exception:
                     pass
 
+    @sentry_sdk.trace
     def putfile(self, fileobj, blob_size=DEFAULT_BLOB_SIZE, commit=True, logger=nooplogger):
         """
         Save a fileobj into a number of chunks.
@@ -300,6 +302,7 @@ class AbstractFile(Model):
             self.save()
         return results
 
+    @sentry_sdk.trace
     def assemble_from_file_blob_ids(self, file_blob_ids, checksum, commit=True):
         """
         This creates a file, from file blobs and returns a temp file with the

--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -270,7 +270,7 @@ class AbstractFile(Model):
                 except Exception:
                     pass
 
-    @sentry_sdk.trace
+    @sentry_sdk.tracing.trace
     def putfile(self, fileobj, blob_size=DEFAULT_BLOB_SIZE, commit=True, logger=nooplogger):
         """
         Save a fileobj into a number of chunks.
@@ -302,7 +302,7 @@ class AbstractFile(Model):
             self.save()
         return results
 
-    @sentry_sdk.trace
+    @sentry_sdk.tracing.trace
     def assemble_from_file_blob_ids(self, file_blob_ids, checksum, commit=True):
         """
         This creates a file, from file blobs and returns a temp file with the

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -11,6 +11,7 @@ from tempfile import TemporaryDirectory
 from typing import IO, ClassVar, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
+import sentry_sdk
 from django.core.files.base import File as FileObj
 from django.db import models, router
 
@@ -372,6 +373,7 @@ class _ArtifactIndexGuard:
         )
 
 
+@sentry_sdk.trace
 def read_artifact_index(
     release: Release, dist: Optional[Distribution], use_cache: bool = False, **filter_args
 ) -> Optional[dict]:
@@ -385,6 +387,7 @@ def _compute_sha1(archive: ReleaseArchive, url: str) -> str:
     return sha1(data).hexdigest()
 
 
+@sentry_sdk.trace
 def update_artifact_index(release: Release, dist: Optional[Distribution], archive_file: File):
     """Add information from release archive to artifact index
 
@@ -424,6 +427,7 @@ def update_artifact_index(release: Release, dist: Optional[Distribution], archiv
     return releasefile
 
 
+@sentry_sdk.trace
 def delete_from_artifact_index(release: Release, dist: Optional[Distribution], url: str) -> bool:
     """Delete the file with the given url from the manifest.
 

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -373,7 +373,7 @@ class _ArtifactIndexGuard:
         )
 
 
-@sentry_sdk.trace
+@sentry_sdk.tracing.trace
 def read_artifact_index(
     release: Release, dist: Optional[Distribution], use_cache: bool = False, **filter_args
 ) -> Optional[dict]:
@@ -387,7 +387,7 @@ def _compute_sha1(archive: ReleaseArchive, url: str) -> str:
     return sha1(data).hexdigest()
 
 
-@sentry_sdk.trace
+@sentry_sdk.tracing.trace
 def update_artifact_index(release: Release, dist: Optional[Distribution], archive_file: File):
     """Add information from release archive to artifact index
 
@@ -427,7 +427,7 @@ def update_artifact_index(release: Release, dist: Optional[Distribution], archiv
     return releasefile
 
 
-@sentry_sdk.trace
+@sentry_sdk.tracing.trace
 def delete_from_artifact_index(release: Release, dist: Optional[Distribution], url: str) -> bool:
     """Delete the file with the given url from the manifest.
 

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -63,7 +63,7 @@ class AssembleResult(NamedTuple):
         self.bundle_temp_file.close()
 
 
-@sentry_sdk.trace
+@sentry_sdk.tracing.trace
 def assemble_file(
     task, org_or_project, name, checksum, chunks, file_type
 ) -> Optional[AssembleResult]:
@@ -331,7 +331,7 @@ class ReleaseBundlePostAssembler(PostAssembler):
         with metrics.timer("tasks.assemble.release_bundle"):
             self._create_release_file()
 
-    @sentry_sdk.trace
+    @sentry_sdk.tracing.trace
     def _create_release_file(self):
         manifest = self.archive.manifest
 
@@ -369,7 +369,7 @@ class ReleaseBundlePostAssembler(PostAssembler):
             }
             self._store_single_files(meta, True)
 
-    @sentry_sdk.trace
+    @sentry_sdk.tracing.trace
     def _store_single_files(self, meta: dict, count_as_artifacts: bool):
         try:
             temp_dir = self.archive.extract()
@@ -465,7 +465,7 @@ class ArtifactBundlePostAssembler(PostAssembler):
         with metrics.timer("tasks.assemble.artifact_bundle"):
             self._create_artifact_bundle()
 
-    @sentry_sdk.trace
+    @sentry_sdk.tracing.trace
     def _create_artifact_bundle(self) -> None:
         # We want to give precedence to the request fields and only if they are unset fallback to the manifest's
         # contents.
@@ -566,7 +566,7 @@ class ArtifactBundlePostAssembler(PostAssembler):
                 date_snapshot=date_snapshot,
             )
 
-    @sentry_sdk.trace
+    @sentry_sdk.tracing.trace
     def _bind_or_create_artifact_bundle(
         self, bundle_id: Optional[str], date_added: datetime
     ) -> Tuple[ArtifactBundle, bool]:
@@ -636,7 +636,7 @@ class ArtifactBundlePostAssembler(PostAssembler):
         # fire the on_delete signal.
         ArtifactBundle.objects.filter(Q(id__in=ids), organization_id=self.organization.id).delete()
 
-    @sentry_sdk.trace
+    @sentry_sdk.tracing.trace
     def _index_bundle_if_needed(self, release: str, dist: str, date_snapshot: datetime):
         # We collect how many times we tried to perform indexing.
         metrics.incr("tasks.assemble.artifact_bundle.try_indexing")


### PR DESCRIPTION
This should make performance transactions for the `assemble_*` tasks a lot more useful.

Right now, there is only auto-instrumentation for SQL queries, which is pretty useless without knowing which function they are in.

![Bildschirmfoto 2023-07-21 um 12 52 45](https://github.com/getsentry/sentry/assets/580492/21b953a6-8b3f-4125-a4b7-958fa1a09028)
