### PR TITLE
chore(django): Address RemovedInDjango41Warning

### DIFF
--- a/src/sentry/auth/providers/github/__init__.py
+++ b/src/sentry/auth/providers/github/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "sentry.auth.providers.github.apps.Config"

--- a/src/sentry/auth/providers/saml2/activedirectory/__init__.py
+++ b/src/sentry/auth/providers/saml2/activedirectory/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "sentry.auth.providers.saml2.activedirectory.apps.Config"

--- a/src/sentry/auth/providers/saml2/auth0/__init__.py
+++ b/src/sentry/auth/providers/saml2/auth0/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "sentry.auth.providers.saml2.auth0.apps.Config"

--- a/src/sentry/auth/providers/saml2/generic/__init__.py
+++ b/src/sentry/auth/providers/saml2/generic/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "sentry.auth.providers.saml2.generic.apps.Config"

--- a/src/sentry/auth/providers/saml2/jumpcloud/__init__.py
+++ b/src/sentry/auth/providers/saml2/jumpcloud/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "sentry.auth.providers.saml2.jumpcloud.apps.Config"

--- a/src/sentry/auth/providers/saml2/okta/__init__.py
+++ b/src/sentry/auth/providers/saml2/okta/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "sentry.auth.providers.saml2.okta.apps.Config"

--- a/src/sentry/auth/providers/saml2/onelogin/__init__.py
+++ b/src/sentry/auth/providers/saml2/onelogin/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "sentry.auth.providers.saml2.onelogin.apps.Config"

--- a/src/sentry/auth/providers/saml2/rippling/__init__.py
+++ b/src/sentry/auth/providers/saml2/rippling/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "sentry.auth.providers.saml2.rippling.apps.Config"


### PR DESCRIPTION
Address these `RemovedInDjango41Warning` warnings that come up in tests:

```
/Users/me/aaa/sentry/sentry/.venv/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'sentry.auth.providers.saml2.activedirectory' defines default_app_config = 'sentry.auth.providers.saml2.activedirectory.apps.Config'. Django now detects this configuration automatically. You can remove default_app_config.
  app_config = AppConfig.create(entry)
/Users/me/aaa/sentry/sentry/.venv/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'sentry.auth.providers.saml2.auth0' defines default_app_config = 'sentry.auth.providers.saml2.auth0.apps.Config'. Django now detects this configuration automatically. You can remove default_app_config.
  app_config = AppConfig.create(entry)
/Users/me/aaa/sentry/sentry/.venv/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'sentry.auth.providers.github' defines default_app_config = 'sentry.auth.providers.github.apps.Config'. Django now detects this configuration automatically. You can remove default_app_config.
  app_config = AppConfig.create(entry)
/Users/me/aaa/sentry/sentry/.venv/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'sentry.auth.providers.saml2.jumpcloud' defines default_app_config = 'sentry.auth.providers.saml2.jumpcloud.apps.Config'. Django now detects this configuration automatically. You can remove default_app_config.
  app_config = AppConfig.create(entry)
/Users/me/aaa/sentry/sentry/.venv/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'sentry.auth.providers.saml2.okta' defines default_app_config = 'sentry.auth.providers.saml2.okta.apps.Config'. Django now detects this configuration automatically. You can remove default_app_config.
  app_config = AppConfig.create(entry)
/Users/me/aaa/sentry/sentry/.venv/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'sentry.auth.providers.saml2.onelogin' defines default_app_config = 'sentry.auth.providers.saml2.onelogin.apps.Config'. Django now detects this configuration automatically. You can remove default_app_config.
  app_config = AppConfig.create(entry)
/Users/me/aaa/sentry/sentry/.venv/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'sentry.auth.providers.saml2.rippling' defines default_app_config = 'sentry.auth.providers.saml2.rippling.apps.Config'. Django now detects this configuration automatically. You can remove default_app_config.
  app_config = AppConfig.create(entry)
/Users/me/aaa/sentry/sentry/.venv/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'sentry.auth.providers.saml2.generic' defines default_app_config = 'sentry.auth.providers.saml2.generic.apps.Config'. Django now detects this configuration automatically. You can remove default_app_config.
  app_config = AppConfig.create(entry)
```