### PR TITLE
ref(hc): Mark silo stable tests stable

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -103,7 +103,7 @@ class OrganizationsListTest(OrganizationIndexTest):
         assert len(response.data) == 0
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
     method = "post"
 

--- a/tests/sentry/api/endpoints/test_organization_relay_usage.py
+++ b/tests/sentry/api/endpoints/test_organization_relay_usage.py
@@ -9,7 +9,7 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class OrganizationRelayHistoryTest(APITestCase):
     endpoint = "sentry-api-0-organization-relay-usage"
 

--- a/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
+++ b/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
@@ -55,7 +55,7 @@ class UserNotificationFineTuningGetTest(UserNotificationFineTuningTestBase):
         assert response.data.get(self.organization.id) == "0"
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
     method = "put"
 

--- a/tests/sentry/api/serializers/test_activity.py
+++ b/tests/sentry/api/serializers/test_activity.py
@@ -5,7 +5,7 @@ from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class GroupActivityTestCase(TestCase):
     def test_pr_activity(self):
         self.org = self.create_organization(name="Rowdy Tiger")

--- a/tests/sentry/api/serializers/test_app_platform_event.py
+++ b/tests/sentry/api/serializers/test_app_platform_event.py
@@ -4,7 +4,7 @@ from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class AppPlatformEventSerializerTest(TestCase):
     def setUp(self):
         self.user = self.create_user(username="foo")

--- a/tests/sentry/api/serializers/test_group_tombstone.py
+++ b/tests/sentry/api/serializers/test_group_tombstone.py
@@ -5,7 +5,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class GroupTombstoneSerializerTest(TestCase):
     def test_simple(self):
         user = self.create_user("foo@example.com")

--- a/tests/sentry/api/serializers/test_grouptagkey.py
+++ b/tests/sentry/api/serializers/test_grouptagkey.py
@@ -4,7 +4,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class GroupTagKeySerializerTest(TestCase):
     def test(self):
         user = self.create_user()

--- a/tests/sentry/api/serializers/test_grouptagvalue.py
+++ b/tests/sentry/api/serializers/test_grouptagvalue.py
@@ -6,7 +6,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class GroupTagValueSerializerTest(TestCase):
     def test_with_user(self):
         user = self.create_user()

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -358,7 +358,7 @@ class ConvertActorOrNoneValueTest(TestCase):
         )
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class ConvertUserValueTest(TestCase):
     def test_me(self):
         result = convert_user_value(["me"], [self.project], self.user, None)

--- a/tests/sentry/api/validators/sentry_apps/test_issue_link.py
+++ b/tests/sentry/api/validators/sentry_apps/test_issue_link.py
@@ -8,7 +8,7 @@ from sentry.api.validators.sentry_apps.schema import validate_component
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class TestIssueLinkSchemaValidation(unittest.TestCase):
     def setUp(self):
         self.schema: dict[str, Any] = {

--- a/tests/sentry/api/validators/sentry_apps/test_issue_media.py
+++ b/tests/sentry/api/validators/sentry_apps/test_issue_media.py
@@ -8,7 +8,7 @@ from sentry.api.validators.sentry_apps.schema import validate_component
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class TestIssueMediaSchemaValidation(unittest.TestCase):
     def setUp(self):
         self.schema: dict[str, Any] = {

--- a/tests/sentry/audit_log/test_register.py
+++ b/tests/sentry/audit_log/test_register.py
@@ -3,7 +3,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class AuditLogEventRegisterTest(TestCase):
     def test_get_api_names(self):
         audit_log_api_name_list = [

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -90,7 +90,7 @@ class AuthIdentityHandlerTest(TestCase):
         return user, auth_identity
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class HandleNewUserTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
     @mock.patch("sentry.analytics.record")
     def test_simple(self, mock_record):
@@ -167,7 +167,7 @@ class HandleNewUserTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
         assert assigned_member.id == member.id
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class HandleExistingIdentityTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
     @mock.patch("sentry.auth.helper.auth")
     def test_simple(self, mock_auth):
@@ -219,7 +219,7 @@ class HandleExistingIdentityTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
             self.assert_org_member_mapping(org_member=persisted_om)
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class HandleAttachIdentityTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
     @mock.patch("sentry.auth.helper.messages")
     def test_new_identity(self, mock_messages):
@@ -355,7 +355,7 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
         assert not AuthIdentity.objects.filter(id=existing_identity.id).exists()
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
     def _test_simple(self, mock_render, expected_template):
         redirect = self.handler.handle_unknown_identity(self.state)
@@ -429,7 +429,7 @@ class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
     # TODO: More test cases for various values of request.POST.get("op")
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class AuthHelperTest(TestCase):
     def setUp(self):
         self.provider = "dummy"

--- a/tests/sentry/deletions/test_rule.py
+++ b/tests/sentry/deletions/test_rule.py
@@ -12,7 +12,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test()
+@region_silo_test(stable=True)
 class DeleteRuleTest(TestCase):
     def test_simple(self):
         project = self.create_project()

--- a/tests/sentry/eventtypes/test_default.py
+++ b/tests/sentry/eventtypes/test_default.py
@@ -3,7 +3,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class DefaultEventTest(TestCase):
     def test_get_metadata(self):
         inst = DefaultEvent()

--- a/tests/sentry/eventtypes/test_error.py
+++ b/tests/sentry/eventtypes/test_error.py
@@ -7,7 +7,7 @@ from sentry.eventtypes.error import ErrorEvent
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class ErrorEventTest(TestCase):
     def test_get_metadata(self):
         inst = ErrorEvent()

--- a/tests/sentry/hybrid_cloud/test_auth.py
+++ b/tests/sentry/hybrid_cloud/test_auth.py
@@ -13,7 +13,7 @@ from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 
 
 @django_db_all(transaction=True)
-@all_silo_test
+@all_silo_test(stable=True)
 @use_real_service(auth_service, None)
 def test_get_org_auth_config():
     org_with_many_api_keys = Factories.create_organization()

--- a/tests/sentry/hybrid_cloud/test_user_option.py
+++ b/tests/sentry/hybrid_cloud/test_user_option.py
@@ -8,7 +8,7 @@ from sentry.testutils.silo import all_silo_test
 
 
 @django_db_all(transaction=True)
-@all_silo_test
+@all_silo_test(stable=True)
 @use_real_service(user_option_service, None)
 def test_user_option_service():
     objects = [1, dict(a=dict(b=3)), "asdf", 9873, [1, 2, 3], 511]

--- a/tests/sentry/incidents/endpoints/test_organization_incident_subscription_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_subscription_index.py
@@ -35,7 +35,7 @@ class BaseOrganizationSubscriptionEndpointTest:
             assert resp.status_code == 403
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class OrganizationIncidentSubscribeEndpointTest(
     BaseOrganizationSubscriptionEndpointTest, APITestCase
 ):
@@ -54,7 +54,7 @@ class OrganizationIncidentSubscribeEndpointTest(
         assert sub.user_id == self.user.id
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class OrganizationIncidentUnsubscribeEndpointTest(
     BaseOrganizationSubscriptionEndpointTest, APITestCase
 ):

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -29,7 +29,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class FetchForOrganizationTest(TestCase):
     def test_empty(self):
         incidents = Incident.objects.fetch_for_organization(self.organization, [self.project])
@@ -390,7 +390,7 @@ class IncidentCurrentEndDateTest(unittest.TestCase):
         assert incident.current_end_date == timezone.now() - timedelta(minutes=10)
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class AlertRuleFetchForOrganizationTest(TestCase):
     def test_empty(self):
         alert_rule = AlertRule.objects.fetch_for_organization(self.organization)

--- a/tests/sentry/incidents/test_receivers.py
+++ b/tests/sentry/incidents/test_receivers.py
@@ -12,7 +12,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class AddProjectToIncludeAllRulesTest(TestCase):
     def test_include_all_projects_enabled(self):
         alert_rule = self.create_alert_rule(include_all_projects=True)

--- a/tests/sentry/integrations/discord/test_uninstall.py
+++ b/tests/sentry/integrations/discord/test_uninstall.py
@@ -18,7 +18,7 @@ LEAVE_GUILD_URL = (
 )
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class DiscordUninstallTest(APITestCase):
     endpoint = "sentry-api-0-organization-integration-details"
     method = "delete"

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -92,7 +92,7 @@ class SlackRequestTest(TestCase):
             assert e.status == 403
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class SlackEventRequestTest(TestCase):
     def setUp(self):
         super().setUp()

--- a/tests/sentry/integrations/slack/webhooks/events/test_url_verification.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_url_verification.py
@@ -5,7 +5,7 @@ from sentry.testutils.silo import region_silo_test
 from . import BaseEventTest
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class UrlVerificationEventTest(BaseEventTest):
     challenge = "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P"
 

--- a/tests/sentry/issues/test_attributes.py
+++ b/tests/sentry/issues/test_attributes.py
@@ -6,7 +6,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class GroupAttributesTest(TestCase):
     def test_retrieve_group_values(self) -> None:
         group = self.create_group()

--- a/tests/sentry/issues/test_grouptype.py
+++ b/tests/sentry/issues/test_grouptype.py
@@ -31,7 +31,7 @@ class BaseGroupTypeTest(TestCase):
         self.registry_patcher.__exit__(None, None, None)
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class GroupTypeTest(BaseGroupTypeTest):
     def test_get_types_by_category(self) -> None:
         @dataclass(frozen=True)
@@ -118,7 +118,7 @@ class GroupTypeTest(BaseGroupTypeTest):
         assert TestGroupType.noise_config.expiry_time == timedelta(hours=12)
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class GroupTypeReleasedTest(BaseGroupTypeTest):
     def test_released(self) -> None:
         @dataclass(frozen=True)

--- a/tests/sentry/issues/test_issue_occurrence.py
+++ b/tests/sentry/issues/test_issue_occurrence.py
@@ -4,7 +4,7 @@ from sentry.testutils.silo import region_silo_test
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class IssueOccurenceSerializeTest(OccurrenceTestMixin, TestCase):
     def test(self) -> None:
         occurrence = self.build_occurrence()
@@ -19,7 +19,7 @@ class IssueOccurenceSerializeTest(OccurrenceTestMixin, TestCase):
         assert occurrence.level == DEFAULT_LEVEL
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class IssueOccurenceSaveAndFetchTest(OccurrenceTestMixin, TestCase):
     def test(self) -> None:
         occurrence = self.build_occurrence()
@@ -29,7 +29,7 @@ class IssueOccurenceSaveAndFetchTest(OccurrenceTestMixin, TestCase):
         self.assert_occurrences_identical(occurrence, fetched_occurrence)
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class IssueOccurrenceEvidenceDisplayPrimaryTest(OccurrenceTestMixin, TestCase):
     def test(self) -> None:
         important_evidence = IssueEvidence("Hello", "Hi", True)

--- a/tests/sentry/middleware/integrations/parsers/test_jira_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira_server.py
@@ -18,7 +18,7 @@ from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
 
 
-@control_silo_test()
+@control_silo_test(stable=True)
 class JiraServerRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     middleware = IntegrationControlMiddleware(get_response)

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -11,7 +11,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class FileBlobTest(TestCase):
     def test_from_file(self):
         fileobj = ContentFile(b"foo bar")

--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -8,7 +8,7 @@ from sentry.testutils.silo import region_silo_test
 
 @django_db_all
 @pytest.mark.parametrize("upsert_sample_rate", [0, 1])
-@region_silo_test
+@region_silo_test(stable=True)
 def test_increment(default_project, upsert_sample_rate):
     options.set("store.projectcounter-modern-upsert-sample-rate", upsert_sample_rate)
 

--- a/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
+++ b/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
@@ -91,7 +91,7 @@ class DummyEndpoint(Endpoint):
     permission_classes = (AllowAny,)
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class TestDefaultToGroup(TestCase):
     def setUp(self) -> None:
         self.view = DummyEndpoint.as_view()

--- a/tests/sentry/rules/actions/test_notify_event.py
+++ b/tests/sentry/rules/actions/test_notify_event.py
@@ -6,7 +6,7 @@ from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class NotifyEventActionTest(RuleTestCase):
     rule_cls = NotifyEventAction
 

--- a/tests/sentry/rules/conditions/test_every_event.py
+++ b/tests/sentry/rules/conditions/test_every_event.py
@@ -3,7 +3,7 @@ from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class EveryEventConditionTest(RuleTestCase):
     rule_cls = EveryEventCondition
 

--- a/tests/sentry/rules/conditions/test_first_seen_event.py
+++ b/tests/sentry/rules/conditions/test_first_seen_event.py
@@ -4,7 +4,7 @@ from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class FirstSeenEventConditionTest(RuleTestCase):
     rule_cls = FirstSeenEventCondition
 

--- a/tests/sentry/rules/conditions/test_reappeared_event.py
+++ b/tests/sentry/rules/conditions/test_reappeared_event.py
@@ -3,7 +3,7 @@ from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class ReappearedEventConditionTest(RuleTestCase):
     rule_cls = ReappearedEventCondition
 

--- a/tests/sentry/rules/conditions/test_regression_event.py
+++ b/tests/sentry/rules/conditions/test_regression_event.py
@@ -3,7 +3,7 @@ from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class RegressionEventConditionTest(RuleTestCase):
     rule_cls = RegressionEventCondition
 

--- a/tests/sentry/rules/conditions/test_tagged_event.py
+++ b/tests/sentry/rules/conditions/test_tagged_event.py
@@ -3,7 +3,7 @@ from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class TaggedEventConditionTest(RuleTestCase):
     rule_cls = TaggedEventCondition
 

--- a/tests/sentry/rules/filters/test_issue_occurrences.py
+++ b/tests/sentry/rules/filters/test_issue_occurrences.py
@@ -3,7 +3,7 @@ from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class IssueOccurrencesTest(RuleTestCase):
     rule_cls = IssueOccurrencesFilter
 

--- a/tests/sentry/rules/history/endpoints/test_project_rule_stats.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_stats.py
@@ -27,7 +27,7 @@ class TimeSeriesValueSerializerTest(TestCase):
 
 
 @freeze_time()
-@region_silo_test
+@region_silo_test(stable=True)
 class ProjectRuleStatsIndexEndpointTest(APITestCase):
     endpoint = "sentry-api-0-project-rule-stats-index"
 

--- a/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
@@ -26,7 +26,7 @@ from sentry.utils.performance_issues.performance_problem import PerformanceProbl
 SECOND = 1000
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class ConsecutiveDbDetectorTest(TestCase):
     def setUp(self):

--- a/tests/sentry/utils/performance_issues/test_consecutive_http_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_http_detector.py
@@ -26,7 +26,7 @@ from sentry.utils.performance_issues.performance_problem import PerformanceProbl
 MIN_SPAN_DURATION = 900  # ms
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class ConsecutiveHTTPSpansDetectorTest(TestCase):
     def setUp(self):

--- a/tests/sentry/utils/performance_issues/test_db_main_thread_detector.py
+++ b/tests/sentry/utils/performance_issues/test_db_main_thread_detector.py
@@ -17,7 +17,7 @@ from sentry.utils.performance_issues.performance_detection import (
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class DBMainThreadDetectorTest(TestCase):
     def setUp(self):

--- a/tests/sentry/utils/performance_issues/test_file_io_on_main_thread_detector.py
+++ b/tests/sentry/utils/performance_issues/test_file_io_on_main_thread_detector.py
@@ -37,7 +37,7 @@ org.slf4j.helpers.Util$ClassContextSecurityManager -> org.a.b.g$a:
 """
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class FileIOMainThreadDetectorTest(TestCase):
     def setUp(self):

--- a/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
+++ b/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
@@ -63,7 +63,7 @@ def find_problems(settings, event: dict[str, Any]) -> list[PerformanceProblem]:
     return list(detector.stored_problems.values())
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class HTTPOverheadDetectorTest(TestCase):
     def setUp(self):

--- a/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
+++ b/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
@@ -19,7 +19,7 @@ from sentry.utils.performance_issues.performance_detection import (
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class LargeHTTPPayloadDetectorTest(TestCase):
     def setUp(self):

--- a/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
@@ -21,7 +21,7 @@ from sentry.utils.performance_issues.performance_detection import (
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class MNPlusOneDBDetectorTest(TestCase):
     def setUp(self):

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -25,7 +25,7 @@ from sentry.utils.performance_issues.performance_detection import (
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class NPlusOneAPICallsDetectorTest(TestCase):
     def setUp(self):

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_db_span_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_db_span_detector.py
@@ -21,7 +21,7 @@ from sentry.utils.performance_issues.performance_detection import (
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class NPlusOneDbDetectorTest(unittest.TestCase):
     def setUp(self):

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_db_span_detector_extended.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_db_span_detector_extended.py
@@ -20,7 +20,7 @@ from sentry.utils.performance_issues.performance_detection import (
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class NPlusOneDbDetectorTest(unittest.TestCase):
     def setUp(self):

--- a/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
+++ b/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
@@ -61,7 +61,7 @@ def find_problems(settings, event: dict[str, Any]) -> list[PerformanceProblem]:
     return list(detector.stored_problems.values())
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class RenderBlockingAssetDetectorTest(TestCase):
     def setUp(self):

--- a/tests/sentry/utils/performance_issues/test_slow_db_span_detector.py
+++ b/tests/sentry/utils/performance_issues/test_slow_db_span_detector.py
@@ -21,7 +21,7 @@ from sentry.utils.performance_issues.performance_detection import (
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class SlowDBQueryDetectorTest(TestCase):
     def setUp(self):

--- a/tests/sentry/utils/performance_issues/test_uncompressed_asset_detector.py
+++ b/tests/sentry/utils/performance_issues/test_uncompressed_asset_detector.py
@@ -41,7 +41,7 @@ def create_compressed_asset_span():
     )
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @pytest.mark.django_db
 class UncompressedAssetsDetectorTest(TestCase):
     def setUp(self):

--- a/tests/sentry/utils/test_ratelimits.py
+++ b/tests/sentry/utils/test_ratelimits.py
@@ -13,7 +13,7 @@ RELAXED_CONFIG = {
 }
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class ForOrganizationMemberTestCase(TestCase):
     def test_by_email(self):
         organization = Organization(id=1)

--- a/tests/sentry/web/frontend/test_project_avatar.py
+++ b/tests/sentry/web/frontend/test_project_avatar.py
@@ -8,7 +8,7 @@ from sentry.testutils.silo import region_silo_test
 from sentry.web.frontend.generic import FOREVER_CACHE
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class ProjectAvatarTest(TestCase):
     def test_headers(self):
         project = self.create_project()

--- a/tests/sentry/web/frontend/test_team_avatar.py
+++ b/tests/sentry/web/frontend/test_team_avatar.py
@@ -8,7 +8,7 @@ from sentry.testutils.silo import region_silo_test
 from sentry.web.frontend.generic import FOREVER_CACHE
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class TeamAvatarTest(TestCase):
     def test_headers(self):
         team = self.create_team()


### PR DESCRIPTION
This adds `stable=True` to silo test decorators where doing so will already pass without any additional changes. This isn't exhaustive by any means, just a starting point on some of the easiest ones to find locally.