### PR TITLE
ref: convert some usage of pytz.utc / pytz.UTC to datetime.timezone.utc

### DIFF
--- a/src/sentry/api/endpoints/project_create_sample_transaction.py
+++ b/src/sentry/api/endpoints/project_create_sample_transaction.py
@@ -1,8 +1,7 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
-import pytz
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -37,7 +36,7 @@ def fix_event_data(data):
     """
     timestamp = datetime.utcnow() - timedelta(minutes=1)
     timestamp = timestamp - timedelta(microseconds=timestamp.microsecond % 1000)
-    timestamp = timestamp.replace(tzinfo=pytz.utc)
+    timestamp = timestamp.replace(tzinfo=timezone.utc)
     data["timestamp"] = to_timestamp(timestamp)
 
     start_timestamp = timestamp - timedelta(seconds=3)

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -4,7 +4,7 @@ import itertools
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import (
     Any,
     Callable,
@@ -21,7 +21,6 @@ from typing import (
     Union,
 )
 
-import pytz
 import sentry_sdk
 from django.conf import settings
 from django.db.models import Min, prefetch_related_objects
@@ -546,11 +545,11 @@ class GroupSerializerBase(Serializer, ABC):
                     last_seen = item["last_seen"]
 
         if last_seen is None:
-            return datetime.now(pytz.utc) - timedelta(days=30)
+            return datetime.now(timezone.utc) - timedelta(days=30)
 
         return max(
-            min(last_seen - timedelta(days=1), datetime.now(pytz.utc) - timedelta(days=14)),
-            datetime.now(pytz.utc) - timedelta(days=90),
+            min(last_seen - timedelta(days=1), datetime.now(timezone.utc) - timedelta(days=14)),
+            datetime.now(timezone.utc) - timedelta(days=90),
         )
 
     @staticmethod

--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -1,8 +1,7 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, OrderedDict, Set
 
-import pytz
 import sentry_sdk
 
 from sentry import features, quotas
@@ -37,7 +36,7 @@ def is_recently_added(model: Model) -> bool:
     like this one, the boosting will not happen.
     """
     if hasattr(model, "date_added"):
-        ten_minutes_ago = datetime.now(tz=pytz.UTC) - timedelta(
+        ten_minutes_ago = datetime.now(tz=timezone.utc) - timedelta(
             minutes=NEW_MODEL_THRESHOLD_IN_MINUTES
         )
         return bool(model.date_added >= ten_minutes_ago)

--- a/src/sentry/dynamic_sampling/tasks/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/sliding_window.py
@@ -1,8 +1,7 @@
 from calendar import IllegalMonthError, monthrange
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
-import pytz
 import sentry_sdk
 
 from sentry import options
@@ -131,8 +130,8 @@ def extrapolate_monthly_volume(volume: int, hours: int) -> Optional[int]:
         return None
 
     # Get current year and month
-    year = datetime.now(tz=pytz.UTC).year
-    month = datetime.now(tz=pytz.UTC).month
+    year = datetime.now(tz=timezone.utc).year
+    month = datetime.now(tz=timezone.utc).month
 
     try:
         # Get number of days in the month.

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -4,11 +4,10 @@ import abc
 import logging
 import string
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from hashlib import md5
 from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional, Sequence, Tuple, cast
 
-import pytz
 import sentry_sdk
 from dateutil.parser import parse as parse_date
 from django.conf import settings
@@ -104,11 +103,11 @@ class BaseEvent(metaclass=abc.ABCMeta):
     def datetime(self) -> datetime:
         column = self._get_column_name(Columns.TIMESTAMP)
         if column in self._snuba_data:
-            return parse_date(self._snuba_data[column]).replace(tzinfo=pytz.utc)
+            return parse_date(self._snuba_data[column]).replace(tzinfo=timezone.utc)
 
         timestamp = self.data.get("timestamp")
         date = datetime.fromtimestamp(timestamp)
-        date = date.replace(tzinfo=pytz.utc)
+        date = date.replace(tzinfo=timezone.utc)
         return date
 
     @property

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -14,7 +14,6 @@ from typing import (
 )
 from uuid import uuid4
 
-import pytz
 import sentry_kafka_schemas
 import urllib3
 
@@ -221,7 +220,7 @@ class SnubaProtocolEventStream(EventStream):
             "transaction_id": uuid4().hex,
             "project_id": project_id,
             "group_ids": list(group_ids),
-            "datetime": datetime.now(tz=pytz.utc),
+            "datetime": datetime.now(tz=timezone.utc),
         }
 
         self._send(project_id, "start_delete_groups", extra_data=(state,), asynchronous=False)
@@ -230,7 +229,7 @@ class SnubaProtocolEventStream(EventStream):
 
     def end_delete_groups(self, state: Mapping[str, Any]) -> None:
         state_copy: MutableMapping[str, Any] = {**state}
-        state_copy["datetime"] = json.datetime_to_str(datetime.now(tz=pytz.utc))
+        state_copy["datetime"] = json.datetime_to_str(datetime.now(tz=timezone.utc))
         self._send(
             state_copy["project_id"],
             "end_delete_groups",
@@ -249,7 +248,7 @@ class SnubaProtocolEventStream(EventStream):
             "project_id": project_id,
             "previous_group_ids": list(previous_group_ids),
             "new_group_id": new_group_id,
-            "datetime": json.datetime_to_str(datetime.now(tz=pytz.utc)),
+            "datetime": json.datetime_to_str(datetime.now(tz=timezone.utc)),
         }
 
         self._send(project_id, "start_merge", extra_data=(state,), asynchronous=False)
@@ -258,7 +257,7 @@ class SnubaProtocolEventStream(EventStream):
 
     def end_merge(self, state: Mapping[str, Any]) -> None:
         state_copy: MutableMapping[str, Any] = {**state}
-        state_copy["datetime"] = datetime.now(tz=pytz.utc)
+        state_copy["datetime"] = datetime.now(tz=timezone.utc)
         self._send(
             state_copy["project_id"], "end_merge", extra_data=(state_copy,), asynchronous=False
         )
@@ -275,7 +274,7 @@ class SnubaProtocolEventStream(EventStream):
             "previous_group_id": previous_group_id,
             "new_group_id": new_group_id,
             "hashes": list(hashes),
-            "datetime": json.datetime_to_str(datetime.now(tz=pytz.utc)),
+            "datetime": json.datetime_to_str(datetime.now(tz=timezone.utc)),
         }
 
         self._send(project_id, "start_unmerge", extra_data=(state,), asynchronous=False)
@@ -284,7 +283,7 @@ class SnubaProtocolEventStream(EventStream):
 
     def end_unmerge(self, state: Mapping[str, Any]) -> None:
         state_copy: MutableMapping[str, Any] = {**state}
-        state_copy["datetime"] = json.datetime_to_str(datetime.now(tz=pytz.utc))
+        state_copy["datetime"] = json.datetime_to_str(datetime.now(tz=timezone.utc))
         self._send(
             state_copy["project_id"], "end_unmerge", extra_data=(state_copy,), asynchronous=False
         )
@@ -297,7 +296,7 @@ class SnubaProtocolEventStream(EventStream):
             "transaction_id": uuid4().hex,
             "project_id": project_id,
             "tag": tag,
-            "datetime": json.datetime_to_str(datetime.now(tz=pytz.utc)),
+            "datetime": json.datetime_to_str(datetime.now(tz=timezone.utc)),
         }
 
         self._send(project_id, "start_delete_tag", extra_data=(state,), asynchronous=False)
@@ -306,7 +305,7 @@ class SnubaProtocolEventStream(EventStream):
 
     def end_delete_tag(self, state: Mapping[str, Any]) -> None:
         state_copy: MutableMapping[str, Any] = {**state}
-        state_copy["datetime"] = json.datetime_to_str(datetime.now(tz=pytz.utc))
+        state_copy["datetime"] = json.datetime_to_str(datetime.now(tz=timezone.utc))
         self._send(
             state_copy["project_id"], "end_delete_tag", extra_data=(state_copy,), asynchronous=False
         )

--- a/src/sentry/incidents/receivers.py
+++ b/src/sentry/incidents/receivers.py
@@ -1,6 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
-import pytz
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
@@ -24,4 +23,4 @@ def add_project_to_include_all_rules(instance, created, **kwargs):
 
 @receiver(pre_save, sender=IncidentTrigger)
 def pre_save_incident_trigger(instance, sender, *args, **kwargs):
-    instance.date_modified = datetime.utcnow().replace(tzinfo=pytz.utc)
+    instance.date_modified = datetime.utcnow().replace(tzinfo=timezone.utc)

--- a/src/sentry/mediators/token_exchange/grant_exchanger.py
+++ b/src/sentry/mediators/token_exchange/grant_exchanger.py
@@ -1,6 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
-import pytz
 from django.db import router
 
 from sentry import analytics
@@ -59,7 +58,7 @@ class GrantExchanger(Mediator):
         return self.grant.application.owner == self.user
 
     def _grant_is_active(self):
-        return self.grant.expires_at > datetime.now(pytz.UTC)
+        return self.grant.expires_at > datetime.now(timezone.utc)
 
     def _delete_grant(self):
         self.grant.delete()

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, List, Sequence, TypedDict, cast
 
-import pytz
 from django.db.models import Count, Max, OuterRef, Subquery
 from django.db.models.functions import TruncHour
 
@@ -82,8 +81,8 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
     def fetch_rule_hourly_stats(
         self, rule: Rule, start: datetime, end: datetime
     ) -> Sequence[TimeSeriesValue]:
-        start = start.replace(tzinfo=pytz.utc)
-        end = end.replace(tzinfo=pytz.utc)
+        start = start.replace(tzinfo=timezone.utc)
+        end = end.replace(tzinfo=timezone.utc)
         qs = (
             RuleFireHistory.objects.filter(
                 rule=rule,

--- a/src/sentry/snuba/query_subscriptions/consumer.py
+++ b/src/sentry/snuba/query_subscriptions/consumer.py
@@ -1,7 +1,7 @@
 import logging
+from datetime import timezone
 from typing import Callable, Dict
 
-import pytz
 import sentry_sdk
 from dateutil.parser import parse as parse_date
 from sentry_kafka_schemas.codecs import Codec, ValidationError
@@ -58,7 +58,7 @@ def parse_message_value(value: bytes, jsoncodec: Codec[SubscriptionResult]) -> S
         "entity": payload["entity"],
         "subscription_id": payload["subscription_id"],
         "values": payload["result"],
-        "timestamp": parse_date(payload["timestamp"]).replace(tzinfo=pytz.utc),
+        "timestamp": parse_date(payload["timestamp"]).replace(tzinfo=timezone.utc),
     }
 
 

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -1,8 +1,7 @@
 import math
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Sequence, Set, Tuple
 
-import pytz
 from snuba_sdk import Request
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op
@@ -36,7 +35,7 @@ def _get_conditions_and_filter_keys(project_releases, environments):
 def _get_changed_project_release_model_adoptions(project_ids, now=None):
     """Returns the last 72 hours worth of releases."""
     if now is None:
-        now = datetime.now(pytz.utc)
+        now = datetime.now(timezone.utc)
 
     start = now - timedelta(days=3)
     rv = []
@@ -61,7 +60,7 @@ def _get_oldest_health_data_for_releases(project_releases, now=None):
     in 90 days.  This is used for backfilling.
     """
     if now is None:
-        now = datetime.now(pytz.utc)
+        now = datetime.now(timezone.utc)
 
     conditions = [["release", "IN", [x[1] for x in project_releases]]]
     filter_keys = {"project_id": [x[0] for x in project_releases]}
@@ -91,7 +90,7 @@ def _check_has_health_data(projects_list, now=None):
     """
 
     if now is None:
-        now = datetime.now(pytz.utc)
+        now = datetime.now(timezone.utc)
 
     if len(projects_list) == 0:
         return set()
@@ -307,7 +306,7 @@ def get_rollup_starts_and_buckets(period, now=None):
         raise TypeError("Invalid stats period")
     seconds, buckets = STATS_PERIODS[period]
     if now is None:
-        now = datetime.now(pytz.utc)
+        now = datetime.now(timezone.utc)
     start = now - timedelta(seconds=seconds * buckets)
     return seconds, start, buckets
 
@@ -316,7 +315,7 @@ def _get_release_adoption(project_releases, environments=None, now=None):
     """Get the adoption of the last 24 hours (or a difference reference timestamp)."""
     conditions, filter_keys = _get_conditions_and_filter_keys(project_releases, environments)
     if now is None:
-        now = datetime.now(pytz.utc)
+        now = datetime.now(timezone.utc)
     start = now - timedelta(days=1)
 
     total_conditions = []
@@ -525,7 +524,7 @@ def _get_crash_free_breakdown(project_id, release, start, environments=None, now
         conditions.append(["environment", "IN", environments])
 
     if now is None:
-        now = datetime.now(pytz.utc)
+        now = datetime.now(timezone.utc)
 
     def _query_stats(end):
         row = raw_query(

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -1,10 +1,9 @@
 import itertools
 import logging
 import math
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
-import pytz
 from snuba_sdk import Column, Condition, Function, Limit, Op
 
 from sentry.api.utils import get_date_range_from_params
@@ -385,7 +384,7 @@ class NonPreflightOrderByException(InvalidParams):
 
 def get_now():
     """Wrapper function to make it mockable in unit tests"""
-    return datetime.now(tz=pytz.utc)
+    return datetime.now(tz=timezone.utc)
 
 
 def get_constrained_date_range(

--- a/src/sentry/tasks/check_am2_compatibility.py
+++ b/src/sentry/tasks/check_am2_compatibility.py
@@ -1,9 +1,8 @@
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, Mapping, Optional, Set, Tuple
 
-import pytz
 import sentry_sdk
 from django.db.models import Q
 
@@ -330,8 +329,8 @@ class CheckAM2Compatibility:
         params = {
             "organization_id": organization_id,
             "project_objects": project_objects,
-            "start": datetime.now(tz=pytz.UTC) - timedelta(days=QUERY_TIME_RANGE_IN_DAYS),
-            "end": datetime.now(tz=pytz.UTC),
+            "start": datetime.now(tz=timezone.utc) - timedelta(days=QUERY_TIME_RANGE_IN_DAYS),
+            "end": datetime.now(tz=timezone.utc),
         }
 
         try:
@@ -355,8 +354,8 @@ class CheckAM2Compatibility:
         params = {
             "organization_id": organization_id,
             "project_objects": project_objects,
-            "start": datetime.now(tz=pytz.UTC) - timedelta(days=QUERY_TIME_RANGE_IN_DAYS),
-            "end": datetime.now(tz=pytz.UTC),
+            "start": datetime.now(tz=timezone.utc) - timedelta(days=QUERY_TIME_RANGE_IN_DAYS),
+            "end": datetime.now(tz=timezone.utc),
         }
 
         try:
@@ -413,8 +412,8 @@ class CheckAM2Compatibility:
         params = {
             "organization_id": organization.id,
             "project_objects": project_objects,
-            "start": datetime.now(tz=pytz.UTC) - timedelta(days=QUERY_TIME_RANGE_IN_DAYS),
-            "end": datetime.now(tz=pytz.UTC),
+            "start": datetime.now(tz=timezone.utc) - timedelta(days=QUERY_TIME_RANGE_IN_DAYS),
+            "end": datetime.now(tz=timezone.utc),
         }
 
         projects = {project.id: project for project in project_objects}

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -1,10 +1,9 @@
 import os.path
 import random
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
-import pytz
 from django.core.exceptions import SuspiciousFileOperation
 
 from sentry.constants import DATA_ROOT, INTEGRATION_ID_TO_PLATFORM_DATA
@@ -184,14 +183,14 @@ def load_data(
     if timestamp is None:
         timestamp = datetime.utcnow() - timedelta(minutes=1)
         timestamp = timestamp - timedelta(microseconds=timestamp.microsecond % 1000)
-    timestamp = timestamp.replace(tzinfo=pytz.utc)
+    timestamp = timestamp.replace(tzinfo=timezone.utc)
     data.setdefault("timestamp", to_timestamp(timestamp))
 
     if data.get("type") == "transaction":
         if start_timestamp is None:
             start_timestamp = timestamp - timedelta(seconds=3)
         else:
-            start_timestamp = start_timestamp.replace(tzinfo=pytz.utc)
+            start_timestamp = start_timestamp.replace(tzinfo=timezone.utc)
         data["start_timestamp"] = to_timestamp(start_timestamp)
 
         if trace is None:

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from hashlib import sha1
 from typing import (
     Any,
@@ -25,7 +25,6 @@ from typing import (
 )
 from urllib.parse import urlparse
 
-import pytz
 import sentry_sdk
 import urllib3
 from dateutil.parser import parse as parse_datetime
@@ -1530,7 +1529,7 @@ def shrink_time_window(issues, start):
 
 
 def naiveify_datetime(dt):
-    return dt if not dt.tzinfo else dt.astimezone(pytz.utc).replace(tzinfo=None)
+    return dt if not dt.tzinfo else dt.astimezone(timezone.utc).replace(tzinfo=None)
 
 
 def quantize_time(time, key_hash, duration=300):

--- a/src/sentry/web/frontend/debug/debug_new_release_email.py
+++ b/src/sentry/web/frontend/debug/debug_new_release_email.py
@@ -1,6 +1,6 @@
 import datetime
+from datetime import timezone
 
-import pytz
 from django.http import HttpRequest, HttpResponse
 from django.views.generic import View
 from sentry_relay import parse_release
@@ -25,14 +25,14 @@ class DebugNewReleaseEmailView(View):
         release = Release(
             organization_id=org.id,
             version=version,
-            date_added=datetime.datetime(2016, 10, 12, 15, 39, tzinfo=pytz.utc),
+            date_added=datetime.datetime(2016, 10, 12, 15, 39, tzinfo=timezone.utc),
         )
 
         deploy = Deploy(
             release=release,
             organization_id=org.id,
             environment_id=1,
-            date_finished=datetime.datetime(2016, 10, 12, 15, 39, tzinfo=pytz.utc),
+            date_finished=datetime.datetime(2016, 10, 12, 15, 39, tzinfo=timezone.utc),
         )
 
         release_links = [
@@ -47,7 +47,7 @@ class DebugNewReleaseEmailView(View):
                     (
                         Commit(
                             key="48b86fcd677da3dba5679d7a738240ce6fb74b20",
-                            date_added=datetime.datetime(2016, 10, 11, 15, 39, tzinfo=pytz.utc),
+                            date_added=datetime.datetime(2016, 10, 11, 15, 39, tzinfo=timezone.utc),
                         ),
                         None,
                     ),
@@ -56,7 +56,7 @@ class DebugNewReleaseEmailView(View):
                             key="a53a2756bb8d111b43196210b34df90b87ed336b",
                             message="Fix billing",
                             author=CommitAuthor(name="David Cramer", email="david@sentry.io"),
-                            date_added=datetime.datetime(2016, 10, 11, 16, 45, tzinfo=pytz.utc),
+                            date_added=datetime.datetime(2016, 10, 11, 16, 45, tzinfo=timezone.utc),
                         ),
                         User(email="david@sentry.io", name="David Cramer"),
                     ),
@@ -68,7 +68,7 @@ class DebugNewReleaseEmailView(View):
                     (
                         Commit(
                             key="3c8eb3b4af6ee2a29c68daa188fc730c8e4b39fd",
-                            date_added=datetime.datetime(2016, 10, 10, 15, 39, tzinfo=pytz.utc),
+                            date_added=datetime.datetime(2016, 10, 10, 15, 39, tzinfo=timezone.utc),
                         ),
                         None,
                     ),
@@ -77,7 +77,7 @@ class DebugNewReleaseEmailView(View):
                             key="373562702009df1692da6eb80a933139f29e094b",
                             message="Fix padding",
                             author=CommitAuthor(name="Chris Jennings", email="chris@sentry.io"),
-                            date_added=datetime.datetime(2016, 10, 10, 16, 39, tzinfo=pytz.utc),
+                            date_added=datetime.datetime(2016, 10, 10, 16, 39, tzinfo=timezone.utc),
                         ),
                         None,
                     ),
@@ -86,7 +86,7 @@ class DebugNewReleaseEmailView(View):
                             key="631cd9096bd9811a046a472bb0aa8b573e86e1f1",
                             message="Update README.rst",
                             author=CommitAuthor(name="David Cramer", email="david@sentry.io"),
-                            date_added=datetime.datetime(2016, 10, 11, 10, 39, tzinfo=pytz.utc),
+                            date_added=datetime.datetime(2016, 10, 11, 10, 39, tzinfo=timezone.utc),
                         ),
                         User(email="david@sentry.io", name="David Cramer"),
                     ),

--- a/tests/apidocs/endpoints/organizations/test_org_stats_v2.py
+++ b/tests/apidocs/endpoints/organizations/test_org_stats_v2.py
@@ -1,6 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
-import pytz
 from django.test.client import RequestFactory
 from django.urls import reverse
 
@@ -15,7 +14,7 @@ from sentry.utils.outcomes import Outcome
 class OrganizationStatsDocs(APIDocsTestCase, OutcomesSnubaTest):
     def setUp(self):
         super().setUp()
-        self.now = datetime(2021, 3, 14, 12, 27, 28, tzinfo=pytz.utc)
+        self.now = datetime(2021, 3, 14, 12, 27, 28, tzinfo=timezone.utc)
         self.login_as(user=self.user)
         self.store_outcomes(
             {

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -1,8 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
-import pytz
 
 from sentry.analytics import Attribute, Event, Map
 from sentry.testutils import TestCase
@@ -33,7 +32,7 @@ class EventTest(TestCase):
             id="1",
             map={"key": "value"},
             optional=False,
-            datetime=datetime(2001, 4, 18, tzinfo=pytz.utc),
+            datetime=datetime(2001, 4, 18, tzinfo=timezone.utc),
         )
         assert result.data == {"id": 1, "map": {"key": "value"}, "optional": False}
         assert result.serialize() == {

--- a/tests/sentry/api/endpoints/test_organization_relay_usage.py
+++ b/tests/sentry/api/endpoints/test_organization_relay_usage.py
@@ -1,7 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import cached_property
 
-import pytz
 from django.urls import reverse
 
 from sentry.models import RelayUsage
@@ -32,29 +31,29 @@ class OrganizationRelayHistoryTest(APITestCase):
                 "relay_id": "r1",
                 "public_key": pks[0],
                 "version": "1.1.1",
-                "first_seen": datetime(2001, 1, 1, tzinfo=pytz.UTC),
-                "last_seen": datetime(2001, 1, 2, tzinfo=pytz.UTC),
+                "first_seen": datetime(2001, 1, 1, tzinfo=timezone.utc),
+                "last_seen": datetime(2001, 1, 2, tzinfo=timezone.utc),
             },
             {
                 "relay_id": "r1",
                 "public_key": pks[0],
                 "version": "1.1.2",
-                "first_seen": datetime(2001, 2, 1, tzinfo=pytz.UTC),
-                "last_seen": datetime(2001, 2, 2, tzinfo=pytz.UTC),
+                "first_seen": datetime(2001, 2, 1, tzinfo=timezone.utc),
+                "last_seen": datetime(2001, 2, 2, tzinfo=timezone.utc),
             },
             {
                 "relay_id": "r2",
                 "public_key": pks[1],
                 "version": "1.1.1",
-                "first_seen": datetime(2002, 1, 1, tzinfo=pytz.UTC),
-                "last_seen": datetime(2002, 1, 1, tzinfo=pytz.UTC),
+                "first_seen": datetime(2002, 1, 1, tzinfo=timezone.utc),
+                "last_seen": datetime(2002, 1, 1, tzinfo=timezone.utc),
             },
             {
                 "relay_id": "r3",
                 "public_key": pks[2],
                 "version": "1.1.1",
-                "first_seen": datetime(2003, 1, 1, tzinfo=pytz.UTC),
-                "last_seen": datetime(2003, 1, 1, tzinfo=pytz.UTC),
+                "first_seen": datetime(2003, 1, 1, tzinfo=timezone.utc),
+                "last_seen": datetime(2003, 1, 1, tzinfo=timezone.utc),
             },
         ]
 

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -1,8 +1,7 @@
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
-import pytz
 from django.urls import reverse
 
 from sentry.api.endpoints.organization_release_details import OrganizationReleaseSerializer
@@ -1269,7 +1268,7 @@ class ReleaseSerializerTest(unittest.TestCase):
         result = serializer.validated_data
         assert result["ref"] == self.ref
         assert result["url"] == self.url
-        assert result["dateReleased"] == datetime(1000, 10, 10, 6, 6, tzinfo=pytz.UTC)
+        assert result["dateReleased"] == datetime(1000, 10, 10, 6, 6, tzinfo=timezone.utc)
         assert result["commits"] == self.commits
         assert result["headCommits"] == self.headCommits
         assert result["refs"] == self.refs

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from abc import ABC
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from time import time
 from typing import Any
 from unittest import mock
 
-import pytz
 from django.db import router
 from django.urls import reverse
 
@@ -1373,7 +1372,9 @@ class TestProjectDetailsDynamicSamplingBase(APITestCase, ABC):
     def _apply_old_date_to_project_and_org(self):
         # We have to create the project and organization in the past, since we boost new orgs and projects to 100%
         # automatically.
-        old_date = datetime.now(tz=pytz.UTC) - timedelta(minutes=NEW_MODEL_THRESHOLD_IN_MINUTES + 1)
+        old_date = datetime.now(tz=timezone.utc) - timedelta(
+            minutes=NEW_MODEL_THRESHOLD_IN_MINUTES + 1
+        )
         # We have to actually update the underneath db models because they are re-fetched, otherwise just the in-memory
         # copy is mutated.
         self.project.organization.update(date_added=old_date)

--- a/tests/sentry/api/endpoints/test_project_release_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_details.py
@@ -1,7 +1,6 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
-import pytz
 from django.urls import reverse
 
 from sentry.api.serializers.rest_framework.release import ReleaseSerializer
@@ -277,7 +276,7 @@ class ReleaseSerializerTest(unittest.TestCase):
         result = serializer.validated_data
         assert result["ref"] == self.ref
         assert result["url"] == self.url
-        assert result["dateReleased"] == datetime(1000, 10, 10, 6, 6, tzinfo=pytz.UTC)
+        assert result["dateReleased"] == datetime(1000, 10, 10, 6, 6, tzinfo=timezone.utc)
         assert result["commits"] == self.commits
 
     def test_fields_not_required(self):

--- a/tests/sentry/api/endpoints/test_rule_snooze.py
+++ b/tests/sentry/api/endpoints/test_rule_snooze.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
-
-import pytz
 
 from sentry import audit_log
 from sentry.models import Rule
@@ -24,7 +22,7 @@ class BaseRuleSnoozeTest(APITestCase):
         self.metric_alert_rule = self.create_alert_rule(
             organization=self.project.organization, projects=[self.project]
         )
-        self.until = datetime.now(pytz.UTC) + timedelta(days=10)
+        self.until = datetime.now(timezone.utc) + timedelta(days=10)
         self.login_as(user=self.user)
 
 
@@ -135,7 +133,7 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
         ).exists()
         assert response.status_code == 201
 
-        everyone_until = datetime.now(pytz.UTC) + timedelta(days=1)
+        everyone_until = datetime.now(timezone.utc) + timedelta(days=1)
         data = {"target": "everyone", "until": everyone_until}
         response = self.get_response(
             self.organization.slug,
@@ -150,7 +148,7 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
 
     def test_mute_issue_alert_everyone_then_user(self):
         """Test that an issue alert can be muted for everyone and then a user can mute the same alert for themselves"""
-        everyone_until = datetime.now(pytz.UTC) + timedelta(days=1)
+        everyone_until = datetime.now(timezone.utc) + timedelta(days=1)
         data = {"target": "everyone", "until": everyone_until}
         response = self.get_response(
             self.organization.slug,
@@ -436,7 +434,7 @@ class PostMetricRuleSnoozeTest(BaseRuleSnoozeTest):
         ).exists()
         assert response.status_code == 201
 
-        everyone_until = datetime.now(pytz.UTC) + timedelta(days=1)
+        everyone_until = datetime.now(timezone.utc) + timedelta(days=1)
         data = {"target": "everyone", "until": everyone_until}
         response = self.get_response(
             self.organization.slug,
@@ -451,7 +449,7 @@ class PostMetricRuleSnoozeTest(BaseRuleSnoozeTest):
 
     def test_mute_metric_alert_everyone_then_user(self):
         """Test that a metric alert can be muted for everyone and then a user can mute the same alert for themselves"""
-        everyone_until = datetime.now(pytz.UTC) + timedelta(days=1)
+        everyone_until = datetime.now(timezone.utc) + timedelta(days=1)
         data = {"target": "everyone", "until": everyone_until}
         response = self.get_response(
             self.organization.slug,

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -1,9 +1,8 @@
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
-import pytz
 from freezegun import freeze_time
 from sentry_relay.processing import validate_project_config
 
@@ -53,7 +52,7 @@ def _apply_old_date_to_project_and_org(project):
     Applies an old date to project and its corresponding org. An old date is determined as a date which is more than
     NEW_MODEL_THRESHOLD_IN_MINUTES minutes in the past.
     """
-    old_date = datetime.now(tz=pytz.UTC) - timedelta(minutes=NEW_MODEL_THRESHOLD_IN_MINUTES + 1)
+    old_date = datetime.now(tz=timezone.utc) - timedelta(minutes=NEW_MODEL_THRESHOLD_IN_MINUTES + 1)
 
     # We have to create the project and organization in the past, since we boost new orgs and projects to 100%
     # automatically.

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -1,6 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
-import pytz
 import requests
 from freezegun import freeze_time
 
@@ -71,14 +70,14 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             name="alert rule",
             organization=self.org,
             projects=[self.project],
-            date_added=before_now(minutes=6).replace(tzinfo=pytz.UTC),
+            date_added=before_now(minutes=6).replace(tzinfo=timezone.utc),
             owner=self.team.actor.get_actor_tuple(),
         )
         self.other_alert_rule = self.create_alert_rule(
             name="other alert rule",
             organization=self.org,
             projects=[self.project2],
-            date_added=before_now(minutes=5).replace(tzinfo=pytz.UTC),
+            date_added=before_now(minutes=5).replace(tzinfo=timezone.utc),
             owner=self.team.actor.get_actor_tuple(),
         )
         self.issue_rule = self.create_issue_alert_rule(
@@ -88,14 +87,14 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",
-                "date_added": before_now(minutes=4).replace(tzinfo=pytz.UTC),
+                "date_added": before_now(minutes=4).replace(tzinfo=timezone.utc),
             }
         )
         self.yet_another_alert_rule = self.create_alert_rule(
             name="yet another alert rule",
             organization=self.org,
             projects=[self.project],
-            date_added=before_now(minutes=3).replace(tzinfo=pytz.UTC),
+            date_added=before_now(minutes=3).replace(tzinfo=timezone.utc),
             owner=self.team2.actor.get_actor_tuple(),
         )
         self.combined_rules_url = f"/api/0/organizations/{self.org.slug}/combined-rules/"
@@ -171,14 +170,14 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             name="!1?",
             organization=self.org,
             projects=[self.project],
-            date_added=before_now(minutes=6).replace(tzinfo=pytz.UTC),
+            date_added=before_now(minutes=6).replace(tzinfo=timezone.utc),
             owner=self.team.actor.get_actor_tuple(),
         )
         alert_rule1 = self.create_alert_rule(
             name="!1?zz",
             organization=self.org,
             projects=[self.project],
-            date_added=before_now(minutes=6).replace(tzinfo=pytz.UTC),
+            date_added=before_now(minutes=6).replace(tzinfo=timezone.utc),
             owner=self.team.actor.get_actor_tuple(),
         )
 
@@ -303,12 +302,12 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.one_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project, self.project2],
-            date_added=date_added.replace(tzinfo=pytz.UTC),
+            date_added=date_added.replace(tzinfo=timezone.utc),
         )
         self.two_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project2],
-            date_added=date_added.replace(tzinfo=pytz.UTC),
+            date_added=date_added.replace(tzinfo=timezone.utc),
         )
         self.three_alert_rule = self.create_alert_rule(
             organization=self.org, projects=[self.project]
@@ -352,12 +351,12 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.one_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project, self.project2],
-            date_added=date_added.replace(tzinfo=pytz.UTC),
+            date_added=date_added.replace(tzinfo=timezone.utc),
         )
         self.two_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project],
-            date_added=date_added.replace(tzinfo=pytz.UTC),
+            date_added=date_added.replace(tzinfo=timezone.utc),
         )
         self.three_alert_rule = self.create_alert_rule(
             organization=self.org, projects=[self.project2]
@@ -396,7 +395,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",
-                "date_added": before_now(minutes=4).replace(tzinfo=pytz.UTC),
+                "date_added": before_now(minutes=4).replace(tzinfo=timezone.utc),
             }
         )
 
@@ -466,7 +465,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.an_unassigned_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project],
-            date_added=before_now(minutes=3).replace(tzinfo=pytz.UTC),
+            date_added=before_now(minutes=3).replace(tzinfo=timezone.utc),
             owner=None,
         )
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -514,7 +513,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",
-                "date_added": before_now(minutes=4).replace(tzinfo=pytz.UTC),
+                "date_added": before_now(minutes=4).replace(tzinfo=timezone.utc),
                 "owner": self.team.actor,
             }
         )
@@ -544,7 +543,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             name="alert rule",
             organization=another_org,
             projects=[another_project],
-            date_added=before_now(minutes=6).replace(tzinfo=pytz.UTC),
+            date_added=before_now(minutes=6).replace(tzinfo=timezone.utc),
             owner=another_org_team.actor.get_actor_tuple(),
         )
 
@@ -555,7 +554,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",
-                "date_added": before_now(minutes=4).replace(tzinfo=pytz.UTC),
+                "date_added": before_now(minutes=4).replace(tzinfo=timezone.utc),
                 "owner": another_org_team.actor,
             }
         )
@@ -825,7 +824,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             name="the best rule",
             organization=self.org,
             projects=[self.project],
-            date_added=before_now(minutes=1).replace(tzinfo=pytz.UTC),
+            date_added=before_now(minutes=1).replace(tzinfo=timezone.utc),
             owner=team.actor.get_actor_tuple(),
         )
         self.create_issue_alert_rule(
@@ -835,7 +834,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",
-                "date_added": before_now(minutes=2).replace(tzinfo=pytz.UTC),
+                "date_added": before_now(minutes=2).replace(tzinfo=timezone.utc),
                 "owner": team.actor,
             }
         )
@@ -858,7 +857,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         assert resp.data[0]["lastTriggered"] is None
         RuleFireHistory.objects.create(project=self.project, rule=rule, group=self.group)
         resp = self.get_success_response(self.organization.slug, expand=["lastTriggered"])
-        assert resp.data[0]["lastTriggered"] == datetime.now().replace(tzinfo=pytz.UTC)
+        assert resp.data[0]["lastTriggered"] == datetime.now().replace(tzinfo=timezone.utc)
 
     def test_project_deleted(self):
         from sentry.models import ScheduledDeletion

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -1,6 +1,6 @@
+from datetime import timezone
 from functools import cached_property
 
-import pytz
 import requests
 from freezegun import freeze_time
 
@@ -161,10 +161,10 @@ class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestC
         self.login_as(self.user)
         self.projects = [self.project, self.create_project()]
         self.alert_rule = self.create_alert_rule(
-            projects=self.projects, date_added=before_now(minutes=6).replace(tzinfo=pytz.UTC)
+            projects=self.projects, date_added=before_now(minutes=6).replace(tzinfo=timezone.utc)
         )
         self.other_alert_rule = self.create_alert_rule(
-            projects=self.projects, date_added=before_now(minutes=5).replace(tzinfo=pytz.UTC)
+            projects=self.projects, date_added=before_now(minutes=5).replace(tzinfo=timezone.utc)
         )
         self.issue_rule = self.create_issue_alert_rule(
             data={
@@ -173,11 +173,11 @@ class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestC
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",
-                "date_added": before_now(minutes=4).replace(tzinfo=pytz.UTC),
+                "date_added": before_now(minutes=4).replace(tzinfo=timezone.utc),
             }
         )
         self.yet_another_alert_rule = self.create_alert_rule(
-            projects=self.projects, date_added=before_now(minutes=3).replace(tzinfo=pytz.UTC)
+            projects=self.projects, date_added=before_now(minutes=3).replace(tzinfo=timezone.utc)
         )
         self.combined_rules_url = (
             f"/api/0/projects/{self.org.slug}/{self.project.slug}/combined-rules/"
@@ -296,10 +296,10 @@ class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestC
 
         date_added = before_now(minutes=1)
         self.one_alert_rule = self.create_alert_rule(
-            projects=self.projects, date_added=date_added.replace(tzinfo=pytz.UTC)
+            projects=self.projects, date_added=date_added.replace(tzinfo=timezone.utc)
         )
         self.two_alert_rule = self.create_alert_rule(
-            projects=self.projects, date_added=date_added.replace(tzinfo=pytz.UTC)
+            projects=self.projects, date_added=date_added.replace(tzinfo=timezone.utc)
         )
         self.three_alert_rule = self.create_alert_rule(projects=self.projects)
 

--- a/tests/sentry/incidents/test_receivers.py
+++ b/tests/sentry/incidents/test_receivers.py
@@ -1,6 +1,4 @@
-from datetime import datetime
-
-import pytz
+from datetime import datetime, timezone
 
 from sentry.incidents.models import (
     AlertRuleTrigger,
@@ -53,8 +51,8 @@ class PreSaveIncidentTriggerTest(TestCase):
             status=IncidentStatus.WARNING.value,
             type=2,
             title="a custom incident title",
-            date_started=datetime.utcnow().replace(tzinfo=pytz.utc),
-            date_detected=datetime.utcnow().replace(tzinfo=pytz.utc),
+            date_started=datetime.utcnow().replace(tzinfo=timezone.utc),
+            date_detected=datetime.utcnow().replace(tzinfo=timezone.utc),
             alert_rule=alert_rule,
         )
         incident_trigger = IncidentTrigger.objects.create(

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -1,4 +1,5 @@
-import pytz
+from datetime import timezone
+
 import responses
 
 from sentry.integrations.pagerduty import PagerDutyNotifyServiceAction
@@ -10,7 +11,7 @@ from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
-event_time = before_now(days=3).replace(tzinfo=pytz.utc)
+event_time = before_now(days=3).replace(tzinfo=timezone.utc)
 # external_id is the account name in pagerduty
 EXTERNAL_ID = "example-pagerduty"
 SERVICES = [

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -2,10 +2,10 @@ import datetime
 import logging
 import uuid
 from copy import deepcopy
+from datetime import timezone
 from typing import Any, Dict, Optional, Sequence, Type
 
 import pytest
-import pytz
 from jsonschema import ValidationError
 
 from sentry import eventstore
@@ -102,7 +102,7 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
     def test_process_profiling_occurrence(self) -> None:
         create_default_projects()
         event_data = load_data("generic-event-profiling")
-        event_data["detection_time"] = datetime.datetime.now(tz=pytz.UTC)
+        event_data["detection_time"] = datetime.datetime.now(tz=timezone.utc)
         with self.feature("organizations:profile-file-io-main-thread-ingest"):
             result = _process_message(event_data)
         assert result is not None

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -1,12 +1,11 @@
 import dataclasses
 import functools
 import threading
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, ContextManager
 from unittest.mock import call, patch
 
 import pytest
-import pytz
 import responses
 from django.conf import settings
 from django.db import connections
@@ -522,7 +521,7 @@ class RegionOutboxTest(TestCase):
         with outbox_runner():
             pass
 
-        start_time = datetime(year=2022, month=10, day=1, second=0, tzinfo=pytz.UTC)
+        start_time = datetime(year=2022, month=10, day=1, second=0, tzinfo=timezone.utc)
         with freeze_time(start_time):
             future_scheduled_outbox = Organization.outbox_for_update(org_id=10001)
             future_scheduled_outbox.scheduled_for = start_time + timedelta(hours=1)
@@ -543,7 +542,7 @@ class RegionOutboxTest(TestCase):
         with outbox_runner():
             pass
 
-        start_time = datetime(year=2022, month=10, day=1, second=0, tzinfo=pytz.UTC)
+        start_time = datetime(year=2022, month=10, day=1, second=0, tzinfo=timezone.utc)
         with freeze_time(start_time):
             future_scheduled_outbox = Organization.outbox_for_update(org_id=10001)
             future_scheduled_outbox.scheduled_for = start_time + timedelta(hours=1)

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -1,10 +1,9 @@
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 from unittest.mock import ANY, patch
 
 import pytest
-import pytz
 from freezegun import freeze_time
 from sentry_relay import validate_project_config
 
@@ -259,7 +258,7 @@ def test_project_config_with_all_biases_enabled(
     default_project.add_team(default_team)
     # We have to create the project and organization in the past, since we boost new orgs and projects to 100%
     # automatically.
-    old_date = datetime.now(tz=pytz.UTC) - timedelta(minutes=NEW_MODEL_THRESHOLD_IN_MINUTES + 1)
+    old_date = datetime.now(tz=timezone.utc) - timedelta(minutes=NEW_MODEL_THRESHOLD_IN_MINUTES + 1)
     default_project.organization.date_added = old_date
     default_project.date_added = old_date
 

--- a/tests/sentry/rules/filters/test_age_comparison.py
+++ b/tests/sentry/rules/filters/test_age_comparison.py
@@ -1,6 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
-import pytz
 from freezegun import freeze_time
 
 from sentry.rules.filters.age_comparison import AgeComparisonFilter
@@ -18,10 +17,10 @@ class AgeComparisonFilterTest(RuleTestCase):
 
         rule = self.get_rule(data=data)
 
-        event.group.first_seen = datetime.now(pytz.utc) - timedelta(hours=3)
+        event.group.first_seen = datetime.now(timezone.utc) - timedelta(hours=3)
         self.assertDoesNotPass(rule, event)
 
-        event.group.first_seen = datetime.now(pytz.utc) - timedelta(hours=10, microseconds=1)
+        event.group.first_seen = datetime.now(timezone.utc) - timedelta(hours=10, microseconds=1)
         # this needs to be offset by 1ms otherwise it's exactly the same time as "now" and won't pass
         self.assertPasses(rule, event)
 
@@ -33,10 +32,10 @@ class AgeComparisonFilterTest(RuleTestCase):
 
         rule = self.get_rule(data=data)
 
-        event.group.first_seen = datetime.now(pytz.utc) - timedelta(hours=3)
+        event.group.first_seen = datetime.now(timezone.utc) - timedelta(hours=3)
         self.assertPasses(rule, event)
 
-        event.group.first_seen = datetime.now(pytz.utc) - timedelta(hours=10)
+        event.group.first_seen = datetime.now(timezone.utc) - timedelta(hours=10)
         self.assertDoesNotPass(rule, event)
 
     def test_fails_on_insufficient_data(self):

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import timedelta, timezone
 
-import pytz
 from freezegun import freeze_time
 
 from sentry.models import Rule
@@ -76,7 +75,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         )
         RuleFireHistory.objects.bulk_create(history)
 
-        base_triggered_date = before_now(days=1).replace(tzinfo=pytz.UTC)
+        base_triggered_date = before_now(days=1).replace(tzinfo=timezone.utc)
 
         self.run_test(
             rule,
@@ -151,7 +150,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
                 event_id=i,
             )
 
-        base_triggered_date = before_now(days=1).replace(tzinfo=pytz.UTC)
+        base_triggered_date = before_now(days=1).replace(tzinfo=timezone.utc)
         self.run_test(
             rule,
             before_now(days=3),

--- a/tests/sentry/rules/history/endpoints/test_project_rule_group_history.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_group_history.py
@@ -1,7 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import freezegun
-import pytz
 
 from sentry.api.serializers import serialize
 from sentry.models import Rule
@@ -61,7 +60,7 @@ class ProjectRuleGroupHistoryIndexEndpointTest(APITestCase):
             start=iso_format(before_now(days=6)),
             end=iso_format(before_now(days=0)),
         )
-        base_triggered_date = before_now(days=1).replace(tzinfo=pytz.UTC)
+        base_triggered_date = before_now(days=1).replace(tzinfo=timezone.utc)
         assert resp.data == serialize(
             [
                 RuleGroupHistory(self.group, 3, base_triggered_date),

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -1,11 +1,10 @@
 import unittest
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from unittest import mock
 
 import pytest
-import pytz
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
 from dateutil.parser import parse as parse_date
@@ -122,7 +121,7 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
         data["payload"].pop("result")
         data["payload"].pop("request")
         data["payload"]["timestamp"] = parse_date(data["payload"]["timestamp"]).replace(
-            tzinfo=pytz.utc
+            tzinfo=timezone.utc
         )
         mock_callback.assert_called_once_with(data["payload"], sub)
 

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
-import pytz
 from freezegun import freeze_time
 
 from sentry.models import (
@@ -30,7 +29,7 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
     @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_simple(self, mock_backend):
-        now = datetime.now(tz=pytz.UTC)
+        now = datetime.now(tz=timezone.utc)
         organization = self.organization
         project = self.create_project(organization=organization)
         group = self.create_group(
@@ -60,7 +59,7 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
     @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_reprocessed(self, mock_backend):
-        now = datetime.now(tz=pytz.UTC)
+        now = datetime.now(tz=timezone.utc)
 
         project = self.create_project()
 
@@ -84,7 +83,7 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
     @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_multiple_old_new(self, mock_backend):
-        now = datetime.now(tz=pytz.UTC)
+        now = datetime.now(tz=timezone.utc)
         project = self.create_project()
         new_groups = []
         older_groups = []
@@ -156,7 +155,7 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
     @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_simple(self, mock_backend):
-        now = datetime.now(tz=pytz.UTC)
+        now = datetime.now(tz=timezone.utc)
         project = self.create_project()
         group = self.create_group(
             project=project,
@@ -195,7 +194,7 @@ class ScheduleAutoEscalatingOngoingIssuesTest(TestCase):
     @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_simple(self, mock_backend):
-        now = datetime.now(tz=pytz.UTC)
+        now = datetime.now(tz=timezone.utc)
         project = self.create_project()
         group = self.create_group(
             project=project,

--- a/tests/sentry/tasks/test_clear_expired_rulesnoozes.py
+++ b/tests/sentry/tasks/test_clear_expired_rulesnoozes.py
@@ -1,6 +1,4 @@
-from datetime import datetime, timedelta
-
-import pytz
+from datetime import datetime, timedelta, timezone
 
 from sentry.models import Rule
 from sentry.models.rulesnooze import RuleSnooze
@@ -16,7 +14,7 @@ class ClearExpiredRuleSnoozesTest(APITestCase):
         self.metric_alert_rule = self.create_alert_rule(
             organization=self.project.organization, projects=[self.project]
         )
-        self.until = datetime.now(pytz.UTC) - timedelta(minutes=1)
+        self.until = datetime.now(timezone.utc) - timedelta(minutes=1)
         self.login_as(user=self.user)
 
     def test_task_persistent_name(self):
@@ -29,26 +27,26 @@ class ClearExpiredRuleSnoozesTest(APITestCase):
             rule=self.issue_alert_rule,
             owner_id=self.user.id,
             until=self.until,
-            date_added=datetime.now(pytz.UTC),
+            date_added=datetime.now(timezone.utc),
         )
         issue_alert_rule_snooze2 = self.snooze_rule(
             rule=self.issue_alert_rule,
             owner_id=self.user.id,
-            until=datetime.now(pytz.UTC) + timedelta(minutes=1),
-            date_added=datetime.now(pytz.UTC),
+            until=datetime.now(timezone.utc) + timedelta(minutes=1),
+            date_added=datetime.now(timezone.utc),
         )
         metric_alert_rule_snooze = self.snooze_rule(
             user_id=self.user.id,
             alert_rule=self.metric_alert_rule,
             owner_id=self.user.id,
             until=self.until,
-            date_added=datetime.now(pytz.UTC),
+            date_added=datetime.now(timezone.utc),
         )
         metric_alert_rule_snooze2 = self.snooze_rule(
             alert_rule=self.metric_alert_rule,
             owner_id=self.user.id,
-            until=datetime.now(pytz.UTC) + timedelta(minutes=1),
-            date_added=datetime.now(pytz.UTC),
+            until=datetime.now(timezone.utc) + timedelta(minutes=1),
+            date_added=datetime.now(timezone.utc),
         )
 
         clear_expired_rulesnoozes()
@@ -64,13 +62,13 @@ class ClearExpiredRuleSnoozesTest(APITestCase):
             user_id=self.user.id,
             rule=self.issue_alert_rule,
             owner_id=self.user.id,
-            date_added=datetime.now(pytz.UTC),
+            date_added=datetime.now(timezone.utc),
         )
         metric_alert_rule_snooze = self.snooze_rule(
             user_id=self.user.id,
             alert_rule=self.metric_alert_rule,
             owner_id=self.user.id,
-            date_added=datetime.now(pytz.UTC),
+            date_added=datetime.now(timezone.utc),
         )
 
         clear_expired_rulesnoozes()

--- a/tests/sentry/tasks/test_weekly_escalating_forecast.py
+++ b/tests/sentry/tasks/test_weekly_escalating_forecast.py
@@ -1,8 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 from unittest.mock import MagicMock, patch
-
-import pytz
 
 from sentry.issues.escalating_group_forecast import ONE_EVENT_FORECAST, EscalatingGroupForecast
 from sentry.models.group import Group, GroupStatus
@@ -59,7 +57,7 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
             )
 
             run_escalating_forecast()
-            approximate_date_added = datetime.now(pytz.utc)
+            approximate_date_added = datetime.now(timezone.utc)
             fetched_forecast = EscalatingGroupForecast.fetch(
                 group_list[0].project.id, group_list[0].id
             )
@@ -86,7 +84,7 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
             )
 
             run_escalating_forecast()
-            approximate_date_added = datetime.now(pytz.utc)
+            approximate_date_added = datetime.now(timezone.utc)
             for i in range(len(group_list)):
                 fetched_forecast = EscalatingGroupForecast.fetch(
                     group_list[i].project.id, group_list[i].id

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -1,8 +1,7 @@
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
-import pytz
 from django.test import override_settings
 
 from sentry.testutils import TestCase
@@ -81,7 +80,7 @@ class RedisTSDBTest(TestCase):
         assert result == "26f980fbe1e8a9d3a0123d2049f95f28"
 
     def test_simple(self):
-        now = datetime.utcnow().replace(tzinfo=pytz.UTC) - timedelta(hours=4)
+        now = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(hours=4)
         dts = [now + timedelta(hours=i) for i in range(4)]
 
         def timestamp(d):
@@ -189,7 +188,7 @@ class RedisTSDBTest(TestCase):
         assert results == {1: 0, 2: 0}
 
     def test_count_distinct(self):
-        now = datetime.utcnow().replace(tzinfo=pytz.UTC) - timedelta(hours=4)
+        now = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(hours=4)
         dts = [now + timedelta(hours=i) for i in range(4)]
 
         model = TSDBModel.users_affected_by_group
@@ -327,7 +326,7 @@ class RedisTSDBTest(TestCase):
         assert results == {1: 0, 2: 0}
 
     def test_frequency_tables(self):
-        now = datetime.utcnow().replace(tzinfo=pytz.UTC)
+        now = datetime.utcnow().replace(tzinfo=timezone.utc)
         model = TSDBModel.frequent_issues_by_project
 
         # None of the registered frequency tables actually support

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -1,6 +1,4 @@
-from datetime import datetime, timedelta
-
-import pytz
+from datetime import datetime, timedelta, timezone
 
 from sentry.constants import DataCategory
 from sentry.testutils.cases import OutcomesSnubaTest
@@ -29,7 +27,7 @@ class SnubaTSDBTest(OutcomesSnubaTest):
         self.db = SnubaTSDB()
 
         # Set up the times
-        self.now = datetime.now(pytz.utc)
+        self.now = datetime.now(timezone.utc)
         self.start_time = self.now - timedelta(days=7)
         self.one_day_later = self.start_time + timedelta(days=1)
         self.day_before_start_time = self.start_time - timedelta(days=1)

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -1,12 +1,11 @@
 import datetime
-
-import pytz
+from datetime import timezone
 
 from sentry.utils.dates import parse_stats_period, to_datetime, to_timestamp
 
 
 def test_timestamp_conversions():
-    value = datetime.datetime(2015, 10, 1, 21, 19, 5, 648517, tzinfo=pytz.utc)
+    value = datetime.datetime(2015, 10, 1, 21, 19, 5, 648517, tzinfo=timezone.utc)
     assert int(to_timestamp(value)) == int(value.strftime("%s"))
     assert to_datetime(to_timestamp(value)) == value
 

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -1,7 +1,6 @@
 import functools
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
-import pytz
 from django.urls import reverse
 from freezegun import freeze_time
 
@@ -16,7 +15,7 @@ from sentry.utils.outcomes import Outcome
 class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
     def setUp(self):
         super().setUp()
-        self.now = datetime(2021, 3, 14, 12, 27, 28, tzinfo=pytz.utc)
+        self.now = datetime(2021, 3, 14, 12, 27, 28, tzinfo=timezone.utc)
 
         self.login_as(user=self.user)
 
@@ -151,7 +150,7 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
         assert response.status_code == 400, response.content
         assert result_sorted(response.data) == {"detail": "start and end are both required"}
 
-    @freeze_time(datetime(2021, 3, 14, 12, 27, 28, tzinfo=pytz.utc))
+    @freeze_time(datetime(2021, 3, 14, 12, 27, 28, tzinfo=timezone.utc))
     def test_future_request(self):
         response = self.do_request(
             {

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -1,9 +1,8 @@
 import datetime
 import uuid
-from datetime import timedelta
+from datetime import timedelta, timezone
 from functools import cached_property
 
-import pytz
 from django.urls import reverse
 
 from sentry.replays.testutils import mock_replay
@@ -572,7 +571,7 @@ class ReplayOrganizationTagKeyValuesTest(OrganizationTagKeyTestCase, ReplaysSnub
         replay1_id = uuid.uuid4().hex
         replay2_id = uuid.uuid4().hex
         replay3_id = uuid.uuid4().hex
-        date_now = datetime.datetime.now(tz=pytz.utc).replace(
+        date_now = datetime.datetime.now(tz=timezone.utc).replace(
             hour=0, minute=0, second=0, microsecond=0
         )
         self.r1_seq1_timestamp = date_now - datetime.timedelta(seconds=22)

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -1,8 +1,7 @@
 import math
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
-import pytz
 from django.http import QueryDict
 from freezegun import freeze_time
 
@@ -39,12 +38,12 @@ def result_sorted(result):
 @freeze_time("2018-12-11 03:21:00")
 def test_round_range():
     start, end, interval = get_constrained_date_range({"statsPeriod": "2d"})
-    assert start == datetime(2018, 12, 9, 4, tzinfo=pytz.utc)
-    assert end == datetime(2018, 12, 11, 3, 22, tzinfo=pytz.utc)
+    assert start == datetime(2018, 12, 9, 4, tzinfo=timezone.utc)
+    assert end == datetime(2018, 12, 11, 3, 22, tzinfo=timezone.utc)
 
     start, end, interval = get_constrained_date_range({"statsPeriod": "2d", "interval": "1d"})
-    assert start == datetime(2018, 12, 10, tzinfo=pytz.utc)
-    assert end == datetime(2018, 12, 11, 3, 22, tzinfo=pytz.utc)
+    assert start == datetime(2018, 12, 10, tzinfo=timezone.utc)
+    assert end == datetime(2018, 12, 11, 3, 22, tzinfo=timezone.utc)
 
 
 def test_invalid_interval():
@@ -56,16 +55,16 @@ def test_round_exact():
     start, end, interval = get_constrained_date_range(
         {"start": "2021-01-12T04:06:16", "end": "2021-01-17T08:26:13", "interval": "1d"},
     )
-    assert start == datetime(2021, 1, 12, tzinfo=pytz.utc)
-    assert end == datetime(2021, 1, 18, tzinfo=pytz.utc)
+    assert start == datetime(2021, 1, 12, tzinfo=timezone.utc)
+    assert end == datetime(2021, 1, 18, tzinfo=timezone.utc)
 
 
 def test_inclusive_end():
     start, end, interval = get_constrained_date_range(
         {"start": "2021-02-24T00:00:00", "end": "2021-02-25T00:00:00", "interval": "1h"},
     )
-    assert start == datetime(2021, 2, 24, tzinfo=pytz.utc)
-    assert end == datetime(2021, 2, 25, 1, tzinfo=pytz.utc)
+    assert start == datetime(2021, 2, 24, tzinfo=timezone.utc)
+    assert end == datetime(2021, 2, 25, 1, tzinfo=timezone.utc)
 
 
 @freeze_time("2021-03-05T11:00:00.000Z")
@@ -73,8 +72,8 @@ def test_future_request():
     start, end, interval = get_constrained_date_range(
         {"start": "2021-03-05T12:00:00", "end": "2021-03-05T13:00:00", "interval": "1h"},
     )
-    assert start == datetime(2021, 3, 5, 11, tzinfo=pytz.utc)
-    assert end == datetime(2021, 3, 5, 11, 1, tzinfo=pytz.utc)
+    assert start == datetime(2021, 3, 5, 11, tzinfo=timezone.utc)
+    assert end == datetime(2021, 3, 5, 11, 1, tzinfo=timezone.utc)
 
 
 @freeze_time("2021-03-05T11:14:17.105Z")


### PR DESCRIPTION
django 4.2 moves to zoneinfo-based timezones deprecating pytz

this is the automated part of this patch -- done with:

```
git grep -El 'pytz\.(utc|UTC)' | xargs grep -L '\btimezone\b' | xargs grep -L 'pytz\.[^uU]' | xargs sed -r -i 's/import pytz/from datetime import timezone/g;s/pytz.(UTC|utc)/timezone.utc/g'
```




<!-- Describe your PR here. -->