### PR TITLE
ref(starfish): Show 3 significant digits for queries per minute

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -79,6 +79,8 @@ export type RenderFunctionBaggage = {
   location: Location;
   organization: Organization;
   eventView?: EventView;
+  // The number of significant digits to display for integer and float values.
+  precision?: number;
   projectSlug?: string;
   unit?: string;
 };
@@ -233,13 +235,13 @@ export const FIELD_FORMATTERS: FieldFormatters = {
   rate: {
     isSortable: true,
     renderFunc: (field, data, baggage) => {
-      const {unit} = baggage ?? {};
-
-      return (
-        <NumberContainer>
-          {`${formatAbbreviatedNumber(data[field])}${unit ? RATE_UNIT_LABELS[unit] : ''}`}
-        </NumberContainer>
-      );
+      const {unit, precision} = baggage ?? {};
+      const renderedUnit = unit ? RATE_UNIT_LABELS[unit] : '';
+      const formattedNumber = `${formatAbbreviatedNumber(
+        data[field],
+        precision
+      )}${renderedUnit}`;
+      return <NumberContainer>{formattedNumber}</NumberContainer>;
     },
   },
   integer: {

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -79,8 +79,6 @@ export type RenderFunctionBaggage = {
   location: Location;
   organization: Organization;
   eventView?: EventView;
-  // The number of significant digits to display for integer and float values.
-  precision?: number;
   projectSlug?: string;
   unit?: string;
 };
@@ -120,6 +118,8 @@ type FieldFormatters = {
 };
 
 export type FieldTypes = keyof FieldFormatters;
+
+const DEFAULT_RATE_SIG_DIGITS = 3;
 
 const EmptyValueContainer = styled('span')`
   color: ${p => p.theme.gray300};
@@ -235,11 +235,11 @@ export const FIELD_FORMATTERS: FieldFormatters = {
   rate: {
     isSortable: true,
     renderFunc: (field, data, baggage) => {
-      const {unit, precision} = baggage ?? {};
+      const {unit} = baggage ?? {};
       const renderedUnit = unit ? RATE_UNIT_LABELS[unit] : '';
       const formattedNumber = `${formatAbbreviatedNumber(
         data[field],
-        precision
+        DEFAULT_RATE_SIG_DIGITS
       )}${renderedUnit}`;
       return <NumberContainer>{formattedNumber}</NumberContainer>;
     },

--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -205,8 +205,10 @@ describe('formatAbbreviatedNumber()', function () {
 
   it('should round to set amount of significant digits', () => {
     expect(formatAbbreviatedNumber(100.12, 3)).toBe('100');
+    expect(formatAbbreviatedNumber(199.99, 3)).toBe('200');
     expect(formatAbbreviatedNumber(1500, 3)).toBe('1.5k');
     expect(formatAbbreviatedNumber(1213122, 3)).toBe('1.21m');
+    expect(formatAbbreviatedNumber(1500000000000, 3)).toBe('1500b');
 
     expect(formatAbbreviatedNumber('1249.23421', 3)).toBe('1.25k');
     expect(formatAbbreviatedNumber('1239567891299', 3)).toBe('1240b');

--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -202,6 +202,16 @@ describe('formatAbbreviatedNumber()', function () {
     expect(formatAbbreviatedNumber(1500)).toBe('1.5k');
     expect(formatAbbreviatedNumber(1213122)).toBe('1.2m');
   });
+
+  it('should round to set amount of significant digits', () => {
+    expect(formatAbbreviatedNumber(100.12, 3)).toBe('100');
+    expect(formatAbbreviatedNumber(1500, 3)).toBe('1.5k');
+    expect(formatAbbreviatedNumber(1213122, 3)).toBe('1.21m');
+
+    expect(formatAbbreviatedNumber('1249.23421', 3)).toBe('1.25k');
+    expect(formatAbbreviatedNumber('1239567891299', 3)).toBe('1240b');
+    expect(formatAbbreviatedNumber('158.80421626984128', 3)).toBe('159');
+  });
 });
 
 describe('formatFloat()', function () {

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -286,7 +286,16 @@ const numberFormats = [
   [1000, 'k'],
 ] as const;
 
-export function formatAbbreviatedNumber(number: number | string) {
+/**
+ * Formats a number to a string with a suffix
+ *
+ * @param number the number to format
+ * @param precision the number of significant digits to include
+ */
+export function formatAbbreviatedNumber(
+  number: number | string,
+  precision?: number
+): string {
   number = Number(number);
 
   let lookup: (typeof numberFormats)[number];
@@ -301,12 +310,21 @@ export function formatAbbreviatedNumber(number: number | string) {
       continue;
     }
 
-    return shortValue / 10 > 1 || !fitsBound
-      ? `${shortValue}${suffix}`
-      : `${formatFloat(number / suffixNum, 1)}${suffix}`;
+    const formattedNumber =
+      shortValue / 10 > 1 || !fitsBound
+        ? shortValue
+        : formatFloat(number / suffixNum, precision || 1);
+
+    const formattedNumberWithPercision =
+      precision === undefined
+        ? formattedNumber
+        : parseFloat(formattedNumber.toPrecision(precision));
+    return `${formattedNumberWithPercision}${suffix}`;
   }
 
-  return number.toLocaleString();
+  return precision === undefined
+    ? number.toLocaleString()
+    : number.toPrecision(precision);
 }
 
 export function formatRate(value: number, unit: RateUnits = RateUnits.PER_SECOND) {

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -312,19 +312,17 @@ export function formatAbbreviatedNumber(
 
     const formattedNumber =
       shortValue / 10 > 1 || !fitsBound
-        ? shortValue
-        : formatFloat(number / suffixNum, precision || 1);
+        ? precision === undefined
+          ? shortValue
+          : parseFloat(shortValue.toPrecision(precision)).toString()
+        : formatFloat(number / suffixNum, precision || 1).toLocaleString(undefined, {
+            maximumSignificantDigits: precision,
+          });
 
-    const formattedNumberWithPercision =
-      precision === undefined
-        ? formattedNumber
-        : parseFloat(formattedNumber.toPrecision(precision));
-    return `${formattedNumberWithPercision}${suffix}`;
+    return `${formattedNumber}${suffix}`;
   }
 
-  return precision === undefined
-    ? number.toLocaleString()
-    : number.toPrecision(precision);
+  return number.toLocaleString(undefined, {maximumSignificantDigits: precision});
 }
 
 export function formatRate(value: number, unit: RateUnits = RateUnits.PER_SECOND) {

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -10,10 +10,7 @@ import Pagination, {CursorHandler} from 'sentry/components/pagination';
 import {Organization} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {EventsMetaType} from 'sentry/utils/discover/eventView';
-import {
-  getFieldRenderer,
-  RenderFunctionBaggage,
-} from 'sentry/utils/discover/fieldRenderers';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -62,12 +59,10 @@ const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_DOMAIN, SPAN_GROUP, SPAN_OP} =
   SpanMetricsFields;
 const {TIME_SPENT_PERCENTAGE, SPS, SPM, HTTP_ERROR_COUNT} = StarfishFunctions;
 
-const SPM_COLUMN_KEY = `${SPM}()`;
-
 const SORTABLE_FIELDS = new Set([
   `avg(${SPAN_SELF_TIME})`,
   `${SPS}()`,
-  SPM_COLUMN_KEY,
+  `${SPM}()`,
   `${TIME_SPENT_PERCENTAGE}()`,
   `${TIME_SPENT_PERCENTAGE}(local)`,
   `${HTTP_ERROR_COUNT}()`,
@@ -175,17 +170,11 @@ function renderBodyCell(
 
   const renderer = getFieldRenderer(column.key, meta.fields, false);
 
-  const rendererBaggage: RenderFunctionBaggage = {
+  const rendered = renderer(row, {
     location,
     organization,
     unit: meta.units?.[column.key],
-  };
-
-  if (column.key === SPM_COLUMN_KEY) {
-    rendererBaggage.precision = 3;
-  }
-
-  const rendered = renderer(row, rendererBaggage);
+  });
 
   return rendered;
 }


### PR DESCRIPTION
1. Add precision arg to `formatAbbreviatedNumber` to set # of significant digits
2. ~Update `getFieldRenderer` renderer baggage to use precision, which is what starfish spans table consumes~ Update `getFieldRenderer` rate renderer to use constant precision of 3 for sig digs.

### Before

<img width="883" alt="image" src="https://github.com/getsentry/sentry/assets/18689448/8db228e4-80a2-49e3-8776-73985e2b54cf">

### After

<img width="887" alt="image" src="https://github.com/getsentry/sentry/assets/18689448/c5464e21-3173-4a64-8b78-7c9d9bad4ea7">
