### PR TITLE
fix(starfish): make analytics optional on detailPanel

### DIFF
--- a/static/app/views/performance/trends/changeExplorer.tsx
+++ b/static/app/views/performance/trends/changeExplorer.tsx
@@ -83,7 +83,11 @@ export function PerformanceChangeExplorer({
   location,
 }: PerformanceChangeExplorerProps) {
   return (
-    <DetailPanel detailKey={!collapsed ? transaction.transaction : ''} onClose={onClose}>
+    <DetailPanel
+      detailKey={!collapsed ? transaction.transaction : ''}
+      onClose={onClose}
+      analytics={false}
+    >
       {!collapsed && (
         <PanelBodyWrapper>
           <ExplorerBody

--- a/static/app/views/performance/trends/changeExplorer.tsx
+++ b/static/app/views/performance/trends/changeExplorer.tsx
@@ -83,11 +83,7 @@ export function PerformanceChangeExplorer({
   location,
 }: PerformanceChangeExplorerProps) {
   return (
-    <DetailPanel
-      detailKey={!collapsed ? transaction.transaction : ''}
-      onClose={onClose}
-      analytics={false}
-    >
+    <DetailPanel detailKey={!collapsed ? transaction.transaction : ''} onClose={onClose}>
       {!collapsed && (
         <PanelBodyWrapper>
           <ExplorerBody

--- a/static/app/views/starfish/components/detailPanel.tsx
+++ b/static/app/views/starfish/components/detailPanel.tsx
@@ -11,21 +11,16 @@ import SlideOverPanel from 'sentry/views/starfish/components/slideOverPanel';
 
 type DetailProps = {
   children: React.ReactNode;
-  analytics?: boolean;
   detailKey?: string;
   onClose?: () => void;
+  onOpen?: () => void;
 };
 
 type DetailState = {
   collapsed: boolean;
 };
 
-export default function Detail({
-  children,
-  detailKey,
-  onClose,
-  analytics = true,
-}: DetailProps) {
+export default function Detail({children, detailKey, onClose, onOpen}: DetailProps) {
   const [state, setState] = useState<DetailState>({collapsed: true});
   const escapeKeyPressed = useKeyPress('Escape');
 
@@ -57,7 +52,7 @@ export default function Detail({
   }, [escapeKeyPressed]);
 
   return (
-    <SlideOverPanel collapsed={state.collapsed} ref={panelRef} analytics={analytics}>
+    <SlideOverPanel collapsed={state.collapsed} ref={panelRef} onOpen={onOpen}>
       <CloseButtonWrapper>
         <CloseButton
           priority="link"

--- a/static/app/views/starfish/components/detailPanel.tsx
+++ b/static/app/views/starfish/components/detailPanel.tsx
@@ -11,6 +11,7 @@ import SlideOverPanel from 'sentry/views/starfish/components/slideOverPanel';
 
 type DetailProps = {
   children: React.ReactNode;
+  analytics?: boolean;
   detailKey?: string;
   onClose?: () => void;
 };
@@ -19,7 +20,12 @@ type DetailState = {
   collapsed: boolean;
 };
 
-export default function Detail({children, detailKey, onClose}: DetailProps) {
+export default function Detail({
+  children,
+  detailKey,
+  onClose,
+  analytics = true,
+}: DetailProps) {
   const [state, setState] = useState<DetailState>({collapsed: true});
   const escapeKeyPressed = useKeyPress('Escape');
 
@@ -51,7 +57,7 @@ export default function Detail({children, detailKey, onClose}: DetailProps) {
   }, [escapeKeyPressed]);
 
   return (
-    <SlideOverPanel collapsed={state.collapsed} ref={panelRef}>
+    <SlideOverPanel collapsed={state.collapsed} ref={panelRef} analytics={analytics}>
       <CloseButtonWrapper>
         <CloseButton
           priority="link"

--- a/static/app/views/starfish/components/slideOverPanel.tsx
+++ b/static/app/views/starfish/components/slideOverPanel.tsx
@@ -3,31 +3,30 @@ import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const PANEL_WIDTH = '50vw';
 
 type SlideOverPanelProps = {
-  analytics: boolean;
   children: React.ReactNode;
   collapsed: boolean;
+  onOpen?: () => void;
 };
 
 export default forwardRef(SlideOverPanel);
 
 function SlideOverPanel(
-  {collapsed, children, analytics}: SlideOverPanelProps,
+  {collapsed, children, onOpen}: SlideOverPanelProps,
   ref: ForwardedRef<HTMLDivElement>
 ) {
   const {query} = useLocation();
   const organization = useOrganization();
   useEffect(() => {
-    if (!collapsed && analytics) {
-      trackAnalytics('starfish.panel.open', {organization});
+    if (!collapsed && onOpen) {
+      onOpen();
     }
-  }, [query, collapsed, organization, analytics]);
+  }, [query, collapsed, organization, onOpen]);
   return (
     <_SlideOverPanel
       ref={ref}

--- a/static/app/views/starfish/components/slideOverPanel.tsx
+++ b/static/app/views/starfish/components/slideOverPanel.tsx
@@ -10,6 +10,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 const PANEL_WIDTH = '50vw';
 
 type SlideOverPanelProps = {
+  analytics: boolean;
   children: React.ReactNode;
   collapsed: boolean;
 };
@@ -17,16 +18,16 @@ type SlideOverPanelProps = {
 export default forwardRef(SlideOverPanel);
 
 function SlideOverPanel(
-  {collapsed, children}: SlideOverPanelProps,
+  {collapsed, children, analytics}: SlideOverPanelProps,
   ref: ForwardedRef<HTMLDivElement>
 ) {
   const {query} = useLocation();
   const organization = useOrganization();
   useEffect(() => {
-    if (!collapsed) {
+    if (!collapsed && analytics) {
       trackAnalytics('starfish.panel.open', {organization});
     }
-  }, [query, collapsed, organization]);
+  }, [query, collapsed, organization, analytics]);
   return (
     <_SlideOverPanel
       ref={ref}

--- a/static/app/views/starfish/components/slideOverPanel.tsx
+++ b/static/app/views/starfish/components/slideOverPanel.tsx
@@ -3,9 +3,6 @@ import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
-import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
-
 const PANEL_WIDTH = '50vw';
 
 type SlideOverPanelProps = {
@@ -20,13 +17,11 @@ function SlideOverPanel(
   {collapsed, children, onOpen}: SlideOverPanelProps,
   ref: ForwardedRef<HTMLDivElement>
 ) {
-  const {query} = useLocation();
-  const organization = useOrganization();
   useEffect(() => {
     if (!collapsed && onOpen) {
       onOpen();
     }
-  }, [query, collapsed, organization, onOpen]);
+  }, [collapsed, onOpen]);
   return (
     <_SlideOverPanel
       ref={ref}

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -7,6 +7,7 @@ import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 import DetailPanel from 'sentry/views/starfish/components/detailPanel';
@@ -39,6 +40,7 @@ export function SampleList({groupId, transactionName, transactionMethod}: Props)
   );
 
   const organization = useOrganization();
+  const {query} = useLocation();
 
   return (
     <PageErrorProvider>
@@ -51,8 +53,10 @@ export function SampleList({groupId, transactionName, transactionMethod}: Props)
           });
         }}
         onOpen={useCallback(() => {
-          trackAnalytics('starfish.panel.open', {organization});
-        }, [organization])}
+          if (query.transaction) {
+            trackAnalytics('starfish.panel.open', {organization});
+          }
+        }, [organization, query.transaction])}
       >
         <h3>{`${transactionMethod} ${transactionName}`}</h3>
         <PageErrorAlert />

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -50,9 +50,9 @@ export function SampleList({groupId, transactionName, transactionMethod}: Props)
             query: omit(router.location.query, 'transaction', 'transactionMethod'),
           });
         }}
-        onOpen={() => {
+        onOpen={useCallback(() => {
           trackAnalytics('starfish.panel.open', {organization});
-        }}
+        }, [organization])}
       >
         <h3>{`${transactionMethod} ${transactionName}`}</h3>
         <PageErrorAlert />

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -2,10 +2,12 @@ import {useCallback, useState} from 'react';
 import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
 
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
+import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 import DetailPanel from 'sentry/views/starfish/components/detailPanel';
 import DurationChart from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
@@ -36,6 +38,8 @@ export function SampleList({groupId, transactionName, transactionMethod}: Props)
     []
   );
 
+  const organization = useOrganization();
+
   return (
     <PageErrorProvider>
       <DetailPanel
@@ -45,6 +49,9 @@ export function SampleList({groupId, transactionName, transactionMethod}: Props)
             pathname: router.location.pathname,
             query: omit(router.location.query, 'transaction', 'transactionMethod'),
           });
+        }}
+        onOpen={() => {
+          trackAnalytics('starfish.panel.open', {organization});
         }}
       >
         <h3>{`${transactionMethod} ${transactionName}`}</h3>


### PR DESCRIPTION
Add `onOpen` parameter to `detailPanel -> slideOverPanel` so starfish analytics are triggered when passed in via `onOpen`.
