### PR TITLE
fix(hc): Add missing using

### DIFF
--- a/tests/sentry/mediators/test_mediator.py
+++ b/tests/sentry/mediators/test_mediator.py
@@ -137,6 +137,8 @@ class TestMediator(TestCase):
 
     def test_automatic_transaction(self):
         class TransactionMediator(Mediator):
+            using = router.db_for_write(User)
+
             def call(self):
                 User.objects.create(username="beep")
                 raise RuntimeError()


### PR DESCRIPTION
This using is required so that the transaction is opened to the correct database when running in split-db mode.