### PR TITLE
fix(starfish): remove operation from span summary

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -168,7 +168,6 @@ function SpanSummaryPage({params, location}: Props) {
                       span?.[SPAN_OP] !== 'db.redis' && (
                         <Block title={t('Table')}>{span?.[SPAN_DOMAIN]}</Block>
                       )}
-                    <Block title={t('Operation')}>{span?.[SPAN_OP]}</Block>
                     <Block
                       title={getThroughputTitle(span?.[SPAN_OP])}
                       description={tct('Throughput of this [spanType] per second', {


### PR DESCRIPTION
Operation is no longer here
<img width="1259" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/86cb4498-135b-4472-92a9-e233867b454d">
