### PR TITLE
ref(stacktrace): Create shared functions for hidden frames toggle logic

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -16,6 +16,7 @@ import {
   findImageForAddress,
   getHiddenFrameIndices,
   getLastFrameIndex,
+  isRepeatedFrame,
   parseAddress,
   stackTracePlatformIcon,
 } from '../../utils';
@@ -43,19 +44,6 @@ type Props = {
   organization?: Organization;
   threadId?: number;
 } & Partial<DefaultProps>;
-
-function isRepeatedFrame(frame: Frame, nextFrame?: Frame) {
-  if (!nextFrame) {
-    return false;
-  }
-  return (
-    frame.lineNo === nextFrame.lineNo &&
-    frame.instructionAddr === nextFrame.instructionAddr &&
-    frame.package === nextFrame.package &&
-    frame.module === nextFrame.module &&
-    frame.function === nextFrame.function
-  );
-}
 
 function Content({
   data,

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -189,8 +189,8 @@ function Content({
     (maxLengthUntilThisPoint, frame) => {
       const correspondingImage = findImageForAddress({
         event,
-        addrMode: frame.instructionAddr!,
-        address: frame.addrMode!,
+        addrMode: frame.addrMode,
+        address: frame.instructionAddr,
       });
 
       try {
@@ -237,8 +237,8 @@ function Content({
           onAddressToggle: handleToggleAddresses,
           image: findImageForAddress({
             event,
-            addrMode: frame.instructionAddr!,
-            address: frame.addrMode!,
+            addrMode: frame.addrMode,
+            address: frame.instructionAddr,
           }),
           maxLengthOfRelativeAddress: maxLengthOfAllRelativeAddresses,
           registers: {}, // TODO: Fix registers

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
@@ -151,8 +151,8 @@ export function NativeContent({
     (maxLengthUntilThisPoint, frame) => {
       const correspondingImage = findImageForAddress({
         event,
-        addrMode: frame.instructionAddr!,
-        address: frame.addrMode!,
+        addrMode: frame.addrMode,
+        address: frame.instructionAddr,
       });
 
       try {
@@ -205,8 +205,8 @@ export function NativeContent({
           },
           image: findImageForAddress({
             event,
-            addrMode: frame.instructionAddr!,
-            address: frame.addrMode!,
+            addrMode: frame.addrMode,
+            address: frame.instructionAddr,
           }),
           maxLengthOfRelativeAddress: maxLengthOfAllRelativeAddresses,
           registers: {},


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/53341

After https://github.com/getsentry/sentry/issues/53300 and https://github.com/getsentry/sentry/issues/52592 are done, we want to ensure that the logic and styles do not diverge between the two stack trace components. We can prevent this by extracting out some common components and functions to be used in both.