### PR TITLE
ref(getting-started-docs): Migrate unity wizard to the main sentry repo

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -77,6 +77,7 @@ export const migratedDocs = [
   'electron',
   'elixir',
   'android',
+  'unity',
 ];
 
 type SdkDocumentationProps = {
@@ -118,6 +119,8 @@ export function SdkDocumentation({
         ? `native/native-qt`
         : platform?.id === 'android'
         ? `android/android`
+        : platform?.id === 'unity'
+        ? `unity/unity`
         : platform?.id.replace(`${platform.language}-`, `${platform.language}/`)
       : `${platform?.language}/${platform?.id}`;
 

--- a/static/app/gettingStartedDocs/unity/unity.spec.tsx
+++ b/static/app/gettingStartedDocs/unity/unity.spec.tsx
@@ -1,0 +1,20 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+
+import {GettingStartedWithUnity, steps} from './unity';
+
+describe('GettingStartedWithUnity', function () {
+  it('renders doc correctly', function () {
+    const {container} = render(<GettingStartedWithUnity dsn="test-dsn" />);
+
+    // Steps
+    for (const step of steps()) {
+      expect(
+        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
+      ).toBeInTheDocument();
+    }
+
+    expect(container).toSnapshot();
+  });
+});

--- a/static/app/gettingStartedDocs/unity/unity.tsx
+++ b/static/app/gettingStartedDocs/unity/unity.tsx
@@ -1,0 +1,131 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Alert} from 'sentry/components/alert';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {t, tct} from 'sentry/locale';
+
+// Configuration Start
+export const steps = ({
+  dsn,
+}: {
+  dsn?: string;
+} = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: (
+      <p>
+        {tct(
+          "Install the package via the [link:Unity Package Manager] using a Git URL to Sentry's SDK repository:",
+          {
+            link: (
+              <ExternalLink href="https://docs.unity3d.com/Manual/upm-ui-giturl.html" />
+            ),
+          }
+        )}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'bash',
+        code: 'https://github.com/getsentry/unity.git#1.5.0',
+      },
+    ],
+    additionalInfo: (
+      <AlertWithoutMarginBottom type="info">
+        {tct(
+          'The Unity SDK now supports line numbers for IL2CPP. The feature is currently in beta, but you can enable it at [code:Tools -> Sentry -> Advanced -> IL2CPP] line numbers. To learn more check out our [link:docs].',
+          {
+            code: <code />,
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/unity/configuration/il2cpp/" />
+            ),
+          }
+        )}
+      </AlertWithoutMarginBottom>
+    ),
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: (
+      <p>
+        {tct(
+          "Access the Sentry configuration window by going to Unity's top menu: [toolsCode:Tools] > [sentryCode:Sentry] and enter the following DSN:",
+          {toolsCode: <code />, sentryCode: <code />}
+        )}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'bash',
+        code: dsn,
+      },
+    ],
+    additionalInfo: (
+      <Fragment>
+        {t("And that's it! Now Sentry can capture errors automatically.")}
+        <p>
+          {tct('If you like additional contexts you could enable [link:Screenshots].', {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/unity/enriching-events/screenshots/" />
+            ),
+          })}
+        </p>
+      </Fragment>
+    ),
+  },
+  {
+    type: StepType.VERIFY,
+    description: t(
+      'Once it is configured with the DSN you can call the SDK from anywhere:'
+    ),
+    configurations: [
+      {
+        language: 'csharp',
+
+        code: `
+using Sentry; // On the top of the script
+
+SentrySdk.CaptureMessage("Test event");
+        `,
+      },
+    ],
+  },
+  {
+    title: t('Troubleshooting'),
+    description: (
+      <Fragment>
+        {t(
+          "Confirm the URL doesn't have a trailing whitespace at the end. The Unity Package Manager will fail to find the package if a trailing whitespace is appended."
+        )}
+        <p>
+          {tct(
+            "If you're running into any kind of issue please check out our [troubleshootingLink:troubleshooting page] or [raiseAnIssueLink:raise an issue].",
+            {
+              troubleshootingLink: (
+                <ExternalLink href="https://docs.sentry.io/platforms/unity/troubleshooting/" />
+              ),
+              raiseAnIssueLink: (
+                <ExternalLink href="https://github.com/getsentry/sentry-unity/issues/new?assignees=&labels=Platform%3A+Unity%2CType%3A+Bug&template=bug.md" />
+              ),
+            }
+          )}
+        </p>
+      </Fragment>
+    ),
+  },
+];
+// Configuration End
+
+export function GettingStartedWithUnity({dsn, ...props}: ModuleProps) {
+  return <Layout steps={steps({dsn})} {...props} />;
+}
+
+export default GettingStartedWithUnity;
+
+const AlertWithoutMarginBottom = styled(Alert)`
+  margin-bottom: 0;
+`;


### PR DESCRIPTION
This PR represents the outcome of our chosen https://github.com/getsentry/sentry/pull/50169, aiming to enhance our getting started documentation in the Sentry repository using React.

closes: https://github.com/getsentry/sentry/issues/52143 and https://github.com/getsentry/sentry/issues/52160