### PR TITLE
fix: Persist query params in login redirects

### DIFF
--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
+from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.exceptions import APIException
@@ -9,7 +10,7 @@ from rest_framework.exceptions import APIException
 from sentry.app import env
 from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.organization.model import RpcOrganization
-from sentry.utils.auth import make_login_link_with_redirect
+from sentry.utils.auth import construct_link_with_query
 from sentry.utils.http import is_using_customer_domain
 
 
@@ -71,7 +72,8 @@ class SsoRequired(SentryAPIException):
             login_url = organization.absolute_url(path=login_url)
 
         if after_login_redirect:
-            login_url = make_login_link_with_redirect(login_url, after_login_redirect)
+            query_params = {REDIRECT_FIELD_NAME: after_login_redirect}
+            login_url = construct_link_with_query(path=login_url, query_params=query_params)
 
         super().__init__(loginUrl=login_url)
 

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -418,5 +418,7 @@ def construct_link_with_query(path: str, query_params: dict[str, str]) -> str:
     note: this function assumes that the redirect has been validated
     """
     query_string = urlencode({k: v for k, v in query_params.items() if v})
-    redirect_uri = f"{path}?{query_string}"
+    redirect_uri = f"{path}"
+    if query_string:
+        redirect_uri += f"?{query_string}"
     return redirect_uri

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -7,7 +7,6 @@ from typing import Any, Collection, Dict, Iterable, Mapping, Sequence, cast
 from urllib.parse import urlencode, urlparse
 
 from django.conf import settings
-from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth import login as _login
 from django.contrib.auth.backends import ModelBackend
 from django.http.request import HttpRequest
@@ -413,11 +412,11 @@ class EmailAuthBackend(ModelBackend):
         return True
 
 
-def make_login_link_with_redirect(path: str, redirect: str) -> str:
+def construct_link_with_query(path: str, query_params: dict[str, str]) -> str:
     """
     append an after login redirect to a path.
     note: this function assumes that the redirect has been validated
     """
-    query_string = urlencode({REDIRECT_FIELD_NAME: redirect})
+    query_string = urlencode({k: v for k, v in query_params.items() if v})
     redirect_uri = f"{path}?{query_string}"
     return redirect_uri

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -128,6 +128,10 @@ def get_login_url(reset: bool = False) -> str:
 
 
 def initiate_login(request: HttpRequest, next_url: str | None = None) -> None:
+    """
+    initiate_login simply clears session cache
+    if provided a `next_url` will append to the session after clearing previous keys
+    """
     for key in ("_next", "_after_2fa", "_pending_2fa"):
         try:
             del request.session[key]
@@ -414,8 +418,7 @@ class EmailAuthBackend(ModelBackend):
 
 def construct_link_with_query(path: str, query_params: dict[str, str]) -> str:
     """
-    append an after login redirect to a path.
-    note: this function assumes that the redirect has been validated
+    constructs a link with url encoded query params given a base path
     """
     query_string = urlencode({k: v for k, v in query_params.items() if v})
     redirect_uri = f"{path}"

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -358,7 +358,6 @@ class BaseView(View, OrganizationMixin):
         return self.auth_required and not (request.user.is_authenticated and request.user.is_active)
 
     def handle_auth_required(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        # NOTE: initiate_login simply clears session cache
         auth.initiate_login(request, next_url=request.get_full_path())
         if "organization_slug" in kwargs:
             redirect_to = reverse("sentry-auth-organization", args=[kwargs["organization_slug"]])

--- a/tests/sentry/utils/test_auth.py
+++ b/tests/sentry/utils/test_auth.py
@@ -9,7 +9,13 @@ import sentry.utils.auth
 from sentry.models import User
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.utils.auth import EmailAuthBackend, SsoSession, get_login_redirect, login
+from sentry.utils.auth import (
+    EmailAuthBackend,
+    SsoSession,
+    construct_link_with_query,
+    get_login_redirect,
+    login,
+)
 
 
 @control_silo_test(stable=True)
@@ -170,3 +176,17 @@ def test_sso_expiry_default():
 def test_sso_expiry_from_env():
     value = sentry.utils.auth._sso_expiry_from_env("20")
     assert value == timedelta(seconds=20)
+
+
+def test_construct_link_with_query():
+    path = "foobar"
+    query_params = {"biz": "baz"}
+    expected_path = "foobar?biz=baz"
+
+    assert construct_link_with_query(path=path, query_params=query_params) == expected_path
+
+    path = "foobar"
+    query_params = {}
+    expected_path = "foobar"
+
+    assert construct_link_with_query(path=path, query_params=query_params) == expected_path

--- a/tests/sentry/utils/test_auth.py
+++ b/tests/sentry/utils/test_auth.py
@@ -179,12 +179,14 @@ def test_sso_expiry_from_env():
 
 
 def test_construct_link_with_query():
+    # testing basic query param construction
     path = "foobar"
     query_params = {"biz": "baz"}
     expected_path = "foobar?biz=baz"
 
     assert construct_link_with_query(path=path, query_params=query_params) == expected_path
 
+    # testing no excess '?' appended if query params are empty
     path = "foobar"
     query_params = {}
     expected_path = "foobar"


### PR DESCRIPTION
Modifies redirect link helper method to strip all null query params

persists login redirect links w/ referrer and the next query param

This should help us track where users are coming from when they get redirected to the login page due to unavailable session