### PR TITLE
ref(ui): Use smaller button for similar stack trace heading

### DIFF
--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
@@ -49,7 +49,7 @@ class SimilarToolbar extends Component<Props, State> {
           message={t('Are you sure you want to merge these issues?')}
           onConfirm={onMerge}
         >
-          <Button size="sm" title={t('Merging %s issues', mergeCount)}>
+          <Button size="xs" title={t('Merging %s issues', mergeCount)}>
             {t('Merge %s', `(${mergeCount || 0})`)}
           </Button>
         </Confirm>


### PR DESCRIPTION
Before

![clipboard.png](https://i.imgur.com/XLp284d.png)

After

![clipboard.png](https://i.imgur.com/No32u7a.png)

Matches what most of our panel headings with buttons look like