### PR TITLE
Put locking around FlatFileIndex marking

### DIFF
--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -86,6 +86,8 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
             file = file.flat_file_index
         else:
             file = file.file
+        if file is None:
+            raise Http404
 
         try:
             fp = file.getfile()

--- a/src/sentry/debug_files/artifact_bundle_indexing.py
+++ b/src/sentry/debug_files/artifact_bundle_indexing.py
@@ -151,7 +151,7 @@ class FlatFileIdentifier(NamedTuple):
         result = ArtifactBundleFlatFileIndex.objects.filter(
             project_id=self.project_id, release_name=self.release, dist_name=self.dist
         ).first()
-        if result is None:
+        if result is None or result.flat_file_index is None:
             return None
 
         return FlatFileMeta(id=result.id, date=result.date_added)


### PR DESCRIPTION
It turns out that `get_or_create` is not atomic enough, and can leave us with duplicates in the database. To avoid that, we are wrapping all this in a distributed lock, just to be safe.

fixes SENTRY-1435
fixes SENTRY-1439
fixes SENTRY-1434
fixes SENTRY-1436