### PR TITLE
ref(starfish): Update action selector empty state label

### DIFF
--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -59,7 +59,7 @@ export function ActionSelector({
           value: EMPTY_OPTION_VALUE,
           label: (
             <EmptyContainer>
-              {t('(No %s)', LABEL_FOR_MODULE_NAME[moduleName])}
+              {t('(No Detected %s)', LABEL_FOR_MODULE_NAME[moduleName])}
             </EmptyContainer>
           ),
         },


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/54172 we updated the dropdown empty state. This PR further adds to that by changing from `No SQL Command` to `No Detected SQL Command`, which is hopefully more actionable and easy to understand for users and ourselves.