### PR TITLE
fix(ui): Remove border-radius on issues ActionBar when stuck

### DIFF
--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -326,6 +326,12 @@ function shouldConfirm(
 
 const StickyActions = styled(Sticky)`
   z-index: ${p => p.theme.zIndex.issuesList.stickyHeader};
+
+  /* Remove border radius from the action bar when stuck. Without this there is
+   * a small gap where color can peek through. */
+  &[data-stuck] > div {
+    border-radius: 0;
+  }
 `;
 
 const ActionsBar = styled('div')`


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="124" src="https://i.imgur.com/zGtUDtv.png" />

After

<img alt="clipboard.png" width="105" src="https://i.imgur.com/LWstnW9.png" />

Notice the red is no longer peeking through