### PR TITLE
feat(metrics-layer): Add span self time

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -153,6 +153,12 @@ def get_metrics(projects: Sequence[Project], use_case_id: UseCaseID) -> Sequence
             "d": "generic_metrics_distributions",
             "g": "generic_metrics_gauges",
         },
+        "spans": {
+            "c": "generic_metrics_counters",
+            "s": "generic_metrics_sets",
+            "d": "generic_metrics_distributions",
+            "g": "generic_metrics_gauges",
+        },
     }
 
     result = []

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 from sentry.snuba.metrics.utils import OP_REGEX
 
-NAMESPACE_REGEX = r"(transactions|errors|issues|sessions|alerts|custom)"
+NAMESPACE_REGEX = r"(transactions|errors|issues|sessions|alerts|custom|spans)"
 ENTITY_TYPE_REGEX = r"(c|s|d|g|e)"
 # This regex allows for a string of words composed of small letters alphabet characters with
 # allowed the underscore character, optionally separated by a single dot
@@ -128,6 +128,8 @@ class TransactionMRI(Enum):
     # Spans (might be moved to their own namespace soon)
     SPAN_USER = "s:transactions/span.user@none"
     SPAN_DURATION = "d:transactions/span.duration@millisecond"
+    SPAN_SELF_TIME = "d:spans/duration@millisecond"
+    SPAN_SELF_TIME_LIGHT = "d:spans/exclusive_time_light@millisecond"
 
     COUNT_ON_DEMAND = "c:transactions/on_demand@none"
     DIST_ON_DEMAND = "d:transactions/on_demand@none"

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -126,9 +126,9 @@ class TransactionMRI(Enum):
     TEAM_KEY_TRANSACTION = "e:transactions/team_key_transaction@none"
 
     # Spans (might be moved to their own namespace soon)
-    SPAN_USER = "s:transactions/span.user@none"
-    SPAN_DURATION = "d:transactions/span.duration@millisecond"
-    SPAN_SELF_TIME = "d:spans/duration@millisecond"
+    SPAN_USER = "s:spans/user@none"
+    SPAN_DURATION = "d:spans/duration@millisecond"
+    SPAN_SELF_TIME = "d:spans/exclusive_time@millisecond"
     SPAN_SELF_TIME_LIGHT = "d:spans/exclusive_time_light@millisecond"
 
     COUNT_ON_DEMAND = "c:transactions/on_demand@none"

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -99,6 +99,8 @@ class TransactionMetricKey(Enum):
     # NOTE: These might be moved to their own namespace soon.
     SPAN_USER = "span.user"
     SPAN_DURATION = "span.duration"
+    SPAN_SELF_TIME = "span.exclusive_time"
+    SPAN_SELF_TIME_LIGHT = "span.exclusive_time_light"
 
     # TODO: Remove this as soon as the MetricsQuery supports private metrics
     COUNT_ON_DEMAND = "count.on_demand"


### PR DESCRIPTION
- This adds the two span self time mris to the metrics layer, also adds spans to the namespace regex so it can be used
- This modifies all the span MRIs to match what's currently being used by starfish