### PR TITLE
feat(replays): add view more button to cards

### DIFF
--- a/static/app/components/panels/panelTable.tsx
+++ b/static/app/components/panels/panelTable.tsx
@@ -146,6 +146,7 @@ const Wrapper = styled(Panel, {
   }
 
   > ${TableEmptyStateWarning}, > ${LoadingWrapper} {
+    margin: auto;
     border: none;
     grid-column: auto / span ${p => p.columns};
   }

--- a/static/app/components/panels/panelTable.tsx
+++ b/static/app/components/panels/panelTable.tsx
@@ -149,6 +149,7 @@ const Wrapper = styled(Panel, {
     margin: auto;
     border: none;
     grid-column: auto / span ${p => p.columns};
+    height: 174px;
   }
 
   /* safari needs an overflow value or the contents will spill out */

--- a/static/app/views/replays/list.tsx
+++ b/static/app/views/replays/list.tsx
@@ -1,8 +1,11 @@
+import styled from '@emotion/styled';
+
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import useReplayPageview from 'sentry/utils/replays/hooks/useReplayPageview';
 import useOrganization from 'sentry/utils/useOrganization';
 import ReplaysFilters from 'sentry/views/replays/list/filters';
@@ -32,8 +35,10 @@ function ReplaysListContainer() {
         <Layout.Body>
           <Layout.Main fullWidth>
             <ReplaysFilters />
-            <ReplaysErroneousDeadRageCards />
-            <ReplaysList />
+            <LayoutGap>
+              <ReplaysErroneousDeadRageCards />
+              <ReplaysList />
+            </LayoutGap>
           </Layout.Main>
         </Layout.Body>
       </PageFiltersContainer>
@@ -41,4 +46,8 @@ function ReplaysListContainer() {
   );
 }
 
+const LayoutGap = styled('div')`
+  display: grid;
+  gap: ${space(2)};
+`;
 export default ReplaysListContainer;

--- a/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
+++ b/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
@@ -1,7 +1,11 @@
 import {useMemo} from 'react';
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
+import {Button} from 'sentry/components/button';
+import {IconClose, IconSearch} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
@@ -119,12 +123,26 @@ function ReplaysErroneousDeadRageCards() {
           location={newLocation}
           organization={organization}
           visibleColumns={errorCols}
+          searchQuery={{
+            ...location.query,
+            cursor: undefined,
+            query: 'count_errors:>0',
+            sort: '-count_errors',
+          }}
+          buttonLabel={t('Show all replays with errors')}
         />
         <CardTable
           eventView={eventViewDeadRage}
           location={newLocation}
           organization={organization}
           visibleColumns={deadRageCols}
+          searchQuery={{
+            ...location.query,
+            cursor: undefined,
+            query: 'count_rage_clicks:>0',
+            sort: '-count_rage_clicks',
+          }}
+          buttonLabel={t('Show all replays with rage clicks')}
         />
       </SplitCardContainer>
     ) : null
@@ -136,10 +154,18 @@ function CardTable({
   location,
   organization,
   visibleColumns,
+  searchQuery,
+  buttonLabel,
 }: {
+  buttonLabel: string;
   eventView: EventView;
   location: Location;
   organization: Organization;
+  searchQuery: {
+    cursor: undefined;
+    query: string;
+    sort: string;
+  };
   visibleColumns: ReplayColumn[];
 }) {
   const {replays, isFetching, fetchError} = useReplayList({
@@ -149,21 +175,63 @@ function CardTable({
     perPage: 3,
   });
 
-  const gridRows = new Array(replays ? (replays.length > 0 ? 4 : 1) : 1)
+  const gridRows = new Array(replays ? (replays.length > 0 ? 3 : 1) : 1)
     .fill(' ')
     .map(_ => '1fr')
     .join(' ');
 
+  const emptyLocation = useLocation();
+
+  const emptySearchQuery = {
+    ...emptyLocation.query,
+    cursor: undefined,
+    query: '',
+    sort: '',
+  };
+
   return (
-    <ReplayTable
-      fetchError={fetchError}
-      isFetching={isFetching}
-      replays={replays}
-      sort={undefined}
-      visibleColumns={visibleColumns}
-      saveLocation
-      gridRows={'auto ' + gridRows}
-    />
+    <div>
+      <ReplayTable
+        fetchError={fetchError}
+        isFetching={isFetching}
+        replays={replays}
+        sort={undefined}
+        visibleColumns={visibleColumns}
+        saveLocation
+        gridRows={'auto ' + gridRows}
+      />
+      <Button
+        style={{
+          width: '100%',
+          borderTop: '0',
+          borderTopLeftRadius: '0',
+          borderTopRightRadius: '0',
+          padding: '20px',
+        }}
+        size="sm"
+        onClick={() => {
+          const newQuery =
+            emptyLocation.query.query === searchQuery.query
+              ? emptySearchQuery
+              : searchQuery;
+          browserHistory.push({
+            pathname: emptyLocation.pathname,
+            query: newQuery,
+          });
+        }}
+        icon={
+          emptyLocation.query.query === searchQuery.query ? (
+            <IconClose size="xs" />
+          ) : (
+            <IconSearch size="xs" />
+          )
+        }
+      >
+        {emptyLocation.query.query === searchQuery.query
+          ? t('Clear filter')
+          : buttonLabel}
+      </Button>
+    </div>
   );
 }
 

--- a/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
+++ b/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
@@ -149,7 +149,7 @@ function CardTable({
     perPage: 3,
   });
 
-  const gridRows = new Array(replays ? (replays.length > 0 ? 3 : 1) : 1)
+  const gridRows = new Array(replays ? (replays.length > 0 ? 4 : 1) : 1)
     .fill(' ')
     .map(_ => '1fr')
     .join(' ');

--- a/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
+++ b/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
@@ -200,14 +200,7 @@ function CardTable({
         saveLocation
         gridRows={'auto ' + gridRows}
       />
-      <Button
-        style={{
-          width: '100%',
-          borderTop: '0',
-          borderTopLeftRadius: '0',
-          borderTopRightRadius: '0',
-          padding: '20px',
-        }}
+      <StyledButton
         size="sm"
         onClick={() => {
           const newQuery =
@@ -230,7 +223,7 @@ function CardTable({
         {emptyLocation.query.query === searchQuery.query
           ? t('Clear filter')
           : buttonLabel}
-      </Button>
+      </StyledButton>
     </div>
   );
 }
@@ -240,6 +233,13 @@ const SplitCardContainer = styled('div')`
   grid-template-columns: 1fr 1fr;
   gap: ${space(2)};
   align-items: stretch;
+`;
+
+const StyledButton = styled(Button)`
+  width: 100%;
+  border-top: none;
+  border-radius: ${p => p.theme.borderRadiusBottom};
+  padding: ${space(3)};
 `;
 
 export default ReplaysErroneousDeadRageCards;

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -137,7 +137,7 @@ function ReplaysListTable({
           ) : undefined
         }
       />
-      <Pagination
+      <ReplayPagination
         pageLinks={pageLinks}
         onCursor={(cursor, path, searchQuery) => {
           trackAnalytics('replay.list-paginated', {
@@ -157,6 +157,10 @@ function ReplaysListTable({
 const EmptyStateSubheading = styled('div')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const ReplayPagination = styled(Pagination)`
+  margin-top: 0;
 `;
 
 export default ReplaysList;

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -246,52 +246,50 @@ function ReplayTable({
         );
       })}
       {isErrorTable || isDeadRageTable ? (
-        <Fragment>
-          <TableFooter>
-            {
-              <Button
-                size="sm"
-                onClick={() => {
-                  setShowMoreReplays(!showMoreReplays);
-                  browserHistory.push({
-                    pathname: newLocation.pathname,
-                    query: showMoreReplays
-                      ? isErrorTable
-                        ? {
-                            ...newLocation.query,
-                            cursor: undefined,
-                            query: 'count_errors:>0',
-                            sort: '-count_errors',
-                          }
-                        : {
-                            ...newLocation.query,
-                            cursor: undefined,
-                            query: 'count_rage_clicks:>0',
-                            sort: '-count_rage_clicks',
-                          }
+        // <Fragment>
+        <TableFooter>
+          {
+            <Button
+              style={{
+                height: '100%',
+                width: '100%',
+              }}
+              borderless
+              size="sm"
+              onClick={() => {
+                setShowMoreReplays(!showMoreReplays);
+                browserHistory.push({
+                  pathname: newLocation.pathname,
+                  query: showMoreReplays
+                    ? isErrorTable
+                      ? {
+                          ...newLocation.query,
+                          cursor: undefined,
+                          query: 'count_errors:>0',
+                          sort: '-count_errors',
+                        }
                       : {
                           ...newLocation.query,
                           cursor: undefined,
-                          query: '',
-                          sort: eventView.sorts[0],
-                        },
-                  });
-                }}
-                icon={
-                  showMoreReplays ? <IconSearch size="xs" /> : <IconClose size="xs" />
-                }
-              >
-                {buttonLabel}
-              </Button>
-            }
-          </TableFooter>
-          <EmptyCell />
-          <EmptyCell />
-          {visibleColumns.includes(ReplayColumn.MOST_ERRONEOUS_REPLAYS) ? (
-            <EmptyCell />
-          ) : undefined}
-        </Fragment>
-      ) : undefined}
+                          query: 'count_rage_clicks:>0',
+                          sort: '-count_rage_clicks',
+                        }
+                    : {
+                        ...newLocation.query,
+                        cursor: undefined,
+                        query: '',
+                        sort: eventView.sorts[0],
+                      },
+                });
+              }}
+              icon={showMoreReplays ? <IconSearch size="xs" /> : <IconClose size="xs" />}
+            >
+              {buttonLabel}
+            </Button>
+          }
+        </TableFooter>
+      ) : // </Fragment>
+      undefined}
     </StyledPanelTable>
   );
 }
@@ -332,11 +330,7 @@ const TableFooter = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(1)};
-  padding: 0 0 0 ${space(2)};
+  grid-column: 1/-1;
+  grid-row: -2;
 `;
-
-const EmptyCell = styled('div')`
-  display: flex;
-`;
-
 export default ReplayTable;

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -1,12 +1,14 @@
 import {Fragment, ReactNode} from 'react';
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {Alert} from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PanelTable from 'sentry/components/panels/panelTable';
-import {IconList} from 'sentry/icons';
+import {IconSearch} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import EventView from 'sentry/utils/discover/eventView';
@@ -136,6 +138,8 @@ function ReplayTable({
 
   const referrer = getRouteStringFromRoutes(routes);
   const eventView = EventView.fromLocation(location);
+  const isErrorTable = visibleColumns.includes(ReplayColumn.MOST_ERRONEOUS_REPLAYS);
+  const isDeadRageTable = visibleColumns.includes(ReplayColumn.MOST_RAGE_CLICKS);
 
   return (
     <StyledPanelTable
@@ -230,12 +234,37 @@ function ReplayTable({
           </Fragment>
         );
       })}
-      {visibleColumns.includes(ReplayColumn.MOST_ERRONEOUS_REPLAYS) ||
-      visibleColumns.includes(ReplayColumn.MOST_RAGE_CLICKS) ? (
+      {isErrorTable || isDeadRageTable ? (
         <Fragment>
           <TableFooter>
-            <IconList size="xs" />
-            {t('Show all replays with xyz')}
+            {
+              <Button
+                size="sm"
+                onClick={() => {
+                  browserHistory.push({
+                    pathname: newLocation.pathname,
+                    query: isErrorTable
+                      ? {
+                          ...newLocation.query,
+                          cursor: undefined,
+                          query: 'count_errors:>0',
+                          sort: '-count_errors',
+                        }
+                      : {
+                          ...newLocation.query,
+                          cursor: undefined,
+                          query: 'count_rage_clicks:>0',
+                          sort: '-count_rage_clicks',
+                        },
+                  });
+                }}
+                icon={<IconSearch size="xs" />}
+              >
+                {isErrorTable
+                  ? t('Show all replays with errors')
+                  : t('Show all replays with rage clicks')}
+              </Button>
+            }
           </TableFooter>
           <EmptyCell />
           <EmptyCell />
@@ -284,7 +313,7 @@ const TableFooter = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(1)};
-  padding: 10px 5px 10px 20px;
+  padding: 0 0 0 ${space(2)};
 `;
 
 const EmptyCell = styled('div')`

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -6,7 +6,9 @@ import {Alert} from 'sentry/components/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PanelTable from 'sentry/components/panels/panelTable';
+import {IconList} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
@@ -228,6 +230,20 @@ function ReplayTable({
           </Fragment>
         );
       })}
+      {visibleColumns.includes(ReplayColumn.MOST_ERRONEOUS_REPLAYS) ||
+      visibleColumns.includes(ReplayColumn.MOST_RAGE_CLICKS) ? (
+        <Fragment>
+          <TableFooter>
+            <IconList size="xs" />
+            {t('Show all replays with xyz')}
+          </TableFooter>
+          <EmptyCell />
+          <EmptyCell />
+          {visibleColumns.includes(ReplayColumn.MOST_ERRONEOUS_REPLAYS) ? (
+            <EmptyCell />
+          ) : undefined}
+        </Fragment>
+      ) : undefined}
     </StyledPanelTable>
   );
 }
@@ -262,6 +278,17 @@ const StyledAlert = styled(Alert)<{showBottomBorder?: boolean}>`
   margin-bottom: 0;
   ${props =>
     props.showBottomBorder ? `border-width: 1px 0 1px 0;` : `border-width: 1px 0 0 0;`}
+`;
+
+const TableFooter = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+  padding: 10px 5px 10px 20px;
+`;
+
+const EmptyCell = styled('div')`
+  display: flex;
 `;
 
 export default ReplayTable;


### PR DESCRIPTION
Closes getsentry/team-replay#123.

User can click on the buttons below the table to query for all replays within a specified env, time, proj that have errors/rage & dead clicks. 

This updates the search tag in the search bar as well. The columns are sorted by replays w/ most errors or most rage clicks.

<img width="1215" alt="SCR-20230728-mykd" src="https://github.com/getsentry/sentry/assets/56095982/0bfea3e7-69f7-48b6-9a74-aaf41a7ec893">
<img width="1248" alt="SCR-20230728-nbxj" src="https://github.com/getsentry/sentry/assets/56095982/8349054a-ad72-4a44-bb9c-8a1438f96c99">
<img width="1260" alt="SCR-20230728-nbus" src="https://github.com/getsentry/sentry/assets/56095982/68b05e65-8d41-4ff2-8ff3-c86e43461974">

