### PR TITLE
ref: require `choices` for ChoiceField to be a Sequence

### DIFF
--- a/src/sentry/replays/validators.py
+++ b/src/sentry/replays/validators.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-VALID_FIELD_SET = {
+VALID_FIELD_SET = (
     "activity",
     "browser",
     "count_dead_clicks",
@@ -27,7 +27,7 @@ VALID_FIELD_SET = {
     "urls",
     "user",
     "clicks",
-}
+)
 
 
 class ReplayValidator(serializers.Serializer):

--- a/tests/tools/mypy_helpers/test_plugin.py
+++ b/tests/tools/mypy_helpers/test_plugin.py
@@ -181,3 +181,41 @@ Found 2 errors in 1 file (checked 1 source file)
     # should be fixed with our special plugin
     ret, _ = call_mypy(code)
     assert ret == 0
+
+
+def test_rest_framework_serializers_require_sequence():
+    code = """\
+from __future__ import annotations
+
+from rest_framework import serializers
+
+SOME_FSET = frozenset(('a', 'b', 'c'))
+SOME_SET = {'a', 'b', 'c'}
+SOME_TUPLE = ('a', 'b', 'c')
+SOME_LIST = ['a', 'b', 'c']
+
+# ok
+serializers.ChoiceField(choices=SOME_TUPLE)
+serializers.ChoiceField(choices=SOME_LIST)
+serializers.MultipleChoiceField(choices=SOME_TUPLE)
+serializers.MultipleChoiceField(choices=SOME_LIST)
+# not ok
+serializers.ChoiceField(choices=SOME_SET)
+serializers.ChoiceField(choices=SOME_FSET)
+serializers.MultipleChoiceField(choices=SOME_SET)
+serializers.MultipleChoiceField(choices=SOME_FSET)
+"""
+    expected = """\
+<string>:16: error: Argument "choices" to "ChoiceField" has incompatible type "Set[str]"; expected "Sequence[Any]"  [arg-type]
+<string>:17: error: Argument "choices" to "ChoiceField" has incompatible type "FrozenSet[str]"; expected "Sequence[Any]"  [arg-type]
+<string>:18: error: Argument "choices" to "MultipleChoiceField" has incompatible type "Set[str]"; expected "Sequence[Any]"  [arg-type]
+<string>:19: error: Argument "choices" to "MultipleChoiceField" has incompatible type "FrozenSet[str]"; expected "Sequence[Any]"  [arg-type]
+Found 4 errors in 1 file (checked 1 source file)
+"""
+    # should be ok without plugins
+    ret, _ = call_mypy(code, plugins=[])
+    assert ret == 0
+    # should be an error with plugins
+    ret, out = call_mypy(code)
+    assert ret
+    assert out == expected

--- a/tools/mypy_helpers/plugin.py
+++ b/tools/mypy_helpers/plugin.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 from mypy.nodes import ARG_POS, TypeInfo
 from mypy.plugin import FunctionSigContext, MethodSigContext, Plugin
-from mypy.types import CallableType, FunctionLike, Instance
+from mypy.types import AnyType, CallableType, FunctionLike, Instance, TypeOfAny
 
 
 def _make_using_required_str(ctx: FunctionSigContext) -> CallableType:
@@ -40,11 +40,21 @@ def replace_transaction_atomic_sig_callback(ctx: FunctionSigContext) -> Callable
     return _make_using_required_str(ctx)
 
 
+def _choice_field_choices_sequence(ctx: FunctionSigContext) -> CallableType:
+    sig = ctx.default_signature
+    assert sig.arg_names[0] == "choices", sig
+    any_type = AnyType(TypeOfAny.explicit)
+    sequence_any = ctx.api.named_generic_type("typing.Sequence", [any_type])
+    return sig.copy_modified(arg_types=[sequence_any, *sig.arg_types[1:]])
+
+
 _FUNCTION_SIGNATURE_HOOKS = {
     "django.db.transaction.atomic": replace_transaction_atomic_sig_callback,
     "django.db.transaction.get_connection": _make_using_required_str,
     "django.db.transaction.on_commit": _make_using_required_str,
     "django.db.transaction.set_rollback": _make_using_required_str,
+    "rest_framework.fields.ChoiceField": _choice_field_choices_sequence,
+    "rest_framework.fields.MultipleChoiceField": _choice_field_choices_sequence,
 }
 
 


### PR DESCRIPTION
when these are unordered collections it causes `api-diff` to flap.


fixed the one error that was outstanding:

```
src/sentry/replays/validators.py:56: error: Argument "choices" to "MultipleChoiceField" has incompatible type "Set[str]"; expected "Sequence[Any]"  [arg-type]
```