### PR TITLE
feat(github-growth): invite banner first pass

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -173,11 +173,13 @@ export interface TeamMember extends Member {
 }
 
 /**
- * Missing org members detected through commit authors
+ * Users that exist in CommitAuthors but are not members of the organization.
+ * These users commit to repos installed for the organization.
  */
 export interface MissingMember {
   commitCount: number;
   email: string;
+  // The user's ID in the repository provider (e.g. Github username)
   userId: string;
 }
 

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -173,6 +173,15 @@ export interface TeamMember extends Member {
 }
 
 /**
+ * Missing org members detected through commit authors
+ */
+export interface MissingMember {
+  commitCount: number;
+  email: string;
+  userId: string;
+}
+
+/**
  * Minimal organization shape used on shared issue views.
  */
 export type SharedViewOrganization = {

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -180,7 +180,7 @@ export interface MissingMember {
   commitCount: number;
   email: string;
   // The user's ID in the repository provider (e.g. Github username)
-  userId: string;
+  externalId: string;
 }
 
 /**

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -54,7 +54,7 @@ export function InviteBanner({missingMembers, onSendInvite}: Props) {
           </SeeMoreContainer>
         </MemberCardContentRow>
         <Subtitle>
-          {tct('Accounting for [totalCommits] missing commits', {
+          {tct('Accounting for [totalCommits] recent commits', {
             totalCommits: missingMembers?.users?.reduce(
               (acc, curr) => acc + curr.commitCount,
               0

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -17,7 +17,7 @@ type Props = {
 export function InviteBanner({missingMembers, onSendInvite}: Props) {
   // TODO(cathy): include snoozing, docs link
 
-  const cards = missingMembers?.users?.slice(0, 5).map(member => (
+  const cards = missingMembers?.users.slice(0, 5).map(member => (
     <MemberCard key={member.userId} data-test-id={`member-card-${member.userId}`}>
       <MemberCardContent>
         <MemberCardContentRow>
@@ -49,13 +49,13 @@ export function InviteBanner({missingMembers, onSendInvite}: Props) {
         <MemberCardContentRow>
           <SeeMoreContainer>
             {tct('See all [missingMembersCount] missing members', {
-              missingMembersCount: missingMembers?.users?.length,
+              missingMembersCount: missingMembers?.users.length,
             })}
           </SeeMoreContainer>
         </MemberCardContentRow>
         <Subtitle>
           {tct('Accounting for [totalCommits] recent commits', {
-            totalCommits: missingMembers?.users?.reduce(
+            totalCommits: missingMembers?.users.reduce(
               (acc, curr) => acc + curr.commitCount,
               0
             ),
@@ -66,7 +66,6 @@ export function InviteBanner({missingMembers, onSendInvite}: Props) {
         size="sm"
         priority="primary"
         // TODO(cathy): open up invite modal
-        // onClick={}
         data-test-id="view-all-missing-members"
       >
         {t('View All')}
@@ -81,7 +80,7 @@ export function InviteBanner({missingMembers, onSendInvite}: Props) {
           <CardTitle>{t('Bring your full GitHub team on board in Sentry')}</CardTitle>
           <Subtitle>
             {tct('[missingMemberCount] missing members that are active in your GitHub', {
-              missingMemberCount: missingMembers?.users?.length,
+              missingMemberCount: missingMembers?.users.length,
             })}
             <Tooltip title="Based on the last 30 days of commit data">
               <IconInfo size="xs" />
@@ -93,7 +92,6 @@ export function InviteBanner({missingMembers, onSendInvite}: Props) {
             priority="primary"
             size="xs"
             // TODO(cathy): open up invite modal
-            // onClick={}
             data-test-id="view-all-missing-members"
           >
             {t('View All')}

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -55,7 +56,11 @@ export function InviteBanner({missingMembers, onSendInvite, organization}: Props
     </MemberCard>
   ));
 
-  cards?.push(<SeeMoreCard missingUsers={missingMembers?.users} />);
+  cards?.push(
+    <Fragment key="see-more">
+      <SeeMoreCard missingUsers={missingMembers?.users} />
+    </Fragment>
+  );
 
   return (
     <StyledCard data-test-id="invite-banner">
@@ -95,7 +100,7 @@ type SeeMoreCardProps = {
 
 function SeeMoreCard({missingUsers}: SeeMoreCardProps) {
   return (
-    <MemberCard key="see-more" data-test-id="see-more-card">
+    <MemberCard data-test-id="see-more-card">
       <MemberCardContent>
         <MemberCardContentRow>
           <SeeMore>

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -1,0 +1,188 @@
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import Card from 'sentry/components/card';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconCommit, IconGithub, IconInfo, IconMail} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {MissingMember} from 'sentry/types';
+
+type Props = {
+  missingMembers: {integration: string; users: MissingMember[]};
+  onSendInvite: (email: string) => void;
+};
+
+export function InviteBanner({missingMembers, onSendInvite}: Props) {
+  // TODO(cathy): include snoozing, docs link
+
+  const cards = missingMembers?.users?.slice(0, 5).map(member => (
+    <MemberCard key={member.userId} data-test-id={`member-card-${member.userId}`}>
+      <MemberCardContent>
+        <MemberCardContentRow>
+          <IconGithub size="sm" />
+          <StyledExternalLink href={`http://github.com/${member.userId}`}>
+            {tct('@[userId]', {userId: member.userId})}
+          </StyledExternalLink>
+        </MemberCardContentRow>
+        <MemberCardContentRow>
+          <IconCommit size="xs" />
+          {tct('[commitCount] Recent Commits', {commitCount: member.commitCount})}
+        </MemberCardContentRow>
+        <Subtitle>{member.email}</Subtitle>
+      </MemberCardContent>
+      <Button
+        size="sm"
+        onClick={() => onSendInvite(member.email)}
+        data-test-id="invite-missing-member"
+        icon={<IconMail />}
+      >
+        {t('Invite')}
+      </Button>
+    </MemberCard>
+  ));
+
+  cards?.push(
+    <MemberCard key="see-more" data-test-id="see-more-card">
+      <MemberCardContent>
+        <MemberCardContentRow>
+          <SeeMoreContainer>
+            {tct('See all [missingMembersCount] missing members', {
+              missingMembersCount: missingMembers?.users?.length,
+            })}
+          </SeeMoreContainer>
+        </MemberCardContentRow>
+        <Subtitle>
+          {tct('Accounting for [totalCommits] missing commits', {
+            totalCommits: missingMembers?.users?.reduce(
+              (acc, curr) => acc + curr.commitCount,
+              0
+            ),
+          })}
+        </Subtitle>
+      </MemberCardContent>
+      <Button
+        size="sm"
+        priority="primary"
+        // TODO(cathy): open up invite modal
+        // onClick={}
+        data-test-id="view-all-missing-members"
+      >
+        {t('View All')}
+      </Button>
+    </MemberCard>
+  );
+
+  return (
+    <StyledCard data-test-id="invite-banner">
+      <CardTitleContainer>
+        <CardTitleContent>
+          <CardTitle>{t('Bring your full GitHub team on board in Sentry')}</CardTitle>
+          <Subtitle>
+            {tct('[missingMemberCount] missing members that are active in your GitHub', {
+              missingMemberCount: missingMembers?.users?.length,
+            })}
+            <Tooltip title="Based on the last 30 days of commit data">
+              <IconInfo size="xs" />
+            </Tooltip>
+          </Subtitle>
+        </CardTitleContent>
+        <ButtonContainer>
+          <Button
+            priority="primary"
+            size="xs"
+            // TODO(cathy): open up invite modal
+            // onClick={}
+            data-test-id="view-all-missing-members"
+          >
+            {t('View All')}
+          </Button>
+        </ButtonContainer>
+      </CardTitleContainer>
+      <MemberCardsContainer>{cards}</MemberCardsContainer>
+    </StyledCard>
+  );
+}
+
+export default InviteBanner;
+
+const StyledCard = styled(Card)`
+  padding: ${space(2)};
+  display: flex;
+  overflow: hidden;
+`;
+
+const CardTitleContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const CardTitleContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+`;
+
+const CardTitle = styled('div')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  font-weight: bold;
+  color: ${p => p.theme.gray400};
+`;
+
+const Subtitle = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: 400;
+  color: ${p => p.theme.gray300};
+  display: flex;
+  align-items: center;
+  & > *:first-child {
+    margin-left: ${space(0.5)};
+    display: flex;
+    align-items: center;
+  }
+`;
+
+const ButtonContainer = styled('div')`
+  display: grid;
+  grid-auto-flow: column;
+  grid-column-gap: ${space(1)};
+`;
+
+const MemberCard = styled(Card)`
+  padding: ${space(2)} 18px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin: ${space(1)} ${space(0.5)} 0 0;
+  min-width: 330px;
+  justify-content: space-between;
+`;
+
+const MemberCardsContainer = styled('div')`
+  display: flex;
+  overflow-x: scroll;
+`;
+
+const MemberCardContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+  width: 75%;
+`;
+
+const MemberCardContentRow = styled('div')`
+  display: flex;
+  align-items: center;
+  font-size: ${p => p.theme.fontSizeSmall};
+  & > *:first-child {
+    margin-right: ${space(0.75)};
+  }
+  margin-bottom: ${space(0.25)};
+`;
+
+const StyledExternalLink = styled(ExternalLink)`
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const SeeMoreContainer = styled('div')`
+  font-size: ${p => p.theme.fontSizeLarge};
+`;

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -55,35 +55,7 @@ export function InviteBanner({missingMembers, onSendInvite, organization}: Props
     </MemberCard>
   ));
 
-  cards?.push(
-    <MemberCard key="see-more" data-test-id="see-more-card">
-      <MemberCardContent>
-        <MemberCardContentRow>
-          <SeeMore>
-            {tct('See all [missingMembersCount] missing members', {
-              missingMembersCount: missingMembers?.users.length,
-            })}
-          </SeeMore>
-        </MemberCardContentRow>
-        <Subtitle>
-          {tct('Accounting for [totalCommits] recent commits', {
-            totalCommits: missingMembers?.users.reduce(
-              (acc, curr) => acc + curr.commitCount,
-              0
-            ),
-          })}
-        </Subtitle>
-      </MemberCardContent>
-      <Button
-        size="sm"
-        priority="primary"
-        // TODO(cathy): open up invite modal
-        data-test-id="view-all-missing-members"
-      >
-        {t('View All')}
-      </Button>
-    </MemberCard>
-  );
+  cards?.push(<SeeMoreCard missingUsers={missingMembers?.users} />);
 
   return (
     <StyledCard data-test-id="invite-banner">
@@ -116,6 +88,39 @@ export function InviteBanner({missingMembers, onSendInvite, organization}: Props
 }
 
 export default withOrganization(InviteBanner);
+
+type SeeMoreCardProps = {
+  missingUsers: MissingMember[];
+};
+
+function SeeMoreCard({missingUsers}: SeeMoreCardProps) {
+  return (
+    <MemberCard key="see-more" data-test-id="see-more-card">
+      <MemberCardContent>
+        <MemberCardContentRow>
+          <SeeMore>
+            {tct('See all [missingMembersCount] missing members', {
+              missingMembersCount: missingUsers.length,
+            })}
+          </SeeMore>
+        </MemberCardContentRow>
+        <Subtitle>
+          {tct('Accounting for [totalCommits] recent commits', {
+            totalCommits: missingUsers.reduce((acc, curr) => acc + curr.commitCount, 0),
+          })}
+        </Subtitle>
+      </MemberCardContent>
+      <Button
+        size="sm"
+        priority="primary"
+        // TODO(cathy): open up invite modal
+        data-test-id="view-all-missing-members"
+      >
+        {t('View All')}
+      </Button>
+    </MemberCard>
+  );
+}
 
 const StyledCard = styled(Card)`
   padding: ${space(2)};
@@ -164,11 +169,13 @@ const MemberCard = styled(Card)`
   flex-direction: row;
   align-items: center;
   margin: ${space(1)} ${space(0.5)} 0 0;
-  min-width: 330px;
-  justify-content: space-between;
+  min-width: 30%;
+  justify-content: center;
+  flex-wrap: wrap;
 `;
 
 const MemberCardsContainer = styled('div')`
+  position: relative;
   display: flex;
   overflow-x: scroll;
 `;
@@ -177,6 +184,7 @@ const MemberCardContent = styled('div')`
   display: flex;
   flex-direction: column;
   width: 75%;
+  flex: 1 1;
 `;
 
 const MemberCardContentRow = styled('div')`

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -15,7 +15,12 @@ type Props = {
 };
 
 export function InviteBanner({missingMembers, onSendInvite}: Props) {
+  // NOTE: this is currently used for Github only
   // TODO(cathy): include snoozing, docs link
+
+  if (!missingMembers?.users) {
+    return null;
+  }
 
   const cards = missingMembers?.users.slice(0, 5).map(member => (
     <MemberCard key={member.userId} data-test-id={`member-card-${member.userId}`}>

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -68,7 +68,7 @@ export function InviteBanner({missingMembers, onSendInvite, organization}: Props
     </MemberCard>
   ));
 
-  cards?.push(<SeeMoreCard key="see-more" missingUsers={users} />);
+  cards.push(<SeeMoreCard key="see-more" missingUsers={users} />);
 
   return (
     <StyledCard data-test-id="invite-banner">
@@ -136,8 +136,8 @@ function SeeMoreCard({missingUsers}: SeeMoreCardProps) {
 }
 
 const StyledCard = styled(Card)`
-  padding: ${space(2)};
   display: flex;
+  padding: ${space(2)};
   overflow: hidden;
 `;
 
@@ -158,11 +158,11 @@ const CardTitle = styled('div')`
 `;
 
 const Subtitle = styled('div')`
+  display: flex;
+  align-items: center;
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 400;
   color: ${p => p.theme.gray300};
-  display: flex;
-  align-items: center;
   & > *:first-child {
     margin-left: ${space(0.5)};
     display: flex;
@@ -177,14 +177,14 @@ const ButtonContainer = styled('div')`
 `;
 
 const MemberCard = styled(Card)`
-  padding: ${space(2)} 18px;
   display: flex;
   flex-direction: row;
-  align-items: center;
-  margin: ${space(1)} ${space(0.5)} 0 0;
-  min-width: 30%;
-  justify-content: center;
   flex-wrap: wrap;
+  min-width: 30%;
+  margin: ${space(1)} ${space(0.5)} 0 0;
+  padding: ${space(2)} 18px;
+  justify-content: center;
+  align-items: center;
 `;
 
 const MemberCardsContainer = styled('div')`
@@ -196,18 +196,18 @@ const MemberCardsContainer = styled('div')`
 const MemberCardContent = styled('div')`
   display: flex;
   flex-direction: column;
-  width: 75%;
   flex: 1 1;
+  width: 75%;
 `;
 
 const MemberCardContentRow = styled('div')`
   display: flex;
   align-items: center;
+  margin-bottom: ${space(0.25)};
   font-size: ${p => p.theme.fontSizeSmall};
   & > *:first-child {
     margin-right: ${space(0.75)};
   }
-  margin-bottom: ${space(0.25)};
 `;
 
 const StyledExternalLink = styled(ExternalLink)`

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -13,7 +13,6 @@ import {
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
-import {MissingMember} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import OrganizationMembersList from 'sentry/views/settings/organizationMembers/organizationMembersList';
 
@@ -43,7 +42,7 @@ const roles = [
   },
 ];
 
-const missingMembers: {integration: string; users: MissingMember[]} = [
+const missingMembers = [
   {
     integration: 'github',
     users: [

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -626,6 +626,18 @@ describe('OrganizationMembersList', function () {
       expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
     });
 
+    it('does not render banner if no missing members', function () {
+      const org = TestStubs.Organization({
+        features: ['integrations-gh-invite'],
+      });
+
+      render(<OrganizationMembersList {...defaultProps} organization={org} />, {
+        context: TestStubs.routerContext([{organization: org}]),
+      });
+
+      expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
+    });
+
     it('does not render banner if lacking org:write', function () {
       const org = TestStubs.Organization({
         features: ['integrations-gh-invite'],

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -49,27 +49,27 @@ const missingMembers = [
       {
         commitCount: 6,
         email: 'hello@sentry.io',
-        userId: 'hello',
+        externalId: 'hello',
       },
       {
         commitCount: 5,
         email: 'abcd@sentry.io',
-        userId: 'abcd',
+        externalId: 'abcd',
       },
       {
         commitCount: 4,
         email: 'hola@sentry.io',
-        userId: 'hola',
+        externalId: 'hola',
       },
       {
         commitCount: 3,
         email: 'test@sentry.io',
-        userId: 'test',
+        externalId: 'test',
       },
       {
         commitCount: 2,
         email: 'five@sentry.io',
-        userId: 'five',
+        externalId: 'five',
       },
     ],
   },

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -671,6 +671,10 @@ describe('OrganizationMembersList', function () {
         context: TestStubs.routerContext([{organization: org}]),
       });
 
+      expect(screen.getByTestId('invite-banner')).toBeInTheDocument();
+      expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);
+      expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
+
       const inviteButton = screen.queryAllByTestId('invite-missing-member')[0];
       await userEvent.click(inviteButton);
       expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(4);

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -13,6 +13,7 @@ import {
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
+import {MissingMember} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import OrganizationMembersList from 'sentry/views/settings/organizationMembers/organizationMembersList';
 
@@ -39,6 +40,39 @@ const roles = [
     name: 'Owner',
     desc: 'This is the owner role',
     allowed: true,
+  },
+];
+
+const missingMembers: {integration: string; users: MissingMember[]} = [
+  {
+    integration: 'github',
+    users: [
+      {
+        commitCount: 6,
+        email: 'hello@sentry.io',
+        userId: 'hello',
+      },
+      {
+        commitCount: 5,
+        email: 'abcd@sentry.io',
+        userId: 'abcd',
+      },
+      {
+        commitCount: 4,
+        email: 'hola@sentry.io',
+        userId: 'hola',
+      },
+      {
+        commitCount: 3,
+        email: 'test@sentry.io',
+        userId: 'test',
+      },
+      {
+        commitCount: 2,
+        email: 'five@sentry.io',
+        userId: 'five',
+      },
+    ],
   },
 ];
 
@@ -143,6 +177,11 @@ describe('OrganizationMembersList', function () {
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/invite-requests/',
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/missing-members/',
       method: 'GET',
       body: [],
     });
@@ -564,6 +603,79 @@ describe('OrganizationMembersList', function () {
         `/organizations/org-slug/invite-requests/${inviteRequest.id}/`,
         expect.objectContaining({data: expect.objectContaining({role: 'admin'})})
       );
+    });
+  });
+
+  describe('inviteBanner', function () {
+    it('renders banner with feature flag', function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/missing-members/',
+        method: 'GET',
+        body: missingMembers,
+      });
+
+      const org = TestStubs.Organization({
+        features: ['integrations-gh-invite'],
+      });
+
+      render(<OrganizationMembersList {...defaultProps} organization={org} />, {
+        context: TestStubs.routerContext([{organization: org}]),
+      });
+
+      expect(screen.getByTestId('invite-banner')).toBeInTheDocument();
+      expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);
+      expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
+    });
+
+    it('does not render banner if lacking org:write', function () {
+      const org = TestStubs.Organization({
+        features: ['integrations-gh-invite'],
+        access: [],
+      });
+
+      render(<OrganizationMembersList {...defaultProps} organization={org} />, {
+        context: TestStubs.routerContext([{organization: org}]),
+      });
+
+      expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
+    });
+
+    it('invites member from banner', async function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/missing-members/',
+        method: 'GET',
+        body: missingMembers,
+      });
+
+      const newMember = TestStubs.Member({
+        id: '6',
+        email: 'hello@sentry.io',
+        teams: [],
+        teamRoles: [],
+        flags: {
+          'sso:linked': true,
+          'idp:provisioned': false,
+        },
+      });
+
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/members/',
+        method: 'POST',
+        body: newMember,
+      });
+
+      const org = TestStubs.Organization({
+        features: ['integrations-gh-invite'],
+      });
+
+      render(<OrganizationMembersList {...defaultProps} organization={org} />, {
+        context: TestStubs.routerContext([{organization: org}]),
+      });
+
+      const inviteButton = screen.queryAllByTestId('invite-missing-member')[0];
+      await userEvent.click(inviteButton);
+      expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(4);
+      expect(screen.getByText('See all 4 missing members')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -173,15 +173,12 @@ class OrganizationMembersList extends DeprecatedAsyncView<Props, State> {
     const {organization} = this.props;
 
     try {
-      const data = await this.api.requestPromise(
-        `/organizations/${organization.slug}/members/`,
-        {
-          method: 'POST',
-          data: {email},
-        }
-      );
+      await this.api.requestPromise(`/organizations/${organization.slug}/members/`, {
+        method: 'POST',
+        data: {email},
+      });
       addSuccessMessage(tct('Sent invite to [email]', {email}));
-      this.setState({members: [...this.state.members, data]});
+      this.fetchMembersList();
       this.setState(state => ({
         missingMembers: state.missingMembers.map(integrationMissingMembers => ({
           ...integrationMissingMembers,
@@ -190,6 +187,23 @@ class OrganizationMembersList extends DeprecatedAsyncView<Props, State> {
       }));
     } catch {
       addErrorMessage(t('Error sending invite'));
+    }
+  };
+
+  fetchMembersList = async () => {
+    const {organization} = this.props;
+
+    try {
+      const data = await this.api.requestPromise(
+        `/organizations/${organization.slug}/members/`,
+        {
+          method: 'GET',
+          data: {paginate: true},
+        }
+      );
+      this.setState({members: data});
+    } catch {
+      addErrorMessage(t('Error fetching members'));
     }
   };
 

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -334,12 +334,10 @@ class OrganizationMembersList extends DeprecatedAsyncView<Props, State> {
     return (
       <Fragment>
         <Feature organization={organization} features={['integrations-gh-invite']}>
-          {organization.access.includes('org:write') && (
-            <InviteBanner
-              missingMembers={githubMissingMembers}
-              onSendInvite={this.handleInviteMissingMember}
-            />
-          )}
+          <InviteBanner
+            missingMembers={githubMissingMembers}
+            onSendInvite={this.handleInviteMissingMember}
+          />
         </Feature>
         <ClassNames>
           {({css}) =>

--- a/static/app/views/settings/organizationMembers/organizationMembersWrapper.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersWrapper.spec.tsx
@@ -50,6 +50,11 @@ describe('OrganizationMembersWrapper', function () {
       method: 'GET',
       body: {},
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/missing-members/',
+      method: 'GET',
+      body: [],
+    });
   });
 
   it('can invite member', async function () {


### PR DESCRIPTION
https://github.com/getsentry/sentry/assets/70817427/43227b82-4dee-470f-ac6e-d73805640538

TODO (follow up):
- Ellipses menu in the top right with dropdown to see the docs or to snooze the banner
- Carousel for the banner instead of scroll left-right

For ER-1740 and ER-1741