### PR TITLE
fix: remove invite_link from backend api response

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/expand/roles.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/roles.py
@@ -65,7 +65,6 @@ class OrganizationMemberWithRolesSerializer(OrganizationMemberWithTeamsSerialize
         )
 
         if self.allowed_roles:
-            context["invite_link"] = obj.get_invite_link()
             context["user"] = attrs.get("serializedUser", {})
 
         context["isOnlyOwner"] = obj.is_only_owner()

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -71,7 +71,7 @@ class GetOrganizationMemberTest(OrganizationMemberTestBase):
         self.get_error_response(self.organization.slug, join_request.id, status_code=404)
         self.get_error_response(self.organization.slug, invite_request.id, status_code=404)
 
-    def test_superuser_can_get_invite_link(self):
+    def test_invite_link_does_not_exist(self):
         pending_om = self.create_member(
             user=None,
             email="bar@example.com",
@@ -81,7 +81,7 @@ class GetOrganizationMemberTest(OrganizationMemberTestBase):
         )
 
         response = self.get_success_response(self.organization.slug, pending_om.id)
-        assert response.data["invite_link"] == pending_om.get_invite_link()
+        assert "invite_link" not in response.data
 
     def test_member_cannot_get_invite_link(self):
         pending_om = self.create_member(
@@ -198,7 +198,7 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
         member_om = OrganizationMember.objects.get(id=member_om.id)
         assert old_invite != member_om.get_invite_link()
         mock_send_invite_email.assert_called_once_with()
-        assert response.data["invite_link"] == member_om.get_invite_link()
+        assert "invite_link" not in response.data
         self.assert_org_member_mapping(org_member=member_om)
 
     @patch("sentry.models.OrganizationMember.send_invite_email")


### PR DESCRIPTION
Removes the invite_link from the backend API response.

Requires https://github.com/getsentry/sentry/pull/53978