### PR TITLE
fix(starfish): add quotes around transaction name

### DIFF
--- a/static/app/views/starfish/queries/useSpanMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.tsx
@@ -58,7 +58,7 @@ function getEventView(
       name: '',
       query: `${SPAN_GROUP}:${group}${
         queryFilters?.transactionName
-          ? ` transaction:${queryFilters?.transactionName}`
+          ? ` transaction:"${queryFilters?.transactionName}"`
           : ''
       }${
         queryFilters?.['transaction.method']

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -73,7 +73,7 @@ function getEventView(
       name: '',
       query: `${SPAN_GROUP}:${group}${
         queryFilters?.transactionName
-          ? ` transaction:${queryFilters?.transactionName}`
+          ? ` transaction:"${queryFilters?.transactionName}"`
           : ''
       }${
         queryFilters?.['transaction.method']

--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -40,7 +40,7 @@ export const useSpanSamples = (options: Options) => {
 
   const query = new MutableSearch([
     `${SPAN_GROUP}:${groupId}`,
-    `transaction:${transactionName}`,
+    `transaction:"${transactionName}"`,
     `transaction.method:${transactionMethod}`,
   ]);
 


### PR DESCRIPTION
Add quotes around transaction name to prevent errors when the transaction name has a space in it.