### PR TITLE
Do not send frame `data` to Symbolicator

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -228,6 +228,9 @@ def _normalize_frame(frame: Any) -> dict:
     if abs_path := frame.get("abs_path"):
         frame["abs_path"] = unquote(abs_path)
 
+    # Symbolicator will *output* `data`, but never use it from the input
+    frame.pop("data", None)
+
     return frame
 
 


### PR DESCRIPTION
Symbolicator expects that to be a deserializable struct, and chokes on `null` values. Just skip it completely.

fixes SENTRY-V0K