### PR TITLE
feat(perf-issues): mark released grouptypes as "released" for ST

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -205,6 +205,7 @@ class PerformanceSlowDBQueryGroupType(PerformanceGroupTypeDefaults, GroupType):
     description = "Slow DB Query"
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=100)
+    released = True
 
 
 @dataclass(frozen=True)
@@ -213,6 +214,7 @@ class PerformanceRenderBlockingAssetSpanGroupType(PerformanceGroupTypeDefaults, 
     slug = "performance_render_blocking_asset_span"
     description = "Large Render Blocking Asset"
     category = GroupCategory.PERFORMANCE.value
+    released = True
 
 
 @dataclass(frozen=True)
@@ -221,6 +223,7 @@ class PerformanceNPlusOneGroupType(PerformanceGroupTypeDefaults, GroupType):
     slug = "performance_n_plus_one_db_queries"
     description = "N+1 Query"
     category = GroupCategory.PERFORMANCE.value
+    released = True
 
 
 @dataclass(frozen=True)
@@ -230,6 +233,7 @@ class PerformanceConsecutiveDBQueriesGroupType(PerformanceGroupTypeDefaults, Gro
     description = "Consecutive DB Queries"
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=15)
+    released = True
 
 
 @dataclass(frozen=True)
@@ -238,6 +242,7 @@ class PerformanceFileIOMainThreadGroupType(PerformanceGroupTypeDefaults, GroupTy
     slug = "performance_file_io_main_thread"
     description = "File IO on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    released = True
 
 
 @dataclass(frozen=True)
@@ -247,6 +252,7 @@ class PerformanceConsecutiveHTTPQueriesGroupType(PerformanceGroupTypeDefaults, G
     description = "Consecutive HTTP"
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=5)
+    released = True
 
 
 @dataclass(frozen=True)
@@ -255,6 +261,7 @@ class PerformanceNPlusOneAPICallsGroupType(GroupType):
     slug = "performance_n_plus_one_api_calls"
     description = "N+1 API Call"
     category = GroupCategory.PERFORMANCE.value
+    released = True
 
 
 @dataclass(frozen=True)
@@ -263,6 +270,7 @@ class PerformanceMNPlusOneDBQueriesGroupType(PerformanceGroupTypeDefaults, Group
     slug = "performance_m_n_plus_one_db_queries"
     description = "MN+1 Query"
     category = GroupCategory.PERFORMANCE.value
+    released = True
 
 
 @dataclass(frozen=True)
@@ -272,6 +280,7 @@ class PerformanceUncompressedAssetsGroupType(PerformanceGroupTypeDefaults, Group
     description = "Uncompressed Asset"
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=100)
+    released = True
 
 
 @dataclass(frozen=True)
@@ -280,6 +289,7 @@ class PerformanceDBMainThreadGroupType(PerformanceGroupTypeDefaults, GroupType):
     slug = "performance_db_main_thread"
     description = "DB on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    released = True
 
 
 @dataclass(frozen=True)
@@ -288,6 +298,7 @@ class PerformanceLargeHTTPPayloadGroupType(PerformanceGroupTypeDefaults, GroupTy
     slug = "performance_large_http_payload"
     description = "Large HTTP payload"
     category = GroupCategory.PERFORMANCE.value
+    released = True
 
 
 @dataclass(frozen=True)

--- a/tests/sentry/issues/test_grouptype.py
+++ b/tests/sentry/issues/test_grouptype.py
@@ -11,7 +11,7 @@ from sentry.issues.grouptype import (
     GroupTypeRegistry,
     NoiseConfig,
     PerformanceGroupTypeDefaults,
-    PerformanceNPlusOneGroupType,
+    PerformanceHTTPOverheadGroupType,
     ProfileJSONDecodeType,
     get_group_type_by_slug,
     get_group_types_by_category,
@@ -166,14 +166,14 @@ class GroupTypeReleasedTest(BaseGroupTypeTest):
 class GroupRegistryTest(BaseGroupTypeTest):
     def test_get_visible(self) -> None:
         registry = GroupTypeRegistry()
-        registry.add(PerformanceNPlusOneGroupType)
+        registry.add(PerformanceHTTPOverheadGroupType)
         registry.add(ProfileJSONDecodeType)
         assert registry.get_visible(self.organization) == []
-        with self.feature(PerformanceNPlusOneGroupType.build_visible_feature_name()):
-            assert registry.get_visible(self.organization) == [PerformanceNPlusOneGroupType]
+        with self.feature(PerformanceHTTPOverheadGroupType.build_visible_feature_name()):
+            assert registry.get_visible(self.organization) == [PerformanceHTTPOverheadGroupType]
         registry.add(ErrorGroupType)
-        with self.feature(PerformanceNPlusOneGroupType.build_visible_feature_name()):
+        with self.feature(PerformanceHTTPOverheadGroupType.build_visible_feature_name()):
             assert set(registry.get_visible(self.organization)) == {
-                PerformanceNPlusOneGroupType,
+                PerformanceHTTPOverheadGroupType,
                 ErrorGroupType,
             }


### PR DESCRIPTION
For performance issues to work in single tenant, their `GroupType` must be marked as `released`. Did so for all of the performance team's released issue types (i.e. everything in `range(1000, 2000)` except the in-progress HTTP/1.1 Overhead detector).