### PR TITLE
ref(ui): Consistent QuestionTooltip usage + sizing

### DIFF
--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -311,9 +311,7 @@ const StyledSidebarSectionContent = styled(SidebarSection.Content)`
 `;
 
 const StyledSidebarTitle = styled(SidebarSection.Title)`
-  display: flex;
   justify-content: space-between;
-  align-items: center;
   margin-right: -${space(1)};
 `;
 

--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -6,14 +6,14 @@ import GroupReleaseChart from 'sentry/components/group/releaseChart';
 import SeenInfo from 'sentry/components/group/seenInfo';
 import Placeholder from 'sentry/components/placeholder';
 import * as SidebarSection from 'sentry/components/sidebarSection';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconQuestion} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {CurrentRelease, Group, Organization, Project, Release} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {useApiQuery} from 'sentry/utils/queryClient';
+
+import QuestionTooltip from '../questionTooltip';
 
 type Props = {
   environments: string[];
@@ -101,17 +101,11 @@ function GroupReleaseStats({
 
           <SidebarSection.Wrap>
             <SidebarSection.Title>
-              <Fragment>
-                {t('Last Seen')}
-                <TooltipWrapper>
-                  <Tooltip
-                    title={t('When the most recent event in this issue was captured.')}
-                    disableForVisualTest
-                  >
-                    <IconQuestion size="sm" color="gray200" />
-                  </Tooltip>
-                </TooltipWrapper>
-              </Fragment>
+              {t('Last Seen')}
+              <QuestionTooltip
+                title={t('When the most recent event in this issue was captured.')}
+                size="xs"
+              />
             </SidebarSection.Title>
             <StyledSidebarSectionContent>
               <SeenInfo
@@ -132,17 +126,11 @@ function GroupReleaseStats({
           </SidebarSection.Wrap>
           <SidebarSection.Wrap>
             <SidebarSection.Title>
-              <Fragment>
-                {t('First Seen')}
-                <TooltipWrapper>
-                  <Tooltip
-                    title={t('When the first event in this issue was captured.')}
-                    disableForVisualTest
-                  >
-                    <IconQuestion size="sm" color="gray200" />
-                  </Tooltip>
-                </TooltipWrapper>
-              </Fragment>
+              {t('First Seen')}
+              <QuestionTooltip
+                title={t('When the first event in this issue was captured.')}
+                size="xs"
+              />
             </SidebarSection.Title>
             <StyledSidebarSectionContent>
               <SeenInfo
@@ -178,10 +166,6 @@ function GroupReleaseStats({
 }
 
 export default memo(GroupReleaseStats);
-
-const TooltipWrapper = styled('span')`
-  margin-left: ${space(0.5)};
-`;
 
 const GraphContainer = styled('div')`
   margin-bottom: ${space(3)};

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -6,9 +6,8 @@ import keyBy from 'lodash/keyBy';
 import {GroupTagResponseItem} from 'sentry/actionCreators/group';
 import LoadingError from 'sentry/components/loadingError';
 import Placeholder from 'sentry/components/placeholder';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import * as SidebarSection from 'sentry/components/sidebarSection';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconQuestion} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Event, Organization, Project} from 'sentry/types';
@@ -181,14 +180,11 @@ function WrapperWithTitle({children}: {children: ReactNode}) {
     <SidebarSection.Wrap>
       <SidebarSection.Title>
         {t('All Tags')}
-        <TooltipWrapper>
-          <Tooltip
-            title={t('The tags associated with all events in this issue')}
-            disableForVisualTest
-          >
-            <IconQuestion size="sm" color="gray200" />
-          </Tooltip>
-        </TooltipWrapper>
+        <QuestionTooltip
+          size="xs"
+          position="top"
+          title={t('The tags associated with all events in this issue')}
+        />
       </SidebarSection.Title>
       {children}
     </SidebarSection.Wrap>
@@ -278,9 +274,4 @@ export const TagFacetsList = styled('ol')`
   list-style: none;
   padding: 0;
   margin: 0 0 ${space(2)};
-`;
-
-const TooltipWrapper = styled('span')`
-  vertical-align: middle;
-  padding-left: ${space(0.5)};
 `;

--- a/static/app/components/sidebarSection.tsx
+++ b/static/app/components/sidebarSection.tsx
@@ -9,6 +9,8 @@ export const Wrap = styled('div')`
 export const Title = styled('h6')`
   color: ${p => p.theme.subText};
   display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
   font-size: ${p => p.theme.fontSizeMedium};
   margin: ${space(1)} 0 0;
 `;

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -122,14 +122,14 @@ export default function GroupSidebar({
 
     return (
       <SidebarSection.Wrap>
-        <StyledSidebarSectionTitle>
+        <SidebarSection.Title>
           {t('Participants (%s)', participants.length)}
           <QuestionTooltip
-            size="sm"
+            size="xs"
             position="top"
             title={t('People who have resolved, ignored, or added a comment')}
           />
-        </StyledSidebarSectionTitle>
+        </SidebarSection.Title>
         <SidebarSection.Content>
           <StyledAvatarList users={participants} avatarSize={28} maxVisibleAvatars={13} />
         </SidebarSection.Content>
@@ -148,14 +148,14 @@ export default function GroupSidebar({
 
     return (
       <SidebarSection.Wrap>
-        <StyledSidebarSectionTitle>
+        <SidebarSection.Title>
           {t('Viewers (%s)', displayUsers.length)}{' '}
           <QuestionTooltip
-            size="sm"
+            size="xs"
             position="top"
             title={t('People who have viewed this issue')}
           />
-        </StyledSidebarSectionTitle>
+        </SidebarSection.Title>
         <SidebarSection.Content>
           <StyledAvatarList
             users={displayUsers}
@@ -228,8 +228,4 @@ const ExternalIssues = styled('div')`
 const StyledAvatarList = styled(AvatarList)`
   justify-content: flex-end;
   padding-left: ${space(0.75)};
-`;
-
-const StyledSidebarSectionTitle = styled(SidebarSection.Title)`
-  gap: ${space(1)};
 `;

--- a/static/app/views/performance/transactionDetails/styles.tsx
+++ b/static/app/views/performance/transactionDetails/styles.tsx
@@ -26,7 +26,7 @@ export function MetaData({
         {headingText}
         <QuestionTooltip
           position="top"
-          size="sm"
+          size="xs"
           containerDisplayMode="block"
           title={tooltipText}
         />


### PR DESCRIPTION
We weren't using the questionTooltip well in the sidebar headings