### PR TITLE
ref(alerts): Soft deprecate projectalertruledetails delete method

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -6,12 +6,10 @@ from rest_framework.response import Response
 from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
-from sentry.auth.superuser import is_active_superuser
 from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint
 from sentry.incidents.logic import AlreadyDeletedError, delete_alert_rule
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
-from sentry.models import OrganizationMemberTeam, SentryAppComponent, SentryAppInstallation
-from sentry.models.actor import ACTOR_TYPES
+from sentry.models import SentryAppComponent, SentryAppInstallation
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.user.service import user_service
@@ -93,30 +91,12 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         )
 
         if serializer.is_valid():
-            if not self._verify_user_has_permission(request, alert_rule):
-                return Response(
-                    {
-                        "detail": [
-                            "You do not have permission to edit this alert rule because you are not a member of the assigned team."
-                        ]
-                    },
-                    status=403,
-                )
             alert_rule = serializer.save()
             return Response(serialize(alert_rule, request.user), status=status.HTTP_200_OK)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request: Request, organization, alert_rule) -> Response:
-        if not self._verify_user_has_permission(request, alert_rule):
-            return Response(
-                {
-                    "detail": [
-                        "You do not have permission to delete this alert rule because you are not a member of the assigned team."
-                    ]
-                },
-                status=403,
-            )
         try:
             delete_alert_rule(
                 alert_rule, user=request.user, ip_address=request.META.get("REMOTE_ADDR")
@@ -126,13 +106,3 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
             return Response(
                 "This rule has already been deleted", status=status.HTTP_400_BAD_REQUEST
             )
-
-    def _verify_user_has_permission(self, request: Request, alert_rule):
-        if not is_active_superuser(request):
-            if alert_rule.owner and alert_rule.owner.type == ACTOR_TYPES["team"]:
-                team = alert_rule.owner.resolve()
-                if not OrganizationMemberTeam.objects.filter(
-                    organizationmember__user_id=request.user.id, team=team, is_active=True
-                ).exists():
-                    return False
-        return True

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -6,11 +6,8 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import AlertRuleSerializer
 from sentry.incidents.endpoints.bases import ProjectAlertRuleEndpoint
-from sentry.incidents.logic import (
-    AlreadyDeletedError,
-    delete_alert_rule,
-    get_slack_actions_with_async_lookups,
-)
+from sentry.incidents.endpoints.organization_alert_rule_details import remove_alert_rule
+from sentry.incidents.logic import get_slack_actions_with_async_lookups
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.utils.sentry_apps import trigger_sentry_app_action_creators_for_incidents
 from sentry.integrations.slack.utils import RedisRuleStatus
@@ -63,10 +60,9 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request: Request, project, alert_rule) -> Response:
-        try:
-            delete_alert_rule(alert_rule, request.user, ip_address=request.META.get("REMOTE_ADDR"))
-            return Response(status=status.HTTP_204_NO_CONTENT)
-        except AlreadyDeletedError:
-            return Response(
-                "This rule has already been deleted", status=status.HTTP_400_BAD_REQUEST
-            )
+        """
+        Delete a metric alert rule. @deprecated. Use OrganizationAlertRuleDetailsEndpoint instead.
+        ``````````````````
+        :auth: required
+        """
+        return remove_alert_rule(request, project.organization, alert_rule)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -521,7 +521,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
 
     def test_team_permission(self):
         # Test ensures you can only edit alerts owned by your team or no one.
-
         om = self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]
         )
@@ -537,7 +536,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         ).delete()
         with self.feature("organizations:incidents"):
             resp = self.get_response(self.organization.slug, alert_rule.id, **serialized_alert_rule)
-        assert resp.status_code == 403
+        assert resp.status_code == 200
         self.create_team_membership(team=self.team, member=om)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(
@@ -624,7 +623,10 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
         ).delete()
         with self.feature("organizations:incidents"):
             resp = self.get_response(self.organization.slug, alert_rule.id)
-        assert resp.status_code == 403
+        assert resp.status_code == 204
+        another_alert_rule = self.alert_rule
+        alert_rule.owner = self.team.actor
+        another_alert_rule.save()
         self.create_team_membership(team=self.team, member=om)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug, alert_rule.id, status_code=204)


### PR DESCRIPTION
Another follow up to https://github.com/getsentry/sentry/pull/53126 but for the `ProjectAlertRuleDetailsEndpoint` DELETE method. It's purpose is duplicated by the `OrganizationAlertRuleDetailsEndpoint`, so this PR removes the duplication by putting code into a shared function. 

Future PRs will address the GET and PUT methods, update any front end usages to use the `OrganizationAlertRuleDetailsEndpoint`, and later on we'll implement the real `@deprecated` decorator.