### PR TITLE
feat(escalating-issues): Allow substatus validator to be null for RESOLVED status

### DIFF
--- a/src/sentry/api/helpers/group_index/validators/group.py
+++ b/src/sentry/api/helpers/group_index/validators/group.py
@@ -18,7 +18,8 @@ class GroupValidator(serializers.Serializer):
     )
     statusDetails = StatusDetailsValidator()
     substatus = serializers.ChoiceField(
-        choices=list(zip(SUBSTATUS_UPDATE_CHOICES.keys(), SUBSTATUS_UPDATE_CHOICES.keys()))
+        choices=list(zip(SUBSTATUS_UPDATE_CHOICES.keys(), SUBSTATUS_UPDATE_CHOICES.keys())),
+        allow_null=True,
     )
     hasSeen = serializers.BooleanField()
     isBookmarked = serializers.BooleanField()

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -96,7 +96,7 @@ class UpdateGroupsTest(TestCase):
 
         request = self.make_request(user=self.user, method="GET")
         request.user = self.user
-        request.data = {"status": "unresolved"}
+        request.data = {"status": "unresolved", "substatus": "ongoing"}
         request.GET = QueryDict(query_string=f"id={resolved_group.id}")
 
         search_fn = Mock()
@@ -107,6 +107,7 @@ class UpdateGroupsTest(TestCase):
         resolved_group.refresh_from_db()
 
         assert resolved_group.status == GroupStatus.UNRESOLVED
+        assert resolved_group.substatus == GroupSubStatus.ONGOING
         assert not send_robust.called
         assert send_unresolved.called
 
@@ -118,7 +119,7 @@ class UpdateGroupsTest(TestCase):
 
         request = self.make_request(user=self.user, method="GET")
         request.user = self.user
-        request.data = {"status": "resolved"}
+        request.data = {"status": "resolved", "substatus": None}
         request.GET = QueryDict(query_string=f"id={unresolved_group.id}")
 
         search_fn = Mock()


### PR DESCRIPTION
## Objective:
Not all Group statuses have a related substatus. The RESOLVED status will have a substatus of None. Our validator should reflect that.