### PR TITLE
feat(unified-consumer): Set default max poll interval to 45 seconds

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -684,6 +684,7 @@ def profiles_consumer(**options):
 @click.option(
     "--max-poll-interval-ms",
     type=int,
+    default=45000,
 )
 @click.option(
     "--synchronize-commit-log-topic",


### PR DESCRIPTION
We've been running with this value in the indexer for quite a while now, let's roll it this default to all consumers.
