### PR TITLE
chore(hybrid-cloud): Mark Bitbucket webhook endpoint as region silo

### DIFF
--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -7,9 +7,9 @@ from django.http import Http404, HttpResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
-from django.views.generic import View
 from rest_framework.request import Request
 
+from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.integrations.bitbucket.constants import BITBUCKET_IP_RANGES, BITBUCKET_IPS
 from sentry.models import Commit, CommitAuthor, Organization, Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
@@ -105,7 +105,9 @@ class PushEventWebhook(Webhook):
                     pass
 
 
-class BitbucketWebhookEndpoint(View):
+@region_silo_endpoint
+class BitbucketWebhookEndpoint(Endpoint):
+    permission_classes = ()
     _handlers = {"repo:push": PushEventWebhook}
 
     def get_handler(self, event_type):

--- a/tests/sentry/integrations/bitbucket/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket/test_webhook.py
@@ -16,6 +16,7 @@ BITBUCKET_IP_IN_RANGE = "104.192.143.10"
 BITBUCKET_IP = "34.198.178.64"
 
 
+@region_silo_test(stable=True)
 class WebhookBaseTest(APITestCase):
     endpoint = "sentry-extensions-bitbucket-webhook"
 
@@ -67,11 +68,13 @@ class WebhookBaseTest(APITestCase):
         )
 
 
+@region_silo_test(stable=True)
 class WebhookGetTest(WebhookBaseTest):
     def test_get_request_fails(self):
         self.get_error_response(self.organization_id, status_code=405)
 
 
+@region_silo_test(stable=True)
 class WebhookTest(WebhookBaseTest):
     method = "post"
 
@@ -107,7 +110,7 @@ class WebhookTest(WebhookBaseTest):
         )
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class PushEventWebhookTest(WebhookBaseTest):
     method = "post"
 


### PR DESCRIPTION


<!-- Describe your PR here. -->