### PR TITLE
feat(celery): record task duration

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import resource
 from contextlib import contextmanager
+from datetime import datetime
 from functools import wraps
 from typing import Any, Callable, Iterable, Sequence, Type
 
@@ -79,7 +80,7 @@ def load_model_from_db(cls, instance_or_id, allow_cache=True):
     return instance_or_id
 
 
-def instrumented_task(name, stat_suffix=None, silo_mode=None, **kwargs):
+def instrumented_task(name, stat_suffix=None, silo_mode=None, record_timing=False, **kwargs):
     """
     Decorator for defining celery tasks.
 
@@ -94,15 +95,26 @@ def instrumented_task(name, stat_suffix=None, silo_mode=None, **kwargs):
     def wrapped(func):
         @wraps(func)
         def _wrapped(*args, **kwargs):
+
             # TODO(dcramer): we want to tag a transaction ID, but overriding
             # the base on app.task seems to cause problems w/ Celery internals
             transaction_id = kwargs.pop("__transaction_id", None)
+            start_time = kwargs.pop("__start_time", None)
 
             key = "jobs.duration"
             if stat_suffix:
                 instance = f"{name}.{stat_suffix(*args, **kwargs)}"
             else:
                 instance = name
+
+            if start_time and record_timing:
+                curr_time = datetime.now().timestamp()
+                duration = (curr_time - start_time) * 1000
+                metrics.timing(
+                    "jobs.queue_time",
+                    duration,
+                    instance=instance,
+                )
 
             with configure_scope() as scope:
                 scope.set_tag("task_name", name)


### PR DESCRIPTION
This PR adds a new option called record_timing which will record how long a task is in the queue before it is picked up. Eventually, we will remove the option and make recording the time the default.

Follow up to this [PR](https://github.com/getsentry/sentry/pull/52630/files#) which got reverted. The problem was that we needed to pop off the start time before we started to pass it because it causes a problem during deploys.