### PR TITLE
feat(helpful-event): Add back trace.sampled to sort

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -202,6 +202,7 @@ class EventOrdering(Enum):
         "-replayId",
         "-profile.id",
         "num_processing_errors",
+        "-trace.sampled",
         "-timestamp",
     ]
 


### PR DESCRIPTION
`trace.sampled` values from the last 7 days should now be reliable, so we can go back to sorting on them. See https://github.com/getsentry/sentry/pull/53065 for why it was temporarily removed.