### PR TITLE
fix(starfish): Include user query in secondary sample query

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -159,7 +159,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
             selected_columns=["project", "transaction.id", column, "timestamp", "span_id"],
             orderby=["timestamp"],
             params=params,
-            query=f"span_id:[{','.join(span_ids)}]",
+            query=f"span_id:[{','.join(span_ids)}] {request.query_params.get('query')}",
             referrer=Referrer.API_SPAN_SAMPLE_GET_SPAN_DATA.value,
         )
         return Response({"data": result["data"]})


### PR DESCRIPTION
- Include the user query in the secondary sample query. This should help improve perforamnce significantly since the user query will have both the group id and the transaction name. In snuba admin this reduced the scanned rows to 0.03% of what they were at before