### PR TITLE
fix(starfish): Fixes Span Sample Chart hover causing echarts error

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -1,4 +1,5 @@
-import {useState} from 'react';
+import {useCallback, useState} from 'react';
+import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
 
 import {
@@ -26,6 +27,14 @@ export function SampleList({groupId, transactionName, transactionMethod}: Props)
     groupId && transactionName && transactionMethod
       ? `${groupId}:${transactionName}:${transactionMethod}`
       : undefined;
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debounceSetHighlightedSpanId = useCallback(
+    debounce(id => {
+      setHighlightedSpanId(id);
+    }, 10),
+    []
+  );
 
   return (
     <PageErrorProvider>
@@ -55,8 +64,8 @@ export function SampleList({groupId, transactionName, transactionMethod}: Props)
               `/performance/${span.project}:${span['transaction.id']}/#span-${span.span_id}`
             );
           }}
-          onMouseOverSample={sample => setHighlightedSpanId(sample.span_id)}
-          onMouseLeaveSample={() => setHighlightedSpanId(undefined)}
+          onMouseOverSample={sample => debounceSetHighlightedSpanId(sample.span_id)}
+          onMouseLeaveSample={() => debounceSetHighlightedSpanId(undefined)}
           highlightedSpanId={highlightedSpanId}
         />
 


### PR DESCRIPTION
Bandaid fixes an issue with state being updated too frequently based on hover movement, causing echarts rerendering and often breaking.