### PR TITLE
fix(dropdownMenu): Allow submenus to be toggled on mobile devices

### DIFF
--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -1,5 +1,5 @@
 import {forwardRef, Fragment, useContext, useEffect, useRef} from 'react';
-import {useHover, useKeyboard, usePress} from '@react-aria/interactions';
+import {useHover, useKeyboard} from '@react-aria/interactions';
 import {useMenuItem} from '@react-aria/menu';
 import {mergeProps} from '@react-aria/utils';
 import {TreeState} from '@react-stately/tree';
@@ -132,10 +132,6 @@ function BaseDropdownMenuItem(
 
   // Open submenu on hover
   const {hoverProps, isHovered} = useHover({});
-  // Toggle submenu on press
-  const {pressProps} = usePress({
-    onPress: () => state.selectionManager.toggleSelection(node.key),
-  });
   const prevIsHovered = usePrevious(isHovered);
   const prevIsFocused = usePrevious(isFocused);
   useEffect(() => {
@@ -200,13 +196,7 @@ function BaseDropdownMenuItem(
 
   // Merged menu item props, class names are combined, event handlers chained,
   // etc. See: https://react-spectrum.adobe.com/react-aria/mergeProps.html
-  const mergedProps = mergeProps(
-    props,
-    menuItemProps,
-    hoverProps,
-    keyboardProps,
-    pressProps
-  );
+  const mergedProps = mergeProps(props, menuItemProps, hoverProps, keyboardProps);
   const itemLabel = node.rendered ?? label;
   const innerWrapProps = {as: to ? Link : 'div', to};
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/53742, https://github.com/getsentry/sentry/issues/54134

`actionHandler` toggles the submenu, so the `onPress` handler is unnecessary (and was toggling it back to the same value).