### PR TITLE
feat(github-growth): snoozing the invite banner

### DIFF
--- a/fixtures/js-stubs/missingMembers.js
+++ b/fixtures/js-stubs/missingMembers.js
@@ -1,0 +1,30 @@
+export function MissingMembers(params = []) {
+  return [
+    {
+      commitCount: 6,
+      email: 'hello@sentry.io',
+      externalId: 'hello',
+    },
+    {
+      commitCount: 5,
+      email: 'abcd@sentry.io',
+      externalId: 'abcd',
+    },
+    {
+      commitCount: 4,
+      email: 'hola@sentry.io',
+      externalId: 'hola',
+    },
+    {
+      commitCount: 3,
+      email: 'test@sentry.io',
+      externalId: 'test',
+    },
+    {
+      commitCount: 2,
+      email: 'five@sentry.io',
+      externalId: 'five',
+    },
+    ...params,
+  ];
+}

--- a/fixtures/js-stubs/missingMembers.tsx
+++ b/fixtures/js-stubs/missingMembers.tsx
@@ -1,4 +1,6 @@
-export function MissingMembers(params = []) {
+import {MissingMember} from 'sentry/types';
+
+export function MissingMembers(params = []): MissingMember[] {
   return [
     {
       commitCount: 6,

--- a/fixtures/js-stubs/types.tsx
+++ b/fixtures/js-stubs/types.tsx
@@ -98,6 +98,7 @@ type TestStubFixtures = {
   MetricsMeta: OverridableStub;
   MetricsSessionUserCountByStatusByRelease: SimpleStub;
   MetricsTotalCountByReleaseIn24h: SimpleStub;
+  MissingMembers: OverridableStubList;
   OrgOwnedApps: SimpleStub;
   OrgRoleList: OverridableStub;
   Organization: OverridableStub;

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -1,0 +1,131 @@
+import {browserHistory} from 'react-router';
+import moment from 'moment';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {MissingMember} from 'sentry/types';
+import {DEFAULT_SNOOZE_PROMPT_DAYS} from 'sentry/utils/promptIsDismissed';
+import {InviteBanner} from 'sentry/views/settings/organizationMembers/inviteBanner';
+
+const missingMembers = {
+  integration: 'github',
+  users: TestStubs.MissingMembers() as MissingMember[],
+};
+
+const noMissingMembers = {
+  integration: 'github',
+  users: [] as MissingMember[],
+};
+
+describe('inviteBanner', function () {
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/missing-members/',
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      method: 'GET',
+      body: {
+        dismissed_ts: undefined,
+        snoozed_ts: undefined,
+      },
+    });
+    (browserHistory.push as jest.Mock).mockReset();
+  });
+
+  it('does not render banner if no missing members', function () {
+    const org = TestStubs.Organization({
+      features: ['integrations-gh-invite'],
+    });
+
+    render(
+      <InviteBanner
+        missingMembers={noMissingMembers}
+        onSendInvite={() => undefined}
+        organization={org}
+      />
+    );
+
+    expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
+  });
+
+  it('does not render banner if lacking org:write', function () {
+    const org = TestStubs.Organization({
+      features: ['integrations-gh-invite'],
+      access: [],
+    });
+
+    render(
+      <InviteBanner
+        missingMembers={noMissingMembers}
+        onSendInvite={() => undefined}
+        organization={org}
+      />
+    );
+
+    expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders banner if snoozed_ts days is longer than threshold', function () {
+    const org = TestStubs.Organization({
+      features: ['integrations-gh-invite'],
+    });
+    const promptResponse = {
+      dismissed_ts: undefined,
+      snoozed_ts: moment
+        .utc()
+        .subtract(DEFAULT_SNOOZE_PROMPT_DAYS + 1, 'days')
+        .unix(),
+    };
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      method: 'GET',
+      body: {data: promptResponse},
+    });
+
+    render(
+      <InviteBanner
+        missingMembers={missingMembers}
+        onSendInvite={() => undefined}
+        organization={org}
+      />
+    );
+
+    expect(screen.queryByTestId('invite-banner')).toBeInTheDocument();
+  });
+
+  it('renders banner if snoozed_ts days is shorter than threshold', async function () {
+    const org = TestStubs.Organization({
+      features: ['integrations-gh-invite'],
+    });
+    const promptResponse = {
+      dismissed_ts: undefined,
+      snoozed_ts: moment
+        .utc()
+        .subtract(DEFAULT_SNOOZE_PROMPT_DAYS - 1, 'days')
+        .unix(),
+    };
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      method: 'GET',
+      body: {data: promptResponse},
+    });
+
+    jest.useFakeTimers();
+
+    render(
+      <InviteBanner
+        missingMembers={missingMembers}
+        onSendInvite={() => undefined}
+        organization={org}
+      />
+    );
+
+    jest.runAllTimers();
+
+    expect(await screen.findByTestId('invite-banner')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -1,20 +1,18 @@
-import {browserHistory} from 'react-router';
 import moment from 'moment';
 
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {MissingMember} from 'sentry/types';
 import {DEFAULT_SNOOZE_PROMPT_DAYS} from 'sentry/utils/promptIsDismissed';
 import {InviteBanner} from 'sentry/views/settings/organizationMembers/inviteBanner';
 
 const missingMembers = {
   integration: 'github',
-  users: TestStubs.MissingMembers() as MissingMember[],
+  users: TestStubs.MissingMembers(),
 };
 
 const noMissingMembers = {
   integration: 'github',
-  users: [] as MissingMember[],
+  users: [],
 };
 
 describe('inviteBanner', function () {
@@ -33,7 +31,6 @@ describe('inviteBanner', function () {
         snoozed_ts: undefined,
       },
     });
-    (browserHistory.push as jest.Mock).mockReset();
   });
 
   it('render banners with feature flag', async function () {
@@ -51,7 +48,9 @@ describe('inviteBanner', function () {
 
     await act(tick);
 
-    expect(screen.getByTestId('invite-banner')).toBeInTheDocument();
+    expect(
+      screen.getByText('Bring your full GitHub team on board in Sentry')
+    ).toBeInTheDocument();
     expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);
     expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
   });
@@ -71,7 +70,9 @@ describe('inviteBanner', function () {
 
     await act(tick);
 
-    expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Bring your full GitHub team on board in Sentry')
+    ).not.toBeInTheDocument();
   });
 
   it('does not render banner if no missing members', async function () {
@@ -89,7 +90,9 @@ describe('inviteBanner', function () {
 
     await act(tick);
 
-    expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Bring your full GitHub team on board in Sentry')
+    ).not.toBeInTheDocument();
   });
 
   it('does not render banner if lacking org:write', async function () {
@@ -108,7 +111,9 @@ describe('inviteBanner', function () {
 
     await act(tick);
 
-    expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Bring your full GitHub team on board in Sentry')
+    ).not.toBeInTheDocument();
   });
 
   it('renders banner if snoozed_ts days is longer than threshold', async function () {
@@ -138,7 +143,9 @@ describe('inviteBanner', function () {
 
     await act(tick);
 
-    expect(screen.queryByTestId('invite-banner')).toBeInTheDocument();
+    expect(
+      screen.getByText('Bring your full GitHub team on board in Sentry')
+    ).toBeInTheDocument();
   });
 
   it('does not render banner if snoozed_ts days is shorter than threshold', async function () {
@@ -168,6 +175,8 @@ describe('inviteBanner', function () {
 
     await act(tick);
 
-    expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Bring your full GitHub team on board in Sentry')
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -36,7 +36,7 @@ describe('inviteBanner', function () {
     (browserHistory.push as jest.Mock).mockReset();
   });
 
-  it('render banners with feature flag', function () {
+  it('render banners with feature flag', async function () {
     const org = TestStubs.Organization({
       features: ['integrations-gh-invite'],
     });
@@ -49,12 +49,14 @@ describe('inviteBanner', function () {
       />
     );
 
+    await act(tick);
+
     expect(screen.getByTestId('invite-banner')).toBeInTheDocument();
     expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);
     expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
   });
 
-  it('does not render banner if no feature flag', function () {
+  it('does not render banner if no feature flag', async function () {
     const org = TestStubs.Organization({
       features: [],
     });
@@ -66,6 +68,8 @@ describe('inviteBanner', function () {
         organization={org}
       />
     );
+
+    await act(tick);
 
     expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
   });

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -36,6 +36,40 @@ describe('inviteBanner', function () {
     (browserHistory.push as jest.Mock).mockReset();
   });
 
+  it('render banners with feature flag', function () {
+    const org = TestStubs.Organization({
+      features: ['integrations-gh-invite'],
+    });
+
+    render(
+      <InviteBanner
+        missingMembers={missingMembers}
+        onSendInvite={() => undefined}
+        organization={org}
+      />
+    );
+
+    expect(screen.getByTestId('invite-banner')).toBeInTheDocument();
+    expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);
+    expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
+  });
+
+  it('does not render banner if no feature flag', function () {
+    const org = TestStubs.Organization({
+      features: [],
+    });
+
+    render(
+      <InviteBanner
+        missingMembers={missingMembers}
+        onSendInvite={() => undefined}
+        organization={org}
+      />
+    );
+
+    expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
+  });
+
   it('does not render banner if no missing members', async function () {
     const org = TestStubs.Organization({
       features: ['integrations-gh-invite'],

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {DEFAULT_SNOOZE_PROMPT_DAYS} from 'sentry/utils/promptIsDismissed';
 import {InviteBanner} from 'sentry/views/settings/organizationMembers/inviteBanner';
@@ -46,16 +46,16 @@ describe('inviteBanner', function () {
       />
     );
 
-    await act(tick);
-
     expect(
-      screen.getByText('Bring your full GitHub team on board in Sentry')
+      await screen.findByRole('heading', {
+        name: 'Bring your full GitHub team on board in Sentry',
+      })
     ).toBeInTheDocument();
     expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);
     expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
   });
 
-  it('does not render banner if no feature flag', async function () {
+  it('does not render banner if no feature flag', function () {
     const org = TestStubs.Organization({
       features: [],
     });
@@ -68,14 +68,14 @@ describe('inviteBanner', function () {
       />
     );
 
-    await act(tick);
-
     expect(
-      screen.queryByText('Bring your full GitHub team on board in Sentry')
+      screen.queryByRole('heading', {
+        name: 'Bring your full GitHub team on board in Sentry',
+      })
     ).not.toBeInTheDocument();
   });
 
-  it('does not render banner if no missing members', async function () {
+  it('does not render banner if no missing members', function () {
     const org = TestStubs.Organization({
       features: ['integrations-gh-invite'],
     });
@@ -88,14 +88,14 @@ describe('inviteBanner', function () {
       />
     );
 
-    await act(tick);
-
     expect(
-      screen.queryByText('Bring your full GitHub team on board in Sentry')
+      screen.queryByRole('heading', {
+        name: 'Bring your full GitHub team on board in Sentry',
+      })
     ).not.toBeInTheDocument();
   });
 
-  it('does not render banner if lacking org:write', async function () {
+  it('does not render banner if lacking org:write', function () {
     const org = TestStubs.Organization({
       features: ['integrations-gh-invite'],
       access: [],
@@ -109,10 +109,10 @@ describe('inviteBanner', function () {
       />
     );
 
-    await act(tick);
-
     expect(
-      screen.queryByText('Bring your full GitHub team on board in Sentry')
+      screen.queryByRole('heading', {
+        name: 'Bring your full GitHub team on board in Sentry',
+      })
     ).not.toBeInTheDocument();
   });
 
@@ -141,14 +141,14 @@ describe('inviteBanner', function () {
       />
     );
 
-    await act(tick);
-
     expect(
-      screen.getByText('Bring your full GitHub team on board in Sentry')
+      await screen.findByRole('heading', {
+        name: 'Bring your full GitHub team on board in Sentry',
+      })
     ).toBeInTheDocument();
   });
 
-  it('does not render banner if snoozed_ts days is shorter than threshold', async function () {
+  it('does not render banner if snoozed_ts days is shorter than threshold', function () {
     const org = TestStubs.Organization({
       features: ['integrations-gh-invite'],
     });
@@ -159,7 +159,7 @@ describe('inviteBanner', function () {
         .subtract(DEFAULT_SNOOZE_PROMPT_DAYS - 1, 'days')
         .unix(),
     };
-    MockApiClient.addMockResponse({
+    const mockPrompt = MockApiClient.addMockResponse({
       url: '/prompts-activity/',
       method: 'GET',
       body: {data: promptResponse},
@@ -173,10 +173,11 @@ describe('inviteBanner', function () {
       />
     );
 
-    await act(tick);
-
+    expect(mockPrompt).toHaveBeenCalled();
     expect(
-      screen.queryByText('Bring your full GitHub team on board in Sentry')
+      screen.queryByRole('heading', {
+        name: 'Bring your full GitHub team on board in Sentry',
+      })
     ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -1,7 +1,7 @@
 import {browserHistory} from 'react-router';
 import moment from 'moment';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {MissingMember} from 'sentry/types';
 import {DEFAULT_SNOOZE_PROMPT_DAYS} from 'sentry/utils/promptIsDismissed';
@@ -36,7 +36,7 @@ describe('inviteBanner', function () {
     (browserHistory.push as jest.Mock).mockReset();
   });
 
-  it('does not render banner if no missing members', function () {
+  it('does not render banner if no missing members', async function () {
     const org = TestStubs.Organization({
       features: ['integrations-gh-invite'],
     });
@@ -49,10 +49,12 @@ describe('inviteBanner', function () {
       />
     );
 
+    await act(tick);
+
     expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
   });
 
-  it('does not render banner if lacking org:write', function () {
+  it('does not render banner if lacking org:write', async function () {
     const org = TestStubs.Organization({
       features: ['integrations-gh-invite'],
       access: [],
@@ -66,10 +68,12 @@ describe('inviteBanner', function () {
       />
     );
 
+    await act(tick);
+
     expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
   });
 
-  it('renders banner if snoozed_ts days is longer than threshold', function () {
+  it('renders banner if snoozed_ts days is longer than threshold', async function () {
     const org = TestStubs.Organization({
       features: ['integrations-gh-invite'],
     });
@@ -94,10 +98,12 @@ describe('inviteBanner', function () {
       />
     );
 
+    await act(tick);
+
     expect(screen.queryByTestId('invite-banner')).toBeInTheDocument();
   });
 
-  it('renders banner if snoozed_ts days is shorter than threshold', async function () {
+  it('does not render banner if snoozed_ts days is shorter than threshold', async function () {
     const org = TestStubs.Organization({
       features: ['integrations-gh-invite'],
     });
@@ -114,8 +120,6 @@ describe('inviteBanner', function () {
       body: {data: promptResponse},
     });
 
-    jest.useFakeTimers();
-
     render(
       <InviteBanner
         missingMembers={missingMembers}
@@ -124,8 +128,8 @@ describe('inviteBanner', function () {
       />
     );
 
-    jest.runAllTimers();
+    await act(tick);
 
-    expect(await screen.findByTestId('invite-banner')).toBeInTheDocument();
+    expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -2,6 +2,7 @@ import {useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {promptsCheck, promptsUpdate} from 'sentry/actionCreators/prompts';
+import Feature from 'sentry/components/acl/feature';
 import {Button} from 'sentry/components/button';
 import Card from 'sentry/components/card';
 import {openConfirmModal} from 'sentry/components/confirm';
@@ -125,44 +126,49 @@ export function InviteBanner({missingMembers, onSendInvite, organization}: Props
   cards.push(<SeeMoreCard key="see-more" missingUsers={users} />);
 
   return (
-    <StyledCard data-test-id="invite-banner">
-      <CardTitleContainer>
-        <CardTitleContent>
-          <CardTitle>{t('Bring your full GitHub team on board in Sentry')}</CardTitle>
-          <Subtitle>
-            {tct('[missingMemberCount] missing members that are active in your GitHub', {
-              missingMemberCount: users.length,
-            })}
-            <Tooltip title="Based on the last 30 days of commit data">
-              <IconInfo size="xs" />
-            </Tooltip>
-          </Subtitle>
-        </CardTitleContent>
-        <ButtonContainer>
-          <Button
-            priority="primary"
-            size="xs"
-            // TODO(cathy): open up invite modal
-            data-test-id="view-all-missing-members"
-          >
-            {t('View All')}
-          </Button>
-          <DropdownMenu
-            items={menuItems}
-            trigger={triggerProps => (
-              <Button
-                {...triggerProps}
-                aria-label={t('Actions')}
-                size="xs"
-                icon={<IconEllipsis direction="down" size="sm" />}
-                data-test-id="banner-edit-dropdown"
-              />
-            )}
-          />
-        </ButtonContainer>
-      </CardTitleContainer>
-      <MemberCardsContainer>{cards}</MemberCardsContainer>
-    </StyledCard>
+    <Feature organization={organization} features={['integrations-gh-invite']}>
+      <StyledCard data-test-id="invite-banner">
+        <CardTitleContainer>
+          <CardTitleContent>
+            <CardTitle>{t('Bring your full GitHub team on board in Sentry')}</CardTitle>
+            <Subtitle>
+              {tct(
+                '[missingMemberCount] missing members that are active in your GitHub',
+                {
+                  missingMemberCount: users.length,
+                }
+              )}
+              <Tooltip title="Based on the last 30 days of commit data">
+                <IconInfo size="xs" />
+              </Tooltip>
+            </Subtitle>
+          </CardTitleContent>
+          <ButtonContainer>
+            <Button
+              priority="primary"
+              size="xs"
+              // TODO(cathy): open up invite modal
+              data-test-id="view-all-missing-members"
+            >
+              {t('View All')}
+            </Button>
+            <DropdownMenu
+              items={menuItems}
+              trigger={triggerProps => (
+                <Button
+                  {...triggerProps}
+                  aria-label={t('Actions')}
+                  size="xs"
+                  icon={<IconEllipsis direction="down" size="sm" />}
+                  data-test-id="banner-edit-dropdown"
+                />
+              )}
+            />
+          </ButtonContainer>
+        </CardTitleContainer>
+        <MemberCardsContainer>{cards}</MemberCardsContainer>
+      </StyledCard>
+    </Feature>
   );
 }
 

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -206,6 +206,7 @@ const CardTitleContent = styled('div')`
 `;
 
 const CardTitle = styled('h6')`
+  margin: 0;
   font-size: ${p => p.theme.fontSizeLarge};
   font-weight: bold;
   color: ${p => p.theme.gray400};

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -625,7 +625,9 @@ describe('OrganizationMembersList', function () {
 
       await act(tick);
 
-      expect(screen.getByTestId('invite-banner')).toBeInTheDocument();
+      expect(
+        screen.getByText('Bring your full GitHub team on board in Sentry')
+      ).toBeInTheDocument();
       expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);
       expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
 

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import selectEvent from 'react-select-event';
 
 import {
+  act,
   render,
   renderGlobalModal,
   screen,
@@ -456,7 +457,7 @@ describe('OrganizationMembersList', function () {
       teams: [],
     });
 
-    it('disable buttons for no access', function () {
+    it('disable buttons for no access', async function () {
       const org = TestStubs.Organization({
         status: {
           id: 'active',
@@ -475,6 +476,8 @@ describe('OrganizationMembersList', function () {
       render(<OrganizationMembersList {...defaultProps} organization={org} />, {
         context: TestStubs.routerContext([{organization: org}]),
       });
+
+      await act(tick);
 
       expect(screen.getByText('Pending Members')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Approve'})).toBeDisabled();
@@ -588,26 +591,6 @@ describe('OrganizationMembersList', function () {
   });
 
   describe('inviteBanner', function () {
-    it('renders banner with feature flag', function () {
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/missing-members/',
-        method: 'GET',
-        body: missingMembers,
-      });
-
-      const org = TestStubs.Organization({
-        features: ['integrations-gh-invite'],
-      });
-
-      render(<OrganizationMembersList {...defaultProps} organization={org} />, {
-        context: TestStubs.routerContext([{organization: org}]),
-      });
-
-      expect(screen.getByTestId('invite-banner')).toBeInTheDocument();
-      expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);
-      expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
-    });
-
     it('invites member from banner', async function () {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/missing-members/',
@@ -639,6 +622,8 @@ describe('OrganizationMembersList', function () {
       render(<OrganizationMembersList {...defaultProps} organization={org} />, {
         context: TestStubs.routerContext([{organization: org}]),
       });
+
+      await act(tick);
 
       expect(screen.getByTestId('invite-banner')).toBeInTheDocument();
       expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -45,33 +45,7 @@ const roles = [
 const missingMembers = [
   {
     integration: 'github',
-    users: [
-      {
-        commitCount: 6,
-        email: 'hello@sentry.io',
-        externalId: 'hello',
-      },
-      {
-        commitCount: 5,
-        email: 'abcd@sentry.io',
-        externalId: 'abcd',
-      },
-      {
-        commitCount: 4,
-        email: 'hola@sentry.io',
-        externalId: 'hola',
-      },
-      {
-        commitCount: 3,
-        email: 'test@sentry.io',
-        externalId: 'test',
-      },
-      {
-        commitCount: 2,
-        email: 'five@sentry.io',
-        externalId: 'five',
-      },
-    ],
+    users: TestStubs.MissingMembers(),
   },
 ];
 
@@ -183,6 +157,14 @@ describe('OrganizationMembersList', function () {
       url: '/organizations/org-slug/missing-members/',
       method: 'GET',
       body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      method: 'GET',
+      body: {
+        dismissed_ts: undefined,
+        snoozed_ts: undefined,
+      },
     });
     (browserHistory.push as jest.Mock).mockReset();
     OrganizationsStore.load([organization]);
@@ -624,31 +606,6 @@ describe('OrganizationMembersList', function () {
       expect(screen.getByTestId('invite-banner')).toBeInTheDocument();
       expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);
       expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
-    });
-
-    it('does not render banner if no missing members', function () {
-      const org = TestStubs.Organization({
-        features: ['integrations-gh-invite'],
-      });
-
-      render(<OrganizationMembersList {...defaultProps} organization={org} />, {
-        context: TestStubs.routerContext([{organization: org}]),
-      });
-
-      expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
-    });
-
-    it('does not render banner if lacking org:write', function () {
-      const org = TestStubs.Organization({
-        features: ['integrations-gh-invite'],
-        access: [],
-      });
-
-      render(<OrganizationMembersList {...defaultProps} organization={org} />, {
-        context: TestStubs.routerContext([{organization: org}]),
-      });
-
-      expect(screen.queryByTestId('invite-banner')).not.toBeInTheDocument();
     });
 
     it('invites member from banner', async function () {

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -2,7 +2,6 @@ import {browserHistory} from 'react-router';
 import selectEvent from 'react-select-event';
 
 import {
-  act,
   render,
   renderGlobalModal,
   screen,
@@ -457,7 +456,7 @@ describe('OrganizationMembersList', function () {
       teams: [],
     });
 
-    it('disable buttons for no access', async function () {
+    it('disable buttons for no access', function () {
       const org = TestStubs.Organization({
         status: {
           id: 'active',
@@ -476,8 +475,6 @@ describe('OrganizationMembersList', function () {
       render(<OrganizationMembersList {...defaultProps} organization={org} />, {
         context: TestStubs.routerContext([{organization: org}]),
       });
-
-      await act(tick);
 
       expect(screen.getByText('Pending Members')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Approve'})).toBeDisabled();
@@ -623,10 +620,10 @@ describe('OrganizationMembersList', function () {
         context: TestStubs.routerContext([{organization: org}]),
       });
 
-      await act(tick);
-
       expect(
-        screen.getByText('Bring your full GitHub team on board in Sentry')
+        await screen.findByRole('heading', {
+          name: 'Bring your full GitHub team on board in Sentry',
+        })
       ).toBeInTheDocument();
       expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);
       expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -6,7 +6,6 @@ import styled from '@emotion/styled';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {resendMemberInvite} from 'sentry/actionCreators/members';
 import {redirectToRemainingOrganization} from 'sentry/actionCreators/organizations';
-import Feature from 'sentry/components/acl/feature';
 import {AsyncComponentState} from 'sentry/components/deprecatedAsyncComponent';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import HookOrDefault from 'sentry/components/hookOrDefault';
@@ -333,12 +332,10 @@ class OrganizationMembersList extends DeprecatedAsyncView<Props, State> {
 
     return (
       <Fragment>
-        <Feature organization={organization} features={['integrations-gh-invite']}>
-          <InviteBanner
-            missingMembers={githubMissingMembers}
-            onSendInvite={this.handleInviteMissingMember}
-          />
-        </Feature>
+        <InviteBanner
+          missingMembers={githubMissingMembers}
+          onSendInvite={this.handleInviteMissingMember}
+        />
         <ClassNames>
           {({css}) =>
             this.renderSearchInput({

--- a/static/app/views/settings/organizationMembers/organizationMembersWrapper.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersWrapper.spec.tsx
@@ -1,5 +1,3 @@
-import {act} from 'react-dom/test-utils';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -111,9 +109,7 @@ describe('OrganizationMembersWrapper', function () {
       </OrganizationMembersWrapper>
     );
 
-    await act(tick);
-
-    expect(screen.getByText('Members')).toBeInTheDocument();
+    expect(await screen.findByText('Members')).toBeInTheDocument();
     expect(screen.getByText(member.name)).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/organizationMembers/organizationMembersWrapper.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersWrapper.spec.tsx
@@ -1,3 +1,5 @@
+import {act} from 'react-dom/test-utils';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -92,17 +94,24 @@ describe('OrganizationMembersWrapper', function () {
     expect(openInviteMembersModal).toHaveBeenCalled();
   });
 
-  it('renders member list', function () {
+  it('renders member list', async function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',
       method: 'GET',
       body: [member],
+    });
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      method: 'GET',
+      body: {},
     });
     render(
       <OrganizationMembersWrapper organization={organization} {...routerProps}>
         <OrganizationMembersList {...routerProps} />
       </OrganizationMembersWrapper>
     );
+
+    await act(tick);
 
     expect(screen.getByText('Members')).toBeInTheDocument();
     expect(screen.getByText(member.name)).toBeInTheDocument();


### PR DESCRIPTION
Allow snoozing the invite banner through a dropdown.

https://github.com/getsentry/sentry/assets/70817427/9a83200e-50d5-44e1-a456-6e5487d45f76

For ER-1742