### PR TITLE
feat(auth): oauth revoke endpoint

### DIFF
--- a/src/sentry/web/frontend/oauth_revoke.py
+++ b/src/sentry/web/frontend/oauth_revoke.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 from hashlib import sha256
-from typing import Optional
 
 from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
@@ -31,7 +32,13 @@ class OAuthRevokeView(View):
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 
-    def error(self, request: HttpRequest, name, error_description=None, status=400):
+    def error(
+        self,
+        request: HttpRequest,
+        name: str,
+        error_description: str | None = None,
+        status: int = 400,
+    ):
         client_id = request.POST.get("client_id")
 
         logger.error(
@@ -101,7 +108,7 @@ class OAuthRevokeView(View):
                 status=401,
             )
 
-        token_to_delete: ApiToken = self._get_token_to_delete(
+        token_to_delete: ApiToken | None = self._get_token_to_delete(
             token=token,
             token_type_hint=token_type_hint,
             application=application,  # an application can only revoke tokens it owns
@@ -132,8 +139,8 @@ class OAuthRevokeView(View):
         return HttpResponse(status=200)
 
     def _get_token_to_delete(
-        self, token: str, token_type_hint: Optional[str], application: ApiApplication
-    ) -> Optional[ApiToken]:
+        self, token: str, token_type_hint: str | None, application: ApiApplication
+    ) -> ApiToken | None:
         try:
             if token_type_hint == "access_token":
                 token_to_delete = ApiToken.objects.get(token=token, application=application)

--- a/src/sentry/web/frontend/oauth_revoke.py
+++ b/src/sentry/web/frontend/oauth_revoke.py
@@ -115,7 +115,7 @@ class OAuthRevokeView(View):
         )
 
         # only delete the token if one was found
-        if token_to_delete:
+        if isinstance(token_to_delete, ApiToken):
             token_to_delete.delete()
             logger.info(
                 "oauth.revoke-success",

--- a/src/sentry/web/frontend/oauth_revoke.py
+++ b/src/sentry/web/frontend/oauth_revoke.py
@@ -30,7 +30,6 @@ class OAuthRevokeView(View):
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 
-    # Note: the reason parameter is for internal use only
     def error(self, request: HttpRequest, name, error_description=None, status=400):
         client_id = request.POST.get("client_id")
 
@@ -111,7 +110,7 @@ class OAuthRevokeView(View):
             return self.error(
                 request=request,
                 name="invalid_credentials",
-                reason="invalid client_id or client_secret",
+                error_description="invalid client_id or client_secret",
                 status=401,
             )
 

--- a/src/sentry/web/frontend/oauth_revoke.py
+++ b/src/sentry/web/frontend/oauth_revoke.py
@@ -29,7 +29,7 @@ class OAuthRevokeView(View):
 
     @csrf_exempt
     @method_decorator(never_cache)
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request: HttpRequest, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 
     def error(

--- a/src/sentry/web/frontend/oauth_revoke.py
+++ b/src/sentry/web/frontend/oauth_revoke.py
@@ -1,0 +1,127 @@
+import logging
+from typing import Optional
+
+from django.db.models import Q
+from django.http import HttpRequest, HttpResponse
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_exempt
+from django.views.generic.base import View
+
+from sentry.models import ApiApplication, ApiApplicationStatus, ApiToken
+from sentry.utils import json, metrics
+
+logger = logging.getLogger("sentry.api.oauth_revoke")
+
+
+class OAuthRevokeView(View):
+    """
+    OAuth 2.0 token revoke endpoint per RFC 7009
+    https://www.rfc-editor.org/rfc/rfc7009
+
+    Clients can provide either the access_token or refresh_token in the request.
+
+    When revoking the token, the associated access_token or refresh_token is also
+    revoked.
+    """
+
+    @csrf_exempt
+    @method_decorator(never_cache)
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)
+
+    # Note: the reason parameter is for internal use only
+    def error(self, request: HttpRequest, name, reason=None, status=400):
+        client_id = request.POST.get("client_id")
+
+        logging.error(
+            "oauth.revoke-error",
+            extra={
+                "error_name": name,
+                "status": status,
+                "client_id": client_id,
+                "reason": reason,
+            },
+        )
+        return HttpResponse(
+            json.dumps({"error": name}), content_type="application/json", status=status
+        )
+
+    @method_decorator(never_cache)
+    def post(self, request: HttpRequest) -> HttpResponse:
+        token = request.POST.get("token")
+        token_type_hint = request.POST.get("token_type_hint")  # optional
+        client_id = request.POST.get("client_id")
+        client_secret = request.POST.get("client_secret")
+
+        metrics.incr(
+            "oauth_revoke.post.start",
+            sample_rate=1.0,
+            tags={
+                "client_id_exists": bool(client_id),
+                "client_secret_exists": bool(client_secret),
+            },
+        )
+
+        if not client_id:
+            return self.error(request=request, name="missing_client_id", reason="missing client_id")
+
+        if not client_secret:
+            return self.error(
+                request=request, name="missing_client_secret", reason="missing client_secret"
+            )
+
+        if not token:
+            return self.error(request=request, name="missing_token", reason="missing token")
+
+        try:
+            application = ApiApplication.objects.get(
+                client_id=client_id, client_secret=client_secret, status=ApiApplicationStatus.active
+            )
+        except ApiApplication.DoesNotExist:
+            metrics.incr(
+                "oauth_revoke.post.invalid",
+                sample_rate=1.0,
+            )
+            logger.warning("Invalid client_id / secret pair", extra={"client_id": client_id})
+            return self.error(
+                request=request,
+                name="invalid_credentials",
+                reason="invalid client_id or client_secret",
+                status=401,
+            )
+
+        token_to_delete = self.get_token_to_delete(
+            token=token, token_type_hint=token_type_hint, application=application
+        )
+
+        # only delete the token if one was found
+        if token_to_delete:
+            token_to_delete.delete()
+
+        # even in the case of invalid tokens we are supposed to respond with an HTTP 200 per the RFC
+        # See: https://www.rfc-editor.org/rfc/rfc7009#section-2.2
+        return HttpResponse(status=200)
+
+    def get_token_to_delete(
+        self, token: str, token_type_hint: Optional[str], application: ApiApplication
+    ) -> Optional[ApiToken]:
+        try:
+            if token_type_hint == "access_token":
+                token_to_delete = ApiToken.objects.get(token=token)
+            elif token_type_hint == "refresh_token":
+                token_to_delete = ApiToken.objects.get(refresh_token=token)
+            else:
+                # the client request did not provide a token hint so we must check both token (aka. access_token)
+                # and refresh_token for a match
+                query = Q(token=token)
+                query.add(Q(refresh_token=token), Q.OR)
+                query.add(
+                    Q(application=application), Q.AND
+                )  # restrict to the oauth client application
+                token_to_delete = ApiToken.objects.get(query)
+
+            return token_to_delete
+        except ApiToken.DoesNotExist:
+            # RFC 7009 requires us to gracefully handle request for revocation of tokens that do not exist
+            return None

--- a/src/sentry/web/frontend/oauth_revoke.py
+++ b/src/sentry/web/frontend/oauth_revoke.py
@@ -147,8 +147,8 @@ class OAuthRevokeView(View):
             elif token_type_hint == "refresh_token":
                 token_to_delete = ApiToken.objects.get(refresh_token=token, application=application)
             else:
-                # the client request did not provide a token hint so we must check both token (aka. access_token)
-                # and refresh_token for a match
+                # the client request did not provide a token hint so we must check both `token` (aka. access_token)
+                # and `refresh_token` for a match
                 query = Q(token=token)
                 query.add(Q(refresh_token=token), Q.OR)
                 query.add(

--- a/src/sentry/web/frontend/oauth_revoke.py
+++ b/src/sentry/web/frontend/oauth_revoke.py
@@ -101,7 +101,9 @@ class OAuthRevokeView(View):
             )
 
         token_to_delete = self.get_token_to_delete(
-            token=token, token_type_hint=token_type_hint, application=application
+            token=token,
+            token_type_hint=token_type_hint,
+            application=application,  # an application can only revoke tokens it owns
         )
 
         # only delete the token if one was found
@@ -117,9 +119,9 @@ class OAuthRevokeView(View):
     ) -> Optional[ApiToken]:
         try:
             if token_type_hint == "access_token":
-                token_to_delete = ApiToken.objects.get(token=token)
+                token_to_delete = ApiToken.objects.get(token=token, application=application)
             elif token_type_hint == "refresh_token":
-                token_to_delete = ApiToken.objects.get(refresh_token=token)
+                token_to_delete = ApiToken.objects.get(refresh_token=token, application=application)
             else:
                 # the client request did not provide a token hint so we must check both token (aka. access_token)
                 # and refresh_token for a match

--- a/src/sentry/web/frontend/oauth_revoke.py
+++ b/src/sentry/web/frontend/oauth_revoke.py
@@ -115,7 +115,7 @@ class OAuthRevokeView(View):
                 extra={
                     "client_id": client_id,
                     # don't log the actual token, just a hash of it
-                    "sha256_token": sha256(bytes(token, "utf-8")).hexdigest(),
+                    "sha256_token": sha256(token.encode("utf-8")).hexdigest(),
                 },
             )
 

--- a/src/sentry/web/frontend/oauth_revoke.py
+++ b/src/sentry/web/frontend/oauth_revoke.py
@@ -59,7 +59,7 @@ class OAuthRevokeView(View):
     @method_decorator(never_cache)
     def post(self, request: HttpRequest) -> HttpResponse:
         """
-        Handles POST request to revoke an access_token or refresh_token.
+        Revokes an access_token or refresh_token per RFC 6749 specification.
         Will respond with errors aligned with RFC 6749 Section 5.2.
         https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
         """

--- a/src/sentry/web/frontend/oauth_revoke.py
+++ b/src/sentry/web/frontend/oauth_revoke.py
@@ -114,9 +114,8 @@ class OAuthRevokeView(View):
                 "oauth.revoke-success",
                 extra={
                     "client_id": client_id,
-                    "sha256_token": sha256(
-                        token
-                    ).hexdigest(),  # don't log the actual token, just a hash of it
+                    # don't log the actual token, just a hash of it
+                    "sha256_token": sha256(bytes(token, "utf-8")).hexdigest(),
                 },
             )
 

--- a/src/sentry/web/frontend/oauth_revoke.py
+++ b/src/sentry/web/frontend/oauth_revoke.py
@@ -101,7 +101,7 @@ class OAuthRevokeView(View):
                 status=401,
             )
 
-        token_to_delete = self._get_token_to_delete(
+        token_to_delete: ApiToken = self._get_token_to_delete(
             token=token,
             token_type_hint=token_type_hint,
             application=application,  # an application can only revoke tokens it owns
@@ -114,8 +114,16 @@ class OAuthRevokeView(View):
                 "oauth.revoke-success",
                 extra={
                     "client_id": client_id,
+                    "application_id": application.id,
                     # don't log the actual token, just a hash of it
-                    "sha256_token": sha256(token.encode("utf-8")).hexdigest(),
+                    "sha256_provided_token": sha256(token.encode("utf-8")).hexdigest(),
+                    "sha256_access_token": sha256(
+                        token_to_delete.token.encode("utf-8")
+                    ).hexdigest(),
+                    "sha256_refresh_token": sha256(
+                        token_to_delete.refresh_token.encode("utf-8")
+                    ).hexdigest(),
+                    "resource_owner_id": token_to_delete.user.id,
                 },
             )
 

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -42,6 +42,7 @@ from sentry.web.frontend.js_sdk_loader import JavaScriptSdkLoader
 from sentry.web.frontend.mailgun_inbound_webhook import MailgunInboundWebhookView
 from sentry.web.frontend.newest_issue import NewestIssueView
 from sentry.web.frontend.oauth_authorize import OAuthAuthorizeView
+from sentry.web.frontend.oauth_revoke import OAuthRevokeView
 from sentry.web.frontend.oauth_token import OAuthTokenView
 from sentry.web.frontend.organization_auth_settings import OrganizationAuthSettingsView
 from sentry.web.frontend.organization_avatar import OrganizationAvatarPhotoView
@@ -191,6 +192,11 @@ urlpatterns += [
                 re_path(
                     r"^authorize/$",
                     OAuthAuthorizeView.as_view(),
+                ),
+                re_path(
+                    r"^revoke/$",
+                    OAuthRevokeView.as_view(),
+                    name="sentry-oauth-revoke",
                 ),
                 re_path(
                     r"^token/$",

--- a/tests/sentry/web/frontend/test_oauth_revoke.py
+++ b/tests/sentry/web/frontend/test_oauth_revoke.py
@@ -1,0 +1,116 @@
+from functools import cached_property
+from typing import List
+
+import pytest
+from django.urls import reverse
+
+from sentry.models import ApiApplication, ApiGrant, ApiToken
+from sentry.testutils import TestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test(stable=True)
+class OAuthRevokeTest(TestCase):
+    @cached_property
+    def path(self):
+        return reverse("sentry-oauth-revoke")
+
+    def setUp(self):
+        super().setUp()
+
+        # create a dummy api application
+        self.application = ApiApplication.objects.create(
+            owner=self.user,
+            redirect_uris="http://localhost:1234",
+        )
+
+        # authorize the api application to act on behalf of the test user
+        self.grants: List[ApiGrant] = []
+
+        for i in range(4):
+            grant = ApiGrant.objects.create(
+                user=self.user,
+                application=self.application,
+                redirect_uri="http://localhost:1234",
+            )
+            self.grants.append(grant)
+
+        # create some oauth tokens
+        self.tokens: List[ApiToken] = []
+
+        for i in range(4):
+            token = ApiToken.from_grant(self.grants[i])
+            self.tokens.append(token)
+
+    def test_no_get(self):
+        self.login_as(self.user)
+        resp = self.client.get(self.path)
+        assert resp.status_code == 405
+
+    def test_can_revoke_by_access_token(self):
+        resp = self.client.post(
+            self.path,
+            data={
+                "client_id": self.application.client_id,
+                "client_secret": self.application.client_secret,
+                "token_type_hint": "access_token",  # provided access_token hint
+                "token": self.tokens[0].token,  # access_token
+            },
+        )
+        assert resp.status_code == 200
+
+        with pytest.raises(ApiToken.DoesNotExist):
+            ApiToken.objects.get(id=self.tokens[0].id)
+
+    def test_can_revoke_by_refresh_token(self):
+        resp = self.client.post(
+            self.path,
+            data={
+                "client_id": self.application.client_id,
+                "client_secret": self.application.client_secret,
+                "token_type_hint": "refresh_token",  # provided refresh_token hint
+                "token": self.tokens[1].refresh_token,  # refresh_token
+            },
+        )
+        assert resp.status_code == 200
+
+        with pytest.raises(ApiToken.DoesNotExist):
+            ApiToken.objects.get(id=self.tokens[1].id)
+
+    def test_can_revoke_by_access_token_without_hint(self):
+        resp = self.client.post(
+            self.path,
+            data={
+                "client_id": self.application.client_id,
+                "client_secret": self.application.client_secret,
+                "token": self.tokens[2].token,  # just provided the access token, no hint
+            },
+        )
+        assert resp.status_code == 200
+
+        with pytest.raises(ApiToken.DoesNotExist):
+            ApiToken.objects.get(id=self.tokens[2].id)
+
+    def test_can_revoke_by_refresh_token_without_hint(self):
+        resp = self.client.post(
+            self.path,
+            data={
+                "client_id": self.application.client_id,
+                "client_secret": self.application.client_secret,
+                "token": self.tokens[3].refresh_token,  # just provided the refresh_token, no hint
+            },
+        )
+        assert resp.status_code == 200
+
+        with pytest.raises(ApiToken.DoesNotExist):
+            ApiToken.objects.get(id=self.tokens[3].id)
+
+    def test_400_without_token(self):
+        resp = self.client.post(
+            self.path,
+            data={
+                "client_id": self.application.client_id,
+                "client_secret": self.application.client_secret,
+            },
+        )
+        assert resp.status_code == 400

--- a/tests/sentry/web/frontend/test_oauth_revoke.py
+++ b/tests/sentry/web/frontend/test_oauth_revoke.py
@@ -5,7 +5,7 @@ import pytest
 from django.urls import reverse
 
 from sentry.models import ApiApplication, ApiGrant, ApiToken
-from sentry.testutils import TestCase
+from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 
 

--- a/tests/sentry/web/frontend/test_oauth_revoke.py
+++ b/tests/sentry/web/frontend/test_oauth_revoke.py
@@ -30,10 +30,11 @@ class OAuthRevokeTest(TestCase):
             redirect_uris="http://localhost:5678",
         )
 
-        # authorize the api application to act on behalf of the test user
         self.grants: List[ApiGrant] = []
+        self.tokens: List[ApiToken] = []
 
         for i in range(4):
+            # authorize the api application to act on behalf of the test user
             grant = ApiGrant.objects.create(
                 user=self.user,
                 application=self.application,
@@ -41,10 +42,7 @@ class OAuthRevokeTest(TestCase):
             )
             self.grants.append(grant)
 
-        # create some oauth tokens
-        self.tokens: List[ApiToken] = []
-
-        for i in range(4):
+            # create associated token from the grant
             token = ApiToken.from_grant(self.grants[i])
             self.tokens.append(token)
 

--- a/tests/sentry/web/frontend/test_oauth_revoke.py
+++ b/tests/sentry/web/frontend/test_oauth_revoke.py
@@ -30,8 +30,8 @@ class OAuthRevokeTest(TestCase):
             redirect_uris="http://localhost:5678",
         )
 
-        self.grants: List[ApiGrant] = []
-        self.tokens: List[ApiToken] = []
+        self.grants: list[ApiGrant] = []
+        self.tokens: list[ApiToken] = []
 
         for i in range(4):
             # authorize the api application to act on behalf of the test user


### PR DESCRIPTION
Implementation of the `/revoke` OAuth endpoint defined in [RFC 7009](https://www.rfc-editor.org/rfc/rfc7009) to allow confidential clients (ie. API Applications, Sentry Integrations, and Sentry Apps) to revoke access and refresh tokens.