### PR TITLE
ref(replay): Simplfy the Replay>Dom css, no more line or :hover

### DIFF
--- a/static/app/views/replays/detail/domMutations/domMutationRow.tsx
+++ b/static/app/views/replays/detail/domMutations/domMutationRow.tsx
@@ -95,40 +95,6 @@ const MutationListItem = styled('div')`
   /* Overridden in TabItemContainer, depending on *CurrentTime and *HoverTime classes */
   border-top: 1px solid transparent;
   border-bottom: 1px solid transparent;
-
-  &:hover {
-    background-color: ${p => p.theme.hover};
-  }
-
-  /*
-  Draw a vertical line behind the breadcrumb icon.
-  The line connects each row together, but is truncated for the first and last items.
-  */
-  position: relative;
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    /* $padding + $half_icon_width - $space_for_the_line */
-    left: calc(${space(1.5)} + (24px / 2) - 1px);
-    width: 1px;
-    height: 100%;
-    background: ${p => p.theme.gray200};
-  }
-
-  &:first-of-type::after {
-    top: ${space(1)};
-    bottom: 0;
-  }
-
-  &:last-of-type::after {
-    top: 0;
-    height: ${space(1)};
-  }
-
-  &:only-of-type::after {
-    height: 0;
-  }
 `;
 
 const List = styled('div')`


### PR DESCRIPTION
The line connecting each 'click' icon is removed now. It cleans up the look, less vertical lines crowding for space.

| Before | After |
| --- | --- |
| <img width="716" alt="SCR-20230807-jafv" src="https://github.com/getsentry/sentry/assets/187460/97c3d19e-c0fc-41a9-a5ff-9a15f86e8d03"> | <img width="715" alt="SCR-20230807-jada" src="https://github.com/getsentry/sentry/assets/187460/a16fc29d-a5ac-4613-880f-76382eb2c447"> |

Also the hover background is gone. The rows are not clickable, and the hover treatment is distracting me.
