### PR TITLE
chore(statistical-detectors): Add options to enable statistical detec…

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1428,3 +1428,22 @@ register(
 
 # The flag activates whether to send group attributes messages to kafka
 register("issues.group_attributes.send_kafka", default=False, flags=FLAG_MODIFIABLE_BOOL)
+
+# Enables statistical detectors for a project
+register(
+    "statistical_detectors.enable",
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "statistical_detectors.enable.projects.performance",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "statistical_detectors.enable.projects.profiling",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
…tors

Options to allow us to control if statistical detectors are enabled or not and which projects to run it on.