### PR TITLE
fix(starfish): Remove http method if already on transaction

### DIFF
--- a/static/app/views/starfish/views/webServiceView/endpointList.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointList.tsx
@@ -81,8 +81,9 @@ function EndpointList({eventView, location, organization, setError}: Props) {
 
     if (field === 'transaction') {
       let prefix = '';
-      if (dataRow['http.method']) {
-        prefix = `${dataRow['http.method']} `;
+      const method = dataRow['http.method'];
+      if (method && !(dataRow.transaction as string).startsWith(method as string)) {
+        prefix = `${method} `;
       }
 
       return (

--- a/static/app/views/starfish/views/webServiceView/endpointList.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointList.tsx
@@ -80,11 +80,11 @@ function EndpointList({eventView, location, organization, setError}: Props) {
     const rendered = fieldRenderer(dataRow, {organization, location});
 
     if (field === 'transaction') {
-      let prefix = '';
       const method = dataRow['http.method'];
-      if (method && !(dataRow.transaction as string).startsWith(method as string)) {
-        prefix = `${method} `;
-      }
+      const prefix =
+        method && !dataRow.transaction.toString().startsWith(method.toString())
+          ? `${method} `
+          : '';
 
       return (
         <Link

--- a/static/app/views/starfish/views/webServiceView/endpointList.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointList.tsx
@@ -81,10 +81,10 @@ function EndpointList({eventView, location, organization, setError}: Props) {
 
     if (field === 'transaction') {
       const method = dataRow['http.method'];
-      const prefix =
+      const endpointName =
         method && !dataRow.transaction.toString().startsWith(method.toString())
-          ? `${method} `
-          : '';
+          ? `${method} ${dataRow.transaction}`
+          : dataRow.transaction;
 
       return (
         <Link
@@ -106,8 +106,7 @@ function EndpointList({eventView, location, organization, setError}: Props) {
             });
           }}
         >
-          {prefix}
-          {dataRow.transaction}
+          {endpointName}
         </Link>
       );
     }


### PR DESCRIPTION
Some SDKs send `http.method` as part of the description. To prevent rendering duplicate methods (for ex. `GET GET /route`), this patch updates the body cell renderer to only set an http method if it has not been defined already.

### Before

<img width="1245" alt="image" src="https://github.com/getsentry/sentry/assets/18689448/1a3fa1d7-afb9-4411-b045-78c63a97f6f4">

### After

<img width="1266" alt="image" src="https://github.com/getsentry/sentry/assets/18689448/dfccc62d-6b83-4352-a6cf-5be51622d8bf">
