### PR TITLE
ref(features): Remove ProjectFeature inheritence from ProjectPluginFeature

### DIFF
--- a/src/sentry/features/base.py
+++ b/src/sentry/features/base.py
@@ -62,10 +62,14 @@ class ProjectFeature(Feature):
         return self.project.organization
 
 
-class ProjectPluginFeature(ProjectFeature):
+class ProjectPluginFeature(Feature):
     def __init__(self, name: str, project: Project, plugin: Any) -> None:
-        super().__init__(name, project=project)
+        super().__init__(name)
+        self.project = project
         self.plugin = plugin
+
+    def get_subject(self) -> Organization:
+        return self.project.organization
 
 
 class UserFeature(Feature):


### PR DESCRIPTION
This class should not inherit ProjectFeature, it is different from a ProjectFeature and was likely only inheriting ProjectFeature to share code (which is not what inheritance is for).

This fixes an issue exposed by GH-51169 where a call to `features.all(feature_name=ProjectFeature)` was including ProjectPluginFeature's and failing to instantiate the classes since they also require a `plugin` parameter.

This fixes that by simply removing ProjectPluginFeature's from the inheritance tree.