### PR TITLE
fix(sdk): Fix client report recording in multiplexer

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -421,6 +421,14 @@ def configure_sdk():
                         tags={"reason": "unsafe"},
                     )
 
+        def record_lost_event(self, *args, **kwargs):
+            # pass through client report recording to sentry_saas_transport
+            # not entirely accurate for some cases like rate limiting but does the job
+            if sentry_saas_transport:
+                record = getattr(sentry_saas_transport, "record_lost_event", None)
+                if record:
+                    record(*args, **kwargs)
+
         def is_healthy(self):
             if sentry4sentry_transport:
                 if not sentry4sentry_transport.is_healthy():


### PR DESCRIPTION
`MultiplexingTransport` didn't implement `record_lost_event` so our sentry setup is completely missing Client Reports. Note that this is not 100% accurate for some cases like rate limiting on the s4s transport but it's fine.