### PR TITLE
fix(github-comments): specify comment task minute

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1110,7 +1110,7 @@ CELERYBEAT_SCHEDULE_REGION = {
     },
     "github_comment_reactions": {
         "task": "sentry.tasks.integrations.github_comment_reactions",
-        "schedule": crontab(hour=16),  # 9:00 PDT, 12:00 EDT, 16:00 UTC
+        "schedule": crontab(minute=0, hour=16),  # 9:00 PDT, 12:00 EDT, 16:00 UTC
     },
     "poll_recap_servers": {
         "task": "sentry.tasks.poll_recap_servers",


### PR DESCRIPTION
We are having comment tasks running once a day for every minute within the 16th hour of the day. We just want it to run once, so we need to specify the minute for it to run only for that 1 minute in the 16th hour.