### PR TITLE
feat(rca): Add base endpoint for testing RCA

### DIFF
--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -1,0 +1,24 @@
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+
+
+@region_silo_endpoint
+class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEndpoint):
+    def get(self, request, organization):
+        if not features.has(
+            "organizations:statistical-detectors-root-cause-analysis",
+            organization,
+            actor=request.user,
+        ):
+            return Response(status=404)
+
+        root_cause_results = {}
+
+        transaction_name = request.GET.get("transaction")
+        if not transaction_name:
+            return Response(status=400)
+
+        return Response(status=200, data=root_cause_results)

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -27,12 +27,13 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
 
         params = self.get_snuba_params(request, organization)
 
-        transaction_count_query = metrics_query(
-            ["count()"],
-            f"event.type:transaction transaction:{transaction_name} project_id:{project_id}",
-            params,
-            referrer="api.organization-events-root-cause-analysis",
-        )
+        with self.handle_query_errors():
+            transaction_count_query = metrics_query(
+                ["count()"],
+                f"event.type:transaction transaction:{transaction_name} project_id:{project_id}",
+                params,
+                referrer="api.organization-events-root-cause-analysis",
+            )
 
         if transaction_count_query["data"][0]["count"] == 0:
             return Response(status=400, data="Transaction not found")

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -2,11 +2,12 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
+from sentry.snuba.metrics_performance import query as metrics_query
 
 
 @region_silo_endpoint
-class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEndpoint):
+class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
         if not features.has(
             "organizations:statistical-detectors-root-cause-analysis",
@@ -23,5 +24,17 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEndpoint):
             # Project ID is required to ensure the events we query for are
             # the same transaction
             return Response(status=400)
+
+        params = self.get_snuba_params(request, organization)
+
+        # How do we check if 1, this transaction exists, and 2, if it's even a transaction?
+        # We can query for the transaction and count the number of events returned.
+        # query = f"event.type:transaction transaction:{transaction_name} project:{project_id}"
+        transaction_count_query = metrics_query(
+            "count()",
+            f"event.type:transaction transaction:{transaction_name} project_id:{project_id}",
+            params,
+        )
+        breakpoint()
 
         return Response(status=200, data=root_cause_results)

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -27,14 +27,16 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
 
         params = self.get_snuba_params(request, organization)
 
-        # How do we check if 1, this transaction exists, and 2, if it's even a transaction?
-        # We can query for the transaction and count the number of events returned.
-        # query = f"event.type:transaction transaction:{transaction_name} project:{project_id}"
         transaction_count_query = metrics_query(
-            "count()",
+            ["count()"],
             f"event.type:transaction transaction:{transaction_name} project_id:{project_id}",
             params,
+            referrer="api.organization-events-root-cause-analysis",
         )
-        breakpoint()
 
+        if transaction_count_query["data"][0]["count"] == 0:
+            return Response(status=400, data="Transaction not found")
+
+        # TODO: This is only a temporary stub for surfacing RCA data
+        root_cause_results["transaction_count"] = transaction_count_query["data"][0]["count"]
         return Response(status=200, data=root_cause_results)

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -18,7 +18,10 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEndpoint):
         root_cause_results = {}
 
         transaction_name = request.GET.get("transaction")
-        if not transaction_name:
+        project_id = request.GET.get("project")
+        if not transaction_name or not project_id:
+            # Project ID is required to ensure the events we query for are
+            # the same transaction
             return Response(status=400)
 
         return Response(status=200, data=root_cause_results)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -8,6 +8,9 @@ from sentry.api.endpoints.org_auth_tokens import OrgAuthTokensEndpoint
 from sentry.api.endpoints.organization_events_facets_stats_performance import (
     OrganizationEventsFacetsStatsPerformanceEndpoint,
 )
+from sentry.api.endpoints.organization_events_root_cause_analysis import (
+    OrganizationEventsRootCauseAnalysisEndpoint,
+)
 from sentry.api.endpoints.organization_events_starfish import OrganizationEventsStarfishEndpoint
 from sentry.api.endpoints.organization_missing_org_members import OrganizationMissingMembersEndpoint
 from sentry.api.endpoints.organization_projects_experiment import (
@@ -1209,6 +1212,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_slug>[^\/]+)/events-spans-stats/$",
         OrganizationEventsSpansStatsEndpoint.as_view(),
         name="sentry-api-0-organization-events-spans-stats",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/events-root-cause-analysis/$",
+        OrganizationEventsRootCauseAnalysisEndpoint.as_view(),
+        name="sentry-api-0-organization-events-root-cause-analysis",
     ),
     re_path(
         r"^(?P<organization_slug>[^\/]+)/events-meta/$",

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 import pytest
 from django.urls import reverse
 from freezegun import freeze_time
@@ -7,14 +5,10 @@ from freezegun import freeze_time
 from sentry.snuba.metrics.naming_layer import TransactionMRI
 from sentry.testutils.cases import MetricsAPIBaseTestCase
 from sentry.testutils.silo import region_silo_test
-from sentry.utils.samples import load_data
 
 ROOT_CAUSE_FEATURE_FLAG = "organizations:statistical-detectors-root-cause-analysis"
-PERFORMANCE_METRICS = "organizations:performance-use-metrics"
-PERFORMANCE_VIEW = "organizations:performance-view"
-GLOBAL_VIEWS = "organizations:global-views"
 
-FEATURES = [ROOT_CAUSE_FEATURE_FLAG, PERFORMANCE_METRICS, PERFORMANCE_VIEW, GLOBAL_VIEWS]
+FEATURES = [ROOT_CAUSE_FEATURE_FLAG]
 
 pytestmark = [pytest.mark.sentry_metrics]
 
@@ -30,17 +24,6 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
         self.url = reverse(
             "sentry-api-0-organization-events-root-cause-analysis", args=[self.org.slug]
         )
-
-        self.create_transaction(
-            transaction="foo",
-            trace_id="a" * 32,
-            span_id="b" * 16,
-            parent_span_id=None,
-            spans=None,
-            project_id=self.project.id,
-            start_timestamp=self.now - timedelta(days=1),
-            duration=800,
-        )
         self.store_performance_metric(
             name=TransactionMRI.DURATION.value,
             tags={"transaction": "foo"},
@@ -53,47 +36,9 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
     def now(self):
         return MetricsAPIBaseTestCase.MOCK_DATETIME
 
-    def create_transaction(
-        self,
-        transaction,
-        trace_id,
-        span_id,
-        parent_span_id,
-        spans,
-        project_id,
-        start_timestamp,
-        duration,
-        transaction_id=None,
-    ):
-        timestamp = start_timestamp + timedelta(milliseconds=duration)
-
-        data = load_data(
-            "transaction",
-            trace=trace_id,
-            span_id=span_id,
-            spans=spans,
-            start_timestamp=start_timestamp,
-            timestamp=timestamp,
-        )
-        if transaction_id is not None:
-            data["event_id"] = transaction_id
-        data["transaction"] = transaction
-        data["contexts"]["trace"]["parent_span_id"] = parent_span_id
-        return self.store_event(data, project_id=project_id)
-
     def test_404s_without_feature_flag(self):
         response = self.client.get(self.url, format="json")
         assert response.status_code == 404, response.content
-
-    def test_can_call_endpoint(self):
-        with self.feature(FEATURES):
-            response = self.client.get(
-                self.url,
-                format="json",
-                data={"transaction": "foo", "project": self.project.id, "statsPeriod": "7d"},
-            )
-
-        assert response.status_code == 200, response.content
 
     def test_transaction_name_required(self):
         with self.feature(FEATURES):
@@ -112,7 +57,19 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             response = self.client.get(
                 self.url,
                 format="json",
-                data={"transaction": "foo", "project": self.project.id, "statsPeriod": "7d"},
+                data={"transaction": "foo", "project": self.project.id},
             )
 
         assert response.status_code == 200, response.content
+
+        with self.feature(FEATURES):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "transaction": "does not exist",
+                    "project": self.project.id,
+                },
+            )
+
+        assert response.status_code == 400, response.content

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -4,6 +4,9 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
 
 ROOT_CAUSE_FEATURE_FLAG = "organizations:statistical-detectors-root-cause-analysis"
+PERFORMANCE_METRICS = "organizations:performance-use-metrics"
+
+FEATURES = [ROOT_CAUSE_FEATURE_FLAG, PERFORMANCE_METRICS]
 
 
 @region_silo_test(stable=True)
@@ -22,7 +25,7 @@ class OrganizationRootCauseAnalysisTest(APITestCase):
         assert response.status_code == 404, response.content
 
     def test_can_call_endpoint(self):
-        with self.feature(ROOT_CAUSE_FEATURE_FLAG):
+        with self.feature(FEATURES):
             response = self.client.get(
                 self.url, format="json", data={"transaction": "foo", "project": "1"}
             )
@@ -30,13 +33,21 @@ class OrganizationRootCauseAnalysisTest(APITestCase):
         assert response.status_code == 200, response.content
 
     def test_transaction_name_required(self):
-        with self.feature(ROOT_CAUSE_FEATURE_FLAG):
+        with self.feature(FEATURES):
             response = self.client.get(self.url, format="json")
 
         assert response.status_code == 400, response.content
 
     def test_project_id_required(self):
-        with self.feature(ROOT_CAUSE_FEATURE_FLAG):
+        with self.feature(FEATURES):
             response = self.client.get(self.url, format="json", data={"transaction": "foo"})
 
         assert response.status_code == 400, response.content
+
+    def test_transaction_must_exist(self):
+        with self.feature(FEATURES):
+            response = self.client.get(
+                self.url, format="json", data={"transaction": "foo", "project": "1"}
+            )
+
+        assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -44,6 +44,8 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
         self.store_performance_metric(
             name=TransactionMRI.DURATION.value,
             tags={"transaction": "foo"},
+            org_id=self.org.id,
+            project_id=self.project.id,
             value=1,
         )
 

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -1,0 +1,34 @@
+from django.urls import reverse
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+
+ROOT_CAUSE_FEATURE_FLAG = "organizations:statistical-detectors-root-cause-analysis"
+
+
+@region_silo_test(stable=True)
+class OrganizationRootCauseAnalysisTest(APITestCase):
+    def setUp(self):
+        self.login_as(self.user)
+        self.org = self.create_organization(owner=self.user)
+        self.url = reverse(
+            "sentry-api-0-organization-events-root-cause-analysis", args=[self.org.slug]
+        )
+
+        return super().setUp()
+
+    def test_404s_without_feature_flag(self):
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == 404, response.content
+
+    def test_can_call_endpoint(self):
+        with self.feature(ROOT_CAUSE_FEATURE_FLAG):
+            response = self.client.get(self.url, format="json", data={"transaction": "foo"})
+
+        assert response.status_code == 200, response.content
+
+    def test_transaction_name_required(self):
+        with self.feature(ROOT_CAUSE_FEATURE_FLAG):
+            response = self.client.get(self.url, format="json")
+
+        assert response.status_code == 400, response.content

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -1,24 +1,83 @@
-from django.urls import reverse
+from datetime import timedelta
 
-from sentry.testutils.cases import APITestCase
+import pytest
+from django.urls import reverse
+from freezegun import freeze_time
+
+from sentry.snuba.metrics.naming_layer import TransactionMRI
+from sentry.testutils.cases import MetricsAPIBaseTestCase
 from sentry.testutils.silo import region_silo_test
+from sentry.utils.samples import load_data
 
 ROOT_CAUSE_FEATURE_FLAG = "organizations:statistical-detectors-root-cause-analysis"
 PERFORMANCE_METRICS = "organizations:performance-use-metrics"
+PERFORMANCE_VIEW = "organizations:performance-view"
+GLOBAL_VIEWS = "organizations:global-views"
 
-FEATURES = [ROOT_CAUSE_FEATURE_FLAG, PERFORMANCE_METRICS]
+FEATURES = [ROOT_CAUSE_FEATURE_FLAG, PERFORMANCE_METRICS, PERFORMANCE_VIEW, GLOBAL_VIEWS]
+
+pytestmark = [pytest.mark.sentry_metrics]
 
 
 @region_silo_test(stable=True)
-class OrganizationRootCauseAnalysisTest(APITestCase):
+@freeze_time(MetricsAPIBaseTestCase.MOCK_DATETIME)
+class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
     def setUp(self):
+        super().setUp()
         self.login_as(self.user)
         self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
         self.url = reverse(
             "sentry-api-0-organization-events-root-cause-analysis", args=[self.org.slug]
         )
 
-        return super().setUp()
+        self.create_transaction(
+            transaction="foo",
+            trace_id="a" * 32,
+            span_id="b" * 16,
+            parent_span_id=None,
+            spans=None,
+            project_id=self.project.id,
+            start_timestamp=self.now - timedelta(days=1),
+            duration=800,
+        )
+        self.store_performance_metric(
+            name=TransactionMRI.DURATION.value,
+            tags={"transaction": "foo"},
+            value=1,
+        )
+
+    @property
+    def now(self):
+        return MetricsAPIBaseTestCase.MOCK_DATETIME
+
+    def create_transaction(
+        self,
+        transaction,
+        trace_id,
+        span_id,
+        parent_span_id,
+        spans,
+        project_id,
+        start_timestamp,
+        duration,
+        transaction_id=None,
+    ):
+        timestamp = start_timestamp + timedelta(milliseconds=duration)
+
+        data = load_data(
+            "transaction",
+            trace=trace_id,
+            span_id=span_id,
+            spans=spans,
+            start_timestamp=start_timestamp,
+            timestamp=timestamp,
+        )
+        if transaction_id is not None:
+            data["event_id"] = transaction_id
+        data["transaction"] = transaction
+        data["contexts"]["trace"]["parent_span_id"] = parent_span_id
+        return self.store_event(data, project_id=project_id)
 
     def test_404s_without_feature_flag(self):
         response = self.client.get(self.url, format="json")
@@ -27,7 +86,9 @@ class OrganizationRootCauseAnalysisTest(APITestCase):
     def test_can_call_endpoint(self):
         with self.feature(FEATURES):
             response = self.client.get(
-                self.url, format="json", data={"transaction": "foo", "project": "1"}
+                self.url,
+                format="json",
+                data={"transaction": "foo", "project": self.project.id, "statsPeriod": "7d"},
             )
 
         assert response.status_code == 200, response.content
@@ -47,7 +108,9 @@ class OrganizationRootCauseAnalysisTest(APITestCase):
     def test_transaction_must_exist(self):
         with self.feature(FEATURES):
             response = self.client.get(
-                self.url, format="json", data={"transaction": "foo", "project": "1"}
+                self.url,
+                format="json",
+                data={"transaction": "foo", "project": self.project.id, "statsPeriod": "7d"},
             )
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -23,12 +23,20 @@ class OrganizationRootCauseAnalysisTest(APITestCase):
 
     def test_can_call_endpoint(self):
         with self.feature(ROOT_CAUSE_FEATURE_FLAG):
-            response = self.client.get(self.url, format="json", data={"transaction": "foo"})
+            response = self.client.get(
+                self.url, format="json", data={"transaction": "foo", "project": "1"}
+            )
 
         assert response.status_code == 200, response.content
 
     def test_transaction_name_required(self):
         with self.feature(ROOT_CAUSE_FEATURE_FLAG):
             response = self.client.get(self.url, format="json")
+
+        assert response.status_code == 400, response.content
+
+    def test_project_id_required(self):
+        with self.feature(ROOT_CAUSE_FEATURE_FLAG):
+            response = self.client.get(self.url, format="json", data={"transaction": "foo"})
 
         assert response.status_code == 400, response.content


### PR DESCRIPTION
This PR adds an endpoint where we will add Root Cause Analysis logic to run against a transaction and a breakpoint. In this first version it does some light validation on whether transaction name and project ID are passed in, as well as if there is transaction data to query.

In the next PRs I will add a breakpoint as a param and return spans along with other information.