### PR TITLE
ref(generic-metrics): Define `ParsedMessage` as specialization of `IngestMetric`

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/parsed_message.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parsed_message.py
@@ -1,26 +1,10 @@
-from typing import Dict, List, Literal, TypedDict, Union
-
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 from typing_extensions import Required
 
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 
 
-class ParsedMessage(TypedDict, total=False):
+class ParsedMessage(IngestMetric):
     """Internal representation of a parsed ingest metric message for indexer to support generic metrics"""
 
     use_case_id: Required[UseCaseID]
-    org_id: Required[int]
-    project_id: Required[int]
-    name: Required[str]
-    type: Required["_IngestMetricType"]
-    timestamp: Required[int]
-    tags: Required[Dict[str, str]]
-    value: Required[Union["CounterMetricValue", "SetMetricValue", "DistributionMetricValue"]]
-    retention_days: Required[int]
-
-
-_IngestMetricType = Union[Literal["c"], Literal["d"], Literal["s"]]
-CounterMetricValue = Union[int, float]
-DistributionMetricValue = List[Union[int, float]]
-SetMetricValue = List["_SetMetricValueItem"]
-_SetMetricValueItem = int


### PR DESCRIPTION
### Overview

`ParsedMessage` used to be `IngestMetric` copy and pasted, but that solution is not maintainable as the `IngestMetric` definition is subjected to change based on the kafka schema.

This PR defines `ParsedMessage` as a specialization of `IngestMetric` so that we don't need to update `ParsedMessage` on schema changes.