### PR TITLE
feat(store): Add an option to control which platforms should use highcpu queue at runtime

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -130,6 +130,12 @@ ALL_KILLSWITCH_OPTIONS = {
             "platform": "The event platform as defined in the event payload's platform field, or 'none'",
         },
     ),
+    "store.save-event-highcpu-platforms": KillswitchInfo(
+        description="Send highcpu platform events to save_event highcpu queue",
+        fields={
+            "platform": "The event platform as defined in the event payload's platform field, or 'none'",
+        },
+    ),
     "store.symbolicate-event-lpq-never": KillswitchInfo(
         description="""
         Never allow a project's symbolication events to be demoted to symbolicator's low priority queue.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -722,6 +722,9 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "store.save-event-highcpu-platforms", type=Sequence, default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+register(
     "store.symbolicate-event-lpq-never", type=Sequence, default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 register(


### PR DESCRIPTION
This PR registers an option to control which platforms should use highcpu queue at runtime