### PR TITLE
fix(android): handle potential value error in signature parsing

### DIFF
--- a/src/sentry/profiles/java.py
+++ b/src/sentry/profiles/java.py
@@ -35,13 +35,13 @@ def parse_obfuscated_signature(signature: str) -> Tuple[List[str], str]:
         elif t == "L":
             start_index = i - arrays
             try:
-                end_index = parameter_types[i:].index(";")
+                end_index = parameter_types.index(";", i)
             except ValueError:
                 # the lack of `;` indicates a malformed signature
                 return [], ""
-            types.append(parameter_types[start_index : i + end_index + 1])
+            types.append(parameter_types[start_index : end_index + 1])
             arrays = 0
-            i += end_index
+            i = end_index
         elif t == "[":
             arrays += 1
         else:

--- a/src/sentry/profiles/java.py
+++ b/src/sentry/profiles/java.py
@@ -35,7 +35,7 @@ def parse_obfuscated_signature(signature: str) -> Tuple[List[str], str]:
         elif t == "L":
             start_index = i - arrays
             try:
-                end_index = parameter_types[i:].index(";")
+                end_index = parameter_types[i:].index(";", i)
             except ValueError:
                 # the lack of `;` indicates a malformed signature
                 return [], ""

--- a/src/sentry/profiles/java.py
+++ b/src/sentry/profiles/java.py
@@ -34,7 +34,11 @@ def parse_obfuscated_signature(signature: str) -> Tuple[List[str], str]:
             arrays = 0
         elif t == "L":
             start_index = i - arrays
-            end_index = parameter_types[i:].index(";")
+            try:
+                end_index = parameter_types[i:].index(";")
+            except ValueError:
+                # the lack of `;` indicates a malformed signature
+                return [], ""
             types.append(parameter_types[start_index : i + end_index + 1])
             arrays = 0
             i += end_index

--- a/src/sentry/profiles/java.py
+++ b/src/sentry/profiles/java.py
@@ -35,7 +35,7 @@ def parse_obfuscated_signature(signature: str) -> Tuple[List[str], str]:
         elif t == "L":
             start_index = i - arrays
             try:
-                end_index = parameter_types[i:].index(";", i)
+                end_index = parameter_types[i:].index(";")
             except ValueError:
                 # the lack of `;` indicates a malformed signature
                 return [], ""

--- a/tests/sentry/profiles/test_java.py
+++ b/tests/sentry/profiles/test_java.py
@@ -36,6 +36,7 @@ def mapper():
         # invalid signatures
         ("", ""),
         ("()", ""),
+        ("(L)", ""),
         # valid signatures
         ("()V", "()"),
         ("([I)V", "(int[])"),
@@ -44,7 +45,10 @@ def mapper():
         ("([[J)V", "(long[][])"),
         ("(I)I", "(int): int"),
         ("([B)V", "(byte[])"),
-        ("(L)", ""),
+        (
+            "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+            "(java.lang.String, java.lang.String): java.lang.String",
+        ),
     ],
 )
 def test_deobfuscate_signature(mapper, obfuscated, expected):

--- a/tests/sentry/profiles/test_java.py
+++ b/tests/sentry/profiles/test_java.py
@@ -44,6 +44,7 @@ def mapper():
         ("([[J)V", "(long[][])"),
         ("(I)I", "(int): int"),
         ("([B)V", "(byte[])"),
+        ("(L)", ""),
     ],
 )
 def test_deobfuscate_signature(mapper, obfuscated, expected):


### PR DESCRIPTION
In the case a malformed signature is received, it should not error.