### PR TITLE
fix(settings): Stop truncating team name

### DIFF
--- a/static/app/views/settings/organizationTeams/teamDetails.tsx
+++ b/static/app/views/settings/organizationTeams/teamDetails.tsx
@@ -93,7 +93,7 @@ function TeamDetails({children}: Props) {
       {team.hasAccess ? (
         <div>
           <h3>
-            <IdBadge hideAvatar team={team} avatarSize={36} />
+            <IdBadge hideAvatar hideOverflow={false} team={team} avatarSize={36} />
           </h3>
 
           <NavTabs underlined>{navigationTabs}</NavTabs>


### PR DESCRIPTION
On the team settings page https://sentry.sentry.io/settings/teams/discover-n-dashboards/members/

example
<img width="791" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/c9863b5d-aa5c-4dbf-bcba-53e8f8c74547">
