### PR TITLE
feat(crons): Render timeline view on crons issue details page

### DIFF
--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -1,0 +1,149 @@
+import {useCallback, useRef} from 'react';
+import styled from '@emotion/styled';
+
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import Panel from 'sentry/components/panels/panel';
+import Placeholder from 'sentry/components/placeholder';
+import {SegmentedControl} from 'sentry/components/segmentedControl';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {Event, Organization} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useDimensions} from 'sentry/utils/useDimensions';
+import useRouter from 'sentry/utils/useRouter';
+import {CheckInTimeline} from 'sentry/views/monitors/components/overviewTimeline/checkInTimeline';
+import {
+  GridLineOverlay,
+  GridLineTimeLabels,
+} from 'sentry/views/monitors/components/overviewTimeline/gridLines';
+import {
+  MonitorBucketData,
+  TimeWindow,
+} from 'sentry/views/monitors/components/overviewTimeline/types';
+import {timeWindowConfig} from 'sentry/views/monitors/components/overviewTimeline/utils';
+import {getTimeRangeFromEvent} from 'sentry/views/monitors/utils/getTimeRangeFromEvent';
+
+interface Props {
+  event: Event;
+  organization: Organization;
+}
+
+const DEFAULT_ENVIRONMENT = 'production';
+
+export function CronTimelineSection({event, organization}: Props) {
+  const {replace, location} = useRouter();
+  const monitorSlug = event.tags.find(({key}) => key === 'monitor.slug')?.value;
+  const environment = event.tags.find(({key}) => key === 'environment')?.value;
+  const timeWindow: TimeWindow = location.query?.timeWindow ?? '24h';
+  const nowRef = useRef<Date>(new Date());
+  const {start, end} = getTimeRangeFromEvent(event, nowRef.current, timeWindow);
+  const {elementRef, width: timelineWidth} = useDimensions<HTMLDivElement>();
+  const elapsedMinutes = timeWindowConfig[timeWindow].elapsedMinutes;
+  const rollup = Math.floor((elapsedMinutes * 60) / timelineWidth);
+
+  const handleResolutionChange = useCallback(
+    (value: TimeWindow) => {
+      replace({...location, query: {...location.query, timeWindow: value}});
+    },
+    [location, replace]
+  );
+
+  const monitorStatsQueryKey = `/organizations/${organization.slug}/monitors-stats/`;
+  const {data: monitorStats, isLoading} = useApiQuery<Record<string, MonitorBucketData>>(
+    [
+      monitorStatsQueryKey,
+      {
+        query: {
+          until: Math.floor(end.getTime() / 1000),
+          since: Math.floor(start.getTime() / 1000),
+          monitor: monitorSlug,
+          resolution: `${rollup}s`,
+        },
+      },
+    ],
+    {
+      staleTime: 0,
+      enabled: !!monitorSlug && timelineWidth > 0,
+    }
+  );
+
+  if (!monitorSlug) {
+    return null;
+  }
+
+  return (
+    <EventDataSection
+      title={t('Check-ins')}
+      type="check-ins"
+      help={t('A timeline of check-ins that happened before and after this event')}
+    >
+      <ListFilters>
+        <SegmentedControl<TimeWindow>
+          value={timeWindow}
+          onChange={handleResolutionChange}
+          size="xs"
+          aria-label={t('Time Scale')}
+        >
+          <SegmentedControl.Item key="1h">{t('Hour')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="24h">{t('Day')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="7d">{t('Week')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="30d">{t('Month')}</SegmentedControl.Item>
+        </SegmentedControl>
+      </ListFilters>
+      <TimelineContainer>
+        <TimelineWidthTracker ref={elementRef} />
+        <StyledGridLineTimeLabels
+          timeWindow={timeWindow}
+          end={end}
+          width={timelineWidth}
+        />
+        <StyledGridLineOverlay
+          showCursor={!isLoading}
+          timeWindow={timeWindow}
+          end={end}
+          width={timelineWidth}
+        />
+        {monitorStats && !isLoading ? (
+          <CheckInTimeline
+            width={timelineWidth}
+            bucketedData={monitorStats[monitorSlug]}
+            start={start}
+            end={end}
+            timeWindow={timeWindow}
+            environment={environment ?? DEFAULT_ENVIRONMENT}
+          />
+        ) : (
+          <Placeholder />
+        )}
+      </TimelineContainer>
+    </EventDataSection>
+  );
+}
+
+const ListFilters = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  margin-bottom: ${space(1)};
+`;
+
+const TimelineContainer = styled(Panel)`
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 40px 75px;
+  align-items: center;
+`;
+
+const StyledGridLineTimeLabels = styled(GridLineTimeLabels)`
+  grid-column: 0;
+`;
+
+const StyledGridLineOverlay = styled(GridLineOverlay)`
+  grid-column: 0;
+`;
+
+const TimelineWidthTracker = styled('div')`
+  position: absolute;
+  width: 100%;
+  grid-row: 1;
+  grid-column: 0;
+`;

--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -2,6 +2,7 @@ import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {Overlay} from 'sentry/components/overlay';
 import Panel from 'sentry/components/panels/panel';
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
@@ -66,6 +67,10 @@ export function CronTimelineSection({event, organization}: Props) {
     return null;
   }
 
+  const msPerPixel = (elapsedMinutes * 60 * 1000) / timelineWidth;
+  const eventTickLeft =
+    (new Date(event.dateReceived).valueOf() - start.valueOf()) / msPerPixel;
+
   return (
     <EventDataSection
       title={t('Check-ins')}
@@ -86,6 +91,10 @@ export function CronTimelineSection({event, organization}: Props) {
           end={end}
           width={timelineWidth}
         />
+        <EventLineTick left={eventTickLeft} />
+        <EventLineLabel left={eventTickLeft} timelineWidth={timelineWidth}>
+          {t('Event Created')}
+        </EventLineLabel>
         {monitorStats && !isLoading ? (
           <CheckInTimeline
             width={timelineWidth}
@@ -110,7 +119,7 @@ const StyledResolutionSelector = styled(ResolutionSelector)`
 const TimelineContainer = styled(Panel)`
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: 40px 75px;
+  grid-template-rows: 40px 100px;
   align-items: center;
 `;
 
@@ -127,4 +136,26 @@ const TimelineWidthTracker = styled('div')`
   width: 100%;
   grid-row: 1;
   grid-column: 0;
+`;
+
+const EventLineTick = styled('div')<{left: number}>`
+  background: ${p => p.theme.translucentBorder};
+  width: 2px;
+  height: 100%;
+  grid-row: 2 / 3;
+  position: absolute;
+  top: 0;
+  left: ${p => p.left}px;
+  transform: translateX(-2px);
+`;
+
+const EventLineLabel = styled(Overlay)<{left: number; timelineWidth: number}>`
+  width: max-content;
+  padding: ${space(0.75)} ${space(1)};
+  color: ${p => p.theme.textColor};
+  font-size: ${p => p.theme.fontSizeSmall};
+  position: absolute;
+  bottom: ${space(1)};
+  left: clamp(0px, ${p => p.left}px, calc(${p => p.timelineWidth}px - 50px));
+  transform: translateX(-50%);
 `;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -16,6 +16,7 @@ import {EventSdk} from 'sentry/components/events/eventSdk';
 import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScreenshot';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
 import {EventGroupingInfo} from 'sentry/components/events/groupingInfo';
+import {CronTimelineSection} from 'sentry/components/events/interfaces/crons/cronTimelineSection';
 import {AnrRootCause} from 'sentry/components/events/interfaces/performance/anrRootCause';
 import {SpanEvidenceSection} from 'sentry/components/events/interfaces/performance/spanEvidence';
 import {EventPackageData} from 'sentry/components/events/packageData';
@@ -99,6 +100,9 @@ function GroupEventDetailsContent({
             issueId={group.id}
           />
         </EventDataSection>
+      )}
+      {group.issueCategory === IssueCategory.CRON && (
+        <CronTimelineSection event={event} organization={organization} />
       )}
       <EventTagsAndScreenshot
         event={event}

--- a/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
@@ -16,6 +16,7 @@ interface Props {
   end: Date;
   timeWindow: TimeWindow;
   width: number;
+  className?: string;
   showCursor?: boolean;
 }
 

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -1,9 +1,7 @@
-import {useCallback, useRef} from 'react';
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import Panel from 'sentry/components/panels/panel';
-import {SegmentedControl} from 'sentry/components/segmentedControl';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useDimensions} from 'sentry/utils/useDimensions';
@@ -13,6 +11,7 @@ import {
   GridLineOverlay,
   GridLineTimeLabels,
 } from 'sentry/views/monitors/components/overviewTimeline/gridLines';
+import {ResolutionSelector} from 'sentry/views/monitors/components/overviewTimeline/resolutionSelector';
 import {TimelineTableRow} from 'sentry/views/monitors/components/overviewTimeline/timelineTableRow';
 
 import {Monitor} from '../../types';
@@ -25,20 +24,13 @@ interface Props {
 }
 
 export function OverviewTimeline({monitorList}: Props) {
-  const {replace, location} = useRouter();
+  const {location} = useRouter();
   const organization = useOrganization();
 
   const timeWindow: TimeWindow = location.query?.timeWindow ?? '24h';
   const nowRef = useRef<Date>(new Date());
   const start = getStartFromTimeWindow(nowRef.current, timeWindow);
   const {elementRef, width: timelineWidth} = useDimensions<HTMLDivElement>();
-
-  const handleResolutionChange = useCallback(
-    (value: TimeWindow) => {
-      replace({...location, query: {...location.query, timeWindow: value}});
-    },
-    [location, replace]
-  );
 
   const rollup = Math.floor(
     (timeWindowConfig[timeWindow].elapsedMinutes * 60) / timelineWidth
@@ -65,19 +57,7 @@ export function OverviewTimeline({monitorList}: Props) {
 
   return (
     <MonitorListPanel>
-      <ListFilters>
-        <SegmentedControl<TimeWindow>
-          value={timeWindow}
-          onChange={handleResolutionChange}
-          size="xs"
-          aria-label={t('Time Scale')}
-        >
-          <SegmentedControl.Item key="1h">{t('Hour')}</SegmentedControl.Item>
-          <SegmentedControl.Item key="24h">{t('Day')}</SegmentedControl.Item>
-          <SegmentedControl.Item key="7d">{t('Week')}</SegmentedControl.Item>
-          <SegmentedControl.Item key="30d">{t('Month')}</SegmentedControl.Item>
-        </SegmentedControl>
-      </ListFilters>
+      <StyledResolutionSelector />
       <TimelineWidthTracker ref={elementRef} />
       <GridLineTimeLabels
         timeWindow={timeWindow}
@@ -111,9 +91,7 @@ const MonitorListPanel = styled(Panel)`
   grid-template-columns: 350px 135px 1fr;
 `;
 
-const ListFilters = styled('div')`
-  display: flex;
-  gap: ${space(1)};
+const StyledResolutionSelector = styled(ResolutionSelector)`
   padding: ${space(1.5)} ${space(2)};
   border-bottom: 1px solid ${p => p.theme.border};
   grid-column: 1/3;

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -11,11 +11,11 @@ import {
   GridLineOverlay,
   GridLineTimeLabels,
 } from 'sentry/views/monitors/components/overviewTimeline/gridLines';
-import {ResolutionSelector} from 'sentry/views/monitors/components/overviewTimeline/resolutionSelector';
-import {TimelineTableRow} from 'sentry/views/monitors/components/overviewTimeline/timelineTableRow';
 
 import {Monitor} from '../../types';
 
+import {ResolutionSelector} from './resolutionSelector';
+import {TimelineTableRow} from './timelineTableRow';
 import {MonitorBucketData, TimeWindow} from './types';
 import {getStartFromTimeWindow, timeWindowConfig} from './utils';
 

--- a/static/app/views/monitors/components/overviewTimeline/resolutionSelector.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/resolutionSelector.tsx
@@ -1,0 +1,45 @@
+import {useCallback} from 'react';
+import styled from '@emotion/styled';
+
+import {SegmentedControl} from 'sentry/components/segmentedControl';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import useRouter from 'sentry/utils/useRouter';
+import {TimeWindow} from 'sentry/views/monitors/components/overviewTimeline/types';
+
+interface Props {
+  className?: string;
+}
+
+export function ResolutionSelector({className}: Props) {
+  const {replace, location} = useRouter();
+  const handleResolutionChange = useCallback(
+    (value: TimeWindow) => {
+      replace({...location, query: {...location.query, timeWindow: value}});
+    },
+    [location, replace]
+  );
+
+  const timeWindow: TimeWindow = location.query?.timeWindow ?? '24h';
+
+  return (
+    <ListFilters className={className}>
+      <SegmentedControl<TimeWindow>
+        value={timeWindow}
+        onChange={handleResolutionChange}
+        size="xs"
+        aria-label={t('Time Scale')}
+      >
+        <SegmentedControl.Item key="1h">{t('Hour')}</SegmentedControl.Item>
+        <SegmentedControl.Item key="24h">{t('Day')}</SegmentedControl.Item>
+        <SegmentedControl.Item key="7d">{t('Week')}</SegmentedControl.Item>
+        <SegmentedControl.Item key="30d">{t('Month')}</SegmentedControl.Item>
+      </SegmentedControl>
+    </ListFilters>
+  );
+}
+
+const ListFilters = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+`;

--- a/static/app/views/monitors/utils/getTimeRangeFromEvent.spec.tsx
+++ b/static/app/views/monitors/utils/getTimeRangeFromEvent.spec.tsx
@@ -1,0 +1,23 @@
+import {getTimeRangeFromEvent} from './getTimeRangeFromEvent';
+
+describe('getTimeRangeFromEvent', function () {
+  it('correctly creates a centered 24h time window', function () {
+    const event = TestStubs.Event({dateReceived: '2023-07-26T09:00:00Z'});
+    const now = new Date('2023-07-27T11:00:00Z');
+
+    const {start, end} = getTimeRangeFromEvent(event, now, '24h');
+
+    expect(start).toEqual(new Date('2023-07-25T21:00:00Z'));
+    expect(end).toEqual(new Date('2023-07-26T21:00:00Z'));
+  });
+
+  it('falls back to last 24h if the event cannot be centered', function () {
+    const event = TestStubs.Event({dateReceived: '2023-07-27T09:00:00Z'});
+    const now = new Date('2023-07-27T11:00:00Z');
+
+    const {start, end} = getTimeRangeFromEvent(event, now, '24h');
+
+    expect(start).toEqual(new Date('2023-07-26T11:00:00Z'));
+    expect(end).toEqual(new Date('2023-07-27T11:00:00Z'));
+  });
+});

--- a/static/app/views/monitors/utils/getTimeRangeFromEvent.tsx
+++ b/static/app/views/monitors/utils/getTimeRangeFromEvent.tsx
@@ -1,0 +1,24 @@
+import moment from 'moment';
+
+import {Event} from 'sentry/types';
+import {TimeWindow} from 'sentry/views/monitors/components/overviewTimeline/types';
+import {timeWindowConfig} from 'sentry/views/monitors/components/overviewTimeline/utils';
+
+/**
+ * Given a cron event, current time, and time window, attempt to return a
+ * centered date window (start, end) around the event. If the event happened
+ * too recently, a last 24h, 1d, 7d, etc window will be returned instead
+ */
+export function getTimeRangeFromEvent(
+  event: Event,
+  now: Date,
+  timeWindow: TimeWindow
+): {end: Date; start: Date} {
+  const elapsedMinutes = timeWindowConfig[timeWindow].elapsedMinutes;
+  let end = moment(event.dateReceived).add(elapsedMinutes / 2, 'minute');
+  if (end > moment(now)) {
+    end = moment(now);
+  }
+  const start = moment(end).subtract(elapsedMinutes, 'minute');
+  return {start: start.toDate(), end: end.toDate()};
+}


### PR DESCRIPTION
Renders a timeline view in the issue details page like so:

<img width="923" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/22f2b496-4926-4b9c-978a-962f5766b9e4">

<img width="916" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/446d34f0-a944-4efc-8979-30700ee63880">

