### PR TITLE
docs(events): Capitalize title and fix description

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -31,7 +31,7 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
     public = {"GET"}
 
     @extend_schema(
-        operation_id="Debug issues related to source maps for a given event",
+        operation_id="Debug Issues Related to Source Maps for a Given Event",
         parameters=[
             GlobalParams.ORG_SLUG,
             GlobalParams.PROJECT_SLUG,
@@ -49,8 +49,6 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
     )
     def get(self, request: Request, project: Project, event_id: str) -> Response:
         """
-        Retrieve information about source maps for a given event.
-        ```````````````````````````````````````````
         Return a list of source map errors for a given event.
         """
         frame_idx = request.GET.get("frame_idx")


### PR DESCRIPTION
We may want to re-name this API request to follow naming convention on our [API docs](https://docs.sentry.io/api/) page. Something along the lines of `List Source Map Issues for an Event`. 

Ideally this endpoint would also include an example response body, which can be done by creating an example in `src/sentry/apidocs/examples/*.py` in the appropriate file and using that example by setting `examples=...` in the `@extend_schema` decorator.

## Old
<img width="1070" alt="Screenshot 2023-08-04 at 4 50 57 PM" src="https://github.com/getsentry/sentry/assets/67301797/ee67acf1-0de2-45a8-95cd-929c9a250ac0">

## New
<img width="1070" alt="Screenshot 2023-08-04 at 4 56 59 PM" src="https://github.com/getsentry/sentry/assets/67301797/d0a141b0-99ed-416b-9201-1105d97bc6f4">