### PR TITLE
fix(hc): ApiApplication.delete had copy paste bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -621,7 +621,6 @@ module = [
     "sentry.migrations.0407_recreate_perf_alert_subscriptions",
     "sentry.migrations.0418_add_actor_constraints",
     "sentry.models.actor",
-    "sentry.models.apiapplication",
     "sentry.models.artifactbundle",
     "sentry.models.auditlogentry",
     "sentry.models.authprovider",

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -71,10 +71,6 @@ class ApiApplication(Model):
         return self.name
 
     def delete(self, **kwargs):
-        from sentry.models import NotificationSetting
-
-        # There is no foreign key relationship so we have to manually cascade.
-        NotificationSetting.objects.remove_for_project(self)
         with outbox_context(transaction.atomic(router.db_for_write(ApiApplication)), flush=False):
             for outbox in self.outboxes_for_update():
                 outbox.save()


### PR DESCRIPTION
A copy paste of the Project.delete method likely resulted in this duplicated behavior.

fortunately, I don't think this will have caused too much a widespread issue.  `ApiApplications` are very rarely deleted generally, but also, the query inside of `NotificationSetting` would require the id of the api application to correspond also to a team notification setting, which, are the rarest of all settings.