### PR TITLE
nit(api): Fix list parameter type

### DIFF
--- a/src/sentry/replays/validators.py
+++ b/src/sentry/replays/validators.py
@@ -60,7 +60,9 @@ UTC ISO8601 or epoch seconds. Use along with `start` instead of `statsPeriod`.
         required=False,
     )
     project = serializers.ListField(
-        required=False, help_text="The ID of the projects to filter by."
+        required=False,
+        help_text="The ID of the projects to filter by.",
+        child=serializers.IntegerField(),
     )
     environment = serializers.CharField(help_text="The environment to filter by.", required=False)
     sort = serializers.CharField(help_text="The field to sort the output by.", required=False)


### PR DESCRIPTION
Small fix I found when messing around with parameter types:
![Screenshot 2023-08-02 at 2 06 40 PM](https://github.com/getsentry/sentry/assets/67301797/dfd9c2d6-3436-4d4d-9145-ae0002fcac6b)
to
![Screenshot 2023-08-02 at 2 06 46 PM](https://github.com/getsentry/sentry/assets/67301797/bea1e99d-dccb-4c45-bbff-248fb8ab9656)
