### PR TITLE
fix(starfish): Improve time spent column formatting

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -127,7 +127,7 @@ export enum RateUnits {
 export const RATE_UNIT_LABELS = {
   [RateUnits.PER_SECOND]: '/s',
   [RateUnits.PER_MINUTE]: '/min',
-  [RateUnits.PER_HOUR]: '/h',
+  [RateUnits.PER_HOUR]: '/hr',
 };
 
 const CONDITIONS_ARGUMENTS: SelectValue<string>[] = [

--- a/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
+++ b/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export function TimeSpentCell({percentage, total}: Props) {
   const formattedPercentage = formatPercentage(clamp(percentage ?? 0, 0, 1));
-  const formattedTotal = getDuration((total ?? 0) / 1000, 2, true, true);
+  const formattedTotal = getDuration((total ?? 0) / 1000, 2, true);
   const tooltip = tct(
     'The application spent [percentage] of its total time on this span.',
     {

--- a/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
+++ b/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export function TimeSpentCell({percentage, total}: Props) {
   const formattedPercentage = formatPercentage(clamp(percentage ?? 0, 0, 1));
-  const formattedTotal = getDuration((total ?? 0) / 1000, 1, true, true);
+  const formattedTotal = getDuration((total ?? 0) / 1000, 2, true, true);
   const tooltip = tct(
     'The application spent [percentage] of its total time on this span.',
     {

--- a/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
+++ b/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import clamp from 'lodash/clamp';
 
 import {Tooltip} from 'sentry/components/tooltip';
@@ -24,10 +25,17 @@ export function TimeSpentCell({percentage, total}: Props) {
   return (
     <TextAlignRight>
       <Tooltip isHoverable title={tooltip} showUnderline>
-        {defined(total) ? formattedTotal : '--'} {'('}
-        {defined(percentage) ? formattedPercentage : '--%'}
-        {')'}
+        {defined(total) ? formattedTotal : '--'}
+        <Deemphasized>
+          {' ('}
+          {defined(percentage) ? formattedPercentage : '--%'}
+          {')'}
+        </Deemphasized>
       </Tooltip>
     </TextAlignRight>
   );
 }
+
+const Deemphasized = styled('span')`
+  color: ${p => p.theme.gray300};
+`;

--- a/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
+++ b/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export function TimeSpentCell({percentage, total}: Props) {
   const formattedPercentage = formatPercentage(clamp(percentage ?? 0, 0, 1));
-  const formattedTotal = getDuration((total ?? 0) / 1000, 1);
+  const formattedTotal = getDuration((total ?? 0) / 1000, 1, true, true);
   const tooltip = tct(
     'The application spent [percentage] of its total time on this span.',
     {


### PR DESCRIPTION
- Use extra-short abbreviations
- Show 2 decimal places
- Align rate units with short duration units
- De-emphasize the time spent percentage

**e.g.,**

![Screenshot 2023-08-01 at 5 54 54 PM](https://github.com/getsentry/sentry/assets/989898/28f7d71e-951a-4c90-971b-de9da86c8ccb)
