### PR TITLE
feat(replays): add analytics tracking to cards

### DIFF
--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -44,6 +44,11 @@ export type ReplayEventParameters = {
     seconds: number;
     user_email: string;
   };
+  'replay.erroroneous-table-navigate-to-details': {
+    platform: string | undefined;
+    project_id: string | undefined;
+    referrer: string;
+  };
   // similar purpose as "replay.details-viewed", however we're capturing the navigation action
   // in order to also include a project platform
   'replay.list-navigate-to-details': {
@@ -65,6 +70,11 @@ export type ReplayEventParameters = {
   'replay.play-pause': {
     play: boolean;
     user_email: string;
+  };
+  'replay.rage-dead-table-navigate-to-details': {
+    platform: string | undefined;
+    project_id: string | undefined;
+    referrer: string;
   };
   'replay.render-issues-group-list': {
     platform: string | undefined;
@@ -102,6 +112,10 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.details-tab-changed': 'Changed Replay Details Tab',
   'replay.details-time-spent': 'Time Spent Viewing Replay Details',
   'replay.list-navigate-to-details': 'Replays List Navigate to Replay Details',
+  'replay.erroroneous-table-navigate-to-details':
+    'Replays Erroneous Table Navigate to Replay Details',
+  'replay.rage-dead-table-navigate-to-details':
+    'Replays Dead and Rage Click Table Navigate to Replay Details',
   'replay.list-paginated': 'Paginated Replay List',
   'replay.list-sorted': 'Sorted Replay List',
   'replay.list-time-spent': 'Time Spent Viewing Replay List',

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -1,5 +1,6 @@
 import type {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLayout';
 import {Output} from 'sentry/views/replays/detail/network/details/getOutputType';
+import {ReferrerTableType} from 'sentry/views/replays/replayTable/tableCell';
 
 export type ReplayEventParameters = {
   'replay.details-data-loaded': {
@@ -44,17 +45,13 @@ export type ReplayEventParameters = {
     seconds: number;
     user_email: string;
   };
-  'replay.erroroneous-table-navigate-to-details': {
-    platform: string | undefined;
-    project_id: string | undefined;
-    referrer: string;
-  };
   // similar purpose as "replay.details-viewed", however we're capturing the navigation action
   // in order to also include a project platform
   'replay.list-navigate-to-details': {
     platform: string | undefined;
     project_id: string | undefined;
     referrer: string;
+    referrer_table: ReferrerTableType;
   };
   'replay.list-paginated': {
     direction: 'next' | 'prev';
@@ -70,11 +67,6 @@ export type ReplayEventParameters = {
   'replay.play-pause': {
     play: boolean;
     user_email: string;
-  };
-  'replay.rage-dead-table-navigate-to-details': {
-    platform: string | undefined;
-    project_id: string | undefined;
-    referrer: string;
   };
   'replay.render-issues-group-list': {
     platform: string | undefined;
@@ -112,10 +104,6 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.details-tab-changed': 'Changed Replay Details Tab',
   'replay.details-time-spent': 'Time Spent Viewing Replay Details',
   'replay.list-navigate-to-details': 'Replays List Navigate to Replay Details',
-  'replay.erroroneous-table-navigate-to-details':
-    'Replays Erroneous Table Navigate to Replay Details',
-  'replay.rage-dead-table-navigate-to-details':
-    'Replays Dead and Rage Click Table Navigate to Replay Details',
   'replay.list-paginated': 'Paginated Replay List',
   'replay.list-sorted': 'Sorted Replay List',
   'replay.list-time-spent': 'Time Spent Viewing Replay List',

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -133,7 +133,7 @@ function ReplayTable({
                       organization={organization}
                       referrer={referrer}
                       showUrl
-                      trackingEvent="session"
+                      referrer_table="main"
                     />
                   );
 
@@ -155,7 +155,7 @@ function ReplayTable({
                       referrer={referrer}
                       showUrl={false}
                       eventView={eventView}
-                      trackingEvent="mostRageClicks"
+                      referrer_table="dead-rage-table"
                     />
                   );
 
@@ -168,7 +168,7 @@ function ReplayTable({
                       referrer={referrer}
                       showUrl={false}
                       eventView={eventView}
-                      trackingEvent="mostErroneousReplays"
+                      referrer_table="errors-table"
                     />
                   );
 

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -133,6 +133,7 @@ function ReplayTable({
                       organization={organization}
                       referrer={referrer}
                       showUrl
+                      trackingEvent="session"
                     />
                   );
 
@@ -154,6 +155,7 @@ function ReplayTable({
                       referrer={referrer}
                       showUrl={false}
                       eventView={eventView}
+                      trackingEvent="mostRageClicks"
                     />
                   );
 
@@ -166,6 +168,7 @@ function ReplayTable({
                       referrer={referrer}
                       showUrl={false}
                       eventView={eventView}
+                      trackingEvent="mostErroneousReplays"
                     />
                   );
 

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -53,11 +53,13 @@ export function ReplayCell({
   referrer,
   replay,
   showUrl,
+  trackingEvent,
 }: Props & {
   eventView: EventView;
   organization: Organization;
   referrer: string;
   showUrl: boolean;
+  trackingEvent: string;
 }) {
   const {projects} = useProjects();
   const project = projects.find(p => p.id === replay.project_id);
@@ -70,8 +72,19 @@ export function ReplayCell({
     },
   };
 
+  const setTrackingEvent = () => {
+    switch (trackingEvent) {
+      case 'mostRageClicks':
+        return 'replay.dead-rage-table-navigate-to-details';
+      case 'mostErroneousReplays':
+        return 'replay.erroroneous-table-navigate-to-details';
+      default:
+        return 'replay.list-navigate-to-details';
+    }
+  };
+
   const trackNavigationEvent = () =>
-    trackAnalytics('replay.list-navigate-to-details', {
+    trackAnalytics(setTrackingEvent(), {
       project_id: project?.id,
       platform: project?.platform,
       organization,

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -29,6 +29,8 @@ type Props = {
   replay: ReplayListRecord | ReplayListRecordWithTx;
 };
 
+export type ReferrerTableType = 'main' | 'dead-rage-table' | 'errors-table';
+
 function getUserBadgeUser(replay: Props['replay']) {
   return replay.is_archived
     ? {
@@ -53,13 +55,13 @@ export function ReplayCell({
   referrer,
   replay,
   showUrl,
-  trackingEvent,
+  referrer_table,
 }: Props & {
   eventView: EventView;
   organization: Organization;
   referrer: string;
+  referrer_table: ReferrerTableType;
   showUrl: boolean;
-  trackingEvent: string;
 }) {
   const {projects} = useProjects();
   const project = projects.find(p => p.id === replay.project_id);
@@ -72,23 +74,13 @@ export function ReplayCell({
     },
   };
 
-  const setTrackingEvent = () => {
-    switch (trackingEvent) {
-      case 'mostRageClicks':
-        return 'replay.dead-rage-table-navigate-to-details';
-      case 'mostErroneousReplays':
-        return 'replay.erroroneous-table-navigate-to-details';
-      default:
-        return 'replay.list-navigate-to-details';
-    }
-  };
-
   const trackNavigationEvent = () =>
-    trackAnalytics(setTrackingEvent(), {
+    trackAnalytics('replay.list-navigate-to-details', {
       project_id: project?.id,
       platform: project?.platform,
       organization,
       referrer,
+      referrer_table,
     });
 
   if (replay.is_archived) {


### PR DESCRIPTION
Tracking whether the user enters the replays details page from the big replays table, the erroneous card table, or the dead/rage click table.

Fixes getsentry/team-replay#127

Console logged to make sure the right event is being tracked:
<img width="547" alt="SCR-20230726-jgnr" src="https://github.com/getsentry/sentry/assets/56095982/df4bf4e0-78a6-44d8-bfa8-b4b2cd9da75b">