### PR TITLE
feat(starfish): Improve query syntax highlighting

### DIFF
--- a/static/app/styles/prism.tsx
+++ b/static/app/styles/prism.tsx
@@ -38,7 +38,7 @@ export const prismStyles = (theme: Theme) => css`
     font-family: ${theme.text.familyMono};
     direction: ltr;
     text-align: left;
-    white-space: pre;
+    white-space: pre-wrap;
     word-spacing: normal;
     word-break: normal;
     -moz-tab-size: 4;

--- a/static/app/styles/prism.tsx
+++ b/static/app/styles/prism.tsx
@@ -38,7 +38,7 @@ export const prismStyles = (theme: Theme) => css`
     font-family: ${theme.text.familyMono};
     direction: ltr;
     text-align: left;
-    white-space: pre-wrap;
+    white-space: pre;
     word-spacing: normal;
     word-break: normal;
     -moz-tab-size: 4;

--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -1,43 +1,29 @@
 import styled from '@emotion/styled';
 
-import {FormattedCode} from 'sentry/views/starfish/components/formattedCode';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
-import {highlightSql} from 'sentry/views/starfish/utils/highlightSql';
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {SpanMetricsFields, SpanMetricsFieldTypes} from 'sentry/views/starfish/types';
 
-const {SPAN_DESCRIPTION, SPAN_ACTION, SPAN_DOMAIN} = SpanMetricsFields;
-
-type SpanMeta = {
-  'span.action': string;
-  'span.description': string;
-  'span.domain': string;
-  'span.op': string;
+type Props = {
+  span: Pick<
+    SpanMetricsFieldTypes,
+    SpanMetricsFields.SPAN_OP | SpanMetricsFields.SPAN_DESCRIPTION
+  >;
 };
 
-export function SpanDescription({spanMeta}: {spanMeta: SpanMeta}) {
-  if (spanMeta['span.op'].startsWith('db')) {
-    return <DatabaseSpanDescription spanMeta={spanMeta} />;
+export function SpanDescription({span}: Props) {
+  if (span[SpanMetricsFields.SPAN_OP].startsWith('db')) {
+    return <DatabaseSpanDescription span={span} />;
   }
 
-  return <DescriptionWrapper>{spanMeta[SPAN_DESCRIPTION]}</DescriptionWrapper>;
+  return <WordBreak>{span[SpanMetricsFields.SPAN_DESCRIPTION]}</WordBreak>;
 }
 
-function DatabaseSpanDescription({spanMeta}: {spanMeta: SpanMeta}) {
+function DatabaseSpanDescription({span}: Props) {
   return (
-    <CodeWrapper>
-      <FormattedCode>
-        {highlightSql(spanMeta[SPAN_DESCRIPTION] || '', {
-          action: spanMeta[SPAN_ACTION] || '',
-          domain: spanMeta[SPAN_DOMAIN] || '',
-        })}
-      </FormattedCode>
-    </CodeWrapper>
+    <CodeSnippet language="sql">{span[SpanMetricsFields.SPAN_DESCRIPTION]}</CodeSnippet>
   );
 }
 
-const CodeWrapper = styled('div')`
-  font-size: ${p => p.theme.fontSizeMedium};
-`;
-
-const DescriptionWrapper = styled('div')`
+const WordBreak = styled('div')`
   word-break: break-word;
 `;

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -234,7 +234,7 @@ function SpanSummaryPage({params, location}: Props) {
                             <DescriptionTitle>
                               {spanDescriptionCardTitle}
                             </DescriptionTitle>
-                            <SpanDescription spanMeta={span} />
+                            <SpanDescription span={span} />
                           </DescriptionContainer>
                         </DescriptionPanelBody>
                       </Panel>

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -391,6 +391,7 @@ const DescriptionPanelBody = styled(PanelBody)`
 const BlockWrapper = styled('div')`
   padding-right: ${space(4)};
   flex: 1;
+  min-width: 0;
 `;
 
 const DescriptionTitle = styled('h4')`


### PR DESCRIPTION
Instead of using our custom tokenizer (don't worry, it'll be back), use an existing highlight component. Next up I'll work on introducing better line breaks.

- Remove custom SQL highlighting
- Prevent blocks from overflowing
- Allow code blocks to wrap

**Before:**
<img width="357" alt="Screenshot 2023-07-24 at 6 13 09 PM" src="https://github.com/getsentry/sentry/assets/989898/e4119f7d-9cb4-413f-a2d0-b6fa644d3e53">

**After:**
<img width="479" alt="Screenshot 2023-07-25 at 5 09 45 PM" src="https://github.com/getsentry/sentry/assets/989898/17a74959-eea5-49b7-9b79-8c1cfe10257d">

