### PR TITLE
fix(alerts): Move recently active members to first

### DIFF
--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -271,8 +271,8 @@ class FallthroughChoiceType(Enum):
 
 
 FALLTHROUGH_CHOICES = [
-    (FallthroughChoiceType.ALL_MEMBERS.value, "All Project Members"),
     (FallthroughChoiceType.ACTIVE_MEMBERS.value, "Recently Active Members"),
+    (FallthroughChoiceType.ALL_MEMBERS.value, "All Project Members"),
     (FallthroughChoiceType.NO_ONE.value, "No One"),
 ]
 


### PR DESCRIPTION
fixes #53248

should only be used in the UI for the ordering of the options