### PR TITLE
fix(apidocs): add replay_id as a path parameter

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -421,3 +421,13 @@ class TeamParams:
 Specify `"0"` to return team details that do not include projects.
 """,
     )
+
+
+class ReplayParams:
+    REPLAY_ID = OpenApiParameter(
+        name="replay_id",
+        location="path",
+        required=True,
+        type=OpenApiTypes.UUID,
+        description="""The id of the replay you'd like to retrieve.""",
+    )

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -9,7 +9,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import NoProjects, OrganizationEndpoint
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
 from sentry.apidocs.examples.replay_examples import ReplayExamples
-from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.parameters import GlobalParams, ReplayParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.models.organization import Organization
@@ -31,7 +31,7 @@ class OrganizationReplayDetailsEndpoint(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="Retrieve a Replay Instance",
-        parameters=[GlobalParams.ORG_SLUG, ReplayValidator],
+        parameters=[GlobalParams.ORG_SLUG, ReplayParams.REPLAY_ID, ReplayValidator],
         responses={
             200: inline_sentry_response_serializer("data", ReplayDetailsResponse),
             400: RESPONSE_BAD_REQUEST,


### PR DESCRIPTION
fixes currently broken openapi build. 

followup: add verification that every path parameter has a description.