### PR TITLE
ref(grouping): Parameterize boolean values in event message

### DIFF
--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/message_with_key_pair_values.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2023-07-24T22:43:03.707098Z'
+created: '2023-07-24T22:47:08.366266Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
-  hash: "c5719fccd9d95c4eddb130cf98d78cda"
+  hash: "d2ab1028e9cb44352a824e878951f412"
   component:
     default*
       message* (stripped event-specific values)
-        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."
+        "Error key1=<quoted_str> key2=<int> key3=<bool> key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/message_with_key_pair_values.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2023-07-24T22:43:46.663689Z'
+created: '2023-07-24T22:47:47.424381Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
-  hash: "c5719fccd9d95c4eddb130cf98d78cda"
+  hash: "d2ab1028e9cb44352a824e878951f412"
   component:
     default*
       message* (stripped event-specific values)
-        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."
+        "Error key1=<quoted_str> key2=<int> key3=<bool> key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/message_with_key_pair_values.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2023-07-24T22:42:42.075927Z'
+created: '2023-07-24T22:46:44.614750Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
-  hash: "c5719fccd9d95c4eddb130cf98d78cda"
+  hash: "d2ab1028e9cb44352a824e878951f412"
   component:
     default*
       message* (stripped event-specific values)
-        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."
+        "Error key1=<quoted_str> key2=<int> key3=<bool> key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/message_with_key_pair_values.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2023-07-24T22:42:52.586415Z'
+created: '2023-07-24T22:46:55.422933Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
-  hash: "c5719fccd9d95c4eddb130cf98d78cda"
+  hash: "d2ab1028e9cb44352a824e878951f412"
   component:
     default*
       message* (stripped event-specific values)
-        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."
+        "Error key1=<quoted_str> key2=<int> key3=<bool> key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/message_with_key_pair_values.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2023-07-24T22:43:19.678209Z'
+created: '2023-07-24T22:47:22.571430Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
-  hash: "c5719fccd9d95c4eddb130cf98d78cda"
+  hash: "d2ab1028e9cb44352a824e878951f412"
   component:
     default*
       message* (stripped event-specific values)
-        "Error key1=<quoted_str> key2=<int> key3=False key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."
+        "Error key1=<quoted_str> key2=<int> key3=<bool> key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."


### PR DESCRIPTION
When considering an event's message as part of the grouping algorithm, we strip out event-specific values to increase the chances that events with "the same message" will match each other and be grouped together. One of the (no pun intended) key places we do this is with key-value pairs, so that events whose respective messages are `[INFO] Dogs are great. name='Maisey' dob=12-31-2012` and `[INFO] Dogs are great. name='Charlie' dob=11-21-2012` both become `[INFO] Dogs are great. name=<quoted_str> dob=<date>` for the purposes of grouping.

This PR adds booleans to the list of datatypes we parameterize.

Ref: https://github.com/getsentry/sentry/issues/52719