### PR TITLE
chore(issues): Add more logging for sample event

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -139,11 +139,6 @@ class EventStream(Service):
         skip_consume: bool = False,
         group_states: Optional[GroupStates] = None,
     ) -> None:
-        if event.get_tag("sample_event"):
-            logger.info(
-                "insert: inserting event",
-                extra={"event.id": event.event_id, "project_id": event.project_id},
-            )
         self._dispatch_post_process_group_task(
             event.event_id,
             event.project_id,

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -129,6 +129,16 @@ class KafkaEventStream(SnubaProtocolEventStream):
         **kwargs: Any,
     ) -> None:
         event_type = self._get_event_type(event)
+        if event.get_tag("sample_event"):
+            logger.info(
+                "insert: inserting event in KafkaEventStream",
+                extra={
+                    "event.id": event.event_id,
+                    "project_id": event.project_id,
+                    "sample_event": True,
+                    "event_type": event_type.value,
+                },
+            )
 
         assign_partitions_randomly = (
             (event_type == EventStreamEventType.Generic)
@@ -142,6 +152,15 @@ class KafkaEventStream(SnubaProtocolEventStream):
         if assign_partitions_randomly:
             kwargs[KW_SKIP_SEMANTIC_PARTITIONING] = True
 
+        if event.get_tag("sample_event"):
+            logger.info(
+                "insert: inserting event in SnubaProtocolEventStream",
+                extra={
+                    "event.id": event.event_id,
+                    "project_id": event.project_id,
+                    "sample_event": True,
+                },
+            )
         super().insert(
             event,
             is_new,

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -121,8 +121,12 @@ class SnubaProtocolEventStream(EventStream):
     ) -> None:
         if event.get_tag("sample_event") == "true":
             logger.info(
-                "insert: attempting to insert event in Snuba",
-                extra={"event.id": event.event_id, "project_id": event.project_id},
+                "insert: attempting to insert event in SnubaProtocolEventStream",
+                extra={
+                    "event.id": event.event_id,
+                    "project_id": event.project_id,
+                    "sample_event": True,
+                },
             )
         if isinstance(event, GroupEvent) and not event.occurrence:
             logger.error(
@@ -180,11 +184,6 @@ class SnubaProtocolEventStream(EventStream):
             # transactions processing has a configurable 'skipped contexts' to skip writing specific contexts maps
             # to the row. for now, we're ignoring that until we have a need for it
 
-        if event.get_tag("sample_event") == "true":
-            logger.info(
-                "insert: inserting event in Snuba",
-                extra={"event.id": event.event_id, "project_id": event.project_id},
-            )
         self._send(
             project.id,
             "insert",


### PR DESCRIPTION
Last round of logging for sample event creation to confirm we're handling the event in the KafkaEventStream.