### PR TITLE
ref(escalating-issues): Use new index for more efficient query

### DIFF
--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -131,7 +131,7 @@ def schedule_auto_transition_to_ongoing() -> None:
 @log_error_if_queue_has_items
 def auto_transition_issues_new_to_ongoing(
     project_ids: List[int],
-    first_seen_lte: int,  # TODO(nisanthan): Remove this arg in next PR
+    first_seen_lte: int,
     **kwargs,
 ) -> None:
     """

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -89,22 +89,22 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
         new_groups = []
         older_groups = []
         for day, hours in [
-            (0, 0),
-            (1, 1),
-            (2, 2),
-            (2, 9),  # recent group_inbox should stay the same
-            (3, 1),
-            (3, 2),
-            (3, 3),
-            (3, 12),
-            (3, 15),
-            (3, 18),
-            (3, 21),
-            (3, 24),  # 3+ day olds ones
-            (7, 14),
-            (12, 1),
+            (17, 2),  # really old issues would be created first
             (15, 5),
-            (17, 2),  # really old issues
+            (12, 1),
+            (7, 14),
+            (3, 24),  # 3+ day olds ones
+            (3, 21),
+            (3, 18),
+            (3, 15),
+            (3, 12),
+            (3, 3),
+            (3, 2),
+            (3, 1),
+            (2, 9),  # recent group_inbox should stay the same
+            (2, 2),
+            (1, 1),
+            (0, 0),
         ]:
             group = self.create_group(
                 project=project,


### PR DESCRIPTION
## Objective:
Use a more efficient query in the `auto_transition_issues_new_to_ongoing` task. Uses index from https://github.com/getsentry/sentry/pull/53499