### PR TITLE
test(backup): Move helpers to testutils

### DIFF
--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Type
+
+from click.testing import CliRunner
+from django.core.management import call_command
+
+from sentry.runner.commands.backup import (
+    ComparatorFindings,
+    ComparatorMap,
+    export,
+    import_,
+    validate,
+)
+from sentry.silo import unguarded_write
+from sentry.testutils.factories import get_fixture_path
+from sentry.utils import json
+from sentry.utils.json import JSONData
+
+__all__ = [
+    "ValidationError",
+    "export_to_file",
+    "get_final_derivations_of",
+    "get_exportable_final_derivations_of",
+    "import_export_then_validate",
+    "import_export_from_fixture_then_validate",
+]
+
+
+class ValidationError(Exception):
+    def __init__(self, info: ComparatorFindings):
+        super().__init__(info.pretty())
+        self.info = info
+
+
+def export_to_file(path: Path) -> JSONData:
+    """Helper function that exports the current state of the database to the specified file."""
+
+    json_file_path = str(path)
+    rv = CliRunner().invoke(
+        export, [json_file_path], obj={"silent": True, "indent": 2, "exclude": None}
+    )
+    assert rv.exit_code == 0, rv.output
+
+    with open(json_file_path) as tmp_file:
+        # print("\n\n\nOUT: \n\n\n" + tmp_file.read())
+        output = json.load(tmp_file)
+    return output
+
+
+def get_final_derivations_of(model: Type):
+    """A "final" derivation of the given `model` base class is any non-abstract class for the
+    "sentry" app with `BaseModel` as an ancestor. Top-level calls to this class should pass in
+    `BaseModel` as the argument."""
+
+    out = set()
+    for sub in model.__subclasses__():
+        subs = sub.__subclasses__()
+        if subs:
+            out.update(get_final_derivations_of(sub))
+        if not sub._meta.abstract and sub._meta.db_table and sub._meta.app_label == "sentry":
+            out.add(sub)
+    return out
+
+
+def get_exportable_final_derivations_of(model: Type):
+    """Like `get_final_derivations_of`, except that it further filters the results to include only
+    `__include_in_export__ = True`."""
+
+    return set(
+        filter(
+            lambda c: getattr(c, "__include_in_export__") is True,
+            get_final_derivations_of(model),
+        )
+    )
+
+
+def import_export_then_validate(method_name: str) -> JSONData:
+    """Test helper that validates that dat imported from an export of the current state of the test
+    database correctly matches the actual outputted export data."""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_expect = Path(tmpdir).joinpath(f"{method_name}.expect.json")
+        tmp_actual = Path(tmpdir).joinpath(f"{method_name}.actual.json")
+
+        # Export the current state of the database into the "expected" temporary file, then
+        # parse it into a JSON object for comparison.
+        expect = export_to_file(tmp_expect)
+
+        # Write the contents of the "expected" JSON file into the now clean database.
+        # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
+        with unguarded_write(using="default"):
+            # Reset the Django database.
+            call_command("flush", verbosity=0, interactive=False)
+
+            rv = CliRunner().invoke(import_, [str(tmp_expect)])
+            assert rv.exit_code == 0, rv.output
+
+        # Validate that the "expected" and "actual" JSON matches.
+        actual = export_to_file(tmp_actual)
+        res = validate(expect, actual)
+        if res.findings:
+            raise ValidationError(res)
+
+    return actual
+
+
+EMPTY_COMPARATORS_FOR_TESTING: ComparatorMap = {}
+
+
+def import_export_from_fixture_then_validate(
+    tmp_path: Path,
+    fixture_file_name: str,
+    map: ComparatorMap = EMPTY_COMPARATORS_FOR_TESTING,
+) -> None:
+    """Test helper that validates that data imported from a fixture `.json` file correctly matches
+    the actual outputted export data."""
+
+    fixture_file_path = get_fixture_path("backup", fixture_file_name)
+    with open(fixture_file_path) as backup_file:
+        expect = json.load(backup_file)
+
+    # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
+    with unguarded_write(using="default"):
+        rv = CliRunner().invoke(import_, [str(fixture_file_path)])
+        assert rv.exit_code == 0, rv.output
+
+    res = validate(expect, export_to_file(tmp_path.joinpath("tmp_test_file.json")), map)
+    if res.findings:
+        raise ValidationError(res)

--- a/tests/sentry/backup/__init__.py
+++ b/tests/sentry/backup/__init__.py
@@ -1,53 +1,10 @@
 from __future__ import annotations
 
-import tempfile
-from pathlib import Path
 from typing import Type
 
-from click.testing import CliRunner
-from django.core.management import call_command
-from django.db import models, router
+from django.db import models
 
-from sentry.models.organization import Organization
-from sentry.runner.commands.backup import (
-    ComparatorFindings,
-    DatetimeSafeDjangoJSONEncoder,
-    export,
-    import_,
-    validate,
-)
-from sentry.silo import unguarded_write
-from sentry.utils import json
-from sentry.utils.json import JSONData
-
-
-class ValidationError(Exception):
-    def __init__(self, info: ComparatorFindings):
-        super().__init__(info.pretty())
-        self.info = info
-
-
-def get_final_derivations_of(model: Type):
-    """A "final" derivation of the given `model` base class is any non-abstract class for the
-    "sentry" app with `BaseModel` as an ancestor. Top-level calls to this class should pass in `BaseModel` as the argument."""
-    out = set()
-    for sub in model.__subclasses__():
-        subs = sub.__subclasses__()
-        if subs:
-            out.update(get_final_derivations_of(sub))
-        if not sub._meta.abstract and sub._meta.db_table and sub._meta.app_label == "sentry":
-            out.add(sub)
-    return out
-
-
-def get_exportable_final_derivations_of(model: Type):
-    """Like `get_final_derivations_of`, except that it further filters the results to include only `__include_in_export__ = True`."""
-    return set(
-        filter(
-            lambda c: getattr(c, "__include_in_export__") is True,
-            get_final_derivations_of(model),
-        )
-    )
+from sentry.runner.commands.backup import DatetimeSafeDjangoJSONEncoder
 
 
 def targets(expected_models: list[Type]):
@@ -138,50 +95,3 @@ def targets(expected_models: list[Type]):
         return wrapped
 
     return decorator
-
-
-def export_to_file(path: Path) -> json.JSONData:
-    """Helper function that exports the current state of the database to the specified file."""
-
-    json_file_path = str(path)
-    rv = CliRunner().invoke(
-        export, [json_file_path], obj={"silent": True, "indent": 2, "exclude": None}
-    )
-    assert rv.exit_code == 0, rv.output
-
-    with open(json_file_path) as tmp_file:
-        output = json.load(tmp_file)
-    return output
-
-
-def import_export_then_validate(method_name: str) -> JSONData:
-    """Test helper that validates that data imported from a temporary `.json` file correctly
-    matches the actual outputted export data.
-
-    Return the actual JSON, so that we may use the `@targets` decorator to ensure that we have
-    at least one instance of all the "tested for" models in the actual output."""
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_expect = Path(tmpdir).joinpath(f"{method_name}.expect.json")
-        tmp_actual = Path(tmpdir).joinpath(f"{method_name}.actual.json")
-
-        # Export the current state of the database into the "expected" temporary file, then
-        # parse it into a JSON object for comparison.
-        expect = export_to_file(tmp_expect)
-
-        # Write the contents of the "expected" JSON file into the now clean database.
-        # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
-        with unguarded_write(using=router.db_for_write(Organization)):
-            # Reset the Django database.
-            call_command("flush", verbosity=0, interactive=False)
-
-            rv = CliRunner().invoke(import_, [str(tmp_expect)])
-            assert rv.exit_code == 0, rv.output
-
-        # Validate that the "expected" and "actual" JSON matches.
-        actual = export_to_file(tmp_actual)
-        res = validate(expect, actual)
-        if res.findings:
-            raise ValidationError(res)
-
-    return actual

--- a/tests/sentry/backup/test_correctness.py
+++ b/tests/sentry/backup/test_correctness.py
@@ -1,56 +1,23 @@
-from pathlib import Path
-
 import pytest
-from click.testing import CliRunner
 
-from sentry.runner.commands.backup import (
-    DEFAULT_COMPARATORS,
-    ComparatorMap,
-    InstanceID,
-    import_,
-    validate,
+from sentry.runner.commands.backup import DEFAULT_COMPARATORS, InstanceID
+from sentry.testutils.helpers.backups import (
+    ValidationError,
+    import_export_from_fixture_then_validate,
 )
-from sentry.silo import unguarded_write
-from sentry.testutils.factories import get_fixture_path
-from sentry.utils import json
 from sentry.utils.pytest.fixtures import django_db_all
-from tests.sentry.backup import ValidationError, export_to_file
-
-EMPTY_COMPARATORS_FOR_TESTING: ComparatorMap = {}
-
-
-def import_export_then_validate(
-    tmp_path: Path,
-    fixture_file_name: str,
-    map: ComparatorMap = EMPTY_COMPARATORS_FOR_TESTING,
-) -> None:
-    """Test helper that validates that data imported from a fixture `.json` file correctly matches
-    the actual outputted export data."""
-
-    fixture_file_path = get_fixture_path("backup", fixture_file_name)
-    with open(fixture_file_path) as backup_file:
-        expect = json.load(backup_file)
-
-    # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
-    with unguarded_write(using="default"):
-        rv = CliRunner().invoke(import_, [str(fixture_file_path)])
-        assert rv.exit_code == 0, rv.output
-
-    res = validate(expect, export_to_file(tmp_path.joinpath("tmp_test_file.json")), map)
-    if res.findings:
-        raise ValidationError(res)
 
 
 @django_db_all(transaction=True, reset_sequences=True)
 def test_good_fresh_install_validation(tmp_path):
-    import_export_then_validate(tmp_path, "fresh-install.json", DEFAULT_COMPARATORS)
+    import_export_from_fixture_then_validate(tmp_path, "fresh-install.json", DEFAULT_COMPARATORS)
 
 
 @django_db_all(transaction=True, reset_sequences=True)
 def test_bad_fresh_install_validation(tmp_path):
 
     with pytest.raises(ValidationError) as excinfo:
-        import_export_then_validate(tmp_path, "fresh-install.json")
+        import_export_from_fixture_then_validate(tmp_path, "fresh-install.json")
     info = excinfo.value.info
     assert len(info.findings) == 2
     assert info.findings[0].kind == "UnequalJSON"
@@ -61,4 +28,4 @@ def test_bad_fresh_install_validation(tmp_path):
 
 @django_db_all(transaction=True, reset_sequences=True)
 def test_datetime_formatting(tmp_path):
-    import_export_then_validate(tmp_path, "datetime-formatting.json")
+    import_export_from_fixture_then_validate(tmp_path, "datetime-formatting.json")

--- a/tests/sentry/backup/test_coverage.py
+++ b/tests/sentry/backup/test_coverage.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from sentry.db.models import BaseModel
-from tests.sentry.backup import get_exportable_final_derivations_of, get_final_derivations_of
+from sentry.testutils.helpers.backups import (
+    get_exportable_final_derivations_of,
+    get_final_derivations_of,
+)
 from tests.sentry.backup.test_models import UNIT_TESTED_MODELS
 from tests.sentry.backup.test_releases import RELEASE_TESTED_MODELS
 

--- a/tests/sentry/backup/test_models.py
+++ b/tests/sentry/backup/test_models.py
@@ -5,7 +5,6 @@ from typing import Literal, Type
 from uuid import uuid4
 
 from django.core.management import call_command
-from django.db import router
 from django.utils import timezone
 from sentry_relay.auth import generate_key_pair
 
@@ -89,12 +88,12 @@ from sentry.sentry_apps.apps import SentryAppUpdater
 from sentry.silo import unguarded_write
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.testutils import TransactionTestCase
-from sentry.utils.json import JSONData
-from tests.sentry.backup import (
+from sentry.testutils.helpers.backups import (
     get_exportable_final_derivations_of,
     import_export_then_validate,
-    targets,
 )
+from sentry.utils.json import JSONData
+from tests.sentry.backup import targets
 
 UNIT_TESTED_MODELS = set()
 
@@ -127,7 +126,7 @@ class ModelBackupTests(TransactionTestCase):
 
     def setUp(self):
         # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
-        with unguarded_write(using=router.db_for_write(Organization)):
+        with unguarded_write(using="default"):
             # Reset the Django database.
             call_command("flush", verbosity=0, interactive=False)
 

--- a/tests/sentry/backup/test_releases.py
+++ b/tests/sentry/backup/test_releases.py
@@ -63,12 +63,12 @@ from sentry.monitors.models import (
 from sentry.sentry_apps.apps import SentryAppUpdater
 from sentry.silo import unguarded_write
 from sentry.testutils import TransactionTestCase
-from sentry.utils.json import JSONData
-from tests.sentry.backup import (
+from sentry.testutils.helpers.backups import (
     get_exportable_final_derivations_of,
     import_export_then_validate,
-    targets,
 )
+from sentry.utils.json import JSONData
+from tests.sentry.backup import targets
 
 RELEASE_TESTED_MODELS = set()
 


### PR DESCRIPTION
The following change will add a standalone release test generation script that will live outside of the test directory and will use this functions. Because of this, a better home for them is in src/testutils, rather than in their tesat-local `__init__.py` file.

Issue: getsentry/team-ospo#159