### PR TITLE
fix: Don't url decode abs_path before processing

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Any, Dict
-from urllib.parse import unquote
 
 from sentry.debug_files.artifact_bundles import maybe_renew_artifact_bundles_from_processing
 from sentry.lang.native.error import SymbolicationFailed, write_error
@@ -222,18 +221,6 @@ def generate_scraping_config(project: Project) -> Dict[str, Any]:
     }
 
 
-def _normalize_frame(frame: Any) -> dict:
-    frame = dict(frame)
-
-    if abs_path := frame.get("abs_path"):
-        frame["abs_path"] = unquote(abs_path)
-
-    # Symbolicator will *output* `data`, but never use it from the input
-    frame.pop("data", None)
-
-    return frame
-
-
 def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     project = symbolicator.project
     scraping_config = generate_scraping_config(project)
@@ -244,7 +231,7 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     stacktraces = [
         {
             "frames": [
-                _normalize_frame(frame)
+                dict(frame)
                 for frame in sinfo.stacktrace.get("frames") or ()
                 if _handles_frame(frame, data)
             ],

--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -221,6 +221,15 @@ def generate_scraping_config(project: Project) -> Dict[str, Any]:
     }
 
 
+def _normalize_frame(frame: Any) -> dict:
+    frame = dict(frame)
+
+    # Symbolicator will *output* `data`, but never use it from the input
+    frame.pop("data", None)
+
+    return frame
+
+
 def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     project = symbolicator.project
     scraping_config = generate_scraping_config(project)
@@ -231,7 +240,7 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     stacktraces = [
         {
             "frames": [
-                dict(frame)
+                _normalize_frame(frame)
                 for frame in sinfo.stacktrace.get("frames") or ()
                 if _handles_frame(frame, data)
             ],

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -637,68 +637,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
     @requires_symbolicator
     @pytest.mark.symbolicator
-    def test_urlencoded_files(self):
-        project = self.project
-        release = Release.objects.create(organization_id=project.organization_id, version="abc")
-        release.add_project(project)
-
-        for file, name in [
-            ("file.min.js", "~/_next/static/chunks/pages/foo/[bar]-1234.js"),
-            ("file.wc.sourcemap.js", "~/_next/static/chunks/pages/foo/[bar]-1234.js.map"),
-        ]:
-            with open(get_fixture_path(file), "rb") as f:
-                headers = {"sourcemap": name + ".map"} if name.endswith(".js") else {}
-                file_obj = File.objects.create(name=name, type="release.file", headers=headers)
-                file_obj.putfile(f)
-            ReleaseFile.objects.create(
-                name=name,
-                release_id=release.id,
-                organization_id=project.organization_id,
-                file=file_obj,
-            )
-
-        data = {
-            "timestamp": self.min_ago,
-            "message": "hello",
-            "platform": "javascript",
-            "release": "abc",
-            "exception": {
-                "values": [
-                    {
-                        "type": "Error",
-                        "stacktrace": {
-                            "frames": [
-                                {
-                                    "abs_path": "app:///_next/static/chunks/pages/foo/%5Bbar%5D-1234.js",
-                                    "lineno": 1,
-                                    "colno": 79,
-                                }
-                            ]
-                        },
-                    }
-                ]
-            },
-        }
-
-        event = self.post_and_retrieve_event(data)
-
-        assert "errors" not in event.data
-
-        exception = event.interfaces["exception"]
-        frame_list = exception.values[0].stacktrace.frames
-
-        assert len(frame_list) == 1
-        frame = frame_list[0]
-        assert frame.data["resolved_with"] == "release-old"
-        assert frame.data["symbolicated"]
-
-        assert frame.function == "multiply"
-        assert frame.filename == "file2.js"
-        assert frame.lineno == 3
-        assert frame.colno == 2
-
-    @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_indexed_sourcemap_source_expansion(self):
         self.project.update_option("sentry:scrape_javascript", False)
         release = Release.objects.create(


### PR DESCRIPTION
This reverts commit 096b21418cd3e6ebc778da255ca0c66679c04672 (PR #53255)

Url decoding will mess up the matching logic between `debug_meta.code_file` and `abs_path` because the normalization is not applied to both fields in the same way.