### PR TITLE
chore(starfish): Add an xfail for split granularities

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -603,6 +603,12 @@ class MetricsQueryBuilder(QueryBuilder):
         self.validate_having_clause()
         self.validate_orderby_clause()
 
+        # TODO(bool-conditions): Currently Boolean Condition is not supported by the metrics layer
+        # Uncomment this when they are
+        # granularity_condition, new_granularity = self.resolve_split_granularity()
+        # self.granularity = new_granularity
+        # self.where += granularity_condition
+
         prefix = "generic_" if self.dataset is Dataset.PerformanceMetrics else ""
         return Request(
             dataset=self.dataset.value,

--- a/src/sentry/snuba/metrics/mqb_query_transformer.py
+++ b/src/sentry/snuba/metrics/mqb_query_transformer.py
@@ -1,7 +1,7 @@
 import inspect
 from typing import Set
 
-from snuba_sdk import AliasedExpression, Column, Condition, Function, Granularity, Op
+from snuba_sdk import AliasedExpression, Column, Condition, Function, Op
 from snuba_sdk.query import Query
 
 from sentry.api.utils import InvalidParams
@@ -447,7 +447,7 @@ def transform_mqb_query_to_metrics_query(
         "offset": query.offset,
         "include_totals": True,
         "include_series": include_series,
-        "granularity": query.granularity if query.granularity is not None else Granularity(3600),
+        "granularity": query.granularity,
         "orderby": _transform_orderby(query.orderby),
         "interval": interval,
         "is_alerts_query": is_alerts_query,


### PR DESCRIPTION
- The MQB currently has an optimization where we query multiple granularities so we merge less buckets while still querying accurate data.
- This makes some minor changes so the query can be run & tested
- Draft for now, this is so Metrics Layer folks have a test they can run until it passes