### PR TITLE
ref(getting-started-docs): Make project deletion onBack enabled by default

### DIFF
--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -165,9 +165,6 @@ describe('Onboarding', function () {
     };
 
     const {routerProps, routerContext, organization} = initializeOrg({
-      organization: {
-        features: ['onboarding-project-deletion-on-back-click'],
-      },
       router: {
         params: routeParams,
       },
@@ -258,9 +255,6 @@ describe('Onboarding', function () {
     };
 
     const {routerProps, routerContext, organization} = initializeOrg({
-      organization: {
-        features: ['onboarding-project-deletion-on-back-click'],
-      },
       router: {
         params: routeParams,
       },

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -138,12 +138,7 @@ function Onboarding(props: Props) {
     props.location.pathname,
   ]);
 
-  const projectDeletionOnBackClick = !!organization?.features.includes(
-    'onboarding-project-deletion-on-back-click'
-  );
-
   const shallProjectBeDeleted =
-    projectDeletionOnBackClick &&
     onboardingSteps[stepIndex].id === 'setup-docs' &&
     recentCreatedProject &&
     // if the project has received a first error, we don't delete it

--- a/static/app/views/projectInstall/platformDocHeader.tsx
+++ b/static/app/views/projectInstall/platformDocHeader.tsx
@@ -28,17 +28,12 @@ export function PlatformDocHeader({platform, projectSlug}: Props) {
   const api = useApi();
   const router = useRouter();
 
-  const projectDeletionOnBackClick = !!organization?.features.includes(
-    'onboarding-project-deletion-on-back-click'
-  );
-
   const recentCreatedProject = useRecentCreatedProject({
     orgSlug: organization.slug,
     projectSlug,
   });
 
   const shallProjectBeDeleted =
-    projectDeletionOnBackClick &&
     recentCreatedProject &&
     // if the project has received a first error, we don't delete it
     recentCreatedProject.firstError === false &&


### PR DESCRIPTION
We have made the decision to enable the project deletion feature by default during the onboarding/project creation flow. As a result, this pull request (PR) removes the feature flag associated with this functionality.