### PR TITLE
fix(functions): Ensure functions timeseries is non empty

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -178,6 +178,7 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
                         "request_end": v[data["function"]]["end"],
                     }
                     for k, v in stats_data.items()
+                    if v[data["function"]]["data"]
                 },
                 "sort": data["trend"].as_sort(),
                 "trendFunction": data["function"],


### PR DESCRIPTION
It's possible that the timeseries is an empty array which will error when we try to use the first 20% as historical data. Make sure to handle this.

Fixes SENTRY-1402