### PR TITLE
feat(issues): Split group statusDetails by status

### DIFF
--- a/static/app/components/actions/archive.spec.tsx
+++ b/static/app/components/actions/archive.spec.tsx
@@ -6,7 +6,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import ArchiveActions from 'sentry/components/actions/archive';
-import {ResolutionStatus} from 'sentry/types';
+import {GroupStatus} from 'sentry/types';
 
 describe('ArchiveActions', () => {
   const onUpdate = jest.fn();
@@ -18,7 +18,7 @@ describe('ArchiveActions', () => {
     render(<ArchiveActions onUpdate={onUpdate} />);
     await userEvent.click(screen.getByRole('button', {name: 'Archive'}));
     expect(onUpdate).toHaveBeenCalledWith({
-      status: ResolutionStatus.IGNORED,
+      status: GroupStatus.IGNORED,
       statusDetails: {},
       substatus: 'archived_until_escalating',
     });
@@ -53,7 +53,7 @@ describe('ArchiveActions', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
 
     expect(onUpdate).toHaveBeenCalledWith({
-      status: ResolutionStatus.IGNORED,
+      status: GroupStatus.IGNORED,
       statusDetails: {},
       substatus: 'archived_until_escalating',
     });

--- a/static/app/components/actions/archive.tsx
+++ b/static/app/components/actions/archive.tsx
@@ -8,7 +8,7 @@ import {DropdownMenu, MenuItemProps} from 'sentry/components/dropdownMenu';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {IconChevron} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import {GroupStatusResolution, GroupSubstatus, ResolutionStatus} from 'sentry/types';
+import {GroupStatus, GroupStatusResolution, GroupSubstatus} from 'sentry/types';
 
 interface ArchiveActionProps {
   onUpdate: (params: GroupStatusResolution) => void;
@@ -22,12 +22,12 @@ interface ArchiveActionProps {
 }
 
 const ARCHIVE_UNTIL_ESCALATING: GroupStatusResolution = {
-  status: ResolutionStatus.IGNORED,
+  status: GroupStatus.IGNORED,
   statusDetails: {},
   substatus: GroupSubstatus.ARCHIVED_UNTIL_ESCALATING,
 };
 const ARCHIVE_FOREVER: GroupStatusResolution = {
-  status: ResolutionStatus.IGNORED,
+  status: GroupStatus.IGNORED,
   statusDetails: {},
   substatus: GroupSubstatus.ARCHIVED_FOREVER,
 };
@@ -101,7 +101,7 @@ function ArchiveActions({
         title={t('Change status to unresolved')}
         onClick={() =>
           onUpdate({
-            status: ResolutionStatus.UNRESOLVED,
+            status: GroupStatus.UNRESOLVED,
             statusDetails: {},
             substatus: GroupSubstatus.ONGOING,
           })

--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -11,10 +11,10 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconChevron} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {
+  GroupStatus,
   GroupStatusResolution,
   GroupSubstatus,
-  ResolutionStatus,
-  ResolutionStatusDetails,
+  IgnoredStatusDetails,
   SelectValue,
 } from 'sentry/types';
 import {getDuration} from 'sentry/utils/formatters';
@@ -53,14 +53,14 @@ export function getIgnoreActions({
   'shouldConfirm' | 'confirmMessage' | 'confirmLabel' | 'onUpdate'
 >) {
   const onIgnore = (
-    statusDetails: ResolutionStatusDetails | undefined = {},
+    statusDetails: IgnoredStatusDetails | undefined = {},
     {bypassConfirm} = {bypassConfirm: false}
   ) => {
     openConfirmModal({
       bypass: bypassConfirm || !shouldConfirm,
       onConfirm: () =>
         onUpdate({
-          status: ResolutionStatus.IGNORED,
+          status: GroupStatus.IGNORED,
           statusDetails,
           substatus: GroupSubstatus.ARCHIVED_UNTIL_CONDITION_MET,
         }),
@@ -69,7 +69,7 @@ export function getIgnoreActions({
     });
   };
 
-  const onCustomIgnore = (statusDetails: ResolutionStatusDetails) => {
+  const onCustomIgnore = (statusDetails: IgnoredStatusDetails) => {
     onIgnore(statusDetails, {bypassConfirm: true});
   };
 
@@ -231,7 +231,7 @@ function IgnoreActions({
           size="xs"
           onClick={() =>
             onUpdate({
-              status: ResolutionStatus.UNRESOLVED,
+              status: GroupStatus.UNRESOLVED,
               statusDetails: {},
               substatus: GroupSubstatus.ONGOING,
             })

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -13,11 +13,11 @@ import {IconChevron, IconReleases} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {
+  GroupStatus,
   GroupStatusResolution,
   GroupSubstatus,
   Project,
-  ResolutionStatus,
-  ResolutionStatusDetails,
+  ResolvedStatusDetails,
 } from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatVersion, isSemverRelease} from 'sentry/utils/formatters';
@@ -87,19 +87,17 @@ function ResolveActions({
 }: ResolveActionsProps) {
   const organization = useOrganization();
 
-  function handleCommitResolution(statusDetails: ResolutionStatusDetails) {
+  function handleCommitResolution(statusDetails: ResolvedStatusDetails) {
     onUpdate({
-      status: ResolutionStatus.RESOLVED,
+      status: GroupStatus.RESOLVED,
       statusDetails,
       substatus: null,
     });
   }
 
-  function handleAnotherExistingReleaseResolution(
-    statusDetails: ResolutionStatusDetails
-  ) {
+  function handleAnotherExistingReleaseResolution(statusDetails: ResolvedStatusDetails) {
     onUpdate({
-      status: ResolutionStatus.RESOLVED,
+      status: GroupStatus.RESOLVED,
       statusDetails,
       substatus: null,
     });
@@ -112,7 +110,7 @@ function ResolveActions({
   function handleCurrentReleaseResolution() {
     if (hasRelease) {
       onUpdate({
-        status: ResolutionStatus.RESOLVED,
+        status: GroupStatus.RESOLVED,
         statusDetails: {
           inRelease: latestRelease ? latestRelease.version : 'latest',
         },
@@ -129,7 +127,7 @@ function ResolveActions({
   function handleNextReleaseResolution() {
     if (hasRelease) {
       onUpdate({
-        status: ResolutionStatus.RESOLVED,
+        status: GroupStatus.RESOLVED,
         statusDetails: {
           inNextRelease: true,
         },
@@ -161,7 +159,7 @@ function ResolveActions({
           disabled={isAutoResolved}
           onClick={() =>
             onUpdate({
-              status: ResolutionStatus.UNRESOLVED,
+              status: GroupStatus.UNRESOLVED,
               statusDetails: {},
               substatus: GroupSubstatus.ONGOING,
             })
@@ -265,7 +263,7 @@ function ResolveActions({
     openModal(deps => (
       <CustomCommitsResolutionModal
         {...deps}
-        onSelected={(statusDetails: ResolutionStatusDetails) =>
+        onSelected={(statusDetails: ResolvedStatusDetails) =>
           handleCommitResolution(statusDetails)
         }
         orgSlug={organization.slug}
@@ -278,7 +276,7 @@ function ResolveActions({
     openModal(deps => (
       <CustomResolutionModal
         {...deps}
-        onSelected={(statusDetails: ResolutionStatusDetails) =>
+        onSelected={(statusDetails: ResolvedStatusDetails) =>
           handleAnotherExistingReleaseResolution(statusDetails)
         }
         organization={organization}
@@ -304,7 +302,7 @@ function ResolveActions({
               bypass: !shouldConfirm,
               onConfirm: () =>
                 onUpdate({
-                  status: ResolutionStatus.RESOLVED,
+                  status: GroupStatus.RESOLVED,
                   statusDetails: {},
                   substatus: null,
                 }),

--- a/static/app/components/archivedBox.tsx
+++ b/static/app/components/archivedBox.tsx
@@ -3,12 +3,12 @@ import Duration from 'sentry/components/duration';
 import {BannerContainer, BannerSummary} from 'sentry/components/events/styles';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t} from 'sentry/locale';
-import {Group, GroupSubstatus, Organization, ResolutionStatusDetails} from 'sentry/types';
+import {Group, GroupSubstatus, IgnoredStatusDetails, Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
 interface ArchivedBoxProps {
   organization: Organization;
-  statusDetails: ResolutionStatusDetails;
+  statusDetails: IgnoredStatusDetails;
   substatus: Group['substatus'];
 }
 

--- a/static/app/components/customCommitsResolutionModal.tsx
+++ b/static/app/components/customCommitsResolutionModal.tsx
@@ -7,10 +7,10 @@ import TimeSince from 'sentry/components/timeSince';
 import Version from 'sentry/components/version';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Commit, ResolutionStatusDetails} from 'sentry/types';
+import type {Commit, ResolvedStatusDetails} from 'sentry/types';
 
 interface CustomCommitsResolutionModalProps extends ModalRenderProps {
-  onSelected: (x: ResolutionStatusDetails) => void;
+  onSelected: (x: ResolvedStatusDetails) => void;
   orgSlug: string;
   projectSlug?: string;
 }

--- a/static/app/components/customIgnoreCountModal.tsx
+++ b/static/app/components/customIgnoreCountModal.tsx
@@ -6,7 +6,7 @@ import ButtonBar from 'sentry/components/buttonBar';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import {t} from 'sentry/locale';
-import {ResolutionStatusDetails, SelectValue} from 'sentry/types';
+import {IgnoredStatusDetails, SelectValue} from 'sentry/types';
 
 type CountNames = 'ignoreCount' | 'ignoreUserCount';
 type WindowNames = 'ignoreWindow' | 'ignoreUserWindow';
@@ -15,7 +15,7 @@ type Props = ModalRenderProps & {
   countLabel: string;
   countName: CountNames;
   label: string;
-  onSelected: (statusDetails: ResolutionStatusDetails) => void;
+  onSelected: (statusDetails: IgnoredStatusDetails) => void;
   windowName: WindowNames;
   windowOptions: SelectValue<number>[];
 };
@@ -35,7 +35,7 @@ class CustomIgnoreCountModal extends Component<Props, State> {
     const {count, window} = this.state;
     const {countName, windowName} = this.props;
 
-    const statusDetails: ResolutionStatusDetails = {[countName]: count};
+    const statusDetails: IgnoredStatusDetails = {[countName]: count};
     if (window) {
       statusDetails[windowName] = window;
     }

--- a/static/app/components/customIgnoreDurationModal.tsx
+++ b/static/app/components/customIgnoreDurationModal.tsx
@@ -7,14 +7,14 @@ import {Alert} from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {t} from 'sentry/locale';
-import {ResolutionStatusDetails} from 'sentry/types';
+import {IgnoredStatusDetails} from 'sentry/types';
 
 const defaultProps = {
   label: t('Ignore this issue until \u2026'),
 };
 
 type Props = ModalRenderProps & {
-  onSelected: (details: ResolutionStatusDetails) => void;
+  onSelected: (details: IgnoredStatusDetails) => void;
 } & typeof defaultProps;
 
 type State = {

--- a/static/app/components/group/inboxBadges/statusBadge.spec.tsx
+++ b/static/app/components/group/inboxBadges/statusBadge.spec.tsx
@@ -1,13 +1,13 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {GroupStatusBadge} from 'sentry/components/group/inboxBadges/statusBadge';
-import {GroupSubstatus, ResolutionStatus} from 'sentry/types';
+import {GroupStatus, GroupSubstatus} from 'sentry/types';
 
 describe('GroupStatusBadge', () => {
   it('should display archived until escalating as a tooltip', async () => {
     render(
       <GroupStatusBadge
-        status={ResolutionStatus.IGNORED}
+        status={GroupStatus.IGNORED}
         substatus={GroupSubstatus.ARCHIVED_UNTIL_ESCALATING}
       />
     );
@@ -16,17 +16,14 @@ describe('GroupStatusBadge', () => {
   });
   it('should display new', () => {
     render(
-      <GroupStatusBadge
-        status={ResolutionStatus.UNRESOLVED}
-        substatus={GroupSubstatus.NEW}
-      />
+      <GroupStatusBadge status={GroupStatus.UNRESOLVED} substatus={GroupSubstatus.NEW} />
     );
     expect(screen.getByText('New')).toBeInTheDocument();
   });
   it('should display escalating', () => {
     render(
       <GroupStatusBadge
-        status={ResolutionStatus.UNRESOLVED}
+        status={GroupStatus.UNRESOLVED}
         substatus={GroupSubstatus.ESCALATING}
       />
     );
@@ -35,14 +32,14 @@ describe('GroupStatusBadge', () => {
   it('should display regression', () => {
     render(
       <GroupStatusBadge
-        status={ResolutionStatus.UNRESOLVED}
+        status={GroupStatus.UNRESOLVED}
         substatus={GroupSubstatus.REGRESSED}
       />
     );
     expect(screen.getByText('Regressed')).toBeInTheDocument();
   });
   it('should display resolved', () => {
-    render(<GroupStatusBadge status={ResolutionStatus.RESOLVED} />);
+    render(<GroupStatusBadge status={GroupStatus.RESOLVED} />);
     expect(screen.getByText('Resolved')).toBeInTheDocument();
   });
 });

--- a/static/app/components/mutedBox.tsx
+++ b/static/app/components/mutedBox.tsx
@@ -3,10 +3,10 @@ import Duration from 'sentry/components/duration';
 import {BannerContainer, BannerSummary} from 'sentry/components/events/styles';
 import {IconMute} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {ResolutionStatusDetails} from 'sentry/types';
+import {IgnoredStatusDetails} from 'sentry/types';
 
 type Props = {
-  statusDetails: ResolutionStatusDetails;
+  statusDetails: IgnoredStatusDetails;
 };
 
 function MutedBox({statusDetails}: Props) {

--- a/static/app/components/resolutionBox.tsx
+++ b/static/app/components/resolutionBox.tsx
@@ -15,17 +15,18 @@ import {
   GroupActivitySetByResolvedInRelease,
   GroupActivityType,
   Repository,
-  ResolutionStatusDetails,
+  ResolvedStatusDetails,
 } from 'sentry/types';
 
 type Props = {
   projectId: string;
-  statusDetails: ResolutionStatusDetails;
+  // TODO(ts): This should be a union type `IgnoredStatusDetails | ResolvedStatusDetails`
+  statusDetails: ResolvedStatusDetails;
   activities?: GroupActivity[];
 };
 
 function renderReason(
-  statusDetails: ResolutionStatusDetails,
+  statusDetails: ResolvedStatusDetails,
   projectId: string,
   activities: GroupActivity[]
 ) {

--- a/static/app/components/stream/group.spec.tsx
+++ b/static/app/components/stream/group.spec.tsx
@@ -4,7 +4,7 @@ import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import StreamGroup from 'sentry/components/stream/group';
 import GroupStore from 'sentry/stores/groupStore';
 import GuideStore from 'sentry/stores/guideStore';
-import {Group, ResolutionStatus} from 'sentry/types';
+import {GroupStatus, GroupStatusResolution, MarkReviewed} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
 jest.mock('sentry/utils/analytics');
@@ -61,7 +61,7 @@ describe('StreamGroup', function () {
     );
 
     expect(screen.getByTestId('group')).toHaveAttribute('data-test-reviewed', 'false');
-    const data: Partial<Group> = {inbox: false};
+    const data: MarkReviewed = {inbox: false};
     act(() => GroupStore.onUpdate('1337', undefined, data));
     act(() => GroupStore.onUpdateSuccess('1337', undefined, data));
 
@@ -77,7 +77,10 @@ describe('StreamGroup', function () {
     });
 
     expect(screen.queryByTestId('resolved-issue')).not.toBeInTheDocument();
-    const data: Partial<Group> = {status: ResolutionStatus.RESOLVED, statusDetails: {}};
+    const data: GroupStatusResolution = {
+      status: GroupStatus.RESOLVED,
+      statusDetails: {},
+    };
     act(() => GroupStore.onUpdate('1337', undefined, data));
     act(() => GroupStore.onUpdateSuccess('1337', undefined, data));
     expect(screen.getByTestId('resolved-issue')).toBeInTheDocument();

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -1,6 +1,6 @@
-import type {ResolutionStatus} from 'sentry/types';
-import {CommonGroupAnalyticsData} from 'sentry/utils/events';
-import {Tab} from 'sentry/views/issueDetails/types';
+import type {GroupStatus} from 'sentry/types';
+import type {CommonGroupAnalyticsData} from 'sentry/utils/events';
+import type {Tab} from 'sentry/views/issueDetails/types';
 
 type RuleViewed = {
   alert_type: 'issue' | 'metric';
@@ -81,7 +81,7 @@ export type TeamInsightsEventParameters = {
       | 'discarded'
       | 'open_in_discover'
       | 'assign'
-      | ResolutionStatus;
+      | GroupStatus;
     action_status_details?: string;
     action_substatus?: string;
     assigned_suggestion_reason?: string;

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -479,7 +479,7 @@ export type CommonGroupAnalyticsData = {
   is_assigned?: boolean;
   issue_level?: string;
   issue_status?: string;
-  issue_substatus?: string;
+  issue_substatus?: string | null;
 };
 
 export function getAnalyticsDataForGroup(group?: Group | null): CommonGroupAnalyticsData {

--- a/static/app/views/dashboards/datasetConfig/issues.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.spec.tsx
@@ -1,4 +1,4 @@
-import {ResolutionStatus} from 'sentry/types';
+import {GroupStatus} from 'sentry/types';
 import {transformIssuesResponseToTable} from 'sentry/views/dashboards/datasetConfig/issues';
 
 describe('transformIssuesResponseToTable', function () {
@@ -12,7 +12,7 @@ describe('transformIssuesResponseToTable', function () {
             project: TestStubs.Project({
               id: '3',
             }),
-            status: ResolutionStatus.UNRESOLVED,
+            status: GroupStatus.UNRESOLVED,
             owners: [
               {
                 type: 'ownershipRule',

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -33,12 +33,13 @@ import GroupStore from 'sentry/stores/groupStore';
 import {space} from 'sentry/styles/space';
 import {
   Group,
+  GroupStatus,
   GroupStatusResolution,
   GroupSubstatus,
   IssueCategory,
+  MarkReviewed,
   Organization,
   Project,
-  ResolutionStatus,
   SavedQueryVersions,
 } from 'sentry/types';
 import {Event} from 'sentry/types/event';
@@ -60,7 +61,7 @@ import SubscribeAction from './subscribeAction';
 type UpdateData =
   | {isBookmarked: boolean}
   | {isSubscribed: boolean}
-  | {inbox: boolean}
+  | MarkReviewed
   | GroupStatusResolution;
 
 const isResolutionStatus = (data: UpdateData): data is GroupStatusResolution => {
@@ -134,7 +135,7 @@ export function Actions(props: Props) {
       | 'mark_reviewed'
       | 'discarded'
       | 'open_in_discover'
-      | ResolutionStatus,
+      | GroupStatus,
     substatus?: GroupSubstatus | null,
     statusDetailsKey?: string
   ) => {
@@ -501,7 +502,7 @@ export function Actions(props: Props) {
           disabled={disabled || isAutoResolved}
           onClick={() =>
             onUpdate({
-              status: ResolutionStatus.UNRESOLVED,
+              status: GroupStatus.UNRESOLVED,
               statusDetails: {},
               substatus: GroupSubstatus.ONGOING,
             })

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -23,7 +23,7 @@ import {TabPanels, Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import {space} from 'sentry/styles/space';
-import {Group, IssueCategory, Organization, Project} from 'sentry/types';
+import {Group, GroupStatus, IssueCategory, Organization, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -502,11 +502,7 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
   }, [isGroupError, groupError, handleError]);
 
   const refetchGroup = useCallback(() => {
-    if (
-      group?.status !== ReprocessingStatus.REPROCESSING ||
-      loadingGroup ||
-      loadingEvent
-    ) {
+    if (group?.status !== GroupStatus.REPROCESSING || loadingGroup || loadingEvent) {
       return;
     }
 

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -17,9 +17,9 @@ import {TransactionProfileIdProvider} from 'sentry/components/profiling/transact
 import ResolutionBox from 'sentry/components/resolutionBox';
 import {space} from 'sentry/styles/space';
 import {
-  BaseGroupStatusReprocessing,
   Group,
   GroupActivityReprocess,
+  GroupReprocessing,
   Organization,
   Project,
 } from 'sentry/types';
@@ -201,8 +201,7 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
             <ReprocessingProgress
               totalEvents={(mostRecentActivity as GroupActivityReprocess).data.eventCount}
               pendingEvents={
-                (group.statusDetails as BaseGroupStatusReprocessing['statusDetails'])
-                  .pendingEvents
+                (group.statusDetails as GroupReprocessing['statusDetails']).pendingEvents
               }
             />
           ) : (

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -10,7 +10,7 @@ import {DropdownMenu, MenuItemProps} from 'sentry/components/dropdownMenu';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
-import {BaseGroup, Project, ResolutionStatus} from 'sentry/types';
+import {BaseGroup, GroupStatus, Project} from 'sentry/types';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {IssueTypeConfig} from 'sentry/utils/issueTypeConfig/types';
 import Projects from 'sentry/utils/projects';
@@ -166,7 +166,7 @@ function ActionSet({
       onAction: () => {
         openConfirmModal({
           bypass: !onShouldConfirm(ConfirmAction.UNRESOLVE),
-          onConfirm: () => onUpdate({status: ResolutionStatus.UNRESOLVED}),
+          onConfirm: () => onUpdate({status: GroupStatus.UNRESOLVED}),
           message: confirm({action: ConfirmAction.UNRESOLVE, canBeUndone: true}),
           confirmText: label('unresolve'),
         });
@@ -198,7 +198,7 @@ function ActionSet({
           onClick={() => {
             openConfirmModal({
               bypass: !onShouldConfirm(ConfirmAction.UNRESOLVE),
-              onConfirm: () => onUpdate({status: ResolutionStatus.UNRESOLVED}),
+              onConfirm: () => onUpdate({status: GroupStatus.UNRESOLVED}),
               message: confirm({action: ConfirmAction.UNRESOLVE, canBeUndone: true}),
               confirmText: label('unarchive'),
             });

--- a/static/app/views/issueList/actions/utils.tsx
+++ b/static/app/views/issueList/actions/utils.tsx
@@ -4,7 +4,7 @@ import capitalize from 'lodash/capitalize';
 import {Alert} from 'sentry/components/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct, tn} from 'sentry/locale';
-import {Organization, ResolutionStatusDetails} from 'sentry/types';
+import {IgnoredStatusDetails, Organization} from 'sentry/types';
 
 import ExtraDescription from './extraDescription';
 
@@ -163,7 +163,7 @@ export function getLabel(numIssues: number, allInQuerySelected: boolean) {
 }
 
 export function performanceIssuesSupportsIgnoreAction(
-  statusDetails: ResolutionStatusDetails
+  statusDetails: IgnoredStatusDetails
 ) {
   return !(statusDetails.ignoreWindow || statusDetails.ignoreUserWindow);
 }


### PR DESCRIPTION
- Fixes `BaseGroup.status` being a string
- Breaks `Group.statusDetails` into different interfaces depending on the status. For example, if the status is **resolved** the statusDetails will not have ignoredUntil
- Renames `ResolutionStatus` to `GroupStatus`
- Stops extending the Resolution object
