### PR TITLE
fix(replay): Fix replay TimestampButton alignment

### DIFF
--- a/static/app/components/replays/virtualizedGrid/bodyCell.tsx
+++ b/static/app/components/replays/virtualizedGrid/bodyCell.tsx
@@ -2,7 +2,6 @@ import {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
-import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
 const cellBackground = (p: CellProps & {theme: Theme}) => {
   if (p.isSelected) {
@@ -69,6 +68,7 @@ export const AvatarWrapper = styled('div')`
   align-self: center;
 `;
 
-export const StyledTimestampButton = styled(TimestampButton)`
+export const ButtonWrapper = styled('div')`
+  align-items: center;
   padding-inline: ${space(1.5)};
 `;

--- a/static/app/views/replays/detail/errorList/errorTableCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorTableCell.tsx
@@ -6,8 +6,8 @@ import Avatar from 'sentry/components/avatar';
 import Link from 'sentry/components/links/link';
 import {
   AvatarWrapper,
+  ButtonWrapper,
   Cell,
-  StyledTimestampButton,
   Text,
 } from 'sentry/components/replays/virtualizedGrid/bodyCell';
 import {getShortEventId} from 'sentry/utils/events';
@@ -18,6 +18,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {QuickContextHovercard} from 'sentry/views/discover/table/quickContext/quickContextHovercard';
 import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
 import useSortErrors from 'sentry/views/replays/detail/errorList/useSortErrors';
+import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
 const EMPTY_CELL = '--';
 
@@ -204,14 +205,17 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
       ),
       () => (
         <Cell {...columnProps} numeric>
-          <StyledTimestampButton
-            format="mm:ss.SSS"
-            onClick={() => {
-              onClickTimestamp(frame);
-            }}
-            startTimestampMs={startTimestampMs}
-            timestampMs={frame.timestampMs}
-          />
+          <ButtonWrapper>
+            <TimestampButton
+              format="mm:ss.SSS"
+              onClick={event => {
+                event.stopPropagation();
+                onClickTimestamp(frame);
+              }}
+              startTimestampMs={startTimestampMs}
+              timestampMs={frame.timestampMs}
+            />
+          </ButtonWrapper>
         </Cell>
       ),
     ];

--- a/static/app/views/replays/detail/network/networkTableCell.tsx
+++ b/static/app/views/replays/detail/network/networkTableCell.tsx
@@ -1,10 +1,10 @@
-import {ComponentProps, CSSProperties, forwardRef, MouseEvent} from 'react';
+import {ComponentProps, CSSProperties, forwardRef} from 'react';
 import classNames from 'classnames';
 
 import FileSize from 'sentry/components/fileSize';
 import {
+  ButtonWrapper,
   Cell,
-  StyledTimestampButton,
   Text,
 } from 'sentry/components/replays/virtualizedGrid/bodyCell';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -16,6 +16,7 @@ import {
 import type {SpanFrame} from 'sentry/utils/replays/types';
 import useUrlParams from 'sentry/utils/useUrlParams';
 import useSortNetwork from 'sentry/views/replays/detail/network/useSortNetwork';
+import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 import {operationName} from 'sentry/views/replays/detail/utils';
 
 const EMPTY_CELL = '--';
@@ -148,15 +149,17 @@ const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
       ),
       () => (
         <Cell {...columnProps} numeric>
-          <StyledTimestampButton
-            format="mm:ss.SSS"
-            onClick={(event: MouseEvent) => {
-              event.stopPropagation();
-              onClickTimestamp(frame);
-            }}
-            startTimestampMs={startTimestampMs}
-            timestampMs={frame.timestampMs}
-          />
+          <ButtonWrapper>
+            <TimestampButton
+              format="mm:ss.SSS"
+              onClick={event => {
+                event.stopPropagation();
+                onClickTimestamp(frame);
+              }}
+              startTimestampMs={startTimestampMs}
+              timestampMs={frame.timestampMs}
+            />
+          </ButtonWrapper>
         </Cell>
       ),
     ];


### PR DESCRIPTION
Checked all the places, things all seem to line up well now:

| Where | Pic |
| --- | --- |
| Console | <img width="302" alt="console" src="https://github.com/getsentry/sentry/assets/187460/c43484c3-81a9-4690-a3e3-c4183f8bbcf0"> |
| Dom | <img width="125" alt="errors" src="https://github.com/getsentry/sentry/assets/187460/ff206730-bea3-46c0-8b5b-450015c315dc"> |
| Errors | <img width="217" alt="dom" src="https://github.com/getsentry/sentry/assets/187460/4aae13e2-b8c3-4c0a-81ad-021570146f7f"> |
| Network | <img width="188" alt="network" src="https://github.com/getsentry/sentry/assets/187460/11f493b6-2d73-4f53-b42b-c36e52447632"> |
| Fetch/XHR panel | <img width="228" alt="network panel" src="https://github.com/getsentry/sentry/assets/187460/3f2e3625-5179-43a1-9a12-87b2bda78f0f"> |



Note that the Network & Errors sections are both using the virtualized grid, so same css wrapping it
And the Console & Dom sections use the virtualized list
