### PR TITLE
chore(github-growth): rename auto-repo-linking feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1323,7 +1323,7 @@ SENTRY_FEATURES = {
     # Enables the cron job to auto-enable codecov integrations.
     "organizations:auto-enable-codecov": False,
     # Enables automatically linking repositories using commit webhook data
-    "organizations:auto-repo-linking": False,
+    "organizations:integrations-auto-repo-linking": False,
     # The overall flag for codecov integration, gated by plans.
     "organizations:codecov-integration": False,
     # Enables getting commit sha from git blame for codecov.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -68,7 +68,7 @@ default_manager.add("organizations:alert-crash-free-metrics", OrganizationFeatur
 default_manager.add("organizations:alert-filters", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:api-keys", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:auto-repo-linking", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:integrations-auto-repo-linking", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:crash-rate-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:customer-domains", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:dashboards-mep", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -89,15 +89,6 @@ class Webhook:
                 )
             }
 
-            logger.info(
-                "github.repository-event",
-                extra={
-                    "organization_ids": set(orgs.keys()),
-                    "external_id": str(event["repository"]["id"]),
-                    "repository": event.get("repository", {}).get("full_name", None),
-                },
-            )
-
             # TODO: Replace with repository_service; deal with potential multiple regions
             repos = Repository.objects.filter(
                 organization_id__in=orgs.keys(),
@@ -106,15 +97,6 @@ class Webhook:
             )
 
             if not repos.exists():
-                logger.info(
-                    "github.auto-repo-linking",
-                    extra={
-                        "organization_ids": set(orgs.keys()),
-                        "external_id": str(event["repository"]["id"]),
-                        "repository": event.get("repository", {}).get("full_name", None),
-                    },
-                )
-
                 provider = get_integration_repository_provider(integration)
 
                 config = {
@@ -124,30 +106,14 @@ class Webhook:
                 }
 
                 for org in orgs.values():
-                    logger.info(
-                        "github.auto-repo-linking.orgs",
-                        extra={"organization_id": org.id},
-                    )
                     rpc_org = serialize_rpc_organization(org)
 
                     if features.has("organizations:integrations-auto-repo-linking", org):
-                        logger.info(
-                            "github.auto-repo-linking.create_repository",
-                            extra={"organization_id": rpc_org.id},
-                        )
                         try:
                             provider.create_repository(repo_config=config, organization=rpc_org)
                         except RepoExistsError:
-                            logger.info(
-                                "github.auto-repo-linking.repo_exists",
-                                extra={"organization_id": rpc_org.id},
-                            )
                             metrics.incr("sentry.integration_repo_provider.repo_exists")
                             continue
-                        logger.info(
-                            "github.auto-repo-linking.create_repository",
-                            extra={"organization_id": rpc_org.id},
-                        )
                         metrics.incr("github.webhook.create_repository")
 
                 repos = repos.all()

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -130,7 +130,7 @@ class Webhook:
                     )
                     rpc_org = serialize_rpc_organization(org)
 
-                    if features.has("organizations:auto-repo-linking", org):
+                    if features.has("organizations:integrations-auto-repo-linking", org):
                         logger.info(
                             "github.auto-repo-linking.create_repository",
                             extra={"organization_id": rpc_org.id},

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -135,7 +135,7 @@ class PushEventWebhookTest(APITestCase):
         repos = Repository.objects.all()
         assert len(repos) == 0
 
-    @with_feature("organizations:auto-repo-linking")
+    @with_feature("organizations:integrations-auto-repo-linking")
     @patch("sentry.integrations.github.webhook.metrics")
     def test_creates_missing_repo(self, mock_metrics):
         project = self.project  # force creation
@@ -150,7 +150,7 @@ class PushEventWebhookTest(APITestCase):
         assert repos[0].name == "baxterthehacker/public-repo"
         mock_metrics.incr.assert_called_with("github.webhook.create_repository")
 
-    @with_feature("organizations:auto-repo-linking")
+    @with_feature("organizations:integrations-auto-repo-linking")
     def test_ignores_hidden_repo(self):
         project = self.project  # force creation
 
@@ -278,7 +278,7 @@ class PushEventWebhookTest(APITestCase):
         )
         assert len(commit_list) == 0
 
-    @with_feature("organizations:auto-repo-linking")
+    @with_feature("organizations:integrations-auto-repo-linking")
     @patch("sentry.integrations.github.webhook.metrics")
     def test_multiple_orgs_creates_missing_repos(self, mock_metrics):
         project = self.project  # force creation
@@ -318,7 +318,7 @@ class PushEventWebhookTest(APITestCase):
             assert repo.name == "baxterthehacker/public-repo"
         mock_metrics.incr.assert_called_with("github.webhook.create_repository")
 
-    @with_feature("organizations:auto-repo-linking")
+    @with_feature("organizations:integrations-auto-repo-linking")
     def test_multiple_orgs_ignores_hidden_repo(self):
         project = self.project  # force creation
 
@@ -428,7 +428,7 @@ class PullRequestEventWebhook(APITestCase):
         repos = Repository.objects.all()
         assert len(repos) == 0
 
-    @with_feature("organizations:auto-repo-linking")
+    @with_feature("organizations:integrations-auto-repo-linking")
     @patch("sentry.integrations.github.webhook.metrics")
     def test_creates_missing_repo(self, mock_metrics):
         project = self.project  # force creation
@@ -442,7 +442,7 @@ class PullRequestEventWebhook(APITestCase):
         assert repos[0].name == "baxterthehacker/public-repo"
         mock_metrics.incr.assert_called_with("github.webhook.create_repository")
 
-    @with_feature("organizations:auto-repo-linking")
+    @with_feature("organizations:integrations-auto-repo-linking")
     def test_ignores_hidden_repo(self):
         project = self.project  # force creation
 
@@ -461,7 +461,7 @@ class PullRequestEventWebhook(APITestCase):
         assert len(repos) == 1
         assert repos[0] == repo
 
-    @with_feature("organizations:auto-repo-linking")
+    @with_feature("organizations:integrations-auto-repo-linking")
     @patch("sentry.integrations.github.webhook.metrics")
     def test_multiple_orgs_creates_missing_repo(self, mock_metrics):
         project = self.project  # force creation
@@ -501,7 +501,7 @@ class PullRequestEventWebhook(APITestCase):
             assert repo.name == "baxterthehacker/public-repo"
         mock_metrics.incr.assert_called_with("github.webhook.create_repository")
 
-    @with_feature("organizations:auto-repo-linking")
+    @with_feature("organizations:integrations-auto-repo-linking")
     def test_multiple_orgs_ignores_hidden_repo(self):
         project = self.project  # force creation
 


### PR DESCRIPTION
`organizations:auto-repo-linking` --> `organizations:integrations-auto-repo-linking`

Also cleans up the loggers I threw at the Github webhook to debug today.