### PR TITLE
feat(org-tokens): Allow GET access to repo for org:ci scope

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -127,7 +127,7 @@ class OrganizationIntegrationsPermission(OrganizationPermission):
 
 class OrganizationIntegrationsLoosePermission(OrganizationPermission):
     scope_map = {
-        "GET": ["org:read", "org:write", "org:admin", "org:integrations"],
+        "GET": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
         "POST": ["org:read", "org:write", "org:admin", "org:integrations"],
         "PUT": ["org:read", "org:write", "org:admin", "org:integrations"],
         "DELETE": ["org:admin", "org:integrations"],


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-cli/issues/1707

We did a check of what endpoints may be used by sentry-cli with the org tokens, and found a leftover we forgot:

* `/organizations/{org}/releases/{version}/` ✅ 
* `/projects/{org}/{project}/releases/{version}/` ✅ 
* `/projects/{org}/{project}/releases/` ✅ 
* `/organizations/{org}/releases/` ✅ 
* `/organizations/{org}/repos/` 🚫  --> updating this
* `/organizations/{org}/releases/{version}/previous-with-commits/` ✅ 

We only need GET access to /repos/ - can we verify this @loewenheim ? Just to be sure 😅 
To all the other endpoints mentioned here we currently have GET, POST & PUT access. `/repos` uses a different base permission class (`OrganizationIntegrationsLoosePermission` vs `OrganizationReleasePermission` for the rest).