### PR TITLE
fix(notification-actions): allow org and team admins to modify

### DIFF
--- a/src/sentry/api/endpoints/notifications/notification_actions_details.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_details.py
@@ -40,16 +40,14 @@ class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
         # projects where the user has project membership
         projects = self.get_projects(request, organization)
 
+        # team admins and regular org members don't have project:write on an org level
         if not request.access.has_scope("project:write"):
-            if (
-                projects
-                and not all(
-                    [
-                        request.access.has_project_scope(project, "project:write")
-                        for project in projects
-                    ]
-                )
-            ) or not projects:
+            # team admins will have project:write scoped to their projects, members will not
+            team_admin_has_access = all(
+                [request.access.has_project_scope(project, "project:write") for project in projects]
+            )
+            # all() returns True for empty list, so include a check for it
+            if not team_admin_has_access or not projects:
                 raise PermissionDenied
 
         try:

--- a/src/sentry/api/endpoints/notifications/notification_actions_details.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_details.py
@@ -40,9 +40,17 @@ class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
         # projects where the user has project membership
         projects = self.get_projects(request, organization)
 
-        # org admins can modify projects and not have direct project access
-        if not projects and not request.access.has_scope("project:write"):
-            raise PermissionDenied
+        if not request.access.has_scope("project:write"):
+            if (
+                projects
+                and not all(
+                    [
+                        request.access.has_project_scope(project, "project:write")
+                        for project in projects
+                    ]
+                )
+            ) or not projects:
+                raise PermissionDenied
 
         try:
             # It must either have no project affiliation, or be accessible to the user...

--- a/src/sentry/api/endpoints/notifications/notification_actions_index.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_index.py
@@ -81,22 +81,29 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         )
 
     def post(self, request: Request, organization: Organization) -> Response:
-        projects = self.get_projects(request, organization)
-
+        # team admins and regular org members don't have project:write on an org level
         if not request.access.has_scope("project:write"):
-            if (
-                projects
-                and not all(
-                    [
-                        request.access.has_project_scope(project, "project:write")
-                        for project in projects
-                    ]
+            # check if user has access to create notification actions for all requested projects
+            requested_projects = request.data.get("projects")
+            projects = self.get_projects(request, organization)
+            project_slugs = [project.slug for project in projects]
+            missing_access_projects = set(requested_projects).difference(set(project_slugs))
+
+            if missing_access_projects:
+                raise PermissionDenied(
+                    detail="You do not have permission to create notification actions for projects "
+                    + str(list(missing_access_projects))
                 )
-            ) or not projects:
+            # team admins will have project:write scoped to their projects, members will not
+            team_admin_has_access = all(
+                [request.access.has_project_scope(project, "project:write") for project in projects]
+            )
+            # all() returns True for empty list, so include a check for it
+            if not team_admin_has_access or not projects:
                 raise PermissionDenied
 
         serializer = NotificationActionSerializer(
-            context={"access": request.access, "organization": organization, "projects": projects},
+            context={"access": request.access, "organization": organization},
             data=request.data,
         )
         if not serializer.is_valid():

--- a/src/sentry/api/endpoints/notifications/notification_actions_index.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_index.py
@@ -84,7 +84,7 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         # team admins and regular org members don't have project:write on an org level
         if not request.access.has_scope("project:write"):
             # check if user has access to create notification actions for all requested projects
-            requested_projects = request.data.get("projects")
+            requested_projects = request.data.get("projects", [])
             projects = self.get_projects(request, organization)
             project_slugs = [project.slug for project in projects]
             missing_access_projects = set(requested_projects).difference(set(project_slugs))

--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -263,6 +263,10 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
         data = self.validate_slack_channel(data)
         data = self.validate_pagerduty_service(data)
 
+        # we may pass in a list of projects in which the user has project membership
+        if self.context.get("projects"):
+            data["projects"] = [project.id for project in self.context["projects"]]
+
         return data
 
     class Meta:

--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -263,10 +263,6 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
         data = self.validate_slack_channel(data)
         data = self.validate_pagerduty_service(data)
 
-        # we may pass in a list of projects in which the user has project membership
-        if self.context.get("projects"):
-            data["projects"] = [project.id for project in self.context["projects"]]
-
         return data
 
     class Meta:

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
@@ -229,6 +229,21 @@ class NotificationActionsIndexEndpointTest(APITestCase):
             **data,
         )
 
+    def test_post_org_member(self):
+        user = self.create_user("hornet@hk.com")
+        self.create_member(user=user, organization=self.organization, teams=[self.team])
+        self.login_as(user)
+        data = {
+            **self.base_data,
+            "projects": [p.slug for p in self.projects],
+        }
+        self.get_error_response(
+            self.organization.slug,
+            status_code=status.HTTP_403_FORBIDDEN,
+            method="POST",
+            **data,
+        )
+
     @patch.dict(NotificationAction._registry, {})
     def test_post_raises_validation_from_registry(self):
         error_message = "oops-idea-installed"


### PR DESCRIPTION
Org and team admins should be able to `POST` / `PUT` / `DELETE` notification actions for projects. Org admins should be able to modify notification actions for all projects since they have org-wide `project:write`, and team admins should be able to modify notification actions for all projects they are on teams with (fetched through `self.get_projects()`).