### PR TITLE
fix(hc): Make serializable RPC models match DB models

### DIFF
--- a/src/sentry/services/hybrid_cloud/hook/model.py
+++ b/src/sentry/services/hybrid_cloud/hook/model.py
@@ -13,7 +13,7 @@ from sentry.services.hybrid_cloud import RpcModel
 class RpcServiceHook(RpcModel):
     id: int = -1
     guid: Optional[str] = ""
-    application_id: int = -1
+    application_id: Optional[int] = None
     installation_id: Optional[int] = None
     project_id: Optional[int] = None
     organization_id: Optional[int] = None

--- a/src/sentry/services/hybrid_cloud/log/model.py
+++ b/src/sentry/services/hybrid_cloud/log/model.py
@@ -22,7 +22,7 @@ class AuditLogEvent(RpcModel):
     # 'datetime' is apparently reserved attribute name for dataclasses.
     date_added: datetime.datetime = DEFAULT_DATE
     event_id: int = -1
-    actor_label: str = ""
+    actor_label: Optional[str] = None
     actor_user_id: Optional[int] = None
     actor_key_id: Optional[int] = None
     ip_address: Optional[str] = None

--- a/src/sentry/services/hybrid_cloud/notifications/model.py
+++ b/src/sentry/services/hybrid_cloud/notifications/model.py
@@ -27,7 +27,7 @@ class RpcNotificationSetting(RpcModel):
     scope_type: NotificationScopeType = NotificationScopeType.USER
     scope_identifier: int = -1
     id: int = -1
-    target_id: int = -1
+    target_id: Optional[int] = None
     team_id: Optional[int] = None
     user_id: Optional[int] = None
     provider: ExternalProviders = ExternalProviders.EMAIL

--- a/src/sentry/services/hybrid_cloud/repository/model.py
+++ b/src/sentry/services/hybrid_cloud/repository/model.py
@@ -14,6 +14,6 @@ class RpcRepository(RpcModel):
     name: str
     external_id: Optional[str]
     config: Dict[str, Any]
-    integration_id: int
+    integration_id: Optional[int]
     provider: str
     status: int


### PR DESCRIPTION
Each field that is modified to be optional corresponds to a nullable database field.