### PR TITLE
fix(alerts): Max width when creating issue alerts

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1165,7 +1165,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
     // the form with a loading mask on top of it, but force a re-render by using
     // a different key when we have fetched the rule so that form inputs are filled in
     return (
-      <Main fullWidth>
+      <Main>
         <PermissionAlert access={['alerts:write']} project={project} />
 
         <StyledForm


### PR DESCRIPTION
The width of the issue alert editor is different when creating or editing alerts. This makes them the same
