### PR TITLE
ref: automatically move some django.utils.timezone.utc -> datetime.timezone.utc

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -1,13 +1,12 @@
 import bisect
 import functools
 import math
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.parse import quote
 
 from django.core.exceptions import EmptyResultSet, ObjectDoesNotExist
 from django.db import connections
 from django.db.models.functions import Lower
-from django.utils import timezone
 
 from sentry.utils.cursors import Cursor, CursorResult, build_cursor
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Sequence
 
 import sentry_sdk
 import sqlparse
-from django.utils import timezone
 from sentry_relay import meta_with_chunks
 
 from sentry.api.serializers import Serializer, register, serialize

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -1,11 +1,10 @@
 import logging
 import pickle
 import threading
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from time import time
 
 from django.db import models
-from django.utils import timezone
 from django.utils.encoding import force_bytes, force_str
 
 from sentry.buffer.base import Buffer

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -1,10 +1,10 @@
 import ipaddress
 import logging
+from datetime import timezone
 
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, router, transaction
 from django.http import Http404, HttpResponse
-from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request

--- a/src/sentry/integrations/bitbucket_server/repository.py
+++ b/src/sentry/integrations/bitbucket_server/repository.py
@@ -1,8 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from django.core.cache import cache
 from django.urls import reverse
-from django.utils import timezone
 
 from sentry.plugins.providers.integration_repository import IntegrationRepositoryProvider
 from sentry.shared_integrations.exceptions import ApiError

--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -1,9 +1,8 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from django.db import IntegrityError, router, transaction
 from django.http import Http404, HttpResponse
-from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import View

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import hashlib
 import hmac
 import logging
+from datetime import timezone
 from typing import Any, Callable, Dict, List, Mapping, MutableMapping
 
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, router, transaction
 from django.http import HttpResponse
-from django.utils import timezone
 from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import logging
+from datetime import timezone
 from typing import Any, Mapping, Tuple
 
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, router, transaction
 from django.http import Http404, HttpResponse
-from django.utils import timezone
 from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -8,7 +8,7 @@ import re
 import sys
 import time
 import zlib
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from io import BytesIO
 from itertools import groupby
@@ -18,7 +18,6 @@ from urllib.parse import urlsplit
 
 import sentry_sdk
 from django.conf import settings
-from django.utils import timezone
 from django.utils.encoding import force_bytes, force_str
 from requests.utils import get_encoding_from_headers
 from symbolic.sourcemap import SourceView

--- a/src/sentry/nodestore/filesystem/backend.py
+++ b/src/sentry/nodestore/filesystem/backend.py
@@ -1,8 +1,8 @@
 import datetime
 import os
+from datetime import timezone
 
 from django.conf import settings
-from django.utils import timezone
 
 from sentry.nodestore.base import NodeStorage
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import logging
+from datetime import timezone
 from typing import Any, MutableMapping
 
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, router, transaction
-from django.utils import timezone
 from rest_framework.exceptions import APIException
 from rest_framework.request import Request
 from rest_framework.response import Response

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -1,9 +1,8 @@
 from collections import namedtuple
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
-from django.utils import timezone
 from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import BooleanCondition, Condition

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable, NamedTuple, Optional, Set
 
 import sentry_sdk
-from django.utils import timezone
 
 from sentry.db.models.fields.node import NodeData
 from sentry.models import Project, Release

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -1,11 +1,10 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from time import time
 from typing import Any, Callable, Dict, List, Optional
 
 import sentry_sdk
 from django.conf import settings
-from django.utils import timezone
 from sentry_relay.processing import StoreNormalizer
 
 from sentry import options, reprocessing, reprocessing2

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -1,8 +1,7 @@
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from random import Random
 
-from django.utils import timezone
 from django.utils.text import slugify
 
 from sentry.models import Group, Organization, Project

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -1,10 +1,10 @@
 import ipaddress
 import logging
+from datetime import timezone
 
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, router, transaction
 from django.http import Http404, HttpResponse
-from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View

--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -1,9 +1,9 @@
 import logging
+from datetime import timezone
 
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, router, transaction
 from django.http import Http404
-from django.utils import timezone
 
 from sentry.models import Commit, CommitAuthor, Integration, Repository
 from sentry.models.commitfilechange import CommitFileChange

--- a/tests/acceptance/test_issue_details_workflow.py
+++ b/tests/acceptance/test_issue_details_workflow.py
@@ -1,6 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
-from django.utils import timezone
 from selenium.webdriver.common.by import By
 
 from fixtures.page_objects.issue_details import IssueDetailsPage

--- a/tests/acceptance/test_project_keys.py
+++ b/tests/acceptance/test_project_keys.py
@@ -1,6 +1,4 @@
-from datetime import datetime
-
-from django.utils import timezone
+from datetime import datetime, timezone
 
 from sentry.models import ProjectKey
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase

--- a/tests/acceptance/test_project_similar_issues.py
+++ b/tests/acceptance/test_project_similar_issues.py
@@ -1,6 +1,4 @@
-from datetime import datetime
-
-from django.utils import timezone
+from datetime import datetime, timezone
 
 from sentry.testutils import AcceptanceTestCase
 from sentry.utils.samples import create_sample_event

--- a/tests/sentry/api/endpoints/test_organization_member_unreleased_commits.py
+++ b/tests/sentry/api/endpoints/test_organization_member_unreleased_commits.py
@@ -1,6 +1,4 @@
-from datetime import datetime
-
-from django.utils import timezone
+from datetime import datetime, timezone
 
 from sentry.testutils import APITestCase
 from sentry.testutils.silo import region_silo_test

--- a/tests/sentry/api/endpoints/test_project_processingissues.py
+++ b/tests/sentry/api/endpoints/test_project_processingissues.py
@@ -1,7 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from django.urls import reverse
-from django.utils import timezone
 
 from sentry.models import EventError, EventProcessingIssue, ProcessingIssue, RawEvent
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -1,9 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import cached_property
 
 import pytz
 from django.urls import reverse
-from django.utils import timezone
 from rest_framework.exceptions import ErrorDetail
 
 from sentry.api.serializers.rest_framework.release import ReleaseWithVersionSerializer

--- a/tests/sentry/api/endpoints/test_team_alerts_triggered.py
+++ b/tests/sentry/api/endpoints/test_team_alerts_triggered.py
@@ -1,4 +1,5 @@
-from django.utils import timezone
+from datetime import timezone
+
 from freezegun import freeze_time
 
 from sentry.incidents.models import (

--- a/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
+++ b/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
@@ -1,6 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
-from django.utils import timezone
 from django.utils.timezone import now
 from freezegun import freeze_time
 

--- a/tests/sentry/api/endpoints/test_team_groups_old.py
+++ b/tests/sentry/api/endpoints/test_team_groups_old.py
@@ -1,6 +1,4 @@
-from datetime import datetime, timedelta
-
-from django.utils import timezone
+from datetime import datetime, timedelta, timezone
 
 from sentry.models import GroupAssignee, GroupEnvironment, GroupStatus
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_team_issue_breakdown.py
+++ b/tests/sentry/api/endpoints/test_team_issue_breakdown.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import timedelta, timezone
 
-from django.utils import timezone
 from django.utils.timezone import now
 from freezegun import freeze_time
 

--- a/tests/sentry/api/endpoints/test_user_ips.py
+++ b/tests/sentry/api/endpoints/test_user_ips.py
@@ -1,6 +1,4 @@
-from datetime import datetime
-
-from django.utils import timezone
+from datetime import datetime, timezone
 
 from sentry.models import UserIP
 from sentry.testutils import APITestCase

--- a/tests/sentry/backup/test_models.py
+++ b/tests/sentry/backup/test_models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import tempfile
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Type
 from uuid import uuid4
@@ -9,7 +9,6 @@ from uuid import uuid4
 from click.testing import CliRunner
 from django.core.management import call_command
 from django.db import models, router
-from django.utils import timezone
 from sentry_relay.auth import generate_key_pair
 
 from sentry.incidents.models import (

--- a/tests/sentry/integrations/bitbucket/test_repository.py
+++ b/tests/sentry/integrations/bitbucket/test_repository.py
@@ -1,9 +1,9 @@
 import datetime
+from datetime import timezone
 from functools import cached_property
 
 import pytest
 import responses
-from django.utils import timezone
 
 from fixtures.bitbucket import COMMIT_DIFF_PATCH, COMPARE_COMMITS_EXAMPLE, REPO
 from sentry.integrations.bitbucket.repository import BitbucketRepositoryProvider

--- a/tests/sentry/integrations/bitbucket/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket/test_webhook.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
-
-from django.utils import timezone
 
 from fixtures.bitbucket import PUSH_EVENT_EXAMPLE
 from sentry.integrations.bitbucket.webhook import PROVIDER_NAME

--- a/tests/sentry/integrations/bitbucket_server/test_repository.py
+++ b/tests/sentry/integrations/bitbucket_server/test_repository.py
@@ -1,9 +1,9 @@
 import datetime
+from datetime import timezone
 from functools import cached_property
 
 import pytest
 import responses
-from django.utils import timezone
 
 from fixtures.bitbucket_server import (
     COMMIT_CHANGELIST_EXAMPLE,

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -1,8 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 from uuid import uuid4
-
-from django.utils import timezone
 
 from fixtures.github import (
     PULL_REQUEST_CLOSED_EVENT_EXAMPLE,

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -1,9 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
-from django.utils import timezone
 
 from fixtures.github_enterprise import (
     PULL_REQUEST_CLOSED_EVENT_EXAMPLE,

--- a/tests/sentry/integrations/jira/test_sentry_issue_details.py
+++ b/tests/sentry/integrations/jira/test_sentry_issue_details.py
@@ -1,8 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import responses
-from django.utils import timezone
 from jwt import ExpiredSignatureError
 
 from sentry.integrations.jira import JIRA_KEY

--- a/tests/sentry/integrations/vsts/test_repository.py
+++ b/tests/sentry/integrations/vsts/test_repository.py
@@ -1,9 +1,9 @@
 import datetime
+from datetime import timezone
 from functools import cached_property
 from time import time
 
 import responses
-from django.utils import timezone
 
 from fixtures.vsts import COMMIT_DETAILS_EXAMPLE, COMPARE_COMMITS_EXAMPLE, FILE_CHANGES_EXAMPLE
 from sentry.integrations.vsts.repository import VstsRepositoryProvider

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py
@@ -1,6 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
-from django.utils import timezone
 from freezegun import freeze_time
 
 from sentry.monitors.models import CheckInStatus, MonitorCheckIn

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -1,8 +1,8 @@
 import datetime
 import re
+from datetime import timezone
 
 import pytest
-from django.utils import timezone
 from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op, Or

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -1,10 +1,10 @@
 import datetime
 import math
+from datetime import timezone
 from typing import List
 from unittest import mock
 
 import pytest
-from django.utils import timezone
 from snuba_sdk import AliasedExpression, Column, Condition, Function, Op
 
 from sentry.exceptions import IncompatibleMetricsQuery

--- a/tests/sentry/search/events/builder/test_profile_functions.py
+++ b/tests/sentry/search/events/builder/test_profile_functions.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
-from django.utils import timezone
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.function import Function

--- a/tests/sentry/search/events/builder/test_span_metrics.py
+++ b/tests/sentry/search/events/builder/test_span_metrics.py
@@ -1,7 +1,7 @@
 import datetime
+from datetime import timezone
 
 import pytest
-from django.utils import timezone
 from snuba_sdk import And, Column, Condition, Op, Or
 
 from sentry.search.events.builder import (

--- a/tests/sentry/snuba/test_profiles.py
+++ b/tests/sentry/snuba/test_profiles.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
-from django.utils import timezone
 from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op, Or

--- a/tests/sentry_plugins/bitbucket/endpoints/test_webhooks.py
+++ b/tests/sentry_plugins/bitbucket/endpoints/test_webhooks.py
@@ -1,6 +1,4 @@
-from datetime import datetime
-
-from django.utils import timezone
+from datetime import datetime, timezone
 
 from sentry.models import Commit, CommitAuthor, Repository
 from sentry.testutils import APITestCase

--- a/tests/sentry_plugins/github/endpoints/test_installation_push_event.py
+++ b/tests/sentry_plugins/github/endpoints/test_installation_push_event.py
@@ -1,7 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import uuid4
-
-from django.utils import timezone
 
 from sentry.models import Commit, Integration, Repository
 from sentry.testutils import APITestCase

--- a/tests/sentry_plugins/github/endpoints/test_push_event.py
+++ b/tests/sentry_plugins/github/endpoints/test_push_event.py
@@ -1,7 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import uuid4
-
-from django.utils import timezone
 
 from sentry.models import Commit, CommitAuthor, OrganizationOption, Repository
 from sentry.testutils import APITestCase

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -1,8 +1,8 @@
+from datetime import timezone
 from unittest import mock
 
 import pytest
 from django.urls import reverse
-from django.utils import timezone
 from pytz import utc
 from rest_framework.exceptions import ParseError
 

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -5,11 +5,10 @@ import hashlib
 import itertools
 import logging
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytz
-from django.utils import timezone
 
 from sentry import eventstream, tagstore, tsdb
 from sentry.eventstore.models import Event


### PR DESCRIPTION
via `git grep -l "timezone\.utc" | xargs grep -L "timezone\.[^u]" | xargs sed -i "s/from django.utils import timezone/from datetime import timezone/g"`

django 4.2 deprecates this alias and is quite noisy about it.

there's a bunch more usages of this but I wanted to split out the automatically fixable ones first

<!-- Describe your PR here. -->