### PR TITLE
fix(alerts): skip on demand for standard alerts

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -1000,7 +1000,7 @@ class AlertMetricsQueryBuilder(MetricsQueryBuilder):
 
             snuba_request = self.get_metrics_layer_snql_query()
 
-            if self.on_demand_metrics_enabled:
+            if self.on_demand_metrics_enabled and self._on_demand_spec:
                 metrics_query = self._get_on_demand_metrics_query()
             else:
                 metrics_query = transform_mqb_query_to_metrics_query(


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/53409
Fixes one case skipped by
- #53416
