### PR TITLE
Add metrics to bundle uploads

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1669,8 +1669,6 @@ SENTRY_FEATURES = {
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.
     "projects:custom-inbound-filters": False,
-    # Enable indexing of artifact bundles for sourcemaps.
-    "organizations:sourcemaps-bundle-indexing": False,
     # Enable data forwarding functionality for projects.
     "projects:data-forwarding": True,
     # Enable functionality to discard groups.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -259,7 +259,6 @@ default_manager.add("organizations:ds-sliding-window-org", OrganizationFeature, 
 default_manager.add("organizations:pr-comment-bot", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:ds-org-recalibration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-use-new-lookup", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:sourcemaps-bundle-indexing", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 
 # Project scoped features
 default_manager.add("projects:alert-filters", ProjectFeature, FeatureHandlerStrategy.INTERNAL)

--- a/tests/sentry/debug_files/test_artifact_bundles.py
+++ b/tests/sentry/debug_files/test_artifact_bundles.py
@@ -9,7 +9,6 @@ from sentry.models import FileBlob
 from sentry.models.artifactbundle import ArtifactBundle, ArtifactBundleIndex
 from sentry.tasks.assemble import assemble_artifacts
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.utils import json
 
 
@@ -83,7 +82,6 @@ class ArtifactLookupTest(TestCase):
         redis_client = get_redis_cluster_for_artifact_bundles()
         redis_client.flushall()
 
-    @with_feature("organizations:sourcemaps-bundle-indexing")
     def test_indexing_artifacts(self):
         self.clear_cache()
 

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -625,17 +625,16 @@ class AssembleArtifactsTest(BaseAssembleTest):
         blob1_1 = FileBlob.from_file(ContentFile(bundle_file_1))
         total_checksum_1 = sha1(bundle_file_1).hexdigest()
 
-        with self.feature("organizations:sourcemaps-bundle-indexing"):
-            # We try to upload the first bundle.
-            assemble_artifacts(
-                org_id=self.organization.id,
-                project_ids=[self.project.id],
-                version=release,
-                dist=dist,
-                checksum=total_checksum_1,
-                chunks=[blob1_1.checksum],
-                upload_as_artifact_bundle=True,
-            )
+        # We try to upload the first bundle.
+        assemble_artifacts(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            version=release,
+            dist=dist,
+            checksum=total_checksum_1,
+            chunks=[blob1_1.checksum],
+            upload_as_artifact_bundle=True,
+        )
 
         # Since the threshold is not surpassed we expect the system to not perform indexing.
         index_artifact_bundles_for_release.assert_not_called()
@@ -646,17 +645,16 @@ class AssembleArtifactsTest(BaseAssembleTest):
         blob1_2 = FileBlob.from_file(ContentFile(bundle_file_2))
         total_checksum_2 = sha1(bundle_file_2).hexdigest()
 
-        with self.feature("organizations:sourcemaps-bundle-indexing"):
-            # We try to upload the first bundle.
-            assemble_artifacts(
-                org_id=self.organization.id,
-                project_ids=[self.project.id],
-                version=release,
-                dist=dist,
-                checksum=total_checksum_2,
-                chunks=[blob1_2.checksum],
-                upload_as_artifact_bundle=True,
-            )
+        # We try to upload the first bundle.
+        assemble_artifacts(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            version=release,
+            dist=dist,
+            checksum=total_checksum_2,
+            chunks=[blob1_2.checksum],
+            upload_as_artifact_bundle=True,
+        )
 
         bundles = ArtifactBundle.objects.all()
 


### PR DESCRIPTION
As a driveby, this also removes the enabled-by-default feature flag for bundle indexing