### PR TITLE
fix(starfish): Fall back to metrics span descriptions

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -242,7 +242,8 @@ function SpanSummaryPage({params, location}: Props) {
                               span={{
                                 ...span,
                                 [SpanMetricsFields.SPAN_DESCRIPTION]:
-                                  fullSpanDescription ?? '',
+                                  fullSpanDescription ??
+                                  spanMetrics?.[SpanMetricsFields.SPAN_DESCRIPTION],
                               }}
                             />
                           </DescriptionContainer>


### PR DESCRIPTION
Not all span groups have samples (whoops), so we can't always fetch a full description. In those cases, show the metrics one, even if it's truncated.
