### PR TITLE
ref(replays): change widgets to be rage & dead clicks

### DIFF
--- a/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
+++ b/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
@@ -47,32 +47,7 @@ function ReplaysErroneousDeadRageCards() {
     location.query.end,
   ]);
 
-  const eventViewErrors = useMemo(() => {
-    return EventView.fromNewQueryWithLocation(
-      {
-        id: '',
-        name: '',
-        version: 2,
-        fields: [
-          'activity',
-          'duration',
-          'count_errors',
-          'id',
-          'project_id',
-          'user',
-          'finished_at',
-          'is_archived',
-          'started_at',
-        ],
-        projects: [],
-        query: 'count_errors:>0',
-        orderby: '-count_errors',
-      },
-      newLocation
-    );
-  }, [newLocation]);
-
-  const eventViewDeadRage = useMemo(() => {
+  const eventViewDead = useMemo(() => {
     return EventView.fromNewQueryWithLocation(
       {
         id: '',
@@ -82,6 +57,30 @@ function ReplaysErroneousDeadRageCards() {
           'activity',
           'duration',
           'count_dead_clicks',
+          'id',
+          'project_id',
+          'user',
+          'finished_at',
+          'is_archived',
+          'started_at',
+        ],
+        projects: [],
+        query: 'count_dead_clicks:>0',
+        orderby: '-count_dead_clicks',
+      },
+      newLocation
+    );
+  }, [newLocation]);
+
+  const eventViewRage = useMemo(() => {
+    return EventView.fromNewQueryWithLocation(
+      {
+        id: '',
+        name: '',
+        version: 2,
+        fields: [
+          'activity',
+          'duration',
           'count_rage_clicks',
           'id',
           'project_id',
@@ -102,40 +101,31 @@ function ReplaysErroneousDeadRageCards() {
   const hasDeadRageCards = organization.features.includes('replay-error-click-cards');
   const {hasSentOneReplay, fetching} = useHaveSelectedProjectsSentAnyReplayEvents();
 
-  const deadRageCols = [
-    ReplayColumn.MOST_RAGE_CLICKS,
-    ReplayColumn.COUNT_DEAD_CLICKS,
-    ReplayColumn.COUNT_RAGE_CLICKS,
-  ];
+  const deadCols = [ReplayColumn.MOST_DEAD_CLICKS, ReplayColumn.COUNT_DEAD_CLICKS];
 
-  const errorCols = [
-    ReplayColumn.MOST_ERRONEOUS_REPLAYS,
-    ReplayColumn.DURATION,
-    ReplayColumn.COUNT_ERRORS,
-    ReplayColumn.ACTIVITY,
-  ];
+  const rageCols = [ReplayColumn.MOST_RAGE_CLICKS, ReplayColumn.COUNT_RAGE_CLICKS];
 
   return hasSessionReplay && !fetching && hasSentOneReplay ? (
     hasDeadRageCards ? (
       <SplitCardContainer>
         <CardTable
-          eventView={eventViewErrors}
+          eventView={eventViewDead}
           location={newLocation}
           organization={organization}
-          visibleColumns={errorCols}
+          visibleColumns={deadCols}
           searchQuery={{
             ...location.query,
             cursor: undefined,
-            query: 'count_errors:>0',
-            sort: '-count_errors',
+            query: 'count_dead_clicks:>0',
+            sort: '-count_dead_clicks',
           }}
-          buttonLabel={t('Show all replays with errors')}
+          buttonLabel={t('Show all replays with dead clicks')}
         />
         <CardTable
-          eventView={eventViewDeadRage}
+          eventView={eventViewRage}
           location={newLocation}
           organization={organization}
-          visibleColumns={deadRageCols}
+          visibleColumns={rageCols}
           searchQuery={{
             ...location.query,
             cursor: undefined,

--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -67,6 +67,9 @@ function HeaderCell({column, sort}: Props) {
     case ReplayColumn.MOST_RAGE_CLICKS:
       return <SortableHeader label={t('Most rage clicks')} />;
 
+    case ReplayColumn.MOST_DEAD_CLICKS:
+      return <SortableHeader label={t('Most dead clicks')} />;
+
     case ReplayColumn.SLOWEST_TRANSACTION:
       return (
         <SortableHeader

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -59,7 +59,6 @@ function ReplayTable({
   const routes = useRoutes();
   const newLocation = useLocation();
   const organization = useOrganization();
-  const showBottomBorder = visibleColumns.includes(ReplayColumn.MOST_RAGE_CLICKS);
 
   const {
     selection: {projects},
@@ -96,7 +95,7 @@ function ReplayTable({
         data-test-id="replay-table"
         gridRows={undefined}
       >
-        <StyledAlert type="error" showIcon showBottomBorder={showBottomBorder}>
+        <StyledAlert type="error" showIcon>
           {typeof fetchError === 'string'
             ? fetchError
             : t(
@@ -109,7 +108,8 @@ function ReplayTable({
 
   if (
     needSDKUpgrade.needsUpdate &&
-    visibleColumns.includes(ReplayColumn.COUNT_DEAD_CLICKS)
+    (visibleColumns.includes(ReplayColumn.COUNT_DEAD_CLICKS) ||
+      visibleColumns.includes(ReplayColumn.COUNT_RAGE_CLICKS))
   ) {
     return (
       <StyledPanelTable
@@ -120,13 +120,11 @@ function ReplayTable({
         loader={<LoadingIndicator style={{margin: '54px auto'}} />}
         disablePadding
       >
-        <StyledAlert type="info" showIcon showBottomBorder={showBottomBorder}>
+        <StyledAlert type="info" showIcon>
           {tct('[data] requires [sdkPrompt]. [link:Upgrade now.]', {
             data: <strong>Rage and dead clicks</strong>,
             sdkPrompt: <strong>{t('SDK version >= 7.60.1')}</strong>,
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platforms/javascript/install/npm/" />
-            ),
+            link: <ExternalLink href="https://docs.sentry.io/platforms/javascript/" />,
           })}
         </StyledAlert>
       </StyledPanelTable>
@@ -205,7 +203,20 @@ function ReplayTable({
                       referrer={referrer}
                       showUrl={false}
                       eventView={eventView}
-                      referrer_table="dead-rage-table"
+                      referrer_table="rage-table"
+                    />
+                  );
+
+                case ReplayColumn.MOST_DEAD_CLICKS:
+                  return (
+                    <ReplayCell
+                      key="mostDeadClicks"
+                      replay={replay}
+                      organization={organization}
+                      referrer={referrer}
+                      showUrl={false}
+                      eventView={eventView}
+                      referrer_table="dead-table"
                     />
                   );
 
@@ -237,6 +248,7 @@ function ReplayTable({
 const flexibleColumns = [
   ReplayColumn.REPLAY,
   ReplayColumn.MOST_RAGE_CLICKS,
+  ReplayColumn.MOST_DEAD_CLICKS,
   ReplayColumn.MOST_ERRONEOUS_REPLAYS,
 ];
 
@@ -246,6 +258,7 @@ const StyledPanelTable = styled(PanelTable)<{
 }>`
   ${props =>
     props.visibleColumns.includes(ReplayColumn.MOST_RAGE_CLICKS) ||
+    props.visibleColumns.includes(ReplayColumn.MOST_DEAD_CLICKS) ||
     props.visibleColumns.includes(ReplayColumn.MOST_ERRONEOUS_REPLAYS)
       ? `border-bottom-left-radius: 0; border-bottom-right-radius: 0;`
       : ``}
@@ -264,12 +277,10 @@ const StyledPanelTable = styled(PanelTable)<{
       : `grid-template-rows: 44px max-content;`}
 `;
 
-const StyledAlert = styled(Alert)<{showBottomBorder?: boolean}>`
+const StyledAlert = styled(Alert)`
   border-radius: 0;
   grid-column: 1/-1;
   margin-bottom: 0;
-  ${props =>
-    props.showBottomBorder ? `border-width: 1px 0 1px 0;` : `border-width: 1px 0 0 0;`}
 `;
 
 export default ReplayTable;

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -29,7 +29,7 @@ type Props = {
   replay: ReplayListRecord | ReplayListRecordWithTx;
 };
 
-export type ReferrerTableType = 'main' | 'dead-rage-table' | 'errors-table';
+export type ReferrerTableType = 'main' | 'dead-table' | 'errors-table' | 'rage-table';
 
 function getUserBadgeUser(replay: Props['replay']) {
   return replay.is_archived
@@ -97,7 +97,9 @@ export function ReplayCell({
     switch (referrer_table) {
       case 'errors-table':
         return replayDetailsErrorTab;
-      case 'dead-rage-table':
+      case 'dead-table':
+        return replayDetailsDOMEventsTab;
+      case 'rage-table':
         return replayDetailsDOMEventsTab;
       default:
         return replayDetails;

--- a/static/app/views/replays/replayTable/types.tsx
+++ b/static/app/views/replays/replayTable/types.tsx
@@ -7,6 +7,7 @@ export enum ReplayColumn {
   DURATION = 'duration',
   MOST_ERRONEOUS_REPLAYS = 'mostErroneousReplays',
   MOST_RAGE_CLICKS = 'mostRageClicks',
+  MOST_DEAD_CLICKS = 'mostDeadClicks',
   OS = 'os',
   REPLAY = 'replay',
   SLOWEST_TRANSACTION = 'slowestTransaction',


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry/issues/53455

Refactored the replays index widgets to be most rage clicks and most dead clicks.

![SCR-20230801-mlko](https://github.com/getsentry/sentry/assets/56095982/f8789ae4-5867-4bcd-9b1a-a00669601e42)
![SCR-20230801-mneg](https://github.com/getsentry/sentry/assets/56095982/1c30d128-b2bd-4f7b-afea-ab3ca6a66905)
![SCR-20230801-mlvz](https://github.com/getsentry/sentry/assets/56095982/b954ffef-88a4-40ab-8537-0e150a86a220)
![SCR-20230801-mlra](https://github.com/getsentry/sentry/assets/56095982/79777679-b86a-417c-946a-b1fda029c40e)

