### PR TITLE
ref(crons): Use the slug for team selection

### DIFF
--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
@@ -71,7 +71,7 @@ function SentryMemberTeamSelectorField({
 
   const teamOptions = teams?.map(team => ({
     value: `team:${team.id}`,
-    label: team.name,
+    label: `#${team.slug}`,
     leadingItems: <Avatar team={team} size={avatarSize} />,
   }));
 


### PR DESCRIPTION
Changing to team slug since it's how we refer to teams around the rest of the application

before:
<img width="397" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/166d0154-3f93-4cd6-a5d5-5d64f07a6d80">

after:
<img width="393" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/e9122e1f-a5ff-4dbe-b4c3-0ddb60e71e40">
