### PR TITLE
fix(profiling): cap config size

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -502,6 +502,7 @@ function Flamegraph(): ReactElement {
           minWidth: uiFrames.minFrameDuration,
           barHeight: 0,
           depthOffset: 0,
+          maxHeight: 100,
         },
       });
 

--- a/static/app/utils/profiling/canvasView.tsx
+++ b/static/app/utils/profiling/canvasView.tsx
@@ -13,7 +13,10 @@ export class CanvasView<T extends {configSpace: Rect}> {
   configSpaceTransform: mat3 = mat3.create();
 
   inverted: boolean;
+
   minWidth: number;
+  maxHeight: number;
+
   depthOffset: number;
   barHeight: number;
 
@@ -34,6 +37,7 @@ export class CanvasView<T extends {configSpace: Rect}> {
       configSpaceTransform?: Rect;
       depthOffset?: number;
       inverted?: boolean;
+      maxHeight?: number;
       minWidth?: number;
     };
     mode?: CanvasView<T>['mode'];
@@ -41,6 +45,7 @@ export class CanvasView<T extends {configSpace: Rect}> {
     this.mode = mode || this.mode;
     this.inverted = !!options.inverted;
     this.minWidth = options.minWidth ?? 0;
+    this.maxHeight = options.maxHeight ?? 0;
     this.model = model;
     this.canvas = canvas;
     this.depthOffset = options.depthOffset ?? 0;
@@ -103,10 +108,11 @@ export class CanvasView<T extends {configSpace: Rect}> {
           0,
           0,
           this.model.configSpace.width,
-          Math.max(
-            this.model.configSpace.height + this.depthOffset,
-            canvas.physicalSpace.height / this.barHeight
-          )
+          this.maxHeight ||
+            Math.max(
+              this.model.configSpace.height + this.depthOffset,
+              canvas.physicalSpace.height / this.barHeight
+            )
         );
       }
     }
@@ -119,14 +125,14 @@ export class CanvasView<T extends {configSpace: Rect}> {
         return;
       }
       case 'anchorBottom': {
-        const newHeight = canvas.physicalSpace.height / this.barHeight;
+        const newHeight = this.maxHeight || canvas.physicalSpace.height / this.barHeight;
         const newY = Math.max(0, Math.ceil(space.y - (newHeight - space.height)));
         this.configView = Rect.From(space).withHeight(newHeight).withY(newY);
         return;
       }
       case 'anchorTop': {
         this.configView = Rect.From(space).withHeight(
-          canvas.physicalSpace.height / this.barHeight
+          this.maxHeight || canvas.physicalSpace.height / this.barHeight
         );
         return;
       }


### PR DESCRIPTION
When px size / height > max height then the view can be initialized to a larger value than we want to allow. For example in CPU chart max height is 100% and not 120