### PR TITLE
fix(hybridcloud) Remove incorrect operation from ApiApplication.delete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -621,7 +621,6 @@ module = [
     "sentry.migrations.0407_recreate_perf_alert_subscriptions",
     "sentry.migrations.0418_add_actor_constraints",
     "sentry.models.actor",
-    "sentry.models.apiapplication",
     "sentry.models.artifactbundle",
     "sentry.models.auditlogentry",
     "sentry.models.authprovider",

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -71,10 +71,6 @@ class ApiApplication(Model):
         return self.name
 
     def delete(self, **kwargs):
-        from sentry.models import NotificationSetting
-
-        # There is no foreign key relationship so we have to manually cascade.
-        NotificationSetting.objects.remove_for_project(self)
         with outbox_context(transaction.atomic(router.db_for_write(ApiApplication)), flush=False):
             for outbox in self.outboxes_for_update():
                 outbox.save()


### PR DESCRIPTION
ApiApplication is not a project and we don't need to delete NotificationSetting records when ApiApplication records are removed as there is no link between those.