### PR TITLE
chore(github-growth): more loggers

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -98,7 +98,12 @@ class Webhook:
 
             if not repos.exists():
                 logger.info(
-                    "github.auto-repo-linking", extra={"organization_ids": list(orgs.keys())}
+                    "github.auto-repo-linking",
+                    extra={
+                        "organization_ids": set(orgs.keys()),
+                        "external_id": str(event["repository"]["id"]),
+                        "repository": event.get("repository", {}).get("full_name", None),
+                    },
                 )
 
                 provider = get_integration_repository_provider(integration)
@@ -112,7 +117,7 @@ class Webhook:
                 for org in orgs.values():
                     rpc_org = serialize_rpc_organization(org)
 
-                    if features.has("organizations:auto-repo-linking", rpc_org):
+                    if features.has("organizations:auto-repo-linking", org):
                         logger.info(
                             "github.auto-repo-linking.create_repository",
                             extra={"organization_id": rpc_org.id},

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -115,6 +115,10 @@ class Webhook:
                 }
 
                 for org in orgs.values():
+                    logger.info(
+                        "github.auto-repo-linking.orgs",
+                        extra={"organization_id": org.id},
+                    )
                     rpc_org = serialize_rpc_organization(org)
 
                     if features.has("organizations:auto-repo-linking", org):

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -89,6 +89,15 @@ class Webhook:
                 )
             }
 
+            logger.info(
+                "github.repository-event",
+                extra={
+                    "organization_ids": set(orgs.keys()),
+                    "external_id": str(event["repository"]["id"]),
+                    "repository": event.get("repository", {}).get("full_name", None),
+                },
+            )
+
             # TODO: Replace with repository_service; deal with potential multiple regions
             repos = Repository.objects.filter(
                 organization_id__in=orgs.keys(),


### PR DESCRIPTION
After digging through GCP Logs, we appear to not be entering the loop for auto-linking repositories -- at least not where the feature flag is located. We're also not exiting early out of the Webhook `__call__` function because the integration doesn't exist. Add some more loggers to see whether we're correctly finding the repository.