### PR TITLE
Migrate FlatFileIndex to nodestore

### DIFF
--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -80,14 +80,14 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
             )
             metrics.incr("sourcemaps.download.flat_file_index")
 
+            if file is not None and (data := file.load_flat_file_index()):
+                return HttpResponse(data, content_type="application/json")
+            else:
+                return Http404
+
         if file is None:
             raise Http404
-        if isinstance(file, ArtifactBundleFlatFileIndex):
-            file = file.flat_file_index
-        else:
-            file = file.file
-        if file is None:
-            raise Http404
+        file = file.file
 
         try:
             fp = file.getfile()

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1980,6 +1980,10 @@ SENTRY_SNUBA_CACHE_TTL_SECONDS = 60
 SENTRY_NODESTORE = "sentry.nodestore.django.DjangoNodeStorage"
 SENTRY_NODESTORE_OPTIONS: dict[str, Any] = {}
 
+# Node storage backend used for ArtifactBundle indexing (aka FlatFileIndex aka BundleIndex)
+SENTRY_INDEXSTORE = "sentry.nodestore.django.DjangoNodeStorage"
+SENTRY_INDEXSTORE_OPTIONS: dict[str, Any] = {}
+
 # Tag storage backend
 SENTRY_TAGSTORE = os.environ.get("SENTRY_TAGSTORE", "sentry.tagstore.snuba.SnubaTagStorage")
 SENTRY_TAGSTORE_OPTIONS: dict[str, Any] = {}

--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import zipfile
 from enum import Enum
-from io import BytesIO
 from typing import IO, Callable, Dict, List, Mapping, Optional, Set, Tuple
 
-from django.db import models, router
+from django.db import models
 from django.db.models.signals import post_delete
 from django.utils import timezone
 from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import SymbolicError
 
+from sentry import nodestore
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -19,7 +19,6 @@ from sentry.db.models import (
     region_silo_only_model,
 )
 from sentry.utils import json
-from sentry.utils.db import atomic_transaction
 from sentry.utils.hashlib import sha1_text
 
 # Sentinel values used to represent a null state in the database. This is done since the `NULL` type in the db is
@@ -134,41 +133,20 @@ class ArtifactBundleFlatFileIndex(Model):
 
         index_together = (("project_id", "release_name", "dist_name"),)
 
-    def update_flat_file_index(self, file_contents: str):
-        from sentry.models import File
+    def _nodestore_id(self) -> str:
+        return f"bundle_index:{self.project_id}:{self.id}"
 
-        with atomic_transaction(
-            using=(router.db_for_write(File), router.db_for_write(ArtifactBundleFlatFileIndex))
-        ):
-            current_file = self.flat_file_index
+    def update_flat_file_index(self, data: str):
+        nodestore.set_bytes(self._nodestore_id(), data.encode())
 
-            updated_file = self._create_flat_file_index_object(file_contents)
+        current_file = self.flat_file_index
+        if current_file:
+            current_file.delete()
 
-            # We have to update the new index file and also the date added, which is required for expiration.
-            self.update(flat_file_index=updated_file, date_added=timezone.now())
+        self.update(flat_file_index=None, date_added=timezone.now())
 
-            if current_file is not None:
-                # It's important to also delete the old file, otherwise we will end up with orphan files in the
-                # database.
-                current_file.delete()
-
-    def load_flat_file_index(self) -> Optional[str]:
-        if self.flat_file_index is None:
-            return None
-
-        return self.flat_file_index.getfile().read().decode()
-
-    @classmethod
-    def _create_flat_file_index_object(cls, file_contents: str):
-        from sentry.models import File
-
-        file = File.objects.create(
-            name="artifact_bundle_flat_file_index",
-            type="flat_file_index",
-        )
-        file.putfile(BytesIO(file_contents.encode()))
-
-        return file
+    def load_flat_file_index(self) -> Optional[bytes]:
+        return nodestore.get_bytes(self._nodestore_id())
 
 
 @region_silo_only_model

--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -142,11 +142,11 @@ class ArtifactBundleFlatFileIndex(Model):
 
         index_together = (("project_id", "release_name", "dist_name"),)
 
-    def _nodestore_id(self) -> str:
+    def _indexstore_id(self) -> str:
         return f"bundle_index:{self.project_id}:{self.id}"
 
     def update_flat_file_index(self, data: str):
-        indexstore.set_bytes(self._nodestore_id(), data.encode())
+        indexstore.set_bytes(self._indexstore_id(), data.encode())
 
         current_file = self.flat_file_index
         if current_file:
@@ -155,7 +155,7 @@ class ArtifactBundleFlatFileIndex(Model):
         self.update(flat_file_index=None, date_added=timezone.now())
 
     def load_flat_file_index(self) -> Optional[bytes]:
-        return indexstore.get_bytes(self._nodestore_id())
+        return indexstore.get_bytes(self._indexstore_id())
 
 
 @region_silo_only_model

--- a/src/sentry/nodestore/base.py
+++ b/src/sentry/nodestore/base.py
@@ -64,8 +64,10 @@ class NodeStorage(local, Service):
         "delete",
         "delete_multi",
         "get",
+        "get_bytes",
         "get_multi",
         "set",
+        "set_bytes",
         "set_subkeys",
         "cleanup",
         "validate",
@@ -114,11 +116,14 @@ class NodeStorage(local, Service):
         except StopIteration:
             return None
 
-    def _get_bytes(self, id):
+    def get_bytes(self, id):
         """
         >>> nodestore._get_bytes('key1')
         b'{"message": "hello world"}'
         """
+        return self._get_bytes(id)
+
+    def _get_bytes(self, id):
         raise NotImplementedError
 
     def get(self, id, subkey=None):
@@ -210,10 +215,13 @@ class NodeStorage(local, Service):
 
         return b"\n".join(lines)
 
+    def set_bytes(self, id, data, ttl=None):
+        """
+        >>> nodestore.set_bytes('key1', b"{'foo': 'bar'}")
+        """
+        return self._set_bytes(id, data, ttl)
+
     def _set_bytes(self, id, data, ttl=None):
-        """
-        >>> nodestore.set('key1', b"{'foo': 'bar'}")
-        """
         raise NotImplementedError
 
     def set(self, id, data, ttl=None):

--- a/tests/sentry/lang/native/test_sources.py
+++ b/tests/sentry/lang/native/test_sources.py
@@ -20,7 +20,7 @@ def _mock_flat_file_index(
         dist_name=dist or "",
         flat_file_index=None,
     )
-    index.update_flat_file_index(file_contents="{}")
+    index.update_flat_file_index("{}")
 
     return index
 


### PR DESCRIPTION
This will write contents of the `FlatFileIndex` into nodestore, and delete any existing file.
It will *not* use and merge the contents of existing `File`-based storage, as we want to have a clear cutoff point.