### PR TITLE
fix(subscriptions): Skip issue validation on delete

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -223,6 +223,7 @@ class QueryBuilder(BaseQueryBuilder):
         # of a top events request
         skip_tag_resolution: bool = False,
         on_demand_metrics_enabled: bool = False,
+        skip_issue_validation: bool = False,
     ):
         self.dataset = dataset
 
@@ -248,6 +249,7 @@ class QueryBuilder(BaseQueryBuilder):
             "query": set(),
             "columns": set(),
         }
+        self.skip_issue_validation = skip_issue_validation
 
         # Base Tenant IDs for any Snuba Request built/executed using a QueryBuilder
         org_id = self.organization_id or (

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1597,6 +1597,9 @@ class DiscoverDatasetConfig(DatasetConfig):
         return filter_aliases.semver_build_filter_converter(self.builder, search_filter)
 
     def _issue_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
+        if self.builder.skip_issue_validation:
+            return None
+
         operator = search_filter.operator
         value = to_list(search_filter.value.value)
         # `unknown` is a special value for when there is no issue associated with the event

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -152,6 +152,7 @@ class BaseEntitySubscription(ABC, _EntitySubscription):
         project_ids: Sequence[int],
         environment: Optional[Environment],
         params: Optional[MutableMapping[str, Any]] = None,
+        skip_issue_validation: bool = False,
     ) -> QueryBuilder:
         raise NotImplementedError
 
@@ -172,6 +173,7 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
         project_ids: Sequence[int],
         environment: Optional[Environment],
         params: Optional[MutableMapping[str, Any]] = None,
+        skip_issue_validation: bool = False,
     ) -> QueryBuilder:
         from sentry.search.events.builder import QueryBuilder
 
@@ -193,6 +195,7 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
             limit=None,
             skip_time_conditions=True,
             parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
+            skip_issue_validation=skip_issue_validation,
         )
 
     def get_entity_extra_params(self) -> Mapping[str, Any]:
@@ -252,6 +255,7 @@ class SessionsEntitySubscription(BaseEntitySubscription):
         project_ids: Sequence[int],
         environment: Optional[Environment],
         params: Optional[MutableMapping[str, Any]] = None,
+        skip_issue_validation: bool = False,
     ) -> QueryBuilder:
         from sentry.search.events.builder import SessionsQueryBuilder
 
@@ -286,6 +290,7 @@ class SessionsEntitySubscription(BaseEntitySubscription):
             functions_acl=["identity"],
             skip_time_conditions=True,
             parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
+            skip_issue_validation=skip_issue_validation,
         )
 
 
@@ -365,6 +370,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
         project_ids: Sequence[int],
         environment: Optional[Environment],
         params: Optional[MutableMapping[str, Any]] = None,
+        skip_issue_validation: bool = False,
     ) -> QueryBuilder:
         from sentry.search.events.builder import AlertMetricsQueryBuilder
 
@@ -383,6 +389,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
             granularity=self.get_granularity(),
             use_metrics_layer=self.use_metrics_layer,
             on_demand_metrics_enabled=self.on_demand_metrics_enabled,
+            skip_issue_validation=skip_issue_validation,
         )
         extra_conditions = self.get_snql_extra_conditions()
 
@@ -666,7 +673,10 @@ def get_entity_subscription_from_snuba_query(
 
 
 def get_entity_key_from_snuba_query(
-    snuba_query: SnubaQuery, organization_id: int, project_id: int
+    snuba_query: SnubaQuery,
+    organization_id: int,
+    project_id: int,
+    skip_issue_validation: bool = False,
 ) -> EntityKey:
     entity_subscription = get_entity_subscription_from_snuba_query(
         snuba_query,
@@ -677,5 +687,6 @@ def get_entity_key_from_snuba_query(
         [project_id],
         None,
         {"organization_id": organization_id},
+        skip_issue_validation=skip_issue_validation,
     )
     return get_entity_key_from_query_builder(query_builder)

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -173,6 +173,9 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
 
     if subscription.subscription_id is not None:
         query_dataset = Dataset(subscription.snuba_query.dataset)
+
+        # Clear the query because we don't need it to delete the subscription
+        subscription.snuba_query.query = ""
         entity_key = get_entity_key_from_snuba_query(
             subscription.snuba_query, subscription.project.organization_id, subscription.project_id
         )

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -173,11 +173,11 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
 
     if subscription.subscription_id is not None:
         query_dataset = Dataset(subscription.snuba_query.dataset)
-
-        # Clear the query because we don't need it to delete the subscription
-        subscription.snuba_query.query = ""
         entity_key = get_entity_key_from_snuba_query(
-            subscription.snuba_query, subscription.project.organization_id, subscription.project_id
+            subscription.snuba_query,
+            subscription.project.organization_id,
+            subscription.project_id,
+            skip_issue_validation=True,
         )
         _delete_from_snuba(
             query_dataset,

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -251,6 +251,16 @@ class DeleteSubscriptionFromSnubaTest(BaseSnubaTaskTest, TestCase):
         delete_subscription_from_snuba(sub.id)
         assert not QuerySubscription.objects.filter(id=sub.id).exists()
 
+    def test_invalid_subscription_query(self):
+        subscription_id = f"1/{uuid4().hex}"
+        sub = self.create_subscription(
+            QuerySubscription.Status.DELETING,
+            subscription_id=subscription_id,
+            query="issue:INVALID-1",
+        )
+        delete_subscription_from_snuba(sub.id)
+        assert not QuerySubscription.objects.filter(id=sub.id).exists()
+
 
 class BuildSnqlQueryTest(TestCase):
     aggregate_mappings = {


### PR DESCRIPTION
Building the query builder during subscription deletion would trigger validation, and if there was an issue in validation then the subscription could not be deleted.

This PR adds a flag to bypass the group validation on deletion.

Fixes SENTRY-XZZ