### PR TITLE
ref: remove unused request.timezone attribute stuffing

### DIFF
--- a/src/sentry/middleware/locale.py
+++ b/src/sentry/middleware/locale.py
@@ -1,4 +1,3 @@
-import pytz
 import sentry_sdk
 from django.conf import settings
 from django.http.request import HttpRequest
@@ -47,9 +46,6 @@ class SentryLocaleMiddleware(LocaleMiddleware):
         if language := get_option_from_list(options, key="language"):
             # TODO: django 4.x removes this from session
             request.session[translation.LANGUAGE_SESSION_KEY] = language  # type: ignore[attr-defined]
-
-        if timezone := get_option_from_list(options, key="timezone"):
-            request.timezone = pytz.timezone(timezone)  # type: ignore[attr-defined]
 
     def process_response(
         self, request: HttpRequest, response: HttpResponseBase


### PR DESCRIPTION
last used in 5c93fc10da5a09724e72580475c3ccf624e8fd80