### PR TITLE
build(most-helpful-event): Add backend key for popup guide

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -27,6 +27,7 @@ GUIDES = {
     "create_conditional_rule": 28,
     "explain_archive_button_issue_details": 29,
     "explain_archive_tab_issue_stream": 30,
+    "explain_new_default_event_issue_detail": 31,
 }
 
 # demo mode has different guides


### PR DESCRIPTION
Backend for https://github.com/getsentry/sentry/issues/53915