### PR TITLE
fix(workflow): Paginate projects in notification settings

### DIFF
--- a/static/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -142,16 +142,6 @@ type State = DeprecatedAsyncView['state'] & {
 };
 
 class AccountNotificationFineTuning extends DeprecatedAsyncView<Props, State> {
-  getDefaultState() {
-    return {
-      ...super.getDefaultState(),
-      emails: [],
-      fineTuneData: null,
-      notifications: [],
-      projects: [],
-    };
-  }
-
   getEndpoints(): ReturnType<DeprecatedAsyncView['getEndpoints']> {
     const {fineTuneType: pathnameType} = this.props.params;
     const fineTuneType = getNotificationTypeFromPathname(pathnameType);
@@ -223,7 +213,7 @@ class AccountNotificationFineTuning extends DeprecatedAsyncView<Props, State> {
     const field = ACCOUNT_NOTIFICATION_FIELDS[fineTuneType];
     const {title, description} = field;
 
-    const [stateKey, url] = isProject ? this.getEndpoints()[2] : [];
+    const [stateKey] = isProject ? this.getEndpoints()[2] : [];
     const hasProjects = !!projects?.length;
 
     if (fineTuneType === 'email') {
@@ -272,7 +262,7 @@ class AccountNotificationFineTuning extends DeprecatedAsyncView<Props, State> {
                 />
                 {this.renderSearchInput({
                   placeholder: t('Search Projects'),
-                  url,
+                  url: `/projects/?organizationId=${orgId}`,
                   stateKey,
                 })}
               </Fragment>

--- a/static/app/views/settings/account/notifications/notificationSettingsByOrganization.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByOrganization.tsx
@@ -1,4 +1,5 @@
 import Form from 'sentry/components/forms/form';
+import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
 import {OrganizationSummary} from 'sentry/types';
 import withOrganizations from 'sentry/utils/withOrganizations';
@@ -31,25 +32,27 @@ function NotificationSettingsByOrganization({
   organizations,
 }: Props) {
   return (
-    <Form
-      saveOnBlur
-      apiMethod="PUT"
-      apiEndpoint="/users/me/notification-settings/"
-      initialData={getParentData(notificationType, notificationSettings, organizations)}
-      onSubmitSuccess={onSubmitSuccess}
-    >
-      <StyledJsonForm
-        title={t('Organizations')}
-        fields={organizations.map(organization => {
-          return getParentField(
-            notificationType,
-            notificationSettings,
-            organization,
-            onChange
-          );
-        })}
-      />
-    </Form>
+    <Panel>
+      <Form
+        saveOnBlur
+        apiMethod="PUT"
+        apiEndpoint="/users/me/notification-settings/"
+        initialData={getParentData(notificationType, notificationSettings, organizations)}
+        onSubmitSuccess={onSubmitSuccess}
+      >
+        <StyledJsonForm
+          title={t('Organizations')}
+          fields={organizations.map(organization => {
+            return getParentField(
+              notificationType,
+              notificationSettings,
+              organization,
+              onChange
+            );
+          })}
+        />
+      </Form>
+    </Panel>
   );
 }
 

--- a/static/app/views/settings/account/notifications/notificationSettingsByProjects.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByProjects.spec.tsx
@@ -5,7 +5,7 @@ import {Project} from 'sentry/types';
 import NotificationSettingsByProjects from 'sentry/views/settings/account/notifications/notificationSettingsByProjects';
 
 const renderComponent = (projects: Project[]) => {
-  const {routerContext, organization} = initializeOrg();
+  const {organization} = initializeOrg();
 
   MockApiClient.addMockResponse({
     url: `/projects/`,
@@ -28,11 +28,8 @@ const renderComponent = (projects: Project[]) => {
       notificationSettings={notificationSettings}
       onChange={jest.fn()}
       onSubmitSuccess={jest.fn()}
-      organizationId={organization.id}
       organizations={[organization]}
-      handleOrgChange={jest.fn()}
-    />,
-    {context: routerContext}
+    />
   );
 };
 

--- a/static/app/views/settings/account/notifications/notificationSettingsByProjects.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByProjects.tsx
@@ -125,7 +125,6 @@ class NotificationSettingsByProjects extends DeprecatedAsyncComponent<Props, Sta
 
     const renderSearch: RenderSearch = ({defaultSearchBar}) => defaultSearchBar;
     const orgId = this.getOrganizationId();
-
     return (
       <Fragment>
         <Panel>
@@ -135,7 +134,6 @@ class NotificationSettingsByProjects extends DeprecatedAsyncComponent<Props, Sta
               organizationId={orgId}
               handleOrgChange={this.handleOrgChange}
             />
-
             {canSearch &&
               this.renderSearchInput({
                 stateKey: 'projects',

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -1,6 +1,6 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import ConfigStore from 'sentry/stores/configStore';
 import {OrganizationIntegration} from 'sentry/types/integrations';
 import {NotificationSettingsObject} from 'sentry/views/settings/account/notifications/constants';
 import NotificationSettingsByType from 'sentry/views/settings/account/notifications/notificationSettingsByType';
@@ -41,16 +41,18 @@ function renderComponent(
   identities: Identity[] = [],
   organizationIntegrations: OrganizationIntegration[] = []
 ) {
-  const {routerContext} = initializeOrg();
   const org = TestStubs.Organization();
   renderMockRequests(notificationSettings, identities, organizationIntegrations);
 
-  render(<NotificationSettingsByType notificationType="alerts" organizations={[org]} />, {
-    context: routerContext,
-  });
+  render(<NotificationSettingsByType notificationType="alerts" organizations={[org]} />);
 }
 
 describe('NotificationSettingsByType', function () {
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+  });
+
   it('should render when everything is disabled', function () {
     renderComponent({
       alerts: {user: {me: {email: 'never', slack: 'never'}}},
@@ -110,5 +112,38 @@ describe('NotificationSettingsByType', function () {
         /You've selected Slack as your delivery method, but do not have a linked account for the following organizations/
       )
     ).not.toBeInTheDocument();
+  });
+
+  it('should default to the subdomain org', async function () {
+    const organization = TestStubs.Organization();
+    const otherOrganization = TestStubs.Organization({
+      id: '2',
+      slug: 'other-org',
+      name: 'other org',
+    });
+    ConfigStore.set('customerDomain', {
+      ...ConfigStore.get('customerDomain')!,
+      subdomain: otherOrganization.slug,
+    });
+    renderMockRequests({
+      alerts: {user: {me: {email: 'always', slack: 'always'}}},
+    });
+    const projectsMock = MockApiClient.addMockResponse({
+      url: '/projects/',
+      query: {
+        organizationId: otherOrganization.id,
+      },
+      method: 'GET',
+      body: [],
+    });
+
+    render(
+      <NotificationSettingsByType
+        notificationType="alerts"
+        organizations={[organization, otherOrganization]}
+      />
+    );
+    expect(await screen.findByText(otherOrganization.name)).toBeInTheDocument();
+    expect(projectsMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -1,11 +1,9 @@
 import {Fragment} from 'react';
 
 import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
-import SelectControl from 'sentry/components/forms/controls/selectControl';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import {Field} from 'sentry/components/forms/types';
-import Panel from 'sentry/components/panels/panel';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {Organization, OrganizationSummary} from 'sentry/types';
@@ -41,45 +39,6 @@ import {
 } from 'sentry/views/settings/account/notifications/utils';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
-
-type OrganizationSelectHeaderProps = {
-  handleOrgChange: Function;
-  organizationId: string;
-  organizations: Organization[];
-};
-
-export function OrganizationSelectHeader({
-  handleOrgChange,
-  organizationId,
-  organizations,
-}: OrganizationSelectHeaderProps) {
-  const getOrganizationOptions = () => {
-    return organizations.map(org => {
-      return {
-        label: org.name,
-        value: org.id,
-      };
-    });
-  };
-
-  return (
-    <Fragment>
-      {t('Settings for Organization')}
-      <SelectControl
-        options={getOrganizationOptions()}
-        onChange={handleOrgChange}
-        // getOptionValue={option => option.value}
-        value={organizationId}
-        styles={{
-          container: (provided: {[x: string]: string | number | boolean}) => ({
-            ...provided,
-            minWidth: `300px`,
-          }),
-        }}
-      />
-    </Fragment>
-  );
-}
 
 type Props = {
   notificationType: string;
@@ -119,7 +78,6 @@ class NotificationSettingsByType extends DeprecatedAsyncComponent<Props, State> 
       notificationSettings: {},
       identities: [],
       organizationIntegrations: [],
-      organizationId: null,
     };
   }
 
@@ -360,10 +318,6 @@ class NotificationSettingsByType extends DeprecatedAsyncComponent<Props, State> 
     });
   };
 
-  handleOrgChange = (option: {label: string; value: string}) => {
-    this.setState({organizationId: option.value});
-  };
-
   renderBody() {
     const {notificationType} = this.props;
     const {notificationSettings} = this.state;
@@ -396,28 +350,23 @@ class NotificationSettingsByType extends DeprecatedAsyncComponent<Props, State> 
             fields={this.getFields()}
           />
         </Form>
-        {!isEverythingDisabled(notificationType, notificationSettings) && (
-          <Panel>
-            {isGroupedByProject(notificationType) ? (
-              <NotificationSettingsByProjects
-                notificationType={notificationType}
-                notificationSettings={notificationSettings}
-                onChange={this.getStateToPutForParent}
-                onSubmitSuccess={() => this.trackTuningUpdated('project')}
-                organizations={this.props.organizations}
-                organizationId={this.state.organizationId}
-                handleOrgChange={this.handleOrgChange}
-              />
-            ) : (
-              <NotificationSettingsByOrganization
-                notificationType={notificationType}
-                notificationSettings={notificationSettings}
-                onChange={this.getStateToPutForParent}
-                onSubmitSuccess={() => this.trackTuningUpdated('organization')}
-              />
-            )}
-          </Panel>
-        )}
+        {!isEverythingDisabled(notificationType, notificationSettings) &&
+          (isGroupedByProject(notificationType) ? (
+            <NotificationSettingsByProjects
+              notificationType={notificationType}
+              notificationSettings={notificationSettings}
+              onChange={this.getStateToPutForParent}
+              onSubmitSuccess={() => this.trackTuningUpdated('project')}
+              organizations={this.props.organizations}
+            />
+          ) : (
+            <NotificationSettingsByOrganization
+              notificationType={notificationType}
+              notificationSettings={notificationSettings}
+              onChange={this.getStateToPutForParent}
+              onSubmitSuccess={() => this.trackTuningUpdated('organization')}
+            />
+          ))}
       </Fragment>
     );
   }

--- a/static/app/views/settings/account/notifications/organizationSelectHeader.tsx
+++ b/static/app/views/settings/account/notifications/organizationSelectHeader.tsx
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+
+import SelectControl from 'sentry/components/forms/controls/selectControl';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
+
+type OrganizationSelectHeaderProps = {
+  handleOrgChange: (orgId: string) => void;
+  organizationId: string | undefined;
+  organizations: Organization[];
+};
+
+export function OrganizationSelectHeader({
+  handleOrgChange,
+  organizationId,
+  organizations,
+}: OrganizationSelectHeaderProps) {
+  return (
+    <OrgControlWrapper>
+      {t('Settings for Organization')}
+      <StyledSelectControl
+        options={organizations.map(org => {
+          return {
+            label: org.name,
+            value: org.id,
+          };
+        })}
+        onChange={option => handleOrgChange(option.value)}
+        value={organizationId}
+        styles={{
+          container: (provided: {[x: string]: string | number | boolean}) => ({
+            ...provided,
+            minWidth: `200px`,
+          }),
+        }}
+      />
+    </OrgControlWrapper>
+  );
+}
+
+const StyledSelectControl = styled(SelectControl)`
+  text-transform: initial;
+  font-weight: normal;
+`;
+
+const OrgControlWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(2)};
+  flex-grow: 1;
+`;

--- a/static/app/views/settings/account/notifications/organizationSelectHeader.tsx
+++ b/static/app/views/settings/account/notifications/organizationSelectHeader.tsx
@@ -29,7 +29,7 @@ export function OrganizationSelectHeader({
         onChange={option => handleOrgChange(option.value)}
         value={organizationId}
         styles={{
-          container: (provided: {[x: string]: string | number | boolean}) => ({
+          container: (provided: Record<string, string>) => ({
             ...provided,
             minWidth: `200px`,
           }),
@@ -39,6 +39,7 @@ export function OrganizationSelectHeader({
   );
 }
 
+// Resetting styles because its in a panel header
 const StyledSelectControl = styled(SelectControl)`
   text-transform: initial;
   font-weight: normal;

--- a/static/app/views/settings/account/notifications/organizationSelectHeader.tsx
+++ b/static/app/views/settings/account/notifications/organizationSelectHeader.tsx
@@ -47,6 +47,6 @@ const StyledSelectControl = styled(SelectControl)`
 const OrgControlWrapper = styled('div')`
   display: flex;
   align-items: center;
-  gap: ${space(2)};
+  gap: ${space(1)};
   flex-grow: 1;
 `;


### PR DESCRIPTION
- Somewhat fixes project pagination in fine tune. >100 projects will still display incorrectly since we don't have the notification settings data but you can paginate through projects correctly.
- Default to the org in the current subdomain instead of `organizations[0]`
- Fixes org picker layout overflow on mobile
- Fixes bold and capitalized dropdown because the header is in the panel header
- Moves selected organization id to the query parameters

alignment issues before
![image](https://github.com/getsentry/sentry/assets/1400464/1c3c60e1-f614-49ed-819e-7f985803cd3b)

after
![image](https://github.com/getsentry/sentry/assets/1400464/4c2a1dc8-b4da-41c4-8356-09d9e1a3d46c)
