### PR TITLE
ref(perf): Add asset timing visualization

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -38,6 +38,7 @@ import {
 import {
   getDurationDisplay,
   getHumanDuration,
+  lightenBarColor,
   toPercent,
 } from 'sentry/components/performance/waterfall/utils';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -82,10 +83,12 @@ import {
   getMeasurements,
   getSpanID,
   getSpanOperation,
+  getSpanSubTimings,
   isEventFromBrowserJavaScriptSDK,
   isGapSpan,
   isOrphanSpan,
   isOrphanTreeDepth,
+  shouldLimitAffectedToTiming,
   SpanBoundsType,
   SpanGeneratedBoundsType,
   spanTargetHash,
@@ -313,10 +316,10 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
     );
   }
 
-  getBounds(): SpanViewBoundsType {
+  getBounds(bounds?: SpanGeneratedBoundsType): SpanViewBoundsType {
     const {event, span, generateBounds} = this.props;
 
-    const bounds = generateBounds({
+    bounds ??= generateBounds({
       startTimestamp: span.start_timestamp,
       endTimestamp: span.timestamp,
     });
@@ -971,15 +974,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
     errors: TraceError[] | null;
     transactions: QuickTraceEvent[] | null;
   }) {
-    const {span, spanBarColor, spanBarType, spanNumber} = this.props;
-    const startTimestamp: number = span.start_timestamp;
-    const endTimestamp: number = span.timestamp;
-    const duration = Math.abs(endTimestamp - startTimestamp);
-    const durationString = getHumanDuration(duration);
-    const bounds = this.getBounds();
     const {dividerPosition, addGhostDividerLineRef} = dividerHandlerChildrenProps;
-    const displaySpanBar = defined(bounds.left) && defined(bounds.width);
-    const durationDisplay = getDurationDisplay(bounds);
 
     return (
       <RowCellContainer showDetail={this.state.showDetail}>
@@ -1006,7 +1001,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
         <RowCell
           data-type="span-row-cell"
           showDetail={this.state.showDetail}
-          showStriping={spanNumber % 2 !== 0}
+          showStriping={this.props.spanNumber % 2 !== 0}
           style={{
             width: `calc(${toPercent(1 - dividerPosition)} - 0.5px)`,
           }}
@@ -1014,25 +1009,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
             this.toggleDisplayDetail();
           }}
         >
-          {displaySpanBar && (
-            <RowRectangle
-              spanBarType={spanBarType}
-              style={{
-                backgroundColor: spanBarColor,
-                left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
-                width: toPercent(bounds.width || 0),
-              }}
-            >
-              <DurationPill
-                durationDisplay={durationDisplay}
-                showDetail={this.state.showDetail}
-                spanBarType={spanBarType}
-              >
-                {durationString}
-                {this.renderWarningText()}
-              </DurationPill>
-            </RowRectangle>
-          )}
+          {this.renderSpanBarRectangles()}
           {this.renderMeasurements()}
           <SpanBarCursorGuide />
         </RowCell>
@@ -1059,6 +1036,69 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
           </DividerLineGhostContainer>
         )}
       </RowCellContainer>
+    );
+  }
+
+  renderSpanBarRectangles() {
+    const {span, spanBarColor, spanBarType, generateBounds} = this.props;
+    const startTimestamp: number = span.start_timestamp;
+    const endTimestamp: number = span.timestamp;
+    const duration = Math.abs(endTimestamp - startTimestamp);
+    const durationString = getHumanDuration(duration);
+    const bounds = this.getBounds();
+    const displaySpanBar = defined(bounds.left) && defined(bounds.width);
+    if (!displaySpanBar) {
+      return null;
+    }
+
+    const subTimings = getSpanSubTimings(span);
+    const hasSubTimings = !!subTimings;
+
+    const subSpans = hasSubTimings
+      ? subTimings.map(timing => {
+          const timingGeneratedBounds = generateBounds(timing);
+          const timingBounds = this.getBounds(timingGeneratedBounds);
+          const isAffectedSubTiming = shouldLimitAffectedToTiming(timing);
+          return (
+            <RowRectangle
+              key={timing.name}
+              spanBarType={isAffectedSubTiming ? spanBarType : undefined}
+              style={{
+                backgroundColor: lightenBarColor(
+                  getSpanOperation(span),
+                  timing.colorLighten
+                ),
+                left: `min(${toPercent(timingBounds.left || 0)}, calc(100% - 1px))`,
+                width: toPercent(timingBounds.width || 0),
+              }}
+            />
+          );
+        })
+      : null;
+
+    const durationDisplay = getDurationDisplay(bounds);
+    return (
+      <Fragment>
+        <RowRectangle
+          spanBarType={spanBarType}
+          style={{
+            backgroundColor: hasSubTimings ? 'rgba(0,0,0,0.0)' : spanBarColor,
+            left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+            width: toPercent(bounds.width || 0),
+          }}
+          isHidden={hasSubTimings}
+        >
+          <DurationPill
+            durationDisplay={durationDisplay}
+            showDetail={this.state.showDetail}
+            spanBarType={spanBarType}
+          >
+            {durationString}
+            {this.renderWarningText()}
+          </DurationPill>
+        </RowRectangle>
+        {subSpans}
+      </Fragment>
     );
   }
 

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -43,6 +43,9 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
+import {getPerformanceDuration} from 'sentry/views/performance/utils';
+
+import {OpsDot} from '../../opsBreakdown';
 
 import * as SpanEntryContext from './context';
 import {GapSpanDetails} from './gapSpanDetails';
@@ -52,10 +55,13 @@ import {ParsedTraceType, ProcessedSpanType, rawSpanKeys, RawSpanType} from './ty
 import {
   getCumulativeAlertLevelFromErrors,
   getFormattedTimeRangeWithLeadingAndTrailingZero,
+  getSpanSubTimings,
   getTraceDateTimeRange,
   isGapSpan,
+  isHiddenDataKey,
   isOrphanSpan,
   scrollToSpan,
+  SubTimingInfo,
 } from './utils';
 
 const DEFAULT_ERRORS_VISIBLE = 5;
@@ -67,19 +73,6 @@ const SIZE_DATA_KEYS = [
   'http.response_content_length',
   'http.decoded_response_content_length',
   'http.response_transfer_size',
-];
-
-const HIDDEN_DATA_KEYS = [
-  'http.request.redirect_start',
-  'http.request.fetch_start',
-  'http.request.domain_lookup_start',
-  'http.request.domain_lookup_end',
-  'http.request.connect_start',
-  'http.request.secure_connection_start',
-  'http.request.connection_end',
-  'http.request.request_start',
-  'http.request.response_start',
-  'http.request.response_end',
 ];
 
 type TransactionResult = {
@@ -100,10 +93,6 @@ type Props = {
   span: ProcessedSpanType;
   trace: Readonly<ParsedTraceType>;
 };
-
-function isSpanKeyVisible(key: string) {
-  return !HIDDEN_DATA_KEYS.includes(key);
-}
 
 function SpanDetail(props: Props) {
   const [errorsOpened, setErrorsOpened] = useState(false);
@@ -407,7 +396,7 @@ function SpanDetail(props: Props) {
     const durationString = `${Number(duration.toFixed(3)).toLocaleString()}ms`;
 
     const unknownKeys = Object.keys(span).filter(key => {
-      return isSpanKeyVisible(key) && !rawSpanKeys.has(key as any);
+      return !isHiddenDataKey(key) && !rawSpanKeys.has(key as any);
     });
 
     const {sizeKeys, nonSizeKeys} = partitionSizes(span?.data ?? {});
@@ -415,6 +404,8 @@ function SpanDetail(props: Props) {
     const allZeroSizes = SIZE_DATA_KEYS.map(key => sizeKeys[key]).every(
       value => value === 0
     );
+
+    const timingKeys = getSpanSubTimings(span) ?? [];
 
     return (
       <Fragment>
@@ -520,6 +511,15 @@ function SpanDetail(props: Props) {
                   ? `${Number(span.exclusive_time.toFixed(3)).toLocaleString()}ms`
                   : null}
               </Row>
+              {timingKeys.map(timing => (
+                <Row
+                  title={timing.name}
+                  key={timing.name}
+                  prefix={<RowTimingPrefix timing={timing} />}
+                >
+                  {getPerformanceDuration(Number(timing.duration) * 1000)}
+                </Row>
+              ))}
               <Tags span={span} />
               {allZeroSizes && (
                 <TextTr>
@@ -540,7 +540,7 @@ function SpanDetail(props: Props) {
                 </Row>
               ))}
               {map(nonSizeKeys, (value, key) =>
-                isSpanKeyVisible(key) ? (
+                !isHiddenDataKey(key) ? (
                   <Row title={key} key={key}>
                     {maybeStringify(value)}
                   </Row>
@@ -569,6 +569,10 @@ function SpanDetail(props: Props) {
       {renderSpanDetails()}
     </SpanDetailContainer>
   );
+}
+
+function RowTimingPrefix({timing}: {timing: SubTimingInfo}) {
+  return <OpsDot style={{backgroundColor: timing.color}} />;
 }
 
 function maybeStringify(value: unknown): string {
@@ -642,12 +646,14 @@ export function Row({
   title,
   keep,
   children,
+  prefix,
   extra = null,
 }: {
   children: React.ReactNode;
   title: JSX.Element | string | null;
   extra?: React.ReactNode;
   keep?: boolean;
+  prefix?: JSX.Element;
 }) {
   if (!keep && !children) {
     return null;
@@ -655,7 +661,12 @@ export function Row({
 
   return (
     <tr>
-      <td className="key">{title}</td>
+      <td className="key">
+        <Flex>
+          {prefix}
+          {title}
+        </Flex>
+      </td>
       <ValueTd className="value">
         <ValueRow>
           <StyledPre>
@@ -702,6 +713,10 @@ function generateSlug(result: TransactionResult): string {
   });
 }
 
+const Flex = styled('div')`
+  display: flex;
+  align-items: center;
+`;
 const ButtonGroup = styled('div')`
   display: flex;
   flex-direction: column;

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -32,6 +32,13 @@ export type RawSpanType = {
   tags?: {[key: string]: string};
 };
 
+/**
+ * Extendeds the Raw type from json with a type for discriminating the union.
+ */
+type BaseSpanType = RawSpanType & {
+  type?: undefined;
+};
+
 export const rawSpanKeys: Set<keyof RawSpanType> = new Set([
   'trace_id',
   'parent_span_id',
@@ -49,11 +56,11 @@ export const rawSpanKeys: Set<keyof RawSpanType> = new Set([
   'exclusive_time',
 ]);
 
-export type OrphanSpanType = {
+export type OrphanSpanType = RawSpanType & {
   type: 'orphan';
-} & RawSpanType;
+};
 
-export type SpanType = RawSpanType | OrphanSpanType;
+export type SpanType = BaseSpanType | OrphanSpanType;
 
 // this type includes natural spans which are part of the transaction event payload,
 // and as well as pseudo-spans (e.g. gap spans)

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -80,7 +80,7 @@ enum TimestampStatus {
   EQUAL = 2,
 }
 
-enum SpanSubTimingMark {
+export enum SpanSubTimingMark {
   SPAN_START = 0,
   SPAN_END = 1,
   HTTP_REQUEST_START = 'http.request.request_start',
@@ -363,7 +363,7 @@ const SPAN_SUB_TIMINGS: Record<string, SubTimingDefinition[]> = {
   ],
 };
 
-function subTimingMarkToTime(span: RawSpanType, mark: SpanSubTimingMark) {
+export function subTimingMarkToTime(span: RawSpanType, mark: SpanSubTimingMark) {
   if (mark === SpanSubTimingMark.SPAN_START) {
     return span.start_timestamp;
   }

--- a/static/app/components/events/opsBreakdown.tsx
+++ b/static/app/components/events/opsBreakdown.tsx
@@ -320,7 +320,7 @@ export const OpsLine = styled('div')`
   }
 `;
 
-const OpsDot = styled('div')`
+export const OpsDot = styled('div')`
   content: '';
   display: block;
   width: 8px;

--- a/static/app/components/performance/waterfall/rowBar.tsx
+++ b/static/app/components/performance/waterfall/rowBar.tsx
@@ -14,6 +14,7 @@ import {
 import {space} from 'sentry/styles/space';
 
 export const RowRectangle = styled('div')<{
+  isHidden?: boolean;
   spanBarType?: SpanBarType;
 }>`
   position: absolute;
@@ -22,7 +23,7 @@ export const RowRectangle = styled('div')<{
   min-width: 1px;
   user-select: none;
   transition: border-color 0.15s ease-in-out;
-  ${p => getHatchPattern(p.spanBarType, p.theme)}
+  ${p => !p.isHidden && getHatchPattern(p.spanBarType, p.theme)}
 `;
 
 export const DurationPill = styled('div')<{

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -1,4 +1,5 @@
 import {Theme} from '@emotion/react';
+import Color from 'color';
 
 import {DurationDisplay} from 'sentry/components/performance/waterfall/types';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
@@ -274,4 +275,12 @@ export const pickBarColor = (input: string | undefined): string => {
   return colorsAsArray[
     (letterIndex1 + letterIndex2 + letterIndex3 + letterIndex4) % colorsAsArray.length
   ];
+};
+
+export const lightenBarColor = (
+  input: string | undefined,
+  lightenRatio: number
+): string => {
+  const barColor = pickBarColor(input);
+  return Color(barColor).lighten(lightenRatio).string();
 };


### PR DESCRIPTION
### Summary
Adds asset timing visualization to spanbars, which will help users a lot with determining if performance issues are browser related vs. upstream. This _only_ applies if a span has sub-timings that are defined in  `SPAN_SUB_TIMINGS`. 

When it does, it will pick out sub-timings from data attributes on that span and build out an alternative set of spans to show with lightened colors to visually split them. When sub timings exist, the previous span bar has it's color set to transparent, which happens since we still want the `DurationPill` to float on the outside of the overall span time, not individual sub timings.

### Other
- Had to fix RawSpanType so the `ProcessedSpanType` union is easier to narrow
- Added `name` to timings
- We'll re-arrange where those times are in the layout in the span details reesign.

### Screenshots
#### Span Waterfall
Before            |  After
:-------------------------:|:-------------------------:
![Screenshot 2023-07-21 at 3 47 06 PM](https://github.com/getsentry/sentry/assets/6111995/e6930442-c736-44b4-9e59-e05c66583a7e) |  ![Screenshot 2023-07-21 at 3 45 57 PM](https://github.com/getsentry/sentry/assets/6111995/d6dc5f81-8346-40b4-a991-4f68c6c6408c)

#### Span details outline what the times are
![Screenshot 2023-07-21 at 4 09 10 PM](https://github.com/getsentry/sentry/assets/6111995/2754bc37-8567-4bbf-865b-d71335f670b4)


#### Adjusts the embedded transactions with clock skew to the beginning of the response start if it exists
Before            |  After
:-------------------------:|:-------------------------:
![Screenshot 2023-07-21 at 5 15 59 PM](https://github.com/getsentry/sentry/assets/6111995/dae5337e-229c-4df0-9a0e-d53edb36178f)  |  ![Screenshot 2023-07-21 at 5 09 51 PM](https://github.com/getsentry/sentry/assets/6111995/2b0e2d7e-b9d6-4d27-9461-044184113990)



