### PR TITLE
feat(alerts): Handle  % change alert incident reason text

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricHistory.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricHistory.spec.tsx
@@ -13,8 +13,19 @@ describe('MetricHistory', () => {
   it('renders a critical incident', () => {
     render(<MetricHistory incidents={[TestStubs.Incident()]} />);
     expect(screen.getByRole('link', {name: '#123'})).toBeInTheDocument();
-    expect(screen.getByText('Number of Errors above 70')).toBeInTheDocument();
+    expect(screen.getByText('Number of errors above 70 in 1 hour')).toBeInTheDocument();
     expect(screen.getByText('12hr')).toBeInTheDocument();
+  });
+
+  it('renders a critical % change incident', () => {
+    const incident = TestStubs.Incident();
+    incident.alertRule.comparisonDelta = 60;
+    render(<MetricHistory incidents={[incident]} />);
+    expect(
+      screen.getByText(
+        'Number of errors 70% higher in the last 1 hour compared to the same time one hour ago'
+      )
+    ).toBeInTheDocument();
   });
 
   it('collapses the incidents panel if the number of incidents > 3', async () => {

--- a/static/app/views/alerts/rules/metric/details/metricHistory.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricHistory.spec.tsx
@@ -23,7 +23,7 @@ describe('MetricHistory', () => {
     render(<MetricHistory incidents={[incident]} />);
     expect(
       screen.getByText(
-        'Number of errors 70% higher in the last 1 hour compared to the same time one hour ago'
+        'Number of errors 70% higher in 1 hour compared to the same time one hour ago'
       )
     ).toBeInTheDocument();
   });

--- a/static/app/views/alerts/rules/metric/details/metricHistory.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricHistory.tsx
@@ -87,7 +87,7 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
           <Fragment>
             {alertName} {curentTrigger?.alertThreshold}%
             {t(
-              ' %s in the last %s compared to the ',
+              ' %s in %s compared to the ',
               incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
                 ? t('higher')
                 : t('lower'),

--- a/static/app/views/alerts/rules/metric/details/metricHistory.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricHistory.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+import capitalize from 'lodash/capitalize';
 import moment from 'moment-timezone';
 
 import CollapsePanel from 'sentry/components/collapsePanel';
@@ -12,8 +13,10 @@ import StatusIndicator from 'sentry/components/statusIndicator';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types';
+import {getDuration} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import useOrganization from 'sentry/utils/useOrganization';
+import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/rules/metric/constants';
 import {AlertRuleThresholdType} from 'sentry/views/alerts/rules/metric/types';
 import type {ActivityType} from 'sentry/views/alerts/types';
 import {Incident, IncidentActivityType, IncidentStatus} from 'sentry/views/alerts/types';
@@ -56,6 +59,10 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
   const curentTrigger = incident.alertRule.triggers.find(
     trigger => trigger.label === triggerLabel
   );
+  const timeWindow = getDuration(incident.alertRule.timeWindow * 60);
+  const alertName = capitalize(
+    AlertWizardAlertNames[getAlertTypeFromAggregateDataset(incident.alertRule)]
+  );
 
   return (
     <Fragment>
@@ -76,11 +83,29 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
         </Link>
       </Cell>
       <Cell>
-        {AlertWizardAlertNames[getAlertTypeFromAggregateDataset(incident.alertRule)]}{' '}
-        {incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
-          ? t('above')
-          : t('below')}{' '}
-        {curentTrigger?.alertThreshold}
+        {incident.alertRule.comparisonDelta ? (
+          <Fragment>
+            {alertName} {curentTrigger?.alertThreshold}%
+            {t(
+              ' %s in the last %s compared to the ',
+              incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
+                ? t('higher')
+                : t('lower'),
+              timeWindow
+            )}
+            {COMPARISON_DELTA_OPTIONS.find(
+              ({value}) => value === incident.alertRule.comparisonDelta
+            )?.label ?? COMPARISON_DELTA_OPTIONS[0].label}
+          </Fragment>
+        ) : (
+          <Fragment>
+            {alertName}{' '}
+            {incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
+              ? t('above')
+              : t('below')}{' '}
+            {curentTrigger?.alertThreshold} {t('in')} {timeWindow}
+          </Fragment>
+        )}
       </Cell>
       <Cell>
         {activityDuration &&

--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import capitalize from 'lodash/capitalize';
 
 import AlertBadge from 'sentry/components/alertBadge';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
@@ -68,12 +69,15 @@ function TriggerDescription({
     ? t('lower')
     : t('below');
   const timeWindow = <Duration seconds={rule.timeWindow * 60} />;
+  const metricName = capitalize(
+    AlertWizardAlertNames[getAlertTypeFromAggregateDataset(rule)]
+  );
 
   const thresholdText = rule.comparisonDelta
     ? tct(
-        '[metric] is [threshold]% [comparisonType] in [timeWindow] compared to [comparisonDelta]',
+        '[metric] is [threshold]% [comparisonType] in [timeWindow] compared to the [comparisonDelta]',
         {
-          metric: AlertWizardAlertNames[getAlertTypeFromAggregateDataset(rule)],
+          metric: metricName,
           threshold,
           comparisonType: thresholdTypeText,
           timeWindow,
@@ -84,7 +88,7 @@ function TriggerDescription({
         }
       )
     : tct('[metric] is [condition] in [timeWindow]', {
-        metric: AlertWizardAlertNames[getAlertTypeFromAggregateDataset(rule)],
+        metric: metricName,
         condition: `${thresholdTypeText} ${threshold}`,
         timeWindow,
       });


### PR DESCRIPTION
- Changes the incident reason from `Number of Errors above 5` to `Number of errors 5% higher in the last 5 minutes compared to the same time one week ago` which is similar to the metric alert builder.
- Adds interval period for regular metric alerts since it can change if the alert was edited

fixes #48658

before
![image](https://github.com/getsentry/sentry/assets/1400464/7457ad05-302c-42ad-a1df-48b1aace1a41)

after
![Screenshot 2023-07-28 at 4 00 13 PM](https://github.com/getsentry/sentry/assets/1400464/fe59d7c5-39af-4f70-9209-61b4c7de819e)
