### PR TITLE
fix(replays): use http 400 instead of 504 for mem response

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_index.py
@@ -112,4 +112,4 @@ class OrganizationReplayIndexEndpoint(OrganizationEndpoint):
             context = {
                 "detail": "Replay search query limits exceeded. Please narrow the time-range."
             }
-            return self.respond(context, status=504)
+            return self.respond(context, status=400)

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -1251,7 +1251,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 side_effect=QueryMemoryLimitExceeded("mocked error"),
             ):
                 response = self.client.get(self.url)
-                assert response.status_code == 504
+                assert response.status_code == 400
                 assert (
                     response.content
                     == b'{"detail":"Replay search query limits exceeded. Please narrow the time-range."}'


### PR DESCRIPTION
we're seeing weird behavior in prod where it seems like our proxy captures a 504 error and returns an html page instead of the actual response. let's try a 400.