### PR TITLE
fix(hc): Fix split DB test failures

### DIFF
--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -30,7 +30,7 @@ from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_symbolicator
 from sentry.utils import json
-from sentry.utils.pytest.fixtures import django_db_all
+from sentry.testutils.pytest.fixtures import django_db_all
 
 # IMPORTANT:
 #

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -27,10 +27,10 @@ from sentry.tasks.assemble import assemble_artifacts
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
+from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_symbolicator
 from sentry.utils import json
-from sentry.testutils.pytest.fixtures import django_db_all
 
 # IMPORTANT:
 #

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -30,6 +30,7 @@ from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_symbolicator
 from sentry.utils import json
+from sentry.utils.pytest.fixtures import django_db_all
 
 # IMPORTANT:
 #
@@ -103,7 +104,7 @@ def upload_bundle(bundle_file, project, release=None, dist=None, upload_as_artif
     )
 
 
-@pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 class TestJavascriptIntegration(RelayStoreHelper):
     @pytest.fixture(autouse=True)
     def initialize(self, default_projectkey, default_project, set_sentry_option, live_server):


### PR DESCRIPTION
This resolves the A`ssertionError: Database queries to 'control' are not allowed in this test.` errors when running tests in split DB mode since these tests access more than just the `default` database.