### PR TITLE
fix(issues): Check author is not None

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -331,7 +331,8 @@ class PushEventWebhook(Webhook):
             else:
                 author = authors[author_email]
 
-            author.preload_users()
+            if author:
+                author.preload_users()
             try:
                 with transaction.atomic(router.db_for_write(Commit)):
                     c = Commit.objects.create(


### PR DESCRIPTION
`author` is explicitly set to None earlier in the function. Check that `author` isn't None before trying access a property.

https://github.com/getsentry/sentry/blob/cc6e75f118a8cac5f2818043f19cfbad9faecf4b/src/sentry/integrations/github/webhook.py#L304

fixes SENTRY-12K6

