### PR TITLE
feat(metrics): Handle has filter

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -487,6 +487,20 @@ class MetricsQueryBuilder(QueryBuilder):
         operator = search_filter.operator
         value = search_filter.value.value
 
+        # Handle checks for existence
+        if search_filter.operator in ("=", "!=") and search_filter.value.value == "":
+            if name in constants.METRICS_MAP:
+                if search_filter.operator == "!=":
+                    return None
+                else:
+                    raise IncompatibleMetricsQuery("!has isn't compatible with metrics queries")
+            else:
+                return Condition(
+                    Function("has", [Column("tags.key"), self.resolve_metric_index(name)]),
+                    Op.EQ if search_filter.operator == "!=" else Op.NEQ,
+                    1,
+                )
+
         lhs = self.resolve_column(name)
         # If this is an aliasedexpression, we don't need the alias here, just the expression
         if isinstance(lhs, AliasedExpression):
@@ -523,15 +537,6 @@ class MetricsQueryBuilder(QueryBuilder):
             ):
                 raise InvalidSearchQuery(
                     "Filter on timestamp is outside of the selected date range."
-                )
-
-        # Handle checks for existence
-        if search_filter.operator in ("=", "!=") and search_filter.value.value == "":
-            if is_tag:
-                return Condition(
-                    Function("has", [Column("tags.key"), self.resolve_metric_index(name)]),
-                    Op.EQ if search_filter.operator == "!=" else Op.NEQ,
-                    1,
                 )
 
         if search_filter.value.is_wildcard():

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2188,6 +2188,88 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         meta = response.data["meta"]
         assert meta["isMetricsData"]
 
+    def test_has_filter(self):
+        self.store_transaction_metric(
+            1,
+            tags={"transaction": "foo_transaction", "transaction.status": "foobar"},
+            timestamp=self.min_ago,
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction",
+                    "p50()",
+                ],
+                # For the metrics dataset, has on metrics should be no-ops
+                "query": "has:measurements.frames_frozen_rate",
+                "dataset": "metrics",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["p50()"] == 1
+        meta = response.data["meta"]
+        assert meta["isMetricsData"]
+
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction",
+                    "p50()",
+                ],
+                "query": "has:transaction.status",
+                "dataset": "metrics",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["p50()"] == 1
+        meta = response.data["meta"]
+        assert meta["isMetricsData"]
+
+    def test_not_has_filter(self):
+        self.store_transaction_metric(
+            1,
+            tags={"transaction": "foo_transaction", "transaction.status": "foobar"},
+            timestamp=self.min_ago,
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction",
+                    "p50()",
+                ],
+                "query": "!has:transaction.status",
+                "dataset": "metrics",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 0
+        meta = response.data["meta"]
+        assert meta["isMetricsData"]
+
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction",
+                    "p50()",
+                ],
+                # Doing !has on the metrics dataset doesn't really make sense
+                "query": "!has:measurements.frames_frozen_rate",
+                "dataset": "metrics",
+            }
+        )
+
+        assert response.status_code == 400, response.content
+
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     OrganizationEventsMetricsEnhancedPerformanceEndpointTest


### PR DESCRIPTION
- This handles the has filter on the metrics dataset better
- When its has:{some metric} it becomes a no-op since we'll always have that metric if its part of the fields selected
- Previous behaviour is maintained if its has:{some tag}
- !has:{some metric} will throw an error since that doesn't really work in the metrics dataset since its more field based instead


