### PR TITLE
feat(github-growth): fetch missing members in API

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -7,7 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import Serializer, serialize
 from sentry.models import Repository
 from sentry.models.commitauthor import CommitAuthor
@@ -19,8 +19,14 @@ class MissingOrgMemberSerializer(Serializer):
         return {"email": obj.email, "externalId": obj.external_id, "commitCount": obj.commit_count}
 
 
+class MissingMembersPermission(OrganizationPermission):
+    scope_map = {"GET": ["org:write"]}
+
+
 @region_silo_endpoint
 class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
+    permission_classes = (MissingMembersPermission,)
+
     def _get_missing_members(self, organization: Organization) -> QuerySet[CommitAuthor]:
         member_emails = set(
             organization.member_set.exclude(email=None).values_list("email", flat=True)

--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -1,0 +1,69 @@
+from datetime import timedelta
+
+from django.db.models import Count, QuerySet
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.serializers import Serializer, serialize
+from sentry.models import Repository
+from sentry.models.commitauthor import CommitAuthor
+from sentry.models.organization import Organization
+
+
+class MissingOrgMemberSerializer(Serializer):
+    def serialize(self, obj, attrs, user, **kwargs):
+        return {"email": obj.email, "externalId": obj.external_id, "commitCount": obj.commit_count}
+
+
+@region_silo_endpoint
+class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
+    def _get_missing_members(self, organization: Organization) -> QuerySet[CommitAuthor]:
+        member_emails = set(
+            organization.member_set.exclude(email=None).values_list("email", flat=True)
+        )
+        member_emails.update(
+            set(
+                organization.member_set.exclude(user_email=None).values_list(
+                    "user_email", flat=True
+                )
+            )
+        )
+        nonmember_authors = CommitAuthor.objects.filter(organization_id=organization.id).exclude(
+            email__in=member_emails
+        )
+
+        # This is currently for Github only
+        return (
+            nonmember_authors.filter(
+                commit__repository_id__in=set(
+                    Repository.objects.filter(
+                        provider="integrations:github", organization_id=organization.id
+                    ).values_list("id", flat=True)
+                ),
+                commit__date_added__gte=timezone.now() - timedelta(days=30),
+            )
+            .annotate(commit_count=Count("commit"))
+            .order_by("-commit_count")
+        )
+
+    # TODO(cathy): check domain
+
+    def get(self, request: Request, organization) -> Response:
+        # TODO(cathy): search
+        queryset = self._get_missing_members(organization)
+
+        return Response(
+            [
+                {
+                    "integration": "github",
+                    "users": serialize(
+                        list(queryset), request.user, serializer=MissingOrgMemberSerializer()
+                    ),
+                }
+            ],
+            status=status.HTTP_200_OK,
+        )

--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -42,14 +42,14 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
             email__in=member_emails
         )
 
+        org_repos = Repository.objects.filter(
+            provider="integrations:github", organization_id=organization.id
+        ).values_list("id", flat=True)
+
         # This is currently for Github only
         return (
             nonmember_authors.filter(
-                commit__repository_id__in=set(
-                    Repository.objects.filter(
-                        provider="integrations:github", organization_id=organization.id
-                    ).values_list("id", flat=True)
-                ),
+                commit__repository_id__in=set(org_repos),
                 commit__date_added__gte=timezone.now() - timedelta(days=30),
             )
             .annotate(commit_count=Count("commit"))

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -9,6 +9,7 @@ from sentry.api.endpoints.organization_events_facets_stats_performance import (
     OrganizationEventsFacetsStatsPerformanceEndpoint,
 )
 from sentry.api.endpoints.organization_events_starfish import OrganizationEventsStarfishEndpoint
+from sentry.api.endpoints.organization_missing_org_members import OrganizationMissingMembersEndpoint
 from sentry.api.endpoints.organization_projects_experiment import (
     OrganizationProjectsExperimentEndpoint,
 )
@@ -1243,6 +1244,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_slug>[^\/]+)/metrics-compatibility-sums/$",
         OrganizationMetricsCompatibilitySums.as_view(),
         name="sentry-api-0-organization-metrics-compatibility-sums",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/missing-members/$",
+        OrganizationMissingMembersEndpoint.as_view(),
+        name="sentry-api-0-organization-missing-members",
     ),
     re_path(
         r"^(?P<organization_slug>[^\/]+)/events-histogram/$",

--- a/tests/sentry/api/test_organization_missing_members.py
+++ b/tests/sentry/api/test_organization_missing_members.py
@@ -1,3 +1,7 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
 from sentry.testutils import APITestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -42,3 +46,43 @@ class OrganizationMissingMembersTestCase(APITestCase):
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
         ]
+
+    def test_need_org_write(self):
+        user = self.create_user()
+        self.create_member(organization=self.organization, user=user, role="member")
+        self.login_as(user)
+
+        self.get_error_response(self.organization.slug, status=403)
+
+    def test_filters_github_only(self):
+        repo = self.create_repo(project=self.project, provider="integrations:bitbucket")
+        self.create_commit(repo=repo, author=self.commit_author1)
+
+        response = self.get_success_response(self.organization.slug)
+        assert response.data[0]["integration"] == "github"
+        assert response.data[0]["users"] == [
+            {"email": "c@example.com", "externalId": "c", "commitCount": 2},
+            {"email": "d@example.com", "externalId": "d", "commitCount": 1},
+        ]
+
+    def test_filters_old_commits(self):
+        self.create_commit(
+            repo=self.repo,
+            author=self.commit_author1,
+            date_added=timezone.now() - timedelta(days=31),
+        )
+
+        response = self.get_success_response(self.organization.slug)
+        assert response.data[0]["integration"] == "github"
+        assert response.data[0]["users"] == [
+            {"email": "c@example.com", "externalId": "c", "commitCount": 2},
+            {"email": "d@example.com", "externalId": "d", "commitCount": 1},
+        ]
+
+    def test_no_authors(self):
+        org = self.create_organization()
+        self.create_member(user=self.user, organization=org, role="manager")
+
+        response = self.get_success_response(org.slug)
+        assert response.data[0]["integration"] == "github"
+        assert response.data[0]["users"] == []

--- a/tests/sentry/api/test_organization_missing_members.py
+++ b/tests/sentry/api/test_organization_missing_members.py
@@ -1,0 +1,42 @@
+from sentry.testutils import APITestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test(stable=True)
+class OrganizationMissingMembersTestCase(APITestCase):
+    endpoint = "sentry-api-0-organization-missing-members"
+    method = "get"
+
+    def setUp(self):
+        super().setUp()
+
+        self.create_member(
+            email="a@example.com",
+            organization=self.organization,
+        )
+        member = self.create_member(user=self.create_user(), organization=self.organization)
+        member.user_email = "b@example.com"
+        member.save()
+
+        self.commit_author1 = self.create_commit_author(project=self.project, email="c@example.com")
+        self.commit_author1.external_id = "c"
+        self.commit_author1.save()
+
+        self.commit_author2 = self.create_commit_author(project=self.project, email="d@example.com")
+        self.commit_author2.external_id = "d"
+        self.commit_author2.save()
+
+        self.repo = self.create_repo(project=self.project, provider="integrations:github")
+        self.create_commit(repo=self.repo, author=self.commit_author1)
+        self.create_commit(repo=self.repo, author=self.commit_author1)
+        self.create_commit(repo=self.repo, author=self.commit_author2)
+
+        self.login_as(self.user)
+
+    def test_simple(self):
+        response = self.get_success_response(self.organization.slug)
+        assert response.data[0]["integration"] == "github"
+        assert response.data[0]["users"] == [
+            {"email": "c@example.com", "externalId": "c", "commitCount": 2},
+            {"email": "d@example.com", "externalId": "d", "commitCount": 1},
+        ]

--- a/tests/sentry/api/test_organization_missing_members.py
+++ b/tests/sentry/api/test_organization_missing_members.py
@@ -18,6 +18,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
         member.user_email = "b@example.com"
         member.save()
 
+        self.commit_author = self.create_commit_author(project=self.project, email="b@example.com")
         self.commit_author1 = self.create_commit_author(project=self.project, email="c@example.com")
         self.commit_author1.external_id = "c"
         self.commit_author1.save()
@@ -27,6 +28,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
         self.commit_author2.save()
 
         self.repo = self.create_repo(project=self.project, provider="integrations:github")
+        self.create_commit(repo=self.repo, author=self.commit_author)
         self.create_commit(repo=self.repo, author=self.commit_author1)
         self.create_commit(repo=self.repo, author=self.commit_author1)
         self.create_commit(repo=self.repo, author=self.commit_author2)

--- a/tests/sentry/api/test_organization_missing_members.py
+++ b/tests/sentry/api/test_organization_missing_members.py
@@ -22,20 +22,26 @@ class OrganizationMissingMembersTestCase(APITestCase):
         member.user_email = "b@example.com"
         member.save()
 
-        self.commit_author = self.create_commit_author(project=self.project, email="b@example.com")
-        self.commit_author1 = self.create_commit_author(project=self.project, email="c@example.com")
-        self.commit_author1.external_id = "c"
-        self.commit_author1.save()
+        self.member_commit_author = self.create_commit_author(
+            project=self.project, email="b@example.com"
+        )
+        self.nonmember_commit_author1 = self.create_commit_author(
+            project=self.project, email="c@example.com"
+        )
+        self.nonmember_commit_author1.external_id = "c"
+        self.nonmember_commit_author1.save()
 
-        self.commit_author2 = self.create_commit_author(project=self.project, email="d@example.com")
-        self.commit_author2.external_id = "d"
-        self.commit_author2.save()
+        self.nonmember_commit_author2 = self.create_commit_author(
+            project=self.project, email="d@example.com"
+        )
+        self.nonmember_commit_author2.external_id = "d"
+        self.nonmember_commit_author2.save()
 
         self.repo = self.create_repo(project=self.project, provider="integrations:github")
-        self.create_commit(repo=self.repo, author=self.commit_author)
-        self.create_commit(repo=self.repo, author=self.commit_author1)
-        self.create_commit(repo=self.repo, author=self.commit_author1)
-        self.create_commit(repo=self.repo, author=self.commit_author2)
+        self.create_commit(repo=self.repo, author=self.member_commit_author)
+        self.create_commit(repo=self.repo, author=self.nonmember_commit_author1)
+        self.create_commit(repo=self.repo, author=self.nonmember_commit_author1)
+        self.create_commit(repo=self.repo, author=self.nonmember_commit_author2)
 
         self.login_as(self.user)
 
@@ -56,7 +62,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
 
     def test_filters_github_only(self):
         repo = self.create_repo(project=self.project, provider="integrations:bitbucket")
-        self.create_commit(repo=repo, author=self.commit_author1)
+        self.create_commit(repo=repo, author=self.nonmember_commit_author1)
 
         response = self.get_success_response(self.organization.slug)
         assert response.data[0]["integration"] == "github"
@@ -68,7 +74,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
     def test_filters_old_commits(self):
         self.create_commit(
             repo=self.repo,
-            author=self.commit_author1,
+            author=self.nonmember_commit_author1,
             date_added=timezone.now() - timedelta(days=31),
         )
 


### PR DESCRIPTION
Get the GitHub commit authors that are not members of the organization for commits made in the last 30 days (first pass)

For ER-1753 and ER-1754