### PR TITLE
ref: Attach original symbolicator error type to js processing errors

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -113,18 +113,37 @@ def map_symbolicator_process_js_errors(errors):
         abs_path = error["abs_path"]
 
         if ty == "invalid_abs_path" and not should_skip_missing_source_error(abs_path):
-            mapped_errors.append({"type": EventError.JS_MISSING_SOURCE, "url": abs_path})
+            mapped_errors.append(
+                {
+                    "symbolicator_type": ty,
+                    "type": EventError.JS_MISSING_SOURCE,
+                    "url": abs_path,
+                }
+            )
         elif ty == "missing_source" and not should_skip_missing_source_error(abs_path):
-            mapped_errors.append({"type": EventError.JS_MISSING_SOURCE, "url": abs_path})
+            mapped_errors.append(
+                {"symbolicator_type": ty, "type": EventError.JS_MISSING_SOURCE, "url": abs_path}
+            )
         elif ty == "missing_sourcemap" and not should_skip_missing_source_error(abs_path):
-            mapped_errors.append({"type": EventError.JS_MISSING_SOURCE, "url": abs_path})
+            mapped_errors.append(
+                {"symbolicator_type": ty, "type": EventError.JS_MISSING_SOURCE, "url": abs_path}
+            )
         elif ty == "scraping_disabled":
-            mapped_errors.append({"type": EventError.JS_SCRAPING_DISABLED, "url": abs_path})
+            mapped_errors.append(
+                {"symbolicator_type": ty, "type": EventError.JS_SCRAPING_DISABLED, "url": abs_path}
+            )
         elif ty == "malformed_sourcemap":
-            mapped_errors.append({"type": EventError.JS_INVALID_SOURCEMAP, "url": error["url"]})
+            mapped_errors.append(
+                {
+                    "symbolicator_type": ty,
+                    "type": EventError.JS_INVALID_SOURCEMAP,
+                    "url": error["url"],
+                }
+            )
         elif ty == "missing_source_content":
             mapped_errors.append(
                 {
+                    "symbolicator_type": ty,
                     "type": EventError.JS_MISSING_SOURCES_CONTENT,
                     "source": error["source"],
                     "sourcemap": error["sourcemap"],
@@ -133,6 +152,7 @@ def map_symbolicator_process_js_errors(errors):
         elif ty == "invalid_location":
             mapped_errors.append(
                 {
+                    "symbolicator_type": ty,
                     "type": EventError.JS_INVALID_SOURCEMAP_LOCATION,
                     "column": error["col"],
                     "row": error["line"],

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -357,11 +357,13 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
         event = self.post_and_retrieve_event(data)
 
-        assert event.data["errors"] == [{
-            "type": "js_no_source",
-            "symbolicator_type": "missing_source",
-            "url": "http//example.com/index.html"
-        }]
+        assert event.data["errors"] == [
+            {
+                "type": "js_no_source",
+                "symbolicator_type": "missing_source",
+                "url": "http//example.com/index.html",
+            }
+        ]
 
         exception = event.interfaces["exception"]
         frame_list = exception.values[0].stacktrace.frames
@@ -545,11 +547,13 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
         event = self.post_and_retrieve_event(data)
 
-        assert event.data["errors"] == [{
-            "type": "js_no_source",
-            "symbolicator_type": "missing_source",
-            "url": "http//example.com/index.html"
-        }]
+        assert event.data["errors"] == [
+            {
+                "type": "js_no_source",
+                "symbolicator_type": "missing_source",
+                "url": "http//example.com/index.html",
+            }
+        ]
 
         exception = event.interfaces["exception"]
         frame_list = exception.values[0].stacktrace.frames

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -357,9 +357,11 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
         event = self.post_and_retrieve_event(data)
 
-        assert event.data["errors"] == [
-            {"type": "js_no_source", "url": "http//example.com/index.html"}
-        ]
+        assert event.data["errors"] == [{
+            "type": "js_no_source",
+            "symbolicator_type": "missing_source",
+            "url": "http//example.com/index.html"
+        }]
 
         exception = event.interfaces["exception"]
         frame_list = exception.values[0].stacktrace.frames
@@ -543,9 +545,11 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
         event = self.post_and_retrieve_event(data)
 
-        assert event.data["errors"] == [
-            {"type": "js_no_source", "url": "http//example.com/index.html"}
-        ]
+        assert event.data["errors"] == [{
+            "type": "js_no_source",
+            "symbolicator_type": "missing_source",
+            "url": "http//example.com/index.html"
+        }]
 
         exception = event.interfaces["exception"]
         frame_list = exception.values[0].stacktrace.frames
@@ -1927,9 +1931,9 @@ class TestJavascriptIntegration(RelayStoreHelper):
         event = self.post_and_retrieve_event(data)
 
         assert len(event.data["errors"]) == 1
-
         assert event.data["errors"][0] == {
             "type": "js_invalid_source",
+            "symbolicator_type": "malformed_sourcemap",
             "url": "http://example.com/file.malformed.sourcemap.js",
         }
 
@@ -2471,6 +2475,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert len(event.data["errors"]) == 1
         assert event.data["errors"][0] == {
             "type": "js_invalid_source",
+            "symbolicator_type": "malformed_sourcemap",
             "url": "http://example.com/file.malformed.sourcemap.js",
         }
 


### PR DESCRIPTION
It's annoying that `JS_MISSING_SOURCE` can be 3 different errors for example, so reporting upstream service error is imo reasonable.
Depends on merging https://github.com/getsentry/sentry/pull/49675 first and updating relevant tests.