### PR TITLE
fix(hc): Fix split DB test failures

### DIFF
--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -353,7 +353,7 @@ def test_relay_disabled_project(
     assert projectconfig_cache_set == [{str(wrong_id): http_cfg}]
 
 
-@pytest.mark.django_db
+@django_db_all
 def test_health_check_filters(call_endpoint, add_org_key, relay, default_project):
     """
     Test health check filter (aka ignoreTransactions)

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -10,6 +10,7 @@ from sentry import options
 from sentry.buffer.redis import RedisBuffer
 from sentry.models import Group, Project
 from sentry.utils import json
+from sentry.utils.pytest.fixtures import django_db_all
 
 
 class TestRedisBuffer:
@@ -101,7 +102,7 @@ class TestRedisBuffer:
         self.buf.process("foo")
         process.assert_called_once_with(Group, columns, filters, extra, signal_only)
 
-    @pytest.mark.django_db
+    @django_db_all
     @freeze_time()
     def test_group_cache_updated(self, default_group, task_runner):
         # Make sure group is stored in the cache and keep track of times_seen at the time

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -639,7 +639,7 @@ def test_project_config_get_at_path(default_project):
     assert project_cfg.get_at_path() == project_cfg
 
 
-@pytest.mark.django_db
+@django_db_all
 @pytest.mark.parametrize(
     "health_check_set",
     [True, False],


### PR DESCRIPTION
This resolves the `AssertionError: Database queries to 'control' are not allowed in this test.` errors when running tests in split DB mode.