### PR TITLE
fix(auth): Pull proper option for CC signing secret

### DIFF
--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -117,11 +117,11 @@ class OAuthTokenView(View):
             return {"error": "invalid_grant", "reason": "invalid redirect URI"}
 
         token_data = {"token": ApiToken.from_grant(grant=grant)}
-        if grant.has_scope("openid") and options.get("codecov.client-secret"):
+        if grant.has_scope("openid") and options.get("codecov.signing_secret"):
             open_id_token = OpenIDToken(
                 request.POST.get("client_id"),
                 grant.user_id,
-                options.get("codecov.client-secret"),
+                options.get("codecov.signing_secret"),
                 nonce=request.POST.get("nonce"),
             )
             token_data["id_token"] = open_id_token.get_signed_id_token(grant=grant)

--- a/tests/sentry/web/frontend/test_oauth_token.py
+++ b/tests/sentry/web/frontend/test_oauth_token.py
@@ -276,7 +276,7 @@ class OAuthTokenCodeTest(TestCase):
             redirect_uri="https://example.com",
             scope_list=["openid"],
         )
-        with self.options({"codecov.client-secret": "signing_secret"}):
+        with self.options({"codecov.signing_secret": "signing_secret"}):
             resp = self.client.post(
                 self.path,
                 {
@@ -309,7 +309,7 @@ class OAuthTokenCodeTest(TestCase):
             redirect_uri="https://example.com",
             scope_list=["openid", "profile", "email"],
         )
-        with self.options({"codecov.client-secret": "signing_secret"}):
+        with self.options({"codecov.signing_secret": "signing_secret"}):
             resp = self.client.post(
                 self.path,
                 {


### PR DESCRIPTION
We were initially pointing to the wrong option for the key we're using to sign OIDC ID tokens. This fixes that
