### PR TITLE
ref(hybrid-cloud): Moves user avatar endpoints to the control silo instead of the region silo

### DIFF
--- a/src/sentry/api/endpoints/avatar/user.py
+++ b/src/sentry/api/endpoints/avatar/user.py
@@ -2,23 +2,15 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.base import region_silo_endpoint
+from sentry import options
+from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.avatar import AvatarMixin
 from sentry.api.bases.user import UserEndpoint
 from sentry.models import UserAvatar
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.types.region import get_local_region
 
 
-# TODO(hybridcloud) This needs to become a control_silo_endpoint again.
-# Doing this requires that we solve File uploads for ControlSilo
-#
-# This implementation deviates a bit from the typical AvatarMixin because of hybrid cloud
-# We have the usual problems with user->user_id translation, but also need to handle synchronizing
-# attributes across silos to avoid fetching user avatars from user serializers.
-# Despite updating a user attribute, user avatar FILEs live on regions. This allows us to avoid
-# running file stores on the control silo. So we simply update the user with the new attributes.
-@region_silo_endpoint
+@control_silo_endpoint
 class UserAvatarEndpoint(AvatarMixin, UserEndpoint):
     object_type = "user"
     model = UserAvatar
@@ -44,7 +36,8 @@ class UserAvatarEndpoint(AvatarMixin, UserEndpoint):
         # Update the corresponding user attributes
         avatar_url = None
         if user_avatar.get_avatar_type_display() == "upload":
-            avatar_url = get_local_region().to_url(f"/avatar/{user_avatar.ident}/")
+            url_base = options.get("system.url-prefix")
+            avatar_url = f"{url_base}/avatar/{user_avatar.ident}/"
         serialized_user = user_service.update_user(
             user_id=request.user.id,
             attrs=dict(avatar_url=avatar_url, avatar_type=user_avatar.avatar_type),

--- a/tests/sentry/api/endpoints/test_user_avatar.py
+++ b/tests/sentry/api/endpoints/test_user_avatar.py
@@ -9,7 +9,7 @@ from sentry.testutils import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserAvatarTest(APITestCase):
     def test_get(self):
         user = self.create_user(email="a@example.com")


### PR DESCRIPTION



<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
