### PR TITLE
ref(tests): Add tests for `group.created` metric

### DIFF
--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from sentry.constants import LOG_LEVELS_MAP
 from sentry.issues.grouptype import (
+    ErrorGroupType,
     GroupCategory,
     GroupType,
     GroupTypeRegistry,
@@ -125,26 +126,40 @@ class ProcessOccurrenceDataTest(OccurrenceTestMixin, TestCase):
 @region_silo_test
 class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
     def test_new_group(self) -> None:
-        occurrence = self.build_occurrence()
-        event = self.store_event(data={}, project_id=self.project.id)
-        group_info = save_issue_from_occurrence(occurrence, event, None)
-        assert group_info is not None
-        assert group_info.is_new
-        assert not group_info.is_regression
-        group = group_info.group
-        assert group.title == occurrence.issue_title
-        assert group.platform == event.platform
-        assert group.level == LOG_LEVELS_MAP.get(occurrence.level)
-        assert group.last_seen == event.datetime
-        assert group.first_seen == event.datetime
-        assert group.active_at == event.datetime
-        assert group.issue_type == occurrence.type
-        assert group.first_release is None
-        assert group.title == occurrence.issue_title
-        assert group.data["metadata"]["value"] == occurrence.subtitle
-        assert group.culprit == occurrence.culprit
-        assert group.message == "<unlabeled event> something bad happened it was bad api/123"
-        assert group.location() == event.location
+        occurrence = self.build_occurrence(type=ErrorGroupType.type_id)
+        event = self.store_event(
+            data={"platform": "javascript"},
+            project_id=self.project.id,
+        )
+
+        with patch("sentry.issues.ingest.metrics.incr") as mock_metrics_incr:
+            group_info = save_issue_from_occurrence(occurrence, event, None)
+            assert group_info is not None
+            assert group_info.is_new
+            assert not group_info.is_regression
+
+            group = group_info.group
+            assert group.title == occurrence.issue_title
+            assert group.platform == event.platform
+            assert group.level == LOG_LEVELS_MAP.get(occurrence.level)
+            assert group.last_seen == event.datetime
+            assert group.first_seen == event.datetime
+            assert group.active_at == event.datetime
+            assert group.issue_type == occurrence.type
+            assert group.first_release is None
+            assert group.title == occurrence.issue_title
+            assert group.data["metadata"]["value"] == occurrence.subtitle
+            assert group.culprit == occurrence.culprit
+            assert group.message == "<unlabeled event> something bad happened it was bad api/123"
+            assert group.location() == event.location
+            mock_metrics_incr.assert_any_call(
+                "group.created",
+                skip_internal=True,
+                tags={
+                    "platform": "javascript",
+                    "type": ErrorGroupType.type_id,
+                },
+            )
 
     def test_existing_group(self) -> None:
         event = self.store_event(data={}, project_id=self.project.id)


### PR DESCRIPTION
This adds tests for the two spots in which we log the `group.created` metric - in `save_error_events` and `save_issue_from_occurrence`.