### PR TITLE
fix(auth): Raise error if abstract build_identity called

### DIFF
--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -171,7 +171,7 @@ class OAuth2Provider(Provider, abc.ABC):
             'data': self.get_oauth_data(data),
         }
         """
-        pass
+        raise NotImplementedError
 
     def update_identity(self, new_data, current_data):
         # we want to maintain things like refresh_token that might not


### PR DESCRIPTION
This abstract method silently fails if it's called - we should raise an error in this case.