### PR TITLE
ref(sentry apps): Remove new badge for comment webhooks

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -79,7 +79,7 @@ export default class Subscriptions extends Component<Props> {
                 checked={events.includes(choice) && !disabledFromPermissions}
                 resource={choice}
                 onChange={this.onChange}
-                isNew={choice === 'comment'}
+                isNew={false}
               />
             </Fragment>
           );

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionSubscriptions.tsx
@@ -31,7 +31,7 @@ function SentryFunctionSubscriptions(props: Props) {
           checked={props.events.includes(resource)}
           resource={resource}
           onChange={onChange}
-          isNew={resource === 'comment'}
+          isNew={false}
         />
       ))}
     </SentryFunctionsSubscriptionGrid>


### PR DESCRIPTION
Remove the "new" badge for sentry app comment webhooks since this feature went out in March 2022 it's not really new anymore. 

<img width="998" alt="Screenshot 2023-08-04 at 12 15 39 PM" src="https://github.com/getsentry/sentry/assets/29959063/29cda6a6-e3e7-4359-8139-75c02af4d644">
