### PR TITLE
Silence errors uploading different `ArtifactBundle`s

### DIFF
--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -634,8 +634,9 @@ class ArtifactBundlePostAssembler(PostAssembler):
             # We store a reference to the previous file to which the bundle was pointing to.
             existing_file = existing_artifact_bundle.file
 
-            if existing_file.checksum != self.assemble_result.bundle.checksum:
-                logger.error("Detected duplicated `ArtifactBundle` with differing checksums")
+            # FIXME: We might want to get this error, but it currently blocks deploys
+            # if existing_file.checksum != self.assemble_result.bundle.checksum:
+            #    logger.error("Detected duplicated `ArtifactBundle` with differing checksums")
 
             # Only if the file objects are different we want to update the database, otherwise we will end up deleting
             # a newly bound file.


### PR DESCRIPTION
This happens when an `ArtifactBundle` has a `bundle_id` collision, but has a different file checksum. This shouldn’t happen, but for whatever reason this happens a lot actually.

For now, lets silence the error so that deploys can go on.