### PR TITLE
fix(backup): Improve DateUpdatedComparator

### DIFF
--- a/tests/sentry/backup/test_comparators.py
+++ b/tests/sentry/backup/test_comparators.py
@@ -1,6 +1,62 @@
 from sentry.runner.commands.backup import DateUpdatedComparator, InstanceID
 
 
+def test_good_comparator_both_sides_existing():
+    cmp = DateUpdatedComparator("my_date_field")
+    id = InstanceID("test", 1)
+    present = {
+        "model": "test",
+        "pk": 1,
+        "fields": {
+            "my_date_field": "2023-06-22T23:12:34.567Z",
+        },
+    }
+    assert not cmp.existence(id, present, present)
+
+
+def test_good_comparator_neither_side_existing():
+    cmp = DateUpdatedComparator("my_date_field")
+    id = InstanceID("test", 1)
+    missing = {
+        "model": "test",
+        "pk": 1,
+        "fields": {},
+    }
+    assert not cmp.existence(id, missing, missing)
+
+
+def test_bad_comparator_only_one_side_existing():
+    cmp = DateUpdatedComparator("my_date_field")
+    id = InstanceID("test", 1)
+    present = {
+        "model": "test",
+        "pk": 1,
+        "fields": {
+            "my_date_field": "2023-06-22T23:12:34.567Z",
+        },
+    }
+    missing = {
+        "model": "test",
+        "pk": 1,
+        "fields": {},
+    }
+    res = cmp.existence(id, missing, present)
+    assert res
+    assert res[0]
+    assert res[0].on == id
+    assert res[0].kind == "DateUpdatedComparator"
+    assert "left" in res[0].reason
+    assert "my_date_field" in res[0].reason
+
+    res = cmp.existence(id, present, missing)
+    assert res
+    assert res[0]
+    assert res[0].on == id
+    assert res[0].kind == "DateUpdatedComparator"
+    assert "right" in res[0].reason
+    assert "my_date_field" in res[0].reason
+
+
 def test_good_date_updated_comparator():
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("test", 1)
@@ -18,7 +74,7 @@ def test_good_date_updated_comparator():
             "my_date_field": "2023-06-22T23:00:00.123Z",
         },
     }
-    assert cmp.compare(id, left, right) is None
+    assert not cmp.compare(id, left, right)
 
 
 def test_bad_date_updated_comparator():
@@ -39,6 +95,7 @@ def test_bad_date_updated_comparator():
         },
     }
     res = cmp.compare(id, left, right)
-    assert res is not None
-    assert res.on == id
-    assert res.kind == "DateUpdatedComparator"
+    assert res
+    assert res[0]
+    assert res[0].on == id
+    assert res[0].kind == "DateUpdatedComparator"


### PR DESCRIPTION
This comparator had a (granted, unlikely in practice) bug where it would crash if only one of the two models had the field in question set. The new setup tests for field existence before attempting the comparison logic, and always returns a list of comparators (empty on success, filled with findings on failure) rather than using the more confusing union type like before.

Issue: getsentry/team-ospo#157