### PR TITLE
feat(issues): Display if an issue regressed using semver

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -329,6 +329,16 @@ interface GroupActivityMarkReviewed extends GroupActivityBase {
 
 interface GroupActivityRegression extends GroupActivityBase {
   data: {
+    /**
+     * True if the project is using semver to decide if the event is a regression.
+     * Available when the issue was resolved in a release.
+     */
+    follows_semver?: boolean;
+    /**
+     * The version that the issue was previously resolved in.
+     * Available when the issue was resolved in a release.
+     */
+    resolved_in_version?: string;
     version?: string;
   };
   type: GroupActivityType.SET_REGRESSION;

--- a/static/app/views/issueDetails/groupActivity.spec.tsx
+++ b/static/app/views/issueDetails/groupActivity.spec.tsx
@@ -624,4 +624,91 @@ describe('GroupActivity', function () {
       'Foo Bar marked this issue as resolved in releases greater than 1.0.0 (semver)'
     );
   });
+
+  describe('regression', function () {
+    it('renders basic regression', function () {
+      createWrapper({
+        activity: [
+          {
+            id: '123',
+            type: GroupActivityType.SET_REGRESSION,
+            project: TestStubs.Project(),
+            data: {},
+            dateCreated,
+          },
+        ],
+      });
+      expect(screen.getAllByTestId('activity-item').at(-1)).toHaveTextContent(
+        'Sentry marked this issue as a regression'
+      );
+    });
+    it('renders regression with version', function () {
+      createWrapper({
+        activity: [
+          {
+            id: '123',
+            type: GroupActivityType.SET_REGRESSION,
+            project: TestStubs.Project(),
+            data: {
+              version: 'frontend@1.0.0',
+            },
+            dateCreated,
+          },
+        ],
+      });
+      expect(screen.getAllByTestId('activity-item').at(-1)).toHaveTextContent(
+        'Sentry marked this issue as a regression in 1.0.0'
+      );
+    });
+    it('renders regression with semver description', function () {
+      createWrapper({
+        activity: [
+          {
+            id: '123',
+            type: GroupActivityType.SET_REGRESSION,
+            project: TestStubs.Project(),
+            data: {
+              version: 'frontend@2.0.0',
+              resolved_in_version: 'frontend@1.0.0',
+              follows_semver: true,
+            },
+            dateCreated,
+          },
+        ],
+        organization: TestStubs.Organization({features: ['issue-release-semver']}),
+      });
+      const activity = screen.getAllByTestId('activity-item').at(-1);
+      expect(activity).toHaveTextContent(
+        'Sentry marked this issue as a regression in 2.0.0'
+      );
+      expect(activity).toHaveTextContent(
+        '2.0.0 is greater than or equal to 1.0.0 compared via semver'
+      );
+    });
+    it('renders regression with non-semver description', function () {
+      createWrapper({
+        activity: [
+          {
+            id: '123',
+            type: GroupActivityType.SET_REGRESSION,
+            project: TestStubs.Project(),
+            data: {
+              version: 'frontend@abc1',
+              resolved_in_version: 'frontend@abc2',
+              follows_semver: false,
+            },
+            dateCreated,
+          },
+        ],
+        organization: TestStubs.Organization({features: ['issue-release-semver']}),
+      });
+      const activity = screen.getAllByTestId('activity-item').at(-1);
+      expect(activity).toHaveTextContent(
+        'Sentry marked this issue as a regression in abc1'
+      );
+      expect(activity).toHaveTextContent(
+        'abc1 is greater than or equal to abc2 compared via release date'
+      );
+    });
+  });
 });


### PR DESCRIPTION
After resolving an issue in a release, it can become a regression.

Displays if semver or release date was used to decide if the event is a regression.
![image](https://github.com/getsentry/sentry/assets/1400464/0a1c3729-235b-480e-b77f-683df9a66f9a)
