### PR TITLE
fix(github-growth): catch and raise RepoExistsError

### DIFF
--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -6,11 +6,11 @@ from typing import Any, MutableMapping
 
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, router, transaction
-from rest_framework.exceptions import APIException
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.api.exceptions import SentryAPIException, status
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.integrations import IntegrationInstallation
@@ -21,9 +21,10 @@ from sentry.signals import repo_linked
 from sentry.utils import metrics
 
 
-class RepoExistsError(APIException):
-    status_code = 400
-    detail = {"errors": {"__all__": "A repository with that name already exists"}}
+class RepoExistsError(SentryAPIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    code = "repo_exists"
+    message = "A repository with that configuration already exists"
 
 
 def get_integration_repository_provider(integration):
@@ -164,7 +165,7 @@ class IntegrationRepositoryProvider:
             result, repo = self.create_repository(repo_config=config, organization=organization)
         except RepoExistsError as e:
             metrics.incr("sentry.integration_repo_provider.repo_exists")
-            return self.handle_api_error(e)
+            raise (e)
         except Exception as e:
             return self.handle_api_error(e)
 

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -358,3 +358,38 @@ class OrganizationIntegrationRepositoriesCreateTest(APITestCase):
         assert repo.url == "https://github.com/getsentry/sentry"
         assert repo.config == {"name": "getsentry/sentry"}
         assert repo.status == 0
+
+    @patch.object(
+        ExampleRepositoryProvider, "get_repository_data", return_value={"my_config_key": "some_var"}
+    )
+    def test_existing_repo(self, mock_build_repository_config):
+        repo = Repository.objects.create(
+            organization_id=self.org.id,
+            name="getsentry/sentry",
+            status=0,
+            external_id="my_external_id",
+            integration_id="2",
+            provider="integrations:example",
+            url="https://github.com/getsentry/sentry",
+        )
+
+        with patch.object(
+            ExampleRepositoryProvider, "build_repository_config", return_value=self.repo_config_data
+        ) as mock_get_repository_data:
+            response = self.client.post(
+                self.url, data={"provider": "integrations:example", "name": "getsentry/sentry"}
+            )
+            mock_get_repository_data.assert_called_once_with(
+                organization=self.org, data={"my_config_key": "some_var"}
+            )
+
+        assert response.status_code == 201, (response.status_code, response.content)
+        assert response.data["id"]
+        assert response.data["id"] == str(repo.id)
+
+        repo = Repository.objects.get(id=response.data["id"])
+        assert repo.provider == "integrations:example"
+        assert repo.name == "getsentry/sentry"
+        assert repo.url == "https://github.com/getsentry/sentry"
+        assert repo.config == {"name": "getsentry/sentry"}
+        assert repo.status == 0

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -363,7 +363,7 @@ class OrganizationIntegrationRepositoriesCreateTest(APITestCase):
         ExampleRepositoryProvider, "get_repository_data", return_value={"my_config_key": "some_var"}
     )
     def test_existing_repo(self, mock_build_repository_config):
-        repo = Repository.objects.create(
+        Repository.objects.create(
             organization_id=self.org.id,
             name="getsentry/sentry",
             status=0,
@@ -383,13 +383,8 @@ class OrganizationIntegrationRepositoriesCreateTest(APITestCase):
                 organization=self.org, data={"my_config_key": "some_var"}
             )
 
-        assert response.status_code == 201, (response.status_code, response.content)
-        assert response.data["id"]
-        assert response.data["id"] == str(repo.id)
-
-        repo = Repository.objects.get(id=response.data["id"])
-        assert repo.provider == "integrations:example"
-        assert repo.name == "getsentry/sentry"
-        assert repo.url == "https://github.com/getsentry/sentry"
-        assert repo.config == {"name": "getsentry/sentry"}
-        assert repo.status == 0
+        assert response.status_code == 400
+        assert (
+            response.content
+            == b'{"detail":{"code":"repo_exists","message":"A repository with that configuration already exists","extra":{}}}'
+        )


### PR DESCRIPTION
When `self.handle_api_error(e)` is called and `e = RepoExistsError`, the error is not explicitly checked for in `handle_api_error` and it returns a generic 500. If we raise the exception itself, we will get a 400.

This should help reduce the number of issues like https://sentry.sentry.io/issues/4311119036/?project=1