### PR TITLE
fix(alerts): Handle project not in request for project create alert rule

### DIFF
--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -57,4 +57,4 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleIndexMixin):
         """
         Create an alert rule - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.
         """
-        return self.create_metric_alert(request, project.organization)
+        return self.create_metric_alert(request, project.organization, project)


### PR DESCRIPTION
We have some customers using the `ProjectAlertRuleIndexEndpoint` POST method that are not passing the project data in the request, but rather relying on us grabbing that data from the URL. 

Fixes SENTRY-14JD