### PR TITLE
fix: remove make next url

### DIFF
--- a/static/app/views/acceptOrganizationInvite/index.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import {urlEncode} from '@sentry/utils';
 
 import {logout} from 'sentry/actionCreators/account';
 import {Alert} from 'sentry/components/alert';
@@ -61,14 +60,10 @@ class AcceptOrganizationInvite extends DeprecatedAsyncView<Props, State> {
     return t('Accept Organization Invite');
   }
 
-  makeNextUrl(path: string) {
-    return `${path}?${urlEncode({next: window.location.pathname})}`;
-  }
-
   handleLogout = async (e: React.MouseEvent) => {
     e.preventDefault();
     await logout(this.api);
-    window.location.replace(this.makeNextUrl('/auth/login/'));
+    window.location.replace('/auth/login/');
   };
 
   handleAcceptInvite = async () => {
@@ -161,7 +156,7 @@ class AcceptOrganizationInvite extends DeprecatedAsyncView<Props, State> {
               <Button
                 data-test-id="sso-login"
                 priority="primary"
-                href={this.makeNextUrl(`/auth/login/${inviteDetails.orgSlug}/`)}
+                href={`/auth/login/${inviteDetails.orgSlug}/`}
               >
                 {t('Join with %s', inviteDetails.ssoProvider)}
               </Button>
@@ -170,7 +165,7 @@ class AcceptOrganizationInvite extends DeprecatedAsyncView<Props, State> {
               <Button
                 data-test-id="create-account"
                 priority="primary"
-                href={this.makeNextUrl('/auth/register/')}
+                href="/auth/register/"
               >
                 {t('Create a new account')}
               </Button>
@@ -178,7 +173,7 @@ class AcceptOrganizationInvite extends DeprecatedAsyncView<Props, State> {
           </ActionsLeft>
           {!inviteDetails.requireSso && (
             <ExternalLink
-              href={this.makeNextUrl('/auth/login/')}
+              href="/auth/login/"
               openInNewTab={false}
               data-test-id="link-with-existing"
             >
@@ -254,7 +249,7 @@ class AcceptOrganizationInvite extends DeprecatedAsyncView<Props, State> {
               <Button
                 data-test-id="sso-login"
                 priority="primary"
-                href={this.makeNextUrl(`/auth/login/${inviteDetails.orgSlug}/`)}
+                href={`/auth/login/${inviteDetails.orgSlug}/`}
               >
                 {t('Join with %s', inviteDetails.ssoProvider)}
               </Button>


### PR DESCRIPTION
The 'make next url' was adding the `accept/` path as the next route during the accept invite flow.

This is not desirable.