### PR TITLE
ref(generic-metrics): Update option to apply uca limiting by default

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1006,7 +1006,7 @@ register(
 
 register(
     "sentry-metrics.writes-limiter.apply-uca-limiting",
-    default=False,
+    default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 # per-organization limits on the number of timeseries that can be observed in

--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -146,7 +146,6 @@ def test_static_and_non_static_strings_generic_metrics(indexer):
         {
             "sentry-metrics.writes-limiter.limits.spans.global": [],
             "sentry-metrics.writes-limiter.limits.spans.per-org": [],
-            "sentry-metrics.writes-limiter.apply-uca-limiting": True,
         },
     ):
         results = static_indexer.bulk_record(strings=strings)


### PR DESCRIPTION
### Overview

Update the sentry option `sentry-metrics.writes-limiter.apply-uca-limiting` to True by default, this value is already set to `True` in production, so updating this will just make it easier to test the metrics platform locally.

Eventually this option will be removed and uca limiting will be always on.