### PR TITLE
feat(dashboards): Add ANR and Foreground ANR rate

### DIFF
--- a/static/app/types/sessions.tsx
+++ b/static/app/types/sessions.tsx
@@ -24,7 +24,9 @@ export type SessionsOperation =
   | 'count_abnormal'
   | 'count_errored'
   | 'count_healthy'
-  | 'count_crashed';
+  | 'count_crashed'
+  | 'anr_rate'
+  | 'foreground_anr_rate';
 
 export type SessionAggregationColumn = {
   outputType: AggregationOutputType | null;

--- a/static/app/views/dashboards/widgetBuilder/releaseWidget/fields.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/releaseWidget/fields.spec.tsx
@@ -39,6 +39,16 @@ describe('generateReleaseWidgetFieldOptions', function () {
           },
         },
       },
+      'function:anr_rate': {
+        label: 'anr_rate(…)',
+        value: {
+          kind: 'function',
+          meta: {
+            name: 'anr_rate',
+            parameters: [],
+          },
+        },
+      },
       'function:count_abnormal': {
         label: 'count_abnormal(…)',
         value: {
@@ -155,6 +165,16 @@ describe('generateReleaseWidgetFieldOptions', function () {
                 required: true,
               },
             ],
+          },
+        },
+      },
+      'function:foreground_anr_rate': {
+        label: 'foreground_anr_rate(…)',
+        value: {
+          kind: 'function',
+          meta: {
+            name: 'foreground_anr_rate',
+            parameters: [],
           },
         },
       },

--- a/static/app/views/dashboards/widgetBuilder/releaseWidget/fields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/releaseWidget/fields.tsx
@@ -12,6 +12,8 @@ import {defined} from 'sentry/utils';
 import {FieldValue, FieldValueKind} from 'sentry/views/discover/table/types';
 
 enum SessionMetric {
+  ANR_RATE = 'session.anr_rate',
+  FOREGROUND_ANR_RATE = 'session.foreground_anr_rate',
   SESSION = 'sentry.sessions.session',
   SESSION_DURATION = 'sentry.sessions.session.duration',
   SESSION_ERROR = 'sentry.sessions.session.error',
@@ -45,6 +47,8 @@ export enum DerivedStatusFields {
 }
 
 export const FIELD_TO_METRICS_EXPRESSION = {
+  'foreground_anr_rate()': SessionMetric.FOREGROUND_ANR_RATE,
+  'anr_rate()': SessionMetric.ANR_RATE,
   'count_healthy(session)': SessionMetric.SESSION_HEALTHY,
   'count_healthy(user)': SessionMetric.USER_HEALTHY,
   'count_abnormal(session)': SessionMetric.SESSION_ABNORMAL,
@@ -85,6 +89,8 @@ export const SESSIONS_FIELDS: Readonly<Partial<Record<SessionField, SessionsMeta
       'count_abnormal',
       'count_crashed',
       'count_errored',
+      'anr_rate',
+      'foreground_anr_rate',
     ],
     type: 'integer',
   },
@@ -111,6 +117,14 @@ export const SESSIONS_FIELDS: Readonly<Partial<Record<SessionField, SessionsMeta
 export const SESSIONS_OPERATIONS: Readonly<
   Record<SessionsOperation, SessionAggregationColumn>
 > = {
+  anr_rate: {
+    outputType: 'percentage',
+    parameters: [],
+  },
+  foreground_anr_rate: {
+    outputType: 'percentage',
+    parameters: [],
+  },
   sum: {
     outputType: 'integer',
     parameters: [


### PR DESCRIPTION
Add ANR and Foreground ANR rate to widget fields in dashboards.

To test this, you can go to the android project in the Sentry SDK's org and see the ANR rate and compare that with a new widget with the bar chart option selected. This has the same 1 day interval. We can also represent it in line charts but the interval is 30mins so it will look slightly different.

Using a table or a big number should show the same value for the project as the tile in the project page.