### PR TITLE
fix(script) Fix exception management

### DIFF
--- a/src/sentry/runner/commands/configoptions.py
+++ b/src/sentry/runner/commands/configoptions.py
@@ -156,18 +156,18 @@ def configoptions(ctx, dry_run: bool, file: Optional[str], hide_drift: bool) -> 
                 invalid_options.add(key)
             elif not_writable_reason == options.NotWritableReason.DRIFTED:
                 drifted_options.add(key)
+
+            opt = options.lookup_key(key)
+            if not opt.type.test(value):
+                invalid_options.add(key)
+                logger.error(
+                    "Option %s has invalid type. got %s, expected %s.", key, type(value), opt.type
+                )
         except options.UnknownOption:
             invalid_options.add(key)
             logger.error(
                 "Option %s is not registered. and cannot be updated.",
                 key,
-            )
-
-        opt = options.lookup_key(key)
-        if not opt.type.test(value):
-            invalid_options.add(key)
-            logger.error(
-                "Option %s has invalid type. got %s, expected %s.", key, type(value), opt.type
             )
 
     ctx.obj["invalid_options"] = invalid_options

--- a/tests/sentry/runner/commands/badpatch.yaml
+++ b/tests/sentry/runner/commands/badpatch.yaml
@@ -2,3 +2,4 @@ options:
   int_option: 50
   readonly_option: 30
   invalid_type: [1,2,3]
+  inexistent_option: 10

--- a/tests/sentry/runner/commands/test_configoptions.py
+++ b/tests/sentry/runner/commands/test_configoptions.py
@@ -215,6 +215,7 @@ class ConfigOptionsTest(CliTestCase):
 
         assert SET_MSG % ("int_option", 50) in rv.output
         assert "Option invalid_type has invalid type." in rv.output
+        assert "Option inexistent_option is not registered." in rv.output
 
         assert not options.isset("readonly_option")
         assert not options.isset("invalid_type")


### PR DESCRIPTION
The management of inexistent options was out of the try-catch