### PR TITLE
feat(performance-tracing-without-performance): Not returning 404 when…

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -517,9 +517,14 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
         if event_id and not is_event_id(event_id):
             return Response({"detail": INVALID_ID_DETAILS.format("Event ID")}, status=400)
 
+        tracing_without_performance_enabled = features.has(
+            "organizations:performance-tracing-without-performance",
+            organization,
+            actor=request.user,
+        )
         with self.handle_query_errors():
             transactions, errors = query_trace_data(trace_id, params)
-            if len(transactions) == 0:
+            if len(transactions) == 0 and not tracing_without_performance_enabled:
                 return Response(status=404)
             self.record_analytics(transactions, trace_id, self.request.user.id, organization.id)
 


### PR DESCRIPTION
- For the project/task: https://getsentry.atlassian.net/browse/PERF-2052
- When feature flag is enabled:
- - Prevented event-trace and event-trace-light endpoints from returning 404s when no transactions exist in trace.
- The feature flag is only enabled for me.