### PR TITLE
ref(integration): Add logging for disabled integration errors

### DIFF
--- a/src/sentry/integrations/request_buffer.py
+++ b/src/sentry/integrations/request_buffer.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime
 
 from django.conf import settings
@@ -20,13 +19,9 @@ class IntegrationRequestBuffer:
 
     def __init__(self, key):
         self.integrationkey = key
-        logger = logging.getLogger(__name__)
 
-        try:
-            cluster_id = settings.SENTRY_INTEGRATION_ERROR_LOG_REDIS_CLUSTER
-            self.client = redis.redis_clusters.get(cluster_id)
-        except KeyError as e:
-            logger.info("no_redis_cluster", extra={"error": e, "cluster_id": cluster_id})
+        cluster_id = settings.SENTRY_INTEGRATION_ERROR_LOG_REDIS_CLUSTER
+        self.client = redis.redis_clusters.get(cluster_id)
 
     def _convert_obj_to_dict(self, redis_object):
         """

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
-from random import random
+from random import randint, random
 from typing import Any, Callable, Literal, Mapping, Sequence, Type, Union, overload
 
 import sentry_sdk
@@ -384,53 +384,85 @@ class BaseApiClient(TrackResponseMixin):
 
     def record_error(self, error: Exception):
         redis_key = self._get_redis_key()
+        random_value = randint(0, 99)
         if not len(redis_key):
             return
         if not self.is_considered_error(error):
             return
         try:
             buffer = IntegrationRequestBuffer(redis_key)
+        except Exception:
+            if random_value == 0:
+                self.logger.error("integration.disable_on_broken.init.fail", exc_info=True)
+        try:
             buffer.record_error()
             if buffer.is_integration_broken():
                 self.disable_integration()
         except Exception:
+            if random_value == 0:
+                self.logger.error("integration.disable_on_broken.record_error.fail", exc_info=True)
             metrics.incr("integration.slack.disable_on_broken.redis")
             return
 
     def record_request_error(self, resp: Response):
         redis_key = self._get_redis_key()
+        random_value = randint(0, 99)
         if not len(redis_key):
             return
         try:
             buffer = IntegrationRequestBuffer(redis_key)
+        except Exception:
+            if random_value == 0:
+                self.logger.error("integration.disable_on_broken.init.fail", exc_info=True)
+        try:
             buffer.record_error()
             if buffer.is_integration_broken():
                 self.disable_integration()
         except Exception:
+            if random_value == 0:
+                self.logger.error(
+                    "integration.disable_on_broken.record_request_error.fail", exc_info=True
+                )
             metrics.incr("integration.slack.disable_on_broken.redis")
             return
 
     def record_request_success(self, resp: Response):
         redis_key = self._get_redis_key()
+        random_value = randint(0, 99)
         if not len(redis_key):
             return
         try:
             buffer = IntegrationRequestBuffer(redis_key)
+        except Exception:
+            if random_value == 0:
+                self.logger.error("integration.disable_on_broken.init.fail", exc_info=True)
+        try:
             buffer.record_success()
         except Exception:
+            if random_value == 0:
+                self.logger.error(
+                    "integration.disable_on_broken.record_request_success.fail", exc_info=True
+                )
             metrics.incr("integration.slack.disable_on_broken.redis")
             return
 
     def record_request_fatal(self, resp: Response):
         redis_key = self._get_redis_key()
+        random_value = randint(0, 99)
         if not len(redis_key):
             return
         try:
             buffer = IntegrationRequestBuffer(redis_key)
+        except Exception:
+            if random_value == 0:
+                self.logger.error("integration.disable_on_broken.init.fail", exc_info=True)
+        try:
             buffer.record_fatal()
             if buffer.is_integration_broken():
                 self.disable_integration()
         except Exception:
+            if random_value == 0:
+                self.logger.error("integration.disable_on_broken.record_fatal.fail", exc_info=True)
             metrics.incr("integration.slack.disable_on_broken.redis")
             return
 


### PR DESCRIPTION
We're seeing metrics in Datadog ([here](https://app.datadoghq.com/dashboard/dei-yif-h45/integrations-health?fullscreen_end_ts=1690916299116&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1688324299116&fullscreen_widget=3848563232425218&from_ts=1688321711216&to_ts=1690913711216&live=true)) that there is a problem, but we need more information to debug it. Since the volume of metrics is so high, we're only capturing logs at a sampled rate.