### PR TITLE
OPS-3435 - Increase Profiles log verbosity to facilitate debug of weird rabbitmq consumer behavior.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1237,6 +1237,7 @@ LOGGING = {
         "sentry.errors": {"handlers": ["console"], "propagate": False},
         "sentry_sdk.errors": {"handlers": ["console"], "level": "INFO", "propagate": False},
         "sentry.rules": {"handlers": ["console"], "propagate": False},
+        "sentry.profiles": {"level": "INFO"},
         "multiprocessing": {
             "handlers": ["console"],
             # https://github.com/celery/celery/commit/597a6b1f3359065ff6dbabce7237f86b866313df


### PR DESCRIPTION
This PR increases the log level of the `sentry.profiles` module such that better introspection can be done around the rabbitmq workers.

Follow up on INC-368