### PR TITLE
ref(projects): Redirect after project transfer

### DIFF
--- a/static/app/views/acceptProjectTransfer/index.tsx
+++ b/static/app/views/acceptProjectTransfer/index.tsx
@@ -47,7 +47,7 @@ class AcceptProjectTransfer extends DeprecatedAsyncView<Props, State> {
         if (!projectSlug) {
           window.location.href = `${sentryUrl}/organizations/${orgSlug}/projects/`;
         } else {
-          window.location.href = `${sentryUrl}/organizations/${orgSlug}/settings/${orgSlug}/projects/${projectSlug}/teams/`;
+          window.location.href = `${sentryUrl}/organizations/${orgSlug}/settings/projects/${projectSlug}/teams/`;
           // done this way since we need to change subdomains
         }
       },

--- a/static/app/views/acceptProjectTransfer/index.tsx
+++ b/static/app/views/acceptProjectTransfer/index.tsx
@@ -1,6 +1,6 @@
 import {RouteComponentProps} from 'react-router';
 
-import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import Form from 'sentry/components/forms/form';
 import NarrowLayout from 'sentry/components/narrowLayout';
@@ -44,12 +44,12 @@ class AcceptProjectTransfer extends DeprecatedAsyncView<Props, State> {
         const orgSlug = formData.organization;
         const projectSlug = this.state?.transferDetails?.project.slug;
         const sentryUrl = ConfigStore.get('links').sentryUrl;
-        if (projectSlug === null) {
+        if (!projectSlug) {
           window.location.href = `${sentryUrl}/organizations/${orgSlug}/projects/`;
         } else {
           window.location.href = `${sentryUrl}/settings/${orgSlug}/projects/${projectSlug}/teams/`;
+          // done this way since we need to change subdomains
         }
-        addSuccessMessage(t('Project successfully transferred'));
       },
       error: error => {
         const errorMsg =

--- a/static/app/views/acceptProjectTransfer/index.tsx
+++ b/static/app/views/acceptProjectTransfer/index.tsx
@@ -47,7 +47,7 @@ class AcceptProjectTransfer extends DeprecatedAsyncView<Props, State> {
         if (!projectSlug) {
           window.location.href = `${sentryUrl}/organizations/${orgSlug}/projects/`;
         } else {
-          window.location.href = `${sentryUrl}/settings/${orgSlug}/projects/${projectSlug}/teams/`;
+          window.location.href = `${sentryUrl}/organizations/${orgSlug}/settings/${orgSlug}/projects/${projectSlug}/teams/`;
           // done this way since we need to change subdomains
         }
       },


### PR DESCRIPTION
Take 2 of https://github.com/getsentry/sentry/pull/52925 

When a user approves transferring a project to a new organization the project isn't added to a team which results in confusion because the project doesn't show up on the projects page. The user needs to add the project to a team for it to show up in most places in the UI, so we should redirect them to the appropriate page to do so.