### PR TITLE
fix(stacktrace): Update state when switching between events

### DIFF
--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -81,7 +81,8 @@ export function getThreadStateIcon(state: ThreadStates | undefined) {
       return <IconInfo />;
   }
 }
-// We want to track the active thread but that can change if the eventId changes, so if the eventID we set the state to be the new best thread
+
+// We want to set the active thread every time the event changes because the best thread might not be the same between events
 const useActiveThreadState = (
   event: Event,
   threads: Thread[]

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import isNil from 'lodash/isNil';
 
@@ -117,6 +117,15 @@ export function Threads({
   const stackView = activeThread
     ? getIntendedStackView(activeThread, exception)
     : undefined;
+
+  useEffect(() => {
+    const thread = threads.length ? findBestThread(threads) : undefined;
+    setState(s => ({
+      ...s,
+      activeThread: thread,
+    }));
+    // eslint-disable-next-line
+  }, [event.id]);
 
   function renderPills() {
     const {


### PR DESCRIPTION
this pr fixes a bug with some stack traces where the stack trace wouldn't update when switching between events, staying with the stacktrace of the initial event that was loaded. now, when the event changes, the state will also be updated. 

Closes https://github.com/getsentry/sentry/issues/53556 