### PR TITLE
docs(replays): Fix spacing issue and convert to multiline strings

### DIFF
--- a/src/sentry/replays/validators.py
+++ b/src/sentry/replays/validators.py
@@ -32,24 +32,26 @@ VALID_FIELD_SET = (
 
 class ReplayValidator(serializers.Serializer):
     statsPeriod = serializers.CharField(
-        help_text=(
-            "This defines the range of the time series, relative to now. "
-            "The range is given in a `<number><unit>` format. "
-            "For example `1d` for a one day range. Possible units are `m` for minutes, `h` for hours, `d` for days and `w` for weeks."
-            "You must either provide a `statsPeriod`, or a `start` and `end`."
-        ),
+        help_text="""
+This defines the range of the time series, relative to now. The range is given in a
+`<number><unit>` format. For example `1d` for a one day range. Possible units are `m` for
+minutes, `h` for hours, `d` for days and `w` for weeks. You must either provide a
+`statsPeriod`, or a `start` and `end`.
+""",
         required=False,
     )
     start = serializers.DateTimeField(
-        help_text="This defines the start of the time series range as an explicit datetime, either in UTC ISO8601 or epoch seconds."
-        "Use along with `end` instead of `statsPeriod`.",
+        help_text="""
+This defines the start of the time series range as an explicit datetime, either in UTC
+ISO8601 or epoch seconds. Use along with `end` instead of `statsPeriod`.
+""",
         required=False,
     )
     end = serializers.DateTimeField(
-        help_text=(
-            "This defines the inclusive end of the time series range as an explicit datetime, either in UTC ISO8601 or epoch seconds."
-            "Use along with `start` instead of `statsPeriod`."
-        ),
+        help_text="""
+This defines the inclusive end of the time series range as an explicit datetime, either in
+UTC ISO8601 or epoch seconds. Use along with `start` instead of `statsPeriod`.
+""",
         required=False,
     )
     field = serializers.MultipleChoiceField(


### PR DESCRIPTION
Before:
<img width="506" alt="Screenshot 2023-07-31 at 12 01 18 PM" src="https://github.com/getsentry/sentry/assets/67301797/69576a61-e31a-49bf-aa87-496b4ebc097a">

After:
<img width="457" alt="Screenshot 2023-07-31 at 12 01 38 PM" src="https://github.com/getsentry/sentry/assets/67301797/7627a7c0-828f-49c8-8716-8741fc2b6e17">