### PR TITLE
chore(replay): Remove unicode from slack View Replays link

### DIFF
--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -117,7 +117,7 @@ def build_attachment_replay_link(
         referrer = EXTERNAL_PROVIDERS[ExternalProviders.SLACK]
         replay_url = f"{group.get_absolute_url()}replays/?referrer={referrer}"
 
-        return f"\n\n{url_format.format(text='⏵ View Replays', url=absolute_uri(replay_url))}"
+        return f"\n\n{url_format.format(text='View Replays', url=absolute_uri(replay_url))}"
 
     return None
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -244,7 +244,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             attachments = SlackIssuesMessageBuilder(event.group, event).build()
         assert (
             attachments["text"]
-            == f"\n\n<http://testserver/organizations/baz/issues/{event.group.id}/replays/?referrer=slack|⏵ View Replays>"
+            == f"\n\n<http://testserver/organizations/baz/issues/{event.group.id}/replays/?referrer=slack|View Replays>"
         )
 
     def test_build_performance_issue_color_no_event_passed(self):


### PR DESCRIPTION
The unicode doesn't display properly on all devices

Example of it not working:
![Screen Shot 2023-07-25 at 9 38 52 AM](https://github.com/getsentry/sentry/assets/187460/589b3c75-4be6-4464-a5ac-83fe69295387)

Here's where it does work:
<img width="251" alt="SCR-20230725-iivp" src="https://github.com/getsentry/sentry/assets/187460/0a171a9c-bef1-4153-8a46-e4bfa76bd09f">

