### PR TITLE
fix(dynamic-sampling): Remove synchronous computation of sliding window org and cleanup

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import List, Mapping, Optional, Sequence, Tuple
 
-from sentry_sdk import capture_message, set_extra
+import sentry_sdk
 from snuba_sdk import (
     Column,
     Condition,
@@ -90,12 +90,14 @@ def boost_low_volume_projects() -> None:
             ).items():
                 boost_low_volume_projects_of_org.delay(org_id, projects_with_tx_count_and_rates)
     except TimeoutException:
-        set_extra("context-data", context.to_dict())
+        sentry_sdk.set_extra("context-data", context.to_dict())
         log_task_timeout(context)
         raise
     else:
-        set_extra("context-data", context.to_dict())
-        capture_message("timing for sentry.dynamic_sampling.tasks.boost_low_volume_projects")
+        sentry_sdk.set_extra("context-data", context.to_dict())
+        sentry_sdk.capture_message(
+            "timing for sentry.dynamic_sampling.tasks.boost_low_volume_projects"
+        )
         log_task_execution(context)
 
 

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -73,9 +73,7 @@ from sentry.utils.snuba import raw_snql_query
     time_limit=2 * 60 * 60 + 5,
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
-def boost_low_volume_projects(**kwargs) -> None:
-    context: TaskContext = kwargs["context"]
-
+def boost_low_volume_projects(context: TaskContext) -> None:
     for orgs in TimedIterator(context, GetActiveOrgs(max_projects=MAX_PROJECTS_PER_QUERY)):
         for (
             org_id,

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -36,7 +36,6 @@ from sentry.dynamic_sampling.tasks.common import (
     TimedIterator,
     TimeoutException,
     are_equal_with_epsilon,
-    get_adjusted_base_rate_from_cache_or_compute,
     sample_rate_to_float,
 )
 from sentry.dynamic_sampling.tasks.constants import (
@@ -49,6 +48,7 @@ from sentry.dynamic_sampling.tasks.constants import (
 from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
     generate_boost_low_volume_projects_cache_key,
 )
+from sentry.dynamic_sampling.tasks.helpers.sliding_window import get_sliding_window_org_sample_rate
 from sentry.dynamic_sampling.tasks.logging import (
     log_sample_rate_source,
     log_task_execution,
@@ -257,7 +257,7 @@ def adjust_sample_rates_of_projects(
 
     # We get the sample rate either directly from quotas or from the new sliding window org mechanism.
     if organization is not None and is_sliding_window_org_enabled(organization):
-        sample_rate = get_adjusted_base_rate_from_cache_or_compute(org_id, context)
+        sample_rate = get_sliding_window_org_sample_rate(org_id)
         log_sample_rate_source(
             org_id, None, "boost_low_volume_projects", "sliding_window_org", sample_rate
         )

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -94,9 +94,7 @@ class ProjectTransactionsTotals(TypedDict, total=True):
     time_limit=2 * 60 * 60 + 5,
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
-def boost_low_volume_transactions(**kwargs) -> None:
-    context: TaskContext = kwargs["context"]
-
+def boost_low_volume_transactions(context: TaskContext) -> None:
     num_big_trans = int(
         options.get("dynamic-sampling.prioritise_transactions.num_explicit_large_transactions")
     )

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Callable, Dict, Iterator, List, Optional, Sequence, Tuple, TypedDict, Union, cast
 
-from sentry_sdk import capture_message, set_extra
+import sentry_sdk
 from snuba_sdk import (
     AliasedExpression,
     Column,
@@ -145,12 +145,14 @@ def boost_low_volume_transactions() -> None:
             ):
                 boost_low_volume_transactions_of_project.delay(project_transactions)
     except TimeoutException:
-        set_extra("context-data", context.to_dict())
+        sentry_sdk.set_extra("context-data", context.to_dict())
         log_task_timeout(context)
         raise
     else:
-        set_extra("context-data", context.to_dict())
-        capture_message("timing for sentry.dynamic_sampling.tasks.boost_low_volume_transactions")
+        sentry_sdk.set_extra("context-data", context.to_dict())
+        sentry_sdk.capture_message(
+            "timing for sentry.dynamic_sampling.tasks.boost_low_volume_transactions"
+        )
         log_task_execution(context)
 
 

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import Callable, Dict, Iterator, List, Optional, Sequence, Tuple, TypedDict, Union, cast
 
-import sentry_sdk
 from snuba_sdk import (
     AliasedExpression,
     Column,
@@ -26,7 +25,7 @@ from sentry.dynamic_sampling.rules.base import (
     is_sliding_window_enabled,
     is_sliding_window_org_enabled,
 )
-from sentry.dynamic_sampling.tasks.common import GetActiveOrgs, TimedIterator, TimeoutException
+from sentry.dynamic_sampling.tasks.common import GetActiveOrgs, TimedIterator
 from sentry.dynamic_sampling.tasks.constants import (
     BOOST_LOW_VOLUME_TRANSACTIONS_QUERY_INTERVAL,
     CHUNK_SIZE,
@@ -41,13 +40,12 @@ from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_transactions import 
     set_transactions_resampling_rates,
 )
 from sentry.dynamic_sampling.tasks.helpers.sliding_window import get_sliding_window_sample_rate
-from sentry.dynamic_sampling.tasks.logging import (
-    log_sample_rate_source,
-    log_task_execution,
-    log_task_timeout,
-)
+from sentry.dynamic_sampling.tasks.logging import log_sample_rate_source
 from sentry.dynamic_sampling.tasks.task_context import DynamicSamplingLogState, TaskContext
-from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task
+from sentry.dynamic_sampling.tasks.utils import (
+    dynamic_sampling_task,
+    dynamic_sampling_task_with_context,
+)
 from sentry.models import Organization
 from sentry.sentry_metrics import indexer
 from sentry.snuba.dataset import Dataset, EntityKey
@@ -95,8 +93,10 @@ class ProjectTransactionsTotals(TypedDict, total=True):
     soft_time_limit=2 * 60 * 60,
     time_limit=2 * 60 * 60 + 5,
 )
-@dynamic_sampling_task
-def boost_low_volume_transactions() -> None:
+@dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
+def boost_low_volume_transactions(**kwargs) -> None:
+    context: TaskContext = kwargs["context"]
+
     num_big_trans = int(
         options.get("dynamic-sampling.prioritise_transactions.num_explicit_large_transactions")
     )
@@ -104,56 +104,41 @@ def boost_low_volume_transactions() -> None:
         options.get("dynamic-sampling.prioritise_transactions.num_explicit_small_transactions")
     )
 
-    context = TaskContext(
-        "sentry.dynamic_sampling.tasks.boost_low_volume_transactions", MAX_TASK_SECONDS
-    )
-
     get_totals_name = "GetTransactionTotals"
     get_volumes_small = "GetTransactionVolumes(small)"
     get_volumes_big = "GetTransactionVolumes(big)"
 
-    try:
-        orgs_iterator = TimedIterator(context, GetActiveOrgs(max_projects=MAX_PROJECTS_PER_QUERY))
-        for orgs in orgs_iterator:
-            # get the low and high transactions
-            totals_it = TimedIterator(
-                context=context,
-                inner=FetchProjectTransactionTotals(orgs),
-                name=get_totals_name,
-            )
-            small_transactions_it = TimedIterator(
-                context=context,
-                inner=FetchProjectTransactionVolumes(
-                    orgs,
-                    large_transactions=False,
-                    max_transactions=num_small_trans,
-                ),
-                name=get_volumes_small,
-            )
-            big_transactions_it = TimedIterator(
-                context=context,
-                inner=FetchProjectTransactionVolumes(
-                    orgs,
-                    large_transactions=True,
-                    max_transactions=num_big_trans,
-                ),
-                name=get_volumes_big,
-            )
-
-            for project_transactions in transactions_zip(
-                totals_it, big_transactions_it, small_transactions_it
-            ):
-                boost_low_volume_transactions_of_project.delay(project_transactions)
-    except TimeoutException:
-        sentry_sdk.set_extra("context-data", context.to_dict())
-        log_task_timeout(context)
-        raise
-    else:
-        sentry_sdk.set_extra("context-data", context.to_dict())
-        sentry_sdk.capture_message(
-            "timing for sentry.dynamic_sampling.tasks.boost_low_volume_transactions"
+    orgs_iterator = TimedIterator(context, GetActiveOrgs(max_projects=MAX_PROJECTS_PER_QUERY))
+    for orgs in orgs_iterator:
+        # get the low and high transactions
+        totals_it = TimedIterator(
+            context=context,
+            inner=FetchProjectTransactionTotals(orgs),
+            name=get_totals_name,
         )
-        log_task_execution(context)
+        small_transactions_it = TimedIterator(
+            context=context,
+            inner=FetchProjectTransactionVolumes(
+                orgs,
+                large_transactions=False,
+                max_transactions=num_small_trans,
+            ),
+            name=get_volumes_small,
+        )
+        big_transactions_it = TimedIterator(
+            context=context,
+            inner=FetchProjectTransactionVolumes(
+                orgs,
+                large_transactions=True,
+                max_transactions=num_big_trans,
+            ),
+            name=get_volumes_big,
+        )
+
+        for project_transactions in transactions_zip(
+            totals_it, big_transactions_it, small_transactions_it
+        ):
+            boost_low_volume_transactions_of_project.delay(project_transactions)
 
 
 @instrumented_task(

--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -27,11 +27,7 @@ from sentry.dynamic_sampling.tasks.constants import (
     MAX_SECONDS,
     RECALIBRATE_ORGS_QUERY_INTERVAL,
 )
-from sentry.dynamic_sampling.tasks.helpers.sliding_window import (
-    extrapolate_monthly_volume,
-    get_sliding_window_org_sample_rate,
-    get_sliding_window_size,
-)
+from sentry.dynamic_sampling.tasks.helpers.sliding_window import extrapolate_monthly_volume
 from sentry.dynamic_sampling.tasks.logging import log_extrapolated_monthly_volume, log_query_timeout
 from sentry.dynamic_sampling.tasks.task_context import DynamicSamplingLogState, TaskContext
 from sentry.sentry_metrics import indexer
@@ -650,35 +646,3 @@ def compute_sliding_window_sample_rate(
 
     # We assume that the sample_rate is a float.
     return float(sample_rate)
-
-
-def get_adjusted_base_rate_from_cache_or_compute(
-    org_id: int, context: TaskContext
-) -> Optional[float]:
-    """
-    Gets the adjusted base sample rate from the sliding window directly from the Redis cache or tries to compute
-    it synchronously.
-    """
-    # We first try to get from cache the sliding window org sample rate.
-    sample_rate = get_sliding_window_org_sample_rate(org_id)
-    if sample_rate is not None:
-        return sample_rate
-
-    # In case we didn't find the value in cache, we want to compute it synchronously.
-    window_size = get_sliding_window_size()
-    # In case the size is None it means that we disabled the sliding window entirely.
-    if window_size is not None:
-        # We want to synchronously fetch the orgs and compute the sliding window org sample rate.
-        orgs_with_counts = fetch_orgs_with_total_root_transactions_count(
-            org_ids=[org_id], window_size=window_size
-        )
-        if (org_total_root_count := orgs_with_counts.get(org_id)) is not None:
-            return compute_guarded_sliding_window_sample_rate(
-                org_id,
-                None,
-                org_total_root_count,
-                window_size,
-                context,
-            )
-
-    return None

--- a/src/sentry/dynamic_sampling/tasks/logging.py
+++ b/src/sentry/dynamic_sampling/tasks/logging.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable, Dict, Optional
+from typing import Optional
 
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.utils import metrics
@@ -79,11 +79,3 @@ def log_recalibrate_org_state(
             "target_effective_ratio": target_sample_rate / effective_sample_rate,
         },
     )
-
-
-def log_action_if(name: str, extra: Dict[str, Any], block: Callable[[], bool]):
-    if block():
-        logger.info(
-            f"dynamic_sampling.{name}",
-            extra=extra,
-        )

--- a/src/sentry/dynamic_sampling/tasks/logging.py
+++ b/src/sentry/dynamic_sampling/tasks/logging.py
@@ -42,6 +42,7 @@ def log_sample_rate_source(
 
 def log_task_timeout(context: TaskContext) -> None:
     logger.error("dynamic_sampling.task_timeout", extra=context.to_dict())
+    metrics.incr("dynamic_sampling.task_timeout", tags={"task_name": context.name})
 
 
 def log_task_execution(context: TaskContext) -> None:

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -1,6 +1,6 @@
 import time
 
-from sentry_sdk import capture_message, set_extra
+import sentry_sdk
 from snuba_sdk import Granularity
 
 from sentry.dynamic_sampling.tasks.common import (
@@ -71,15 +71,15 @@ def recalibrate_orgs() -> None:
                 try:
                     recalibrate_org(org_volume, context)
                 except RecalibrationError as e:
-                    set_extra("context-data", context.to_dict())
+                    sentry_sdk.set_extra("context-data", context.to_dict())
                     log_recalibrate_org_error(org_volume.org_id, str(e))
     except TimeoutException:
-        set_extra("context-data", context.to_dict())
+        sentry_sdk.set_extra("context-data", context.to_dict())
         log_task_timeout(context)
         raise
     else:
-        set_extra("context-data", context.to_dict())
-        capture_message("timing for sentry.dynamic_sampling.tasks.recalibrate_orgs")
+        sentry_sdk.set_extra("context-data", context.to_dict())
+        sentry_sdk.capture_message("timing for sentry.dynamic_sampling.tasks.recalibrate_orgs")
         log_task_execution(context)
 
 

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -53,9 +53,7 @@ class RecalibrationError(Exception):
     time_limit=2 * 60 * 60 + 5,
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
-def recalibrate_orgs(**kwargs) -> None:
-    context: TaskContext = kwargs["context"]
-
+def recalibrate_orgs(context: TaskContext) -> None:
     for org_volumes in TimedIterator(
         context,
         GetActiveOrgsVolumes(

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -8,7 +8,6 @@ from sentry.dynamic_sampling.tasks.common import (
     OrganizationDataVolume,
     TimedIterator,
     TimeoutException,
-    get_adjusted_base_rate_from_cache_or_compute,
 )
 from sentry.dynamic_sampling.tasks.constants import (
     CHUNK_SIZE,
@@ -23,6 +22,7 @@ from sentry.dynamic_sampling.tasks.helpers.recalibrate_orgs import (
     get_adjusted_factor,
     set_guarded_adjusted_factor,
 )
+from sentry.dynamic_sampling.tasks.helpers.sliding_window import get_sliding_window_org_sample_rate
 from sentry.dynamic_sampling.tasks.logging import (
     log_action_if,
     log_recalibrate_org_error,
@@ -114,9 +114,7 @@ def recalibrate_org(org_volume: OrganizationDataVolume, context: TaskContext) ->
             "ready_for_recalibration", {"org_id": org_volume.org_id}, orgs_to_check(org_volume)
         )
 
-        target_sample_rate = get_adjusted_base_rate_from_cache_or_compute(
-            org_volume.org_id, context
-        )
+        target_sample_rate = get_sliding_window_org_sample_rate(org_volume.org_id)
         log_sample_rate_source(
             org_volume.org_id, None, "recalibrate_orgs", "sliding_window_org", target_sample_rate
         )

--- a/src/sentry/dynamic_sampling/tasks/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import List, Mapping, Sequence, Tuple
 
-from sentry_sdk import capture_message, set_extra
+import sentry_sdk
 from snuba_sdk import (
     Column,
     Condition,
@@ -96,21 +96,17 @@ def sliding_window() -> None:
                             context,
                         )
 
+            # Due to the synchronous nature of the sliding window, when we arrived here, we can confidently say that the
+            # execution of the sliding window was successful. We will keep this state for 1 hour.
+            mark_sliding_window_executed()
     except TimeoutException:
-        set_extra("context-data", context.to_dict())
+        sentry_sdk.set_extra("context-data", context.to_dict())
         log_task_timeout(context)
         raise
     else:
-        set_extra("context-data", context.to_dict())
-        capture_message("timing for sentry.dynamic_sampling.tasks.sliding_window")
+        sentry_sdk.set_extra("context-data", context.to_dict())
+        sentry_sdk.capture_message("timing for sentry.dynamic_sampling.tasks.sliding_window")
         log_task_execution(context)
-    finally:
-        # TODO (RaduW) Hot fix, we need to see if this is indeed what we want to do, or we can mark the sliding window
-        #   as executed only when the task is successful.
-
-        # Due to the synchronous nature of the sliding window, when we arrived here, we can confidently say that the
-        # execution of the sliding window was successful. We will keep this state for 1 hour.
-        mark_sliding_window_executed()
 
 
 def adjust_base_sample_rates_of_projects(

--- a/src/sentry/dynamic_sampling/tasks/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window.py
@@ -140,11 +140,9 @@ def adjust_base_sample_rates_of_projects(
                 context,
             )
 
-            # If the sample rate is None, we want to add a sentinel value into Redis, the goal being that when generating
-            # rules we can distinguish between:
-            # 1. Value in the cache
-            # 2. No value in the cache
-            # 3. Error happened
+            # If the sample rate is None, we want to add a sentinel value into Redis, the goal being that when
+            # generating rules we can distinguish between: 1. Value in the cache 2. No value in the cache 3. Error
+            # happened
             projects_with_rebalanced_sample_rate.append(
                 (
                     project_id,
@@ -162,8 +160,8 @@ def adjust_base_sample_rates_of_projects(
 
         # For efficiency reasons, we start a pipeline that will apply a set of operations without multiple round trips.
         with redis_client.pipeline(transaction=False) as pipeline:
-            # We want to delete the Redis hash before adding new sample rate since we don't back-fill projects that have no
-            # root count metrics in the considered window.
+            # We want to delete the Redis hash before adding new sample rate since we don't back-fill projects that
+            # have no root count metrics in the considered window.
             pipeline.delete(cache_key)
 
             # For each project we want to now save the new sample rate.
@@ -174,7 +172,8 @@ def adjust_base_sample_rates_of_projects(
 
                 # We want to get the old sample rate, which will be None in case it was not set.
                 old_sample_rate = sample_rate_to_float(old_sample_rates.get(str(project_id), ""))
-                # We also get the new sample rate, which will be None in case we stored a SLIDING_WINDOW_CALCULATION_ERROR.
+                # We also get the new sample rate, which will be None in case we stored a
+                # SLIDING_WINDOW_CALCULATION_ERROR.
                 sample_rate = sample_rate_to_float(sample_rate)  # type:ignore
                 # We invalidate the caches only if there was a change in the sample rate. This is to avoid flooding the
                 # system with project config invalidations.
@@ -184,11 +183,13 @@ def adjust_base_sample_rates_of_projects(
                     )
 
             pipeline.execute()
-    state = context.get_function_state(func_name)
-    state.num_orgs += 1
-    state.num_projects += len(projects_with_total_root_count)
-    state.num_iterations += 1
-    context.set_function_state(func_name, state)
+
+    context.incr_function_state(
+        function_id=func_name,
+        num_orgs=1,
+        num_projects=len(projects_with_total_root_count),
+        num_iterations=1,
+    )
 
 
 def fetch_projects_with_total_root_transactions_count(

--- a/src/sentry/dynamic_sampling/tasks/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window.py
@@ -59,9 +59,7 @@ from sentry.utils.snuba import raw_snql_query
     time_limit=2 * 60 * 60 + 5,
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
-def sliding_window(**kwargs) -> None:
-    context: TaskContext = kwargs["context"]
-
+def sliding_window(context: TaskContext) -> None:
     window_size = get_sliding_window_size()
     # In case the size is None it means that we disabled the sliding window entirely.
     if window_size is not None:

--- a/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
@@ -95,9 +95,9 @@ def adjust_base_sample_rate_of_org(
                 window_size,
                 context,
             )
-            state = context.get_function_state(guarded_sliding_window_name)
-            state.num_iterations += 1
-            context.set_function_state(guarded_sliding_window_name, state)
+
+            context.incr_function_state(guarded_sliding_window_name, num_iterations=1)
+
         # If the sample rate is None, we don't want to store a value into Redis, but we prefer to keep the system
         # with the old value.
         if sample_rate is None:
@@ -111,11 +111,7 @@ def adjust_base_sample_rate_of_org(
                 pipeline.set(cache_key, sample_rate)
                 pipeline.pexpire(cache_key, DEFAULT_REDIS_CACHE_KEY_TTL)
                 pipeline.execute()
-            state = context.get_function_state(redis_update_name)
-            state.num_iterations += 1
-            context.set_function_state(redis_update_name, state)
 
-    state = context.get_function_state(func_name)
-    state.num_orgs += 1
-    state.num_iterations += 1
-    context.set_function_state(func_name, state)
+            context.incr_function_state(function_id=redis_update_name, num_iterations=1)
+
+    context.incr_function_state(function_id=func_name, num_orgs=1, num_iterations=1)

--- a/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
@@ -1,7 +1,7 @@
 import time
 from datetime import timedelta
 
-from sentry_sdk import capture_message, set_extra
+import sentry_sdk
 
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 from sentry.dynamic_sampling.tasks.common import (
@@ -65,12 +65,12 @@ def sliding_window_org() -> None:
             # that the execution of the sliding window org was successful. We will keep this state for 1 hour.
             mark_sliding_window_org_executed()
     except TimeoutException:
-        set_extra("context-data", context.to_dict())
+        sentry_sdk.set_extra("context-data", context.to_dict())
         log_task_timeout(context)
         raise
     else:
-        set_extra("context-data", context.to_dict())
-        capture_message("timing for sentry.dynamic_sampling.tasks.sliding_window_org")
+        sentry_sdk.set_extra("context-data", context.to_dict())
+        sentry_sdk.capture_message("timing for sentry.dynamic_sampling.tasks.sliding_window_org")
         log_task_execution(context)
 
 

--- a/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
@@ -1,8 +1,6 @@
 import time
 from datetime import timedelta
 
-import sentry_sdk
-
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 from sentry.dynamic_sampling.tasks.common import (
     GetActiveOrgsVolumes,
@@ -20,9 +18,8 @@ from sentry.dynamic_sampling.tasks.helpers.sliding_window import (
     get_sliding_window_size,
     mark_sliding_window_org_executed,
 )
-from sentry.dynamic_sampling.tasks.logging import log_task_execution, log_task_timeout
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
-from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task
+from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task_with_context
 from sentry.tasks.base import instrumented_task
 
 
@@ -34,44 +31,34 @@ from sentry.tasks.base import instrumented_task
     soft_time_limit=2 * 60 * 60,  # 2 hours
     time_limit=2 * 60 * 60 + 5,
 )
-@dynamic_sampling_task
-def sliding_window_org() -> None:
-    context = TaskContext("sentry.dynamic_sampling.tasks.sliding_window_org", MAX_TASK_SECONDS)
+@dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
+def sliding_window_org(**kwargs) -> None:
+    context: TaskContext = kwargs["context"]
 
     window_size = get_sliding_window_size()
+    # In case the size is None it means that we disabled the sliding window entirely.
+    if window_size is not None:
+        orgs_volumes_iterator = TimedIterator(
+            context,
+            GetActiveOrgsVolumes(
+                max_orgs=CHUNK_SIZE,
+                time_interval=timedelta(hours=window_size),
+                include_keep=False,
+            ),
+        )
 
-    try:
-        # In case the size is None it means that we disabled the sliding window entirely.
-        if window_size is not None:
-            orgs_volumes_iterator = TimedIterator(
-                context,
-                GetActiveOrgsVolumes(
-                    max_orgs=CHUNK_SIZE,
-                    time_interval=timedelta(hours=window_size),
-                    include_keep=False,
-                ),
-            )
+        for orgs_volume in orgs_volumes_iterator:
+            for org_volume in orgs_volume:
+                adjust_base_sample_rate_of_org(
+                    org_id=org_volume.org_id,
+                    total_root_count=org_volume.total,
+                    window_size=window_size,
+                    context=context,
+                )
 
-            for orgs_volume in orgs_volumes_iterator:
-                for org_volume in orgs_volume:
-                    adjust_base_sample_rate_of_org(
-                        org_id=org_volume.org_id,
-                        total_root_count=org_volume.total,
-                        window_size=window_size,
-                        context=context,
-                    )
-
-            # Due to the synchronous nature of the sliding window org, when we arrived here, we can confidently say
-            # that the execution of the sliding window org was successful. We will keep this state for 1 hour.
-            mark_sliding_window_org_executed()
-    except TimeoutException:
-        sentry_sdk.set_extra("context-data", context.to_dict())
-        log_task_timeout(context)
-        raise
-    else:
-        sentry_sdk.set_extra("context-data", context.to_dict())
-        sentry_sdk.capture_message("timing for sentry.dynamic_sampling.tasks.sliding_window_org")
-        log_task_execution(context)
+        # Due to the synchronous nature of the sliding window org, when we arrived here, we can confidently say
+        # that the execution of the sliding window org was successful. We will keep this state for 1 hour.
+        mark_sliding_window_org_executed()
 
 
 def adjust_base_sample_rate_of_org(

--- a/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
@@ -32,9 +32,7 @@ from sentry.tasks.base import instrumented_task
     time_limit=2 * 60 * 60 + 5,
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
-def sliding_window_org(**kwargs) -> None:
-    context: TaskContext = kwargs["context"]
-
+def sliding_window_org(context: TaskContext) -> None:
     window_size = get_sliding_window_size()
     # In case the size is None it means that we disabled the sliding window entirely.
     if window_size is not None:

--- a/src/sentry/dynamic_sampling/tasks/task_context.py
+++ b/src/sentry/dynamic_sampling/tasks/task_context.py
@@ -28,6 +28,22 @@ class DynamicSamplingLogState:
             "executionTime": self.execution_time,
         }
 
+    def increment(
+        self,
+        num_rows_total: int = 0,
+        num_db_calls: int = 0,
+        num_iterations: int = 0,
+        num_projects: int = 0,
+        num_orgs: int = 0,
+    ) -> "DynamicSamplingLogState":
+        self.num_rows_total += num_rows_total
+        self.num_db_calls += num_db_calls
+        self.num_iterations += num_iterations
+        self.num_projects += num_projects
+        self.num_orgs += num_orgs
+
+        return self
+
     @staticmethod
     def from_dict(val: Optional[Dict[Any, Any]]) -> "DynamicSamplingLogState":
         if val is not None:
@@ -68,15 +84,32 @@ class TaskContext:
     def set_function_state(self, function_id: str, log_state: DynamicSamplingLogState):
         if self.context_data is None:
             self.context_data = {}
+
         self.context_data[function_id] = log_state
 
     def get_function_state(self, function_id: str) -> DynamicSamplingLogState:
-
         default = DynamicSamplingLogState()
+
         if self.context_data is None:
             return default
         else:
             return self.context_data.get(function_id, default)
+
+    def incr_function_state(
+        self,
+        function_id: str,
+        num_rows_total: int = 0,
+        num_db_calls: int = 0,
+        num_iterations: int = 0,
+        num_projects: int = 0,
+        num_orgs: int = 0,
+    ):
+        self.set_function_state(
+            function_id,
+            self.get_function_state(function_id).increment(
+                num_rows_total, num_db_calls, num_iterations, num_projects, num_orgs
+            ),
+        )
 
     def get_timer(self, name) -> "NamedTimer":
         return self.timers.get_timer(name)

--- a/src/sentry/dynamic_sampling/tasks/utils.py
+++ b/src/sentry/dynamic_sampling/tasks/utils.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 import sentry_sdk
 
 from sentry.dynamic_sampling.tasks.common import TimeoutException
@@ -12,6 +14,7 @@ def _compute_task_name(function_name: str) -> str:
 
 def dynamic_sampling_task_with_context(max_task_execution: int):
     def wrapper(func):
+        @wraps(func)
         def _wrapper(*args, **kwargs):
             function_name = func.__name__
             task_name = _compute_task_name(function_name)
@@ -39,6 +42,7 @@ def dynamic_sampling_task_with_context(max_task_execution: int):
 
 
 def dynamic_sampling_task(func):
+    @wraps(func)
     def wrapped_func(*args, **kwargs):
         function_name = func.__name__
         task_name = _compute_task_name(function_name)

--- a/src/sentry/dynamic_sampling/tasks/utils.py
+++ b/src/sentry/dynamic_sampling/tasks/utils.py
@@ -1,18 +1,52 @@
+import sentry_sdk
+
+from sentry.dynamic_sampling.tasks.common import TimeoutException
+from sentry.dynamic_sampling.tasks.logging import log_task_execution, log_task_timeout
+from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.utils import metrics
 
 
-def ds_task_with_context(max_task_execution: int):
+def _compute_task_name(function_name: str) -> str:
+    return f"sentry.tasks.dynamic_sampling.{function_name}"
+
+
+def dynamic_sampling_task_with_context(max_task_execution: int):
     def wrapper(func):
         def _wrapper(*args, **kwargs):
             function_name = func.__name__
-            task_name = f"sentry.tasks.dynamic_sampling.{function_name}"
+            task_name = _compute_task_name(function_name)
 
             # We will count how many times the function is run.
             metrics.incr(f"{task_name}.start", sample_rate=1.0)
             # We will count how much it takes to run the function.
             with metrics.timer(task_name, sample_rate=1.0):
-                return func(*args, **kwargs)
+                context = TaskContext(task_name, max_task_execution)
+
+                try:
+                    func(context=context, *args, **kwargs)
+                except TimeoutException:
+                    sentry_sdk.set_extra("context-data", context.to_dict())
+                    log_task_timeout(context)
+                    raise
+                else:
+                    sentry_sdk.set_extra("context-data", context.to_dict())
+                    sentry_sdk.capture_message(f"timing for {task_name}")
+                    log_task_execution(context)
 
         return _wrapper
 
     return wrapper
+
+
+def dynamic_sampling_task(func):
+    def wrapped_func(*args, **kwargs):
+        function_name = func.__name__
+        task_name = _compute_task_name(function_name)
+
+        # We will count how many times the function is run.
+        metrics.incr(f"{task_name}.start", sample_rate=1.0)
+        # We will count how much it takes to run the function.
+        with metrics.timer(task_name, sample_rate=1.0):
+            return func(*args, **kwargs)
+
+    return wrapped_func

--- a/src/sentry/dynamic_sampling/tasks/utils.py
+++ b/src/sentry/dynamic_sampling/tasks/utils.py
@@ -43,7 +43,7 @@ def dynamic_sampling_task_with_context(max_task_execution: int):
 
 def dynamic_sampling_task(func):
     @wraps(func)
-    def wrapped_func():
+    def _wrapper(*args, **kwargs):
         function_name = func.__name__
         task_name = _compute_task_name(function_name)
 
@@ -51,6 +51,6 @@ def dynamic_sampling_task(func):
         metrics.incr(f"{task_name}.start", sample_rate=1.0)
         # We will count how much it takes to run the function.
         with metrics.timer(task_name, sample_rate=1.0):
-            return func()
+            return func(*args, **kwargs)
 
-    return wrapped_func
+    return _wrapper

--- a/src/sentry/dynamic_sampling/tasks/utils.py
+++ b/src/sentry/dynamic_sampling/tasks/utils.py
@@ -1,18 +1,18 @@
 from sentry.utils import metrics
 
 
-def dynamic_sampling_task(func):
-    """
-    Measures a dynamic sampling task by wrapping the function call with metrics collection.
-    """
+def ds_task_with_context(max_task_execution: int):
+    def wrapper(func):
+        def _wrapper(*args, **kwargs):
+            function_name = func.__name__
+            task_name = f"sentry.tasks.dynamic_sampling.{function_name}"
 
-    def wrapped_func(*args, **kwargs):
-        function_name = func.__name__
+            # We will count how many times the function is run.
+            metrics.incr(f"{task_name}.start", sample_rate=1.0)
+            # We will count how much it takes to run the function.
+            with metrics.timer(task_name, sample_rate=1.0):
+                return func(*args, **kwargs)
 
-        # We will count how many times the function is run.
-        metrics.incr(f"sentry.tasks.dynamic_sampling.{function_name}.start", sample_rate=1.0)
-        # We will count how much it takes to run the function.
-        with metrics.timer(f"sentry.tasks.dynamic_sampling.{function_name}", sample_rate=1.0):
-            return func(*args, **kwargs)
+        return _wrapper
 
-    return wrapped_func
+    return wrapper

--- a/src/sentry/dynamic_sampling/tasks/utils.py
+++ b/src/sentry/dynamic_sampling/tasks/utils.py
@@ -15,7 +15,7 @@ def _compute_task_name(function_name: str) -> str:
 def dynamic_sampling_task_with_context(max_task_execution: int):
     def wrapper(func):
         @wraps(func)
-        def _wrapper(*args, **kwargs):
+        def _wrapper():
             function_name = func.__name__
             task_name = _compute_task_name(function_name)
 
@@ -26,7 +26,7 @@ def dynamic_sampling_task_with_context(max_task_execution: int):
                 context = TaskContext(task_name, max_task_execution)
 
                 try:
-                    func(context=context, *args, **kwargs)
+                    func(context=context)
                 except TimeoutException:
                     sentry_sdk.set_extra("context-data", context.to_dict())
                     log_task_timeout(context)
@@ -43,7 +43,7 @@ def dynamic_sampling_task_with_context(max_task_execution: int):
 
 def dynamic_sampling_task(func):
     @wraps(func)
-    def wrapped_func(*args, **kwargs):
+    def wrapped_func():
         function_name = func.__name__
         task_name = _compute_task_name(function_name)
 
@@ -51,6 +51,6 @@ def dynamic_sampling_task(func):
         metrics.incr(f"{task_name}.start", sample_rate=1.0)
         # We will count how much it takes to run the function.
         with metrics.timer(task_name, sample_rate=1.0):
-            return func(*args, **kwargs)
+            return func()
 
     return wrapped_func

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -241,49 +241,6 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         }
         assert generate_rules(proj_d)[0]["samplingValue"] == {"type": "sampleRate", "value": 1.0}
 
-    @patch("sentry.quotas.backend.get_blended_sample_rate")
-    @patch("sentry.quotas.backend.get_transaction_sampling_tier_for_volume")
-    @patch("sentry.dynamic_sampling.tasks.common.extrapolate_monthly_volume")
-    def test_boost_low_volume_projects_simple_with_sliding_window_org_from_sync(
-        self,
-        extrapolate_monthly_volume,
-        get_transaction_sampling_tier_for_volume,
-        get_blended_sample_rate,
-    ):
-        extrapolate_monthly_volume.side_effect = self.forecasted_volume_side_effect
-        get_transaction_sampling_tier_for_volume.side_effect = self.sampling_tier_side_effect
-        get_blended_sample_rate.return_value = 0.8
-        # Create a org
-        test_org = self.create_old_organization(name="sample-org")
-
-        # Create 4 projects
-        proj_a = self.create_project_and_add_metrics("a", 9, test_org)
-        proj_b = self.create_project_and_add_metrics("b", 7, test_org)
-        proj_c = self.create_project_and_add_metrics("c", 3, test_org)
-        proj_d = self.create_project_and_add_metrics("d", 1, test_org)
-
-        with self.feature("organizations:ds-sliding-window-org"):
-            with self.tasks():
-                # We are testing whether the sliding window org sample rate will be synchronously computed
-                # since the cache value is not there.
-                boost_low_volume_projects()
-
-        # we expect only uniform rule
-        # also we test here that `generate_rules` can handle trough redis long floats
-        assert generate_rules(proj_a)[0]["samplingValue"] == {
-            "type": "sampleRate",
-            "value": pytest.approx(0.14814814814814817),
-        }
-        assert generate_rules(proj_b)[0]["samplingValue"] == {
-            "type": "sampleRate",
-            "value": pytest.approx(0.1904761904761905),
-        }
-        assert generate_rules(proj_c)[0]["samplingValue"] == {
-            "type": "sampleRate",
-            "value": pytest.approx(0.4444444444444444),
-        }
-        assert generate_rules(proj_d)[0]["samplingValue"] == {"type": "sampleRate", "value": 1.0}
-
     @patch(
         "sentry.dynamic_sampling.tasks.boost_low_volume_projects.schedule_invalidate_project_config"
     )
@@ -312,6 +269,7 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
 
         with self.feature("organizations:ds-sliding-window-org"):
             with self.tasks():
+                sliding_window_org()
                 boost_low_volume_projects()
 
         assert schedule_invalidate_project_config.call_count == 2

--- a/tests/sentry/dynamic_sampling/tasks/test_utils.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_utils.py
@@ -13,7 +13,7 @@ def test_injection_dynamic_sampling_task_with_context():
     @dynamic_sampling_task_with_context(max_task_execution=duration)
     def inner(context: TaskContext):
         assert context.name == "sentry.tasks.dynamic_sampling.inner"
-        assert context.max_task_execution == duration
+        assert context.num_seconds == duration
 
     inner()
 

--- a/tests/sentry/dynamic_sampling/tasks/test_utils.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_utils.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch
+
+import pytest
+
+from sentry.dynamic_sampling.tasks.sliding_window_org import sliding_window_org
+from sentry.dynamic_sampling.tasks.task_context import TaskContext
+
+
+@pytest.mark.django_db
+@patch("sentry.dynamic_sampling.tasks.sliding_window_org.TimedIterator")
+def test_context_injection_with_decorator(timed_iterator):
+    sliding_window_org()
+
+    assert timed_iterator.call_args[0][0] == TaskContext(
+        name="sentry.tasks.dynamic_sampling.sliding_window_org", num_seconds=420
+    )


### PR DESCRIPTION
This PR improves the dynamic sampling by:
* Improving decorator for automatic `TaskContext` injection.
* Adding metrics for timeouts.
* Improving log state update.
* Removing the synchronous computation of the sliding window org.