### PR TITLE
fix(perf): fix upper margin and heading ellipses on performance change explorer

### DIFF
--- a/static/app/views/performance/trends/changeExplorer.tsx
+++ b/static/app/views/performance/trends/changeExplorer.tsx
@@ -272,7 +272,7 @@ function getTransactionSummaryLink(
 
 const PanelBodyWrapper = styled('div')`
   padding: 0 ${space(2)};
-  margin-top: ${space(4)};
+  margin-top: ${space(1)};
 `;
 
 const HeaderWrapper = styled('div')`
@@ -309,7 +309,7 @@ const TransactionNameWrapper = styled('div')`
   display: flex;
   align-items: center;
   margin-bottom: ${space(3)};
-  width: fit-content;
+  max-width: fit-content;
 `;
 
 const ViewTransactionButton = styled(Button)`


### PR DESCRIPTION
Decreased the upper margin like @narsaynorath suggested and fixed issue where ellipses + link icon wasn't showing up for long transaction names.

<img width="400" alt="image" src="https://github.com/getsentry/sentry/assets/72356613/df0270d8-85d6-48b6-96cf-24100481a0e3">

<img width="400" alt="image" src="https://github.com/getsentry/sentry/assets/72356613/aa449234-f7cb-4536-9159-4ff70a67b75d">
