### PR TITLE
ref(hybrid-cloud): Fix a few tests in split silo mode

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -41,7 +41,7 @@ class AlertRuleSerializer(Serializer):
 
         sentry_app_installations_by_sentry_app_id = app_service.get_related_sentry_app_components(
             organization_ids=[alert_rule.organization_id for alert_rule in alert_rules.values()],
-            sentry_app_ids=trigger_actions.values_list("sentry_app_id", flat=True),
+            sentry_app_ids=list(trigger_actions.values_list("sentry_app_id", flat=True)),
             type="alert-rule-action",
         )
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -13,6 +13,7 @@ from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSeri
 from sentry.models import OrganizationMemberTeam, SentryAppComponent, SentryAppInstallation
 from sentry.models.actor import ACTOR_TYPES
 from sentry.models.rulesnooze import RuleSnooze
+from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.user.service import user_service
 
 
@@ -83,6 +84,9 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
                 "access": request.access,
                 "user": request.user,
                 "ip_address": request.META.get("REMOTE_ADDR"),
+                "installations": app_service.get_installed_for_organization(
+                    organization_id=organization.id
+                ),
             },
             instance=alert_rule,
             data=request.data,

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -267,8 +267,11 @@ def create_incident_activity(
                     for mentioned_user_id in user_ids_to_subscribe
                 ]
             )
-    tasks.send_subscriber_notifications.apply_async(
-        kwargs={"activity_id": activity.id}, countdown=10
+    transaction.on_commit(
+        lambda: tasks.send_subscriber_notifications.apply_async(
+            kwargs={"activity_id": activity.id}, countdown=10
+        ),
+        router.db_for_write(IncidentSubscription),
     )
     if activity_type == IncidentActivityType.COMMENT:
         analytics.record(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -17,7 +17,11 @@ from sentry.incidents.models import (
 )
 from sentry.incidents.serializers import AlertRuleSerializer
 from sentry.models import AuditLogEntry, OrganizationMemberTeam
+from sentry.services.hybrid_cloud.app import app_service
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase
+from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from tests.sentry.incidents.endpoints.test_organization_alert_rule_index import AlertRuleBase
 
 
@@ -33,6 +37,9 @@ class AlertRuleDetailsBase(AlertRuleBase):
                 "organization": self.organization,
                 "access": OrganizationGlobalAccess(self.organization, settings.SENTRY_SCOPES),
                 "user": self.user,
+                "installations": app_service.get_installed_for_organization(
+                    organization_id=self.organization.id
+                ),
             },
             data=data,
         )
@@ -90,6 +97,7 @@ class AlertRuleDetailsBase(AlertRuleBase):
         assert resp.status_code == 404
 
 
+@region_silo_test(stable=True)
 class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
     def test_simple(self):
         self.create_team(organization=self.organization, members=[self.user])
@@ -196,6 +204,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert response.data["snoozeCreatedBy"] == user2.get_display_name()
 
 
+@region_silo_test(stable=True)
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
     method = "put"
 
@@ -210,7 +219,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule = self.get_serialized_alert_rule()
         serialized_alert_rule["name"] = "what"
 
-        with self.feature("organizations:incidents"):
+        with self.feature("organizations:incidents"), outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
@@ -221,9 +230,10 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data["name"] == "what"
         assert resp.data["dateModified"] > serialized_alert_rule["dateModified"]
 
-        audit_log_entry = AuditLogEntry.objects.filter(
-            event=audit_log.get_event_id("ALERT_RULE_EDIT"), target_object=alert_rule.id
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            audit_log_entry = AuditLogEntry.objects.filter(
+                event=audit_log.get_event_id("ALERT_RULE_EDIT"), target_object=alert_rule.id
+            )
         assert len(audit_log_entry) == 1
         assert (
             resp.renderer_context["request"].META["REMOTE_ADDR"]
@@ -538,6 +548,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data == serialize(alert_rule, self.user)
 
 
+@region_silo_test(stable=True)
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
     method = "delete"
 


### PR DESCRIPTION
This avoid passing QuerySet objects into RPC methods, and also marks as safe an RPC read that happens in a transaction. Normally we would work to avoid the latter, but this particular one is nested fairly deeply inside the transaction. We may circle back to it.