### PR TITLE
feat(crons): Add trace_id to applicable error issues

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -293,6 +293,7 @@ def _process_message(wrapper: Dict) -> None:
                 return
 
             status = getattr(CheckInStatus, validated_params["status"].upper())
+            trace_id = validated_params.get("contexts", {}).get("trace", {}).get("trace_id")
 
             # Invalid UUIDs will raise ValueError
             check_in_id = uuid.UUID(params["check_in_id"])
@@ -335,8 +336,6 @@ def _process_message(wrapper: Dict) -> None:
                 monitor_config = monitor.get_validated_config()
                 timeout_at = get_timeout_at(monitor_config, status, date_added)
 
-                trace_id = validated_params.get("contexts", {}).get("trace", {}).get("trace_id")
-
                 # If the UUID is unset (zero value) generate a new UUID
                 if check_in_id.int == 0:
                     guid = uuid.uuid4()
@@ -376,7 +375,9 @@ def _process_message(wrapper: Dict) -> None:
                     return
 
             if check_in.status == CheckInStatus.ERROR:
-                monitor_environment.mark_failed(start_time)
+                monitor_environment.mark_failed(
+                    start_time, occurrence_context={"trace_id": trace_id}
+                )
             else:
                 monitor_environment.mark_ok(check_in, start_time)
 

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -599,6 +599,7 @@ class MonitorEnvironment(Model):
                         "monitor.id": str(self.monitor.guid),
                         "monitor.slug": self.monitor.slug,
                     },
+                    "trace_id": occurrence_context.get("trace_id"),
                     "timestamp": current_timestamp.isoformat(),
                 },
             )

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -140,7 +140,8 @@ def check_timeout(current_datetime=None):
                 monitor_environment.mark_failed(
                     reason=MonitorFailure.DURATION,
                     occurrence_context={
-                        "duration": (checkin.monitor.config or {}).get("max_runtime") or TIMEOUT
+                        "duration": (checkin.monitor.config or {}).get("max_runtime") or TIMEOUT,
+                        "trace_id": checkin.trace_id,
                     },
                 )
         except Exception:

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime
 from unittest.mock import patch
 
@@ -325,7 +326,10 @@ class MonitorEnvironmentTestCase(TestCase):
         )
 
         last_checkin = timezone.now()
-        assert monitor_environment.mark_failed(last_checkin=last_checkin)
+        trace_id = uuid.uuid4().hex
+        assert monitor_environment.mark_failed(
+            last_checkin=last_checkin, occurrence_context={"trace_id": trace_id}
+        )
 
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1
 
@@ -383,6 +387,7 @@ class MonitorEnvironmentTestCase(TestCase):
                     "monitor.id": str(monitor.guid),
                     "monitor.slug": monitor.slug,
                 },
+                "trace_id": trace_id,
             },
         ) == dict(event)
 
@@ -470,6 +475,7 @@ class MonitorEnvironmentTestCase(TestCase):
                     "monitor.id": str(monitor.guid),
                     "monitor.slug": monitor.slug,
                 },
+                "trace_id": None,
             },
         ) == dict(event)
 
@@ -557,6 +563,7 @@ class MonitorEnvironmentTestCase(TestCase):
                     "monitor.id": str(monitor.guid),
                     "monitor.slug": monitor.slug,
                 },
+                "trace_id": None,
             },
         ) == dict(event)
 


### PR DESCRIPTION
If `trace_id` is sent with the check-in add it to the failure cron event