### PR TITLE
fix(hybridcloud) Fix startup warnings for typing related issues.

### DIFF
--- a/src/sentry/services/hybrid_cloud/notifications/model.py
+++ b/src/sentry/services/hybrid_cloud/notifications/model.py
@@ -3,7 +3,9 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from typing import List, Optional, TypedDict
+from typing import List, Optional
+
+from typing_extensions import TypedDict
 
 from sentry.notifications.types import (
     NotificationScopeType,

--- a/src/sentry/services/hybrid_cloud/usersocialauth/impl.py
+++ b/src/sentry/services/hybrid_cloud/usersocialauth/impl.py
@@ -1,4 +1,7 @@
-from __future__ import annotations
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 from typing import Callable, List, Optional
 
@@ -22,7 +25,7 @@ class DatabaseBackedUserSocialAuthService(UserSocialAuthService):
     def get_many(self, *, filter: UserSocialAuthFilterArgs) -> List[RpcUserSocialAuth]:
         return self._FQ.get_many(filter=filter)
 
-    def get_one_or_none(self, *, filter: UserSocialAuthFilterArgs) -> RpcUserSocialAuth | None:
+    def get_one_or_none(self, *, filter: UserSocialAuthFilterArgs) -> Optional[RpcUserSocialAuth]:
         auths = self.get_many(filter=filter)
         if len(auths) == 0:
             return None

--- a/src/sentry/services/hybrid_cloud/usersocialauth/model.py
+++ b/src/sentry/services/hybrid_cloud/usersocialauth/model.py
@@ -3,7 +3,9 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from typing import Any, Dict, TypedDict
+from typing import Any, Dict
+
+from typing_extensions import TypedDict
 
 from sentry.services.hybrid_cloud import RpcModel
 from social_auth.utils import expiration_datetime, get_backend, tokens

--- a/src/sentry/services/hybrid_cloud/usersocialauth/service.py
+++ b/src/sentry/services/hybrid_cloud/usersocialauth/service.py
@@ -1,7 +1,10 @@
-from __future__ import annotations
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
-from typing import List, cast
+from typing import List, Optional, cast
 
 from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
@@ -34,7 +37,7 @@ class UserSocialAuthService(RpcService):
 
     @rpc_method
     @abstractmethod
-    def get_one_or_none(self, *, filter: UserSocialAuthFilterArgs) -> RpcUserSocialAuth | None:
+    def get_one_or_none(self, *, filter: UserSocialAuthFilterArgs) -> Optional[RpcUserSocialAuth]:
         """
         Returns the first RpcUserSocialAuth based on the given filters.
         """


### PR DESCRIPTION
These changes will resolve the following warnings during startup.

```
Error on parameter model for NotificationsService.get_many: You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` with Python < 3.9.2. Without it, there is no way to differentiate required and optional fields when subclassed.
Error on parameter model for UserSocialAuthService.revoke_token: Type annotations on RPC methods must be actual type tokens, not strings.
```