### PR TITLE
ref(backup): Encapsulate old export config

### DIFF
--- a/fixtures/backup/datetime-with-unzeroed-millis.json
+++ b/fixtures/backup/datetime-with-unzeroed-millis.json
@@ -1,13 +1,5 @@
 [
   {
-    "model": "sites.site",
-    "pk": 1,
-    "fields": {
-      "domain": "example.com",
-      "name": "example.com"
-    }
-  },
-  {
     "model": "sentry.option",
     "pk": 1,
     "fields": {

--- a/fixtures/backup/datetime-with-zeroed-millis.json
+++ b/fixtures/backup/datetime-with-zeroed-millis.json
@@ -1,13 +1,5 @@
 [
   {
-    "model": "sites.site",
-    "pk": 1,
-    "fields": {
-      "domain": "example.com",
-      "name": "example.com"
-    }
-  },
-  {
     "model": "sentry.option",
     "pk": 1,
     "fields": {

--- a/fixtures/backup/fresh-install.json
+++ b/fixtures/backup/fresh-install.json
@@ -1,13 +1,5 @@
 [
 {
-  "model": "sites.site",
-  "pk": 1,
-  "fields": {
-    "domain": "example.com",
-    "name": "example.com"
-  }
-},
-{
   "model": "sentry.option",
   "pk": 1,
   "fields": {

--- a/fixtures/backup/single-option.json
+++ b/fixtures/backup/single-option.json
@@ -1,13 +1,5 @@
 [
     {
-        "model": "sites.site",
-        "pk": 1,
-        "fields": {
-        "domain": "example.com",
-        "name": "example.com"
-        }
-    },
-    {
         "model": "sentry.option",
         "pk": 1,
         "fields": {

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import click
 
-from sentry.backup.exports import exports
+from sentry.backup.exports import OldExportConfig, exports
 from sentry.backup.imports import imports
 from sentry.runner.decorators import configuration
 
@@ -12,7 +12,7 @@ from sentry.runner.decorators import configuration
 @click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
 def import_(src, silent):
-    """CLI command wrapping the `exec_import` functionality."""
+    """Imports core data for a Sentry installation."""
 
     imports(src, (lambda *args, **kwargs: None) if silent else click.echo)
 
@@ -26,6 +26,19 @@ def import_(src, silent):
 @click.option("--exclude", default=None, help="Models to exclude from export.", metavar="MODELS")
 @configuration
 def export(dest, silent, indent, exclude):
-    """Exports core metadata for the Sentry installation."""
+    """Exports core data for the Sentry installation."""
 
-    exports(dest, indent, exclude, (lambda *args, **kwargs: None) if silent else click.echo)
+    if exclude is None:
+        exclude = []
+    else:
+        exclude = exclude.lower().split(",")
+
+    exports(
+        dest,
+        OldExportConfig(
+            include_non_sentry_models=True,
+            excluded_models=set(exclude),
+        ),
+        indent,
+        (lambda *args, **kwargs: None) if silent else click.echo,
+    )

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from django.core.management import call_command
 
 from sentry.backup.comparators import ComparatorMap
-from sentry.backup.exports import exports
+from sentry.backup.exports import OldExportConfig, exports
 from sentry.backup.findings import ComparatorFindings
 from sentry.backup.helpers import get_exportable_final_derivations_of, get_final_derivations_of
 from sentry.backup.imports import imports
@@ -39,7 +39,7 @@ def export_to_file(path: Path) -> JSONData:
 
     json_file_path = str(path)
     with open(json_file_path, "w+") as tmp_file:
-        exports(tmp_file, 2, None, NOOP_PRINTER)
+        exports(tmp_file, OldExportConfig(), 2, NOOP_PRINTER)
 
     with open(json_file_path) as tmp_file:
         output = json.load(tmp_file)


### PR DESCRIPTION
There are a number of properties of the export system API that we'd like to eventually change. These include:

- Barring users from manually excluding/including specific models on export
- Only exporting `sentry...` models

To keep the original behavior export system intact until we debut these changes, this commit hides the behind `OldExportConfig`, which allows them to be toggled on (for tests) but left off for the actual CLI tool (for now).

Issue: getsentry/team-ospo#171