### PR TITLE
feat(workflow): Add custom percent change alert text

### DIFF
--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -11,6 +11,7 @@ from sentry.incidents.logic import get_incident_aggregates
 from sentry.incidents.models import (
     INCIDENT_STATUS,
     AlertRule,
+    AlertRuleThresholdType,
     Incident,
     IncidentStatus,
     IncidentTrigger,
@@ -25,6 +26,16 @@ QUERY_AGGREGATION_DISPLAY = {
     "percentage(users_crashed, users)": "% users crash free rate",
 }
 LOGO_URL = absolute_uri(get_asset_url("sentry", "images/sentry-email-avatar.png"))
+# These should be the same as the options in the frontend
+# COMPARISON_DELTA_OPTIONS
+TEXT_COMPARISON_DELTA = {
+    5: ("same time 5 minutes ago"),  # 5 minutes
+    15: ("same time 15 minutes ago"),  # 15 minutes
+    60: ("same time one hour ago"),  # one hour
+    1440: ("same time one day ago"),  # one day
+    10080: ("same time one week ago"),  # one week
+    43200: ("same time one month ago"),  # 30 days
+}
 
 
 def get_metric_count_from_incident(incident: Incident) -> str:
@@ -67,13 +78,26 @@ def get_incident_status_text(alert_rule: AlertRule, metric_value: str) -> str:
 
     time_window = alert_rule.snuba_query.time_window // 60
     interval = "minute" if time_window == 1 else "minutes"
-    text = _("%(metric_and_agg_text)s in the last %(time_window)d %(interval)s") % {
+    # % change alerts have a comparison delta
+    if alert_rule.comparison_delta:
+        metric_and_agg_text = f"{agg_text.capitalize()} {int(metric_value)}%"
+        higher_or_lower = (
+            "higher" if alert_rule.threshold_type == AlertRuleThresholdType.ABOVE.value else "lower"
+        )
+        comparison_delta_minutes = alert_rule.comparison_delta // 60
+        comparison_string = TEXT_COMPARISON_DELTA.get(
+            comparison_delta_minutes, f"same time {comparison_delta_minutes} minutes ago"
+        )
+        return _(
+            f"{metric_and_agg_text} {higher_or_lower} in the last {time_window} {interval} "
+            f"compared to the {comparison_string}"
+        )
+
+    return _("%(metric_and_agg_text)s in the last %(time_window)d %(interval)s") % {
         "metric_and_agg_text": metric_and_agg_text,
         "time_window": time_window,
         "interval": interval,
     }
-
-    return text
 
 
 def incident_attachment_info(incident, new_status: IncidentStatus, metric_value=None):

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -124,6 +124,52 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
             == "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png"
         )
 
+    def test_percent_change_alert(self):
+        # 1 hour comparison_delta
+        alert_rule = self.create_alert_rule(comparison_delta=60)
+        date_started = self.now
+        incident = self.create_incident(
+            self.organization,
+            title="Incident #1",
+            projects=[self.project],
+            alert_rule=alert_rule,
+            status=IncidentStatus.CLOSED.value,
+            date_started=date_started,
+        )
+        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+        metric_value = 123.12
+        data = incident_attachment_info(incident, IncidentStatus.CRITICAL, metric_value)
+        assert (
+            data["text"]
+            == "Events 123% higher in the last 10 minutes compared to the same time one hour ago"
+        )
+
+    def test_percent_change_alert_custom_comparison_delta(self):
+        # 12 hour comparison_delta
+        alert_rule = self.create_alert_rule(comparison_delta=60 * 12)
+        date_started = self.now
+        incident = self.create_incident(
+            self.organization,
+            title="Incident #1",
+            projects=[self.project],
+            alert_rule=alert_rule,
+            status=IncidentStatus.CLOSED.value,
+            date_started=date_started,
+        )
+        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+        metric_value = 123.12
+        data = incident_attachment_info(incident, IncidentStatus.CRITICAL, metric_value)
+        assert (
+            data["text"]
+            == "Events 123% higher in the last 10 minutes compared to the same time 720 minutes ago"
+        )
+
 
 MOCK_NOW = timezone.now().replace(hour=13, minute=0, second=0, microsecond=0)
 


### PR DESCRIPTION
% change metric alerts were displaying "PERCENT_CHANGE events in the last 10 minutes" which was wrong/confusing. Changes the text to be closer to what we display when setting up the alert.

fixes #48658
