### PR TITLE
feat(generic-metrics): Add sentry option to disable misbehaving use case IDs

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -914,6 +914,8 @@ register(
     "sentry-metrics.performance.index-tag-values", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 
+# Option to disable misbehaving use case IDs
+register("sentry-metrics.indexer.disabled-namespaces", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # A slow rollout option for writing "new" cache keys
 # as the transition from UseCaseKey to UseCaseID occurs


### PR DESCRIPTION
### Overview

Adds an option to disable misbehaving use case IDs.
See https://github.com/getsentry/sentry/pull/53369