### PR TITLE
feat(perf): Remove broken error link

### DIFF
--- a/static/app/components/events/interfaces/spans/index.tsx
+++ b/static/app/components/events/interfaces/spans/index.tsx
@@ -74,7 +74,7 @@ function TraceErrorAlerts({
       <Alert type={getCumulativeAlertLevelFromErrors(errors)}>
         <ErrorLabel>{label}</ErrorLabel>
 
-        <TraceErrorList trace={parsedTrace} errors={traceErrors} onClickSpan={() => {}} />
+        <TraceErrorList trace={parsedTrace} errors={traceErrors} />
       </Alert>
     </AlertContainer>
   );

--- a/static/app/components/events/interfaces/spans/traceErrorList.spec.tsx
+++ b/static/app/components/events/interfaces/spans/traceErrorList.spec.tsx
@@ -37,9 +37,7 @@ describe('TraceErrorList', () => {
       }),
     ];
 
-    render(
-      <TraceErrorList trace={parseTrace(event)} errors={errors} onClickSpan={jest.fn()} />
-    );
+    render(<TraceErrorList trace={parseTrace(event)} errors={errors} />);
 
     const listItems = screen.getAllByRole('listitem');
     expect(listItems).toHaveLength(2);
@@ -74,9 +72,7 @@ describe('TraceErrorList', () => {
       }),
     ];
 
-    render(
-      <TraceErrorList trace={parseTrace(event)} errors={errors} onClickSpan={jest.fn()} />
-    );
+    render(<TraceErrorList trace={parseTrace(event)} errors={errors} />);
 
     const listItem = screen.getByRole('listitem');
     expect(listItem).toHaveTextContent('1 warning error in /path');

--- a/static/app/components/events/interfaces/spans/traceErrorList.tsx
+++ b/static/app/components/events/interfaces/spans/traceErrorList.tsx
@@ -1,5 +1,4 @@
 import {memo} from 'react';
-import styled from '@emotion/styled';
 import flatten from 'lodash/flatten';
 import groupBy from 'lodash/groupBy';
 
@@ -15,11 +14,10 @@ import {ParsedTraceType, SpanType} from './types';
 
 interface TraceErrorListProps {
   errors: (TraceError | TracePerformanceIssue)[];
-  onClickSpan: (event: React.MouseEvent, spanId: SpanType['span_id']) => void;
   trace: ParsedTraceType;
 }
 
-function TraceErrorList({trace, errors, onClickSpan}: TraceErrorListProps) {
+function TraceErrorList({trace, errors}: TraceErrorListProps) {
   return (
     <List symbol="bullet" data-test-id="trace-error-list">
       {flatten(
@@ -34,11 +32,7 @@ function TraceErrorList({trace, errors, onClickSpan}: TraceErrorListProps) {
                     spanLevelErrors.length,
                     level === 'error' ? '' : level // Prevents awkward "error errors" copy if the level is "error"
                   ),
-                  link: (
-                    <ErrorLink onClick={event => onClickSpan(event, spanId)}>
-                      {findSpanById(trace, spanId).op}
-                    </ErrorLink>
-                  ),
+                  link: findSpanById(trace, spanId).op,
                 })}
               </ListItem>
             )
@@ -48,13 +42,6 @@ function TraceErrorList({trace, errors, onClickSpan}: TraceErrorListProps) {
     </List>
   );
 }
-
-const ErrorLink = styled('a')`
-  color: ${p => p.theme.textColor};
-  :hover {
-    color: ${p => p.theme.textColor};
-  }
-`;
 
 // Given a span ID, find the associated span. It might be the trace itself
 // (which is technically a type of span) or a specific span associated with


### PR DESCRIPTION
Remove the link so people don't try to click on it. This improves #46853 but a more permanent fix is needed.