### PR TITLE
fix(selfhosted) Revise migration 0434 to run cleanly on django 3.2

### DIFF
--- a/src/sentry/migrations/0434_notification_setting_target_id.py
+++ b/src/sentry/migrations/0434_notification_setting_target_id.py
@@ -26,17 +26,16 @@ class Migration(CheckedMigration):
     operations = [
         migrations.SeparateDatabaseAndState(
             state_operations=[
+                migrations.RemoveField(
+                    model_name="notificationsetting",
+                    name="target",
+                ),
                 migrations.AddField(
                     model_name="notificationsetting",
                     name="target_id",
                     field=sentry.db.models.fields.hybrid_cloud_foreign_key.HybridCloudForeignKey(
                         "sentry.Actor", db_index=True, null=False, on_delete="CASCADE"
                     ),
-                ),
-                migrations.RenameField(
-                    model_name="notificationsetting",
-                    old_name="target",
-                    new_name="target_id",
                 ),
                 migrations.AlterUniqueTogether(
                     name="notificationsetting",


### PR DESCRIPTION
When 0434 and 0439 were written we were on django 2.2. While these migrations ran fine in sentry.io environments, they are not running cleanly for self-hosted users. Several self-hosted users have reported an upgrade issue in 23.7.0 (django 3.2) where migration 0439 fails to run because `notificationsetting.target_id_id` doesn't exist.

By revising the state changes we can correct django 3.2's interpretation of the schema state to run cleanly.

Tested this by:

1. Start off with an empty database.
2. Checkout 23.4.0
3. Run `sentry upgrade` to build schema up to the point of 23.4.0
4. Checkout 23.7.0 and update deps with `make install-py-dev`.
5. Apply this patch.
6. Run `sentry upgrade` again.

Refs getsentry/self-hosted#2281

