### PR TITLE
fix(ingest): Stop clobbering existing event metadata

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1480,7 +1480,7 @@ EventMetadata = Dict[str, Any]
 
 
 def materialize_metadata(
-    data: Mapping[str, Any], event_type: EventType, event_metadata: Mapping[str, Any]
+    data: Mapping[str, Any], event_type: EventType, event_metadata: dict[str, Any]
 ) -> EventMetadata:
     """Returns the materialized metadata to be merged with group or
     event data.  This currently produces the keys `type`, `culprit`,
@@ -1489,6 +1489,9 @@ def materialize_metadata(
 
     # XXX(markus): Ideally this wouldn't take data or event_type, and instead
     # calculate culprit + type from event_metadata
+
+    # Don't clobber existing metadata
+    event_metadata.update(data.get("metadata", {}))
 
     return {
         "type": event_type.key,

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -125,6 +125,8 @@ def materialize_metadata(occurrence: IssueOccurrence, event: Event) -> Occurrenc
     event_type = get_event_type(event.data)
     event_metadata = dict(event_type.get_metadata(event.data))
     event_metadata = dict(event_metadata)
+    # Don't clobber existing metadata
+    event_metadata.update(event.get_event_metadata())
     event_metadata["title"] = occurrence.issue_title
     event_metadata["value"] = occurrence.subtitle
 

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -262,7 +262,7 @@ class CreateIssueKwargsTest(OccurrenceTestMixin, TestCase):
 
 
 class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):
-    def test(self) -> None:
+    def test_simple(self) -> None:
         occurrence = self.build_occurrence()
         event = self.store_event(data={}, project_id=self.project.id)
         assert materialize_metadata(occurrence, event) == {
@@ -272,6 +272,19 @@ class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):
             "title": occurrence.issue_title,
             "location": event.location,
             "last_received": json.datetime_to_str(event.datetime),
+        }
+
+    def test_preserves_existing_metadata(self) -> None:
+        occurrence = self.build_occurrence()
+        event = self.store_event(data={}, project_id=self.project.id)
+        event.data.setdefault("metadata", {})
+        event.data["metadata"]["dogs"] = "are great"  # should not get clobbered
+
+        materialized = materialize_metadata(occurrence, event)
+        assert materialized["metadata"] == {
+            "title": occurrence.issue_title,
+            "value": occurrence.subtitle,
+            "dogs": "are great",
         }
 
 


### PR DESCRIPTION
During ingest, while saving an event, we use `materialize_metadata` to gather metadata to add to the event, both as top-level properties like `title` and `culprit` and as information in the event's `metadata` property. The data it returns is then assigned to properties on the event. The intention is not to overwrite anything - it's just assumed that none of the returned data is yet there. If there is data already there, though, specifically in the `metadata` dictionary, it's lost. This fixes that by merging the existing entries in `metadata` with the incoming ones.

Note: This required changing the type of one of the parameters in `EventManager`'s version of `materialize_metadata` from `Mapping` to `dict`. In the two spots we use the function, that argument is, in fact, a dictionary, so this should be a safe change.