### PR TITLE
fix(ci): Increase codecov `comment.after_n_builds` value

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -51,20 +51,22 @@ flags:
     - "static/app/"
     carryforward: true
     # FE uploads 4 coverage reports. This property ensures codecov waits
-    #  for all reports to be uploaded before creating a GitHub status check.
+    # for all reports to be uploaded before creating a GitHub status check.
+    # NOTE: If you change this, make sure to change `comment.after_n_builds` below as well.
     after_n_builds: 4
   backend:
     paths:
     - "src/sentry/**/*.py"
     carryforward: true
-    # Do not send any status checks until N coverage reports are uploaded
+    # Do not send any status checks until n coverage reports are uploaded.
+    # NOTE: If you change this, make sure to change `comment.after_n_builds` below as well.
     after_n_builds: 18
 
 # Read more here: https://docs.codecov.com/docs/pull-request-comments
 comment:
   # This is the addition of carry forward builds and fresh builds, thus, it's the addition
   # of the FE and BE builds
-  after_n_builds: 20
+  after_n_builds: 22
   layout: "diff, files"
   # Update, if comment exists. Otherwise post new.
   behavior: default


### PR DESCRIPTION
When adding BE test shards, we've been correctly incrementing the `backend.after_n_builds` value in `codecov.yml`, but we've missed incrementing `comment.after_n_builds`, which is meant to be the total of `frontend.after_n_builds` and `backend.after_n_builds`. This fixes that and adds a note to both the frontend and backend values, reminding future folks to keep the `comment.after_n_builds` value in sync.

(The purpose of `comment.after_n_builds` is to make codecov wait until it's gotten that many reports before adding its coverage comment to a PR. When it's too low, coverage calculations are often incorrect, because they're calculated too soon.)