### PR TITLE
ref: Introduce SaveEventTaskKind class

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from time import time
 from typing import Any, Callable, Dict, List, Optional
@@ -77,19 +78,28 @@ def submit_process(
     )
 
 
+@dataclass(frozen=True)
+class SaveEventTaskKind:
+    has_attachments: bool = False
+    from_reprocessing: bool = False
+
+
 def submit_save_event(
+    task_kind: SaveEventTaskKind,
     project_id: int,
-    from_reprocessing: bool,
     cache_key: Optional[str],
     event_id: Optional[str],
     start_time: Optional[int],
     data: Optional[Event],
-    has_attachments: bool,
 ) -> None:
     if cache_key:
         data = None
 
     # XXX: honor from_reprocessing
+    if task_kind.has_attachments:
+        task = save_event_attachments
+    else:
+        task = save_event
 
     task_kwargs = {
         "cache_key": cache_key,
@@ -99,7 +109,7 @@ def submit_save_event(
         "project_id": project_id,
     }
 
-    (save_event_attachments if has_attachments else save_event).delay(**task_kwargs)
+    task.delay(**task_kwargs)
 
 
 def _do_preprocess_event(
@@ -183,14 +193,16 @@ def _do_preprocess_event(
         )
         return
 
+    task_kind = SaveEventTaskKind(
+        has_attachments=has_attachments, from_reprocessing=from_reprocessing
+    )
     submit_save_event(
+        task_kind,
         project_id=project_id,
-        from_reprocessing=from_reprocessing,
         cache_key=cache_key,
         event_id=event_id,
         start_time=start_time,
         data=original_data,
-        has_attachments=has_attachments,
     )
 
 
@@ -298,15 +310,17 @@ def do_process_event(
     event_id = data["event_id"]
 
     def _continue_to_save_event() -> None:
-        from_reprocessing = process_task is process_event_from_reprocessing
+        task_kind = SaveEventTaskKind(
+            from_reprocessing=process_task is process_event_from_reprocessing,
+            has_attachments=has_attachments,
+        )
         submit_save_event(
+            task_kind,
             project_id=project_id,
-            from_reprocessing=from_reprocessing,
             cache_key=cache_key,
             event_id=event_id,
             start_time=start_time,
             data=data,
-            has_attachments=has_attachments,
         )
 
     if killswitch_matches_context(


### PR DESCRIPTION
This introduces a `SaveEventTaskKind` dataclass that bundles together information based on which the right task is selected in `submit_save_event`. Currently, this does almost nothing—there are only two flags and one of them is unused. Rather, this is in preparation for adding a flag for whether an event should go to the "high cpu" queue.