### PR TITLE
Refresh `ArtifactBundle`s based on Symbolicators reported usage 

### DIFF
--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random
 from datetime import datetime, timedelta
 from typing import Dict, List, Set, Tuple
 
@@ -9,6 +10,7 @@ from django.db import router
 from django.db.models import Count
 from django.utils import timezone
 
+from sentry import options
 from sentry.models.artifactbundle import (
     INDEXING_THRESHOLD,
     ArtifactBundle,
@@ -16,6 +18,7 @@ from sentry.models.artifactbundle import (
     ArtifactBundleIndex,
     ArtifactBundleIndexingState,
     DebugIdArtifactBundle,
+    FlatFileIndexState,
     ProjectArtifactBundle,
     ReleaseArtifactBundle,
 )
@@ -169,6 +172,35 @@ def _index_urls_in_bundle(
 # ===== Renewal of Artifact Bundles =====
 
 
+@sentry_sdk.tracing.trace
+def maybe_renew_artifact_bundles_from_processing(project_id: int, used_download_ids: List[str]):
+    if options.get("symbolicator.sourcemaps-bundle-index-refresh-sample-rate") <= random.random():
+        return
+
+    artifact_bundle_ids = []
+    for download_id in used_download_ids:
+        # the `download_id` is in a `artifact_bundle/$ID` format
+        split = download_id.split("/")
+        if len(split) < 2:
+            continue
+        ty, ty_id, *_rest = split
+        if ty != "artifact_bundle":
+            continue
+        artifact_bundle_ids.append(ty_id)
+
+    # FIXME: This function is being called for every processed event, so ideally
+    # we would heavily debounce this and avoid doing such a query directly.
+
+    used_artifact_bundles = {
+        id: date_added
+        for id, date_added in ArtifactBundle.objects.filter(
+            projectartifactbundle__project_id=project_id, id__in=artifact_bundle_ids
+        ).values_list("id", "date_added")
+    }
+
+    maybe_renew_artifact_bundles(used_artifact_bundles)
+
+
 def maybe_renew_artifact_bundles(used_artifact_bundles: Dict[int, datetime]):
     # We take a snapshot in time that MUST be consistent across all updates.
     now = timezone.now()
@@ -184,6 +216,7 @@ def maybe_renew_artifact_bundles(used_artifact_bundles: Dict[int, datetime]):
             renew_artifact_bundle(artifact_bundle_id, threshold_date, now)
 
 
+@sentry_sdk.tracing.trace
 def renew_artifact_bundle(artifact_bundle_id: int, threshold_date: datetime, now: datetime):
     metrics.incr("artifact_bundle_renewal.need_renewal")
     # We want to use a transaction, in order to keep the `date_added` consistent across multiple tables.
@@ -194,6 +227,7 @@ def renew_artifact_bundle(artifact_bundle_id: int, threshold_date: datetime, now
             router.db_for_write(ReleaseArtifactBundle),
             router.db_for_write(DebugIdArtifactBundle),
             router.db_for_write(ArtifactBundleIndex),
+            router.db_for_write(FlatFileIndexState),
         )
     ):
         # We check again for the date_added condition in order to achieve consistency, this is done because
@@ -213,6 +247,9 @@ def renew_artifact_bundle(artifact_bundle_id: int, threshold_date: datetime, now
                 artifact_bundle_id=artifact_bundle_id, date_added__lte=threshold_date
             ).update(date_added=now)
             ArtifactBundleIndex.objects.filter(
+                artifact_bundle_id=artifact_bundle_id, date_added__lte=threshold_date
+            ).update(date_added=now)
+            FlatFileIndexState.objects.filter(
                 artifact_bundle_id=artifact_bundle_id, date_added__lte=threshold_date
             ).update(date_added=now)
 

--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Callable, Dict, Optional
 from urllib.parse import unquote
 
+from sentry.debug_files.artifact_bundles import maybe_renew_artifact_bundles_from_processing
 from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import Symbolicator
 from sentry.models import EventError, Project
@@ -245,6 +246,10 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
 
     if not _handle_response_status(data, response):
         return data
+
+    used_artifact_bundles = response.get("used_artifact_bundles", [])
+    if used_artifact_bundles:
+        maybe_renew_artifact_bundles_from_processing(project.id, used_artifact_bundles)
 
     processing_errors = response.get("errors", [])
     if len(processing_errors) > 0:

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -216,6 +216,8 @@ def get_bundle_index_urls(
     base_url = get_internal_artifact_lookup_source_url(project)
 
     def make_download_url(bundle: ArtifactBundleFlatFileIndex):
+        # TODO: do we want to also auto-expire and refresh the `ArtifactBundleFlatFileIndex`?
+
         timestamp = int(bundle.date_added.timestamp() * 1000)
         # NOTE: The `download` query-parameter is both used by symbolicator as a cache key,
         # and it is also used as the the download key for the artifact-lookup API.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -571,6 +571,12 @@ register(
 register(
     "symbolicator.sourcemaps-bundle-index-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
+# Refresh Bundle Indexes reported as used by symbolicator
+register(
+    "symbolicator.sourcemaps-bundle-index-refresh-sample-rate",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Normalization after processors
 register("store.normalize-after-processing", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)  # unused

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -1,6 +1,7 @@
 import os.path
 import zipfile
 from base64 import b64encode
+from datetime import timedelta
 from hashlib import sha1
 from io import BytesIO
 from uuid import uuid4
@@ -8,6 +9,7 @@ from uuid import uuid4
 import pytest
 import responses
 from django.core.files.base import ContentFile
+from django.utils import timezone
 
 from sentry.models import (
     ArtifactBundle,
@@ -2477,7 +2479,12 @@ class TestJavascriptIntegration(RelayStoreHelper):
     @requires_symbolicator
     @pytest.mark.symbolicator
     @with_feature("organizations:sourcemaps-bundle-flat-file-indexing")
-    @override_options({"symbolicator.sourcemaps-bundle-index-sample-rate": 1.0})
+    @override_options(
+        {
+            "symbolicator.sourcemaps-bundle-index-sample-rate": 1.0,
+            "symbolicator.sourcemaps-bundle-index-refresh-sample-rate": 1.0,
+        }
+    )
     def test_bundle_index(self):
         project = self.project
         release = Release.objects.create(organization_id=project.organization_id, version="abc")
@@ -2502,6 +2509,12 @@ class TestJavascriptIntegration(RelayStoreHelper):
         )
 
         upload_bundle(file_a, self.project, release.version)
+
+        # set the bundle date to something in the past so that it is being refreshed automatically
+        now = timezone.now()
+        ArtifactBundle.objects.filter(
+            organization_id=self.organization.id,
+        ).update(date_added=now - timedelta(days=45))
 
         data = {
             "timestamp": self.min_ago,
@@ -2542,3 +2555,10 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
         assert frame.data["resolved_with"] == "index"
         assert frame.data["symbolicated"]
+
+        artifact_bundles = ArtifactBundle.objects.filter(
+            organization_id=self.organization.id,
+        )
+
+        assert len(artifact_bundles) == 1
+        assert artifact_bundles[0].date_added >= now


### PR DESCRIPTION
Also makes sure that `FlatFileIndexState` is correctly bumped as well

This is on top of https://github.com/getsentry/sentry/pull/53058, and requires https://github.com/getsentry/symbolicator/pull/1269