### PR TITLE
ref(alerts): Share logic for fetching a metric alert rule

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -8,7 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
-from sentry.api.base import region_silo_endpoint
+from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationAlertRulePermission, OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import (
@@ -36,58 +36,78 @@ from sentry.utils.cursors import Cursor, StringCursor
 from .utils import parse_team_params
 
 
-def create_metric_alert(sender, request, organization):
-    if not features.has("organizations:incidents", organization, actor=request.user):
-        raise ResourceDoesNotExist
+class AlertRuleIndexMixin(Endpoint):
+    def fetch_metric_alert(self, request, organization):
+        if not features.has("organizations:incidents", organization, actor=request.user):
+            raise ResourceDoesNotExist
 
-    serializer = AlertRuleSerializer(
-        context={
-            "organization": organization,
-            "access": request.access,
-            "user": request.user,
-            "ip_address": request.META.get("REMOTE_ADDR"),
-            "installations": app_service.get_installed_for_organization(
-                organization_id=organization.id
-            ),
-        },
-        data=request.data,
-    )
-    if serializer.is_valid():
-        trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
-        if get_slack_actions_with_async_lookups(organization, request.user, request.data):
-            # need to kick off an async job for Slack
-            client = RedisRuleStatus()
-            task_args = {
-                "organization_id": organization.id,
-                "uuid": client.uuid,
-                "data": request.data,
-                "user_id": request.user.id,
-            }
-            find_channel_id_for_alert_rule.apply_async(kwargs=task_args)
-            return Response({"uuid": client.uuid}, status=202)
-        else:
-            alert_rule = serializer.save()
-            referrer = request.query_params.get("referrer")
-            session_id = request.query_params.get("sessionId")
-            duplicate_rule = request.query_params.get("duplicateRule")
-            wizard_v3 = request.query_params.get("wizardV3")
-            subscriptions = alert_rule.snuba_query.subscriptions.all()
-            for sub in subscriptions:
-                alert_rule_created.send_robust(
-                    user=request.user,
-                    project=sub.project,
-                    rule=alert_rule,
-                    rule_type="metric",
-                    sender=sender,
-                    referrer=referrer,
-                    session_id=session_id,
-                    is_api_token=request.auth is not None,
-                    duplicate_rule=duplicate_rule,
-                    wizard_v3=wizard_v3,
-                )
-            return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
+        projects = self.get_projects(request, organization)
+        alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
+        if not features.has("organizations:performance-view", organization):
+            # Filter to only error alert rules
+            alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
 
-    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        return self.paginate(
+            request,
+            queryset=alert_rules,
+            order_by="-date_added",
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(x, request.user),
+            default_per_page=25,
+        )
+
+    def create_metric_alert(self, request, organization):
+        if not features.has("organizations:incidents", organization, actor=request.user):
+            raise ResourceDoesNotExist
+
+        serializer = AlertRuleSerializer(
+            context={
+                "organization": organization,
+                "access": request.access,
+                "user": request.user,
+                "ip_address": request.META.get("REMOTE_ADDR"),
+                "installations": app_service.get_installed_for_organization(
+                    organization_id=organization.id
+                ),
+            },
+            data=request.data,
+        )
+        if serializer.is_valid():
+            trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
+            if get_slack_actions_with_async_lookups(organization, request.user, request.data):
+                # need to kick off an async job for Slack
+                client = RedisRuleStatus()
+                task_args = {
+                    "organization_id": organization.id,
+                    "uuid": client.uuid,
+                    "data": request.data,
+                    "user_id": request.user.id,
+                }
+                find_channel_id_for_alert_rule.apply_async(kwargs=task_args)
+                return Response({"uuid": client.uuid}, status=202)
+            else:
+                alert_rule = serializer.save()
+                referrer = request.query_params.get("referrer")
+                session_id = request.query_params.get("sessionId")
+                duplicate_rule = request.query_params.get("duplicateRule")
+                wizard_v3 = request.query_params.get("wizardV3")
+                subscriptions = alert_rule.snuba_query.subscriptions.all()
+                for sub in subscriptions:
+                    alert_rule_created.send_robust(
+                        user=request.user,
+                        project=sub.project,
+                        rule=alert_rule,
+                        rule_type="metric",
+                        sender=self,
+                        referrer=referrer,
+                        session_id=session_id,
+                        is_api_token=request.auth is not None,
+                        duplicate_rule=duplicate_rule,
+                        wizard_v3=wizard_v3,
+                    )
+                return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 @region_silo_endpoint
@@ -215,33 +235,17 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
 
 
 @region_silo_endpoint
-class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint):
+class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMixin):
     permission_classes = (OrganizationAlertRulePermission,)
 
     def get(self, request: Request, organization) -> Response:
         """
-        Fetches alert rules for an organization
+        Fetches metric alert rules for an organization
         """
-        if not features.has("organizations:incidents", organization, actor=request.user):
-            raise ResourceDoesNotExist
-
-        projects = self.get_projects(request, organization)
-        alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
-        if not features.has("organizations:performance-view", organization):
-            # Filter to only error alert rules
-            alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
-
-        return self.paginate(
-            request,
-            queryset=alert_rules,
-            order_by="-date_added",
-            paginator_cls=OffsetPaginator,
-            on_results=lambda x: serialize(x, request.user),
-            default_per_page=25,
-        )
+        return self.fetch_metric_alert(request, organization)
 
     def post(self, request: Request, organization) -> Response:
         """
         Create a metric alert rule
         """
-        return create_metric_alert(self, request, organization)
+        return self.create_metric_alert(request, organization)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -37,13 +37,15 @@ from .utils import parse_team_params
 
 
 class AlertRuleIndexMixin(Endpoint):
-    def fetch_metric_alert(self, request, organization, projects=None):
+    def fetch_metric_alert(self, request, organization, project=None):
         if not features.has("organizations:incidents", organization, actor=request.user):
             raise ResourceDoesNotExist
 
-        if not projects:
+        if not project:
             projects = self.get_projects(request, organization)
-        alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
+            alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
+        else:
+            alert_rules = AlertRule.objects.fetch_for_project(project)
         if not features.has("organizations:performance-view", organization):
             # Filter to only error alert rules
             alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -37,11 +37,12 @@ from .utils import parse_team_params
 
 
 class AlertRuleIndexMixin(Endpoint):
-    def fetch_metric_alert(self, request, organization):
+    def fetch_metric_alert(self, request, organization, projects=None):
         if not features.has("organizations:incidents", organization, actor=request.user):
             raise ResourceDoesNotExist
 
-        projects = self.get_projects(request, organization)
+        if not projects:
+            projects = self.get_projects(request, organization)
         alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
         if not features.has("organizations:performance-view", organization):
             # Filter to only error alert rules

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -51,7 +51,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleIndexMixin):
         """
         Fetches metric alert rules for a project - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.
         """
-        return self.fetch_metric_alert(request, project.organization)
+        return self.fetch_metric_alert(request, project.organization, project)
 
     def post(self, request: Request, project) -> Response:
         """

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -4,15 +4,10 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
-from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.paginator import (
-    CombinedQuerysetIntermediary,
-    CombinedQuerysetPaginator,
-    OffsetPaginator,
-)
+from sentry.api.paginator import CombinedQuerysetIntermediary, CombinedQuerysetPaginator
 from sentry.api.serializers import CombinedRuleSerializer, serialize
 from sentry.constants import ObjectStatus
-from sentry.incidents.endpoints.organization_alert_rule_index import create_metric_alert
+from sentry.incidents.endpoints.organization_alert_rule_index import AlertRuleIndexMixin
 from sentry.incidents.models import AlertRule
 from sentry.models import Rule
 from sentry.snuba.dataset import Dataset
@@ -49,32 +44,17 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
 
 
 @region_silo_endpoint
-class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
+class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleIndexMixin):
     permission_classes = (ProjectAlertRulePermission,)
 
     def get(self, request: Request, project) -> Response:
         """
-        Fetches metric alert rules for a project
+        Fetches metric alert rules for a project - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.
         """
-        if not features.has("organizations:incidents", project.organization, actor=request.user):
-            raise ResourceDoesNotExist
-
-        alert_rules = AlertRule.objects.fetch_for_project(project)
-        if not features.has("organizations:performance-view", project.organization):
-            # Filter to only error alert rules
-            alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
-
-        return self.paginate(
-            request,
-            queryset=alert_rules,
-            order_by="-date_added",
-            paginator_cls=OffsetPaginator,
-            on_results=lambda x: serialize(x, request.user),
-            default_per_page=25,
-        )
+        return self.fetch_metric_alert(request, project.organization)
 
     def post(self, request: Request, project) -> Response:
         """
         Create an alert rule - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.
         """
-        return create_metric_alert(self, request, project.organization)
+        return self.create_metric_alert(request, project.organization)


### PR DESCRIPTION
Another follow up to https://github.com/getsentry/sentry/pull/53126 where I move the GET endpoint logic (which is almost identical) to a shared location for the `ProjectAlertRuleIndexEndpoint` and the `OrganizationAlertRuleIndexEndpoint` to prepare for deprecating the `ProjectAlertRuleIndexEndpoint`. 

This method isn't called anywhere by Sentry, but we do have some customer's sentry apps using it. The deprecation decorator (not yet enabled) will spit out headers informing the users of the upcoming deprecation, and we can send out emails as well. See the [API Deprecation docs](https://www.notion.so/sentry/Sentry-API-Deprecation-Policy-ccbdea15a34c4fdeb50985685adc3368) for more information.

As mentioned in the previous one, I'm not setting the deprecation decorator until all the endpoints and methods I intend to deprecate are ready so we can do it all in a batch.