### PR TITLE
fix(replays): fix loading height

### DIFF
--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {Alert} from 'sentry/components/alert';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PanelTable from 'sentry/components/panels/panelTable';
 import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
@@ -101,6 +102,7 @@ function ReplayTable({
       data-test-id="replay-table"
       emptyMessage={emptyMessage}
       gridRows={isFetching ? undefined : gridRows}
+      loader={<LoadingIndicator style={{margin: '54px auto'}} />}
     >
       {replays?.map(replay => {
         return (


### PR DESCRIPTION
it's not perfect and a bit suspicious but it's better...🤔

<img width="994" alt="SCR-20230726-mqnw" src="https://github.com/getsentry/sentry/assets/56095982/a091292f-037b-4549-b985-5d78010dde9f">

relates to getsentry/team-replay#123