### PR TITLE
ref(getting-started-docs): Migrate cordova to sentry main repo

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -78,6 +78,7 @@ export const migratedDocs = [
   'elixir',
   'android',
   'unity',
+  'cordova',
 ];
 
 type SdkDocumentationProps = {

--- a/static/app/gettingStartedDocs/cordova/cordova.spec.tsx
+++ b/static/app/gettingStartedDocs/cordova/cordova.spec.tsx
@@ -1,0 +1,20 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+
+import {GettingStartedWithCordova, steps} from './cordova';
+
+describe('GettingStartedWithCordova', function () {
+  it('renders doc correctly', function () {
+    const {container} = render(<GettingStartedWithCordova dsn="test-dsn" />);
+
+    // Steps
+    for (const step of steps()) {
+      expect(
+        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
+      ).toBeInTheDocument();
+    }
+
+    expect(container).toSnapshot();
+  });
+});

--- a/static/app/gettingStartedDocs/cordova/cordova.tsx
+++ b/static/app/gettingStartedDocs/cordova/cordova.tsx
@@ -1,0 +1,77 @@
+import {Fragment} from 'react';
+
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {t, tct} from 'sentry/locale';
+
+// Configuration Start
+export const steps = ({
+  dsn,
+}: {
+  dsn?: string;
+} = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: t('Install our SDK using the cordova command:'),
+    configurations: [
+      {
+        language: 'bash',
+        code: 'cordova plugin add sentry-cordova',
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: (
+      <p>
+        {tct(
+          'You should [initCode:init] the SDK in the [deviceReadyCode:deviceReady] function, to make sure the native integrations runs. For more details about Cordova [link:click here]',
+          {
+            initCode: <code />,
+            deviceReadyCode: <code />,
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/cordova/" />
+            ),
+          }
+        )}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+onDeviceReady: function() {
+  var Sentry = cordova.require('sentry-cordova.Sentry');
+  Sentry.init({ dsn: '${dsn}' });
+}
+        `,
+      },
+    ],
+  },
+  {
+    type: StepType.VERIFY,
+    description: (
+      <Fragment>
+        {t(
+          'One way to verify your setup is by intentionally causing an error that breaks your application.'
+        )}
+        <p>{t('Calling an undefined function will throw an exception:')}</p>
+      </Fragment>
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: 'myUndefinedFunction();',
+      },
+    ],
+  },
+];
+// Configuration End
+
+export function GettingStartedWithCordova({dsn, ...props}: ModuleProps) {
+  return <Layout steps={steps({dsn})} {...props} />;
+}
+
+export default GettingStartedWithCordova;


### PR DESCRIPTION
This PR represents the outcome of our chosen https://github.com/getsentry/sentry/pull/50169, aiming to enhance our getting started documentation in the Sentry repository using React.

closes: https://github.com/getsentry/sentry/issues/52210 and https://github.com/getsentry/sentry/issues/52138