### PR TITLE
fix(replays): merge click and dead clicks in the UI

### DIFF
--- a/fixtures/js-stubs/replay/helpers.ts
+++ b/fixtures/js-stubs/replay/helpers.ts
@@ -29,6 +29,24 @@ export function ClickEvent({timestamp}: {timestamp: Date}) {
   });
 }
 
+export function DeadClickEvent({timestamp}: {timestamp: Date}) {
+  return ReplayFrameEvents.BreadcrumbFrameEvent({
+    timestamp,
+    data: {
+      payload: BreadcrumbFrameData.SlowClickFrame({
+        timestamp,
+        message: 'nav[aria-label="Primary Navigation"] > div > a#sidebar-item-projects',
+        data: {
+          nodeId: 42,
+          url: '',
+          timeAfterClickMs: 7000,
+          endReason: 'timeout',
+        },
+      }),
+    },
+  });
+}
+
 export function NavigateEvent({
   startTimestamp,
   endTimestamp,

--- a/static/app/utils/replays/replayReader.spec.tsx
+++ b/static/app/utils/replays/replayReader.spec.tsx
@@ -65,6 +65,8 @@ describe('ReplayReader', () => {
 
   describe('attachment splitting', () => {
     const timestamp = new Date('2023-12-25T00:02:00');
+    const secondTimestamp = new Date('2023-12-25T00:04:00');
+    const thirdTimestamp = new Date('2023-12-25T00:05:00');
 
     const optionsFrame = TestStubs.Replay.OptionFrame({});
     const optionsEvent = TestStubs.Replay.OptionFrameEvent({
@@ -74,6 +76,9 @@ describe('ReplayReader', () => {
     const firstDiv = TestStubs.Replay.RRWebFullSnapshotFrameEvent({timestamp});
     const secondDiv = TestStubs.Replay.RRWebFullSnapshotFrameEvent({timestamp});
     const clickEvent = TestStubs.Replay.ClickEvent({timestamp});
+    const secondClickEvent = TestStubs.Replay.ClickEvent({timestamp: secondTimestamp});
+    const thirdClickEvent = TestStubs.Replay.ClickEvent({timestamp: thirdTimestamp});
+    const deadClickEvent = TestStubs.Replay.DeadClickEvent({timestamp});
     const firstMemory = TestStubs.Replay.MemoryEvent({
       startTimestamp: timestamp,
       endTimestamp: timestamp,
@@ -103,6 +108,8 @@ describe('ReplayReader', () => {
     });
     const attachments = [
       clickEvent,
+      secondClickEvent,
+      thirdClickEvent,
       consoleEvent,
       firstDiv,
       firstMemory,
@@ -111,6 +118,7 @@ describe('ReplayReader', () => {
       secondDiv,
       secondMemory,
       customEvent,
+      deadClickEvent,
     ];
 
     it.each([
@@ -144,7 +152,11 @@ describe('ReplayReader', () => {
       },
       {
         method: 'getDOMFrames',
-        expected: [expect.objectContaining({category: 'ui.click'})],
+        expected: [
+          expect.objectContaining({category: 'ui.slowClickDetected'}),
+          expect.objectContaining({category: 'ui.click'}),
+          expect.objectContaining({category: 'ui.click'}),
+        ],
       },
       {
         method: 'getMemoryFrames',
@@ -157,16 +169,10 @@ describe('ReplayReader', () => {
         method: 'getChapterFrames',
         expected: [
           expect.objectContaining({category: 'replay.init'}),
-          expect.objectContaining({category: 'ui.click'}),
+          expect.objectContaining({category: 'ui.slowClickDetected'}),
           expect.objectContaining({op: 'navigation.navigate'}),
-        ],
-      },
-      {
-        method: 'getTimelineFrames',
-        expected: [
-          expect.objectContaining({category: 'replay.init'}),
           expect.objectContaining({category: 'ui.click'}),
-          expect.objectContaining({op: 'navigation.navigate'}),
+          expect.objectContaining({category: 'ui.click'}),
         ],
       },
       {

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -61,6 +61,32 @@ type RequiredNotNull<T> = {
 
 const sortFrames = (a, b) => a.timestampMs - b.timestampMs;
 
+function removeDuplicateClicks(frames: BreadcrumbFrame[]) {
+  const slowClickFrames = frames.filter(
+    frame => frame.category === 'ui.slowClickDetected'
+  );
+
+  const clickFrames = frames.filter(frame => frame.category === 'ui.click');
+
+  const noClickFrames = frames.filter(
+    frame => !(slowClickFrames.includes(frame) || clickFrames.includes(frame))
+  );
+
+  const uniqueClickFrames: BreadcrumbFrame[] = clickFrames.filter(clickFrame => {
+    return !slowClickFrames.some(
+      slowClickFrame =>
+        slowClickFrame.data &&
+        'nodeId' in slowClickFrame.data &&
+        clickFrame.data &&
+        'nodeId' in clickFrame.data &&
+        slowClickFrame.data.nodeId === clickFrame.data.nodeId &&
+        slowClickFrame.timestampMs === clickFrame.timestampMs
+    );
+  });
+
+  return uniqueClickFrames.concat(noClickFrames).concat(slowClickFrames);
+}
+
 export default class ReplayReader {
   static factory({attachments, errors, replayRecord}: ReplayReaderParams) {
     if (!attachments || !replayRecord || !errors) {
@@ -188,19 +214,23 @@ export default class ReplayReader {
     )
   );
 
-  getDOMFrames = memoize(() => [
-    ...this._sortedBreadcrumbFrames
-      .filter(frame => 'nodeId' in (frame.data ?? {}))
-      .filter(
-        frame =>
-          !(
-            (frame.category === 'ui.slowClickDetected' &&
-              !isDeadClick(frame as SlowClickFrame)) ||
-            frame.category === 'ui.multiClick'
+  getDOMFrames = memoize(() =>
+    [
+      ...removeDuplicateClicks(
+        this._sortedBreadcrumbFrames
+          .filter(frame => 'nodeId' in (frame.data ?? {}))
+          .filter(
+            frame =>
+              !(
+                (frame.category === 'ui.slowClickDetected' &&
+                  !isDeadClick(frame as SlowClickFrame)) ||
+                frame.category === 'ui.multiClick'
+              )
           )
       ),
-    ...this._sortedSpanFrames.filter(frame => 'nodeId' in (frame.data ?? {})),
-  ]);
+      ...this._sortedSpanFrames.filter(frame => 'nodeId' in (frame.data ?? {})),
+    ].sort(sortFrames)
+  );
 
   getDomNodes = memoize(() =>
     extractDomNodes({
@@ -216,14 +246,16 @@ export default class ReplayReader {
 
   getChapterFrames = memoize(() =>
     [
-      ...this._sortedBreadcrumbFrames.filter(
-        frame =>
-          ['navigation', 'replay.init', 'replay.mutations', 'ui.click'].includes(
-            frame.category
-          ) ||
-          (frame.category === 'ui.slowClickDetected' &&
-            (isDeadClick(frame as SlowClickFrame) ||
-              isDeadRageClick(frame as SlowClickFrame)))
+      ...removeDuplicateClicks(
+        this._sortedBreadcrumbFrames.filter(
+          frame =>
+            ['navigation', 'replay.init', 'replay.mutations', 'ui.click'].includes(
+              frame.category
+            ) ||
+            (frame.category === 'ui.slowClickDetected' &&
+              (isDeadClick(frame as SlowClickFrame) ||
+                isDeadRageClick(frame as SlowClickFrame)))
+        )
       ),
       ...this._sortedSpanFrames.filter(frame =>
         ['navigation.navigate', 'navigation.reload', 'navigation.back_forward'].includes(

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -68,7 +68,7 @@ function removeDuplicateClicks(frames: BreadcrumbFrame[]) {
 
   const clickFrames = frames.filter(frame => frame.category === 'ui.click');
 
-  const noClickFrames = frames.filter(
+  const otherFrames = frames.filter(
     frame => !(slowClickFrames.includes(frame) || clickFrames.includes(frame))
   );
 
@@ -84,7 +84,7 @@ function removeDuplicateClicks(frames: BreadcrumbFrame[]) {
     );
   });
 
-  return uniqueClickFrames.concat(noClickFrames).concat(slowClickFrames);
+  return uniqueClickFrames.concat(otherFrames).concat(slowClickFrames);
 }
 
 export default class ReplayReader {
@@ -261,18 +261,6 @@ export default class ReplayReader {
         ['navigation.navigate', 'navigation.reload', 'navigation.back_forward'].includes(
           frame.op
         )
-      ),
-      ...this._errors,
-    ].sort(sortFrames)
-  );
-
-  getTimelineFrames = memoize(() =>
-    [
-      ...this._sortedBreadcrumbFrames.filter(frame =>
-        ['replay.init', 'ui.click'].includes(frame.category)
-      ),
-      ...this._sortedSpanFrames.filter(frame =>
-        ['navigation.navigate', 'navigation.reload'].includes(frame.op)
       ),
       ...this._errors,
     ].sort(sortFrames)

--- a/static/app/views/replays/detail/domMutations/useDomFilters.spec.tsx
+++ b/static/app/views/replays/detail/domMutations/useDomFilters.spec.tsx
@@ -157,7 +157,7 @@ describe('getMutationsTypes', () => {
     const {result} = reactHooks.renderHook(useDomFilters, {initialProps: {actions}});
     expect(result.current.getMutationsTypes()).toStrictEqual([
       {label: 'LCP', value: 'largest-contentful-paint'},
-      {label: 'Click', value: 'ui.click'},
+      {label: 'User Click', value: 'ui.click'},
     ]);
   });
 
@@ -167,7 +167,7 @@ describe('getMutationsTypes', () => {
     const {result} = reactHooks.renderHook(useDomFilters, {initialProps: {actions}});
     expect(result.current.getMutationsTypes()).toStrictEqual([
       {label: 'LCP', value: 'largest-contentful-paint'},
-      {label: 'Click', value: 'ui.click'},
+      {label: 'User Click', value: 'ui.click'},
     ]);
   });
 });

--- a/static/app/views/replays/detail/domMutations/useDomFilters.tsx
+++ b/static/app/views/replays/detail/domMutations/useDomFilters.tsx
@@ -28,7 +28,7 @@ type Return = {
 const TYPE_TO_LABEL: Record<string, string> = {
   'ui.slowClickDetected': 'Rage & Dead Click',
   'largest-contentful-paint': 'LCP',
-  'ui.click': 'Click',
+  'ui.click': 'User Click',
   'ui.keyDown': 'KeyDown',
   'ui.input': 'Input',
 };


### PR DESCRIPTION
- renamed DOM filter from "click" to "user click" for more specificity, since that filter only shows user clicks now
- removed duplicate user clicks & dead/rage clicks in the DOM events tab
- removed duplicates in the timeline
- removed duplicates in the breadcrumbs

Before:
<img width="303" alt="SCR-20230803-khtx" src="https://github.com/getsentry/sentry/assets/56095982/368ee785-d76d-4212-a7a6-a9cd9588285d">
<img width="613" alt="SCR-20230803-khvj" src="https://github.com/getsentry/sentry/assets/56095982/c3367d5b-29ec-4f10-bb15-b46a8594a3f8">
<img width="627" alt="SCR-20230803-khwo" src="https://github.com/getsentry/sentry/assets/56095982/c51ea1f1-a1c0-4de1-8324-92c4568bbe38">


After:
<img width="571" alt="SCR-20230803-sxgc" src="https://github.com/getsentry/sentry/assets/56095982/1fd8514d-cf04-47a0-a7cc-c601a2001323">
<img width="304" alt="SCR-20230803-sxdb" src="https://github.com/getsentry/sentry/assets/56095982/f28dcd23-d1b4-419b-972f-5e0e662b4178">
<img width="566" alt="SCR-20230803-sxjg" src="https://github.com/getsentry/sentry/assets/56095982/53044c35-4bb0-4fec-ab44-29ad8b7c6d4f">


Fixes https://github.com/getsentry/sentry/issues/54031!