### PR TITLE
chore(github-growth): invite banner prompt

### DIFF
--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -13,6 +13,7 @@ DEFAULT_PROMPTS = {
     "quick_trace_missing": {"required_fields": ["organization_id", "project_id"]},
     "code_owners": {"required_fields": ["organization_id", "project_id"]},
     "vitals_alert": {"required_fields": ["organization_id"]},
+    "github_missing_members": {"required_fields": ["organization_id"]},
 }
 
 


### PR DESCRIPTION
Add the `github_missing_members` key to the list of prompts to allow the invite banner to be snoozed / dismissed through hitting `PromptsActivityEndpoint` (https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/prompts_activity.py)

For ER-1742