### PR TITLE
feat(issues): Prompt to setup releases in resolve dropdown

### DIFF
--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -193,4 +193,16 @@ describe('ResolveActions', function () {
     expect(screen.getByText('The current release')).toBeInTheDocument();
     expect(screen.getByText('1.2.3 (semver)')).toBeInTheDocument();
   });
+
+  it('displays prompt to setup releases when there are no releases', async function () {
+    const organization = TestStubs.Organization({
+      features: ['issue-resolve-release-setup'],
+    });
+    render(<ResolveActions onUpdate={spy} hasRelease={false} projectSlug="proj-1" />, {
+      organization,
+    });
+
+    await userEvent.click(screen.getByLabelText('More resolve options'));
+    expect(screen.getByText('Resolving is better with Releases')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Displays a prompt to setup releases in the resolve button "more options" dropdown


![image](https://github.com/getsentry/sentry/assets/1400464/5a79dd8f-2c0a-42ed-adba-78c2370ab5e8)
