### PR TITLE
fix(starfish): Add group raw

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -117,6 +117,7 @@ SPAN_COLUMN_MAP = {
     "span.domain": "domain",
     "span.duration": "duration",
     "span.group": "group",
+    "span.group_raw": "group_raw",
     "span.module": "module",
     "span.op": "op",
     "span.self_time": "exclusive_time",


### PR DESCRIPTION
- This adds the `goup_raw` column to the span indexed dataset, with the public alias of `span.group_raw`