### PR TITLE
fix: bump memory limit for fork-ts-checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
   },
   "fork-ts-checker": {
     "typescript": {
-      "memoryLimit": 6000
+      "memoryLimit": 4096
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -264,5 +264,10 @@
   "volta": {
     "node": "18.12.1",
     "yarn": "1.22.5"
+  },
+  "fork-ts-checker": {
+    "typescript": {
+      "memoryLimit": 6000
+    }
   }
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -359,9 +359,9 @@ const appConfig: Configuration = {
               configOverwrite: {
                 compilerOptions: {incremental: true},
               },
-              memoryLimit: 3072,
             },
             devServer: false,
+            // memorylimit is configured in package.json
           }),
         ]
       : []),


### PR DESCRIPTION
see https://github.com/getsentry/getsentry/pull/11275

consolidating on package.json for this particular configuration because changing the constructor here doesn't affect getsentry devserver