### PR TITLE
feat(profiling): add cpu and memory chart flags

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1387,6 +1387,10 @@ SENTRY_FEATURES = {
     "organizations:profiling-stacktrace-links": False,
     # Enable global suspect functions in profiling
     "organizations:profiling-global-suspect-functions": False,
+    # Enable profiling CPU chart
+    "organizations:profiling-cpu-chart"
+    # Enable profiling Memory chart
+    "organizations:profiling-memory-chart"
     # Enable multi project selection
     "organizations:global-views": False,
     # Enable experimental new version of Merged Issues where sub-hashes are shown


### PR DESCRIPTION
Add separate cpu and memory chart feature flags for upcoming profiling measurements display