### PR TITLE
fix(most-helpful-event): Fix view all events from dropdown

### DIFF
--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -1,6 +1,7 @@
 import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import omit from 'lodash/omit';
 import moment from 'moment-timezone';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -172,11 +173,12 @@ function EventNavigationDropdown({group}: {group: Group}) {
             });
             break;
           case EventNavDropdownOption.ALL:
+            const searchTermWithoutQuery = omit(location.query, 'query');
             browserHistory.push({
               pathname: normalizeUrl(
                 `/organizations/${organization.slug}/issues/${group.id}/events/`
               ),
-              query: location.query,
+              query: searchTermWithoutQuery,
             });
             break;
           default:


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/53714

When opening the dropdown and clicking "View All Events", the all events tab is no longer loaded with the query from the issue stream, which often breaks the search:

![256597523-e525e50d-8b8c-4afa-bbd0-06777984beaf](https://github.com/getsentry/sentry/assets/22582037/a52a9cca-df57-4362-a9ca-180e4a6f4a6c)
