### PR TITLE
feat(code-snippet): Add onSelectAndCopy prop

### DIFF
--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -69,20 +69,6 @@ export function CodeSnippet({
       ? t('Copied')
       : t('Unable to copy');
 
-  useEffect(() => {
-    const element = ref.current;
-    if (!element) {
-      return;
-    }
-
-    if (language in Prism.languages) {
-      Prism.highlightElement(element);
-      return;
-    }
-
-    loadPrismLanguage(language, {onLoad: () => Prism.highlightElement(element)});
-  }, [children, language]);
-
   return (
     <Wrapper className={`${dark ? 'prism-dark ' : ''}${className ?? ''}`}>
       <Header hasFileName={!!filename}>

--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -16,6 +16,10 @@ interface CodeSnippetProps {
   filename?: string;
   hideCopyButton?: boolean;
   onCopy?: (copiedCode: string) => void;
+  /**
+   * Fired when the user selects and copies code snippet manually
+   */
+  onSelectAndCopy?: () => void;
 }
 
 export function CodeSnippet({
@@ -26,6 +30,7 @@ export function CodeSnippet({
   hideCopyButton,
   onCopy,
   className,
+  onSelectAndCopy,
 }: CodeSnippetProps) {
   const ref = useRef<HTMLModElement | null>(null);
 
@@ -64,6 +69,20 @@ export function CodeSnippet({
       ? t('Copied')
       : t('Unable to copy');
 
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+
+    if (language in Prism.languages) {
+      Prism.highlightElement(element);
+      return;
+    }
+
+    loadPrismLanguage(language, {onLoad: () => Prism.highlightElement(element)});
+  }, [children, language]);
+
   return (
     <Wrapper className={`${dark ? 'prism-dark ' : ''}${className ?? ''}`}>
       <Header hasFileName={!!filename}>
@@ -85,7 +104,11 @@ export function CodeSnippet({
       </Header>
 
       <pre className={`language-${String(language)}`}>
-        <code ref={ref} className={`language-${String(language)}`}>
+        <code
+          ref={ref}
+          className={`language-${String(language)}`}
+          onCopy={onSelectAndCopy}
+        >
           {children}
         </code>
       </pre>

--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -43,6 +43,10 @@ type ConfigurationType = {
    * A callback to be invoked when the configuration is copied to the clipboard
    */
   onCopy?: () => void;
+  /**
+   * A callback to be invoked when the configuration is selected and copied to the clipboard
+   */
+  onSelectAndCopy?: () => void;
 };
 
 interface BaseStepProps {
@@ -74,12 +78,18 @@ function getConfiguration({
   language,
   additionalInfo,
   onCopy,
+  onSelectAndCopy,
 }: ConfigurationType) {
   return (
     <Configuration>
       {description && <Description>{description}</Description>}
       {language && code && (
-        <CodeSnippet dark language={language} onCopy={onCopy}>
+        <CodeSnippet
+          dark
+          language={language}
+          onCopy={onCopy}
+          onSelectAndCopy={onSelectAndCopy}
+        >
           {language === 'javascript'
             ? beautify.js(code, {indent_size: 2, e4x: true})
             : code.trim()}

--- a/static/app/components/onboarding/gettingStartedDoc/utils.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils.tsx
@@ -51,6 +51,22 @@ export function getUploadSourceMapsStep({
             }
           );
         },
+        onSelectAndCopy: () => {
+          if (!organization || !projectId || !platformKey) {
+            return;
+          }
+
+          trackAnalytics(
+            newOrg
+              ? 'onboarding.source_maps_wizard_selected_and_copied'
+              : 'project_creation.source_maps_wizard_selected_and_copied',
+            {
+              project_id: projectId,
+              platform: platformKey,
+              organization,
+            }
+          );
+        },
       },
     ],
   };

--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -63,6 +63,10 @@ export type OnboardingEventParameters = {
     platform: string;
     project_id: string;
   };
+  'onboarding.source_maps_wizard_selected_and_copied': {
+    platform: string;
+    project_id: string;
+  };
   'onboarding.view_error_button_clicked': {
     new_organization: boolean;
     platform: string;
@@ -102,4 +106,6 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
   'onboarding.data_removed': 'Onboarding: Data Removed',
   'onboarding.source_maps_wizard_button_copy_clicked':
     'Onboarding: Source Maps Wizard Copy Button Clicked',
+  'onboarding.source_maps_wizard_selected_and_copied':
+    'Onboarding: Source Maps Wizard Selected and Copied',
 };

--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -28,6 +28,10 @@ export type ProjectCreationEventParameters = {
     platform: string;
     project_id: string;
   };
+  'project_creation.source_maps_wizard_selected_and_copied': {
+    platform: string;
+    project_id: string;
+  };
 };
 
 export const projectCreationEventMap: Record<
@@ -52,4 +56,6 @@ export const projectCreationEventMap: Record<
   'project_creation.back_button_clicked': 'Project Creation: Back Button Clicked',
   'project_creation.source_maps_wizard_button_copy_clicked':
     'Project Creation: Source Maps Wizard Button Copy Clicked',
+  'project_creation.source_maps_wizard_selected_and_copied':
+    'Project Creation: Source Maps Wizard Selected and Copied',
 };


### PR DESCRIPTION
In addition to knowing if the user is clicking on the button to copy the code, we would also like to know if the user manually interacts with the code, copying it. This pull request adds the `onSelectAndCopy` prop to the code snippet so that we can trigger more analytics code through this event.

New events:

'onboarding.source_maps_wizard_selected_and_copied': 'Onboarding: Source Maps Wizard Selected and Copied'
'project_creation.source_maps_wizard_selected_and_copied': 'Project Creation: Source Maps Wizard Selected and Copied'


Related to https://github.com/getsentry/sentry/pull/53252