### PR TITLE
ref(alerts): Use OrganizationAlertRuleIndexEndpoint

### DIFF
--- a/static/app/views/alerts/rules/metric/actions.tsx
+++ b/static/app/views/alerts/rules/metric/actions.tsx
@@ -22,9 +22,9 @@ export function addOrUpdateRule(
   query?: object | any
 ) {
   const isExisting = isSavedRule(rule);
-  const endpoint = `/projects/${orgId}/${projectId}/alert-rules/${
-    isSavedRule(rule) ? `${rule.id}/` : ''
-  }`;
+  const endpoint = isExisting
+    ? `/projects/${orgId}/${projectId}/alert-rules/${rule.id}/`
+    : `/organizations/${orgId}/alert-rules/`;
   const method = isExisting ? 'PUT' : 'POST';
 
   return api.requestPromise(endpoint, {

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -114,7 +114,7 @@ describe('Incident Rules Form', () => {
     let createRule;
     beforeEach(() => {
       createRule = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/alert-rules/',
+        url: '/organizations/org-slug/alert-rules/',
         method: 'POST',
       });
     });


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/53126 to replace the single usage we have of the `ProjectAlertRuleIndexEndpoint` with the `OrganizationAlertRuleIndexEndpoint`. 