### PR TITLE
feat(replays): Add selector aggregation endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -87,6 +87,7 @@ from sentry.replays.endpoints.organization_replay_events_meta import (
     OrganizationReplayEventsMetaEndpoint,
 )
 from sentry.replays.endpoints.organization_replay_index import OrganizationReplayIndexEndpoint
+from sentry.replays.endpoints.organization_selector_index import OrganizationSelectorIndexEndpoint
 from sentry.replays.endpoints.project_replay_clicks_index import ProjectReplayClicksIndexEndpoint
 from sentry.replays.endpoints.project_replay_details import ProjectReplayDetailsEndpoint
 from sentry.replays.endpoints.project_replay_recording_segment_details import (
@@ -1698,6 +1699,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_slug>[^\/]+)/replays/$",
         OrganizationReplayIndexEndpoint.as_view(),
         name="sentry-api-0-organization-replay-index",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/replay-selectors/$",
+        OrganizationSelectorIndexEndpoint.as_view(),
+        name="sentry-api-0-organization-replay-selectors-index",
     ),
     re_path(
         r"^(?P<organization_slug>[^\/]+)/replay-count/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -87,7 +87,9 @@ from sentry.replays.endpoints.organization_replay_events_meta import (
     OrganizationReplayEventsMetaEndpoint,
 )
 from sentry.replays.endpoints.organization_replay_index import OrganizationReplayIndexEndpoint
-from sentry.replays.endpoints.organization_selector_index import OrganizationSelectorIndexEndpoint
+from sentry.replays.endpoints.organization_replay_selector_index import (
+    OrganizationReplaySelectorIndexEndpoint,
+)
 from sentry.replays.endpoints.project_replay_clicks_index import ProjectReplayClicksIndexEndpoint
 from sentry.replays.endpoints.project_replay_details import ProjectReplayDetailsEndpoint
 from sentry.replays.endpoints.project_replay_recording_segment_details import (
@@ -1702,7 +1704,7 @@ ORGANIZATION_URLS = [
     ),
     re_path(
         r"^(?P<organization_slug>[^\/]+)/replay-selectors/$",
-        OrganizationSelectorIndexEndpoint.as_view(),
+        OrganizationReplaySelectorIndexEndpoint.as_view(),
         name="sentry-api-0-organization-replay-selectors-index",
     ),
     re_path(

--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -267,7 +267,7 @@ Deletes a replay instance.
 
 ### Browse Replay Selectors [GET]
 
-Retrieve a collection of replays.
+Retrieve a collection of selectors.
 
 **Attributes**
 

--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -238,6 +238,59 @@ Deletes a replay instance.
 
 - Response 204
 
+## Replay Selectors [/organizations/<organization_slug>/replay-selectors/]
+
+- Parameters
+
+  - project (optional, string)
+  - sort (optional, string)
+    Default: -count_dead_clicks
+    Members:
+    - count_dead_clicks
+    - -count_dead_clicks
+    - count_rage_clicks
+    - -count_rage_clicks
+  - statsPeriod (optional, string) - A positive integer suffixed with a unit type.
+    Default: 7d
+    Members:
+    - s
+    - m
+    - h
+    - d
+    - w
+  - start (optional, string) - ISO 8601 format (`YYYY-MM-DDTHH:mm:ss.sssZ`)
+  - end (optional, string) - ISO 8601 format. Required if `start` is set.
+  - limit (optional, number)
+    Default: 10
+  - offset (optional, number)
+    Default: 0
+
+### Browse Replay Selectors [GET]
+
+Retrieve a collection of replays.
+
+**Attributes**
+
+| Column            | Type   | Description                                        |
+| ----------------- | ------ | -------------------------------------------------- |
+| dom_element       | string | -                                                  |
+| count_dead_clicks | number | The number of dead clicks for a given DOM element. |
+| count_rage_clicks | number | The number of rage clicks for a given DOM element. |
+
+- Response 200
+
+  ```json
+  {
+    "data": [
+      {
+        "dom_element": "div#myid.class1.class2",
+        "count_dead_clicks": 2,
+        "count_rage_clicks": 1
+      }
+    ]
+  }
+  ```
+
 ## Replay Recording Segments [/projects/<organization_slug>/<project_slug>/replays/<replay_id>/recording-segments/]
 
 - Parameters

--- a/src/sentry/replays/endpoints/organization_replay_selector_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_selector_index.py
@@ -36,16 +36,11 @@ from sentry.utils.snuba import raw_snql_query
 @region_silo_endpoint
 class OrganizationReplaySelectorIndexEndpoint(OrganizationEndpoint):
     def get_replay_filter_params(self, request, organization):
-
-        query_referrer = request.GET.get("queryReferrer", None)
-
         filter_params = self.get_filter_params(request, organization)
 
-        has_global_views = (
-            features.has("organizations:global-views", organization, actor=request.user)
-            or query_referrer == "issueReplays"
+        has_global_views = features.has(
+            "organizations:global-views", organization, actor=request.user
         )
-
         if not has_global_views and len(filter_params.get("project_id", [])) > 1:
             raise ParseError(detail="You cannot view events from multiple projects.")
 

--- a/src/sentry/replays/endpoints/organization_replay_selector_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_selector_index.py
@@ -34,7 +34,7 @@ from sentry.utils.snuba import raw_snql_query
 
 
 @region_silo_endpoint
-class OrganizationSelectorIndexEndpoint(OrganizationEndpoint):
+class OrganizationReplaySelectorIndexEndpoint(OrganizationEndpoint):
     def get_replay_filter_params(self, request, organization):
 
         query_referrer = request.GET.get("queryReferrer", None)

--- a/src/sentry/replays/endpoints/organization_replay_selector_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_selector_index.py
@@ -95,7 +95,7 @@ def query_selector_collection(
     sort: Optional[str],
     limit: Optional[str],
     offset: Optional[str],
-    organization: Optional[Organization] = None,
+    organization: Organization,
 ) -> dict:
     """Query aggregated replay collection."""
     if organization:
@@ -117,7 +117,7 @@ def query_selector_collection(
 
 
 def query_selector_dataset(
-    project_ids: List[str],
+    project_ids: List[int],
     start: datetime,
     end: datetime,
     pagination: Optional[Paginators],
@@ -126,7 +126,6 @@ def query_selector_dataset(
 ):
     query_options = {}
 
-    # Instance requests do not paginate.
     if pagination:
         query_options["limit"] = Limit(pagination.limit)
         query_options["offset"] = Offset(pagination.offset)

--- a/src/sentry/replays/endpoints/organization_replay_selector_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_selector_index.py
@@ -146,7 +146,6 @@ def query_selector_dataset(
                 Column("click_tag"),
                 Column("click_id"),
                 Column("click_class"),
-                Column("click_text"),
                 Column("click_role"),
                 Column("click_alt"),
                 Column("click_testid"),
@@ -166,7 +165,6 @@ def query_selector_dataset(
                 Column("click_tag"),
                 Column("click_id"),
                 Column("click_class"),
-                Column("click_text"),
                 Column("click_role"),
                 Column("click_alt"),
                 Column("click_testid"),
@@ -184,31 +182,32 @@ def query_selector_dataset(
 def process_raw_response(response: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Process the response further into the expected output."""
 
-    def _iter_response():
-        for r in response:
-            # Tag is always present.
-            selector = r["click_tag"]
+    def make_selector_name(row) -> str:
+        selector = row["click_tag"]
 
-            if r["click_id"]:
-                selector = selector + f"#{r['click_id']}"
-            if r["click_class"]:
-                selector = selector + "." + ".".join(r["click_class"])
+        if row["click_id"]:
+            selector = selector + f"#{row['click_id']}"
+        if row["click_class"]:
+            selector = selector + "." + ".".join(row["click_class"])
 
-            if r["click_role"]:
-                selector = selector + f'[role="{r["click_role"]}"]'
-            if r["click_alt"]:
-                selector = selector + f'[alt="{r["click_alt"]}"]'
-            if r["click_testid"]:
-                selector = selector + f'[testid="{r["click_testid"]}"]'
-            if r["click_aria_label"]:
-                selector = selector + f'[aria="{r["click_aria_label"]}"]'
-            if r["click_title"]:
-                selector = selector + f'[title="{r["click_title"]}"]'
+        if row["click_role"]:
+            selector = selector + f'[role="{row["click_role"]}"]'
+        if row["click_alt"]:
+            selector = selector + f'[alt="{row["click_alt"]}"]'
+        if row["click_testid"]:
+            selector = selector + f'[testid="{row["click_testid"]}"]'
+        if row["click_aria_label"]:
+            selector = selector + f'[aria="{row["click_aria_label"]}"]'
+        if row["click_title"]:
+            selector = selector + f'[title="{row["click_title"]}"]'
 
-            yield {
-                "dom_element": selector,
-                "count_dead_clicks": r["count_dead_clicks"],
-                "count_rage_clicks": r["count_rage_clicks"],
-            }
+        return selector
 
-    return list(_iter_response())
+    return [
+        {
+            "dom_element": make_selector_name(row),
+            "count_dead_clicks": row["count_dead_clicks"],
+            "count_rage_clicks": row["count_rage_clicks"],
+        }
+        for row in response
+    ]

--- a/src/sentry/replays/endpoints/organization_selector_index.py
+++ b/src/sentry/replays/endpoints/organization_selector_index.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, List, Optional
+
+from rest_framework.exceptions import ParseError
+from rest_framework.request import Request
+from rest_framework.response import Response
+from snuba_sdk import (
+    Column,
+    Condition,
+    Direction,
+    Entity,
+    Function,
+    Granularity,
+    Limit,
+    Offset,
+    Op,
+    OrderBy,
+    Query,
+)
+from snuba_sdk import Request as SnubaRequest
+
+from sentry import features
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import NoProjects, OrganizationEndpoint
+from sentry.api.event_search import SearchConfig
+from sentry.api.paginator import GenericOffsetPaginator
+from sentry.models.organization import Organization
+from sentry.replays.lib.query import Number, QueryConfig, get_valid_sort_commands
+from sentry.replays.query import Paginators, make_pagination_values
+from sentry.replays.validators import ReplayValidator
+from sentry.utils.snuba import raw_snql_query
+
+
+@region_silo_endpoint
+class OrganizationSelectorIndexEndpoint(OrganizationEndpoint):
+    def get_replay_filter_params(self, request, organization):
+
+        query_referrer = request.GET.get("queryReferrer", None)
+
+        filter_params = self.get_filter_params(request, organization)
+
+        has_global_views = (
+            features.has("organizations:global-views", organization, actor=request.user)
+            or query_referrer == "issueReplays"
+        )
+
+        if not has_global_views and len(filter_params.get("project_id", [])) > 1:
+            raise ParseError(detail="You cannot view events from multiple projects.")
+
+        return filter_params
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        if not features.has("organizations:session-replay", organization, actor=request.user):
+            return Response(status=404)
+        try:
+            filter_params = self.get_replay_filter_params(request, organization)
+        except NoProjects:
+            return Response({"data": []}, status=200)
+
+        result = ReplayValidator(data=request.GET)
+        if not result.is_valid():
+            raise ParseError(result.errors)
+
+        for key, value in result.validated_data.items():
+            if key not in filter_params:
+                filter_params[key] = value
+
+        def data_fn(offset, limit):
+            return query_selector_collection(
+                project_ids=filter_params["project_id"],
+                start=filter_params["start"],
+                end=filter_params["end"],
+                sort=filter_params.get("sort"),
+                limit=limit,
+                offset=offset,
+                organization=organization,
+            )
+
+        return self.paginate(
+            request=request,
+            paginator=GenericOffsetPaginator(data_fn=data_fn),
+            on_results=lambda results: {"data": process_raw_response(results)},
+        )
+
+
+selector_search_config = SearchConfig(numeric_keys={"count_dead_clicks", "count_rage_clicks"})
+
+
+class SelectorQueryConfig(QueryConfig):
+    count_dead_clicks = Number()
+    count_rage_clicks = Number()
+
+
+def query_selector_collection(
+    project_ids: List[int],
+    start: datetime,
+    end: datetime,
+    sort: Optional[str],
+    limit: Optional[str],
+    offset: Optional[str],
+    organization: Optional[Organization] = None,
+) -> dict:
+    """Query aggregated replay collection."""
+    if organization:
+        tenant_ids = {"organization_id": organization.id}
+    else:
+        tenant_ids = {}
+
+    paginators = make_pagination_values(limit, offset)
+
+    response = query_selector_dataset(
+        project_ids=project_ids,
+        start=start,
+        end=end,
+        pagination=paginators,
+        sort=sort,
+        tenant_ids=tenant_ids,
+    )
+    return response["data"]
+
+
+def query_selector_dataset(
+    project_ids: List[str],
+    start: datetime,
+    end: datetime,
+    pagination: Optional[Paginators],
+    sort: Optional[str],
+    tenant_ids: dict[str, Any] | None = None,
+):
+    query_options = {}
+
+    # Instance requests do not paginate.
+    if pagination:
+        query_options["limit"] = Limit(pagination.limit)
+        query_options["offset"] = Offset(pagination.offset)
+
+    sorting = get_valid_sort_commands(
+        sort,
+        default=OrderBy(Column("count_dead_clicks"), Direction.DESC),
+        query_config=SelectorQueryConfig(),
+    )
+
+    snuba_request = SnubaRequest(
+        dataset="replays",
+        app_id="replay-backend-web",
+        query=Query(
+            match=Entity("replays"),
+            select=[
+                Column("click_tag"),
+                Column("click_id"),
+                Column("click_class"),
+                Column("click_text"),
+                Column("click_role"),
+                Column("click_alt"),
+                Column("click_testid"),
+                Column("click_aria_label"),
+                Column("click_title"),
+                Function("sum", parameters=[Column("click_is_dead")], alias="count_dead_clicks"),
+                Function("sum", parameters=[Column("click_is_rage")], alias="count_rage_clicks"),
+            ],
+            where=[
+                Condition(Column("project_id"), Op.IN, project_ids),
+                Condition(Column("timestamp"), Op.LT, end),
+                Condition(Column("timestamp"), Op.GTE, start),
+                Condition(Column("click_tag"), Op.NEQ, ""),
+            ],
+            orderby=sorting,
+            groupby=[
+                Column("click_tag"),
+                Column("click_id"),
+                Column("click_class"),
+                Column("click_text"),
+                Column("click_role"),
+                Column("click_alt"),
+                Column("click_testid"),
+                Column("click_aria_label"),
+                Column("click_title"),
+            ],
+            granularity=Granularity(3600),
+            **query_options,
+        ),
+        tenant_ids=tenant_ids,
+    )
+    return raw_snql_query(snuba_request, "replays.query.query_replays_dataset")
+
+
+def process_raw_response(response: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Process the response further into the expected output."""
+
+    def _iter_response():
+        for r in response:
+            # Tag is always present.
+            selector = r["click_tag"]
+
+            if r["click_id"]:
+                selector = selector + f"#{r['click_id']}"
+            if r["click_class"]:
+                selector = selector + "." + ".".join(r["click_class"])
+
+            if r["click_role"]:
+                selector = selector + f'[role="{r["click_role"]}"]'
+            if r["click_alt"]:
+                selector = selector + f'[alt="{r["click_alt"]}"]'
+            if r["click_testid"]:
+                selector = selector + f'[testid="{r["click_testid"]}"]'
+            if r["click_aria_label"]:
+                selector = selector + f'[aria="{r["click_aria_label"]}"]'
+            if r["click_title"]:
+                selector = selector + f'[title="{r["click_title"]}"]'
+
+            yield {
+                "dom_element": selector,
+                "count_dead_clicks": r["count_dead_clicks"],
+                "count_rage_clicks": r["count_rage_clicks"],
+            }
+
+    return list(_iter_response())

--- a/tests/sentry/replays/test_organization_selector_index.py
+++ b/tests/sentry/replays/test_organization_selector_index.py
@@ -1,0 +1,100 @@
+import datetime
+import uuid
+
+from django.urls import reverse
+
+from sentry.replays.testutils import mock_replay, mock_replay_click
+from sentry.testutils import APITestCase, ReplaysSnubaTestCase
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
+from sentry.testutils.silo import region_silo_test
+
+REPLAYS_FEATURES = {"organizations:session-replay": True}
+
+
+@region_silo_test
+@apply_feature_flag_on_cls("organizations:global-views")
+class OrganizationSelectorIndexTest(APITestCase, ReplaysSnubaTestCase):
+    endpoint = "sentry-api-0-organization-replay-selectors-index"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.url = reverse(self.endpoint, args=(self.organization.slug,))
+
+    def test_feature_flag_disabled(self):
+        """Test replays can be disabled."""
+        response = self.client.get(self.url)
+        assert response.status_code == 404
+
+    def test_no_projects(self):
+        """Test replays must be used with a project(s)."""
+        with self.feature(REPLAYS_FEATURES):
+            response = self.client.get(self.url)
+            assert response.status_code == 200
+
+            response_data = response.json()
+            assert "data" in response_data
+            assert response_data["data"] == []
+
+    def test_get_replays(self):
+        """Test replays conform to the interchange format."""
+        project = self.create_project(teams=[self.team])
+
+        replay1_id = uuid.uuid4().hex
+        seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=22)
+        seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=5)
+        self.store_replays(mock_replay(seq1_timestamp, project.id, replay1_id))
+        self.store_replays(mock_replay(seq2_timestamp, project.id, replay1_id))
+        self.store_replays(
+            mock_replay_click(
+                seq2_timestamp,
+                project.id,
+                replay1_id,
+                node_id=1,
+                tag="div",
+                id="myid",
+                class_=["class1", "class2"],
+                role="button",
+                testid="1",
+                alt="Alt",
+                aria_label="AriaLabel",
+                title="MyTitle",
+                is_dead=1,
+                is_rage=1,
+                text="Hello",
+            )
+        )
+        self.store_replays(
+            mock_replay_click(
+                seq2_timestamp,
+                project.id,
+                replay1_id,
+                node_id=1,
+                tag="div",
+                id="myid",
+                class_=["class1", "class2"],
+                role="button",
+                testid="1",
+                alt="Alt",
+                aria_label="AriaLabel",
+                title="MyTitle",
+                is_dead=1,
+                is_rage=0,
+                text="Hello",
+            )
+        )
+
+        with self.feature(REPLAYS_FEATURES):
+            response = self.client.get(self.url)
+            assert response.status_code == 200
+
+            response_data = response.json()
+            assert "data" in response_data
+            assert len(response_data["data"]) == 1
+
+            assert (
+                response_data["data"][0]["dom_element"]
+                == 'div#myid.class1.class2[role="button"][alt="Alt"][testid="1"][aria="AriaLabel"][title="MyTitle"]'
+            )
+            assert response_data["data"][0]["count_dead_clicks"] == 2
+            assert response_data["data"][0]["count_rage_clicks"] == 1


### PR DESCRIPTION
Adds click selector aggregation to the replays products.  Reading from this API will show you the top DOM selectors by rage and dead click counts.