### PR TITLE
chore(profiling): Update empty state wording in profiling widgets

### DIFF
--- a/static/app/views/profiling/landing/functionTrendsWidget.tsx
+++ b/static/app/views/profiling/landing/functionTrendsWidget.tsx
@@ -120,7 +120,11 @@ export function FunctionTrendsWidget({
         )}
         {!isError && !isLoading && !hasTrends && (
           <EmptyStateWarning>
-            <p>{t('No functions found')}</p>
+            {trendType === 'regression' ? (
+              <p>{t('No regressed functions detected')}</p>
+            ) : (
+              <p>{t('No improved functions detected')}</p>
+            )}
           </EmptyStateWarning>
         )}
         {hasTrends && (

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -134,7 +134,7 @@ export function SlowestFunctionsWidget({
         )}
         {!isError && !isLoading && !hasFunctions && (
           <EmptyStateWarning>
-            <p>{t('No functions found')}</p>
+            <p>{t('No application functions found')}</p>
           </EmptyStateWarning>
         )}
         {hasFunctions && totalsQuery.isFetched && (

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -134,7 +134,7 @@ export function SlowestFunctionsWidget({
         )}
         {!isError && !isLoading && !hasFunctions && (
           <EmptyStateWarning>
-            <p>{t('No application functions found')}</p>
+            <p>{t('No functions found')}</p>
           </EmptyStateWarning>
         )}
         {hasFunctions && totalsQuery.isFetched && (


### PR DESCRIPTION
Clarify the empty states imply no regression/improvement.