### PR TITLE
Feat(opsgenie): deprecate Opsgenie plugin

### DIFF
--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -168,7 +168,7 @@ class OpsgenieIntegration(IntegrationInstallation):
 
 class OpsgenieIntegrationProvider(IntegrationProvider):
     key = "opsgenie"
-    name = "Opsgenie (Integration)"
+    name = "Opsgenie"
     metadata = metadata
     integration_cls = OpsgenieIntegration
     features = frozenset([IntegrationFeatures.INCIDENT_MANAGEMENT, IntegrationFeatures.ALERT_RULE])

--- a/src/sentry/plugins/__init__.py
+++ b/src/sentry/plugins/__init__.py
@@ -5,4 +5,5 @@ HIDDEN_PLUGINS = (
     "slack",
     "jira",
     "pagerduty",
+    "opsgenie",
 )

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -25,7 +25,7 @@ from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 
 logger = logging.getLogger("sentry.integrations.sentry_app")
-PLUGINS_WITH_FIRST_PARTY_EQUIVALENTS = ["PagerDuty", "Slack"]
+PLUGINS_WITH_FIRST_PARTY_EQUIVALENTS = ["PagerDuty", "Slack", "Opsgenie"]
 
 
 def build_incident_attachment(


### PR DESCRIPTION
Hide the Opsgenie plugin if it's not installed. If it is, mark it as legacy.

Fixes ER-1790