### PR TITLE
fix(ts): Correct types on List / ListItem

### DIFF
--- a/static/app/components/list/index.tsx
+++ b/static/app/components/list/index.tsx
@@ -3,10 +3,13 @@ import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
 
+import {ListItemProps} from './listItem';
 import {getListSymbolStyle, listSymbol} from './utils';
 
+type ListItemChild = React.ReactElement<ListItemProps> | undefined | false;
+
 type Props = {
-  children: React.ReactNode;
+  children: ListItemChild | ListItemChild[];
   className?: string;
   'data-test-id'?: string;
   initialCounterValue?: number;
@@ -37,14 +40,9 @@ const List = styled(
       <Wrapper className={className} {...props}>
         {!symbol || typeof symbol === 'string'
           ? children
-          : Children.map(children, child => {
-              if (!isValidElement(child)) {
-                return child;
-              }
-              return cloneElement(child as React.ReactElement, {
-                symbol,
-              });
-            })}
+          : Children.map(children, child =>
+              !isValidElement(child) ? child : cloneElement(child, {symbol})
+            )}
       </Wrapper>
     );
   }

--- a/static/app/components/list/listItem.tsx
+++ b/static/app/components/list/listItem.tsx
@@ -3,13 +3,13 @@ import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
 
-interface ListeItemProps extends React.HTMLAttributes<HTMLLIElement> {
+export interface ListItemProps extends React.HTMLAttributes<HTMLLIElement> {
   padding?: string;
   symbol?: React.ReactElement;
 }
 
 const ListItem = styled(
-  forwardRef<HTMLLIElement, ListeItemProps>(
+  forwardRef<HTMLLIElement, ListItemProps>(
     ({symbol, children, padding: _padding, ...props}, ref) => (
       <li ref={ref} role={props.onClick ? 'button' : undefined} {...props}>
         {symbol && <Symbol>{symbol}</Symbol>}

--- a/static/app/utils/getSdkUpdateSuggestion.tsx
+++ b/static/app/utils/getSdkUpdateSuggestion.tsx
@@ -115,16 +115,13 @@ function getSdkUpdateSuggestion({
   }
 
   const alertContent = suggestion.enables
-    .map((subSuggestion, index) => {
+    .map(subSuggestion => {
       const subSuggestionContent = getSdkUpdateSuggestion({
         suggestion: subSuggestion,
         sdk,
         capitalized,
       });
-      if (!subSuggestionContent) {
-        return null;
-      }
-      return <ListItem key={index}>{subSuggestionContent}</ListItem>;
+      return subSuggestionContent || null;
     })
     .filter(content => !!content);
 
@@ -135,7 +132,11 @@ function getSdkUpdateSuggestion({
   return (
     <span>
       {tct('[title] so you can:', {title})}
-      <StyledList symbol="bullet">{alertContent}</StyledList>
+      <StyledList symbol="bullet">
+        {alertContent.map((content, index) => (
+          <ListItem key={index}>{content}</ListItem>
+        ))}
+      </StyledList>
     </span>
   );
 }


### PR DESCRIPTION

The children of List needed to be narrowed to `React.ReactElement<ListeItemProps>` to so that we did not need to cast the react element type in the cloneElement call

Even better would probably be to use a context here