### PR TITLE
meta(gitignore): Ignore user-specific VSCode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .cache/
+.code-workspace
 .coverage*
 .DS_Store
 .venv


### PR DESCRIPTION
VSCode has two mechanisms for pulling in repository-local settings, which are applied on top of the global user settings.json: a settings.json file in the /.vscode directory, and a .code-workspace file at the root of the repository. We already track the first of these in git, to enforce some team-scope settings for all users of the repository. This change adds the second method, .code-workspace, to the .gitignore list, allowing users to change their settings if they have a very compelling reason (ex, VSCode running the formatter very slowly, which is what prompted this change).