### PR TITLE
ref(getting-started): Add `@latest` to sentry wizard code snippets

### DIFF
--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -51,7 +51,7 @@ export const steps = ({
     configurations: [
       {
         language: 'bash',
-        code: `npx @sentry/wizard -i nextjs`,
+        code: `npx @sentry/wizard@latest -i nextjs`,
       },
     ],
   },

--- a/static/app/gettingStartedDocs/javascript/sveltekit.tsx
+++ b/static/app/gettingStartedDocs/javascript/sveltekit.tsx
@@ -44,7 +44,7 @@ export const steps = ({
     configurations: [
       {
         language: 'bash',
-        code: `npx @sentry/wizard -i sveltekit`,
+        code: `npx @sentry/wizard@latest -i sveltekit`,
       },
     ],
   },

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -28,7 +28,7 @@ export const steps = ({
       {
         language: 'bash',
         description: <div>{tct('Run [code:@sentry/wizard]:', {code: <code />})}</div>,
-        code: 'npx @sentry/wizard -s -i reactNative',
+        code: 'npx @sentry/wizard@latest -s -i reactNative',
         additionalInfo: (
           <Fragment>
             <p>


### PR DESCRIPTION
Just noticed while setting up a private project with the new getting started docs that the `@latest` version specified for a few `npx @sentry/wizard` command was missing. This causes `npx` to use an old, previously downloaded version of the specified package instead of the latest one which we want to avoid. 