### PR TITLE
feat(open_pr_comments): PR comment qualification check

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -214,6 +214,15 @@ class GitHubClientMixin(GithubProxyClient):
         pullrequest: JSONData = self.get(f"/repos/{repo}/commits/{sha}/pulls")
         return pullrequest
 
+    def get_pullrequest(self, repo: str, pull_number: int) -> JSONData:
+        """
+        https://docs.github.com/en/free-pro-team@latest/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
+
+        Returns the pull request details
+        """
+        pullrequest: JSONData = self.get(f"/repos/{repo}/pulls/{pull_number}")
+        return pullrequest
+
     def get_repo(self, repo: str) -> JSONData:
         """
         https://docs.github.com/en/rest/repos/repos#get-a-repository

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -16,7 +16,7 @@ from sentry.integrations.github.client import GitHubAppsClient
 from sentry.models import Group, GroupOwnerType, Project
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
-from sentry.models.pullrequest import CommentType, PullRequestComment
+from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComment
 from sentry.models.repository import Repository
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions.base import ApiError
@@ -51,6 +51,13 @@ SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url})"
 ISSUE_LOCKED_ERROR_MESSAGE = "Unable to create comment because issue is locked."
 
 RATE_LIMITED_MESSAGE = "API rate limit exceeded"
+
+OPEN_PR_METRIC_BASE = "github_open_pr_comment.{key}"
+
+# Caps the number of files that can be modified in a PR to leave a comment
+OPEN_PR_MAX_FILES_CHANGED = 10
+# Caps the number of lines that can be modified in a PR to leave a comment
+OPEN_PR_MAX_LINES_CHANGED = 500
 
 
 def format_comment(issues: List[PullRequestIssue]):
@@ -318,3 +325,43 @@ def github_comment_reactions():
             continue
 
         metrics.incr("github_pr_comment.comment_reactions.success")
+
+
+# TODO(adas): Change the client typing to allow for multiple SCM Integrations
+def safe_for_comment(
+    gh_client: GitHubAppsClient, repository: Repository, pull_request: PullRequest
+) -> bool:
+    try:
+        pullrequest_resp = gh_client.get_pullrequest(
+            repo=repository.name, pull_number=pull_request.key
+        )
+    except ApiError as e:
+        if e.json and RATE_LIMITED_MESSAGE in e.json.get("message", ""):
+            metrics.incr(
+                OPEN_PR_METRIC_BASE.format(key="api_error"),
+                tags={"type": "gh_rate_limited", "code": e.code},
+            )
+        elif e.code == 404:
+            metrics.incr(
+                OPEN_PR_METRIC_BASE.format(key="api_error"),
+                tags={"type": "missing_gh_pull_request", "code": e.code},
+            )
+        else:
+            metrics.incr(
+                OPEN_PR_METRIC_BASE.format(key="api_error"),
+                tags={"type": "unknown_api_error", "code": e.code},
+            )
+        raise e
+
+    safe_to_comment = True
+    if pullrequest_resp["changed_files"] > OPEN_PR_MAX_FILES_CHANGED:
+        metrics.incr(
+            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "too_many_files"}
+        )
+        safe_to_comment = False
+    if pullrequest_resp["additions"] + pullrequest_resp["deletions"] > OPEN_PR_MAX_LINES_CHANGED:
+        metrics.incr(
+            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "too_many_lines"}
+        )
+        safe_to_comment = False
+    return safe_to_comment

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -351,7 +351,8 @@ def safe_for_comment(
                 OPEN_PR_METRIC_BASE.format(key="api_error"),
                 tags={"type": "unknown_api_error", "code": e.code},
             )
-        raise e
+            logger.exception("github.open_pr_comment.unknown_api_error")
+        return False
 
     safe_to_comment = True
     if pullrequest_resp["changed_files"] > OPEN_PR_MAX_FILES_CHANGED:

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -847,8 +847,7 @@ class TestSafeForComment(GithubCommentTestCase):
             responses.GET, self.gh_path.format(pull_number=self.pr.key), status=404, json={}
         )
 
-        with pytest.raises(ApiError):
-            safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
         self.mock_metrics.incr.assert_called_with(
             "github_open_pr_comment.api_error",
             tags={"type": "missing_gh_pull_request", "code": 404},
@@ -860,8 +859,7 @@ class TestSafeForComment(GithubCommentTestCase):
             responses.GET, self.gh_path.format(pull_number=self.pr.key), status=400, json={}
         )
 
-        with pytest.raises(ApiError):
-            safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
         self.mock_metrics.incr.assert_called_with(
             "github_open_pr_comment.api_error", tags={"type": "unknown_api_error", "code": 400}
         )


### PR DESCRIPTION
For the MVP of open pr comments, we want to limit the size of the PRs that we leave a comment on. This function will return False if a PR has more than 10 files modified, or more than 500 lines modified. In all the error or fail cases, we increment a metric that will be used in a future dashboard

