### PR TITLE
fix(replays): fix card row display when less than 3 replays

### DIFF
--- a/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
+++ b/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
@@ -149,7 +149,7 @@ function CardTable({
     perPage: 3,
   });
 
-  const gridRows = new Array(Math.min(replays?.length ?? 0, 2))
+  const gridRows = new Array(replays ? (replays.length > 0 ? 2 : 0) : 0)
     .fill(' ')
     .map(_ => '1fr')
     .join(' ');

--- a/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
+++ b/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
@@ -149,7 +149,7 @@ function CardTable({
     perPage: 3,
   });
 
-  const gridRows = new Array(replays ? (replays.length > 0 ? 2 : 0) : 0)
+  const gridRows = new Array(replays ? (replays.length > 0 ? 3 : 1) : 1)
     .fill(' ')
     .map(_ => '1fr')
     .join(' ');
@@ -162,7 +162,7 @@ function CardTable({
       sort={undefined}
       visibleColumns={visibleColumns}
       saveLocation
-      gridRows={'auto 1fr ' + gridRows}
+      gridRows={'auto ' + gridRows}
     />
   );
 }

--- a/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
+++ b/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
@@ -157,6 +157,7 @@ function CardTable({
       sort={undefined}
       visibleColumns={visibleColumns}
       saveLocation
+      styleCard
     />
   );
 }
@@ -165,6 +166,7 @@ const SplitCardContainer = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: ${space(2)};
+  align-items: stretch;
 `;
 
 export default ReplaysErroneousDeadRageCards;

--- a/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
+++ b/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
@@ -149,6 +149,11 @@ function CardTable({
     perPage: 3,
   });
 
+  const gridRows = new Array(Math.min(replays?.length ?? 0, 2))
+    .fill(' ')
+    .map(_ => '1fr')
+    .join(' ');
+
   return (
     <ReplayTable
       fetchError={fetchError}
@@ -157,7 +162,7 @@ function CardTable({
       sort={undefined}
       visibleColumns={visibleColumns}
       saveLocation
-      styleCard
+      gridRows={'auto 1fr ' + gridRows}
     />
   );
 }

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -35,6 +35,7 @@ type Props = {
   visibleColumns: ReplayColumn[];
   emptyMessage?: ReactNode;
   saveLocation?: boolean;
+  styleCard?: boolean;
 };
 
 function ReplayTable({
@@ -45,6 +46,7 @@ function ReplayTable({
   visibleColumns,
   emptyMessage,
   saveLocation,
+  styleCard,
 }: Props) {
   const routes = useRoutes();
   const newLocation = useLocation();
@@ -73,6 +75,7 @@ function ReplayTable({
         isLoading={false}
         visibleColumns={visibleColumns}
         data-test-id="replay-table"
+        replays={undefined}
       >
         <StyledAlert type="error" showIcon>
           {typeof fetchError === 'string'
@@ -97,6 +100,7 @@ function ReplayTable({
       disablePadding
       data-test-id="replay-table"
       emptyMessage={emptyMessage}
+      replays={styleCard && replays && replays.length < 3 ? replays : undefined}
     >
       {replays?.map(replay => {
         return (
@@ -187,6 +191,7 @@ const flexibleColumns = [
 ];
 
 const StyledPanelTable = styled(PanelTable)<{
+  replays: undefined | ReplayListRecord[] | ReplayListRecordWithTx[];
   visibleColumns: ReplayColumn[];
 }>`
   grid-template-columns: ${p =>
@@ -196,6 +201,7 @@ const StyledPanelTable = styled(PanelTable)<{
         flexibleColumns.includes(column) ? 'minmax(100px, 1fr)' : 'max-content'
       )
       .join(' ')};
+  grid-template-rows: auto 1fr ${p => (p.replays ?? []).map(_ => '1fr').join(' ')};
 `;
 
 const StyledAlert = styled(Alert)`

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -34,8 +34,8 @@ type Props = {
   sort: Sort | undefined;
   visibleColumns: ReplayColumn[];
   emptyMessage?: ReactNode;
+  gridRows?: string;
   saveLocation?: boolean;
-  styleCard?: boolean;
 };
 
 function ReplayTable({
@@ -46,7 +46,7 @@ function ReplayTable({
   visibleColumns,
   emptyMessage,
   saveLocation,
-  styleCard,
+  gridRows,
 }: Props) {
   const routes = useRoutes();
   const newLocation = useLocation();
@@ -75,7 +75,7 @@ function ReplayTable({
         isLoading={false}
         visibleColumns={visibleColumns}
         data-test-id="replay-table"
-        replays={undefined}
+        gridRows={undefined}
       >
         <StyledAlert type="error" showIcon>
           {typeof fetchError === 'string'
@@ -100,7 +100,7 @@ function ReplayTable({
       disablePadding
       data-test-id="replay-table"
       emptyMessage={emptyMessage}
-      replays={styleCard && replays && replays.length < 3 ? replays : undefined}
+      gridRows={isFetching ? undefined : gridRows}
     >
       {replays?.map(replay => {
         return (
@@ -191,8 +191,8 @@ const flexibleColumns = [
 ];
 
 const StyledPanelTable = styled(PanelTable)<{
-  replays: undefined | ReplayListRecord[] | ReplayListRecordWithTx[];
   visibleColumns: ReplayColumn[];
+  gridRows?: string;
 }>`
   grid-template-columns: ${p =>
     p.visibleColumns
@@ -201,7 +201,8 @@ const StyledPanelTable = styled(PanelTable)<{
         flexibleColumns.includes(column) ? 'minmax(100px, 1fr)' : 'max-content'
       )
       .join(' ')};
-  grid-template-rows: auto 1fr ${p => (p.replays ?? []).map(_ => '1fr').join(' ')};
+
+  ${props => (props.gridRows ? `grid-template-rows: ${props.gridRows};` : '')}
 `;
 
 const StyledAlert = styled(Alert)`


### PR DESCRIPTION
One replay: 
<img width="1215" alt="SCR-20230726-mfbd" src="https://github.com/getsentry/sentry/assets/56095982/56d205b5-8aa0-4e2d-bcd6-634b377a60d7">


Two replays:
<img width="1188" alt="SCR-20230726-kjzj" src="https://github.com/getsentry/sentry/assets/56095982/fc84f0ef-323c-4f05-851f-ed65596ce568">

Three replays:
<img width="1166" alt="SCR-20230726-kvjx" src="https://github.com/getsentry/sentry/assets/56095982/dc0df6fb-a4fe-4d6a-a1c6-e68a39180b89">

Different number of replays for the two tables:
<img width="1207" alt="SCR-20230726-mcfc" src="https://github.com/getsentry/sentry/assets/56095982/fba69fff-5c6b-43b8-a344-d1fb0e777b17">

relates to getsentry/team-replay#123
