### PR TITLE
ref(ui): Use display: block for shortIdBreadcrumb

### DIFF
--- a/static/app/views/issueDetails/shortIdBreadcrumb.tsx
+++ b/static/app/views/issueDetails/shortIdBreadcrumb.tsx
@@ -118,6 +118,7 @@ const ShortIdCopyable = styled('div')`
   align-items: center;
 
   button[aria-haspopup] {
+    display: block;
     opacity: 0;
     transition: opacity 50ms linear;
   }


### PR DESCRIPTION
Because the button was a `inline-block` it had additional space at the bottom for text descenders. We can make the button a block element to fix this.

Good article about this: https://mor10.com/removing-white-space-image-elements-inline-elements-descenders/

Before

![clipboard.png](https://i.imgur.com/uWCrbPh.png)

After

![clipboard.png](https://i.imgur.com/0MMF90o.png)