### PR TITLE
fix(alerts): match interval to granularity

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -126,6 +126,8 @@ class MetricsQueryBuilder(QueryBuilder):
             limit = self.limit
             alias = spec.mri
 
+        granularity = self.resolve_granularity()
+
         return MetricsQuery(
             select=[MetricField(spec.op, spec.mri, alias=alias)],
             where=[
@@ -137,8 +139,9 @@ class MetricsQueryBuilder(QueryBuilder):
             ],
             limit=limit,
             offset=self.offset,
-            granularity=self.resolve_granularity(),
-            is_alerts_query=self.is_alerts_query,
+            interval=int(granularity.granularity),
+            granularity=granularity,
+            is_alerts_query=True,
             org_id=self.params.organization.id,
             project_ids=[p.id for p in self.params.projects],
             include_series=True,


### PR DESCRIPTION
Assures that the query interval is not smaller than the resolved granularity.
Fixes gaps in chart when looking at bigger timeframes 
<img width="784" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/0349277d-3d4f-4352-90a5-07d4f3e11aa5">
