### PR TITLE
fix(codeowners): Remove issues team from app/components codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -441,7 +441,6 @@ yarn.lock                                                @getsentry/owners-js-de
 /tests/sentry/tasks/test_post_process.py            @getsentry/issues
 /tests/snuba/search/                                @getsentry/issues
 /src/sentry/search/snuba/                           @getsentry/issues
-/static/app/components                                       @getsentry/issues
 /static/app/views/issueList                                  @getsentry/issues
 /static/app/views/organizationGroupDetails                   @getsentry/issues
 /src/sentry/api/endpoints/source_map_debug.py                @getsentry/issues


### PR DESCRIPTION
We're getting the profiling team's stuff and this path includes a lot of stuff we don't really own. We could also put this higher up so the profiling team has a higher priority

example https://sentry.sentry.io/issues/4338161809/
