### PR TITLE
ref: fix import to pytz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -669,7 +669,6 @@ module = [
     "sentry.monitors.endpoints.organization_monitor_details",
     "sentry.monitors.endpoints.organization_monitor_index",
     "sentry.monitors.utils",
-    "sentry.monitors.validators",
     "sentry.monkey.pickle",
     "sentry.net.http",
     "sentry.net.socket",

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -1,6 +1,6 @@
+import pytz
 from croniter import croniter
 from django.core.exceptions import ValidationError
-from django.utils.timezone import pytz
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field


### PR DESCRIPTION
django 4.x does not have this attribute at all -- in 3.x this is an import of `pytz`