### PR TITLE
chore(hybrid-cloud): Update repository create/update flows for integration post-install

### DIFF
--- a/src/sentry/db/postgres/transactions.py
+++ b/src/sentry/db/postgres/transactions.py
@@ -14,7 +14,7 @@ from sentry.utils.env import in_test_environment
 def django_test_transaction_water_mark(using: str | None = None):
     """
     Hybrid cloud outbox flushing depends heavily on transaction.on_commit logic, but our tests do not follow
-    production in terms of isolation (TestCase users two outer transactions, and stubbed RPCs cannot simulate
+    production in terms of isolation (TestCase uses two outer transactions, and stubbed RPCs cannot simulate
     transactional isolation without breaking other test case assumptions).  Therefore, in order to correctly
     simulate transaction.on_commit semantics, use this context in any place where we "simulate" inter transaction
     work that in tests should behave that way.

--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -2,6 +2,7 @@ from sentry.locks import locks
 from sentry.models import OrganizationOption
 from sentry.models.apitoken import generate_token
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.email import parse_email, parse_user_name
 from sentry.utils.http import absolute_uri
@@ -41,7 +42,7 @@ class BitbucketRepositoryProvider(IntegrationRepositoryProvider):
                 )
         return secret
 
-    def build_repository_config(self, organization, data):
+    def build_repository_config(self, organization: RpcOrganization, data):
         installation = self.get_installation(data.get("installation"), organization.id)
         client = installation.get_client()
         try:

--- a/src/sentry/integrations/bitbucket_server/repository.py
+++ b/src/sentry/integrations/bitbucket_server/repository.py
@@ -4,6 +4,7 @@ from django.core.cache import cache
 from django.urls import reverse
 
 from sentry.plugins.providers.integration_repository import IntegrationRepositoryProvider
+from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.hashlib import md5_text
 from sentry.utils.http import absolute_uri
@@ -28,7 +29,7 @@ class BitbucketServerRepositoryProvider(IntegrationRepositoryProvider):
             config["repo"] = repo["name"]
         return config
 
-    def build_repository_config(self, organization, data):
+    def build_repository_config(self, organization: RpcOrganization, data):
         installation = self.get_installation(data.get("installation"), organization.id)
         client = installation.get_client()
 

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -6,6 +6,7 @@ from sentry.integrations import IntegrationInstallation
 from sentry.models import Organization, PullRequest, Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.services.hybrid_cloud.integration import integration_service
+from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.utils.json import JSONData
 
@@ -48,7 +49,7 @@ class GitHubRepositoryProvider(IntegrationRepositoryProvider):
         return config
 
     def build_repository_config(
-        self, organization: Organization, data: Mapping[str, Any]
+        self, organization: RpcOrganization, data: Mapping[str, Any]
     ) -> Mapping[str, Any]:
         return {
             "name": data["identifier"],

--- a/src/sentry/integrations/github_enterprise/repository.py
+++ b/src/sentry/integrations/github_enterprise/repository.py
@@ -1,5 +1,6 @@
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.models import Integration
+from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
 WEBHOOK_EVENTS = ["push", "pull_request"]
@@ -23,7 +24,7 @@ class GitHubEnterpriseRepositoryProvider(GitHubRepositoryProvider):
 
         return repo_data
 
-    def build_repository_config(self, organization, data):
+    def build_repository_config(self, organization: RpcOrganization, data):
         integration = Integration.objects.get(
             id=data["integration_id"], provider=self.repo_provider
         )

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -1,4 +1,5 @@
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 from sentry.shared_integrations.exceptions import ApiError
 
 
@@ -29,7 +30,7 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider):
         )
         return config
 
-    def build_repository_config(self, organization, data):
+    def build_repository_config(self, organization: RpcOrganization, data):
 
         installation = self.get_installation(data.get("installation"), organization.id)
         client = installation.get_client()

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -4,6 +4,7 @@ from typing import Any, Mapping, MutableMapping, Sequence
 
 from sentry.models import Commit, Organization, Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 
 MAX_COMMIT_DATA_REQUESTS = 90
 
@@ -37,7 +38,7 @@ class VstsRepositoryProvider(IntegrationRepositoryProvider):
         return config
 
     def build_repository_config(
-        self, organization: Organization, data: Mapping[str, str]
+        self, organization: RpcOrganization, data: Mapping[str, str]
     ) -> Mapping[str, Any]:
         return {
             "name": data["name"],

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -26,6 +26,7 @@ class Repository(Model, PendingDeletionMixin):
     name = models.CharField(max_length=200)
     url = models.URLField(null=True)
     provider = models.CharField(max_length=64, null=True)
+    # The external_id is the id of the repo in the provider's system. (e.g. GitHub's repo id)
     external_id = models.CharField(max_length=64, null=True)
     config = JSONField(default=dict)
     status = BoundedPositiveIntegerField(

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -162,14 +162,15 @@ class IntegrationRepositoryProvider:
                 integration_id=integration_id,
                 external_id=external_id,
             )
-            repo = repositories[0] if repositories else None
-            if repo:
-                for field_name, field_value in repo_update_params.items():
-                    setattr(repo, field_name, field_value)
-                repository_service.update_repository(
-                    organization_id=organization.id,
-                    update=repo,
-                )
+            if repositories:
+                # We anticipate to only update one repository, but we update any duplicates as well.
+                for repo in repositories:
+                    for field_name, field_value in repo_update_params.items():
+                        setattr(repo, field_name, field_value)
+                    repository_service.update_repository(
+                        organization_id=organization.id,
+                        update=repo,
+                    )
 
             raise RepoExistsError
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -5,17 +5,20 @@ from datetime import timezone
 from typing import Any, MutableMapping
 
 from dateutil.parser import parse as parse_date
-from django.db import IntegrityError, router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
 from sentry.api.exceptions import SentryAPIException, status
-from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.integrations import IntegrationInstallation
 from sentry.models import Integration, Repository
+from sentry.models.user import User
 from sentry.services.hybrid_cloud.integration import integration_service
+from sentry.services.hybrid_cloud.organization.model import RpcOrganization
+from sentry.services.hybrid_cloud.repository import repository_service
+from sentry.services.hybrid_cloud.repository.model import RpcCreateRepository
+from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.signals import repo_linked
 from sentry.utils import metrics
@@ -78,13 +81,38 @@ class IntegrationRepositoryProvider:
     def create_repository(
         self,
         repo_config: MutableMapping[str, Any],
-        organization,
+        organization: RpcOrganization,
     ):
         result = self.build_repository_config(organization=organization, data=repo_config)
 
         integration_id = result.get("integration_id")
         external_id = result.get("external_id")
         name = result.get("name")
+
+        # first check if there is an existing hidden repository with an integration that matches
+        repositories = repository_service.get_repositories(
+            organization_id=organization.id,
+            integration_id=integration_id,
+            external_id=external_id,
+            status=ObjectStatus.HIDDEN,
+        )
+        existing_repo = repositories[0] if repositories else None
+        if existing_repo:
+            existing_repo.status = ObjectStatus.ACTIVE
+            existing_repo.name = name
+            repository_service.update_repository(
+                organization_id=organization.id, update=existing_repo
+            )
+            metrics.incr("sentry.integration_repo_provider.repo_relink")
+            return result, existing_repo
+
+        # then check if there is a repository without an integration that matches
+        repositories = repository_service.get_repositories(
+            organization_id=organization.id,
+            has_integration=False,
+            external_id=external_id,
+        )
+        repo = repositories[0] if repositories else None
 
         repo_update_params = {
             "external_id": external_id,
@@ -94,25 +122,6 @@ class IntegrationRepositoryProvider:
             "integration_id": integration_id,
             "name": name,
         }
-
-        # first check if there is an existing hidden repository with an integration that matches
-        existing_repo = Repository.objects.filter(
-            organization_id=organization.id,
-            integration_id=integration_id,
-            external_id=external_id,
-            status=ObjectStatus.HIDDEN,
-        ).first()
-        if existing_repo:
-            existing_repo.status = ObjectStatus.ACTIVE
-            existing_repo.name = name
-            existing_repo.save()
-            metrics.incr("sentry.integration_repo_provider.repo_relink")
-            return result, existing_repo
-
-        # then check if there is a repository without an integration that matches
-        repo = Repository.objects.filter(
-            organization_id=organization.id, external_id=external_id, integration_id=None
-        ).first()
 
         if repo:
             if self.logger:
@@ -129,29 +138,40 @@ class IntegrationRepositoryProvider:
                 setattr(repo, field_name, field_value)
             # also update the status if it was in a bad state
             repo.status = ObjectStatus.ACTIVE
-            repo.save()
+            repository_service.update_repository(organization_id=organization.id, update=repo)
         else:
+            create_repository = RpcCreateRepository.parse_obj(
+                {**repo_update_params, "status": ObjectStatus.ACTIVE}
+            )
+            new_repository = repository_service.create_repository(
+                organization_id=organization.id, create=create_repository
+            )
+            if new_repository is not None:
+                return result, new_repository
+
+            # Try to delete webhook we just created
             try:
-                with transaction.atomic(router.db_for_write(Repository)):
-                    repo = Repository.objects.create(
-                        organization_id=organization.id, **repo_update_params
-                    )
-            except IntegrityError:
-                # Try to delete webhook we just created
-                try:
-                    repo = Repository(organization_id=organization.id, **repo_update_params)
-                    self.on_delete_repository(repo)
-                except IntegrationError:
-                    pass
+                repo = Repository(organization_id=organization.id, **repo_update_params)
+                self.on_delete_repository(repo)
+            except IntegrationError:
+                pass
 
-                # if possible update the repo with matching integration
-                repo = Repository.objects.filter(
+            # if possible update the repo with matching integration
+            repositories = repository_service.get_repositories(
+                organization_id=organization.id,
+                integration_id=integration_id,
+                external_id=external_id,
+            )
+            repo = repositories[0] if repositories else None
+            if repo:
+                for field_name, field_value in repo_update_params.items():
+                    setattr(repo, field_name, field_value)
+                repository_service.update_repository(
                     organization_id=organization.id,
-                    external_id=external_id,
-                    integration_id=integration_id,
-                ).update(**repo_update_params)
+                    update=repo,
+                )
 
-                raise RepoExistsError
+            raise RepoExistsError
 
         return result, repo
 
@@ -177,7 +197,16 @@ class IntegrationRepositoryProvider:
             id=result.get("integration_id"),
             organization_id=organization.id,
         )
-        return Response(serialize(repo, request.user), status=201)
+        return Response(
+            repository_service.serialize_repository(
+                organization_id=organization.id,
+                id=repo.id,
+                as_user=serialize_rpc_user(request.user)
+                if isinstance(request.user, User)
+                else request.user,
+            ),
+            status=201,
+        )
 
     def handle_api_error(self, e):
         context = {"error_type": "unknown"}
@@ -208,7 +237,7 @@ class IntegrationRepositoryProvider:
         """
         return config
 
-    def build_repository_config(self, organization, data):
+    def build_repository_config(self, organization: RpcOrganization, data):
         """
         Builds final dict containing all necessary data to create the repository
 

--- a/src/sentry/services/hybrid_cloud/repository/model.py
+++ b/src/sentry/services/hybrid_cloud/repository/model.py
@@ -17,3 +17,14 @@ class RpcRepository(RpcModel):
     integration_id: Optional[int]
     provider: str
     status: int
+    url: str
+
+
+class RpcCreateRepository(RpcModel):
+    name: str
+    external_id: Optional[str]
+    config: Dict[str, Any]
+    integration_id: int
+    provider: str
+    status: int
+    url: str

--- a/src/sentry/services/hybrid_cloud/repository/serial.py
+++ b/src/sentry/services/hybrid_cloud/repository/serial.py
@@ -14,4 +14,5 @@ def serialize_repository(repository: Repository) -> RpcRepository:
         integration_id=repository.integration_id,
         provider=repository.provider,
         status=repository.status,
+        url=repository.url,
     )

--- a/src/sentry/services/hybrid_cloud/repository/service.py
+++ b/src/sentry/services/hybrid_cloud/repository/service.py
@@ -4,11 +4,13 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
-from typing import List, Optional, cast
+from typing import Any, List, Optional, cast
 
 from sentry.services.hybrid_cloud.region import ByOrganizationId
 from sentry.services.hybrid_cloud.repository import RpcRepository
+from sentry.services.hybrid_cloud.repository.model import RpcCreateRepository
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method
+from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.silo import SiloMode
 
 
@@ -24,11 +26,27 @@ class RepositoryService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
+    def serialize_repository(
+        self,
+        *,
+        organization_id: int,
+        id: int,
+        as_user: Optional[RpcUser] = None,
+    ) -> Optional[Any]:
+        """
+        Attempts to serialize a given repository.  Note that this can be None if the repository is already deleted
+        in the corresponding region silo.
+        """
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
     def get_repositories(
         self,
         *,
         organization_id: int,
         integration_id: Optional[int] = None,
+        external_id: Optional[int] = None,
         providers: Optional[List[str]] = None,
         has_integration: Optional[bool] = None,
         has_provider: Optional[bool] = None,
@@ -43,7 +61,24 @@ class RepositoryService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
+    def create_repository(
+        self, *, organization_id: int, create: RpcCreateRepository
+    ) -> Optional[RpcRepository]:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
     def update_repository(self, *, organization_id: int, update: RpcRepository) -> None:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def reinstall_repositories_for_integration(
+        self, *, organization_id: int, integration_id: int, provider: str
+    ) -> None:
+        """
+        Reinstalls all repositories associated with the given integration by marking them as active.
+        """
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -15,6 +15,7 @@ import pydantic
 import requests
 import sentry_sdk
 from django.conf import settings
+from requests.exceptions import ConnectionError, Timeout
 
 from sentry.services.hybrid_cloud import ArgumentDict, DelegatedBySiloMode, RpcModel, stubbed
 from sentry.silo import SiloMode
@@ -519,7 +520,12 @@ def _fire_request(url: str, path: str, body: Any) -> requests.Response:
         "Content-Type": f"application/json; charset={_RPC_CONTENT_CHARSET}",
         "Authorization": f"Rpcsignature {signature}",
     }
-    return requests.post(url, headers=headers, data=data)
+    try:
+        return requests.post(url, headers=headers, data=data)
+    except ConnectionError as e:
+        raise RpcSendException.from_exception(e) from e
+    except Timeout as e:
+        raise RpcSendException.from_exception(e) from e
 
 
 def compare_signature(url: str, body: bytes, signature: str) -> bool:

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -15,7 +15,6 @@ import pydantic
 import requests
 import sentry_sdk
 from django.conf import settings
-from requests.exceptions import ConnectionError, Timeout
 
 from sentry.services.hybrid_cloud import ArgumentDict, DelegatedBySiloMode, RpcModel, stubbed
 from sentry.silo import SiloMode
@@ -520,12 +519,7 @@ def _fire_request(url: str, path: str, body: Any) -> requests.Response:
         "Content-Type": f"application/json; charset={_RPC_CONTENT_CHARSET}",
         "Authorization": f"Rpcsignature {signature}",
     }
-    try:
-        return requests.post(url, headers=headers, data=data)
-    except ConnectionError as e:
-        raise RpcSendException.from_exception(e) from e
-    except Timeout as e:
-        raise RpcSendException.from_exception(e) from e
+    return requests.post(url, headers=headers, data=data)
 
 
 def compare_signature(url: str, body: bytes, signature: str) -> bool:

--- a/src/sentry/tasks/integrations/link_all_repos.py
+++ b/src/sentry/tasks/integrations/link_all_repos.py
@@ -24,6 +24,7 @@ def get_repo_config(repo, integration_id):
 @instrumented_task(
     name="sentry.integrations.github.link_all_repos",
     queue="integrations",
+    max_retries=3,
 )
 @retry(
     exclude=(

--- a/src/sentry/tasks/integrations/link_all_repos.py
+++ b/src/sentry/tasks/integrations/link_all_repos.py
@@ -2,12 +2,12 @@ import logging
 
 import sentry_sdk
 
-from sentry.models.organization import Organization
 from sentry.plugins.providers.integration_repository import (
     RepoExistsError,
     get_integration_repository_provider,
 )
 from sentry.services.hybrid_cloud.integration import integration_service
+from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
@@ -38,9 +38,8 @@ def link_all_repos(
         metrics.incr("github.link_all_repos.error", tags={"type": "missing_integration"})
         return
 
-    try:
-        organization = Organization.objects.get(id=organization_id)
-    except Organization.DoesNotExist:
+    rpc_org = organization_service.get(id=organization_id)
+    if rpc_org is None:
         logger.error(
             f"{integration_key}.link_all_repos.organization_missing",
             extra={"organization_id": organization_id},
@@ -69,9 +68,7 @@ def link_all_repos(
     for repo in repositories:
         try:
             config = get_repo_config(repo, integration_id)
-            integration_repo_provider.create_repository(
-                repo_config=config, organization=organization
-            )
+            integration_repo_provider.create_repository(repo_config=config, organization=rpc_org)
         except KeyError:
             continue
         except RepoExistsError:

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -13,8 +13,9 @@ from sentry.models import Integration, OrganizationIntegration, Project, Reposit
 from sentry.plugins.base import plugins
 from sentry.plugins.bases.issue2 import IssueTrackingPlugin2
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils.cache import cache
 
 TREE_RESPONSES = {
@@ -62,7 +63,7 @@ class GitHubPlugin(IssueTrackingPlugin2):
     conf_key = slug
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class GitHubIntegrationTest(IntegrationTestCase):
     provider = GitHubIntegrationProvider
     base_url = "https://api.github.com"
@@ -213,33 +214,34 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
     @responses.activate
     def test_plugin_migration(self):
-        accessible_repo = Repository.objects.create(
-            organization_id=self.organization.id,
-            name="Test-Organization/foo",
-            url="https://github.com/Test-Organization/foo",
-            provider="github",
-            external_id=123,
-            config={"name": "Test-Organization/foo"},
-        )
+        with assume_test_silo_mode(SiloMode.REGION):
+            accessible_repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="Test-Organization/foo",
+                url="https://github.com/Test-Organization/foo",
+                provider="github",
+                external_id=123,
+                config={"name": "Test-Organization/foo"},
+            )
 
-        inaccessible_repo = Repository.objects.create(
-            organization_id=self.organization.id,
-            name="Not-My-Org/other",
-            provider="github",
-            external_id=321,
-            config={"name": "Not-My-Org/other"},
-        )
+            inaccessible_repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="Not-My-Org/other",
+                provider="github",
+                external_id=321,
+                config={"name": "Not-My-Org/other"},
+            )
 
         with self.tasks():
             self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)
 
-        # Updates the existing Repository to belong to the new Integration
-        assert Repository.objects.get(id=accessible_repo.id).integration_id == integration.id
-
-        # Doesn't touch Repositories not accessible by the new Integration
-        assert Repository.objects.get(id=inaccessible_repo.id).integration_id is None
+        with assume_test_silo_mode(SiloMode.REGION):
+            # Updates the existing Repository to belong to the new Integration
+            assert Repository.objects.get(id=accessible_repo.id).integration_id == integration.id
+            # Doesn't touch Repositories not accessible by the new Integration
+            assert Repository.objects.get(id=inaccessible_repo.id).integration_id is None
 
     @responses.activate
     def test_basic_flow(self):
@@ -372,20 +374,21 @@ class GitHubIntegrationTest(IntegrationTestCase):
     def test_disable_plugin_when_fully_migrated(self):
         self._stub_github()
 
-        project = Project.objects.create(organization_id=self.organization.id)
+        with assume_test_silo_mode(SiloMode.REGION):
+            project = Project.objects.create(organization_id=self.organization.id)
 
-        plugin = plugins.get("github")
-        plugin.enable(project)
+            plugin = plugins.get("github")
+            plugin.enable(project)
 
-        # Accessible to new Integration - mocked in _stub_github
-        Repository.objects.create(
-            organization_id=self.organization.id,
-            name="Test-Organization/foo",
-            url="https://github.com/Test-Organization/foo",
-            provider="github",
-            external_id="123",
-            config={"name": "Test-Organization/foo"},
-        )
+            # Accessible to new Integration - mocked in _stub_github
+            Repository.objects.create(
+                organization_id=self.organization.id,
+                name="Test-Organization/foo",
+                url="https://github.com/Test-Organization/foo",
+                provider="github",
+                external_id="123",
+                config={"name": "Test-Organization/foo"},
+            )
 
         # Enabled before
         assert "github" in [p.slug for p in plugins.for_project(project)]
@@ -457,15 +460,16 @@ class GitHubIntegrationTest(IntegrationTestCase):
     def test_get_stacktrace_link_file_exists(self):
         self.assert_setup_flow()
         integration = Integration.objects.get(provider=self.provider.key)
-        repo = Repository.objects.create(
-            organization_id=self.organization.id,
-            name="Test-Organization/foo",
-            url="https://github.com/Test-Organization/foo",
-            provider="integrations:github",
-            external_id=123,
-            config={"name": "Test-Organization/foo"},
-            integration_id=integration.id,
-        )
+        with assume_test_silo_mode(SiloMode.REGION):
+            repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="Test-Organization/foo",
+                url="https://github.com/Test-Organization/foo",
+                provider="integrations:github",
+                external_id=123,
+                config={"name": "Test-Organization/foo"},
+                integration_id=integration.id,
+            )
 
         path = "README.md"
         version = "1234567"
@@ -484,15 +488,16 @@ class GitHubIntegrationTest(IntegrationTestCase):
         self.assert_setup_flow()
         integration = Integration.objects.get(provider=self.provider.key)
 
-        repo = Repository.objects.create(
-            organization_id=self.organization.id,
-            name="Test-Organization/foo",
-            url="https://github.com/Test-Organization/foo",
-            provider="integrations:github",
-            external_id=123,
-            config={"name": "Test-Organization/foo"},
-            integration_id=integration.id,
-        )
+        with assume_test_silo_mode(SiloMode.REGION):
+            repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="Test-Organization/foo",
+                url="https://github.com/Test-Organization/foo",
+                provider="integrations:github",
+                external_id=123,
+                config={"name": "Test-Organization/foo"},
+                integration_id=integration.id,
+            )
         path = "README.md"
         version = "master"
         default = "master"
@@ -511,15 +516,16 @@ class GitHubIntegrationTest(IntegrationTestCase):
         self.assert_setup_flow()
         integration = Integration.objects.get(provider=self.provider.key)
 
-        repo = Repository.objects.create(
-            organization_id=self.organization.id,
-            name="Test-Organization/foo",
-            url="https://github.com/Test-Organization/foo",
-            provider="integrations:github",
-            external_id=123,
-            config={"name": "Test-Organization/foo"},
-            integration_id=integration.id,
-        )
+        with assume_test_silo_mode(SiloMode.REGION):
+            repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="Test-Organization/foo",
+                url="https://github.com/Test-Organization/foo",
+                provider="integrations:github",
+                external_id=123,
+                config={"name": "Test-Organization/foo"},
+                integration_id=integration.id,
+            )
         path = "README.md"
         version = "master"
         default = "master"
@@ -541,15 +547,16 @@ class GitHubIntegrationTest(IntegrationTestCase):
         self.assert_setup_flow()
         integration = Integration.objects.get(provider=self.provider.key)
 
-        repo = Repository.objects.create(
-            organization_id=self.organization.id,
-            name="Test-Organization/foo",
-            url="https://github.com/Test-Organization/foo",
-            provider="integrations:github",
-            external_id=123,
-            config={"name": "Test-Organization/foo"},
-            integration_id=integration.id,
-        )
+        with assume_test_silo_mode(SiloMode.REGION):
+            repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="Test-Organization/foo",
+                url="https://github.com/Test-Organization/foo",
+                provider="integrations:github",
+                external_id=123,
+                config={"name": "Test-Organization/foo"},
+                integration_id=integration.id,
+            )
         path = "README.md"
         version = "12345678"
         default = "master"


### PR DESCRIPTION
This pull request patches  [`def link_all_repos()`](https://github.com/getsentry/sentry/blob/7d4a6f9dd5980b19d77b90f3971d7c4b2e9647f3/src/sentry/tasks/integrations/link_all_repos.py#L26-L31) to be control silo legal. This change also includes all other necessary changes to make this happen.

This task runs in the post installation step of the GitHub integration here: https://github.com/getsentry/sentry/blob/ef4ecf16d901427e9c626da893d43651b1f02a6b/src/sentry/integrations/github/integration.py#L318-L324

We anticipate that all the post installation steps of all integrations will run only in the control silo.