### PR TITLE
feat(issues): Record if regression used semver to compare releases

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1876,8 +1876,11 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
             )
 
     if is_regression:
-        activity_data = {"event_id": event.event_id, "version": release.version if release else ""}
-        if resolved_in_activity is not None:
+        activity_data: dict[str, str | bool] = {
+            "event_id": event.event_id,
+            "version": release.version if release else "",
+        }
+        if resolved_in_activity and release:
             activity_data.update(
                 {
                     "follows_semver": follows_semver,

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -694,7 +694,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         If the project follows semver then the regression activity should have `follows_semver` set.
         We should also record which version the issue was resolved in as `resolved_in_version`.
 
-        This allows the UI to say the issue was resolved in 1.0.0 and regressed in 2.0.0 and
+        This allows the UI to say the issue was resolved in 1.0.0, regressed in 2.0.0 and
         the versions were compared using semver.
         """
         plugin_is_regression.return_value = True


### PR DESCRIPTION
We look at a few of the recent releases to determine if the project is using semver. This makes it difficult to tell how the regression version was compared in the frontend. This records the result in a `follows_semver` property, also records the version the release was resolved in.

`follows_semver_versioning_scheme` has caching and should not be an additional query
