### PR TITLE
feat(most-helpful-event): Add event dropdown UI

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -248,14 +248,15 @@ function useEventApiQuery({
   const hasMostHelpfulEventFeature = organization.features.includes(
     'issue-details-most-helpful-event'
   );
-  const eventIdUrl = eventId ?? (hasMostHelpfulEventFeature ? 'helpful' : 'latest');
+  const eventIdUrl = eventId ?? (hasMostHelpfulEventFeature ? 'recommended' : 'latest');
   const helpfulEventQuery =
     hasMostHelpfulEventFeature && typeof location.query.query === 'string'
       ? location.query.query
       : undefined;
 
+  const endpointEventId = eventIdUrl === 'recommended' ? 'helpful' : eventIdUrl;
   const queryKey: ApiQueryKey = [
-    `/issues/${groupId}/events/${eventIdUrl}/`,
+    `/issues/${groupId}/events/${endpointEventId}/`,
     {
       query: getGroupEventDetailsQueryData({
         environments,
@@ -267,7 +268,7 @@ function useEventApiQuery({
   const tab = getCurrentTab({router});
   const isOnDetailsTab = tab === Tab.DETAILS;
 
-  const isLatestOrHelpfulEvent = eventIdUrl === 'latest' || eventIdUrl === 'helpful';
+  const isLatestOrHelpfulEvent = eventIdUrl === 'latest' || eventIdUrl === 'recommended';
   const latestOrHelpfulEvent = useApiQuery<Event>(queryKey, {
     // Latest/helpful event will change over time, so only cache for 30 seconds
     staleTime: 30000,

--- a/static/app/views/issueDetails/groupEventCarousel.spec.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.spec.tsx
@@ -37,7 +37,14 @@ describe('GroupEventCarousel', () => {
     // Because it isn't rendered on smaller screens
     jest.spyOn(useMedia, 'default').mockReturnValue(true);
 
-    render(<GroupEventCarousel {...defaultProps} />);
+    render(<GroupEventCarousel {...defaultProps} />, {
+      organization: TestStubs.Organization({
+        features: [
+          'issue-details-most-helpful-event',
+          'issue-details-most-helpful-event-ui',
+        ],
+      }),
+    });
 
     await userEvent.click(screen.getByRole('button', {name: /recommended event/i}));
     await userEvent.click(screen.getByRole('option', {name: /oldest event/i}));

--- a/static/app/views/issueDetails/groupEventCarousel.spec.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.spec.tsx
@@ -1,5 +1,8 @@
+import {browserHistory} from 'react-router';
+
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
+import * as useMedia from 'sentry/utils/useMedia';
 import {GroupEventCarousel} from 'sentry/views/issueDetails/groupEventCarousel';
 
 describe('GroupEventCarousel', () => {
@@ -21,7 +24,7 @@ describe('GroupEventCarousel', () => {
   };
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
     Object.assign(navigator, {
       clipboard: {
         writeText: jest.fn().mockResolvedValue(''),
@@ -30,13 +33,40 @@ describe('GroupEventCarousel', () => {
     window.open = jest.fn();
   });
 
+  it('can use event dropdown to navigate events', async () => {
+    // Because it isn't rendered on smaller screens
+    jest.spyOn(useMedia, 'default').mockReturnValue(true);
+
+    render(<GroupEventCarousel {...defaultProps} />);
+
+    await userEvent.click(screen.getByRole('button', {name: /recommended event/i}));
+    await userEvent.click(screen.getByRole('option', {name: /oldest event/i}));
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: '/organizations/org-slug/issues/group-id/events/oldest/',
+      query: {referrer: 'oldest-event'},
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: /oldest event/i}));
+    await userEvent.click(screen.getByRole('option', {name: /latest event/i}));
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: '/organizations/org-slug/issues/group-id/events/oldest/',
+      query: {referrer: 'oldest-event'},
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: /latest event/i}));
+    await userEvent.click(screen.getByRole('option', {name: /recommended event/i}));
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: '/organizations/org-slug/issues/group-id/events/recommended/',
+      query: {referrer: 'recommended-event'},
+    });
+  });
+
   it('can navigate next/previous events', () => {
     render(<GroupEventCarousel {...defaultProps} />);
 
-    expect(screen.getByLabelText(/First Event/)).toHaveAttribute(
-      'href',
-      `/organizations/org-slug/issues/group-id/events/oldest/?referrer=oldest-event`
-    );
     expect(screen.getByLabelText(/Previous Event/)).toHaveAttribute(
       'href',
       `/organizations/org-slug/issues/group-id/events/prev-event-id/?referrer=previous-event`
@@ -44,10 +74,6 @@ describe('GroupEventCarousel', () => {
     expect(screen.getByLabelText(/Next Event/)).toHaveAttribute(
       'href',
       `/organizations/org-slug/issues/group-id/events/next-event-id/?referrer=next-event`
-    );
-    expect(screen.getByLabelText(/Latest Event/)).toHaveAttribute(
-      'href',
-      `/organizations/org-slug/issues/group-id/events/latest/?referrer=latest-event`
     );
   });
 

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -9,7 +9,15 @@ import {CompactSelect} from 'sentry/components/compactSelect';
 import DateTime from 'sentry/components/dateTime';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconChevron, IconCopy, IconEllipsis, IconOpen, IconWarning} from 'sentry/icons';
+import {
+  IconChevron,
+  IconCopy,
+  IconEllipsis,
+  IconNext,
+  IconOpen,
+  IconPrevious,
+  IconWarning,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Event, Group, Organization} from 'sentry/types';
@@ -122,7 +130,11 @@ function EventNavigationDropdown({group}: {group: Group}) {
   const organization = useOrganization();
   const largeViewport = useMedia(`(min-width: ${theme.breakpoints.large})`);
 
-  if (!largeViewport) {
+  const isHelpfulEventUiEnabled =
+    organization.features.includes('issue-details-most-helpful-event') &&
+    organization.features.includes('issue-details-most-helpful-event-ui');
+
+  if (!isHelpfulEventUiEnabled || !largeViewport) {
     return null;
   }
 
@@ -214,6 +226,10 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
       ...getAnalyticsDataForEvent(event),
     });
   };
+
+  const isHelpfulEventUiEnabled =
+    organization.features.includes('issue-details-most-helpful-event') &&
+    organization.features.includes('issue-details-most-helpful-event-ui');
 
   return (
     <CarouselAndButtonsWrapper>
@@ -342,6 +358,16 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
         )}
         <EventNavigationDropdown group={group} />
         <NavButtons>
+          {!isHelpfulEventUiEnabled && (
+            <EventNavigationButton
+              group={group}
+              icon={<IconPrevious size={BUTTON_ICON_SIZE} />}
+              disabled={!hasPreviousEvent}
+              title={t('First Event')}
+              eventId="oldest"
+              referrer="oldest-event"
+            />
+          )}
           <EventNavigationButton
             group={group}
             icon={<IconChevron direction="left" size={BUTTON_ICON_SIZE} />}
@@ -358,6 +384,16 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
             eventId={event.nextEventID}
             referrer="next-event"
           />
+          {!isHelpfulEventUiEnabled && (
+            <EventNavigationButton
+              group={group}
+              icon={<IconNext size={BUTTON_ICON_SIZE} />}
+              disabled={!hasNextEvent}
+              title={t('Latest Event')}
+              eventId="latest"
+              referrer="latest-event"
+            />
+          )}
         </NavButtons>
       </ActionsWrapper>
     </CarouselAndButtonsWrapper>

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -1,21 +1,15 @@
+import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button, ButtonProps} from 'sentry/components/button';
+import {CompactSelect} from 'sentry/components/compactSelect';
 import DateTime from 'sentry/components/dateTime';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {Tooltip} from 'sentry/components/tooltip';
-import {
-  IconChevron,
-  IconCopy,
-  IconEllipsis,
-  IconNext,
-  IconOpen,
-  IconPrevious,
-  IconWarning,
-} from 'sentry/icons';
+import {IconChevron, IconCopy, IconEllipsis, IconOpen, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Event, Group, Organization} from 'sentry/types';
@@ -32,6 +26,7 @@ import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import EventCreatedTooltip from 'sentry/views/issueDetails/eventCreatedTooltip';
 
@@ -52,8 +47,22 @@ type EventNavigationButtonProps = {
   eventId?: string | null;
 };
 
+enum EventNavDropdownOption {
+  RECOMMENDED = 'recommended',
+  LATEST = 'latest',
+  OLDEST = 'oldest',
+  ALL = 'all',
+}
+
 const BUTTON_SIZE = 'sm';
 const BUTTON_ICON_SIZE = 'sm';
+
+const EVENT_NAV_DROPDOWN_OPTIONS = [
+  {value: EventNavDropdownOption.RECOMMENDED, label: 'Recommended Event'},
+  {value: EventNavDropdownOption.LATEST, label: 'Latest Event'},
+  {value: EventNavDropdownOption.OLDEST, label: 'Oldest Event'},
+  {options: [{value: EventNavDropdownOption.ALL, label: 'View All Events'}]},
+];
 
 const copyToClipboard = (value: string) => {
   navigator.clipboard
@@ -106,11 +115,70 @@ function EventNavigationButton({
   );
 }
 
+function EventNavigationDropdown({group}: {group: Group}) {
+  const location = useLocation();
+  const params = useParams<{eventId?: string}>();
+  const theme = useTheme();
+  const organization = useOrganization();
+  const largeViewport = useMedia(`(min-width: ${theme.breakpoints.large})`);
+
+  if (!largeViewport) {
+    return null;
+  }
+
+  const getSelectedOption = () => {
+    switch (params.eventId) {
+      case EventNavDropdownOption.RECOMMENDED:
+      case EventNavDropdownOption.LATEST:
+      case EventNavDropdownOption.OLDEST:
+        return params.eventId;
+      case undefined:
+        return EventNavDropdownOption.RECOMMENDED;
+      default:
+        return undefined;
+    }
+  };
+
+  const selectedValue = getSelectedOption();
+
+  return (
+    <CompactSelect
+      size="sm"
+      options={EVENT_NAV_DROPDOWN_OPTIONS}
+      value={selectedValue}
+      triggerLabel={!selectedValue ? 'Navigate Events' : undefined}
+      onChange={selectedOption => {
+        switch (selectedOption.value) {
+          case EventNavDropdownOption.RECOMMENDED:
+          case EventNavDropdownOption.LATEST:
+          case EventNavDropdownOption.OLDEST:
+            browserHistory.push({
+              pathname: normalizeUrl(
+                makeBaseEventsPath({organization, group}) + selectedOption.value + '/'
+              ),
+              query: {...location.query, referrer: `${selectedOption.value}-event`},
+            });
+            break;
+          case EventNavDropdownOption.ALL:
+            browserHistory.push({
+              pathname: normalizeUrl(
+                `/organizations/${organization.slug}/issues/${group.id}/events/`
+              ),
+              query: location.query,
+            });
+            break;
+          default:
+            break;
+        }
+      }}
+    />
+  );
+}
+
 export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarouselProps) {
   const theme = useTheme();
   const organization = useOrganization();
   const location = useLocation();
-  const largeViewport = useMedia(`(min-width: ${theme.breakpoints.large})`);
   const xlargeViewport = useMedia(`(min-width: ${theme.breakpoints.xlarge})`);
 
   const hasReplay = Boolean(event?.tags?.find(({key}) => key === 'replayId')?.value);
@@ -149,48 +217,54 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
 
   return (
     <CarouselAndButtonsWrapper>
-      <EventHeading>
-        <EventIdLabel>Event ID:</EventIdLabel>{' '}
-        <Button
-          aria-label={t('Copy')}
-          borderless
-          onClick={onClickCopy}
-          size="zero"
-          title={event.id}
-          tooltipProps={{overlayStyle: {maxWidth: 'max-content'}}}
-          translucentBorder
-        >
-          <EventId>
-            {getShortEventId(event.id)}
-            <CopyIconContainer>
-              <IconCopy size="xs" />
-            </CopyIconContainer>
-          </EventId>
-        </Button>{' '}
-        {(event.dateCreated ?? event.dateReceived) && (
-          <EventTimeLabel>
-            {getDynamicText({
-              fixed: 'Jan 1, 12:00 AM',
-              value: (
-                <Tooltip
-                  isHoverable
-                  showUnderline
-                  title={<EventCreatedTooltip event={event} />}
-                  overlayStyle={{maxWidth: 300}}
-                >
-                  <DateTime date={event.dateCreated ?? event.dateReceived} />
-                </Tooltip>
-              ),
-            })}
-            {isOverLatencyThreshold && (
-              <Tooltip title="High latency">
-                <StyledIconWarning size="xs" color="warningText" />
-              </Tooltip>
+      <div>
+        <EventHeading>
+          <EventIdAndTimeContainer>
+            <EventIdContainer>
+              <strong>Event ID:</strong>
+              <Button
+                aria-label={t('Copy')}
+                borderless
+                onClick={onClickCopy}
+                size="zero"
+                title={event.id}
+                tooltipProps={{overlayStyle: {maxWidth: 'max-content'}}}
+                translucentBorder
+              >
+                <EventId>
+                  {getShortEventId(event.id)}
+                  <CopyIconContainer>
+                    <IconCopy size="xs" />
+                  </CopyIconContainer>
+                </EventId>
+              </Button>
+            </EventIdContainer>
+            {(event.dateCreated ?? event.dateReceived) && (
+              <EventTimeLabel>
+                {getDynamicText({
+                  fixed: 'Jan 1, 12:00 AM',
+                  value: (
+                    <Tooltip
+                      isHoverable
+                      showUnderline
+                      title={<EventCreatedTooltip event={event} />}
+                      overlayStyle={{maxWidth: 300}}
+                    >
+                      <DateTime date={event.dateCreated ?? event.dateReceived} />
+                    </Tooltip>
+                  ),
+                })}
+                {isOverLatencyThreshold && (
+                  <Tooltip title="High latency">
+                    <StyledIconWarning size="xs" color="warningText" />
+                  </Tooltip>
+                )}
+              </EventTimeLabel>
             )}
-          </EventTimeLabel>
-        )}
+          </EventIdAndTimeContainer>
+        </EventHeading>
         <QuickTrace event={event} organization={organization} location={location} />
-      </EventHeading>
+      </div>
       <ActionsWrapper>
         <DropdownMenu
           position="bottom-end"
@@ -216,7 +290,7 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
               key: 'json',
               label: `JSON (${formatBytesBase2(event.size)})`,
               onAction: downloadJson,
-              hidden: largeViewport,
+              hidden: xlargeViewport,
             },
             {
               key: 'full-event-discover',
@@ -257,7 +331,7 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
             Copy Link
           </Button>
         )}
-        {largeViewport && (
+        {xlargeViewport && (
           <Button
             size={BUTTON_SIZE}
             icon={<IconOpen size={BUTTON_ICON_SIZE} />}
@@ -266,15 +340,8 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
             JSON
           </Button>
         )}
+        <EventNavigationDropdown group={group} />
         <NavButtons>
-          <EventNavigationButton
-            group={group}
-            icon={<IconPrevious size={BUTTON_ICON_SIZE} />}
-            disabled={!hasPreviousEvent}
-            title={t('First Event')}
-            eventId="oldest"
-            referrer="oldest-event"
-          />
           <EventNavigationButton
             group={group}
             icon={<IconChevron direction="left" size={BUTTON_ICON_SIZE} />}
@@ -291,14 +358,6 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
             eventId={event.nextEventID}
             referrer="next-event"
           />
-          <EventNavigationButton
-            group={group}
-            icon={<IconNext size={BUTTON_ICON_SIZE} />}
-            disabled={!hasNextEvent}
-            title={t('Latest Event')}
-            eventId="latest"
-            referrer="latest-event"
-          />
         </NavButtons>
       </ActionsWrapper>
     </CarouselAndButtonsWrapper>
@@ -314,6 +373,10 @@ const CarouselAndButtonsWrapper = styled('div')`
 `;
 
 const EventHeading = styled('div')`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: ${space(1)};
   font-size: ${p => p.theme.fontSizeLarge};
 
   @media (max-width: 600px) {
@@ -355,8 +418,18 @@ const NavButtons = styled('div')`
   }
 `;
 
-const EventIdLabel = styled('span')`
-  font-weight: bold;
+const EventIdAndTimeContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  column-gap: ${space(0.75)};
+  row-gap: 0;
+  flex-wrap: wrap;
+`;
+
+const EventIdContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  column-gap: ${space(0.25)};
 `;
 
 const EventTimeLabel = styled('span')`
@@ -377,6 +450,9 @@ const EventId = styled('span')`
     > span {
       display: flex;
     }
+  }
+  @media (max-width: 600px) {
+    font-size: ${p => p.theme.fontSizeMedium};
   }
 `;
 


### PR DESCRIPTION
This is an experimental UI to help clue the user in on what the default event is. It is gated by both `issue-details-most-helpful-event` and `issue-details-most-helpful-event-ui` so it only shown when both are enabled.

- Removes the oldest/latest nav buttons
- Adds a dropdown with recommended event, latest event, oldest event, and a link to the all events tab
- Adds the `/recommended` route which will act similarly to /oldest and /latest  
- Some style changes to ensure the header looks good at all resolutions

![CleanShot 2023-07-24 at 14 45 54](https://github.com/getsentry/sentry/assets/10888943/c08bd135-ed13-407b-821d-006e1493a51d)