### PR TITLE
fix(integrations): Make ApiClient respect REQUESTS_CA_BUNDLE env variable

### DIFF
--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -246,11 +246,21 @@ class BaseApiClient(TrackResponseMixin):
             try:
                 with build_session() as session:
                     finalized_request = self.finalize_request(_prepared_request)
+                    environment_settings = session.merge_environment_settings(
+                        url=finalized_request.url,
+                        proxies=None,
+                        stream=None,
+                        verify=self.verify_ssl,
+                        cert=None,
+                    )
+                    send_kwargs = {
+                        "timeout": timeout,
+                        "allow_redirects": allow_redirects,
+                        **environment_settings,
+                    }
                     resp: Response = session.send(
                         finalized_request,
-                        allow_redirects=allow_redirects,
-                        timeout=timeout,
-                        verify=self.verify_ssl,
+                        **send_kwargs,
                     )
                     if raw_response:
                         return resp


### PR DESCRIPTION
Fixes: https://github.com/getsentry/self-hosted/issues/2305

When using prepared request flow, the requests library does not take into account the environment. This means that self-signed certificates specified in REQUESTS_CA_BUNDLE will not be taken into account. This change follows the requests documentation guidance of merging the environment settings with your own settings ensuring that they are taken into account. See: [docs](https://requests.readthedocs.io/en/latest/user/advanced/#prepared-requests)


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
