### PR TITLE
fix(hc): Stabilize OrganizationRepositoryDeleteTest

### DIFF
--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -10,7 +10,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
-from sentry.models import Commit, Integration, Repository, ScheduledDeletion
+from sentry.models import Commit, Integration, RegionScheduledDeletion, Repository
 from sentry.services.hybrid_cloud import coerce_id_from
 from sentry.tasks.repository import repository_cascade_delete_on_hide
 
@@ -118,8 +118,8 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
                 repo.rename_on_pending_deletion()
 
                 if has_commits:
-                    ScheduledDeletion.schedule(repo, days=0, hours=1, actor=request.user)
+                    RegionScheduledDeletion.schedule(repo, days=0, hours=1, actor=request.user)
                 else:
-                    ScheduledDeletion.schedule(repo, days=0, actor=request.user)
+                    RegionScheduledDeletion.schedule(repo, days=0, actor=request.user)
 
         return Response(serialize(repo, request.user), status=202)

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -4,13 +4,19 @@ from django.urls import reverse
 from django.utils import timezone
 
 from sentry.constants import ObjectStatus
-from sentry.models import Commit, Integration, OrganizationOption, Repository, ScheduledDeletion
+from sentry.models import (
+    Commit,
+    Integration,
+    OrganizationOption,
+    RegionScheduledDeletion,
+    Repository,
+)
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class OrganizationRepositoryDeleteTest(APITestCase):
     def assert_rename_pending_delete(self, response, repo, external_id=None):
         assert response.data["status"] == "pending_deletion"
@@ -45,7 +51,7 @@ class OrganizationRepositoryDeleteTest(APITestCase):
         repo = Repository.objects.get(id=repo.id)
         assert repo.status == ObjectStatus.PENDING_DELETION
 
-        assert ScheduledDeletion.objects.filter(
+        assert RegionScheduledDeletion.objects.filter(
             object_id=repo.id, model_name="Repository", date_scheduled__lte=timezone.now()
         ).exists()
         self.assert_rename_pending_delete(response, repo)
@@ -68,7 +74,7 @@ class OrganizationRepositoryDeleteTest(APITestCase):
 
         repo = Repository.objects.get(id=repo.id)
         assert repo.status == ObjectStatus.PENDING_DELETION
-        assert ScheduledDeletion.objects.filter(
+        assert RegionScheduledDeletion.objects.filter(
             object_id=repo.id, model_name="Repository", date_scheduled__gt=timezone.now()
         ).exists()
         self.assert_rename_pending_delete(response, repo, "abc123")
@@ -93,7 +99,9 @@ class OrganizationRepositoryDeleteTest(APITestCase):
         repo = Repository.objects.get(id=repo.id)
         assert repo.status == ObjectStatus.PENDING_DELETION
 
-        assert ScheduledDeletion.objects.filter(object_id=repo.id, model_name="Repository").exists()
+        assert RegionScheduledDeletion.objects.filter(
+            object_id=repo.id, model_name="Repository"
+        ).exists()
         self.assert_rename_pending_delete(response, repo, "abc12345")
 
     def test_delete_disabled_with_commits(self):
@@ -115,7 +123,9 @@ class OrganizationRepositoryDeleteTest(APITestCase):
         repo = Repository.objects.get(id=repo.id)
         assert repo.status == ObjectStatus.PENDING_DELETION
 
-        assert ScheduledDeletion.objects.filter(object_id=repo.id, model_name="Repository").exists()
+        assert RegionScheduledDeletion.objects.filter(
+            object_id=repo.id, model_name="Repository"
+        ).exists()
         self.assert_rename_pending_delete(response, repo)
 
     def test_put(self):


### PR DESCRIPTION
`Repository` is a `region_silo_only_model` so deletions are scheduled with `RegionScheduledDeletion`.