### PR TITLE
fix(github-growth): use RpcOrganization in webhook auto-linking

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -120,6 +120,10 @@ class Webhook:
                         try:
                             provider.create_repository(repo_config=config, organization=rpc_org)
                         except RepoExistsError:
+                            logger.info(
+                                "github.auto-repo-linking.repo_exists",
+                                extra={"organization_id": rpc_org.id},
+                            )
                             metrics.incr("sentry.integration_repo_provider.repo_exists")
                             continue
                         metrics.incr("github.webhook.create_repository")

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -126,6 +126,10 @@ class Webhook:
                             )
                             metrics.incr("sentry.integration_repo_provider.repo_exists")
                             continue
+                        logger.info(
+                            "github.auto-repo-linking.create_repository",
+                            extra={"organization_id": rpc_org.id},
+                        )
                         metrics.incr("github.webhook.create_repository")
 
                 repos = repos.all()

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -30,7 +30,7 @@ from sentry.services.hybrid_cloud.integration.model import (
     RpcOrganizationIntegration,
 )
 from sentry.services.hybrid_cloud.integration.service import integration_service
-from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.services.hybrid_cloud.organization.serial import serialize_rpc_organization
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import json, metrics
@@ -109,13 +109,13 @@ class Webhook:
                     "identifier": event.get("repository", {}).get("full_name", None),
                 }
 
-                for org_id in orgs.keys():
-                    rpc_org = organization_service.get(id=org_id)
+                for org in orgs.values():
+                    rpc_org = serialize_rpc_organization(org)
 
                     if features.has("organizations:auto-repo-linking", rpc_org):
                         logger.info(
                             "github.auto-repo-linking.create_repository",
-                            extra={"organization_id": org_id},
+                            extra={"organization_id": rpc_org.id},
                         )
                         try:
                             provider.create_repository(repo_config=config, organization=rpc_org)


### PR DESCRIPTION
The tests work both with and without this change. Also throwing in some loggers for good measure.

After manually testing in prod, I'm seeing that new repos are not being linked upon push events or pull request events in Github. I'm not exactly sure what's going on, but the types should be fixed. The `create_repository` function expects an organization argument that is an `RpcOrganization` but in the webhook we are currently passing an `Organization`.