### PR TITLE
fix(integrations)-org-in-url-notify-disable

### DIFF
--- a/src/sentry/integrations/notify_disable.py
+++ b/src/sentry/integrations/notify_disable.py
@@ -46,7 +46,7 @@ def notify_disable(
     integration_link = get_url(
         organization,
         get_provider_type(redis_key),
-        str(integration_slug) if "sentry-app" in redis_key else integration_name,
+        integration_slug if "sentry-app" in redis_key and integration_slug else integration_name,
     )
 
     for user in organization.get_owners():

--- a/src/sentry/integrations/notify_disable.py
+++ b/src/sentry/integrations/notify_disable.py
@@ -46,13 +46,11 @@ def notify_disable(
     integration_link = get_url(
         organization,
         get_provider_type(redis_key),
-        integration.slug if hasattr(integration, "slug") else integration.provider,
+        integration.provider if integration.get_provider() else integration.slug,
     )
 
     integration_name = (
-        integration.provider.title()
-        if hasattr(integration, "provider")
-        else integration.name.title()
+        integration.get_provider().name if integration.get_provider() else integration.name
     )
 
     for user in organization.get_owners():

--- a/src/sentry/integrations/notify_disable.py
+++ b/src/sentry/integrations/notify_disable.py
@@ -10,13 +10,13 @@ provider_types = {
 }
 
 
-def get_url(organization: Organization, provider_type: str, slug: str) -> str:
+def get_url(organization: Organization, provider_type: str, name: str) -> str:
     if provider_type:
         type_name = provider_types.get(provider_type, "")
         if type_name:
             return str(
                 organization.absolute_url(
-                    f"/settings/{organization.slug}/{type_name}/{slug}/",
+                    f"/settings/{organization.slug}/{type_name}/{name}/",
                 )
             )
 

--- a/src/sentry/integrations/notify_disable.py
+++ b/src/sentry/integrations/notify_disable.py
@@ -1,7 +1,6 @@
 from typing import Union
 
-from sentry.models import Organization, SentryApp
-from sentry.services.hybrid_cloud.integration import RpcIntegration
+from sentry.models import Organization
 from sentry.utils.email import MessageBuilder
 
 provider_types = {
@@ -38,19 +37,16 @@ def get_subject(integration_name: str) -> str:
 
 def notify_disable(
     organization: Organization,
-    integration: Union[SentryApp, RpcIntegration],
+    integration_name: str,
     redis_key: str,
+    integration_slug: Union[str, None] = None,
     project: Union[str, None] = None,
 ):
 
     integration_link = get_url(
         organization,
         get_provider_type(redis_key),
-        integration.provider if integration.get_provider() else integration.slug,
-    )
-
-    integration_name = (
-        integration.get_provider().name if integration.get_provider() else integration.name
+        str(integration_slug) if "sentry-app" in redis_key else integration_name,
     )
 
     for user in organization.get_owners():

--- a/tests/sentry/integrations/slack/test_disable.py
+++ b/tests/sentry/integrations/slack/test_disable.py
@@ -76,7 +76,7 @@ class SlackClientDisable(TestCase):
     def test_email(self):
         client = SlackClient(integration_id=self.integration.id)
         with self.tasks():
-            notify_disable(self.organization, self.integration, client._get_redis_key())
+            notify_disable(self.organization, self.integration.provider, client._get_redis_key())
         assert len(mail.outbox) == 1
         msg = mail.outbox[0]
         assert msg.subject == "Action required: re-authenticate or fix your Slack integration"

--- a/tests/sentry/integrations/slack/test_disable.py
+++ b/tests/sentry/integrations/slack/test_disable.py
@@ -76,11 +76,16 @@ class SlackClientDisable(TestCase):
     def test_email(self):
         client = SlackClient(integration_id=self.integration.id)
         with self.tasks():
-            notify_disable(self.organization, self.integration.provider, client._get_redis_key())
+            notify_disable(self.organization, self.integration, client._get_redis_key())
         assert len(mail.outbox) == 1
         msg = mail.outbox[0]
         assert msg.subject == "Action required: re-authenticate or fix your Slack integration"
-        assert (f"/settings/integrations/{self.integration.provider}") in msg.body
+        assert (
+            self.organization.absolute_url(
+                f"/settings/{self.organization.slug}/integrations/{self.integration.provider}"
+            )
+            in msg.body
+        )
 
     @responses.activate
     def test_fatal_integration(self):


### PR DESCRIPTION
Fix for #53533
Replace URL for notify when integrations are disabled with: `/settings/sentry/developer-settings/just-a-test-eb81a3/`
Currently: `/settings/developer-settings/projects/just%20a%20test/`
Part of [Notify on Disabled Integration project](https://www.notion.so/sentry/Tech-Spec-Notify-on-Disabled-Integration-Spec-e7ea0f86ccd6419cb3e564067cf4a2ef?pvs=4)
