### PR TITLE
Fix(auth): Raise error if abstract get_refresh_token_url called

### DIFF
--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -141,7 +141,7 @@ class OAuth2Provider(Provider, abc.ABC):
 
     @abc.abstractmethod
     def get_refresh_token_url(self) -> str:
-        pass
+        raise NotImplementedError
 
     def get_refresh_token_params(self, refresh_token):
         return {


### PR DESCRIPTION
We should error if abstract methods get called; silently failing makes auth problems a lot harder to debug and diagnose
