### PR TITLE
ref(backup): Split out import/export functions

### DIFF
--- a/src/sentry/backup/exports.py
+++ b/src/sentry/backup/exports.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import click
+from django.core.serializers import serialize
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db.models.fields.related import ManyToManyField
+
+from sentry.backup.helpers import EXCLUDED_APPS
+
+UTC_0 = timezone(timedelta(hours=0))
+
+
+class DatetimeSafeDjangoJSONEncoder(DjangoJSONEncoder):
+    """A wrapper around the default `DjangoJSONEncoder` that always retains milliseconds, even when
+    their implicit value is `.000`. This is necessary because the ECMA-262 compatible
+    `DjangoJSONEncoder` drops these by default."""
+
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.astimezone(UTC_0).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+        return super().default(obj)
+
+
+def sort_dependencies():
+    """
+    Similar to Django's except that we discard the important of natural keys
+    when sorting dependencies (i.e. it works without them).
+    """
+    from django.apps import apps
+
+    from sentry.models.actor import Actor
+    from sentry.models.team import Team
+    from sentry.models.user import User
+
+    # Process the list of models, and get the list of dependencies
+    model_dependencies = []
+    models = set()
+    for app_config in apps.get_app_configs():
+        if app_config.label in EXCLUDED_APPS:
+            continue
+
+        model_iterator = app_config.get_models()
+
+        for model in model_iterator:
+            models.add(model)
+            # Add any explicitly defined dependencies
+            if hasattr(model, "natural_key"):
+                deps = getattr(model.natural_key, "dependencies", [])
+                if deps:
+                    deps = [apps.get_model(*d.split(".")) for d in deps]
+            else:
+                deps = []
+
+            # Now add a dependency for any FK relation with a model that
+            # defines a natural key
+            for field in model._meta.fields:
+                rel_model = getattr(field.remote_field, "model", None)
+                if rel_model is not None and rel_model != model:
+                    # TODO(hybrid-cloud): actor refactor.
+                    # Add cludgy conditional preventing walking actor.team_id, actor.user_id
+                    # Which avoids circular imports
+                    if model == Actor and (rel_model == Team or rel_model == User):
+                        continue
+
+                    deps.append(rel_model)
+
+            # Also add a dependency for any simple M2M relation with a model
+            # that defines a natural key.  M2M relations with explicit through
+            # models don't count as dependencies.
+            many_to_many_fields = [
+                field for field in model._meta.get_fields() if isinstance(field, ManyToManyField)
+            ]
+            for field in many_to_many_fields:
+                rel_model = getattr(field.remote_field, "model", None)
+                if rel_model is not None and rel_model != model:
+                    deps.append(rel_model)
+            model_dependencies.append((model, deps))
+
+    model_dependencies.reverse()
+    # Now sort the models to ensure that dependencies are met. This
+    # is done by repeatedly iterating over the input list of models.
+    # If all the dependencies of a given model are in the final list,
+    # that model is promoted to the end of the final list. This process
+    # continues until the input list is empty, or we do a full iteration
+    # over the input models without promoting a model to the final list.
+    # If we do a full iteration without a promotion, that means there are
+    # circular dependencies in the list.
+    model_list = []
+    while model_dependencies:
+        skipped = []
+        changed = False
+        while model_dependencies:
+            model, deps = model_dependencies.pop()
+
+            # If all of the models in the dependency list are either already
+            # on the final model list, or not on the original serialization list,
+            # then we've found another model with all it's dependencies satisfied.
+            found = True
+            for candidate in ((d not in models or d in model_list) for d in deps):
+                if not candidate:
+                    found = False
+            if found:
+                model_list.append(model)
+                changed = True
+            else:
+                skipped.append((model, deps))
+        if not changed:
+            raise RuntimeError(
+                "Can't resolve dependencies for %s in serialized app list."
+                % ", ".join(
+                    f"{model._meta.app_label}.{model._meta.object_name}"
+                    for model, deps in sorted(skipped, key=lambda obj: obj[0].__name__)
+                )
+            )
+        model_dependencies = skipped
+
+    return model_list
+
+
+def exports(dest, indent, exclude, printer=click.echo):
+    """Exports core metadata for the Sentry installation."""
+
+    if exclude is None:
+        exclude = ()
+    else:
+        exclude = exclude.lower().split(",")
+
+    def yield_objects():
+        # Collate the objects to be serialized.
+        for model in sort_dependencies():
+            if (
+                not getattr(model, "__include_in_export__", True)
+                or model.__name__.lower() in exclude
+                or model._meta.proxy
+            ):
+                printer(f">> Skipping model <{model.__name__}>", err=True)
+                continue
+
+            queryset = model._base_manager.order_by(model._meta.pk.name)
+            yield from queryset.iterator()
+
+    printer(">> Beginning export", err=True)
+    serialize(
+        "json",
+        yield_objects(),
+        indent=indent,
+        stream=dest,
+        use_natural_foreign_keys=True,
+        cls=DatetimeSafeDjangoJSONEncoder,
+    )

--- a/src/sentry/backup/helpers.py
+++ b/src/sentry/backup/helpers.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Type
 
+# Django apps we take care to never import or export from.
+EXCLUDED_APPS = frozenset(("auth", "contenttypes"))
+
 
 def get_final_derivations_of(model: Type) -> set[Type]:
     """A "final" derivation of the given `model` base class is any non-abstract class for the

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from io import StringIO
+
+import click
+from django.apps import apps
+from django.core import management, serializers
+from django.db import IntegrityError, connection, transaction
+
+from sentry.backup.helpers import EXCLUDED_APPS
+
+
+def imports(src, printer=click.echo):
+    """CLI command wrapping the `exec_import` functionality."""
+
+    try:
+        # Import / export only works in monolith mode with a consolidated db.
+        with transaction.atomic("default"):
+            for obj in serializers.deserialize("json", src, stream=True, use_natural_keys=True):
+                if obj.object._meta.app_label not in EXCLUDED_APPS:
+                    obj.save()
+    # For all database integrity errors, let's warn users to follow our
+    # recommended backup/restore workflow before reraising exception. Most of
+    # these errors come from restoring on a different version of Sentry or not restoring
+    # on a clean install.
+    except IntegrityError as e:
+        warningText = ">> Are you restoring from a backup of the same version of Sentry?\n>> Are you restoring onto a clean database?\n>> If so then this IntegrityError might be our fault, you can open an issue here:\n>> https://github.com/getsentry/sentry/issues/new/choose"
+        printer(
+            warningText,
+            err=True,
+        )
+        raise (e)
+
+    sequence_reset_sql = StringIO()
+
+    for app in apps.get_app_configs():
+        management.call_command(
+            "sqlsequencereset", app.label, "--no-color", stdout=sequence_reset_sql
+        )
+
+    with connection.cursor() as cursor:
+        cursor.execute(sequence_reset_sql.getvalue())

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -1,164 +1,20 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
-from io import StringIO
-
 import click
-from django.apps import apps
-from django.core import management, serializers
-from django.core.serializers import serialize
-from django.core.serializers.json import DjangoJSONEncoder
-from django.db import IntegrityError, connection, transaction
-from django.db.models.fields.related import ManyToManyField
 
+from sentry.backup.exports import exports
+from sentry.backup.imports import imports
 from sentry.runner.decorators import configuration
-
-EXCLUDED_APPS = frozenset(("auth", "contenttypes"))
 
 
 @click.command(name="import")
 @click.argument("src", type=click.File("rb"))
+@click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def import_(src):
+def import_(src, silent):
     """CLI command wrapping the `exec_import` functionality."""
 
-    try:
-        # Import / export only works in monolith mode with a consolidated db.
-        with transaction.atomic("default"):
-            for obj in serializers.deserialize("json", src, stream=True, use_natural_keys=True):
-                if obj.object._meta.app_label not in EXCLUDED_APPS:
-                    obj.save()
-    # For all database integrity errors, let's warn users to follow our
-    # recommended backup/restore workflow before reraising exception. Most of
-    # these errors come from restoring on a different version of Sentry or not restoring
-    # on a clean install.
-    except IntegrityError as e:
-        warningText = ">> Are you restoring from a backup of the same version of Sentry?\n>> Are you restoring onto a clean database?\n>> If so then this IntegrityError might be our fault, you can open an issue here:\n>> https://github.com/getsentry/sentry/issues/new/choose"
-        click.echo(
-            warningText,
-            err=True,
-        )
-        raise (e)
-
-    sequence_reset_sql = StringIO()
-
-    for app in apps.get_app_configs():
-        management.call_command(
-            "sqlsequencereset", app.label, "--no-color", stdout=sequence_reset_sql
-        )
-
-    with connection.cursor() as cursor:
-        cursor.execute(sequence_reset_sql.getvalue())
-
-
-def sort_dependencies():
-    """
-    Similar to Django's except that we discard the important of natural keys
-    when sorting dependencies (i.e. it works without them).
-    """
-    from django.apps import apps
-
-    from sentry.models.actor import Actor
-    from sentry.models.team import Team
-    from sentry.models.user import User
-
-    # Process the list of models, and get the list of dependencies
-    model_dependencies = []
-    models = set()
-    for app_config in apps.get_app_configs():
-        if app_config.label in EXCLUDED_APPS:
-            continue
-
-        model_iterator = app_config.get_models()
-
-        for model in model_iterator:
-            models.add(model)
-            # Add any explicitly defined dependencies
-            if hasattr(model, "natural_key"):
-                deps = getattr(model.natural_key, "dependencies", [])
-                if deps:
-                    deps = [apps.get_model(*d.split(".")) for d in deps]
-            else:
-                deps = []
-
-            # Now add a dependency for any FK relation with a model that
-            # defines a natural key
-            for field in model._meta.fields:
-                rel_model = getattr(field.remote_field, "model", None)
-                if rel_model is not None and rel_model != model:
-                    # TODO(hybrid-cloud): actor refactor.
-                    # Add cludgy conditional preventing walking actor.team_id, actor.user_id
-                    # Which avoids circular imports
-                    if model == Actor and (rel_model == Team or rel_model == User):
-                        continue
-
-                    deps.append(rel_model)
-
-            # Also add a dependency for any simple M2M relation with a model
-            # that defines a natural key.  M2M relations with explicit through
-            # models don't count as dependencies.
-            many_to_many_fields = [
-                field for field in model._meta.get_fields() if isinstance(field, ManyToManyField)
-            ]
-            for field in many_to_many_fields:
-                rel_model = getattr(field.remote_field, "model", None)
-                if rel_model is not None and rel_model != model:
-                    deps.append(rel_model)
-            model_dependencies.append((model, deps))
-
-    model_dependencies.reverse()
-    # Now sort the models to ensure that dependencies are met. This
-    # is done by repeatedly iterating over the input list of models.
-    # If all the dependencies of a given model are in the final list,
-    # that model is promoted to the end of the final list. This process
-    # continues until the input list is empty, or we do a full iteration
-    # over the input models without promoting a model to the final list.
-    # If we do a full iteration without a promotion, that means there are
-    # circular dependencies in the list.
-    model_list = []
-    while model_dependencies:
-        skipped = []
-        changed = False
-        while model_dependencies:
-            model, deps = model_dependencies.pop()
-
-            # If all of the models in the dependency list are either already
-            # on the final model list, or not on the original serialization list,
-            # then we've found another model with all it's dependencies satisfied.
-            found = True
-            for candidate in ((d not in models or d in model_list) for d in deps):
-                if not candidate:
-                    found = False
-            if found:
-                model_list.append(model)
-                changed = True
-            else:
-                skipped.append((model, deps))
-        if not changed:
-            raise RuntimeError(
-                "Can't resolve dependencies for %s in serialized app list."
-                % ", ".join(
-                    f"{model._meta.app_label}.{model._meta.object_name}"
-                    for model, deps in sorted(skipped, key=lambda obj: obj[0].__name__)
-                )
-            )
-        model_dependencies = skipped
-
-    return model_list
-
-
-UTC_0 = timezone(timedelta(hours=0))
-
-
-class DatetimeSafeDjangoJSONEncoder(DjangoJSONEncoder):
-    """A wrapper around the default `DjangoJSONEncoder` that always retains milliseconds, even when
-    their implicit value is `.000`. This is necessary because the ECMA-262 compatible
-    `DjangoJSONEncoder` drops these by default."""
-
-    def default(self, obj):
-        if isinstance(obj, datetime):
-            return obj.astimezone(UTC_0).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
-        return super().default(obj)
+    imports(src, (lambda *args, **kwargs: None) if silent else click.echo)
 
 
 @click.command()
@@ -170,35 +26,6 @@ class DatetimeSafeDjangoJSONEncoder(DjangoJSONEncoder):
 @click.option("--exclude", default=None, help="Models to exclude from export.", metavar="MODELS")
 @configuration
 def export(dest, silent, indent, exclude):
-    """CLI command wrapping the `exec_export` functionality."""
+    """Exports core metadata for the Sentry installation."""
 
-    if exclude is None:
-        exclude = ()
-    else:
-        exclude = exclude.lower().split(",")
-
-    def yield_objects():
-        # Collate the objects to be serialized.
-        for model in sort_dependencies():
-            if (
-                not getattr(model, "__include_in_export__", True)
-                or model.__name__.lower() in exclude
-                or model._meta.proxy
-            ):
-                if not silent:
-                    click.echo(f">> Skipping model <{model.__name__}>", err=True)
-                continue
-
-            queryset = model._base_manager.order_by(model._meta.pk.name)
-            yield from queryset.iterator()
-
-    if not silent:
-        click.echo(">> Beginning export", err=True)
-    serialize(
-        "json",
-        yield_objects(),
-        indent=indent,
-        stream=dest,
-        use_natural_foreign_keys=True,
-        cls=DatetimeSafeDjangoJSONEncoder,
-    )
+    exports(dest, indent, exclude, (lambda *args, **kwargs: None) if silent else click.echo)

--- a/tests/sentry/backup/__init__.py
+++ b/tests/sentry/backup/__init__.py
@@ -4,7 +4,7 @@ from typing import Type
 
 from django.db import models
 
-from sentry.runner.commands.backup import DatetimeSafeDjangoJSONEncoder
+from sentry.backup.exports import DatetimeSafeDjangoJSONEncoder
 
 
 def targets(expected_models: list[Type]):


### PR DESCRIPTION
This will have two benefits:

1. It makes the code more testable, since "printing to the terminal" is now a thing tests can intercept and potentially assert against.
2. This allows us to mess with the signature of the underlying functions as we implement more features without exposing the changes to users and causing undue churn. As we add new filtering options, like `--scope` and `--slug`, we want to avoid "releasing" them piecemeal, and instead hide them behind the current interfaces.

Issue: getsentry/team-ospo#166