### PR TITLE
ref(data-scrubbing):fix data scrubbing rule creation messages for regexes that are too long

### DIFF
--- a/static/app/views/settings/components/dataScrubbing/modals/handleError.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/handleError.spec.tsx
@@ -1,0 +1,19 @@
+import handleError from 'sentry/views/settings/components/dataScrubbing/modals/handleError';
+
+describe('Data Scrubbing handleError', function () {
+  it.each([
+    {
+      message: 'Compiled regex exceeds size limit of 262144 bytes.',
+      name: 'regex too long',
+    },
+  ])('recognizes errors "$name"', function ({message}) {
+    const rawError = {
+      responseJSON: {
+        relayPiiConfig: [message],
+      },
+    };
+    const error = handleError(rawError);
+    // check we don't get the default error message
+    expect(error.message.toLowerCase().startsWith('an unknown error')).toBeFalsy();
+  });
+});

--- a/static/app/views/settings/components/dataScrubbing/modals/handleError.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/handleError.tsx
@@ -11,10 +11,10 @@ type Error = {
   type: ErrorType;
 };
 
-type JsonResponse = 'relayPiiConfig';
+type ResponseFields = 'relayPiiConfig';
 
 type ResponseError = {
-  responseJSON?: Record<JsonResponse, Array<string>>;
+  responseJSON?: Record<ResponseFields, Array<string>>;
 };
 
 function handleError(error: ResponseError): Error {

--- a/static/app/views/settings/components/dataScrubbing/modals/handleError.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/handleError.tsx
@@ -11,8 +11,10 @@ type Error = {
   type: ErrorType;
 };
 
+type JsonResponse = 'relayPiiConfig';
+
 type ResponseError = {
-  responseJSON?: Record<string, Array<string>>;
+  responseJSON?: Record<JsonResponse, Array<string>>;
 };
 
 function handleError(error: ResponseError): Error {
@@ -47,6 +49,13 @@ function handleError(error: ResponseError): Error {
         };
       }
     }
+  }
+
+  if (errorMessage.startsWith('Compiled regex exceeds size limit')) {
+    return {
+      type: ErrorType.REGEX_PARSE,
+      message: t('Compiled regex is too large, simplify your regex'),
+    };
   }
 
   return {


### PR DESCRIPTION
This PR adds a dedicated error message for errors related to regexes that would generate a very large compiled regex.

Resolves: #51245