### PR TITLE
devenv: colima followups

### DIFF
--- a/scripts/start-colima.py
+++ b/scripts/start-colima.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import sys
+from typing import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    # platform.processor() changed at some point between these:
+    # 11.2.3: arm
+    # 12.3.1: arm64
+    APPLE_ARM64 = sys.platform == "darwin" and platform.processor() in {"arm", "arm64"}
+
+    cpus = int(subprocess.run(("sysctl", "-n", "hw.ncpu"), check=True, capture_output=True).stdout)
+    memsize_bytes = int(
+        subprocess.run(("sysctl", "-n", "hw.memsize"), check=True, capture_output=True).stdout
+    )
+    args = [
+        "--cpu",
+        f"{cpus//2}",
+        "--memory",
+        f"{memsize_bytes//(2*1024**3)}",
+    ]
+    if APPLE_ARM64:
+        args = [*args, "--vm-type=vz", "--vz-rosetta", "--mount-type=virtiofs"]
+    return subprocess.call(
+        (
+            "colima",
+            "start",
+            f"--mount=/private/tmp/colima:w,{os.path.expanduser('~')}:r",
+            *args,
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/start-colima.py
+++ b/scripts/start-colima.py
@@ -29,7 +29,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         (
             "colima",
             "start",
-            f"--mount=/private/tmp/colima:w,{os.path.expanduser('~')}:r",
+            f"--mount=/var/folders:w,/private/tmp/colima:w,{os.path.expanduser('~')}:r",
             *args,
         )
     )

--- a/scripts/use-colima.sh
+++ b/scripts/use-colima.sh
@@ -41,7 +41,8 @@ echo "Installing colima."
 brew install colima
 brew link colima
 
-# Colima is not started here; devservices up will start it properly.
+echo "Starting colima."
+python3 -uS scripts/start-colima.py
 
 echo "-----------------------------------------------"
 echo "All done. Start devservices at your discretion."

--- a/scripts/use-colima.sh
+++ b/scripts/use-colima.sh
@@ -40,3 +40,8 @@ EOF
 echo "Installing colima."
 brew install colima
 brew link colima
+
+# Colima is not started here; devservices up will start it properly.
+
+echo "-----------------------------------------------"
+echo "All done. Start devservices at your discretion."

--- a/scripts/use-colima.sh
+++ b/scripts/use-colima.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+if [[ "$(sysctl -n machdep.cpu.brand_string)" != Intel* ]]; then
+    case "$(sw_vers -productVersion)" in
+        *12.*|*13.0*|*13.1*|*13.2*)
+            echo "Your ARM Mac is on a version incompatible with colima."
+            echo "Use Docker Desktop for now until you upgrade to at least 13.3."
+            exit 1
+            ;;
+    esac
+fi
+
 echo "Copying your postgres and clickhouse volume for use with colima. Will take a few minutes."
 tmpdir=$(mktemp -d)
 mkdir "${tmpdir}/postgres" "${tmpdir}/clickhouse"

--- a/scripts/use-colima.sh
+++ b/scripts/use-colima.sh
@@ -48,7 +48,7 @@ python3 -uS scripts/start-colima.py
 
 # The context will be colima, we just want to double make sure.
 docker context use colima
-echo "Recreating your postgres volume for use with colima."
+echo "Recreating your postgres volume for use with colima. May take a few minutes."
 docker volume create --name sentry_postgres
 docker run --rm -v "${tmpdir}:/from" -v sentry_postgres:/to alpine ash -c "cd /from ; cp -a . /to"
 rm -rf "$tmpdir"

--- a/scripts/use-colima.sh
+++ b/scripts/use-colima.sh
@@ -10,12 +10,10 @@ if [[ "$(sysctl -n machdep.cpu.brand_string)" != Intel* ]]; then
     esac
 fi
 
-echo "Copying your postgres and clickhouse volume for use with colima. Will take a few minutes."
+echo "Copying your postgres volume for use with colima. Will take a few minutes."
 tmpdir=$(mktemp -d)
-mkdir "${tmpdir}/postgres" "${tmpdir}/clickhouse"
 docker context use desktop-linux
-docker run --rm -v sentry_postgres:/from -v "${tmpdir}/postgres:/to" alpine ash -c "cd /from ; cp -a . /to" || { echo "You need to start Docker Desktop."; exit 1; }
-docker run --rm -v sentry_clickhouse:/from -v "${tmpdir}/clickhouse:/to" alpine ash -c "cd /from ; cp -a . /to"
+docker run --rm -v sentry_postgres:/from -v "${tmpdir}:/to" alpine ash -c "cd /from ; cp -a . /to" || { echo "You need to start Docker Desktop."; exit 1; }
 
 echo "Stopping Docker.app. If a 'process terminated unexpectedly' dialog appears, dismiss it."
 osascript - <<'EOF' || exit
@@ -60,11 +58,9 @@ python3 -uS scripts/start-colima.py
 
 # The context will be colima, we just want to double make sure.
 docker context use colima
-echo "Recreating your postgres and clickhouse volume for use with colima. May take a few minutes."
-# volume create is idempotent noop if already exists
+echo "Recreating your postgres volume for use with colima. May take a few minutes."
 docker volume create --name sentry_postgres
-docker run --rm -v "${tmpdir}/postgres:/from" -v sentry_postgres:/to alpine ash -c "cd /from ; cp -a . /to"
-docker run --rm -v "${tmpdir}/clickhouse:/from" -v sentry_clickhouse:/to alpine ash -c "cd /from ; cp -a . /to"
+docker run --rm -v "${tmpdir}:/from" -v sentry_postgres:/to alpine ash -c "cd /from ; cp -a . /to"
 rm -rf "$tmpdir"
 
 echo "-----------------------------------------------"

--- a/scripts/use-docker-desktop.sh
+++ b/scripts/use-docker-desktop.sh
@@ -4,7 +4,7 @@ set -e
 
 colima stop
 
-echo "Using docker cli from cask."
+echo "Using docker cli from cask. You may be prompted for your password."
 # brew --prefix doesn't seem to apply here - it's just /usr/local
 sudo ln -svf /Applications/Docker.app/Contents/Resources/bin/docker "/usr/local/bin/docker"
 

--- a/scripts/use-docker-desktop.sh
+++ b/scripts/use-docker-desktop.sh
@@ -25,3 +25,9 @@ EOF
 
 echo "Unlinking colima."
 brew unlink colima
+
+echo "Starting Docker."
+open -a /Applications/Docker.app --args --unattended
+
+echo "-----------------------------------------------"
+echo "All done. Start devservices at your discretion."

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -45,35 +45,13 @@ def get_docker_client() -> Generator[docker.DockerClient, None, None]:
             if DARWIN:
                 if USE_COLIMA:
                     click.echo("Attempting to start colima...")
-                    cpus = int(
-                        subprocess.run(
-                            ("sysctl", "-n", "hw.ncpu"), check=True, capture_output=True
-                        ).stdout
-                    )
-                    memsize_bytes = int(
-                        subprocess.run(
-                            ("sysctl", "-n", "hw.memsize"), check=True, capture_output=True
-                        ).stdout
-                    )
-                    args = [
-                        "--cpu",
-                        f"{cpus//2}",
-                        "--memory",
-                        f"{memsize_bytes//(2*1024**3)}",
-                    ]
-                    if APPLE_ARM64:
-                       args = [*args, "--vm-type=vz", "--vz-rosetta", "--mount-type=virtiofs"]
                     subprocess.check_call(
                         (
-                            "colima",
-                            "start",
-                            f"--mount=/private/tmp/colima:w,{os.path.expanduser('~')}:r",
-                            *args,
+                            "python3",
+                            "-uS",
+                            f"{os.path.dirname(__file__)}/../../../../scripts/start-colima.py",
                         )
                     )
-                    # check_call not working?
-                    # we're continuing in python after
-                    # FATA[0065] error starting vm: error at 'starting': exit status 1
                 else:
                     click.echo("Attempting to start docker...")
                     subprocess.check_call(

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -29,7 +29,7 @@ APPLE_ARM64 = DARWIN and platform.processor() in {"arm", "arm64"}
 USE_COLIMA = bool(shutil.which("colima"))
 
 if USE_COLIMA:
-    RAW_SOCKET_PATH = os.path.expanduser("~/.colima/docker.sock")
+    RAW_SOCKET_PATH = os.path.expanduser("~/.colima/default/docker.sock")
 else:
     RAW_SOCKET_PATH = "/var/run/docker.sock"
 

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -29,7 +29,7 @@ APPLE_ARM64 = DARWIN and platform.processor() in {"arm", "arm64"}
 USE_COLIMA = bool(shutil.which("colima"))
 
 if USE_COLIMA:
-    RAW_SOCKET_PATH = os.path.expanduser("~/.colima/default/docker.sock")
+    RAW_SOCKET_PATH = os.path.expanduser("~/.colima/docker.sock")
 else:
     RAW_SOCKET_PATH = "/var/run/docker.sock"
 
@@ -62,7 +62,7 @@ def get_docker_client() -> Generator[docker.DockerClient, None, None]:
                         f"{memsize_bytes//(2*1024**3)}",
                     ]
                     if APPLE_ARM64:
-                        args = [*args, "--vm-type=vz", "--vz-rosetta"]
+                       args = [*args, "--vm-type=vz", "--vz-rosetta", "--mount-type=virtiofs"]
                     subprocess.check_call(
                         (
                             "colima",
@@ -71,6 +71,9 @@ def get_docker_client() -> Generator[docker.DockerClient, None, None]:
                             *args,
                         )
                     )
+                    # check_call not working?
+                    # we're continuing in python after
+                    # FATA[0065] error starting vm: error at 'starting': exit status 1
                 else:
                     click.echo("Attempting to start docker...")
                     subprocess.check_call(


### PR DESCRIPTION
Some improvements following some initial feedback.

- migrate postgres volume over to colima so people don't have to reset-db
  - unfortunately haven't figured out how to migrate clickhouse data successfully, but that's less of an issue imo
- discourage M1 users on macOS < 13.3 (doesn't work with recent colima version(s), will wait until we require >= 13.3)
- standalone `scripts/start-colima.py`