### PR TITLE
Update versions; replace macro with hard coded version

### DIFF
--- a/static/app/gettingStartedDocs/java/java.tsx
+++ b/static/app/gettingStartedDocs/java/java.tsx
@@ -48,7 +48,7 @@ repositories {
 
 // Add Sentry's SDK as a dependency.
 dependencies {
-    implementation 'io.sentry:sentry:6.25.2'
+    implementation 'io.sentry:sentry:6.27.0'
 }
           `,
           },
@@ -96,7 +96,7 @@ sentry {
 <dependency>
   <groupId>io.sentry</groupId>
   <artifactId>sentry</artifactId>
-  <version>6.25.2</version>
+  <version>6.27.0</version>
 </dependency>
             `,
           },
@@ -111,7 +111,7 @@ sentry {
     <plugin>
       <groupId>io.sentry</groupId>
       <artifactId>sentry-maven-plugin</artifactId>
-      <version>0.0.2</version>
+      <version>0.0.3</version>
       <configuration>
       <!-- for showing output of sentry-cli -->
       <debugSentryCli>true</debugSentryCli>
@@ -154,7 +154,7 @@ sentry {
           {
             description: <p>{tct('For [strong:SBT]:', {strong: <strong />})}</p>,
             language: 'scala',
-            code: `libraryDependencies += "io.sentry" % "sentry" % "6.25.2"`,
+            code: `libraryDependencies += "io.sentry" % "sentry" % "6.27.0"`,
           },
         ],
       },

--- a/static/app/gettingStartedDocs/java/log4j2.tsx
+++ b/static/app/gettingStartedDocs/java/log4j2.tsx
@@ -42,7 +42,7 @@ export const steps = ({
 <dependency>
   <groupId>io.sentry</groupId>
   <artifactId>sentry-log4j2</artifactId>
-  <version>6.25.2</version>
+  <version>6.27.0</version>
 </dependency>
           `,
           },
@@ -57,7 +57,7 @@ export const steps = ({
     <plugin>
       <groupId>io.sentry</groupId>
       <artifactId>sentry-maven-plugin</artifactId>
-      <version>0.0.2</version>
+      <version>0.0.3</version>
       <configuration>
       <!-- for showing output of sentry-cli -->
       <debugSentryCli>true</debugSentryCli>
@@ -99,7 +99,7 @@ export const steps = ({
         configurations: [
           {
             language: 'groovy',
-            code: "implementation 'io.sentry:sentry-log4j2:6.25.2'",
+            code: "implementation 'io.sentry:sentry-log4j2:6.27.0'",
           },
           {
             description: t(

--- a/static/app/gettingStartedDocs/java/logback.tsx
+++ b/static/app/gettingStartedDocs/java/logback.tsx
@@ -40,7 +40,7 @@ export const steps = ({
 <dependency>
   <groupId>io.sentry</groupId>
   <artifactId>sentry-logback</artifactId>
-  <version>6.25.2</version>
+  <version>6.27.0</version>
 </dependency>
           `,
           },
@@ -55,7 +55,7 @@ export const steps = ({
     <plugin>
       <groupId>io.sentry</groupId>
       <artifactId>sentry-maven-plugin</artifactId>
-      <version>0.0.2</version>
+      <version>0.0.3</version>
       <configuration>
       <!-- for showing output of sentry-cli -->
       <debugSentryCli>true</debugSentryCli>
@@ -97,7 +97,7 @@ export const steps = ({
         configurations: [
           {
             language: 'groovy',
-            code: "implementation 'io.sentry:sentry-logback:6.25.2'",
+            code: "implementation 'io.sentry:sentry-logback:6.27.0'",
           },
           {
             description: t(

--- a/static/app/gettingStartedDocs/java/spring-boot.tsx
+++ b/static/app/gettingStartedDocs/java/spring-boot.tsx
@@ -46,7 +46,7 @@ export const steps = ({
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-spring-boot-starter</artifactId>
-    <version>{{@inject packages.version('sentry.java.spring-boot', '4.0.0') }}</version>
+    <version>6.27.0</version>
 </dependency>
           `,
           },
@@ -57,7 +57,7 @@ export const steps = ({
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
-    <version>{{@inject packages.version('sentry.java.spring-boot.jakarta', '6.7.0') }}</version>
+    <version>6.27.0</version>
 </dependency>
         `,
           },
@@ -69,12 +69,12 @@ export const steps = ({
           {
             language: 'properties',
             description: <strong>{t('Spring Boot 2')}</strong>,
-            code: "implementation 'io.sentry:sentry-spring-boot-starter:{{@inject packages.version('sentry.java.spring-boot', '4.0.0') }}'",
+            code: "implementation 'io.sentry:sentry-spring-boot-starter:6.27.0'",
           },
           {
             language: 'properties',
             description: <strong>{t('Spring Boot 3')}</strong>,
-            code: "implementation 'io.sentry:sentry-spring-boot-starter-jakarta:{{@inject packages.version('sentry.java.spring-boot.jakarta', '6.7.0') }}'",
+            code: "implementation 'io.sentry:sentry-spring-boot-starter-jakarta:6.27.0'",
           },
         ],
       },
@@ -136,7 +136,7 @@ sentry:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-logback</artifactId>
-    <version>{{@inject packages.version('sentry.java.logback', '4.0.0') }}</version>
+    <version>6.27.0</version>
 </dependency>
           `,
           },
@@ -151,7 +151,7 @@ sentry:
     <plugin>
       <groupId>io.sentry</groupId>
       <artifactId>sentry-maven-plugin</artifactId>
-      <version>{{@inject packages.version('sentry.java.mavenplugin', '0.0.2') }}</version>
+      <version>0.0.3</version>
       <configuration>
         <!-- for showing output of sentry-cli -->
         <debugSentryCli>true</debugSentryCli>
@@ -193,7 +193,7 @@ sentry:
         configurations: [
           {
             language: 'properties',
-            code: "implementation 'io.sentry:sentry-logback:{{@inject packages.version('sentry.java.logback', '4.0.0') }}'",
+            code: "implementation 'io.sentry:sentry-logback:6.27.0'",
           },
           {
             language: 'javascript', // TODO: This shouldn't be javascript but because of better formatting we use it for now
@@ -208,7 +208,7 @@ buildscript {
 }
 
 plugins {
-  id "io.sentry.jvm.gradle" version "{{@inject packages.version('sentry.java.android.gradle-plugin', '3.9.0') }}"
+  id "io.sentry.jvm.gradle" version "3.11.1"
 }
 
 sentry {

--- a/static/app/gettingStartedDocs/java/spring.tsx
+++ b/static/app/gettingStartedDocs/java/spring.tsx
@@ -47,7 +47,7 @@ export const steps = ({
 <dependency>
   <groupId>io.sentry</groupId>
   <artifactId>sentry-spring</artifactId>
-  <version>6.25.2</version>
+  <version>6.27.0</version>
 </dependency>
           `,
           },
@@ -58,7 +58,7 @@ export const steps = ({
 <dependency>
   <groupId>io.sentry</groupId>
   <artifactId>sentry-spring-jakarta</artifactId>
-  <version>6.25.2</version>
+  <version>6.27.0</version>
 </dependency>
         `,
           },
@@ -164,7 +164,7 @@ import org.springframework.core.Ordered
     <plugin>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-maven-plugin</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <configuration>
       <!-- for showing output of sentry-cli -->
       <debugSentryCli>true</debugSentryCli>
@@ -206,12 +206,12 @@ import org.springframework.core.Ordered
           {
             description: <strong>{t('Spring 5')}</strong>,
             language: 'groovy',
-            code: `implementation 'io.sentry:sentry-spring:6.25.2'`,
+            code: `implementation 'io.sentry:sentry-spring:6.27.0'`,
           },
           {
             description: <strong>{t('Spring 6')}</strong>,
             language: 'groovy',
-            code: `implementation 'io.sentry:sentry-spring-jakarta:6.25.2'`,
+            code: `implementation 'io.sentry:sentry-spring-jakarta:6.27.0'`,
           },
         ],
       },


### PR DESCRIPTION
Some versions in the onboarding docs (wizard) are broken because they use a macro like `{{@inject packages.version('sentry.java.logback', '4.0.0') }}`. This PR replaces them with hard coded versions. Also bumped some versions.

closes: https://github.com/getsentry/sentry/issues/53846
