### PR TITLE
fix(getting-started-docs): Fix wrong code snippet for .env

### DIFF
--- a/static/app/gettingStartedDocs/php/laravel.tsx
+++ b/static/app/gettingStartedDocs/php/laravel.tsx
@@ -98,7 +98,7 @@ public function register() {
           </p>
         ),
         language: 'shell',
-        code: `php artisan sentry:publish --dsn=${dsn}`,
+        code: `SENTRY_LARAVEL_DSN=${dsn}`,
       },
     ],
   },


### PR DESCRIPTION
**Before:**

![image](https://github.com/getsentry/sentry/assets/29228205/71bee52f-e6ca-4fc2-a5c5-8ba57216ba48)


**After:** 

![image](https://github.com/getsentry/sentry/assets/29228205/991a36bc-44fa-4e4a-96d2-4a85786ea85f)
