### PR TITLE
feat(github-growth): add search query and domain filtering to MissingMembers API

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -29,9 +29,7 @@ class MissingMembersPermission(OrganizationPermission):
 class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
     permission_classes = (MissingMembersPermission,)
 
-    def _get_missing_members(
-        self, organization: Organization, domain: str = None
-    ) -> QuerySet[CommitAuthor]:
+    def _get_missing_members(self, organization: Organization) -> QuerySet[CommitAuthor]:
         member_emails = set(
             organization.member_set.exclude(email=None).values_list("email", flat=True)
         )
@@ -86,9 +84,9 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
             tokens = tokenize_query(query)
             for key, value in tokens.items():
                 if key == "query":
-                    value = " ".join(value)
+                    query_value = " ".join(value)
                     queryset = queryset.filter(
-                        Q(email__icontains=value) | Q(external_id__icontains=value)
+                        Q(email__icontains=query_value) | Q(external_id__icontains=query_value)
                     )
 
         return Response(

--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -1,17 +1,20 @@
 from datetime import timedelta
+from email.headerregistry import Address
 
-from django.db.models import Count, QuerySet
+from django.db.models import Count, Q, QuerySet
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import roles
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import Serializer, serialize
 from sentry.models import Repository
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.organization import Organization
+from sentry.search.utils import tokenize_query
 
 
 class MissingOrgMemberSerializer(Serializer):
@@ -27,7 +30,9 @@ class MissingMembersPermission(OrganizationPermission):
 class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
     permission_classes = (MissingMembersPermission,)
 
-    def _get_missing_members(self, organization: Organization) -> QuerySet[CommitAuthor]:
+    def _get_missing_members(
+        self, organization: Organization, domain: str = None
+    ) -> QuerySet[CommitAuthor]:
         member_emails = set(
             organization.member_set.exclude(email=None).values_list("email", flat=True)
         )
@@ -42,11 +47,11 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
             email__in=member_emails
         )
 
+        # currently for Github only
         org_repos = Repository.objects.filter(
             provider="integrations:github", organization_id=organization.id
         ).values_list("id", flat=True)
 
-        # This is currently for Github only
         return (
             nonmember_authors.filter(
                 commit__repository_id__in=set(org_repos),
@@ -56,11 +61,40 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
             .order_by("-commit_count")
         )
 
-    # TODO(cathy): check domain
+    def _get_domain_from_email(self, email: str) -> str:
+        domain = Address(email).domain
+        return domain
 
     def get(self, request: Request, organization) -> Response:
-        # TODO(cathy): search
         queryset = self._get_missing_members(organization)
+
+        # if a member has user_email=None, then they have yet to accept an invite
+        org_owners = organization.get_members_with_org_roles(
+            roles=[roles.get_top_dog().id]
+        ).exclude(user_email=None)
+
+        prev_domain = self._get_domain_from_email(org_owners[0].user_email)
+        common_domain = True
+        for org_owner in org_owners:
+            if (
+                prev_domain is not None
+                and self._get_domain_from_email(org_owner.user_email) != prev_domain
+            ):
+                common_domain = False
+                break
+
+        if common_domain:
+            queryset.filter(email__endswith=prev_domain)
+
+        query = request.GET.get("query")
+        if query:
+            tokens = tokenize_query(query)
+            for key, value in tokens.items():
+                if key == "query":
+                    value = " ".join(value)
+                    queryset = queryset.filter(
+                        Q(email__icontains=value) | Q(external_id__icontains=value)
+                    )
 
         return Response(
             [

--- a/tests/sentry/api/test_organization_missing_members.py
+++ b/tests/sentry/api/test_organization_missing_members.py
@@ -13,7 +13,8 @@ class OrganizationMissingMembersTestCase(APITestCase):
 
     def setUp(self):
         super().setUp()
-
+        self.user = self.create_user(email="owner@example.com")
+        self.organization = self.create_organization(owner=self.user)
         self.create_member(
             email="a@example.com",
             organization=self.organization,
@@ -45,7 +46,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
 
         self.login_as(self.user)
 
-    def test_simple(self):
+    def test_simple__common_domain(self):
         response = self.get_success_response(self.organization.slug)
         assert response.data[0]["integration"] == "github"
         assert response.data[0]["users"] == [
@@ -86,9 +87,46 @@ class OrganizationMissingMembersTestCase(APITestCase):
         ]
 
     def test_no_authors(self):
-        org = self.create_organization()
+        org = self.create_organization(owner=self.create_user())
         self.create_member(user=self.user, organization=org, role="manager")
 
         response = self.get_success_response(org.slug)
         assert response.data[0]["integration"] == "github"
         assert response.data[0]["users"] == []
+
+    def test_not_common_domain(self):
+        not_common_domain_author = self.create_commit_author(
+            project=self.project, email="a@notexample.com"
+        )
+        not_common_domain_author.external_id = "not"
+        not_common_domain_author.save()
+        self.create_commit(repo=self.repo, author=not_common_domain_author)
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert response.data[0]["integration"] == "github"
+        assert response.data[0]["users"] == [
+            {"email": "c@example.com", "externalId": "c", "commitCount": 2},
+            {"email": "d@example.com", "externalId": "d", "commitCount": 1},
+            {"email": "a@notexample.com", "externalId": "not", "commitCount": 1},
+        ]
+
+    def test_query(self):
+        nonmember_commit_author = self.create_commit_author(
+            project=self.project, email="c2@example.com"
+        )
+        nonmember_commit_author.external_id = "c@example.com"
+        nonmember_commit_author.save()
+
+        self.create_commit(repo=self.repo, author=nonmember_commit_author)
+
+        self.repo = self.create_repo(project=self.project, provider="integrations:github")
+        self.create_commit(repo=self.repo, author=self.member_commit_author)
+
+        response = self.get_success_response(self.organization.slug, query="c@example.com")
+
+        assert response.data[0]["integration"] == "github"
+        assert response.data[0]["users"] == [
+            {"email": "c@example.com", "externalId": "c", "commitCount": 2},
+            {"email": "c2@example.com", "externalId": "c@example.com", "commitCount": 1},
+        ]

--- a/tests/sentry/api/test_organization_missing_members.py
+++ b/tests/sentry/api/test_organization_missing_members.py
@@ -135,9 +135,6 @@ class OrganizationMissingMembersTestCase(APITestCase):
 
         self.create_commit(repo=self.repo, author=nonmember_commit_author)
 
-        self.repo = self.create_repo(project=self.project, provider="integrations:github")
-        self.create_commit(repo=self.repo, author=self.member_commit_author)
-
         response = self.get_success_response(self.organization.slug, query="c@example.com")
 
         assert response.data[0]["integration"] == "github"

--- a/tests/sentry/api/test_organization_missing_members.py
+++ b/tests/sentry/api/test_organization_missing_members.py
@@ -95,8 +95,11 @@ class OrganizationMissingMembersTestCase(APITestCase):
         assert response.data[0]["users"] == []
 
     def test_not_common_domain(self):
+        self.create_member(
+            organization=self.organization, user=self.create_user(email="owner@exampletwo.com")
+        )
         not_common_domain_author = self.create_commit_author(
-            project=self.project, email="a@notexample.com"
+            project=self.project, email="a@exampletwo.com"
         )
         not_common_domain_author.external_id = "not"
         not_common_domain_author.save()
@@ -108,7 +111,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
         assert response.data[0]["users"] == [
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
-            {"email": "a@notexample.com", "externalId": "not", "commitCount": 1},
+            {"email": "a@exampletwo.com", "externalId": "not", "commitCount": 1},
         ]
 
     def test_query(self):


### PR DESCRIPTION
Add the ability to query the API for usernames / emails. Also filter the missing members list by common domain name on the owners' emails. If all of the owners of the organization have the same email domain name (e.g. sentry.io), then we assume that any commit author with the same domain name should also be part of the organization. Otherwise, we don't add this extra filter on the list of commit authors.

For ER-1753