### PR TITLE
fix(grouping): Restore default value for `Variant.type`

### DIFF
--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from sentry.grouping.utils import hash_from_values, is_default_fingerprint_var
 
 
 class BaseVariant:
     # The type of the variant that is reported to the UI.
-    type: str
+    type: str | None = None
 
     # This is true if `get_hash` does not return `None`.
     contributes = True


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/53787, the default value for `Variant.type` was accidentally removed, causing `AttributeError`s. This restores it.

Fixes SENTRY-1485.