### PR TITLE
ref(option): change this flag to use automator instead of admin

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1421,7 +1421,11 @@ register(
 )
 
 # The flag activates whether to send group attributes messages to kafka
-register("issues.group_attributes.send_kafka", default=False, flags=FLAG_MODIFIABLE_BOOL)
+register(
+    "issues.group_attributes.send_kafka",
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Enables statistical detectors for a project
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1421,11 +1421,7 @@ register(
 )
 
 # The flag activates whether to send group attributes messages to kafka
-register(
-    "issues.group_attributes.send_kafka",
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
+register("issues.group_attributes.send_kafka", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Enables statistical detectors for a project
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1421,7 +1421,11 @@ register(
 )
 
 # The flag activates whether to send group attributes messages to kafka
-register("issues.group_attributes.send_kafka", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register(
+    "issues.group_attributes.send_kafka",
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Enables statistical detectors for a project
 register(


### PR DESCRIPTION
Was recommended by @fpacifici to use this flag instead of the admin modifiable flag. 