### PR TITLE
fix(getting-started-docs): Fix duplicated translation

### DIFF
--- a/static/app/gettingStartedDocs/node/azurefunctions.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.tsx
@@ -2,7 +2,7 @@ import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDo
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {PlatformKey} from 'sentry/data/platformCategories';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types';
 
 type StepProps = {
@@ -36,13 +36,7 @@ npm install --save @sentry/node
   },
   {
     type: StepType.CONFIGURE,
-    description: (
-      <p>
-        {tct('To set up Sentry error logging for an Azure Function:', {
-          code: <code />,
-        })}
-      </p>
-    ),
+    description: t('To set up Sentry error logging for an Azure Function:'),
     configurations: [
       {
         language: 'javascript',
@@ -75,8 +69,8 @@ module.exports = async function (context, req) {
         description: (
           <p>
             {tct(
-              'Note: You need to call both [code:captureException] and [code:flush] for captured events to be successfully delivered to Sentry.',
-              {}
+              'Note: You need to call both [captureExceptionCode:captureException] and [flushCode:flush] for captured events to be successfully delivered to Sentry.',
+              {captureExceptionCode: <code />, flushCode: <code />}
             )}
           </p>
         ),

--- a/static/app/gettingStartedDocs/node/connect.tsx
+++ b/static/app/gettingStartedDocs/node/connect.tsx
@@ -3,7 +3,7 @@ import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDoc
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {PlatformKey} from 'sentry/data/platformCategories';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types';
 
 type StepProps = {
@@ -38,7 +38,7 @@ npm install --save @sentry/node
   },
   {
     type: StepType.CONFIGURE,
-    description: <p>{tct('Configure Sentry as a middleware:', {code: <code />})}</p>,
+    description: t('Configure Sentry as a middleware:'),
     configurations: [
       {
         language: 'javascript',

--- a/static/app/gettingStartedDocs/node/serverlesscloud.tsx
+++ b/static/app/gettingStartedDocs/node/serverlesscloud.tsx
@@ -46,13 +46,7 @@ export const steps = ({
   },
   {
     type: StepType.CONFIGURE,
-    description: (
-      <p>
-        {tct('Sentry should be initialized as early in your app as possible.', {
-          code: <code />,
-        })}
-      </p>
-    ),
+    description: t('Sentry should be initialized as early in your app as possible.'),
     configurations: [
       {
         language: 'javascript',


### PR DESCRIPTION
Fix a few translation duplications due to an issue in the `tct` function and other minor tweaks. Example:

**Before:**

<img width="699" alt="image" src="https://github.com/getsentry/sentry/assets/29228205/76349c70-d1e1-4026-a30e-43632d6d9d4d">

**After:**

<img width="877" alt="image" src="https://github.com/getsentry/sentry/assets/29228205/8cf8d266-4c18-48c8-a591-6c3136a584ec">
