### PR TITLE
ref: port a deprecated usage of pkg_resources

### DIFF
--- a/src/sentry/runner/importer.py
+++ b/src/sentry/runner/importer.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import sys
 import types
 
@@ -105,12 +106,14 @@ def install_plugin_apps(entry_point, settings):
     #         'phabricator = sentry_phabricator'
     #     ],
     # },
-    from pkg_resources import iter_entry_points
-
     installed_apps = list(settings.INSTALLED_APPS)
-    for ep in iter_entry_points(entry_point):
-        if ep.module_name not in installed_apps:
-            installed_apps.append(ep.module_name)
+    for dist in importlib.metadata.distributions():
+        for ep in dist.entry_points:
+            if ep.group == entry_point:
+                assert ":" not in ep.value, ep.value
+                if ep.value not in installed_apps:
+                    installed_apps.append(ep.value)
+
     settings.INSTALLED_APPS = tuple(installed_apps)
 
 


### PR DESCRIPTION
there's a bunch of these to fix -- but this is the first one in the critical path -- unfortunately next on the chopping block is out of our control (google's protobuf definitions) but there's an open PR there so I'm hopeful