### PR TITLE
fix(ui): Align pending request and request access button

### DIFF
--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -291,6 +291,7 @@ export const GRID_TEMPLATE = `
 const TeamPanelItem = styled(PanelItem)`
   ${GRID_TEMPLATE}
   align-items: center;
+  display: flex;
 
   > div:last-child {
     margin-left: auto;


### PR DESCRIPTION
Before:
<img width="1264" alt="Screenshot 2023-07-21 at 3 24 40 PM" src="https://github.com/getsentry/sentry/assets/67301797/8a664fb5-3faa-44a1-9f09-2cc940fac461">

After:
<img width="1248" alt="Screenshot 2023-07-21 at 3 25 12 PM" src="https://github.com/getsentry/sentry/assets/67301797/6a3cf1e8-4ad7-4534-91c3-9a1b28baf53d">