### PR TITLE
fix(starfish): Remove `key` prop from SQL formatting spans

### DIFF
--- a/static/app/views/starfish/utils/sqlish/SQLishFormatter.spec.tsx
+++ b/static/app/views/starfish/utils/sqlish/SQLishFormatter.spec.tsx
@@ -27,6 +27,13 @@ describe('SQLishFormatter', function () {
       return container.innerHTML;
     };
 
+    beforeEach(() => {
+      // The renderer throws an error because elements in the list do not have
+      // a `"key"` prop, but that's intentional. The list elements are spans
+      // with no semantic meaning, and their keys are not meaningful.
+      jest.spyOn(console, 'error').mockImplementation(jest.fn());
+    });
+
     it('Capitalizes keywords', () => {
       expect(getMarkup(formatter.toSimpleMarkup('select hello'))).toEqual(
         '<b>SELECT</b><span> </span><span>hello</span>'

--- a/static/app/views/starfish/utils/sqlish/formatters/simpleMarkup.tsx
+++ b/static/app/views/starfish/utils/sqlish/formatters/simpleMarkup.tsx
@@ -11,13 +11,11 @@ export function simpleMarkup(tokens: Token[]): React.ReactElement[] {
 
     if (typeof content.content === 'string') {
       if (content.type === 'Keyword') {
-        accumulator.push(
-          <b key={toKey(content.content)}>{content.content.toUpperCase()}</b>
-        );
+        accumulator.push(<b>{content.content.toUpperCase()}</b>);
       } else if (content.type === 'Whitespace') {
-        accumulator.push(<span key={toKey(content.content)}> </span>);
+        accumulator.push(<span> </span>);
       } else {
-        accumulator.push(<span key={toKey(content.content)}>{content.content}</span>);
+        accumulator.push(<span>{content.content}</span>);
       }
     }
 
@@ -26,8 +24,4 @@ export function simpleMarkup(tokens: Token[]): React.ReactElement[] {
 
   tokens.forEach(contentize);
   return accumulator;
-}
-
-function toKey(content: string): string {
-  return content.toLowerCase();
 }


### PR DESCRIPTION
It was a mistake to add the keys. The keys are not meaningful whatsoever, they don't help mitigate list updates in any way. Instead, we should memoize this component in the future.

For now, this fixes annoying `key` prop noise in the console.
