### PR TITLE
fix(github-growth): emit metric instead of RepoExistsError

### DIFF
--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -6,7 +6,6 @@ from typing import Any, MutableMapping
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, router, transaction
 from django.utils import timezone
-from rest_framework.exceptions import APIException
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -19,11 +18,6 @@ from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.signals import repo_linked
 from sentry.utils import metrics
-
-
-class RepoExistsError(APIException):
-    status_code = 400
-    detail = {"errors": {"__all__": "A repository with that name already exists"}}
 
 
 def get_integration_repository_provider(integration):

--- a/src/sentry/tasks/integrations/link_all_repos.py
+++ b/src/sentry/tasks/integrations/link_all_repos.py
@@ -3,7 +3,10 @@ import logging
 import sentry_sdk
 
 from sentry.models.organization import Organization
-from sentry.plugins.providers.integration_repository import get_integration_repository_provider
+from sentry.plugins.providers.integration_repository import (
+    RepoExistsError,
+    get_integration_repository_provider,
+)
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.tasks.base import instrumented_task
@@ -72,6 +75,9 @@ def link_all_repos(
                 repo_config=config, organization=organization
             )
         except KeyError:
+            continue
+        except RepoExistsError:
+            metrics.incr("sentry.integration_repo_provider.repo_exists")
             continue
         except Exception as e:
             sentry_sdk.capture_exception(e)

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -1,14 +1,12 @@
 from functools import cached_property
 from unittest.mock import patch
 
-import pytest
 import responses
 from django.db import IntegrityError
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.models import Repository
-from sentry.plugins.providers.integration_repository import RepoExistsError
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
@@ -65,11 +63,12 @@ class IntegrationRepositoryTestCase(TestCase):
         assert repos[0].name == self.repo_name
         assert repos[0].provider == "integrations:github"
 
-    def test_create_repository__repo_exists(self, get_jwt):
-        self._create_repo(external_id=self.config["external_id"])
+    @patch("sentry.plugins.providers.integration_repository.metrics")
+    def test_create_repository__repo_exists(self, mock_metrics, get_jwt):
+        self._create_repo()
 
-        with pytest.raises(RepoExistsError):
-            self.provider.create_repository(self.config, self.organization)
+        self.provider.create_repository(self.config, self.organization)
+        mock_metrics.incr.assert_called_with("sentry.integration_repo_provider.repo_exists")
 
     def test_create_repository__repo_exists_update_name(self, get_jwt):
         repo = self._create_repo(external_id=self.config["external_id"], name="getsentry/santry")
@@ -82,14 +81,17 @@ class IntegrationRepositoryTestCase(TestCase):
 
     @patch("sentry.models.Repository.objects.create")
     @patch("sentry.plugins.providers.IntegrationRepositoryProvider.on_delete_repository")
-    def test_create_repository__delete_webhook(self, mock_on_delete, mock_repo, get_jwt):
+    @patch("sentry.plugins.providers.integration_repository.metrics")
+    def test_create_repository__delete_webhook(
+        self, mock_metrics, mock_on_delete, mock_repo, get_jwt
+    ):
         self._create_repo()
 
         mock_repo.side_effect = IntegrityError
         mock_on_delete.side_effect = IntegrationError
 
-        with pytest.raises(RepoExistsError):
-            self.provider.create_repository(self.config, self.organization)
+        self.provider.create_repository(self.config, self.organization)
+        mock_metrics.incr.assert_called_with("sentry.integration_repo_provider.repo_exists")
 
     @patch("sentry.plugins.providers.integration_repository.metrics")
     def test_create_repository__activates_existing_hidden_repo(self, mock_metrics, get_jwt):
@@ -102,12 +104,14 @@ class IntegrationRepositoryTestCase(TestCase):
         assert repo.status == ObjectStatus.ACTIVE
         mock_metrics.incr.assert_called_with("sentry.integration_repo_provider.repo_relink")
 
-    def test_create_repository__only_activates_hidden_repo(self, get_jwt):
+    @patch("sentry.plugins.providers.integration_repository.metrics")
+    def test_create_repository__only_activates_hidden_repo(self, mock_metrics, get_jwt):
         repo = self._create_repo(external_id=self.config["external_id"])
         repo.status = ObjectStatus.PENDING_DELETION
         repo.save()
 
-        with pytest.raises(RepoExistsError):
-            self.provider.create_repository(self.config, self.organization)
+        self.provider.create_repository(self.config, self.organization)
+
         repo.refresh_from_db()
         assert repo.status == ObjectStatus.PENDING_DELETION
+        mock_metrics.incr.assert_called_with("sentry.integration_repo_provider.repo_exists")

--- a/tests/sentry/tasks/integrations/test_link_all_repos.py
+++ b/tests/sentry/tasks/integrations/test_link_all_repos.py
@@ -184,7 +184,7 @@ class LinkAllReposTestCase(IntegrationTestCase):
         mock_metrics.incr.assert_called_with("github.link_all_repos.rate_limited_error")
 
     @patch("sentry.models.Repository.objects.create")
-    @patch("sentry.plugins.providers.integration_repository.metrics")
+    @patch("sentry.tasks.integrations.link_all_repos.metrics")
     @responses.activate
     def test_link_all_repos_repo_creation_error(self, mock_metrics, mock_repo, _):
         mock_repo.side_effect = IntegrityError


### PR DESCRIPTION
We are getting spammed by `RepoExistsError`, which is not necessarily something we have to be worried about. Emit a metric rather than raise an exception.