### PR TITLE
ref: Remove workaround for docker sock in devservices.py

### DIFF
--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -31,13 +31,7 @@ USE_COLIMA = bool(shutil.which("colima"))
 if USE_COLIMA:
     RAW_SOCKET_PATH = os.path.expanduser("~/.colima/default/docker.sock")
 else:
-    if DARWIN:
-        # Work around a stupid docker issue: https://github.com/docker/for-mac/issues/5025
-        RAW_SOCKET_PATH = os.path.expanduser(
-            "~/Library/Containers/com.docker.docker/Data/docker.raw.sock"
-        )
-    else:
-        RAW_SOCKET_PATH = "/var/run/docker.sock"
+    RAW_SOCKET_PATH = "/var/run/docker.sock"
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Initially created in https://github.com/getsentry/sentry/pull/22250

Both original issues are already solved for over 2.5 years:
- https://github.com/docker/for-mac/issues/5025
- https://github.com/docker/docker-py/issues/2696

This will also allow anyone to use Orbstack without any modifications.