### PR TITLE
feat(opsgenie): refactor validation

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1339,7 +1339,7 @@ def get_alert_rule_trigger_action_opsgenie_team(
     use_async_lookup=False,
     input_channel_id=None,
     integrations=None,
-) -> tuple(str, str):
+) -> tuple[str, str]:
     from sentry.integrations.opsgenie.client import OpsgenieClient
     from sentry.integrations.opsgenie.utils import get_team
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1352,6 +1352,8 @@ def get_alert_rule_trigger_action_opsgenie_team(
 
     integration_key = team["integration_key"]
     integration = integration_service.get_integration(integration_id=integration_id)
+    if integration is None:
+        raise InvalidTriggerActionError("Opsgenie integration not found.")
     client = OpsgenieClient(
         integration=integration,
         integration_key=integration_key,

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1339,7 +1339,7 @@ def get_alert_rule_trigger_action_opsgenie_team(
     use_async_lookup=False,
     input_channel_id=None,
     integrations=None,
-):
+) -> tuple(str, str):
     from sentry.integrations.opsgenie.client import OpsgenieClient
     from sentry.integrations.opsgenie.utils import get_team
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -42,7 +42,7 @@ from sentry.search.events.fields import resolve_field
 from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation, app_service
 from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcOrganizationIntegration
-from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
+from sentry.shared_integrations.exceptions import ApiError, DuplicateDisplayNameError
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import (
     ENTITY_TIME_COLUMNS,
@@ -1340,6 +1340,7 @@ def get_alert_rule_trigger_action_opsgenie_team(
     input_channel_id=None,
     integrations=None,
 ):
+    from sentry.integrations.opsgenie.client import OpsgenieClient
     from sentry.integrations.opsgenie.utils import get_team
 
     oi = integration_service.get_organization_integration(
@@ -1348,6 +1349,18 @@ def get_alert_rule_trigger_action_opsgenie_team(
     team = get_team(target_value, oi)
     if not team:
         raise InvalidTriggerActionError("No Opsgenie team found.")
+
+    integration_key = team["integration_key"]
+    integration = integration_service.get_integration(integration_id=integration_id)
+    client = OpsgenieClient(
+        integration=integration,
+        integration_key=integration_key,
+        org_integration_id=oi.id,
+    )
+    try:
+        client.authorize_integration(type="sentry")
+    except ApiError:
+        raise InvalidTriggerActionError("Invalid integration key.")
     return team["id"], team["team"]
 
 

--- a/src/sentry/integrations/opsgenie/actions/form.py
+++ b/src/sentry/integrations/opsgenie/actions/form.py
@@ -5,9 +5,18 @@ from typing import Any, Mapping
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+from sentry.integrations.opsgenie.client import OpsgenieClient
 from sentry.integrations.opsgenie.utils import get_team
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.services.hybrid_cloud.integration.model import RpcOrganizationIntegration
+from sentry.services.hybrid_cloud.integration.model import (
+    RpcIntegration,
+    RpcOrganizationIntegration,
+)
+from sentry.shared_integrations.exceptions import ApiError
+
+INVALID_TEAM = 1
+INVALID_KEY = 2
+VALID = 3
 
 
 def _validate_int_field(field: str, cleaned_data: Mapping[str, Any]) -> int | None:
@@ -47,24 +56,61 @@ class OpsgenieNotifyTeamForm(forms.Form):
         self.fields["team"].widget.choices = self.fields["team"].choices
 
     def _team_is_valid(
-        self, team_id: str | None, org_integration: RpcOrganizationIntegration | None
-    ) -> bool:
-        return True if get_team(team_id, org_integration) is not None else False
+        self,
+        team_id: str | None,
+        integration: RpcIntegration | None,
+        org_integration: RpcOrganizationIntegration | None,
+    ) -> int:
+        team = get_team(team_id, org_integration)
+        if not team:
+            return INVALID_TEAM
+
+        integration_key = team["integration_key"]
+        client = OpsgenieClient(
+            integration=integration,
+            integration_key=integration_key,
+            org_integration_id=org_integration.id,
+        )
+        # the integration should be of type "sentry"
+        # there's no way to authenticate that a key is an integration key
+        # without specifying the type... even though the type is arbitrary
+        # and all integration keys do the same thing
+        try:
+            client.authorize_integration(type="sentry")
+        except ApiError:
+            return INVALID_KEY
+
+        return VALID
 
     def _validate_team(self, team_id: str | None, integration_id: int | None) -> None:
         params = {
             "account": dict(self.fields["account"].choices).get(integration_id),
             "team": dict(self.fields["team"].choices).get(team_id),
         }
+        integration = integration_service.get_integration(
+            integration_id=integration_id, provider="opsgenie"
+        )
         org_integration = integration_service.get_organization_integration(
             integration_id=integration_id,
             organization_id=self.org_id,
         )
 
-        if not self._team_is_valid(team_id=team_id, org_integration=org_integration):
+        team_status = self._team_is_valid(
+            team_id=team_id, integration=integration, org_integration=org_integration
+        )
+        if team_status == INVALID_TEAM:
             raise forms.ValidationError(
                 _('The team "%(team)s" does not belong to the %(account)s Opsgenie account.'),
-                code="invalid",
+                code="invalid_team",
+                params=params,
+            )
+        elif team_status == INVALID_KEY:
+            raise forms.ValidationError(
+                _(
+                    'The provided API key is invalid. Please make sure that the Opsgenie API \
+                  key is an integration key of type "sentry".'
+                ),
+                code="invalid_key",
                 params=params,
             )
 

--- a/src/sentry/integrations/opsgenie/actions/form.py
+++ b/src/sentry/integrations/opsgenie/actions/form.py
@@ -16,7 +16,7 @@ from sentry.shared_integrations.exceptions import ApiError
 
 INVALID_TEAM = 1
 INVALID_KEY = 2
-VALID = 3
+VALID_TEAM = 3
 
 
 def _validate_int_field(field: str, cleaned_data: Mapping[str, Any]) -> int | None:
@@ -55,7 +55,7 @@ class OpsgenieNotifyTeamForm(forms.Form):
         self.fields["team"].choices = teams
         self.fields["team"].widget.choices = self.fields["team"].choices
 
-    def _team_is_valid(
+    def _get_team_status(
         self,
         team_id: str | None,
         integration: RpcIntegration | None,
@@ -82,7 +82,7 @@ class OpsgenieNotifyTeamForm(forms.Form):
         except ApiError:
             return INVALID_KEY
 
-        return VALID
+        return VALID_TEAM
 
     def _validate_team(self, team_id: str | None, integration_id: int | None) -> None:
         params = {
@@ -97,7 +97,7 @@ class OpsgenieNotifyTeamForm(forms.Form):
             organization_id=self.org_id,
         )
 
-        team_status = self._team_is_valid(
+        team_status = self._get_team_status(
             team_id=team_id, integration=integration, org_integration=org_integration
         )
         if team_status == INVALID_TEAM:

--- a/src/sentry/integrations/opsgenie/actions/form.py
+++ b/src/sentry/integrations/opsgenie/actions/form.py
@@ -66,6 +66,8 @@ class OpsgenieNotifyTeamForm(forms.Form):
             return INVALID_TEAM
 
         integration_key = team["integration_key"]
+        assert integration is not None
+        assert org_integration is not None
         client = OpsgenieClient(
             integration=integration,
             integration_key=integration_key,

--- a/src/sentry/integrations/opsgenie/actions/form.py
+++ b/src/sentry/integrations/opsgenie/actions/form.py
@@ -58,16 +58,14 @@ class OpsgenieNotifyTeamForm(forms.Form):
     def _get_team_status(
         self,
         team_id: str | None,
-        integration: RpcIntegration | None,
-        org_integration: RpcOrganizationIntegration | None,
+        integration: RpcIntegration,
+        org_integration: RpcOrganizationIntegration,
     ) -> int:
         team = get_team(team_id, org_integration)
         if not team:
             return INVALID_TEAM
 
         integration_key = team["integration_key"]
-        assert integration is not None
-        assert org_integration is not None
         client = OpsgenieClient(
             integration=integration,
             integration_key=integration_key,
@@ -96,7 +94,12 @@ class OpsgenieNotifyTeamForm(forms.Form):
             integration_id=integration_id,
             organization_id=self.org_id,
         )
-
+        if integration is None or org_integration is None:
+            raise forms.ValidationError(
+                _("The Opsgenie integration does not exist."),
+                code="invalid_integration",
+                params=params,
+            )
         team_status = self._get_team_status(
             team_id=team_id, integration=integration, org_integration=org_integration
         )
@@ -110,7 +113,7 @@ class OpsgenieNotifyTeamForm(forms.Form):
             raise forms.ValidationError(
                 _(
                     'The provided API key is invalid. Please make sure that the Opsgenie API \
-                  key is an integration key of type "sentry".'
+                  key is an integration key of type "Sentry".'
                 ),
                 code="invalid_key",
                 params=params,

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -58,6 +58,12 @@ class OpsgenieClient(IntegrationProxyClient):
         headers = {"Authorization": "GenieKey " + self.integration_key}
         return self.get(path=path, headers=headers, params=params)
 
+    def authorize_integration(self, type: str) -> BaseApiResponseX:
+        body = {"type": type}
+        path = "/integrations/authenticate"
+        headers = {"Authorization": "GenieKey " + self.integration_key}
+        return self.post(path=path, headers=headers, data=body)
+
     def _get_rule_urls(self, group, rules):
         organization = group.project.organization
         rule_urls = []

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -137,7 +137,10 @@ class OpsgenieIntegration(IntegrationInstallation):
                 "label": "Opsgenie teams with the Sentry integration enabled",
                 "help": "If teams need to be updated, deleted, or added manually please do so here. Alert rules will need to be individually updated for any additions or deletions of teams.",
                 "addButtonText": "",
-                "columnLabels": {"team": "Opsgenie Team", "integration_key": "Integration Key"},
+                "columnLabels": {
+                    "team": "Opsgenie Integration",
+                    "integration_key": "Integration Key",
+                },
                 "columnKeys": ["team", "integration_key"],
                 "confirmDeleteMessage": "Any alert rules associated with this team will stop working. The rules will still exist but will show a `removed` team.",
             }

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -134,15 +134,16 @@ class OpsgenieIntegration(IntegrationInstallation):
             {
                 "name": "team_table",
                 "type": "table",
-                "label": "Opsgenie teams with the Sentry integration enabled",
-                "help": "If teams need to be updated, deleted, or added manually please do so here. Alert rules will need to be individually updated for any additions or deletions of teams.",
+                "label": "Opsgenie integrations",
+                "help": "If integration keys need to be updated, deleted, or added manually please do so here. Your keys must be associated with a 'Sentry' Integration in Opsgenie. \
+                Alert rules will need to be individually updated for any key additions or deletions.",
                 "addButtonText": "",
                 "columnLabels": {
                     "team": "Opsgenie Integration",
                     "integration_key": "Integration Key",
                 },
                 "columnKeys": ["team", "integration_key"],
-                "confirmDeleteMessage": "Any alert rules associated with this team will stop working. The rules will still exist but will show a `removed` team.",
+                "confirmDeleteMessage": "Any alert rules associated with this integration will stop working. The rules will still exist but will show a `removed` team.",
             }
         ]
 

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -36,8 +36,8 @@ class OpsgenieActionHandlerTest(FireTest, TestCase):
 
         resp_data = {
             "result": "Integration [sentry] is valid",
-            "took": 0.093,
-            "requestId": "a0199601-0245-4ed9-b7d7-0752e2f4824b",
+            "took": 1,
+            "requestId": "hello-world",
         }
         responses.add(
             responses.POST,
@@ -63,8 +63,8 @@ class OpsgenieActionHandlerTest(FireTest, TestCase):
         )
         resp_data = {
             "result": "Integration [sentry] is valid",
-            "took": 0.093,
-            "requestId": "a0199601-0245-4ed9-b7d7-0752e2f4824b",
+            "took": 1,
+            "requestId": "hello-world",
         }
         responses.add(
             responses.POST,

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1650,8 +1650,8 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
 
         resp_data = {
             "result": "Integration [sentry] is valid",
-            "took": 0.093,
-            "requestId": "a0199601-0245-4ed9-b7d7-0752e2f4824b",
+            "took": 1,
+            "requestId": "hello-world",
         }
         responses.add(
             responses.POST,

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1630,6 +1630,7 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
                 integration_id=integration.id,
             )
 
+    @responses.activate
     def test_opsgenie(self):
         metadata = {
             "api_key": "1234-ABCD",
@@ -1646,6 +1647,17 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
         )
         org_integration.config = {"team_table": [team]}
         org_integration.save()
+
+        resp_data = {
+            "result": "Integration [sentry] is valid",
+            "took": 0.093,
+            "requestId": "a0199601-0245-4ed9-b7d7-0752e2f4824b",
+        }
+        responses.add(
+            responses.POST,
+            url="https://api.opsgenie.com/v2/integrations/authenticate",
+            json=resp_data,
+        )
 
         type = AlertRuleTriggerAction.Type.OPSGENIE
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC

--- a/tests/sentry/integrations/opsgenie/test_client.py
+++ b/tests/sentry/integrations/opsgenie/test_client.py
@@ -1,6 +1,6 @@
 import responses
 
-from sentry.models import Integration, OrganizationIntegration, Rule
+from sentry.models import Integration, Rule
 from sentry.testutils.cases import APITestCase
 from sentry.utils import json
 
@@ -32,20 +32,19 @@ class OpsgenieClientTest(APITestCase):
         assert client.integration_key == METADATA["api_key"]
 
     @responses.activate
-    def test_get_team_id(self):
+    def test_authorize_integration(self):
         client = self.installation.get_client(integration_key="1234-5678")
 
-        org_integration = OrganizationIntegration.objects.get(
-            organization_id=self.organization.id, integration_id=self.integration.id
-        )
-        org_integration.config = {
-            "team_table": [{"id": "", "team": "cool-team", "integration_key": "1234-5678"}]
+        resp_data = {
+            "result": "Integration [sentry] is valid",
+            "took": 0.093,
+            "requestId": "a0199601-0245-4ed9-b7d7-0752e2f4824b",
         }
-        org_integration.save()
-        resp_data = {"data": {"id": "123-id", "name": "cool-team"}}
-        responses.add(responses.GET, url=f"{client.base_url}/teams/cool-team", json=resp_data)
+        responses.add(
+            responses.POST, url=f"{client.base_url}/integrations/authenticate", json=resp_data
+        )
 
-        resp = client.get_team_id(team_name="cool-team")
+        resp = client.authorize_integration(type="sentry")
         assert resp == resp_data
 
     @responses.activate

--- a/tests/sentry/integrations/opsgenie/test_client.py
+++ b/tests/sentry/integrations/opsgenie/test_client.py
@@ -37,8 +37,8 @@ class OpsgenieClientTest(APITestCase):
 
         resp_data = {
             "result": "Integration [sentry] is valid",
-            "took": 0.093,
-            "requestId": "a0199601-0245-4ed9-b7d7-0752e2f4824b",
+            "took": 1,
+            "requestId": "hello-world",
         }
         responses.add(
             responses.POST, url=f"{client.base_url}/integrations/authenticate", json=resp_data
@@ -51,8 +51,8 @@ class OpsgenieClientTest(APITestCase):
     def test_send_notification(self):
         resp_data = {
             "result": "Request will be processed",
-            "took": 0.302,
-            "requestId": "43a29c5c-3dbf-4fa4-9c26-f4f71023e120",
+            "took": 1,
+            "requestId": "hello-world",
         }
         responses.add(responses.POST, url="https://api.opsgenie.com/v2/alerts", json=resp_data)
 

--- a/tests/sentry/integrations/opsgenie/test_integration.py
+++ b/tests/sentry/integrations/opsgenie/test_integration.py
@@ -101,17 +101,15 @@ class OpsgenieIntegrationTest(IntegrationTestCase):
 
         integration.add_organization(self.organization, self.user)
         installation = integration.get_installation(self.organization.id)
-        opsgenie_client = installation.get_client(integration_key=METADATA["api_key"])
+
+        integration = Integration.objects.get(provider=self.provider.key)
+        org_integration = OrganizationIntegration.objects.get(integration_id=integration.id)
 
         data = {"team_table": [{"id": "", "team": "cool-team", "integration_key": "1234-5678"}]}
-        resp_data = {"data": {"id": "123-id", "name": "cool-team"}}
-        responses.add(
-            responses.GET, url=f"{opsgenie_client.base_url}/teams/cool-team", json=resp_data
-        )
-
         installation.update_organization_config(data)
+        team_id = str(org_integration.id) + "-" + "cool-team"
         assert installation.get_config_data() == {
-            "team_table": [{"id": "123-id", "team": "cool-team", "integration_key": "1234-5678"}]
+            "team_table": [{"id": team_id, "team": "cool-team", "integration_key": "1234-5678"}]
         }
 
     @responses.activate
@@ -122,10 +120,26 @@ class OpsgenieIntegrationTest(IntegrationTestCase):
 
         integration.add_organization(self.organization, self.user)
         installation = integration.get_installation(self.organization.id)
-        opsgenie_client = installation.get_client(integration_key="1234-bad")
 
-        data = {"team_table": [{"id": "", "team": "cool-team", "integration_key": "1234-bad"}]}
-        responses.add(responses.GET, url=f"{opsgenie_client.base_url}/teams/cool-team")
+        org_integration = OrganizationIntegration.objects.get(integration_id=integration.id)
+        team_id = str(org_integration.id) + "-" + "cool-team"
+
+        # valid
+        data = {"team_table": [{"id": "", "team": "cool-team", "integration_key": "1234"}]}
+        installation.update_organization_config(data)
+        assert installation.get_config_data() == {
+            "team_table": [{"id": team_id, "team": "cool-team", "integration_key": "1234"}]
+        }
+
+        # try duplicate name
+        data = {
+            "team_table": [
+                {"id": team_id, "team": "cool-team", "integration_key": "1234"},
+                {"id": "", "team": "cool-team", "integration_key": "1234"},
+            ]
+        }
         with pytest.raises(ValidationError):
             installation.update_organization_config(data)
-        assert installation.get_config_data() == {}
+        assert installation.get_config_data() == {
+            "team_table": [{"id": team_id, "team": "cool-team", "integration_key": "1234"}]
+        }

--- a/tests/sentry/integrations/opsgenie/test_notify_action.py
+++ b/tests/sentry/integrations/opsgenie/test_notify_action.py
@@ -111,8 +111,8 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
     def test_valid_team_selected(self):
         resp_data = {
             "result": "Integration [sentry] is valid",
-            "took": 0.093,
-            "requestId": "a0199601-0245-4ed9-b7d7-0752e2f4824b",
+            "took": 1,
+            "requestId": "hello-world",
         }
         responses.add(
             responses.POST,
@@ -143,8 +143,8 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
 
         resp_data = {
             "result": "Integration [sentry] is valid",
-            "took": 0.093,
-            "requestId": "a0199601-0245-4ed9-b7d7-0752e2f4824b",
+            "took": 1,
+            "requestId": "hello-world",
         }
         responses.add(
             responses.POST,
@@ -193,8 +193,8 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
     def test_bad_integration_key(self):
         resp_data = {
             "message": "API Key does not belong to a [sentry] integration.",
-            "took": 0.001,
-            "requestId": "fe435ce4-4ef2-43c7-b0eb-dc70840ebd42",
+            "took": 1,
+            "requestId": "goodbye-world",
         }
         responses.add(
             responses.POST,


### PR DESCRIPTION
Refactor key validation to allow all types of integration keys. Check that keys are valid upon alert rule save/update.

Fixes ER-1772
Fixes ER-1773
Fixes ER-1774