### PR TITLE
feat(starfish): Update empty states for db dropdown

### DIFF
--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -13,7 +13,7 @@ import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQue
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {
   EMPTY_OPTION_VALUE,
-  EmptyOption,
+  EmptyContainer,
 } from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 const {SPAN_ACTION} = SpanMetricsFields;
@@ -47,10 +47,6 @@ export function ActionSelector({
     ? HTTP_ACTION_OPTIONS
     : [
         {value: '', label: 'All'},
-        {
-          value: EMPTY_OPTION_VALUE,
-          label: <EmptyOption />,
-        },
         ...(actions ?? [])
           .filter(datum => Boolean(datum[SPAN_ACTION]))
           .map(datum => {
@@ -59,6 +55,14 @@ export function ActionSelector({
               label: datum[SPAN_ACTION],
             };
           }),
+        {
+          value: EMPTY_OPTION_VALUE,
+          label: (
+            <EmptyContainer>
+              {t('(No %s)', LABEL_FOR_MODULE_NAME[moduleName])}
+            </EmptyContainer>
+          ),
+        },
       ];
 
   return (

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -14,7 +14,7 @@ import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQue
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {
   EMPTY_OPTION_VALUE,
-  EmptyOption,
+  EmptyContainer,
 } from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 const {SPAN_DOMAIN} = SpanMetricsFields;
@@ -71,10 +71,6 @@ export function DomainSelector({
   const options = optionsReady
     ? [
         {value: '', label: 'All'},
-        {
-          value: EMPTY_OPTION_VALUE,
-          label: <EmptyOption />,
-        },
         ...(domains ?? [])
           .filter(datum => Boolean(datum[SPAN_DOMAIN]))
           .map(datum => {
@@ -84,6 +80,14 @@ export function DomainSelector({
             };
           })
           .sort((a, b) => a.value.localeCompare(b.value)),
+        {
+          value: EMPTY_OPTION_VALUE,
+          label: (
+            <EmptyContainer>
+              {t('(No %s)', LABEL_FOR_MODULE_NAME[moduleName])}
+            </EmptyContainer>
+          ),
+        },
       ]
     : [];
 

--- a/static/app/views/starfish/views/spans/selectors/emptyOption.tsx
+++ b/static/app/views/starfish/views/spans/selectors/emptyOption.tsx
@@ -4,10 +4,10 @@ import {t} from 'sentry/locale';
 
 export const EMPTY_OPTION_VALUE = '(empty)';
 
-const EmptyContainer = styled('span')`
+export const EmptyContainer = styled('span')`
   color: ${p => p.theme.gray300};
 `;
 
-export function EmptyOption() {
+export function DefaultEmptyOption() {
   return <EmptyContainer>{t(`(empty string)`)}</EmptyContainer>;
 }

--- a/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
@@ -11,8 +11,8 @@ import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {
+  DefaultEmptyOption,
   EMPTY_OPTION_VALUE,
-  EmptyOption,
 } from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 const {SPAN_OP} = SpanMetricsFields;
@@ -47,7 +47,7 @@ export function SpanOperationSelector({
         if (datum[SPAN_OP] === '') {
           return {
             value: EMPTY_OPTION_VALUE,
-            label: <EmptyOption />,
+            label: <DefaultEmptyOption />,
           };
         }
         return {


### PR DESCRIPTION
ref https://www.notion.so/sentry/Improve-DB-Module-dropdowns-bb8b9776b7194cdb99ef26273aa452c7?d=f373818634b74aa58e0f00ac68250767#460bfb7733244d43a510edb778192572

Update empty state for action and domain selectors by moving them to the bottom of the list and being more explicit about their state.

<img width="307" alt="image" src="https://github.com/getsentry/sentry/assets/18689448/3ff712bc-1eb7-4d3e-95ff-8a7ed45f82e7">

<img width="325" alt="image" src="https://github.com/getsentry/sentry/assets/18689448/f5d5cf4f-07e5-4720-8d3b-bdddaf1de89b">