### PR TITLE
feat(discord): Add Discord client secret option

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1459,7 +1459,7 @@ SENTRY_FEATURES = {
     # Allow orgs to create a Discord integration
     "organizations:integrations-discord": False,
     # Enable Discord integration notifications
-    "organizations:integrations-discord-notifications"
+    "organizations:integrations-discord-notifications": False,
     # Enable Opsgenie integration
     "organizations:integrations-opsgenie": False,
     # Limit project events endpoint to only query back a certain number of days

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -444,6 +444,7 @@ register("msteams.app-id")
 register("discord.application-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("discord.public-key", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("discord.bot-token", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
+register("discord.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 
 # AWS Lambda Integration
 register("aws-lambda.access-key-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)


### PR DESCRIPTION
- Add discord oauth2 client secret credential
- Add missing default value for discord notifications feature flag

We need this client secret for completing the OAuth2 flow that takes place during identity linking.

Corresponding PR in getsentry will come right after this.