### PR TITLE
fix(alerts): Consolidate delete alert modal copy

### DIFF
--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -217,7 +217,7 @@ function RuleListRow({
           onConfirm: () => onDelete(slug, rule),
           header: <h5>{t('Delete Alert Rule?')}</h5>,
           message: t(
-            "Are you sure you want to delete %s? You won't be able to view the history of this alert once it's deleted.",
+            'Are you sure you want to delete "%s"? You won\'t be able to view the history of this alert once it\'s deleted.',
             rule.name
           ),
           confirmText: t('Delete Rule'),

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -215,10 +215,10 @@ function RuleListRow({
       onAction: () => {
         openConfirmModal({
           onConfirm: () => onDelete(slug, rule),
-          header: t('Delete Alert Rule?'),
-          message: tct(
-            "Are you sure you want to delete [name]? You won't be able to view the history of this alert once it's deleted.",
-            {name: rule.name}
+          header: <h5>{t('Delete Alert Rule?')}</h5>,
+          message: t(
+            "Are you sure you want to delete %s? You won't be able to view the history of this alert once it's deleted.",
+            rule.name
           ),
           confirmText: t('Delete Rule'),
           priority: 'danger',

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -223,7 +223,7 @@ describe('IssueRuleEditor', function () {
       await userEvent.click(screen.getByLabelText('Delete Rule'));
 
       expect(
-        await screen.findByText('Are you sure you want to delete this rule?')
+        await screen.findByText(/Are you sure you want to delete My alert rule\?/)
       ).toBeInTheDocument();
       await userEvent.click(screen.getByTestId('confirm-button'));
 

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -223,7 +223,7 @@ describe('IssueRuleEditor', function () {
       await userEvent.click(screen.getByLabelText('Delete Rule'));
 
       expect(
-        await screen.findByText(/Are you sure you want to delete My alert rule\?/)
+        await screen.findByText(/Are you sure you want to delete "My alert rule"\?/)
       ).toBeInTheDocument();
       await userEvent.click(screen.getByTestId('confirm-button'));
 

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1191,7 +1191,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
                 onConfirm={this.handleDeleteRule}
                 header={<h5>{t('Delete Alert Rule?')}</h5>}
                 message={t(
-                  "Are you sure you want to delete %s? You won't be able to view the history of this alert once it's deleted.",
+                  'Are you sure you want to delete "%s"? You won\'t be able to view the history of this alert once it\'s deleted.',
                   rule.name
                 )}
               >

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1189,8 +1189,11 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
                 priority="danger"
                 confirmText={t('Delete Rule')}
                 onConfirm={this.handleDeleteRule}
-                header={t('Delete Rule')}
-                message={t('Are you sure you want to delete this rule?')}
+                header={<h5>{t('Delete Alert Rule?')}</h5>}
+                message={t(
+                  "Are you sure you want to delete %s? You won't be able to view the history of this alert once it's deleted.",
+                  rule.name
+                )}
               >
                 <Button priority="danger">{t('Delete Rule')}</Button>
               </Confirm>

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -985,7 +985,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
               <Confirm
                 disabled={formDisabled}
                 message={t(
-                  "Are you sure you want to delete %s? You won't be able to view the history of this alert once it's deleted.",
+                  'Are you sure you want to delete "%s"? You won\'t be able to view the history of this alert once it\'s deleted.',
                   rule.name
                 )}
                 header={<h5>{t('Delete Alert Rule?')}</h5>}

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -984,8 +984,11 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
             rule.id ? (
               <Confirm
                 disabled={formDisabled}
-                message={t('Are you sure you want to delete this alert rule?')}
-                header={t('Delete Alert Rule?')}
+                message={t(
+                  "Are you sure you want to delete %s? You won't be able to view the history of this alert once it's deleted.",
+                  rule.name
+                )}
+                header={<h5>{t('Delete Alert Rule?')}</h5>}
                 priority="danger"
                 confirmText={t('Delete Rule')}
                 onConfirm={this.handleDeleteRule}


### PR DESCRIPTION
we were using different copy depending on if you were deleting from the list or the edit page

before:
<img width="637" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/a9c94157-23ce-4b72-b497-bd5603971a04">


after:
<img width="634" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/15e6cbc3-8bfc-4c14-a5b8-074d98922832">
