### PR TITLE
chore: Remove imports in testutils barrel file

### DIFF
--- a/fixtures/apidocs_test_case.py
+++ b/fixtures/apidocs_test_case.py
@@ -5,7 +5,7 @@ from openapi_core import create_spec
 from openapi_core.contrib.django import DjangoOpenAPIRequest, DjangoOpenAPIResponse
 from openapi_core.validation.response.validators import ResponseValidator
 
-from sentry.testutils import APITestCase
+from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils import json
 

--- a/fixtures/gitlab.py
+++ b/fixtures/gitlab.py
@@ -2,7 +2,7 @@ from time import time
 
 from sentry.models import Identity, IdentityProvider, Integration, Repository
 from sentry.silo import SiloMode
-from sentry.testutils import APITestCase
+from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 
 EXTERNAL_ID = "example.gitlab.com:group-x"

--- a/fixtures/vsts.py
+++ b/fixtures/vsts.py
@@ -3,7 +3,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 import responses
 
 from sentry.integrations.vsts import VstsIntegrationProvider
-from sentry.testutils import IntegrationTestCase
+from sentry.testutils.cases import IntegrationTestCase
 
 
 class VstsIntegrationTestCase(IntegrationTestCase):

--- a/src/sentry/testutils/__init__.py
+++ b/src/sentry/testutils/__init__.py
@@ -1,4 +1,0 @@
-from .asserts import *  # NOQA
-from .cases import *  # NOQA
-from .relay import *  # NOQA
-from .skips import *  # NOQA

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -165,7 +165,7 @@ from ..snuba.metrics import (
     get_date_range,
 )
 from ..snuba.metrics.naming_layer.mri import SessionMRI, TransactionMRI, parse_mri
-from . import assert_status_code
+from .asserts import assert_status_code
 from .factories import Factories
 from .fixtures import Fixtures
 from .helpers import AuthProvider, Feature, TaskRunner, override_options, parse_queries

--- a/src/sentry/testutils/helpers/api_gateway.py
+++ b/src/sentry/testutils/helpers/api_gateway.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 
 from sentry.api.base import control_silo_endpoint, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.testutils import APITestCase
+from sentry.testutils.cases import APITestCase
 from sentry.testutils.region import override_regions
 from sentry.types.region import Region, RegionCategory, clear_global_regions
 from sentry.utils import json

--- a/src/sentry/testutils/performance_issues/store_transaction.py
+++ b/src/sentry/testutils/performance_issues/store_transaction.py
@@ -5,7 +5,7 @@ from typing import Optional, Sequence
 from django.utils import timezone
 
 from sentry.snuba.dataset import Dataset
-from sentry.testutils import SnubaTestCase
+from sentry.testutils.cases import SnubaTestCase
 
 
 class PerfIssueTransactionTestMixin:

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -83,7 +83,7 @@ class SiloModeTestDecorator:
 
     @staticmethod
     def _is_acceptance_test(test_class: type) -> bool:
-        from sentry.testutils import AcceptanceTestCase
+        from sentry.testutils.cases import AcceptanceTestCase
 
         return issubclass(test_class, AcceptanceTestCase)
 

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -371,7 +371,7 @@ def pytest_collection_modifyitems(config, items):
         if os.environ.get("RUN_SNUBA_TESTS_ONLY"):
             import inspect
 
-            from sentry.testutils import SnubaTestCase
+            from sentry.testutils.cases import SnubaTestCase
 
             if inspect.isclass(item.cls) and not issubclass(item.cls, SnubaTestCase):
                 # No need to group if we are deselecting this

--- a/tests/sentry/api/test_organization_missing_members.py
+++ b/tests/sentry/api/test_organization_missing_members.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from django.utils import timezone
 
-from sentry.testutils import APITestCase
+from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
 
 

--- a/tests/sentry/backup/test_releases.py
+++ b/tests/sentry/backup/test_releases.py
@@ -62,7 +62,7 @@ from sentry.monitors.models import (
 )
 from sentry.sentry_apps.apps import SentryAppUpdater
 from sentry.silo import unguarded_write
-from sentry.testutils import TransactionTestCase
+from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers.backups import (
     get_exportable_final_derivations_of,
     import_export_then_validate,

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -75,9 +75,13 @@ from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.eventuser import EventUser
 from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
 from sentry.spans.grouping.utils import hash_values
-from sentry.testutils import SnubaTestCase, TestCase, TransactionTestCase
 from sentry.testutils.asserts import assert_mock_called_once_with_partial
-from sentry.testutils.cases import PerformanceIssueTestCase
+from sentry.testutils.cases import (
+    PerformanceIssueTestCase,
+    SnubaTestCase,
+    TestCase,
+    TransactionTestCase,
+)
 from sentry.testutils.helpers import apply_feature_flag_on_cls, override_options
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.performance_issues.event_generators import get_event

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -17,7 +17,7 @@ from sentry.plugins.base import plugins
 from sentry.plugins.bases.issue2 import IssuePlugin2
 from sentry.signals import receivers_raise_on_send
 from sentry.silo import SiloMode, unguarded_write
-from sentry.testutils import IntegrationTestCase
+from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 

--- a/tests/sentry/stacktraces/test_in_app_normalization.py
+++ b/tests/sentry/stacktraces/test_in_app_normalization.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from sentry.grouping.api import get_default_grouping_config_dict, load_grouping_config
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
-from sentry.testutils import TestCase
+from sentry.testutils.cases import TestCase
 
 
 def make_stacktrace(frame_0_in_app="not set", frame_1_in_app="not set") -> dict[str, Any]:


### PR DESCRIPTION
By hollowing this out we can move sentry.utils.pytest under sentry.testutils.

Part of the feedback for #53501

getsentry build will fail until getsentry/getsentry#11308 is merged.