### PR TITLE
chore(hybridcloud) Put relay models in region

### DIFF
--- a/src/sentry/models/relay.py
+++ b/src/sentry/models/relay.py
@@ -3,10 +3,10 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from sentry_relay import PublicKey
 
-from sentry.db.models import Model, control_silo_only_model
+from sentry.db.models import Model, region_silo_only_model
 
 
-@control_silo_only_model
+@region_silo_only_model
 class RelayUsage(Model):
     __include_in_export__ = True
 
@@ -22,7 +22,7 @@ class RelayUsage(Model):
         db_table = "sentry_relayusage"
 
 
-@control_silo_only_model
+@region_silo_only_model
 class Relay(Model):
     __include_in_export__ = True
 

--- a/tests/sentry/api/endpoints/test_relay_projectids.py
+++ b/tests/sentry/api/endpoints/test_relay_projectids.py
@@ -26,7 +26,7 @@ def _get_all_keys(config):
                 yield key
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class RelayProjectIdsEndpointTest(APITestCase):
     _date_regex = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$")
 

--- a/tests/sentry/api/endpoints/test_relay_publickeys.py
+++ b/tests/sentry/api/endpoints/test_relay_publickeys.py
@@ -7,6 +7,7 @@ from sentry_relay import generate_key_pair
 from sentry.auth import system
 from sentry.models import Relay
 from sentry.testutils import APITestCase
+from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 
 
@@ -14,6 +15,7 @@ def disable_internal_networks():
     return mock.patch.object(system, "INTERNAL_NETWORKS", ())
 
 
+@region_silo_test(stable=True)
 class RelayPublicKeysConfigTest(APITestCase):
     def setUp(self):
         super().setUp()

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -7,9 +7,11 @@ from sentry_relay import generate_key_pair
 
 from sentry.models import Relay, RelayUsage
 from sentry.testutils import APITestCase
+from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 
 
+@region_silo_test(stable=True)
 class RelayRegisterTest(APITestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
All of the relay related endpoints are currently in region silo, but we had incorrectly put Relay models in control. Relay and ingestion in general are region bound. Add stable=true for relay endpoint tests.
