### PR TITLE
fix(relay): Change 'global' key to 'global_config'

### DIFF
--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -57,7 +57,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         if request.relay_request_data.get("globalConfig"):
             metrics.incr("relay.project_configs.global.fetched")
             global_config = get_global_config()
-            response["global"] = global_config
+            response["global_config"] = global_config
 
         full_config_requested = request.relay_request_data.get("fullConfig")
 

--- a/tests/sentry/api/endpoints/test_relay_globalconfig.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig.py
@@ -31,7 +31,7 @@ def call_global_config(client, relay, private_key):
 def test_return_global_config(call_global_config):
     result, status_code = call_global_config()
     assert status_code < 400
-    assert result["global"] == {
+    assert result["global_config"] == {
         "measurements": {
             "builtinMeasurements": BUILTIN_MEASUREMENTS,
             "maxCustomMeasurements": CUSTOM_MEASUREMENT_LIMIT,


### PR DESCRIPTION
It makes more sense for the key to request global config and the response key to be the same

see https://github.com/getsentry/relay/pull/2320 for more context