### PR TITLE
ref(getting-started-docs): Other platform crash

### DIFF
--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -5,7 +5,6 @@ import {PlatformIcon} from 'platformicons';
 
 import {Button} from 'sentry/components/button';
 import EmptyMessage from 'sentry/components/emptyMessage';
-import ExternalLink from 'sentry/components/links/externalLink';
 import ListLink from 'sentry/components/links/listLink';
 import NavTabs from 'sentry/components/navTabs';
 import SearchBar from 'sentry/components/searchBar';
@@ -13,7 +12,7 @@ import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import categoryList, {filterAliases, PlatformKey} from 'sentry/data/platformCategories';
 import platforms from 'sentry/data/platforms';
 import {IconClose, IconProject} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization, PlatformIntegration} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -176,17 +175,8 @@ class PlatformPicker extends Component<PlatformPickerProps, State> {
             icon={<IconProject size="xl" />}
             title={t("We don't have an SDK for that yet!")}
           >
-            {tct(
-              `Not finding your platform? You can still create your project,
-              but looks like we don't have an official SDK for your platform
-              yet. However, there's a rich ecosystem of community supported
-              SDKs (including Perl, CFML, Clojure, and ActionScript). Try
-              [search:searching for Sentry clients] or contacting support.`,
-              {
-                search: (
-                  <ExternalLink href="https://github.com/search?q=-org%3Agetsentry+topic%3Asentry&type=Repositories" />
-                ),
-              }
+            {t(
+              "Make sure you've typed the platform correctly. If that doesn't help, we have several SDKs that are still useful if you use a lesser-known platform. For example, Browser JavaScript, Python, Node, .NET & Java."
             )}
           </EmptyMessage>
         )}

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -1,28 +1,11 @@
 import integrationDocsPlatforms from 'integration-docs-platforms';
 import sortBy from 'lodash/sortBy';
 
-import {t} from 'sentry/locale';
 import {PlatformIntegration} from 'sentry/types';
 
 import {tracing} from './platformCategories';
 
-const otherPlatform = {
-  integrations: [
-    {
-      link: 'https://docs.sentry.io/platforms/',
-      type: 'language',
-      id: 'other',
-      name: t('Other'),
-    },
-  ],
-  id: 'other',
-  name: t('Other'),
-};
-
-const platformIntegrations: PlatformIntegration[] = [
-  ...integrationDocsPlatforms.platforms,
-  otherPlatform,
-]
+const platformIntegrations: PlatformIntegration[] = integrationDocsPlatforms.platforms
   .map(platform => {
     const integrations = platform.integrations.reduce((acc, value) => {
       // filter out any javascript-[angular|angularjs|ember|gatsby|nextjs|react|remix|svelte|sveltekit|vue]-* platforms; as they're not meant to be used as a platform in the PlatformPicker component

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -164,6 +164,11 @@ function SetupDocs({route, router, location, recentCreatedProject: project}: Ste
       return;
     }
 
+    // There are no docs for the other platform
+    if (project.platform === 'other') {
+      return;
+    }
+
     try {
       const loadedDocs = await loadDocs({
         api,

--- a/static/app/views/projectInstall/otherPlatformsInfo.tsx
+++ b/static/app/views/projectInstall/otherPlatformsInfo.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+import List from 'sentry/components/list';
+import ListItem from 'sentry/components/list/listItem';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Project, ProjectKey} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function OtherPlatformsInfo({projectSlug}: {projectSlug: Project['slug']}) {
+  const organization = useOrganization();
+
+  const {
+    data = [],
+    isError,
+    isLoading,
+    refetch,
+  } = useApiQuery<ProjectKey[]>([`/projects/${organization.slug}/${projectSlug}/keys/`], {
+    staleTime: Infinity,
+  });
+
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
+
+  if (isError) {
+    return <LoadingError onRetry={refetch} />;
+  }
+
+  return (
+    <Wrapper>
+      {t(
+        "We cannot provide instructions for 'other' projects. However, please find below the DSN key for this project, which is required to instrument Sentry."
+      )}
+      <CodeSnippet dark language="bash">
+        {data[0].dsn.public}
+      </CodeSnippet>
+      {t(
+        'If you use a lesser-known platform, we suggest creating a new project using following SDKs:'
+      )}
+      <List symbol="bullet">
+        <ListItem>Browser JavaScript</ListItem>
+        <ListItem>Python</ListItem>
+        <ListItem>Node</ListItem>
+        <ListItem>.NET</ListItem>
+        <ListItem>JAVA</ListItem>
+      </List>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
+`;

--- a/static/app/views/projectInstall/otherPlatformsInfo.tsx
+++ b/static/app/views/projectInstall/otherPlatformsInfo.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
+import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import LoadingError from 'sentry/components/loadingError';
@@ -11,7 +12,13 @@ import type {Project, ProjectKey} from 'sentry/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export function OtherPlatformsInfo({projectSlug}: {projectSlug: Project['slug']}) {
+export function OtherPlatformsInfo({
+  projectSlug,
+  platform,
+}: {
+  platform: string;
+  projectSlug: Project['slug'];
+}) {
   const organization = useOrganization();
 
   const {
@@ -34,21 +41,44 @@ export function OtherPlatformsInfo({projectSlug}: {projectSlug: Project['slug']}
   return (
     <Wrapper>
       {t(
-        "We cannot provide instructions for 'other' projects. However, please find below the DSN key for this project, which is required to instrument Sentry."
+        "We cannot provide instructions for '%s' projects. However, please find below the DSN key for this project, which is required to instrument Sentry.",
+        platform
       )}
       <CodeSnippet dark language="bash">
         {t('dsn: %s', data[0].dsn.public)}
       </CodeSnippet>
-      {t(
-        'If you use a lesser-known platform, we suggest creating a new project using following SDKs:'
-      )}
-      <List symbol="bullet">
-        <ListItem>Browser JavaScript</ListItem>
-        <ListItem>Python</ListItem>
-        <ListItem>Node</ListItem>
-        <ListItem>.NET</ListItem>
-        <ListItem>JAVA</ListItem>
-      </List>
+      <Suggestion>
+        {t(
+          'Since it can be a lot work creating a Sentry SDK from scratch, we suggest you review the following SDKs which are applicable for a wide variety of applications:'
+        )}
+        <List symbol="bullet">
+          <ListItem>
+            <ExternalLink href="https://docs.sentry.io/platforms/javascript/">
+              Browser JavaScript
+            </ExternalLink>
+          </ListItem>
+          <ListItem>
+            <ExternalLink href="https://docs.sentry.io/platforms/python/">
+              Python
+            </ExternalLink>
+          </ListItem>
+          <ListItem>
+            <ExternalLink href="https://docs.sentry.io/platforms/node/">
+              Node.js
+            </ExternalLink>
+          </ListItem>
+          <ListItem>
+            <ExternalLink href="https://docs.sentry.io/platforms/dotnet/">
+              .NET
+            </ExternalLink>
+          </ListItem>
+          <ListItem>
+            <ExternalLink href="https://docs.sentry.io/platforms/java/">
+              JAVA
+            </ExternalLink>
+          </ListItem>
+        </List>
+      </Suggestion>
     </Wrapper>
   );
 }
@@ -57,4 +87,7 @@ const Wrapper = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(2)};
+`;
+const Suggestion = styled(Wrapper)`
+  gap: ${space(1)};
 `;

--- a/static/app/views/projectInstall/otherPlatformsInfo.tsx
+++ b/static/app/views/projectInstall/otherPlatformsInfo.tsx
@@ -37,7 +37,7 @@ export function OtherPlatformsInfo({projectSlug}: {projectSlug: Project['slug']}
         "We cannot provide instructions for 'other' projects. However, please find below the DSN key for this project, which is required to instrument Sentry."
       )}
       <CodeSnippet dark language="bash">
-        {data[0].dsn.public}
+        {t('dsn: %s', data[0].dsn.public)}
       </CodeSnippet>
       {t(
         'If you use a lesser-known platform, we suggest creating a new project using following SDKs:'

--- a/static/app/views/projectInstall/platform.spec.tsx
+++ b/static/app/views/projectInstall/platform.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {Project} from 'sentry/types';
@@ -81,12 +81,12 @@ describe('ProjectInstallPlatform', function () {
     expect(await screen.findByText('Page Not Found')).toBeInTheDocument();
   });
 
-  it('should redirect to neutral docs if no matching platform', async function () {
+  it('should display info for a non-supported platform', async function () {
     const routeParams = {
       projectId: TestStubs.Project().slug,
     };
 
-    const {organization, router, route, project, routerContext} = initializeOrg({
+    const {organization, router, route, project} = initializeOrg({
       router: {
         location: {
           query: {},
@@ -111,13 +111,12 @@ describe('ProjectInstallPlatform', function () {
       />,
       {
         organization,
-        context: routerContext,
       }
     );
 
-    await waitFor(() => {
-      expect(router.push).toHaveBeenCalledTimes(1);
-    });
+    expect(
+      await screen.findByText(/We cannot provide instructions for 'other' projects/)
+    ).toBeInTheDocument();
   });
 
   it('should render getting started docs for correct platform', async function () {

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -45,6 +45,8 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {SetupDocsLoader} from 'sentry/views/onboarding/setupDocsLoader';
 import {GettingStartedWithProjectContext} from 'sentry/views/projects/gettingStartedWithProjectContext';
 
+import {OtherPlatformsInfo} from './otherPlatformsInfo';
+
 const ProductUnavailableCTAHook = HookOrDefault({
   hookName: 'component:product-unavailable-cta',
 });
@@ -303,11 +305,7 @@ export function ProjectInstallPlatform({location, params, route, router}: Props)
     return null;
   }
 
-  if (platform.key === 'other') {
-    return <div>oi</div>;
-  }
-
-  if (!platform.id) {
+  if (!platform.id && platform.key !== 'other') {
     return <NotFound />;
   }
 
@@ -326,7 +324,7 @@ export function ProjectInstallPlatform({location, params, route, router}: Props)
         <ProductUnavailableCTAHook organization={organization} />
       )}
       <StyledPageHeader>
-        <h2>{t('Configure %(platform)s SDK', {platform: platform.name})}</h2>
+        <h2>{t('Configure %(platform)s SDK', {platform: platform.name ?? 'other'})}</h2>
         <ButtonBar gap={1}>
           <Confirm
             bypass={!shallProjectBeDeleted}
@@ -361,34 +359,43 @@ export function ProjectInstallPlatform({location, params, route, router}: Props)
               {t('Back to Platform Selection')}
             </Button>
           </Confirm>
-          <Button size="sm" href={platform.link ?? undefined} external>
-            {t('Full Documentation')}
-          </Button>
+          {platform.key !== 'other' && (
+            <Button size="sm" href={platform.link ?? undefined} external>
+              {t('Full Documentation')}
+            </Button>
+          )}
         </ButtonBar>
       </StyledPageHeader>
-      {currentPlatform && showLoaderOnboarding ? (
-        <SetupDocsLoader
-          organization={organization}
-          project={project}
-          location={location}
-          platform={currentPlatform.id}
-          close={hideLoaderOnboarding}
-        />
-      ) : currentPlatform && migratedDocs.includes(currentPlatformKey) ? (
-        <SdkDocumentation
-          platform={currentPlatform}
-          organization={organization}
-          projectSlug={project.slug}
-          projectId={project.id}
-          activeProductSelection={products}
-        />
+      {platform.key === 'other' ? (
+        <OtherPlatformsInfo projectSlug={project.slug} />
       ) : (
-        <SetUpGeneralSdkDoc
-          organization={organization}
-          projectSlug={project.slug}
-          platform={platform}
-        />
+        <Fragment>
+          {currentPlatform && showLoaderOnboarding ? (
+            <SetupDocsLoader
+              organization={organization}
+              project={project}
+              location={location}
+              platform={currentPlatform.id}
+              close={hideLoaderOnboarding}
+            />
+          ) : currentPlatform && migratedDocs.includes(currentPlatformKey) ? (
+            <SdkDocumentation
+              platform={currentPlatform}
+              organization={organization}
+              projectSlug={project.slug}
+              projectId={project.id}
+              activeProductSelection={products}
+            />
+          ) : (
+            <SetUpGeneralSdkDoc
+              organization={organization}
+              projectSlug={project.slug}
+              platform={platform}
+            />
+          )}
+        </Fragment>
       )}
+
       <div>
         {isGettingStarted && showPerformancePrompt && (
           <Feature

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -242,18 +242,6 @@ export function ProjectInstallPlatform({location, params, route, router}: Props)
     link: platformIntegration?.link,
   };
 
-  const redirectToNeutralDocs = useCallback(() => {
-    if (!project?.slug) {
-      return;
-    }
-
-    router.push(
-      normalizeUrl(
-        `/organizations/${organization.slug}/projects/${project.slug}/getting-started/`
-      )
-    );
-  }, [organization.slug, project?.slug, router]);
-
   const handleGoBack = useCallback(async () => {
     if (!recentCreatedProject) {
       return;
@@ -311,15 +299,12 @@ export function ProjectInstallPlatform({location, params, route, router}: Props)
     });
   }, [organization, currentPlatform, project?.id]);
 
-  useEffect(() => {
-    // redirect if platform is not known.
-    if (!platform.key || platform.key === 'other') {
-      redirectToNeutralDocs();
-    }
-  }, [platform.key, redirectToNeutralDocs]);
-
   if (!project) {
     return null;
+  }
+
+  if (platform.key === 'other') {
+    return <div>oi</div>;
   }
 
   if (!platform.id) {

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -367,7 +367,10 @@ export function ProjectInstallPlatform({location, params, route, router}: Props)
         </ButtonBar>
       </StyledPageHeader>
       {platform.key === 'other' ? (
-        <OtherPlatformsInfo projectSlug={project.slug} />
+        <OtherPlatformsInfo
+          projectSlug={project.slug}
+          platform={platform.name ?? 'other'}
+        />
       ) : (
         <Fragment>
           {currentPlatform && showLoaderOnboarding ? (


### PR DESCRIPTION
Currently, a user going through the onboarding flow will get a crashed page when choosing to configure an 'other' SDK, this is because there is no documentation for 'other' platforms. As we believe that first-time onboarding users do not intend to create a new SDK or it is a very rare situation, they should not be asked /motivated to do so, so we have updated the copy and from now on we will not allow the creation a project using an unsupported platform.

<img width="1372" alt="image" src="https://github.com/getsentry/sentry/assets/29228205/13c4a17e-d837-4568-95f4-8e61bd2aaf41">


For users with already created 'other' projects and without having completed the installation instructions, we have decided to share the DSN of the project and a message motivating them to create a project using a supported platform.

<img width="1475" alt="image" src="https://github.com/getsentry/sentry/assets/29228205/67b9f617-555e-49bb-9620-86466776ba84">


closes: https://github.com/getsentry/sentry/issues/52120 




