### PR TITLE
Validate assemble_artifact arguments earlier

### DIFF
--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -269,19 +269,12 @@ class ArtifactBundleArchive:
 
     def extract_debug_ids_from_manifest(
         self,
-    ) -> Tuple[Optional[str], Set[Tuple[SourceFileType, str]]]:
+    ) -> Set[Tuple[SourceFileType, str]]:
         # We use a set, since we might have the same debug_id and file_type.
         debug_ids_with_types = set()
 
-        # We also want to extract the bundle_id which is also known as the bundle debug_id. This id is used to uniquely
-        # identify a specific ArtifactBundle in case for example of future deletion.
-        #
-        # If no id is found, it means that we must have an associated release to this ArtifactBundle, through the
-        # ReleaseArtifactBundle table.
-        bundle_id = self._extract_bundle_id()
-
         files = self.manifest.get("files", {})
-        for file_path, info in files.items():
+        for info in files.values():
             headers = self.normalize_headers(info.get("headers", {}))
             if (debug_id := headers.get("debug-id")) is not None:
                 debug_id = self.normalize_debug_id(debug_id)
@@ -294,9 +287,9 @@ class ArtifactBundleArchive:
                 ):
                     debug_ids_with_types.add((source_file_type, debug_id))
 
-        return bundle_id, debug_ids_with_types
+        return debug_ids_with_types
 
-    def _extract_bundle_id(self):
+    def extract_bundle_id(self) -> Optional[str]:
         bundle_id = self.manifest.get("debug_id")
 
         if bundle_id is not None:

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -715,7 +715,9 @@ def prepare_post_assembler(
 ) -> PostAssembler:
     if upload_as_artifact_bundle:
         if not project_ids:
-            raise AssembleArtifactsError("uploading an artifact bundle without a project is prohibited")
+            raise AssembleArtifactsError(
+                "uploading an artifact bundle without a project is prohibited"
+            )
         return ArtifactBundlePostAssembler(
             assemble_result=assemble_result,
             organization=organization,
@@ -725,7 +727,9 @@ def prepare_post_assembler(
         )
     else:
         if not release:
-            raise AssembleArtifactsError("uploading a release bundle without a release is prohibited")
+            raise AssembleArtifactsError(
+                "uploading a release bundle without a release is prohibited"
+            )
         return ReleaseBundlePostAssembler(
             assemble_result=assemble_result, organization=organization, version=release
         )

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -715,7 +715,7 @@ def prepare_post_assembler(
 ) -> PostAssembler:
     if upload_as_artifact_bundle:
         if not project_ids:
-            raise AssembleArtifactsError("uploading a bundle without a project is prohibited")
+            raise AssembleArtifactsError("uploading an artifact bundle without a project is prohibited")
         return ArtifactBundlePostAssembler(
             assemble_result=assemble_result,
             organization=organization,
@@ -725,7 +725,7 @@ def prepare_post_assembler(
         )
     else:
         if not release:
-            raise AssembleArtifactsError("uploading a bundle without a release is prohibited")
+            raise AssembleArtifactsError("uploading a release bundle without a release is prohibited")
         return ReleaseBundlePostAssembler(
             assemble_result=assemble_result, organization=organization, version=release
         )

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -479,12 +479,14 @@ class ArtifactBundlePostAssembler(PostAssembler):
         bundle_id = self.archive.extract_bundle_id()
         if not bundle_id:
             # In case we didn't find the bundle_id in the manifest, we will just generate our own.
-            # XXX: can this ever fail / return `None`?
             bundle_id = ArtifactBundleArchive.normalize_debug_id(
                 self.assemble_result.bundle.checksum
             )
-            if not bundle_id:
-                bundle_id = uuid.uuid4().hex
+        # When normalizing the debug_id from the checksum, or even when reading it from the bundle,
+        # the debug_id can have an additional appendix which we want to remove as it is
+        # incompatible with the SQL `uuid` type, which expects this to be a 16-byte UUID,
+        # formatted with `-` to 36 chars.
+        bundle_id = bundle_id[:36]
 
         analytics.record(
             "artifactbundle.manifest_extracted",

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -486,7 +486,7 @@ class ArtifactBundlePostAssembler(PostAssembler):
         # the debug_id can have an additional appendix which we want to remove as it is
         # incompatible with the SQL `uuid` type, which expects this to be a 16-byte UUID,
         # formatted with `-` to 36 chars.
-        bundle_id = bundle_id[:36]
+        bundle_id = bundle_id[:36] if bundle_id else uuid.uuid4().hex
 
         analytics.record(
             "artifactbundle.manifest_extracted",

--- a/tests/sentry/debug_files/test_artifact_bundles.py
+++ b/tests/sentry/debug_files/test_artifact_bundles.py
@@ -97,6 +97,10 @@ class ArtifactLookupTest(TestCase):
                     "url": "~/path/to/other1.js",
                     "content": b"other1_idx1",
                 },
+                "path/in/zip/baz": {
+                    "url": "~/path/to/only1.js",
+                    "content": b"only1_idx1",
+                },
             }
         )
         upload_bundle(bundle, self.project, "1.0.0")
@@ -127,12 +131,14 @@ class ArtifactLookupTest(TestCase):
         bundles = get_artifact_bundles(self.project, "1.0.0")
         assert len(bundles) == 2
         indexed = get_indexed_files(self.project, "1.0.0", distinct=True)
-        assert len(indexed) == 2
+        assert len(indexed) == 3
 
         assert indexed[0].url == "~/path/to/app.js"
         assert indexed[0].artifact_bundle == bundles[1]
-        assert indexed[1].url == "~/path/to/other1.js"
-        assert indexed[1].artifact_bundle == bundles[1]
+        assert indexed[1].url == "~/path/to/only1.js"
+        assert indexed[1].artifact_bundle == bundles[0]
+        assert indexed[2].url == "~/path/to/other1.js"
+        assert indexed[2].artifact_bundle == bundles[1]
 
         bundle = make_compressed_zip_file(
             {
@@ -152,13 +158,15 @@ class ArtifactLookupTest(TestCase):
         bundles = get_artifact_bundles(self.project, "1.0.0")
         assert len(bundles) == 3
         indexed = get_indexed_files(self.project, "1.0.0", distinct=True)
-        assert len(indexed) == 3
+        assert len(indexed) == 4
 
         # here, we use the more recent bundle for the shared file,
         # all other files are disjoint in this example
         assert indexed[0].url == "~/path/to/app.js"
         assert indexed[0].artifact_bundle == bundles[2]
-        assert indexed[1].url == "~/path/to/other1.js"
-        assert indexed[1].artifact_bundle == bundles[1]
-        assert indexed[2].url == "~/path/to/other2.js"
-        assert indexed[2].artifact_bundle == bundles[2]
+        assert indexed[1].url == "~/path/to/only1.js"
+        assert indexed[1].artifact_bundle == bundles[0]
+        assert indexed[2].url == "~/path/to/other1.js"
+        assert indexed[2].artifact_bundle == bundles[1]
+        assert indexed[3].url == "~/path/to/other2.js"
+        assert indexed[3].artifact_bundle == bundles[2]


### PR DESCRIPTION
- Ensures that we always have a `Project` for ArtifactBundles
- Ensures that there is always a release for a Releasebundle
- Defaults the `bundle_id` earlier