### PR TITLE
fix(crons): Correct UUID(0) lastest check-in logic

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -305,12 +305,14 @@ def _process_message(wrapper: Dict) -> None:
                 if use_latest_checkin:
                     check_in = (
                         MonitorCheckIn.objects.select_for_update()
+                        .filter(monitor_environment=monitor_environment)
                         .exclude(status__in=CheckInStatus.FINISHED_VALUES)
                         .order_by("-date_added")[:1]
                         .get()
                     )
                 else:
                     check_in = MonitorCheckIn.objects.select_for_update().get(
+                        monitor_environment=monitor_environment,
                         guid=check_in_id,
                     )
 

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -326,15 +326,20 @@ class MonitorConsumerTest(TestCase):
         assert open_checkin.status == CheckInStatus.IN_PROGRESS
         assert open_checkin.guid != uuid.UUID(int=0)
 
+        # Send an event to a different monitor environment, tests that when we
+        # use the empty UUID "latest" we properly scope to the latest of the
+        # same monitor environment
+        self.send_message("my-monitor", status="in_progress", environment="dev")
+
         self.send_message(
             "my-monitor",
             status="ok",
             guid=str(uuid.UUID(int=0)),
         )
 
-        close_checkin = MonitorCheckIn.objects.get(guid=open_checkin.guid)
-        assert close_checkin.status == CheckInStatus.OK
-        assert close_checkin.guid != uuid.UUID(int=0)
+        closed_checkin = MonitorCheckIn.objects.get(guid=open_checkin.guid)
+        assert closed_checkin.status == CheckInStatus.OK
+        assert closed_checkin.guid != uuid.UUID(int=0)
 
     def test_rate_limit(self):
         monitor = self._create_monitor(slug="my-monitor")


### PR DESCRIPTION
Prior to this fix when sending a monitor check-in message with a null UUID, we would attempt to find the "most recent check in which is not at a terminal status". The actual query for this was lacking a filter on the monitor_environment that we wanted the most recent check-in for however. This meant we would be **querying the most recent check-in without a terminal value across all of Sentry**.

This was not correct.

This logic was not yet being used by anything aside from the new Relay monitor check-in API.

I've also restricted the MonitorCheckIn lookup for when we have provided a GUID to prevent updating check-ins with known GUIDs that are outside of the monitor environment the check-in was sent for.