### PR TITLE
fix(replays): fix network alert formatting and make copy-pasteable

### DIFF
--- a/static/app/views/replays/detail/network/details/onboarding.spec.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.spec.tsx
@@ -62,7 +62,7 @@ describe('Setup', () => {
       expect(
         screen.getByText(
           textWithMarkupMatcher(
-            'Add /api/0/issues/1234 to your networkDetailAllowUrls list to start capturing data.'
+            'Add the following to your networkDetailAllowUrls list to start capturing data:'
           )
         )
       ).toBeInTheDocument();
@@ -83,7 +83,7 @@ describe('Setup', () => {
       expect(
         screen.getByText(
           textWithMarkupMatcher(
-            'Add /api/0/issues/1234 to your networkDetailAllowUrls list to start capturing data.'
+            'Add the following to your networkDetailAllowUrls list to start capturing data:'
           )
         )
       ).toBeInTheDocument();

--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -1,8 +1,10 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {IconClose, IconInfo} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -172,6 +174,10 @@ function SetupInstructions({
     );
   }
 
+  function trimUrl(oldUrl: string): string {
+    return oldUrl.substring(0, oldUrl.indexOf('?'));
+  }
+
   const urlSnippet = `
       networkDetailAllowUrls: ['${url}'],`;
   const headersSnippet = `
@@ -212,12 +218,27 @@ function SetupInstructions({
         )}
       </p>
       {showSnippet === Output.URL_SKIPPED && url !== '[Filtered]' && (
-        <Alert type="warning">
-          {tct('Add [url] to your [field] list to start capturing data.', {
-            url: <code>{url}</code>,
-            field: <code>networkDetailAllowUrls</code>,
-          })}
-        </Alert>
+        <Fragment>
+          {tct(
+            'Add the following to your [field] list to start capturing data: [alert] ',
+            {
+              field: <code>networkDetailAllowUrls</code>,
+              alert: (
+                <NetworkAlert type="warning">
+                  <StyledCopyButton
+                    borderless
+                    iconSize="xs"
+                    size="xs"
+                    text={trimUrl(url)}
+                  />
+                  {tct('[url]', {
+                    url: <code>{trimUrl(url)}</code>,
+                  })}
+                </NetworkAlert>
+              ),
+            }
+          )}
+        </Fragment>
       )}
       {showSnippet === Output.BODY_SKIPPED && (
         <Alert type="warning">
@@ -246,6 +267,21 @@ function SetupInstructions({
     </StyledInstructions>
   );
 }
+
+const StyledCopyButton = styled(CopyToClipboardButton)`
+  position: sticky;
+  display: fixed;
+  top: 0;
+  right: 0;
+  padding: ${space(0.25)};
+`;
+
+const NetworkAlert = styled(Alert)`
+  white-space: nowrap;
+  overflow: auto;
+  margin: ${space(0.5)} ${space(0.5)} ${space(2)} 0;
+  padding: ${space(0.75)};
+`;
 
 const NoMarginAlert = styled(Alert)`
   margin: 0;

--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -270,7 +270,7 @@ function SetupInstructions({
 
 const StyledCopyButton = styled(CopyToClipboardButton)`
   float: right;
-  margin-top: ${space(0)};
+  margin-top: 0;
 `;
 
 const NetworkAlert = styled(Alert)`

--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -269,18 +269,14 @@ function SetupInstructions({
 }
 
 const StyledCopyButton = styled(CopyToClipboardButton)`
-  position: sticky;
-  display: fixed;
-  top: 0;
-  right: 0;
-  padding: ${space(0.25)};
+  float: right;
+  margin-top: ${space(0)};
 `;
 
 const NetworkAlert = styled(Alert)`
-  white-space: nowrap;
-  overflow: auto;
+  overflow-wrap: break-word;
   margin: ${space(0.5)} ${space(0.5)} ${space(2)} 0;
-  padding: ${space(0.75)};
+  padding: ${space(1)};
 `;
 
 const NoMarginAlert = styled(Alert)`

--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -269,14 +269,16 @@ function SetupInstructions({
 }
 
 const StyledCopyButton = styled(CopyToClipboardButton)`
-  float: right;
-  margin-top: 0;
+  position: sticky;
+  display: fixed;
+  padding: ${space(0.5)} ${space(0.75)};
 `;
 
 const NetworkAlert = styled(Alert)`
-  overflow-wrap: break-word;
-  margin: ${space(0.5)} ${space(0.5)} ${space(2)} 0;
-  padding: ${space(1)};
+  white-space: nowrap;
+  overflow: auto;
+  margin: ${space(0.5)} 0 ${space(2)} 0;
+  padding: ${space(0.75)};
 `;
 
 const NoMarginAlert = styled(Alert)`

--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -1,11 +1,10 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
-import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import ExternalLink from 'sentry/components/links/externalLink';
+import TextCopyInput from 'sentry/components/textCopyInput';
 import {IconClose, IconInfo} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -179,7 +178,7 @@ function SetupInstructions({
   }
 
   const urlSnippet = `
-      networkDetailAllowUrls: ['${url}'],`;
+      networkDetailAllowUrls: ['${trimUrl(url)}'],`;
   const headersSnippet = `
       networkRequestHeaders: ['X-Custom-Header'],
       networkResponseHeaders: ['X-Custom-Header'],`;
@@ -217,29 +216,17 @@ function SetupInstructions({
           }
         )}
       </p>
-      {showSnippet === Output.URL_SKIPPED && url !== '[Filtered]' && (
-        <Fragment>
-          {tct(
+      <NetworkUrlWrapper>
+        {showSnippet === Output.URL_SKIPPED &&
+          url !== '[Filtered]' &&
+          tct(
             'Add the following to your [field] list to start capturing data: [alert] ',
             {
               field: <code>networkDetailAllowUrls</code>,
-              alert: (
-                <NetworkAlert type="warning">
-                  <StyledCopyButton
-                    borderless
-                    iconSize="xs"
-                    size="xs"
-                    text={trimUrl(url)}
-                  />
-                  {tct('[url]', {
-                    url: <code>{trimUrl(url)}</code>,
-                  })}
-                </NetworkAlert>
-              ),
+              alert: <StyledTextCopyInput>{trimUrl(url)}</StyledTextCopyInput>,
             }
           )}
-        </Fragment>
-      )}
+      </NetworkUrlWrapper>
       {showSnippet === Output.BODY_SKIPPED && (
         <Alert type="warning">
           {tct('Enable [field] to capture both Request and Response bodies.', {
@@ -268,17 +255,12 @@ function SetupInstructions({
   );
 }
 
-const StyledCopyButton = styled(CopyToClipboardButton)`
-  position: sticky;
-  display: fixed;
-  padding: ${space(0.5)} ${space(0.75)};
+const StyledTextCopyInput = styled(TextCopyInput)`
+  margin-top: ${space(0.5)};
 `;
 
-const NetworkAlert = styled(Alert)`
-  white-space: nowrap;
-  overflow: auto;
-  margin: ${space(0.5)} 0 ${space(2)} 0;
-  padding: ${space(0.75)};
+const NetworkUrlWrapper = styled('div')`
+  margin: ${space(1)} ${space(0)} ${space(1.5)} ${space(0)};
 `;
 
 const NoMarginAlert = styled(Alert)`


### PR DESCRIPTION
Before:
<img width="573" alt="SCR-20230802-ngth" src="https://github.com/getsentry/sentry/assets/56095982/00632b16-1056-4676-ac06-3c39fa855fba">


After:

<img width="610" alt="SCR-20230802-ocvp" src="https://github.com/getsentry/sentry/assets/56095982/b8c88a6b-5353-488a-9ae3-6df1c35c7667">
<img width="603" alt="SCR-20230802-oema" src="https://github.com/getsentry/sentry/assets/56095982/eff41bac-297f-4541-9e5a-18378ea9f9be">




Fixes https://github.com/getsentry/sentry/issues/50108
