### PR TITLE
fix(crons): Fix variable reference for subtitle

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -650,12 +650,12 @@ def get_occurrence_data(reason: str, **kwargs):
             "subtitle": f"No check-in reported on {expected_time}.",
         }
     elif reason == MonitorFailure.DURATION:
-        timeout = kwargs.get("timeout", 30)
+        duration = kwargs.get("duration", 30)
         return {
             "group_type": MonitorCheckInTimeout,
             "level": "error",
             "reason": "duration",
-            "subtitle": f"Check-in exceeded maximum duration of {timeout} minutes.",
+            "subtitle": f"Check-in exceeded maximum duration of {duration} minutes.",
         }
 
     return {

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -415,7 +415,7 @@ class MonitorEnvironmentTestCase(TestCase):
         assert monitor_environment.mark_failed(
             last_checkin=last_checkin,
             reason=MonitorFailure.DURATION,
-            occurrence_context={"timeout": monitor.config.get("max_runtime")},
+            occurrence_context={"duration": monitor.config.get("max_runtime")},
         )
 
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -394,7 +394,11 @@ class MonitorEnvironmentTestCase(TestCase):
             organization_id=self.organization.id,
             project_id=self.project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+            config={
+                "schedule": [1, "month"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "max_runtime": 10,
+            },
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
@@ -411,7 +415,7 @@ class MonitorEnvironmentTestCase(TestCase):
         assert monitor_environment.mark_failed(
             last_checkin=last_checkin,
             reason=MonitorFailure.DURATION,
-            occurrence_context={"duration": 30},
+            occurrence_context={"timeout": monitor.config.get("max_runtime")},
         )
 
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1
@@ -425,7 +429,7 @@ class MonitorEnvironmentTestCase(TestCase):
                 "project_id": self.project.id,
                 "fingerprint": [hash_from_values(["monitor", str(monitor.guid), "duration"])],
                 "issue_title": f"Monitor failure: {monitor.name}",
-                "subtitle": "Check-in exceeded maximum duration of 30 minutes.",
+                "subtitle": "Check-in exceeded maximum duration of 10 minutes.",
                 "resource_id": None,
                 "evidence_data": {},
                 "evidence_display": [
@@ -454,7 +458,7 @@ class MonitorEnvironmentTestCase(TestCase):
                     "monitor": {
                         "status": "active",
                         "type": "cron_job",
-                        "config": {"schedule_type": 2, "schedule": [1, "month"]},
+                        "config": {"schedule_type": 2, "schedule": [1, "month"], "max_runtime": 10},
                         "id": str(monitor.guid),
                         "name": monitor.name,
                         "slug": monitor.slug,


### PR DESCRIPTION
Fixes variable reference which is passed as `duration` and not `timeout`