### PR TITLE
fix(integration-slack)-record-fatal-responses

### DIFF
--- a/src/sentry/integrations/slack/client.py
+++ b/src/sentry/integrations/slack/client.py
@@ -73,7 +73,7 @@ class SlackClient(IntegrationProxyClient):
         if not resp_json.get("ok"):
             if "account_inactive" == resp_json.get("error", ""):
                 return True
-            return False
+        return False
 
     def track_response_data(
         self,

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -372,7 +372,7 @@ class BaseApiClient(TrackResponseMixin):
                 return output
         return output
 
-    def record_response(self, response: BaseApiResponse):
+    def record_response(self, response: Response):
         if self.is_response_fatal(response):
             self.record_request_fatal(response)
         elif self.is_response_error(response):


### PR DESCRIPTION
Fixing `_is_response_fatal()` in `src/sentry/integrations/slack/client.py` from #53621