### PR TITLE
feat(issue-details): Add tooltip to log level circle

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -1,12 +1,11 @@
 import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import capitalize from 'lodash/capitalize';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
+import ErrorLevel from 'sentry/components/events/errorLevel';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
-import {Tooltip} from 'sentry/components/tooltip';
 import {IconMute, IconStar} from 'sentry/icons';
 import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -57,15 +56,7 @@ function EventOrGroupHeader({
     const {level, status, isBookmarked, hasSeen} = data as Group;
     return (
       <Fragment>
-        {!hideLevel && level && (
-          <Tooltip
-            skipWrapper
-            disabled={level === 'unknown'}
-            title={tct('Error level: [level]', {level: capitalize(level)})}
-          >
-            <GroupLevel level={level} />
-          </Tooltip>
-        )}
+        {!hideLevel && level && <GroupLevel level={level} />}
         {!hideIcons &&
           status === 'ignored' &&
           !organization.features.includes('escalating-issues') && (
@@ -221,14 +212,12 @@ const IconWrapper = styled('span')`
   margin-right: 5px;
 `;
 
-const GroupLevel = styled('div')<{level: Level}>`
+const GroupLevel = styled(ErrorLevel)<{level: Level}>`
   position: absolute;
   left: -1px;
   width: 9px;
   height: 15px;
   border-radius: 0 3px 3px 0;
-
-  background-color: ${p => p.theme.level[p.level] ?? p.theme.level.default};
 `;
 
 const TitleWithLink = styled(GlobalSelectionLink)`

--- a/static/app/components/events/errorLevel.tsx
+++ b/static/app/components/events/errorLevel.tsx
@@ -1,15 +1,31 @@
 import styled from '@emotion/styled';
+import capitalize from 'lodash/capitalize';
 
+import {Tooltip} from 'sentry/components/tooltip';
+import {tct} from 'sentry/locale';
 import {Level} from 'sentry/types';
 
 const DEFAULT_SIZE = '13px';
 
 type Props = {
+  className?: string;
   level?: Level;
   size?: string;
 };
 
-const ErrorLevel = styled('span')<Props>`
+function ErrorLevel({className, level = 'unknown', size = '11px'}: Props) {
+  const levelLabel = tct('Level: [level]', {level: capitalize(level)});
+
+  return (
+    <Tooltip skipWrapper disabled={level === 'unknown'} title={levelLabel}>
+      <ColoredCircle className={className} level={level} size={size}>
+        {levelLabel}
+      </ColoredCircle>
+    </Tooltip>
+  );
+}
+
+const ColoredCircle = styled('span')<Props>`
   padding: 0;
   position: relative;
   width: ${p => p.size || DEFAULT_SIZE};

--- a/static/app/components/events/eventMessage.tsx
+++ b/static/app/components/events/eventMessage.tsx
@@ -16,12 +16,7 @@ type Props = {
 const EventMessage = styled(
   ({className, level, levelIndicatorSize, message, annotations}: Props) => (
     <div className={className}>
-      {level && (
-        <ErrorLevel size={levelIndicatorSize} level={level}>
-          {level}
-        </ErrorLevel>
-      )}
-
+      {level && <ErrorLevel size={levelIndicatorSize} level={level} />}
       {message && <Message>{message}</Message>}
 
       {annotations}

--- a/static/app/components/issues/compactIssue.tsx
+++ b/static/app/components/issues/compactIssue.tsx
@@ -39,7 +39,7 @@ function CompactIssueHeader({data, organization, eventId}: HeaderProps) {
   return (
     <Fragment>
       <IssueHeaderMetaWrapper>
-        <StyledErrorLevel size="12px" level={data.level} title={data.level} />
+        <StyledErrorLevel size="12px" level={data.level} />
         <h3 className="truncate">
           <IconLink to={issueLink || ''}>
             {data.status === 'ignored' && <IconMute size="xs" />}


### PR DESCRIPTION
So users can figure out what the dot means and why it is there.

Since there was some similar logic in the issue stream items, I moved it to the ErrorLevel component to make things more consistent.

<img width="109" alt="CleanShot 2023-08-03 at 15 06 57@2x" src="https://github.com/getsentry/sentry/assets/10888943/1ded1984-361b-4e3f-9125-c255cf3d3308">
