### PR TITLE
ref(grouping): Parameterize double-quoted values in event message

### DIFF
--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -100,7 +100,8 @@ _parameterization_regex = re.compile(
     (?P<quoted_str>
         # The `=` here guarantees we'll only match the value half of key-value pairs,
         # rather than all quoted strings
-        ='([\w\s]+)'
+        ='([^']+)' |
+        ="([^"]+)"
     )
 """
 )

--- a/tests/sentry/grouping/grouping_inputs/message_with_key_pair_values.json
+++ b/tests/sentry/grouping/grouping_inputs/message_with_key_pair_values.json
@@ -1,5 +1,5 @@
 {
-    "message": "Error key1='Some_str123' key2=123456789 key3=False key4=datetime.datetime(2023, 5, 2, 23, 46, tzinfo=datetime.timezone.utc) other_date=datetime.datetime(2023, 5, 3, 1, 10, tzinfo=d...",
+    "message": "Error key1='Some_str123' key2=123456789 key3=False key4=datetime.datetime(2023, 5, 2, 23, 46, tzinfo=datetime.timezone.utc) key5=\"double-quoted\" other_date=datetime.datetime(2023, 5, 3, 1, 10, tzinfo=d...",
     "metadata": {
         "title": "Error key1='Some_str123' key2=123456789 key3=False k..."
     },
@@ -11,12 +11,12 @@
                 "type": "log",
                 "category": "network_evaluation_scheduler.processors.flight_snapshot_processor",
                 "level": "error",
-                "message": "Error key1='Some_str123' key2=123456789 key3=False key4=datetime.datetime(2023, 5, 2, 23, 46, tzinfo=datetime.timezone.utc) other_date=datetime.datetime(2023, 5, 3, 1, 10, tzinfo=d..."
+                "message": "Error key1='Some_str123' key2=123456789 key3=False key4=datetime.datetime(2023, 5, 2, 23, 46, tzinfo=datetime.timezone.utc) key5=\"double-quoted\" other_date=datetime.datetime(2023, 5, 3, 1, 10, tzinfo=d..."
             }
         ]
     },
     "logentry": {
-        "formatted": "Error key1='Some_str123' key2=123456789 key3=False key4=datetime.datetime(2023, 5, 2, 23, 46, tzinfo=datetime.timezone.utc) other_date=datetime.datetime(2023, 5, 3, 1, 10, tzinfo=d...",
+        "formatted": "Error key1='Some_str123' key2=123456789 key3=False key4=datetime.datetime(2023, 5, 2, 23, 46, tzinfo=datetime.timezone.utc) key5=\"double-quoted\" other_date=datetime.datetime(2023, 5, 3, 1, 10, tzinfo=d...",
         "params": []
     }
 }

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/message_with_key_pair_values.pysnap
@@ -1,9 +1,11 @@
 ---
+created: '2023-07-24T22:42:31.602082Z'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
-  hash: "4a0a375b4876203928159c841d799b43"
+  hash: "61490ee252f3d4dd5a19680dca2410d3"
   component:
     default*
       message*
-        "Error key1='Some_str123' key2=123456789 key3=False key4=datetime.datetime(2023, 5, 2, 23, 46, tzinfo=datetime.timezone.utc) other_date=datetime.datetime(2023, 5, 3, 1, 10, tzinfo=d..."
+        "Error key1='Some_str123' key2=123456789 key3=False key4=datetime.datetime(2023, 5, 2, 23, 46, tzinfo=datetime.timezone.utc) key5=\"double-quoted\" other_date=datetime.datetime(2023, 5, 3, 1, 10, tzinfo=d..."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/message_with_key_pair_values.pysnap
@@ -1,9 +1,11 @@
 ---
+created: '2023-07-24T22:43:03.707098Z'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
-  hash: "e02854e73673e108fe54768e0f19317b"
+  hash: "c5719fccd9d95c4eddb130cf98d78cda"
   component:
     default*
       message* (stripped event-specific values)
-        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."
+        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/message_with_key_pair_values.pysnap
@@ -1,9 +1,11 @@
 ---
+created: '2023-07-24T22:43:34.318316Z'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
-  hash: "4a0a375b4876203928159c841d799b43"
+  hash: "61490ee252f3d4dd5a19680dca2410d3"
   component:
     default*
       message*
-        "Error key1='Some_str123' key2=123456789 key3=False key4=datetime.datetime(2023, 5, 2, 23, 46, tzinfo=datetime.timezone.utc) other_date=datetime.datetime(2023, 5, 3, 1, 10, tzinfo=d..."
+        "Error key1='Some_str123' key2=123456789 key3=False key4=datetime.datetime(2023, 5, 2, 23, 46, tzinfo=datetime.timezone.utc) key5=\"double-quoted\" other_date=datetime.datetime(2023, 5, 3, 1, 10, tzinfo=d..."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/message_with_key_pair_values.pysnap
@@ -1,9 +1,11 @@
 ---
+created: '2023-07-24T22:43:46.663689Z'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
-  hash: "e02854e73673e108fe54768e0f19317b"
+  hash: "c5719fccd9d95c4eddb130cf98d78cda"
   component:
     default*
       message* (stripped event-specific values)
-        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."
+        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/message_with_key_pair_values.pysnap
@@ -1,9 +1,11 @@
 ---
+created: '2023-07-24T22:42:42.075927Z'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
-  hash: "e02854e73673e108fe54768e0f19317b"
+  hash: "c5719fccd9d95c4eddb130cf98d78cda"
   component:
     default*
       message* (stripped event-specific values)
-        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."
+        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/message_with_key_pair_values.pysnap
@@ -1,9 +1,11 @@
 ---
+created: '2023-07-24T22:42:52.586415Z'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
-  hash: "e02854e73673e108fe54768e0f19317b"
+  hash: "c5719fccd9d95c4eddb130cf98d78cda"
   component:
     default*
       message* (stripped event-specific values)
-        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."
+        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/message_with_key_pair_values.pysnap
@@ -1,9 +1,11 @@
 ---
+created: '2023-07-24T22:43:19.678209Z'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
-  hash: "e02854e73673e108fe54768e0f19317b"
+  hash: "c5719fccd9d95c4eddb130cf98d78cda"
   component:
     default*
       message* (stripped event-specific values)
-        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."
+        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."


### PR DESCRIPTION
When considering an event's message as part of the grouping algorithm, we strip out event-specific values to increase the chances that events with "the same message" will match each other and be grouped together. One of the (no pun intended) key places we do this is with key-value pairs, so that event whose respective messages are `[INFO] Dogs are great. name='Maisey' dob=12-31-2012` and `[INFO] Dogs are great. name='Charlie' dob=11-21-2012` both become `[INFO] Dogs are great. name=<quoted_str> dob=<date>` for the purposes of grouping.

Though this parameterization works with string values using single quotes, it doesn't work for string values using double quotes. This PR adds that ability. It also fixes a small bug with our existing single-quoted-string parameterization, wherein strings containing non-word, non-digit characters (things like `-` and `%`) weren't being matched.

Ref: https://github.com/getsentry/sentry/issues/52719