### PR TITLE
ref(alerts): Use OrganizationAlertRuleDetails Endpoint

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -755,7 +755,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
 
     try {
       await this.api.requestPromise(
-        `/projects/${organization.slug}/${projectId}/alert-rules/${ruleId}/`,
+        `/organizations/${organization.slug}/${projectId}/alert-rules/${ruleId}/`,
         {
           method: 'DELETE',
         }


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/53630 and a follow up to https://github.com/getsentry/sentry/pull/53970 to replace the only usage we have of the `ProjectAlertRuleDetailsEndpoint` DELETE method with the `OrganizationAlertRuleDetailsEndpoint` one.