### PR TITLE
feat(spans): Add metric strings for mobile

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -150,9 +150,8 @@ SHARED_TAG_STRINGS = {
     "span.group": PREFIX + 252,
     "transaction.method": PREFIX + 253,
     "span.category": PREFIX + 254,
-    "span.contribution": PREFIX + 255,
-    "span.main_thread": PREFIX + 256,
-    "device.class": PREFIX + 257,
+    "span.main_thread": PREFIX + 255,
+    "device.class": PREFIX + 256,
     # More Transactions
     "has_profile": PREFIX + 260,
     "query_hash": PREFIX + 261,

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -150,6 +150,9 @@ SHARED_TAG_STRINGS = {
     "span.group": PREFIX + 252,
     "transaction.method": PREFIX + 253,
     "span.category": PREFIX + 254,
+    "span.contribution": PREFIX + 255,
+    "span.main_thread": PREFIX + 256,
+    "device.class": PREFIX + 257,
     # More Transactions
     "has_profile": PREFIX + 260,
     "query_hash": PREFIX + 261,
@@ -168,6 +171,8 @@ SPAN_METRICS_NAMES = {
     "d:spans/duration@millisecond": PREFIX + 404,
     "d:spans/exclusive_time@millisecond": PREFIX + 405,
     "d:spans/exclusive_time_light@millisecond": PREFIX + 406,
+    "d:spans/frames_frozen@none": PREFIX + 407,
+    "d:spans/frames_slow@none": PREFIX + 408,
 }
 
 SHARED_STRINGS = {


### PR DESCRIPTION
As a follow-up to https://github.com/getsentry/relay/pull/2379 and in preparation for future PRs around mobile span metrics, add corresponding strings to the static indexer lookup.