### PR TITLE
ref(alerts): Fix deleting metric alert rule

### DIFF
--- a/static/app/views/alerts/list/rules/index.tsx
+++ b/static/app/views/alerts/list/rules/index.tsx
@@ -113,11 +113,11 @@ class AlertRulesList extends DeprecatedAsyncComponent<
 
   handleDeleteRule = async (projectId: string, rule: CombinedMetricIssueAlerts) => {
     const {organization} = this.props;
-    const alertPath = isIssueAlert(rule) ? 'rules' : 'alert-rules';
-
     try {
       await this.api.requestPromise(
-        `/projects/${organization.slug}/${projectId}/${alertPath}/${rule.id}/`,
+        isIssueAlert(rule)
+          ? `/projects/${organization.slug}/${projectId}/rules/${rule.id}/`
+          : `/organizations/${organization.slug}/alert-rules/${rule.id}/`,
         {
           method: 'DELETE',
         }

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -752,11 +752,11 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
 
   handleDeleteRule = async () => {
     const {organization, params} = this.props;
-    const {projectId, ruleId} = params;
+    const {ruleId} = params;
 
     try {
       await this.api.requestPromise(
-        `/organizations/${organization.slug}/${projectId}/alert-rules/${ruleId}/`,
+        `/organizations/${organization.slug}/alert-rules/${ruleId}/`,
         {
           method: 'DELETE',
         }


### PR DESCRIPTION
Fix the URL path for deleting a metric alert rule in the metric alert rule details page and also use the organization alert rule details endpoint when deleting a metric alert rule in the alerts list view. 