### PR TITLE
fix(starfish): infinite sample loading

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -94,8 +94,7 @@ function SampleTable({
     isFetchingSpanMetrics ||
     isFetchingSamples ||
     !isSamplesEnabled ||
-    !isTransactionsEnabled ||
-    (!areNoSamples && isFetchingTransactions);
+    (!areNoSamples && isFetchingTransactions && !isTransactionsEnabled);
 
   if (sampleError || transactionError) {
     setPageError(t('An error has occured while loading the samples table'));


### PR DESCRIPTION
This should fix the infinite loading when there are no samples, ie `areNoSamples === true`. The issue being when there were no samples, the transactions query would be disabled, so `isLoading` would still be true.

I'm going to write some tests for this logic and maybe simplify a bit in a another PR as it i've ran into a couple of issues with it already.