### PR TITLE
fix(panel): Fix <Panel> Loading & Empty state sizes

### DIFF
--- a/static/app/components/panels/panelTable.tsx
+++ b/static/app/components/panels/panelTable.tsx
@@ -146,10 +146,8 @@ const Wrapper = styled(Panel, {
   }
 
   > ${TableEmptyStateWarning}, > ${LoadingWrapper} {
-    margin: auto;
     border: none;
     grid-column: auto / span ${p => p.columns};
-    height: 174px;
   }
 
   /* safari needs an overflow value or the contents will spill out */

--- a/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
+++ b/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
@@ -179,7 +179,7 @@ function CardTable({
 
   return (
     <Fragment>
-      <StyledReplayTable
+      <ReplayTable
         fetchError={fetchError}
         isFetching={isFetching}
         replays={replays}
@@ -223,10 +223,6 @@ const SplitCardContainer = styled('div')`
   grid-auto-flow: column;
   gap: 0 ${space(2)};
   align-items: stretch;
-`;
-
-const StyledReplayTable = styled(ReplayTable)`
-  height: 221px;
 `;
 
 const StyledButton = styled(Button)`

--- a/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
+++ b/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -105,47 +105,45 @@ function ReplaysErroneousDeadRageCards() {
 
   const rageCols = [ReplayColumn.MOST_RAGE_CLICKS, ReplayColumn.COUNT_RAGE_CLICKS];
 
-  return hasSessionReplay && !fetching && hasSentOneReplay ? (
-    hasDeadRageCards ? (
-      <SplitCardContainer>
-        <CardTable
-          eventView={eventViewDead}
-          location={newLocation}
-          organization={organization}
-          visibleColumns={deadCols}
-          searchQuery={{
-            ...location.query,
-            cursor: undefined,
-            query: 'count_dead_clicks:>0',
-            sort: '-count_dead_clicks',
-          }}
-          buttonLabel={t('Show all replays with dead clicks')}
-        />
-        <CardTable
-          eventView={eventViewRage}
-          location={newLocation}
-          organization={organization}
-          visibleColumns={rageCols}
-          searchQuery={{
-            ...location.query,
-            cursor: undefined,
-            query: 'count_rage_clicks:>0',
-            sort: '-count_rage_clicks',
-          }}
-          buttonLabel={t('Show all replays with rage clicks')}
-        />
-      </SplitCardContainer>
-    ) : null
+  return hasSessionReplay && hasDeadRageCards && hasSentOneReplay && !fetching ? (
+    <SplitCardContainer>
+      <CardTable
+        eventView={eventViewDead}
+        location={newLocation}
+        organization={organization}
+        visibleColumns={deadCols}
+        searchQuery={{
+          ...location.query,
+          cursor: undefined,
+          query: 'count_dead_clicks:>0',
+          sort: '-count_dead_clicks',
+        }}
+        buttonLabel={t('Show all replays with dead clicks')}
+      />
+      <CardTable
+        eventView={eventViewRage}
+        location={newLocation}
+        organization={organization}
+        visibleColumns={rageCols}
+        searchQuery={{
+          ...location.query,
+          cursor: undefined,
+          query: 'count_rage_clicks:>0',
+          sort: '-count_rage_clicks',
+        }}
+        buttonLabel={t('Show all replays with rage clicks')}
+      />
+    </SplitCardContainer>
   ) : null;
 }
 
 function CardTable({
+  buttonLabel,
   eventView,
   location,
   organization,
-  visibleColumns,
   searchQuery,
-  buttonLabel,
+  visibleColumns,
 }: {
   buttonLabel: string;
   eventView: EventView;
@@ -180,8 +178,8 @@ function CardTable({
   };
 
   return (
-    <div>
-      <ReplayTable
+    <Fragment>
+      <StyledReplayTable
         fetchError={fetchError}
         isFetching={isFetching}
         replays={replays}
@@ -214,15 +212,21 @@ function CardTable({
           ? t('Clear filter')
           : buttonLabel}
       </StyledButton>
-    </div>
+    </Fragment>
   );
 }
 
 const SplitCardContainer = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: ${space(2)};
+  grid-template-rows: max-content max-content;
+  grid-auto-flow: column;
+  gap: 0 ${space(2)};
   align-items: stretch;
+`;
+
+const StyledReplayTable = styled(ReplayTable)`
+  height: 221px;
 `;
 
 const StyledButton = styled(Button)`

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -279,6 +279,7 @@ const StyledPanelTable = styled(PanelTable)<{
 
 const StyledAlert = styled(Alert)`
   border-radius: 0;
+  border-width: 1px 0 0 0;
   grid-column: 1/-1;
   margin-bottom: 0;
 `;


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/53757/files#diff-a7c9e3dc09edff686f9cb20409e155adf62efed39c8d30fb1f918f7498423196R148-R153 we updated `PanelTable` so we could align new cards at the top of the Replay list. Unfortunately the change was made to some global css, so the Empty state and Loading state of all panels looks funny in different places around the app sometimes.

IE: it can look like this:
![image (6)](https://github.com/getsentry/sentry/assets/187460/5ac4358d-359e-4c59-9d04-60b059d65444)


So what i've done here is:
- Remove the global css change
- Re-implement the Replay List specific measurements using css grid.

It's a 2.2 grid now, so the body of the tables are always the same height, and the "show all" buttons are always aligned. Here's the grid:
<img width="1119" alt="SCR-20230804-kqhf" src="https://github.com/getsentry/sentry/assets/187460/fde17024-8c9f-4da8-af4e-876f6c749d67">
