### PR TITLE
feat(profiling): first draw step on CPU chart

### DIFF
--- a/static/app/components/profiling/flamegraph/collapsibleTimeline.tsx
+++ b/static/app/components/profiling/flamegraph/collapsibleTimeline.tsx
@@ -19,7 +19,10 @@ function CollapsibleTimeline(props: CollapsibleTimelineProps) {
   const theme = useFlamegraphTheme();
   return (
     <Fragment>
-      <CollapsibleTimelineHeader border={theme.COLORS.GRID_LINE_COLOR}>
+      <CollapsibleTimelineHeader
+        labelHeight={theme.SIZES.TIMELINE_LABEL_HEIGHT}
+        border={theme.COLORS.GRID_LINE_COLOR}
+      >
         <CollapsibleTimelineLabel>{props.title}</CollapsibleTimelineLabel>
         <StyledButton
           size="xs"
@@ -31,7 +34,9 @@ function CollapsibleTimeline(props: CollapsibleTimelineProps) {
         </StyledButton>
       </CollapsibleTimelineHeader>
       {props.open ? (
-        <CollapsibleTimelineContainer>{props.children}</CollapsibleTimelineContainer>
+        <CollapsibleTimelineContainer labelHeight={theme.SIZES.TIMELINE_LABEL_HEIGHT}>
+          {props.children}
+        </CollapsibleTimelineContainer>
       ) : null}
     </Fragment>
   );
@@ -68,10 +73,10 @@ export function CollapsibleTimelineLoadingIndicator({size}: {size?: number}) {
   );
 }
 
-const CollapsibleTimelineContainer = styled('div')`
+const CollapsibleTimelineContainer = styled('div')<{labelHeight: number}>`
   position: relative;
   width: 100%;
-  height: calc(100% - 20px);
+  height: calc(100% - ${p => p.labelHeight}px);
 `;
 
 const CollapsibleTimelineLoadingIndicatorContainer = styled('div')`
@@ -83,14 +88,14 @@ const CollapsibleTimelineLoadingIndicatorContainer = styled('div')`
   height: 100%;
 `;
 
-const CollapsibleTimelineHeader = styled('div')<{border: string}>`
+const CollapsibleTimelineHeader = styled('div')<{border: string; labelHeight: number}>`
   display: flex;
   justify-content: space-between;
   align-items: center;
   position: relative;
   z-index: 1;
-  height: 20px;
-  min-height: 20px;
+  height: ${p => p.labelHeight}px;
+  min-height: ${p => p.labelHeight}px;
   border-top: 1px solid ${p => p.border};
   background-color: ${p => p.theme.backgroundSecondary};
 `;

--- a/static/app/components/profiling/flamegraph/collapsibleTimeline.tsx
+++ b/static/app/components/profiling/flamegraph/collapsibleTimeline.tsx
@@ -71,7 +71,7 @@ export function CollapsibleTimelineLoadingIndicator({size}: {size?: number}) {
 const CollapsibleTimelineContainer = styled('div')`
   position: relative;
   width: 100%;
-  height: 100%;
+  height: calc(100% - 20px);
 `;
 
 const CollapsibleTimelineLoadingIndicatorContainer = styled('div')`

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -495,9 +495,11 @@ function Flamegraph(): ReactElement {
         model: CPUChart,
         mode: 'stretchToFit',
         options: {
-          inverted: flamegraph.inverted,
+          // Invert chart so origin is at bottom left
+          // corner as opposed to top left
+          inverted: true,
           minWidth: uiFrames.minFrameDuration,
-          barHeight: 10,
+          barHeight: 0,
           depthOffset: 0,
         },
       });
@@ -510,7 +512,7 @@ function Flamegraph(): ReactElement {
 
       return newView;
     },
-    [flamegraphView, flamegraphCanvas, flamegraph, CPUChart, uiFrames.minFrameDuration]
+    [flamegraphView, flamegraphCanvas, CPUChart, uiFrames.minFrameDuration]
   );
 
   const spansView = useMemoWithPrevious<CanvasView<SpanChart> | null>(
@@ -612,6 +614,9 @@ function Flamegraph(): ReactElement {
         if (uiFramesView) {
           uiFramesView.transformConfigView(mat);
         }
+        if (cpuChartView) {
+          cpuChartView.transformConfigView(mat);
+        }
       }
 
       if (sourceTransformConfigView === spansView) {
@@ -621,6 +626,9 @@ function Flamegraph(): ReactElement {
         flamegraphView.setConfigView(flamegraphView.configView.withY(beforeY));
         if (uiFramesView) {
           uiFramesView.transformConfigView(mat);
+        }
+        if (cpuChartView) {
+          cpuChartView.transformConfigView(mat);
         }
       }
 
@@ -634,6 +642,9 @@ function Flamegraph(): ReactElement {
       }
       if (uiFramesView && uiFramesCanvas) {
         uiFramesView.resetConfigView(uiFramesCanvas);
+      }
+      if (cpuChartView && cpuChartCanvas) {
+        cpuChartView.resetConfigView(cpuChartCanvas);
       }
       canvasPoolManager.draw();
     };
@@ -654,6 +665,11 @@ function Flamegraph(): ReactElement {
           newConfigView.withHeight(uiFramesView.configView.height)
         );
       }
+      if (cpuChartView) {
+        cpuChartView.setConfigView(
+          newConfigView.withHeight(cpuChartView.configView.height)
+        );
+      }
       canvasPoolManager.draw();
     };
 
@@ -669,16 +685,21 @@ function Flamegraph(): ReactElement {
       ).transformRect(spansView.configSpaceTransform);
 
       spansView.setConfigView(newConfigView);
-      if (uiFramesView) {
-        uiFramesView.setConfigView(
-          newConfigView.withHeight(uiFramesView.configView.height)
-        );
-      }
       flamegraphView.setConfigView(
         newConfigView
           .withHeight(flamegraphView.configView.height)
           .withY(flamegraphView.configView.y)
       );
+      if (uiFramesView) {
+        uiFramesView.setConfigView(
+          newConfigView.withHeight(uiFramesView.configView.height)
+        );
+      }
+      if (cpuChartView) {
+        cpuChartView.setConfigView(
+          newConfigView.withHeight(cpuChartView.configView.height)
+        );
+      }
       canvasPoolManager.draw();
     };
 
@@ -704,6 +725,8 @@ function Flamegraph(): ReactElement {
     spansView,
     uiFramesCanvas,
     uiFramesView,
+    cpuChartCanvas,
+    cpuChartView,
   ]);
 
   const minimapCanvases = useMemo(() => {

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -502,6 +502,7 @@ function Flamegraph(): ReactElement {
           minWidth: uiFrames.minFrameDuration,
           barHeight: 0,
           depthOffset: 0,
+          maxHeight: 100,
         },
       });
 

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -584,10 +584,9 @@ function Flamegraph(): ReactElement {
         if (uiFramesView) {
           uiFramesView.setConfigView(rect);
         }
-        // @TODO ADD BACK
-        // if (cpuChartView) {
-        //   cpuChartView.setConfigView(rect);
-        // }
+        if (cpuChartView) {
+          cpuChartView.setConfigView(rect);
+        }
       }
 
       if (sourceConfigViewChange === spansView) {
@@ -599,10 +598,9 @@ function Flamegraph(): ReactElement {
         if (uiFramesView) {
           uiFramesView.setConfigView(rect);
         }
-        // @TODO ADD BACK
-        // if (cpuChartView) {
-        //   cpuChartView.setConfigView(rect);
-        // }
+        if (cpuChartView) {
+          cpuChartView.setConfigView(rect);
+        }
       }
       canvasPoolManager.draw();
     };
@@ -624,10 +622,9 @@ function Flamegraph(): ReactElement {
         if (uiFramesView) {
           uiFramesView.transformConfigView(mat);
         }
-        // @TODO ADD BACK
-        // if (cpuChartView) {
-        //   cpuChartView.transformConfigView(mat);
-        // }
+        if (cpuChartView) {
+          cpuChartView.transformConfigView(mat);
+        }
       }
 
       if (sourceTransformConfigView === spansView) {
@@ -638,10 +635,9 @@ function Flamegraph(): ReactElement {
         if (uiFramesView) {
           uiFramesView.transformConfigView(mat);
         }
-        // @TODO ADD BACK
-        // if (cpuChartView) {
-        //   cpuChartView.transformConfigView(mat);
-        // }
+        if (cpuChartView) {
+          cpuChartView.transformConfigView(mat);
+        }
       }
 
       canvasPoolManager.draw();
@@ -655,10 +651,9 @@ function Flamegraph(): ReactElement {
       if (uiFramesView && uiFramesCanvas) {
         uiFramesView.resetConfigView(uiFramesCanvas);
       }
-      // @TODO ADD BACK
-      // if (cpuChartView && cpuChartCanvas) {
-      //   cpuChartView.resetConfigView(cpuChartCanvas);
-      // }
+      if (cpuChartView && cpuChartCanvas) {
+        cpuChartView.resetConfigView(cpuChartCanvas);
+      }
       canvasPoolManager.draw();
     };
 
@@ -678,12 +673,11 @@ function Flamegraph(): ReactElement {
           newConfigView.withHeight(uiFramesView.configView.height)
         );
       }
-      // @TODO ADD BACK
-      // if (cpuChartView) {
-      //   cpuChartView.setConfigView(
-      //     newConfigView.withHeight(cpuChartView.configView.height)
-      //   );
-      // }
+      if (cpuChartView) {
+        cpuChartView.setConfigView(
+          newConfigView.withHeight(cpuChartView.configView.height)
+        );
+      }
       canvasPoolManager.draw();
     };
 
@@ -709,12 +703,11 @@ function Flamegraph(): ReactElement {
           newConfigView.withHeight(uiFramesView.configView.height)
         );
       }
-      // @TODO ADD BACK
-      // if (cpuChartView) {
-      //   cpuChartView.setConfigView(
-      //     newConfigView.withHeight(cpuChartView.configView.height)
-      //   );
-      // }
+      if (cpuChartView) {
+        cpuChartView.setConfigView(
+          newConfigView.withHeight(cpuChartView.configView.height)
+        );
+      }
       canvasPoolManager.draw();
     };
 
@@ -741,6 +734,7 @@ function Flamegraph(): ReactElement {
     uiFramesCanvas,
     uiFramesView,
     cpuChartCanvas,
+    cpuChartView,
   ]);
 
   const minimapCanvases = useMemo(() => {
@@ -780,7 +774,7 @@ function Flamegraph(): ReactElement {
     return [cpuChartCanvasRef];
   }, [cpuChartCanvasRef]);
 
-  const _cpuChartCanvasBounds = useResizeCanvasObserver(
+  const cpuChartCanvasBounds = useResizeCanvasObserver(
     chartCanvases,
     canvasPoolManager,
     cpuChartCanvas,
@@ -997,6 +991,7 @@ function Flamegraph(): ReactElement {
               cpuChartCanvasRef={cpuChartCanvasRef}
               cpuChartCanvas={cpuChartCanvas}
               setCpuChartCanvasRef={setCpuChartCanvasRef}
+              canvasBounds={cpuChartCanvasBounds}
               cpuChartView={cpuChartView}
               canvasPoolManager={canvasPoolManager}
               chart={CPUChart}

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -64,6 +64,8 @@ import {
   useSetProfiles,
 } from 'sentry/views/profiling/profilesProvider';
 
+import {FlamegraphChart} from '../../../utils/profiling/flamegraphChart';
+
 import {FlamegraphDrawer} from './flamegraphDrawer/flamegraphDrawer';
 import {FlamegraphWarnings} from './flamegraphOverlays/FlamegraphWarnings';
 import {useViewKeyboardNavigation} from './interactions/useViewKeyboardNavigation';
@@ -227,6 +229,19 @@ function Flamegraph(): ReactElement {
 
     return new SpanChart(spanTree, {unit: profile.unit});
   }, [spanTree, profile]);
+
+  const CPUChart = useMemo(() => {
+    if (!profile) {
+      return null;
+    }
+
+    return new FlamegraphChart(
+      profileGroup.measurements?.cpu_usage_0 ?? {
+        unit: 'percentage',
+        values: [],
+      }
+    );
+  }, [profile, profileGroup.measurements?.cpu_usage_0]);
 
   const flamegraph = useMemo(() => {
     if (typeof threadId !== 'number') {
@@ -889,7 +904,7 @@ function Flamegraph(): ReactElement {
             />
           ) : null
         }
-        cpuChart={hasCPUChart ? <FlamegraphCpuChart /> : null}
+        cpuChart={hasCPUChart ? <FlamegraphCpuChart chart={CPUChart} /> : null}
         spansTreeDepth={spanChart?.depth}
         spans={
           spanChart ? (

--- a/static/app/components/profiling/flamegraph/flamegraphCpuChart.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphCpuChart.tsx
@@ -53,6 +53,8 @@ export function FlamegraphCpuChart({
     const drawCpuChart = () => {
       cpuChartRenderer.draw(
         cpuChartView.configView,
+        cpuChartView.configSpace,
+        cpuChartCanvas.physicalSpace,
         cpuChartView.fromConfigView(cpuChartCanvas.physicalSpace)
       );
     };

--- a/static/app/components/profiling/flamegraph/flamegraphCpuChart.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphCpuChart.tsx
@@ -1,11 +1,15 @@
-import {CSSProperties, Fragment} from 'react';
+import {CSSProperties, Fragment, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
-import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
+import {
+  CanvasPoolManager,
+  useCanvasScheduler,
+} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import type {FlamegraphChart} from 'sentry/utils/profiling/flamegraphChart';
+import {FlamegraphChartRenderer} from 'sentry/utils/profiling/renderers/chartRenderer';
 import {useProfiles} from 'sentry/views/profiling/profilesProvider';
 
 import {
@@ -22,16 +26,52 @@ interface FlamegraphChartProps {
   setCpuChartCanvasRef: (ref: HTMLCanvasElement | null) => void;
 }
 
-export function FlamegraphCpuChart(props: FlamegraphChartProps) {
+export function FlamegraphCpuChart({
+  chart,
+  canvasPoolManager,
+  cpuChartView,
+  cpuChartCanvas,
+  cpuChartCanvasRef,
+  setCpuChartCanvasRef,
+}: FlamegraphChartProps) {
   const profiles = useProfiles();
+  const scheduler = useCanvasScheduler(canvasPoolManager);
+
+  const cpuChartRenderer = useMemo(() => {
+    if (!cpuChartCanvasRef || !chart) {
+      return null;
+    }
+
+    return new FlamegraphChartRenderer(cpuChartCanvasRef, chart);
+  }, [cpuChartCanvasRef, chart]);
+
+  useEffect(() => {
+    if (!cpuChartCanvas || !chart || !cpuChartView || !cpuChartRenderer) {
+      return undefined;
+    }
+
+    const drawCpuChart = () => {
+      cpuChartRenderer.draw(
+        cpuChartView.configView,
+        cpuChartView.fromConfigView(cpuChartCanvas.physicalSpace)
+      );
+    };
+
+    scheduler.registerBeforeFrameCallback(drawCpuChart);
+    scheduler.draw();
+
+    return () => {
+      scheduler.unregisterBeforeFrameCallback(drawCpuChart);
+    };
+  }, [scheduler, chart, cpuChartCanvas, cpuChartRenderer, cpuChartView]);
 
   return (
     <Fragment>
-      <Canvas style={{display: 'none'}} />
+      <Canvas ref={setCpuChartCanvasRef} />
       {/* transaction loads after profile, so we want to show loading even if it's in initial state */}
       {profiles.type === 'loading' || profiles.type === 'initial' ? (
         <CollapsibleTimelineLoadingIndicator />
-      ) : profiles.type === 'resolved' && !props.chart?.series.length ? (
+      ) : profiles.type === 'resolved' && !chart?.series.length ? (
         <CollapsibleTimelineMessage>
           {t('Profile has no CPU measurements')}
         </CollapsibleTimelineMessage>

--- a/static/app/components/profiling/flamegraph/flamegraphCpuChart.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphCpuChart.tsx
@@ -10,6 +10,7 @@ import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import type {FlamegraphChart} from 'sentry/utils/profiling/flamegraphChart';
 import {FlamegraphChartRenderer} from 'sentry/utils/profiling/renderers/chartRenderer';
+import {Rect} from 'sentry/utils/profiling/speedscope';
 import {useProfiles} from 'sentry/views/profiling/profilesProvider';
 
 import {
@@ -18,6 +19,7 @@ import {
 } from './collapsibleTimeline';
 
 interface FlamegraphChartProps {
+  canvasBounds: Rect;
   canvasPoolManager: CanvasPoolManager;
   chart: FlamegraphChart | null;
   cpuChartCanvas: FlamegraphCanvas | null;

--- a/static/app/components/profiling/flamegraph/flamegraphCpuChart.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphCpuChart.tsx
@@ -1,3 +1,45 @@
-export function FlamegraphCpuChart() {
-  return null;
+import {CSSProperties, Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {t} from 'sentry/locale';
+import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
+import type {FlamegraphChart} from 'sentry/utils/profiling/flamegraphChart';
+import {useProfiles} from 'sentry/views/profiling/profilesProvider';
+
+import {
+  CollapsibleTimelineLoadingIndicator,
+  CollapsibleTimelineMessage,
+} from './collapsibleTimeline';
+
+interface FlamegraphChartProps {
+  canvasPoolManager: CanvasPoolManager;
+  chart: FlamegraphChart | null;
 }
+
+export function FlamegraphCpuChart(props: FlamegraphChartProps) {
+  const profiles = useProfiles();
+
+  return (
+    <Fragment>
+      <Canvas style={{display: 'none'}} />
+      {/* transaction loads after profile, so we want to show loading even if it's in initial state */}
+      {profiles.type === 'loading' || profiles.type === 'initial' ? (
+        <CollapsibleTimelineLoadingIndicator />
+      ) : profiles.type === 'resolved' && !props.chart?.series.length ? (
+        <CollapsibleTimelineMessage>
+          {t('Profile has no CPU measurements')}
+        </CollapsibleTimelineMessage>
+      ) : null}
+    </Fragment>
+  );
+}
+
+const Canvas = styled('canvas')<{cursor?: CSSProperties['cursor']}>`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  user-select: none;
+  cursor: ${p => p.cursor};
+`;

--- a/static/app/components/profiling/flamegraph/flamegraphCpuChart.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphCpuChart.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
 import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import type {FlamegraphChart} from 'sentry/utils/profiling/flamegraphChart';
 import {useProfiles} from 'sentry/views/profiling/profilesProvider';
 
@@ -14,6 +16,10 @@ import {
 interface FlamegraphChartProps {
   canvasPoolManager: CanvasPoolManager;
   chart: FlamegraphChart | null;
+  cpuChartCanvas: FlamegraphCanvas | null;
+  cpuChartCanvasRef: HTMLCanvasElement | null;
+  cpuChartView: CanvasView<FlamegraphChart> | null;
+  setCpuChartCanvasRef: (ref: HTMLCanvasElement | null) => void;
 }
 
 export function FlamegraphCpuChart(props: FlamegraphChartProps) {

--- a/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
@@ -264,10 +264,10 @@ const FlamegraphGrid = styled('div')<{
   width: 100%;
   grid-template-rows: ${({layout}) =>
     layout === 'table bottom'
-      ? 'auto auto auto 1fr'
+      ? 'auto auto auto auto 1fr'
       : layout === 'table right'
-      ? 'min-content min-content min-content 1fr'
-      : 'min-content min-content min-content 1fr'};
+      ? 'min-content min-content min-content min-content 1fr'
+      : 'min-content min-content min-content min-content 1fr'};
   grid-template-columns: ${({layout}) =>
     layout === 'table bottom'
       ? '100%'
@@ -283,6 +283,7 @@ const FlamegraphGrid = styled('div')<{
         'minimap'
         'ui-frames'
         'spans'
+        'cpu-chart'
         'flamegraph'
         'frame-stack'
         `
@@ -291,6 +292,7 @@ const FlamegraphGrid = styled('div')<{
         'minimap    frame-stack'
         'ui-frames  frame-stack'
         'spans     frame-stack'
+        'cpu-chart frame-stack'
         'flamegraph frame-stack'
       `
       : layout === 'table left'
@@ -298,6 +300,7 @@ const FlamegraphGrid = styled('div')<{
         'frame-stack minimap'
         'frame-stack ui-frames'
         'frame-stack spans'
+        'frame-stack cpu-chart'
         'frame-stack flamegraph'
     `
       : ''};

--- a/static/app/types/profiling.d.ts
+++ b/static/app/types/profiling.d.ts
@@ -12,27 +12,18 @@ declare namespace Profiling {
     value: number;
   };
 
+  type Measurement = {
+    unit: string;
+    values: MeasurementValue[];
+  };
+
   type Measurements = {
-    cpu_usage?: {
-      unit: string;
-      values: MeasurementValue[];
-    }
-    memory_footprint?: {
-      unit: string;
-      values: MeasurementValue[];
-    };
-    frozen_frame_renders?: {
-      unit: string;
-      values: MeasurementValue[];
-    };
-    screen_frame_rates?: {
-      unit: string;
-      values: MeasurementValue[];
-    };
-    slow_frame_renders?: {
-      unit: string;
-      values: MeasurementValue[];
-    };
+    cpu_usage?: Measurement;
+    memory_footprint?: Measurement;
+    frozen_frame_renders?: Measurement;
+    screen_frame_rates?: Measurement;
+    slow_frame_renders?: Measurement;
+    [key: string]: Measurement;
   };
 
   type SentrySampledProfileSample = {

--- a/static/app/utils/profiling/canvasView.tsx
+++ b/static/app/utils/profiling/canvasView.tsx
@@ -44,7 +44,7 @@ export class CanvasView<T extends {configSpace: Rect}> {
     this.model = model;
     this.canvas = canvas;
     this.depthOffset = options.depthOffset ?? 0;
-    this.barHeight = options.barHeight ? options.barHeight * window.devicePixelRatio : 0;
+    this.barHeight = options.barHeight ? options.barHeight * window.devicePixelRatio : 1;
 
     // This is a transformation matrix that is applied to the configView, it allows us to
     // transform an entire view and render it without having to recompute the models.

--- a/static/app/utils/profiling/canvasView.tsx
+++ b/static/app/utils/profiling/canvasView.tsx
@@ -13,7 +13,10 @@ export class CanvasView<T extends {configSpace: Rect}> {
   configSpaceTransform: mat3 = mat3.create();
 
   inverted: boolean;
+
   minWidth: number;
+  maxHeight: number;
+
   depthOffset: number;
   barHeight: number;
 
@@ -34,6 +37,7 @@ export class CanvasView<T extends {configSpace: Rect}> {
       configSpaceTransform?: Rect;
       depthOffset?: number;
       inverted?: boolean;
+      maxHeight?: number;
       minWidth?: number;
     };
     mode?: CanvasView<T>['mode'];
@@ -41,6 +45,7 @@ export class CanvasView<T extends {configSpace: Rect}> {
     this.mode = mode || this.mode;
     this.inverted = !!options.inverted;
     this.minWidth = options.minWidth ?? 0;
+    this.maxHeight = options.maxHeight ?? 0;
     this.model = model;
     this.canvas = canvas;
     this.depthOffset = options.depthOffset ?? 0;
@@ -103,10 +108,11 @@ export class CanvasView<T extends {configSpace: Rect}> {
           0,
           0,
           this.model.configSpace.width,
-          Math.max(
-            this.model.configSpace.height + this.depthOffset,
-            canvas.physicalSpace.height / this.barHeight
-          )
+          this.maxHeight ||
+            Math.max(
+              this.model.configSpace.height + this.depthOffset,
+              canvas.physicalSpace.height / this.barHeight
+            )
         );
       }
     }
@@ -119,14 +125,14 @@ export class CanvasView<T extends {configSpace: Rect}> {
         return;
       }
       case 'anchorBottom': {
-        const newHeight = canvas.physicalSpace.height / this.barHeight;
+        const newHeight = this.maxHeight || canvas.physicalSpace.height / this.barHeight;
         const newY = Math.max(0, Math.ceil(space.y - (newHeight - space.height)));
         this.configView = Rect.From(space).withHeight(newHeight).withY(newY);
         return;
       }
       case 'anchorTop': {
         this.configView = Rect.From(space).withHeight(
-          canvas.physicalSpace.height / this.barHeight
+          this.maxHeight || canvas.physicalSpace.height / this.barHeight
         );
         return;
       }

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -105,6 +105,7 @@ export interface FlamegraphTheme {
     SPANS_DEPTH_OFFSET: number;
     SPANS_FONT_SIZE: number;
     TIMELINE_HEIGHT: number;
+    TIMELINE_LABEL_HEIGHT: number;
     TOOLTIP_FONT_SIZE: number;
     UI_FRAMES_HEIGHT: number;
   };
@@ -160,6 +161,7 @@ const SIZES: FlamegraphTheme['SIZES'] = {
   MAX_SPANS_HEIGHT: 160,
   TIMELINE_HEIGHT: 20,
   TOOLTIP_FONT_SIZE: 12,
+  TIMELINE_LABEL_HEIGHT: 20,
   UI_FRAMES_HEIGHT: 60,
 };
 

--- a/static/app/utils/profiling/flamegraphChart.tsx
+++ b/static/app/utils/profiling/flamegraphChart.tsx
@@ -2,14 +2,14 @@ import {Rect} from 'sentry/utils/profiling/speedscope';
 
 import {makeFormatter} from './units/units';
 
-interface Serie {
+interface Series {
   points: {x: number; y: number}[];
 }
 
 export class FlamegraphChart {
   configSpace: Rect;
   formatter: ReturnType<typeof makeFormatter>;
-  series: Serie[];
+  series: Series[];
   domains: {
     x: [number, number];
     y: [number, number];
@@ -21,7 +21,7 @@ export class FlamegraphChart {
   static Empty = new FlamegraphChart(Rect.Empty(), {unit: 'percent', values: []});
 
   constructor(configSpace: Rect, measurement: Profiling.Measurement) {
-    this.series = new Array<Serie>();
+    this.series = new Array<Series>();
 
     this.series[0] = {
       points: new Array(measurement.values.length),

--- a/static/app/utils/profiling/flamegraphChart.tsx
+++ b/static/app/utils/profiling/flamegraphChart.tsx
@@ -1,0 +1,18 @@
+import {Rect} from 'sentry/utils/profiling/speedscope';
+
+import {makeFormatter} from './units/units';
+
+export class FlamegraphChart {
+  configSpace: Rect;
+  formatter: ReturnType<typeof makeFormatter>;
+  series: {x: number; y: number}[];
+
+  constructor(measurement: Profiling.Measurement, configSpace?: Rect) {
+    this.series = measurement.values.map(c => {
+      return {x: c.elapsed_since_start_ns, y: c.value};
+    });
+
+    this.configSpace = configSpace ?? Rect.Empty();
+    this.formatter = makeFormatter(measurement.unit);
+  }
+}

--- a/static/app/utils/profiling/flamegraphChart.tsx
+++ b/static/app/utils/profiling/flamegraphChart.tsx
@@ -51,12 +51,7 @@ export class FlamegraphChart {
 
     this.domains.y[1] = 100;
     this.configSpace = configSpace.withHeight(this.domains.y[1] - this.domains.y[0]);
-    // this.configSpace = configSpace.withHeight(this.domains.y[1] - this.domains.y[0] + 10).withY(this.domains.y[0] - 10);
-    // new Rect(
-    //   ...this.domains.x,
-    //   this.domains.x[1] - this.domains.x[0],
-    //   this.domains.y[1] - this.domains.y[0]
-    // ) ?? Rect.Empty();
+
     this.formatter = makeFormatter(measurement.unit);
   }
 }

--- a/static/app/utils/profiling/flamegraphChart.tsx
+++ b/static/app/utils/profiling/flamegraphChart.tsx
@@ -18,7 +18,9 @@ export class FlamegraphChart {
     y: [0, 0],
   };
 
-  constructor(measurement: Profiling.Measurement) {
+  static Empty = new FlamegraphChart(Rect.Empty(), {unit: 'percent', values: []});
+
+  constructor(configSpace: Rect, measurement: Profiling.Measurement) {
     this.series = new Array<Serie>();
 
     this.series[0] = {
@@ -48,13 +50,13 @@ export class FlamegraphChart {
     }
 
     this.domains.y[1] = 100;
-
-    this.configSpace =
-      new Rect(
-        ...this.domains.x,
-        this.domains.x[1] - this.domains.x[0],
-        this.domains.y[1] - this.domains.y[0]
-      ) ?? Rect.Empty();
+    this.configSpace = configSpace.withHeight(this.domains.y[1] - this.domains.y[0]);
+    // this.configSpace = configSpace.withHeight(this.domains.y[1] - this.domains.y[0] + 10).withY(this.domains.y[0] - 10);
+    // new Rect(
+    //   ...this.domains.x,
+    //   this.domains.x[1] - this.domains.x[0],
+    //   this.domains.y[1] - this.domains.y[0]
+    // ) ?? Rect.Empty();
     this.formatter = makeFormatter(measurement.unit);
   }
 }

--- a/static/app/utils/profiling/flamegraphChart.tsx
+++ b/static/app/utils/profiling/flamegraphChart.tsx
@@ -2,17 +2,59 @@ import {Rect} from 'sentry/utils/profiling/speedscope';
 
 import {makeFormatter} from './units/units';
 
+interface Serie {
+  points: {x: number; y: number}[];
+}
+
 export class FlamegraphChart {
   configSpace: Rect;
   formatter: ReturnType<typeof makeFormatter>;
-  series: {x: number; y: number}[];
+  series: Serie[];
+  domains: {
+    x: [number, number];
+    y: [number, number];
+  } = {
+    x: [0, 0],
+    y: [0, 0],
+  };
 
-  constructor(measurement: Profiling.Measurement, configSpace?: Rect) {
-    this.series = measurement.values.map(c => {
-      return {x: c.elapsed_since_start_ns, y: c.value};
-    });
+  constructor(measurement: Profiling.Measurement) {
+    this.series = new Array<Serie>();
 
-    this.configSpace = configSpace ?? Rect.Empty();
+    this.series[0] = {
+      points: new Array(measurement.values.length),
+    };
+
+    for (let i = 0; i < measurement.values.length; i++) {
+      const m = measurement.values[i];
+
+      // Track and update Y max and min
+      if (m.value > this.domains.y[1]) {
+        this.domains.y[1] = m.value;
+      }
+      if (m.value < this.domains.y[0]) {
+        this.domains.y[0] = m.value;
+      }
+
+      // Track and update X domain max and min
+      if (m.elapsed_since_start_ns > this.domains.x[1]) {
+        this.domains.x[1] = m.elapsed_since_start_ns;
+      }
+      if (m.elapsed_since_start_ns < this.domains.x[0]) {
+        this.domains.x[1] = m.elapsed_since_start_ns;
+      }
+
+      this.series[0].points[i] = {x: m.elapsed_since_start_ns, y: m.value};
+    }
+
+    this.domains.y[1] = 100;
+
+    this.configSpace =
+      new Rect(
+        ...this.domains.x,
+        this.domains.x[1] - this.domains.x[0],
+        this.domains.y[1] - this.domains.y[0]
+      ) ?? Rect.Empty();
     this.formatter = makeFormatter(measurement.unit);
   }
 }

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -278,9 +278,9 @@ export function measureText(string: string, ctx?: CanvasRenderingContext2D): Rec
  * @param values {Array<T> | ReadonlyArray<T>}
  * @returns number
  */
-export function upperBound<T extends {end: number; start: number}>(
+export function upperBound<T extends {end: number; start: number; x: number}>(
   target: number,
-  values: Array<T> | ReadonlyArray<T>
+  values: Array<T> | ReadonlyArray<T> | Record<any, any>
 ) {
   let low = 0;
   let high = values.length;

--- a/static/app/utils/profiling/renderers/chartRenderer.tsx
+++ b/static/app/utils/profiling/renderers/chartRenderer.tsx
@@ -21,7 +21,12 @@ export class FlamegraphChartRenderer {
     // @TODO binary search for closes value
   }
 
-  draw(_configView: Rect, configViewToPhysicalSpace: mat3) {
+  draw(
+    _configView: Rect,
+    _configSpace: Rect,
+    _physicalSpace: Rect,
+    configViewToPhysicalSpace: mat3
+  ) {
     if (!this.canvas) {
       throw new Error('No canvas to draw on');
     }
@@ -34,6 +39,15 @@ export class FlamegraphChartRenderer {
 
     // Helper lines for dev
     this.context.font = '16px sans-serif';
+    this.context.textBaseline = 'middle';
+
+    this.context.strokeStyle = `red`;
+    this.context.beginPath();
+    const origin = new Rect(0, 0, 1, 1).transformRect(configViewToPhysicalSpace);
+    this.context.arc(origin.x, origin.y, 10, 0, 2 * Math.PI);
+    this.context.fill();
+
+    this.context.strokeStyle = `black`;
     for (const h of [0, 25, 50, 75, 100]) {
       const r = new Rect(0, h, 1, 1).transformRect(configViewToPhysicalSpace);
 
@@ -44,6 +58,7 @@ export class FlamegraphChartRenderer {
       this.context.fillText(h.toString(), this.canvas.width / 2, r.y);
     }
 
+    // @TODO draw series
     // for (let i = 0; i < this.chart.series.length; i++) {
     //   this.context.strokeStyle = `red`;
     //   this.context.beginPath();

--- a/static/app/utils/profiling/renderers/chartRenderer.tsx
+++ b/static/app/utils/profiling/renderers/chartRenderer.tsx
@@ -1,0 +1,62 @@
+import {mat3, vec2} from 'gl-matrix';
+
+import {FlamegraphChart} from 'sentry/utils/profiling/flamegraphChart';
+import {getContext, resizeCanvasToDisplaySize} from 'sentry/utils/profiling/gl/utils';
+import {Rect} from 'sentry/utils/profiling/speedscope';
+
+export class FlamegraphChartRenderer {
+  canvas: HTMLCanvasElement | null;
+  chart: FlamegraphChart;
+  context: CanvasRenderingContext2D;
+
+  constructor(canvas: HTMLCanvasElement, chart: FlamegraphChart) {
+    this.canvas = canvas;
+    this.chart = chart;
+
+    this.context = getContext(this.canvas, '2d');
+    resizeCanvasToDisplaySize(this.canvas);
+  }
+
+  findHoveredNode(_configSpaceCursor: vec2): void {
+    // @TODO binary search for closes value
+  }
+
+  draw(_configView: Rect, configViewToPhysicalSpace: mat3) {
+    if (!this.canvas) {
+      throw new Error('No canvas to draw on');
+    }
+
+    if (!this.chart.series.length) {
+      return;
+    }
+
+    this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+
+    // Helper lines for dev
+    this.context.font = '16px sans-serif';
+    for (const h of [0, 25, 50, 75, 100]) {
+      const r = new Rect(0, h, 1, 1).transformRect(configViewToPhysicalSpace);
+
+      this.context.beginPath();
+      this.context.moveTo(0, r.y);
+      this.context.lineTo(this.canvas.width, r.y);
+      this.context.stroke();
+      this.context.fillText(h.toString(), this.canvas.width / 2, r.y);
+    }
+
+    // for (let i = 0; i < this.chart.series.length; i++) {
+    //   this.context.strokeStyle = `red`;
+    //   this.context.beginPath();
+    //   const serie = this.chart.series[i];
+
+    //   for (let j = 0; j < serie.points.length; j++) {
+    //     const point = serie.points[j];
+    //     const r = new Rect(point.x, point.y, 1, 1).transformRect(
+    //       configViewToPhysicalSpace
+    //     );
+    //     this.context.lineTo(r.x, r.y);
+    //   }
+    //   this.context.stroke();
+    // }
+  }
+}

--- a/static/app/utils/profiling/units/units.ts
+++ b/static/app/utils/profiling/units/units.ts
@@ -15,7 +15,8 @@ export type ProfilingFormatterUnit =
   | 'milliseconds'
   | 'second'
   | 'seconds'
-  | 'count';
+  | 'count'
+  | 'percent';
 
 const durationMappings: Record<ProfilingFormatterUnit, number> = {
   nanosecond: 1e-9,
@@ -27,6 +28,7 @@ const durationMappings: Record<ProfilingFormatterUnit, number> = {
   second: 1,
   seconds: 1,
   count: 1,
+  percent: 1,
 };
 
 export function makeFormatTo(
@@ -67,9 +69,9 @@ const format = (v: number, abbrev: string, precision: number) => {
 };
 
 export function makeFormatter(
-  from: ProfilingFormatterUnit | string
+  from: ProfilingFormatterUnit | string,
+  precision: number = 2
 ): (value: number) => string {
-  const DEFAULT_PRECISION = 2;
   const multiplier = durationMappings[from];
 
   if (multiplier === undefined) {
@@ -78,7 +80,12 @@ export function makeFormatter(
 
   if (from === 'count') {
     return (value: number) => {
-      return value.toFixed(0);
+      return value.toFixed(precision);
+    };
+  }
+  if (from === 'percent') {
+    return (value: number) => {
+      return value.toFixed(precision) + '%';
     };
   }
 
@@ -86,15 +93,15 @@ export function makeFormatter(
     const duration = value * multiplier;
 
     if (duration >= 1) {
-      return format(duration, 's', DEFAULT_PRECISION);
+      return format(duration, 's', precision);
     }
     if (duration / 1e-3 >= 1) {
-      return format(duration / 1e-3, 'ms', DEFAULT_PRECISION);
+      return format(duration / 1e-3, 'ms', precision);
     }
     if (duration / 1e-6 >= 1) {
-      return format(duration / 1e-6, 'μs', DEFAULT_PRECISION);
+      return format(duration / 1e-6, 'μs', precision);
     }
-    return format(duration / 1e-9, 'ns', DEFAULT_PRECISION);
+    return format(duration / 1e-9, 'ns', precision);
   };
 }
 


### PR DESCRIPTION
Currently only draws helper lines from 0-100% in 25% intervals. I'm opening this because the next few PR's will require a tiny refactor in CanvasView that I want to isolate. 

The changes here are pretty much the same boilerplate we use for other render steps, we add a model, the corresponding renderer and wire it up.

I will follow up with a stacked PR that addresses the @TODO comments and fixes configView. I disabled it while I worked on it so that the view was always zoomed out