### PR TITLE
ref(alerts): Delete unused function

### DIFF
--- a/static/app/views/alerts/rules/metric/actions.tsx
+++ b/static/app/views/alerts/rules/metric/actions.tsx
@@ -34,20 +34,3 @@ export function addOrUpdateRule(
     includeAllArgs: true,
   });
 }
-
-/**
- * Delete an existing rule
- *
- * @param api API Client
- * @param orgId Organization slug
- * @param rule Saved or Unsaved Metric Rule
- */
-export function deleteRule(
-  api: Client,
-  orgId: string,
-  rule: SavedMetricRule
-): Promise<void> {
-  return api.requestPromise(`/organizations/${orgId}/alert-rules/${rule.id}/`, {
-    method: 'DELETE',
-  });
-}


### PR DESCRIPTION
As far as I can tell, this function isn't used anywhere. We delete metric alert rules here: https://github.com/getsentry/sentry/blob/master/static/app/views/alerts/rules/metric/ruleForm.tsx#L757