### PR TITLE
fix(options): Incorrect db route for options

### DIFF
--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -95,7 +95,7 @@ class SystemOptionsEndpoint(Endpoint):
                 )
 
             try:
-                with transaction.atomic(router.db_for_write(type(option))):
+                with transaction.atomic(router.db_for_write(options.default_store.model)):
                     if not (option.flags & options.FLAG_ALLOW_EMPTY) and not v:
                         options.delete(k)
                     else:


### PR DESCRIPTION
Using `type(option)` gives us a `sentry.options.store.Key` but we want the db model that it will be written to which can be access via `options.default_store.model`.