### PR TITLE
chore(hybrid-cloud): Patch participant notifications utility functions

### DIFF
--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -301,7 +301,7 @@ def get_owner_reason(
 
 def disabled_users_from_project(project: Project) -> Mapping[ExternalProviders, set[User]]:
     """Get a set of users that have disabled Issue Alert notifications for a given project."""
-    user_ids = project.member_set.values_list("user", flat=True)
+    user_ids = list(project.member_set.values_list("user", flat=True))
     rpc_users = user_service.get_many(filter={"user_ids": user_ids})
     users = RpcActor.many_from_object(rpc_users)
 
@@ -462,13 +462,13 @@ def get_fallthrough_recipients(
 
     elif fallthrough_choice == FallthroughChoiceType.ALL_MEMBERS:
         return user_service.get_many(
-            filter=dict(user_ids=project.member_set.values_list("user_id", flat=True))
+            filter=dict(user_ids=list(project.member_set.values_list("user_id", flat=True)))
         )
 
     elif fallthrough_choice == FallthroughChoiceType.ACTIVE_MEMBERS:
         member_users = user_service.get_many(
             filter={
-                "user_ids": project.member_set.values_list("user_id", flat=True),
+                "user_ids": list(project.member_set.values_list("user_id", flat=True)),
             },
         )
         member_users.sort(

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -251,7 +251,7 @@ class GetSendToOwnersTest(_ParticipantsTest):
             organization_id=self.organization.id, name=self.organization.id
         )
 
-        user_ids = self.project.member_set.values_list("user_id", flat=True)
+        user_ids = list(self.project.member_set.values_list("user_id", flat=True))
         with assume_test_silo_mode(SiloMode.CONTROL):
             users = [Owner("user", user.email) for user in User.objects.filter(id__in=user_ids)]
         ProjectOwnership.objects.create(

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -31,10 +31,11 @@ from sentry.ownership import grammar
 from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.cache import cache
 from tests.sentry.mail import make_event_data
@@ -74,6 +75,7 @@ class _ParticipantsTest(TestCase):
         assert actual == expected
 
 
+@region_silo_test(stable=True)
 class GetSendToMemberTest(_ParticipantsTest):
     def get_send_to_member(
         self, project: Optional[Project] = None, user_id: Optional[int] = None
@@ -92,13 +94,14 @@ class GetSendToMemberTest(_ParticipantsTest):
             self.get_send_to_member(), email=[self.user.id], slack=[self.user.id]
         )
 
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.NEVER,
-            user_id=self.user.id,
-            project=self.project,
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.NEVER,
+                user_id=self.user.id,
+                project=self.project,
+            )
 
         self.assert_recipients_are(self.get_send_to_member(), slack=[self.user.id])
 
@@ -128,23 +131,24 @@ class GetSendToMemberTest(_ParticipantsTest):
         assert self.get_send_to_member(self.project, user_3.id) == {}
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class GetSendToTeamTest(_ParticipantsTest):
     def setUp(self):
         super().setUp()
-        # disable slack
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.SLACK,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.NEVER,
-            team_id=self.team.id,
-        )
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.SLACK,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.NEVER,
-            user_id=self.user.id,
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            # disable slack
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.SLACK,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.NEVER,
+                team_id=self.team.id,
+            )
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.SLACK,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.NEVER,
+                user_id=self.user.id,
+            )
 
     def get_send_to_team(
         self, project: Optional[Project] = None, team_id: Optional[int] = None
@@ -161,33 +165,36 @@ class GetSendToTeamTest(_ParticipantsTest):
     def test_send_to_team(self):
         self.assert_recipients_are(self.get_send_to_team(), email=[self.user.id])
 
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.NEVER,
-            user_id=self.user.id,
-            project=self.project,
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.NEVER,
+                user_id=self.user.id,
+                project=self.project,
+            )
 
         assert self.get_send_to_team() == {}
 
     def test_send_to_team_direct(self):
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.SLACK,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.ALWAYS,
-            team_id=self.team.id,
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.SLACK,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.ALWAYS,
+                team_id=self.team.id,
+            )
         assert self.get_send_to_team() == {
             ExternalProviders.SLACK: {RpcActor.from_orm_team(self.team)}
         }
 
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.SLACK,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.NEVER,
-            team_id=self.team.id,
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.SLACK,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.NEVER,
+                team_id=self.team.id,
+            )
         self.assert_recipients_are(self.get_send_to_team(), email=[self.user.id])
 
     def test_other_project_team(self):
@@ -212,6 +219,7 @@ class GetSendToTeamTest(_ParticipantsTest):
         assert self.get_send_to_team(self.project, team_2.id) == {}
 
 
+@region_silo_test(stable=True)
 class GetSendToOwnersTest(_ParticipantsTest):
     def get_send_to_owners(self, event: Event) -> Mapping[ExternalProviders, Set[RpcActor]]:
         return get_send_to(
@@ -243,6 +251,9 @@ class GetSendToOwnersTest(_ParticipantsTest):
             organization_id=self.organization.id, name=self.organization.id
         )
 
+        user_ids = self.project.member_set.values_list("user_id", flat=True)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            users = [Owner("user", user.email) for user in User.objects.filter(id__in=user_ids)]
         ProjectOwnership.objects.create(
             project_id=self.project.id,
             schema=dump_schema(
@@ -253,12 +264,7 @@ class GetSendToOwnersTest(_ParticipantsTest):
                     grammar.Rule(Matcher("path", "*.java"), [Owner("user", self.user.email)]),
                     grammar.Rule(
                         Matcher("path", "*.cbl"),
-                        [
-                            Owner("user", user.email)
-                            for user in User.objects.filter(
-                                id__in=self.project.member_set.values_list("user_id", flat=True)
-                            )
-                        ],
+                        users,
                     ),
                     grammar.Rule(Matcher("path", "*.lol"), []),
                 ]
@@ -267,14 +273,15 @@ class GetSendToOwnersTest(_ParticipantsTest):
         )
 
         # turn off slack for teams
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.SLACK,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.NEVER,
-            team_id=self.team2.id,
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.SLACK,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.NEVER,
+                team_id=self.team2.id,
+            )
 
-        self.integration.add_organization(self.project.organization, self.user)
+            self.integration.add_organization(self.project.organization, self.user)
 
     def create_sample_commit(self, user: User) -> Commit:
         return self.create_commit(
@@ -297,14 +304,15 @@ class GetSendToOwnersTest(_ParticipantsTest):
             self.get_send_to_owners(event), email=[self.user.id], slack=[self.user.id]
         )
 
-        # Make sure that disabling mail alerts works as expected
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.NEVER,
-            user_id=self.user.id,
-            project=self.project,
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            # Make sure that disabling mail alerts works as expected
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.NEVER,
+                user_id=self.user.id,
+                project=self.project,
+            )
 
         self.assert_recipients_are(self.get_send_to_owners(event), slack=[self.user.id])
 
@@ -322,14 +330,15 @@ class GetSendToOwnersTest(_ParticipantsTest):
             slack=[self.user.id, self.user2.id],
         )
 
-        # Make sure that disabling mail alerts works as expected
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.NEVER,
-            user_id=self.user2.id,
-            project=self.project,
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            # Make sure that disabling mail alerts works as expected
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.NEVER,
+                user_id=self.user2.id,
+                project=self.project,
+            )
         self.assert_recipients_are(
             self.get_send_to_owners(event),
             email=[self.user.id],
@@ -339,22 +348,23 @@ class GetSendToOwnersTest(_ParticipantsTest):
     def test_disable_alerts_multiple_scopes(self):
         event = self.store_event_owners("everyone.cbl")
 
-        # Project-independent setting.
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.ALWAYS,
-            user_id=self.user2.id,
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            # Project-independent setting.
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.ALWAYS,
+                user_id=self.user2.id,
+            )
 
-        # Per-project setting.
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.NEVER,
-            user_id=self.user2.id,
-            project=self.project,
-        )
+            # Per-project setting.
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.NEVER,
+                user_id=self.user2.id,
+                project=self.project,
+            )
 
         self.assert_recipients_are(
             self.get_send_to_owners(event), email=[self.user.id], slack=[self.user.id]
@@ -585,6 +595,7 @@ class GetSendToOwnersTest(_ParticipantsTest):
         )
 
 
+@region_silo_test(stable=True)
 class GetOwnersCase(_ParticipantsTest):
     def setUp(self):
         self.user_1 = self.create_user(email="paul@atreides.space")
@@ -726,6 +737,7 @@ class GetOwnersCase(_ParticipantsTest):
         assert owner_reason is None
 
 
+@region_silo_test(stable=True)
 class GetSendToFallthroughTest(_ParticipantsTest):
     def get_send_to_fallthrough(
         self,
@@ -767,13 +779,14 @@ class GetSendToFallthroughTest(_ParticipantsTest):
         )
 
         # turn off slack for teams
-        for user in [self.user, self.user2, self.user3]:
-            NotificationSetting.objects.update_settings(
-                ExternalProviders.SLACK,
-                NotificationSettingTypes.ISSUE_ALERTS,
-                NotificationSettingOptionValues.NEVER,
-                user_id=user.id,
-            )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            for user in [self.user, self.user2, self.user3]:
+                NotificationSetting.objects.update_settings(
+                    ExternalProviders.SLACK,
+                    NotificationSettingTypes.ISSUE_ALERTS,
+                    NotificationSettingOptionValues.NEVER,
+                    user_id=user.id,
+                )
 
     def test_feature_off_no_owner(self):
         event = self.store_event("empty.lol", self.project)
@@ -874,13 +887,14 @@ class GetSendToFallthroughTest(_ParticipantsTest):
         new_team = self.create_team(organization=self.organization, members=notified_users)
         self.project.add_team(new_team)
 
-        for user in notified_users:
-            NotificationSetting.objects.update_settings(
-                ExternalProviders.SLACK,
-                NotificationSettingTypes.ISSUE_ALERTS,
-                NotificationSettingOptionValues.NEVER,
-                user_id=user.id,
-            )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            for user in notified_users:
+                NotificationSetting.objects.update_settings(
+                    ExternalProviders.SLACK,
+                    NotificationSettingTypes.ISSUE_ALERTS,
+                    NotificationSettingOptionValues.NEVER,
+                    user_id=user.id,
+                )
 
         event = self.store_event("admin.lol", self.project)
         # Check that the notified users are only the 2 active users.
@@ -899,13 +913,14 @@ class GetSendToFallthroughTest(_ParticipantsTest):
             )
             notifiable_users.append(new_user)
 
-        for user in notifiable_users:
-            NotificationSetting.objects.update_settings(
-                ExternalProviders.SLACK,
-                NotificationSettingTypes.ISSUE_ALERTS,
-                NotificationSettingOptionValues.NEVER,
-                user_id=user.id,
-            )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            for user in notifiable_users:
+                NotificationSetting.objects.update_settings(
+                    ExternalProviders.SLACK,
+                    NotificationSettingTypes.ISSUE_ALERTS,
+                    NotificationSettingOptionValues.NEVER,
+                    user_id=user.id,
+                )
 
         event = self.store_event("admin.lol", self.project)
         expected_notified_users = {RpcActor.from_orm_user(user) for user in notifiable_users}
@@ -926,13 +941,14 @@ class GetSendToFallthroughTest(_ParticipantsTest):
             )
             notifiable_users.append(new_user)
 
-        for user in notifiable_users:
-            NotificationSetting.objects.update_settings(
-                ExternalProviders.SLACK,
-                NotificationSettingTypes.ISSUE_ALERTS,
-                NotificationSettingOptionValues.NEVER,
-                user_id=user.id,
-            )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            for user in notifiable_users:
+                NotificationSetting.objects.update_settings(
+                    ExternalProviders.SLACK,
+                    NotificationSettingTypes.ISSUE_ALERTS,
+                    NotificationSettingOptionValues.NEVER,
+                    user_id=user.id,
+                )
 
         event = self.store_event("admin.lol", self.project)
         expected_notified_users = {RpcActor.from_orm_user(user) for user in notifiable_users}
@@ -947,11 +963,12 @@ class GetSendToFallthroughTest(_ParticipantsTest):
     def test_fallthrough_recipients_active_member_ordering(self):
         present = timezone.now()
 
-        self.user.last_active = present - timedelta(days=1)
-        self.user.save()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.user.last_active = present - timedelta(days=1)
+            self.user.save()
 
-        self.user2.last_active = present - timedelta(days=10)
-        self.user2.save()
+            self.user2.last_active = present - timedelta(days=10)
+            self.user2.save()
 
         recipients = list(
             get_fallthrough_recipients(self.project, FallthroughChoiceType.ACTIVE_MEMBERS)


### PR DESCRIPTION
1. Stabilize tests in `tests/sentry/notifications/utils/test_participants.py`
2. Force lazy evaluation of querysets before being passed to service calls.
3. Tests pass in split database mode with `SENTRY_USE_SPLIT_DBS=1`