### PR TITLE
fix(replays): remove slow click and multiclick surfacing on DOM events tab

### DIFF
--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -63,7 +63,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame) => Details> = {
           'Click on [selector] did not cause a visible effect within [timeout] ms',
           {
             selector: stringifyNodeAttributes(node),
-            timeout: frame.data.timeAfterClickMs,
+            timeout: Math.round(frame.data.timeAfterClickMs),
           }
         ),
         type: BreadcrumbType.ERROR,
@@ -77,7 +77,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame) => Details> = {
         'Click on [selector] took [duration] ms to have a visible effect',
         {
           selector: stringifyNodeAttributes(node),
-          duration: frame.data.timeAfterClickMs,
+          duration: Math.round(frame.data.timeAfterClickMs),
         }
       ),
       type: BreadcrumbType.WARNING,

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -188,20 +188,22 @@ export default class ReplayReader {
     )
   );
 
-  getDOMFrames = memoize(() => [
-    ...this._sortedBreadcrumbFrames.filter(frame => 'nodeId' in (frame.data ?? {})),
-    ...this._sortedSpanFrames.filter(frame => 'nodeId' in (frame.data ?? {})),
-  ]);
+  getDOMFrames = memoize(() =>
+    [
+      ...this._sortedBreadcrumbFrames.filter(frame => 'nodeId' in (frame.data ?? {})),
+      ...this._sortedSpanFrames.filter(frame => 'nodeId' in (frame.data ?? {})),
+    ].filter(
+      frame =>
+        !(
+          (frame as SlowClickFrame).category === 'ui.slowClickDetected' &&
+          !isDeadClick(frame as SlowClickFrame)
+        )
+    )
+  );
 
   getDomNodes = memoize(() =>
     extractDomNodes({
-      frames: this.getDOMFrames().filter(
-        frame =>
-          !(
-            (frame as SlowClickFrame).category === 'ui.slowClickDetected' &&
-            !isDeadClick(frame as SlowClickFrame)
-          )
-      ),
+      frames: this.getDOMFrames(),
       rrwebEvents: this.getRRWebFrames(),
       finishedAt: this._replayRecord.finished_at,
     })

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -20,6 +20,7 @@ import type {
   BreadcrumbFrame,
   ErrorFrame,
   MemoryFrame,
+  MultiClickFrame,
   OptionFrame,
   RecordingFrame,
   SlowClickFrame,
@@ -195,8 +196,9 @@ export default class ReplayReader {
     ].filter(
       frame =>
         !(
-          (frame as SlowClickFrame).category === 'ui.slowClickDetected' &&
-          !isDeadClick(frame as SlowClickFrame)
+          ((frame as SlowClickFrame).category === 'ui.slowClickDetected' &&
+            !isDeadClick(frame as SlowClickFrame)) ||
+          (frame as MultiClickFrame).category === 'ui.multiClick'
         )
     )
   );
@@ -223,7 +225,6 @@ export default class ReplayReader {
           (frame.category === 'ui.slowClickDetected' &&
             (isDeadClick(frame as SlowClickFrame) ||
               isDeadRageClick(frame as SlowClickFrame)))
-        // Hiding all ui.multiClick (multi or rage clicks)
       ),
       ...this._sortedSpanFrames.filter(frame =>
         ['navigation.navigate', 'navigation.reload', 'navigation.back_forward'].includes(

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -195,7 +195,13 @@ export default class ReplayReader {
 
   getDomNodes = memoize(() =>
     extractDomNodes({
-      frames: this.getDOMFrames(),
+      frames: this.getDOMFrames().filter(
+        frame =>
+          !(
+            (frame as SlowClickFrame).category === 'ui.slowClickDetected' &&
+            !isDeadClick(frame as SlowClickFrame)
+          )
+      ),
       rrwebEvents: this.getRRWebFrames(),
       finishedAt: this._replayRecord.finished_at,
     })

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -20,7 +20,6 @@ import type {
   BreadcrumbFrame,
   ErrorFrame,
   MemoryFrame,
-  MultiClickFrame,
   OptionFrame,
   RecordingFrame,
   SlowClickFrame,
@@ -189,19 +188,19 @@ export default class ReplayReader {
     )
   );
 
-  getDOMFrames = memoize(() =>
-    [
-      ...this._sortedBreadcrumbFrames.filter(frame => 'nodeId' in (frame.data ?? {})),
-      ...this._sortedSpanFrames.filter(frame => 'nodeId' in (frame.data ?? {})),
-    ].filter(
-      frame =>
-        !(
-          ((frame as SlowClickFrame).category === 'ui.slowClickDetected' &&
-            !isDeadClick(frame as SlowClickFrame)) ||
-          (frame as MultiClickFrame).category === 'ui.multiClick'
-        )
-    )
-  );
+  getDOMFrames = memoize(() => [
+    ...this._sortedBreadcrumbFrames
+      .filter(frame => 'nodeId' in (frame.data ?? {}))
+      .filter(
+        frame =>
+          !(
+            (frame.category === 'ui.slowClickDetected' &&
+              !isDeadClick(frame as SlowClickFrame)) ||
+            frame.category === 'ui.multiClick'
+          )
+      ),
+    ...this._sortedSpanFrames.filter(frame => 'nodeId' in (frame.data ?? {})),
+  ]);
 
   getDomNodes = memoize(() =>
     extractDomNodes({


### PR DESCRIPTION
We want to hide slow clicks and multiclicks on the UI, specifically in the DOM events tab.

Before (slow clicks):
<img width="633" alt="SCR-20230803-jwfu" src="https://github.com/getsentry/sentry/assets/56095982/a9f72401-918a-4cde-af1e-8626ef6c8b0d">

After (no slow clicks):
<img width="618" alt="SCR-20230803-jwex" src="https://github.com/getsentry/sentry/assets/56095982/f22992d2-3306-4211-b695-b6a9a5a6a5be">

Before (multi clicks in the "unknown" category):
<img width="619" alt="SCR-20230803-kfif" src="https://github.com/getsentry/sentry/assets/56095982/066202fe-97b8-4d34-9f24-102883d785f4">


After (no unknown category --> no multi clicks):
<img width="513" alt="SCR-20230803-kfov" src="https://github.com/getsentry/sentry/assets/56095982/2af1d1a7-3bd0-4109-bc37-41aa8facf334">


Also closes https://github.com/getsentry/sentry/issues/54068.