### PR TITLE
feat(issues): Use short release version in resolved notification

### DIFF
--- a/src/sentry/notifications/notifications/activity/resolved_in_release.py
+++ b/src/sentry/notifications/notifications/activity/resolved_in_release.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from html import escape
 from typing import Any, Mapping
 
+from sentry_relay import parse_release
+
+from sentry.models import Activity
 from sentry.types.integrations import ExternalProviders
 
 from .base import GroupActivityNotification
@@ -12,29 +15,31 @@ class ResolvedInReleaseActivityNotification(GroupActivityNotification):
     metrics_key = "resolved_in_release_activity"
     title = "Resolved Issue"
 
-    def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
-        data = self.activity.data
+    def __init__(self, activity: Activity) -> None:
+        super().__init__(activity)
+        self.version = self.activity.data.get("version", "")
+        self.version_parsed = parse_release(self.version)["description"]
 
+    def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         url = self.organization.absolute_url(
-            f"/organizations/{self.organization.slug}/releases/{data['version']}/",
+            f"/organizations/{self.organization.slug}/releases/{self.version}/",
             query=f"project={self.project.id}",
         )
 
-        if data.get("version"):
+        if self.version:
             return (
                 "{author} marked {an issue} as resolved in {version}",
-                {"version": data["version"]},
-                {"version": '<a href="{}">{}</a>'.format(url, escape(data["version"]))},
+                {"version": self.version_parsed},
+                {"version": f'<a href="{url}">{escape(self.version_parsed)}</a>'},
             )
         return "{author} marked {an issue} as resolved in an upcoming release", {}, {}
 
     def get_notification_title(
         self, provider: ExternalProviders, context: Mapping[str, Any] | None = None
     ) -> str:
-        data = self.activity.data
         if self.user:
             author = self.user.get_display_name()
         else:
             author = "Unknown"
-        release = data["version"] if data.get("version") else "an upcoming release"
+        release = self.version_parsed if self.version else "an upcoming release"
         return f"Issue marked as resolved in {release} by {author}"

--- a/src/sentry/notifications/notifications/activity/resolved_in_release.py
+++ b/src/sentry/notifications/notifications/activity/resolved_in_release.py
@@ -21,12 +21,12 @@ class ResolvedInReleaseActivityNotification(GroupActivityNotification):
         self.version_parsed = parse_release(self.version)["description"]
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
-        url = self.organization.absolute_url(
-            f"/organizations/{self.organization.slug}/releases/{self.version}/",
-            query=f"project={self.project.id}",
-        )
-
         if self.version:
+            url = self.organization.absolute_url(
+                f"/organizations/{self.organization.slug}/releases/{self.version}/",
+                query=f"project={self.project.id}",
+            )
+
             return (
                 "{author} marked {an issue} as resolved in {version}",
                 {"version": self.version_parsed},

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -367,9 +367,10 @@ class ActivityNotificationTest(APITestCase):
 
         msg = mail.outbox[0]
         assert isinstance(msg, EmailMultiAlternatives)
+        parsed_version = parse_release(release.version)["description"]
         # check the txt version
         assert (
-            f"Resolved Issue\n\n{self.user.username} marked {self.short_id} as resolved in {release.version}"
+            f"Resolved Issue\n\n{self.user.username} marked {self.short_id} as resolved in {parsed_version}"
             in msg.body
         )
         # check the html version
@@ -379,7 +380,7 @@ class ActivityNotificationTest(APITestCase):
         )
 
         attachment, text = get_attachment()
-        assert text == f"Issue marked as resolved in {release.version} by {self.name}"
+        assert text == f"Issue marked as resolved in {parsed_version} by {self.name}"
         assert attachment["title"] == self.group.title
         assert (
             attachment["footer"]


### PR DESCRIPTION
formats the release version similar to other notifications. Based this change off the regression notification https://github.com/getsentry/sentry/blob/master/src/sentry/notifications/notifications/activity/regression.py#L21

avoids this
![image](https://github.com/getsentry/sentry/assets/1400464/1c2a6db0-51a7-47c5-aac6-ce0bdc00cfe7)
