### PR TITLE
fix(stats): pin future start date to now

### DIFF
--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -414,6 +414,9 @@ def get_constrained_date_range(
     start, end = get_date_range_from_params(params)
     now = get_now()
 
+    if start > now:
+        raise InvalidParams("start must be before the current time")
+
     # if `end` is explicitly given, we add a second to it, so it is treated as
     # inclusive. the rounding logic down below will take care of the rest.
     if params.get("end"):

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -415,7 +415,7 @@ def get_constrained_date_range(
     now = get_now()
 
     if start > now:
-        raise InvalidParams("start must be before the current time")
+        start = now
 
     # if `end` is explicitly given, we add a second to it, so it is treated as
     # inclusive. the rounding logic down below will take care of the rest.

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -151,6 +151,20 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
         assert response.status_code == 400, response.content
         assert result_sorted(response.data) == {"detail": "start and end are both required"}
 
+    @freeze_time(datetime(2021, 3, 14, 12, 27, 28, tzinfo=pytz.utc))
+    def test_future_start(self):
+        response = self.do_request(
+            {
+                "field": ["sum(quantity)"],
+                "interval": "1d",
+                "category": ["error"],
+                "start": "2021-03-14T15:30:00",
+                "end": "2021-03-14T16:30:00",
+            }
+        )
+        assert response.status_code == 400, response.content
+        assert response.data == {"detail": "start must be before the current time"}
+
     def test_unknown_category(self):
         response = self.do_request(
             {

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -152,18 +152,17 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
         assert result_sorted(response.data) == {"detail": "start and end are both required"}
 
     @freeze_time(datetime(2021, 3, 14, 12, 27, 28, tzinfo=pytz.utc))
-    def test_future_start(self):
+    def test_future_request(self):
         response = self.do_request(
             {
                 "field": ["sum(quantity)"],
-                "interval": "1d",
+                "interval": "1h",
                 "category": ["error"],
                 "start": "2021-03-14T15:30:00",
                 "end": "2021-03-14T16:30:00",
             }
         )
-        assert response.status_code == 400, response.content
-        assert response.data == {"detail": "start must be before the current time"}
+        assert response.status_code == 200, response.content
 
     def test_unknown_category(self):
         response = self.do_request(

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -163,6 +163,14 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
             }
         )
         assert response.status_code == 200, response.content
+        assert result_sorted(response.data) == {
+            "intervals": ["2021-03-14T12:00:00Z"],
+            "groups": [
+                {"by": {}, "series": {"sum(quantity)": [0]}, "totals": {"sum(quantity)": 0}}
+            ],
+            "start": "2021-03-14T12:00:00Z",
+            "end": "2021-03-14T12:28:00Z",
+        }
 
     def test_unknown_category(self):
         response = self.do_request(

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -69,11 +69,12 @@ def test_inclusive_end():
 
 
 @freeze_time("2021-03-05T11:00:00.000Z")
-def test_future_start():
-    with pytest.raises(InvalidParams):
-        get_constrained_date_range(
-            {"start": "2021-03-05T12:00:00", "end": "2021-03-05T13:00:00", "interval": "1h"},
-        )
+def test_future_request():
+    start, end, interval = get_constrained_date_range(
+        {"start": "2021-03-05T12:00:00", "end": "2021-03-05T13:00:00", "interval": "1h"},
+    )
+    assert start == datetime(2021, 3, 5, 11, tzinfo=pytz.utc)
+    assert end == datetime(2021, 3, 5, 11, 1, tzinfo=pytz.utc)
 
 
 @freeze_time("2021-03-05T11:14:17.105Z")

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -68,6 +68,14 @@ def test_inclusive_end():
     assert end == datetime(2021, 2, 25, 1, tzinfo=pytz.utc)
 
 
+@freeze_time("2021-03-05T11:00:00.000Z")
+def test_future_start():
+    with pytest.raises(InvalidParams):
+        get_constrained_date_range(
+            {"start": "2021-03-05T12:00:00", "end": "2021-03-05T13:00:00", "interval": "1h"},
+        )
+
+
 @freeze_time("2021-03-05T11:14:17.105Z")
 def test_interval_restrictions():
     # making sure intervals are cleanly divisible


### PR DESCRIPTION
Fixes https://sentry.sentry.io/issues/4007307163/?project=1

Explicitly check if the start date is in the future and pin it to the current time so we return 200 instead of an Internal Server Error.

For ER-1762