### PR TITLE
fix(starfish): Database module chart improvements

### DIFF
--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -113,15 +113,17 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
   if (diffInMinutes > SIX_HOURS) {
     // Between six hours and 24 hours
     if (fidelity === 'high') {
-      return '30m';
+      return '5m';
     }
+
     if (fidelity === 'medium') {
-      return '1h';
+      return '15m';
     }
+
     if (fidelity === 'metrics') {
       return '5m';
     }
-    return '6h';
+    return '1h';
   }
 
   if (diffInMinutes > ONE_HOUR) {

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -78,7 +78,7 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
       return '4h';
     }
     if (fidelity === 'metrics') {
-      return '1d';
+      return '12h';
     }
     return '1d';
   }
@@ -91,13 +91,13 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
       return '1h';
     }
     if (fidelity === 'metrics') {
-      return '1h';
+      return '4h';
     }
     return '12h';
   }
 
   if (diffInMinutes > TWENTY_FOUR_HOURS) {
-    // Greater than 24 hours
+    // Between 24 hours and 14 days
     if (fidelity === 'high') {
       return '30m';
     }
@@ -105,13 +105,27 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
       return '1h';
     }
     if (fidelity === 'metrics') {
+      return '30m';
+    }
+    return '6h';
+  }
+
+  if (diffInMinutes > SIX_HOURS) {
+    // Between six hours and 24 hours
+    if (fidelity === 'high') {
+      return '30m';
+    }
+    if (fidelity === 'medium') {
       return '1h';
+    }
+    if (fidelity === 'metrics') {
+      return '5m';
     }
     return '6h';
   }
 
   if (diffInMinutes > ONE_HOUR) {
-    // Between 1 hour and 24 hours
+    // Between 1 hour and 6 hours
     if (fidelity === 'high') {
       return '5m';
     }
@@ -119,7 +133,7 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
       return '15m';
     }
     if (fidelity === 'metrics') {
-      return '1h';
+      return '1m';
     }
     return '1h';
   }

--- a/static/app/views/starfish/utils/constants.tsx
+++ b/static/app/views/starfish/utils/constants.tsx
@@ -1,4 +1,4 @@
 // This constant is to be used as an arg for `getInterval`.
 // 'metrics' fidelity is intended to match the granularities of stored metrics.
 // This gives us the best/highest fidelity of data for minimum amount of work (don't need to merge buckets).
-export const STARFISH_CHART_INTERVAL_FIDELITY = 'high';
+export const STARFISH_CHART_INTERVAL_FIDELITY = 'metrics';

--- a/static/app/views/starfish/utils/constants.tsx
+++ b/static/app/views/starfish/utils/constants.tsx
@@ -1,4 +1,4 @@
 // This constant is to be used as an arg for `getInterval`.
 // 'metrics' fidelity is intended to match the granularities of stored metrics.
 // This gives us the best/highest fidelity of data for minimum amount of work (don't need to merge buckets).
-export const STARFISH_CHART_INTERVAL_FIDELITY = 'metrics';
+export const STARFISH_CHART_INTERVAL_FIDELITY = 'high';

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -54,7 +54,7 @@ const DEFAULT_SORT: Sort = {
   field: 'time_spent_percentage(local)',
 };
 
-const CHART_HEIGHT = 140;
+const CHART_HEIGHT = 160;
 
 type Props = {
   location: Location;

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -54,6 +54,8 @@ const DEFAULT_SORT: Sort = {
   field: 'time_spent_percentage(local)',
 };
 
+const CHART_HEIGHT = 140;
+
 type Props = {
   location: Location;
 } & RouteComponentProps<{groupId: string}, {transaction: string}>;
@@ -246,7 +248,7 @@ function SpanSummaryPage({params, location}: Props) {
                       title={getThroughputChartTitle(span?.[SpanMetricsFields.SPAN_OP])}
                     >
                       <Chart
-                        height={140}
+                        height={CHART_HEIGHT}
                         data={[spanMetricsThroughputSeries]}
                         loading={areSpanMetricsSeriesLoading}
                         utc={false}
@@ -266,7 +268,7 @@ function SpanSummaryPage({params, location}: Props) {
                   <Block>
                     <ChartPanel title={DataTitles.avg}>
                       <Chart
-                        height={140}
+                        height={CHART_HEIGHT}
                         data={[
                           spanMetricsSeriesData?.[
                             `avg(${SpanMetricsFields.SPAN_SELF_TIME})`
@@ -285,7 +287,7 @@ function SpanSummaryPage({params, location}: Props) {
                     <Block>
                       <ChartPanel title={DataTitles.errorCount}>
                         <Chart
-                          height={140}
+                          height={CHART_HEIGHT}
                           data={[spanMetricsSeriesData?.[`http_error_count()`]]}
                           loading={areSpanMetricsSeriesLoading}
                           utc={false}

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -25,7 +25,7 @@ import {NULL_SPAN_CATEGORY} from 'sentry/views/starfish/views/webServiceView/spa
 
 const {SPAN_SELF_TIME, SPAN_OP, SPAN_MODULE, SPAN_DESCRIPTION} = SpanMetricsFields;
 
-const CHART_HEIGHT = 100;
+const CHART_HEIGHT = 140;
 
 type Props = {
   appliedFilters: AppliedFilters;

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -25,6 +25,8 @@ import {NULL_SPAN_CATEGORY} from 'sentry/views/starfish/views/webServiceView/spa
 
 const {SPAN_SELF_TIME, SPAN_OP, SPAN_MODULE, SPAN_DESCRIPTION} = SpanMetricsFields;
 
+const CHART_HEIGHT = 100;
+
 type Props = {
   appliedFilters: AppliedFilters;
   moduleName: ModuleName;
@@ -123,7 +125,7 @@ function ThroughputChart({moduleName, filters}: ChartProps): JSX.Element {
 
   return (
     <Chart
-      height={100}
+      height={CHART_HEIGHT}
       data={throughputTimeSeries}
       loading={isLoading}
       utc={false}
@@ -179,7 +181,7 @@ function DurationChart({moduleName, filters}: ChartProps): JSX.Element {
 
   return (
     <Chart
-      height={100}
+      height={CHART_HEIGHT}
       data={[...avgSeries]}
       loading={isLoading}
       utc={false}
@@ -213,7 +215,7 @@ function ErrorChart({moduleName, filters}: ChartProps): JSX.Element {
 
   return (
     <Chart
-      height={100}
+      height={CHART_HEIGHT}
       data={[errorRateSeries]}
       loading={isLoading}
       utc={false}


### PR DESCRIPTION
- Increase chart height. 100 and 140 is very squashy, let's give them some breathing room
- Increase metrics fidelity!

The `"metrics"` granularity of intervals has this behaviour:

- 60+ days we return a minimum of 60 points, maximum 90
- 30+ days it's minimum 30, maximum 60
- 14+ days it's minimum 336, maximum 672
- 24+ hours it's min 24, max 336
- 1+ hour it's min 1, maximum 24
- <1 hour it's min 1, maximum 60

That's a little uneven! With this change, every time range above an hour has a minimum of ~60 data points (even though IMO it's still not enough)

- 60+ days we return a minimum of 60 points, maximum 90
- 30+ days it's minimum 60, maximum 120
- 14+ days it's minimum 84, maximum 180
- 24+ hours it's min 48, max 672
- 6+ hours it's min 72, max 288
- 1+ hour it's min 60, maximum 360
- <1 hour it's min 1, maximum 60
