### PR TITLE
fix(hybridcloud) Don't attempt RPC based authentication in RPC requests

### DIFF
--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -112,6 +112,12 @@ class HybridCloudAuthenticationMiddleware(MiddlewareMixin):
     def process_request(self, request: Request):
         from sentry.web.frontend.accounts import expired
 
+        if request.path.startswith("/api/0/internal/rpc/"):
+            # Avoid doing RPC authentication when we're already
+            # in an RPC request.
+            request.user = AnonymousUser()
+            return
+
         auth_result = auth_service.authenticate(request=authentication_request_from(request))
         request.user_from_signed_request = auth_result.user_from_signed_request
 

--- a/tests/sentry/middleware/test_auth.py
+++ b/tests/sentry/middleware/test_auth.py
@@ -131,6 +131,17 @@ class AuthenticationMiddlewareTestCase(TestCase):
         assert request.user.is_anonymous
         assert request.auth is None
 
+    def test_process_request_rpc_path_ignored(self):
+        request = self.make_request(
+            method="GET", path="/api/0/internal/rpc/organization/get_organization_by_id"
+        )
+        request.META["HTTP_AUTHORIZATION"] = b"Rpcsignature not-a-checksum"
+
+        self.middleware.process_request(request)
+        # No errors, and no user identified.
+        assert request.user.is_anonymous
+        assert request.auth is None
+
     @patch("sentry.models.userip.geo_by_addr")
     def test_process_request_log_userip(self, mock_geo_by_addr):
         mock_geo_by_addr.return_value = {


### PR DESCRIPTION
If we're handling an RPC request, we should not attempt RPC based authentication as RPC requests include request signatures, and no other forms of authentication. Skipping this auth request in the middleware makes the dev environment much faster, and hopefully helps resolve the errors we're seeing in the siloed test environment.
