### PR TITLE
chore(statistical-detectors): Update option flags

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1427,17 +1427,17 @@ register("issues.group_attributes.send_kafka", default=False, flags=FLAG_MODIFIA
 register(
     "statistical_detectors.enable",
     default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "statistical_detectors.enable.projects.performance",
     type=Sequence,
     default=[],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "statistical_detectors.enable.projects.profiling",
     type=Sequence,
     default=[],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )


### PR DESCRIPTION
The admin UI is being sunsetted in favour of the automator. So remove the admin UI flag. Also prioritize disk so we can overwrite it in `SENTRY_OPTIONS`.