### PR TITLE
fix(Issues): Switch from "timestamp" to "non-semver"

### DIFF
--- a/static/app/components/customResolutionModal.spec.tsx
+++ b/static/app/components/customResolutionModal.spec.tsx
@@ -111,7 +111,7 @@ describe('CustomResolutionModal', () => {
 
     selectEvent.openMenu(screen.getByText('e.g. 1.0.4'));
     expect(
-      await screen.findByRole('menuitemradio', {name: 'abcdef (timestamp)'})
+      await screen.findByRole('menuitemradio', {name: 'abcdef (non-semver)'})
     ).toBeInTheDocument();
     expect(
       screen.getByRole('menuitemradio', {name: '1.2.3 (semver)'})

--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -40,7 +40,7 @@ function CustomResolutionModal(props: CustomResolutionModalProps) {
             {hasIssueReleaseSemver
               ? isVersionInfoSemver(release.versionInfo.version)
                 ? t('(semver)')
-                : t('(timestamp)')
+                : t('(non-semver)')
               : null}
           </Fragment>
         ),

--- a/static/app/views/issueDetails/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/groupActivityItem.tsx
@@ -251,7 +251,7 @@ function GroupActivityItem({activity, organization, projectId, author}: Props) {
               semver: organization.features.includes('issue-release-semver')
                 ? isSemverRelease(currentVersion)
                   ? t('(semver)')
-                  : t('(timestamp)')
+                  : t('(non-semver)')
                 : '',
             }
           );
@@ -267,7 +267,7 @@ function GroupActivityItem({activity, organization, projectId, author}: Props) {
               semver: organization.features.includes('issue-release-semver')
                 ? isSemverRelease(version)
                   ? t('(semver)')
-                  : t('(timestamp)')
+                  : t('(non-semver)')
                 : '',
             })
           : tct('[author] marked this issue as resolved in the upcoming release', {

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -581,18 +581,4 @@ describe('ReleasesList', () => {
 
     expect(await screen.findByText('sentry@0.5.3')).toBeInTheDocument();
   });
-
-  it('renders if the version is using semver or timestamp', async () => {
-    const org = {...organization, features: ['issue-release-semver']};
-    render(<ReleasesList {...props} organization={org} />, {
-      context: routerContext,
-      organization: org,
-    });
-    const items = await screen.findAllByTestId('release-panel');
-
-    expect(items.length).toEqual(3);
-
-    expect(within(items.at(0)!).getByText('1.0.0')).toBeInTheDocument();
-    expect(within(items.at(0)!).getByText('(semver)')).toBeInTheDocument();
-  });
 });

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -17,7 +17,6 @@ import Version from 'sentry/components/version';
 import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization, PageFilters, Release} from 'sentry/types';
-import {isVersionInfoSemver} from 'sentry/views/releases/utils';
 
 import {ReleasesDisplayOption} from '../releasesDisplayOptions';
 import {ReleasesRequestRenderProps} from '../releasesRequest';
@@ -130,18 +129,13 @@ class ReleaseCard extends Component<Props> {
             )}
           </ReleaseInfoHeader>
           <ReleaseInfoSubheader>
-            <PackageSemver>
-              {versionInfo?.package && (
+            {versionInfo?.package && (
+              <PackageName>
                 <TextOverflow ellipsisDirection="left">
                   {versionInfo.package}
                 </TextOverflow>
-              )}
-              {organization.features.includes('issue-release-semver')
-                ? isVersionInfoSemver(versionInfo.version)
-                  ? t('(semver)')
-                  : t('(timestamp)')
-                : null}
-            </PackageSemver>
+              </PackageName>
+            )}
             <TimeSince date={lastDeploy?.dateFinished || dateCreated} />
             {lastDeploy?.dateFinished && ` \u007C ${lastDeploy.environment}`}
           </ReleaseInfoSubheader>
@@ -254,7 +248,7 @@ const ReleaseInfoSubheader = styled('div')`
   color: ${p => p.theme.gray400};
 `;
 
-const PackageSemver = styled('div')`
+const PackageName = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   color: ${p => p.theme.textColor};
   display: flex;


### PR DESCRIPTION
Responding to feedback:
- Instead of semver or timestamp. We're using semver or non-semver.
- Removes semver information from the release list.
