### PR TITLE
fix(hybrid-cloud): Adds default control storage config for testing, updates avatar tests accordingly

### DIFF
--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -210,7 +210,7 @@ class UserSerializer(Serializer):
         if attrs.get("avatar"):
             avatar: SerializedAvatarFields = {
                 "avatarType": attrs["avatar"].get_avatar_type_display(),
-                "avatarUuid": attrs["avatar"].ident if attrs["avatar"].file_id else None,
+                "avatarUuid": attrs["avatar"].ident if attrs["avatar"].get_file_id else None,
             }
         else:
             avatar = {"avatarType": "letter_avatar", "avatarUuid": None}

--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -210,7 +210,7 @@ class UserSerializer(Serializer):
         if attrs.get("avatar"):
             avatar: SerializedAvatarFields = {
                 "avatarType": attrs["avatar"].get_avatar_type_display(),
-                "avatarUuid": attrs["avatar"].ident if attrs["avatar"].get_file_id else None,
+                "avatarUuid": attrs["avatar"].ident if attrs["avatar"].get_file_id() else None,
             }
         else:
             avatar = {"avatarType": "letter_avatar", "avatarUuid": None}

--- a/src/sentry/models/avatars/base.py
+++ b/src/sentry/models/avatars/base.py
@@ -127,10 +127,7 @@ class AvatarBase(Model):
             photo = None
 
         with atomic_transaction(
-            using=(
-                router.db_for_write(cls),
-                router.db_for_write(cls.file_class()),
-            )
+            using=router.db_for_write(cls),
         ):
             if relation.get("sentry_app") and color is not None:
                 instance, created = cls.objects.get_or_create(**relation, color=color)

--- a/src/sentry/models/avatars/base.py
+++ b/src/sentry/models/avatars/base.py
@@ -70,7 +70,6 @@ class AvatarBase(Model):
             self.update(**update)
             return None
 
-    @property
     def get_file_id(self):
         return self.file_id
 

--- a/src/sentry/models/avatars/base.py
+++ b/src/sentry/models/avatars/base.py
@@ -70,6 +70,10 @@ class AvatarBase(Model):
             self.update(**update)
             return None
 
+    @property
+    def get_file_id(self):
+        return self.file_id
+
     def delete(self, *args, **kwargs):
         file = self.get_file()
         if file:

--- a/src/sentry/models/avatars/control_base.py
+++ b/src/sentry/models/avatars/control_base.py
@@ -23,6 +23,5 @@ class ControlAvatarBase(AvatarBase):
             return "control_file_id"
         return "file_id"
 
-    @property
     def get_file_id(self):
         return self.control_file_id or self.file_id

--- a/src/sentry/models/avatars/control_base.py
+++ b/src/sentry/models/avatars/control_base.py
@@ -25,4 +25,4 @@ class ControlAvatarBase(AvatarBase):
 
     @property
     def get_file_id(self):
-        return self.control_file_id
+        return self.control_file_id or self.file_id

--- a/src/sentry/models/avatars/control_base.py
+++ b/src/sentry/models/avatars/control_base.py
@@ -22,3 +22,7 @@ class ControlAvatarBase(AvatarBase):
         if ControlFileBlob._storage_config():
             return "control_file_id"
         return "file_id"
+
+    @property
+    def get_file_id(self):
+        return self.control_file_id

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -200,6 +200,10 @@ def pytest_configure(config):
     # this isn't the real secret
     settings.SENTRY_OPTIONS["github.integration-hook-secret"] = "b3002c3e321d4b7880360d397db2ccfd"
 
+    # Configure control backend settings for storage
+    settings.SENTRY_OPTIONS["filestore.control.backend"] = "filesystem"
+    settings.SENTRY_OPTIONS["filestore.control.options"] = {"location": "/tmp/sentry-files"}
+
     # This is so tests can assume this feature is off by default
     settings.SENTRY_FEATURES["organizations:performance-view"] = False
 

--- a/tests/sentry/api/endpoints/test_sentry_app_avatar.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_avatar.py
@@ -3,6 +3,7 @@ from base64 import b64encode
 from sentry import options as options_store
 from sentry.models import SentryAppAvatar
 from sentry.testutils import APITestCase
+from sentry.testutils.silo import control_silo_test
 
 
 class SentryAppAvatarTestBase(APITestCase):
@@ -35,6 +36,7 @@ class SentryAppAvatarTestBase(APITestCase):
         return self.get_success_response(self.unpublished_app.slug, **data)
 
 
+@control_silo_test(stable=True)
 class SentryAppAvatarTest(SentryAppAvatarTestBase):
     def test_get(self):
         response = self.get_success_response(self.unpublished_app.slug)
@@ -52,6 +54,7 @@ class SentryAppAvatarTest(SentryAppAvatarTestBase):
         assert response.data["uuid"] == str(self.unpublished_app.uuid)
 
 
+@control_silo_test(stable=True)
 class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
     method = "put"
 
@@ -59,7 +62,7 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
         resp = self.create_avatar(is_color=True)
 
         avatar = SentryAppAvatar.objects.get(sentry_app=self.unpublished_app, color=True)
-        assert avatar.file_id
+        assert avatar.control_file_id
         assert avatar.get_avatar_type_display() == "upload"
         color_avatar = self.get_avatar(resp)
         assert color_avatar["avatarType"] == "upload"
@@ -90,14 +93,14 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
         avatars = SentryAppAvatar.objects.filter(sentry_app=self.unpublished_app)
 
         assert len(avatars) == 2
-        assert avatars[0].file_id
+        assert avatars[0].control_file_id
         assert avatars[0].get_avatar_type_display() == "upload"
         color_avatar = self.get_avatar(resp)
         assert color_avatar["color"] is True
         assert color_avatar["avatarType"] == "upload"
         assert color_avatar["avatarUuid"] is not None
 
-        assert avatars[1].file_id
+        assert avatars[1].control_file_id
         assert avatars[1].get_avatar_type_display() == "upload"
         simple_avatar = self.get_avatar(resp, False)
         assert simple_avatar["color"] is False

--- a/tests/sentry/api/endpoints/test_sentry_app_avatar.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_avatar.py
@@ -62,7 +62,7 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
         resp = self.create_avatar(is_color=True)
 
         avatar = SentryAppAvatar.objects.get(sentry_app=self.unpublished_app, color=True)
-        assert avatar.get_file_id
+        assert avatar.get_file_id()
         assert avatar.get_avatar_type_display() == "upload"
         color_avatar = self.get_avatar(resp)
         assert color_avatar["avatarType"] == "upload"
@@ -79,7 +79,7 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
             resp = self.create_avatar(is_color=True)
 
             avatar = SentryAppAvatar.objects.get(sentry_app=self.unpublished_app, color=True)
-            assert avatar.get_file_id
+            assert avatar.get_file_id()
             assert avatar.get_avatar_type_display() == "upload"
             color_avatar = self.get_avatar(resp)
             assert color_avatar["avatarType"] == "upload"
@@ -93,14 +93,14 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
         avatars = SentryAppAvatar.objects.filter(sentry_app=self.unpublished_app)
 
         assert len(avatars) == 2
-        assert avatars[0].control_file_id
+        assert avatars[0].get_file_id()
         assert avatars[0].get_avatar_type_display() == "upload"
         color_avatar = self.get_avatar(resp)
         assert color_avatar["color"] is True
         assert color_avatar["avatarType"] == "upload"
         assert color_avatar["avatarUuid"] is not None
 
-        assert avatars[1].control_file_id
+        assert avatars[1].get_file_id()
         assert avatars[1].get_avatar_type_display() == "upload"
         simple_avatar = self.get_avatar(resp, False)
         assert simple_avatar["color"] is False

--- a/tests/sentry/api/endpoints/test_sentry_app_avatar.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_avatar.py
@@ -62,7 +62,7 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
         resp = self.create_avatar(is_color=True)
 
         avatar = SentryAppAvatar.objects.get(sentry_app=self.unpublished_app, color=True)
-        assert avatar.control_file_id
+        assert avatar.get_file_id
         assert avatar.get_avatar_type_display() == "upload"
         color_avatar = self.get_avatar(resp)
         assert color_avatar["avatarType"] == "upload"
@@ -79,7 +79,7 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
             resp = self.create_avatar(is_color=True)
 
             avatar = SentryAppAvatar.objects.get(sentry_app=self.unpublished_app, color=True)
-            assert avatar.control_file_id
+            assert avatar.get_file_id
             assert avatar.get_avatar_type_display() == "upload"
             color_avatar = self.get_avatar(resp)
             assert color_avatar["avatarType"] == "upload"

--- a/tests/sentry/api/endpoints/test_user_avatar.py
+++ b/tests/sentry/api/endpoints/test_user_avatar.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 
 from sentry import options as options_store
 from sentry.models import UserAvatar
-from sentry.models.files import ControlFile, File
+from sentry.models.files import ControlFile
 from sentry.testutils import APITestCase
 from sentry.testutils.silo import control_silo_test
 
@@ -54,7 +54,7 @@ class UserAvatarTest(APITestCase):
         avatar = UserAvatar.objects.get(user=user)
         assert response.status_code == 200, response.content
         assert avatar.get_avatar_type_display() == "upload"
-        assert avatar.file_id
+        assert avatar.control_file_id
 
     def test_transition_to_control_before_options_set(self):
         with self.tasks():
@@ -74,8 +74,8 @@ class UserAvatarTest(APITestCase):
 
             avatar = UserAvatar.objects.get(user=user)
             assert response.status_code == 200, response.content
-            assert avatar.file_id
-            assert isinstance(avatar.get_file(), File)
+            assert avatar.control_file_id
+            assert isinstance(avatar.get_file(), ControlFile)
 
     def test_transition_to_control_after_options_set(self):
         with self.options(

--- a/tests/sentry/api/endpoints/test_user_avatar.py
+++ b/tests/sentry/api/endpoints/test_user_avatar.py
@@ -54,7 +54,7 @@ class UserAvatarTest(APITestCase):
         avatar = UserAvatar.objects.get(user=user)
         assert response.status_code == 200, response.content
         assert avatar.get_avatar_type_display() == "upload"
-        assert avatar.control_file_id
+        assert avatar.get_file_id
 
     def test_transition_to_control_before_options_set(self):
         with self.tasks():
@@ -74,7 +74,7 @@ class UserAvatarTest(APITestCase):
 
             avatar = UserAvatar.objects.get(user=user)
             assert response.status_code == 200, response.content
-            assert avatar.control_file_id
+            assert avatar.get_file_id
             assert isinstance(avatar.get_file(), ControlFile)
 
     def test_transition_to_control_after_options_set(self):
@@ -101,7 +101,7 @@ class UserAvatarTest(APITestCase):
 
                 avatar = UserAvatar.objects.get(user=user)
                 assert response.status_code == 200, response.content
-                assert avatar.control_file_id
+                assert avatar.get_file_id
                 assert isinstance(avatar.get_file(), ControlFile)
 
     def test_put_bad(self):

--- a/tests/sentry/api/endpoints/test_user_avatar.py
+++ b/tests/sentry/api/endpoints/test_user_avatar.py
@@ -54,7 +54,7 @@ class UserAvatarTest(APITestCase):
         avatar = UserAvatar.objects.get(user=user)
         assert response.status_code == 200, response.content
         assert avatar.get_avatar_type_display() == "upload"
-        assert avatar.get_file_id
+        assert avatar.get_file_id()
 
     def test_transition_to_control_before_options_set(self):
         with self.tasks():
@@ -74,7 +74,7 @@ class UserAvatarTest(APITestCase):
 
             avatar = UserAvatar.objects.get(user=user)
             assert response.status_code == 200, response.content
-            assert avatar.get_file_id
+            assert avatar.get_file_id()
             assert isinstance(avatar.get_file(), ControlFile)
 
     def test_transition_to_control_after_options_set(self):
@@ -101,7 +101,7 @@ class UserAvatarTest(APITestCase):
 
                 avatar = UserAvatar.objects.get(user=user)
                 assert response.status_code == 200, response.content
-                assert avatar.get_file_id
+                assert avatar.get_file_id()
                 assert isinstance(avatar.get_file(), ControlFile)
 
     def test_put_bad(self):


### PR DESCRIPTION
This PR should also fix Issue #51918, as the avatar upload was broken for users whose uploaded avatar never had an older `file_id` set.