### PR TITLE
feat(dynamic-sampling): allow sample rate read access

### DIFF
--- a/src/sentry/api/endpoints/project_dynamic_sampling.py
+++ b/src/sentry/api/endpoints/project_dynamic_sampling.py
@@ -36,13 +36,17 @@ class QueryTimeRange:
     end_time: datetime
 
 
+class DynamicSamplingReadPermission(ProjectPermission):
+    scope_map = {"GET": ["project:read"]}
+
+
 class DynamicSamplingPermission(ProjectPermission):
     scope_map = {"GET": ["project:write"]}
 
 
 @region_silo_endpoint
 class ProjectDynamicSamplingRateEndpoint(ProjectEndpoint):
-    permission_classes = (DynamicSamplingPermission,)
+    permission_classes = (DynamicSamplingReadPermission,)
 
     def get(self, request: Request, project: Project) -> Response:
         try:


### PR DESCRIPTION
Followup of: #53435 
Allows Endpoint access to users with project read permission