### PR TITLE
feat(open-pr-comments): PR comment qualification check

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -214,6 +214,15 @@ class GitHubClientMixin(GithubProxyClient):
         pullrequest: JSONData = self.get(f"/repos/{repo}/commits/{sha}/pulls")
         return pullrequest
 
+    def get_pullrequest(self, repo: str, pull_number: int) -> JSONData:
+        """
+        https://docs.github.com/en/free-pro-team@latest/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
+
+        Returns the pull request details
+        """
+        pullrequest: JSONData = self.get(f"/repos/{repo}/pulls/{pull_number}")
+        return pullrequest
+
     def get_repo(self, repo: str) -> JSONData:
         """
         https://docs.github.com/en/rest/repos/repos#get-a-repository

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -352,7 +352,8 @@ def safe_for_comment(
                 OPEN_PR_METRIC_BASE.format(key="api_error"),
                 tags={"type": "unknown_api_error", "code": e.code},
             )
-        raise e
+            logger.exception("github.open_pr_comment.unknown_api_error")
+        return False
 
     safe_to_comment = True
     if pullrequest_resp["changed_files"] > OPEN_PR_MAX_FILES_CHANGED:

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -15,7 +15,7 @@ from sentry.integrations.github.client import GitHubAppsClient
 from sentry.models import Group, GroupOwnerType, Project
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
-from sentry.models.pullrequest import CommentType, PullRequestComment
+from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComment
 from sentry.models.repository import Repository
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions.base import ApiError
@@ -53,6 +53,13 @@ SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url})"
 ISSUE_LOCKED_ERROR_MESSAGE = "Unable to create comment because issue is locked."
 
 RATE_LIMITED_MESSAGE = "API rate limit exceeded"
+
+OPEN_PR_METRIC_BASE = "github_open_pr_comment.{key}"
+
+# Caps the number of files that can be modified in a PR to leave a comment
+OPEN_PR_MAX_FILES_CHANGED = 10
+# Caps the number of lines that can be modified in a PR to leave a comment
+OPEN_PR_MAX_LINES_CHANGED = 500
 
 
 def format_comment(issues: List[PullRequestIssue]):
@@ -319,3 +326,43 @@ def github_comment_reactions():
             continue
 
         metrics.incr("github_pr_comment.comment_reactions.success")
+
+
+# TODO(adas): Change the client typing to allow for multiple SCM Integrations
+def safe_for_comment(
+    gh_client: GitHubAppsClient, repository: Repository, pull_request: PullRequest
+) -> bool:
+    try:
+        pullrequest_resp = gh_client.get_pullrequest(
+            repo=repository.name, pull_number=pull_request.key
+        )
+    except ApiError as e:
+        if e.json and RATE_LIMITED_MESSAGE in e.json.get("message", ""):
+            metrics.incr(
+                OPEN_PR_METRIC_BASE.format(key="api_error"),
+                tags={"type": "gh_rate_limited", "code": e.code},
+            )
+        elif e.code == 404:
+            metrics.incr(
+                OPEN_PR_METRIC_BASE.format(key="api_error"),
+                tags={"type": "missing_gh_pull_request", "code": e.code},
+            )
+        else:
+            metrics.incr(
+                OPEN_PR_METRIC_BASE.format(key="api_error"),
+                tags={"type": "unknown_api_error", "code": e.code},
+            )
+        raise e
+
+    safe_to_comment = True
+    if pullrequest_resp["changed_files"] > OPEN_PR_MAX_FILES_CHANGED:
+        metrics.incr(
+            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "too_many_files"}
+        )
+        safe_to_comment = False
+    if pullrequest_resp["additions"] + pullrequest_resp["deletions"] > OPEN_PR_MAX_LINES_CHANGED:
+        metrics.incr(
+            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "too_many_lines"}
+        )
+        safe_to_comment = False
+    return safe_to_comment

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -356,6 +356,11 @@ def safe_for_comment(
         return False
 
     safe_to_comment = True
+    if pullrequest_resp["state"] != "open":
+        metrics.incr(
+            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "incorrect_state"}
+        )
+        safe_to_comment = False
     if pullrequest_resp["changed_files"] > OPEN_PR_MAX_FILES_CHANGED:
         metrics.incr(
             OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "too_many_files"}

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -839,8 +839,7 @@ class TestSafeForComment(GithubCommentTestCase):
             responses.GET, self.gh_path.format(pull_number=self.pr.key), status=404, json={}
         )
 
-        with pytest.raises(ApiError):
-            safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
         self.mock_metrics.incr.assert_called_with(
             "github_open_pr_comment.api_error",
             tags={"type": "missing_gh_pull_request", "code": 404},
@@ -852,8 +851,7 @@ class TestSafeForComment(GithubCommentTestCase):
             responses.GET, self.gh_path.format(pull_number=self.pr.key), status=400, json={}
         )
 
-        with pytest.raises(ApiError):
-            safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
         self.mock_metrics.incr.assert_called_with(
             "github_open_pr_comment.api_error", tags={"type": "unknown_api_error", "code": 400}
         )

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -861,7 +861,7 @@ class TestSafeForComment(GithubCommentTestCase):
             responses.GET,
             self.gh_path.format(pull_number=self.pr.key),
             status=200,
-            json={"changed_files": 10, "additions": 100, "deletions": 100, "state": "closed"},
+            json={"changed_files": 5, "additions": 100, "deletions": 100, "state": "closed"},
         )
 
         assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -23,6 +23,7 @@ from sentry.tasks.integrations.github.pr_comment import (
     github_comment_reactions,
     github_comment_workflow,
     pr_to_issue_query,
+    safe_for_comment,
 )
 from sentry.testutils.cases import IntegrationTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -79,6 +80,7 @@ class GithubCommentTestCase(IntegrationTestCase):
         self.pr_key = 1
         self.commit_sha = 1
         self.fingerprint = 1
+        patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1").start()
 
     def add_commit_to_repo(self, repo, user, project):
         if user not in self.user_to_commit_author_map:
@@ -336,10 +338,9 @@ class TestCommentWorkflow(GithubCommentTestCase):
         self.cache_key = DEBOUNCE_PR_COMMENT_CACHE_KEY(self.pr.id)
 
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @responses.activate
-    def test_comment_workflow(self, mock_metrics, get_jwt, mock_issues):
+    def test_comment_workflow(self, mock_metrics, mock_issues):
         groups = [g.id for g in Group.objects.all()]
         mock_issues.return_value = [{"group_id": id, "event_count": 10} for id in groups]
 
@@ -368,11 +369,10 @@ class TestCommentWorkflow(GithubCommentTestCase):
         mock_metrics.incr.assert_called_with("github_pr_comment.comment_created")
 
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @responses.activate
     @freeze_time(datetime(2023, 6, 8, 0, 0, 0, tzinfo=timezone.utc))
-    def test_comment_workflow_updates_comment(self, mock_metrics, get_jwt, mock_issues):
+    def test_comment_workflow_updates_comment(self, mock_metrics, mock_issues):
         groups = [g.id for g in Group.objects.all()]
         mock_issues.return_value = [{"group_id": id, "event_count": 10} for id in groups]
         pull_request_comment = PullRequestComment.objects.create(
@@ -417,10 +417,9 @@ class TestCommentWorkflow(GithubCommentTestCase):
         mock_metrics.incr.assert_called_with("github_pr_comment.comment_updated")
 
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @responses.activate
-    def test_comment_workflow_api_error(self, mock_metrics, get_jwt, mock_issues):
+    def test_comment_workflow_api_error(self, mock_metrics, mock_issues):
         cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
         mock_issues.return_value = [
             {"group_id": g.id, "event_count": 10} for g in Group.objects.all()
@@ -444,10 +443,9 @@ class TestCommentWorkflow(GithubCommentTestCase):
             mock_metrics.incr.assert_called_with("github_pr_comment.api_error")
 
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @responses.activate
-    def test_comment_workflow_api_error_locked_issue(self, mock_metrics, get_jwt, mock_issues):
+    def test_comment_workflow_api_error_locked_issue(self, mock_metrics, mock_issues):
         cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
         mock_issues.return_value = [
             {"group_id": g.id, "event_count": 10} for g in Group.objects.all()
@@ -475,10 +473,9 @@ class TestCommentWorkflow(GithubCommentTestCase):
         )
 
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @responses.activate
-    def test_comment_workflow_api_error_rate_limited(self, mock_metrics, get_jwt, mock_issues):
+    def test_comment_workflow_api_error_rate_limited(self, mock_metrics, mock_issues):
         cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
         mock_issues.return_value = [
             {"group_id": g.id, "event_count": 10} for g in Group.objects.all()
@@ -626,10 +623,9 @@ class TestCommentReactionsTask(GithubCommentTestCase):
         self.expired_pr.date_added = timezone.now() - timedelta(days=35)
         self.expired_pr.save()
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @responses.activate
-    def test_comment_reactions_task(self, mock_metrics, get_jwt):
+    def test_comment_reactions_task(self, mock_metrics):
         old_comment = PullRequestComment.objects.create(
             external_id="1",
             pull_request=self.expired_pr,
@@ -669,10 +665,9 @@ class TestCommentReactionsTask(GithubCommentTestCase):
 
         mock_metrics.incr.assert_called_with("github_pr_comment.comment_reactions.success")
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @responses.activate
-    def test_comment_reactions_task_missing_repo(self, mock_metrics, get_jwt):
+    def test_comment_reactions_task_missing_repo(self, mock_metrics):
         self.gh_repo.delete()
 
         responses.add(
@@ -693,10 +688,9 @@ class TestCommentReactionsTask(GithubCommentTestCase):
         assert self.comment.reactions is None
         mock_metrics.incr.assert_called_with("github_pr_comment.comment_reactions.missing_repo")
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @responses.activate
-    def test_comment_reactions_task_missing_integration(self, mock_metrics, get_jwt):
+    def test_comment_reactions_task_missing_integration(self, mock_metrics):
         # invalid integration id
         self.gh_repo.integration_id = 0
         self.gh_repo.save()
@@ -721,10 +715,9 @@ class TestCommentReactionsTask(GithubCommentTestCase):
             "github_pr_comment.comment_reactions.missing_integration"
         )
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @responses.activate
-    def test_comment_reactions_task_api_error(self, mock_metrics, get_jwt):
+    def test_comment_reactions_task_api_error(self, mock_metrics):
         responses.add(
             responses.POST,
             self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
@@ -743,10 +736,9 @@ class TestCommentReactionsTask(GithubCommentTestCase):
         assert self.comment.reactions is None
         mock_metrics.incr.assert_called_with("github_pr_comment.comment_reactions.api_error")
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @responses.activate
-    def test_comment_reactions_task_api_error_rate_limited(self, mock_metrics, get_jwt):
+    def test_comment_reactions_task_api_error_rate_limited(self, mock_metrics):
         responses.add(
             responses.POST,
             self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
@@ -770,10 +762,9 @@ class TestCommentReactionsTask(GithubCommentTestCase):
             "github_pr_comment.comment_reactions.rate_limited_error"
         )
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @patch("sentry.tasks.integrations.github.pr_comment.metrics")
     @responses.activate
-    def test_comment_reactions_task_api_error_404(self, mock_metrics, get_jwt):
+    def test_comment_reactions_task_api_error_404(self, mock_metrics):
         responses.add(
             responses.POST,
             self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
@@ -791,3 +782,123 @@ class TestCommentReactionsTask(GithubCommentTestCase):
         self.comment.refresh_from_db()
         assert self.comment.reactions is None
         mock_metrics.incr.assert_called_with("github_pr_comment.comment_reactions.not_found_error")
+
+
+@region_silo_test(stable=True)
+class TestSafeForComment(GithubCommentTestCase):
+    base_url = "https://api.github.com"
+
+    def setUp(self):
+        super().setUp()
+        access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+        expires_at = isoformat_z(timezone.now() + timedelta(days=365))
+        self.pr = self.create_pr_issues()
+        self.mock_metrics = patch("sentry.tasks.integrations.github.pr_comment.metrics").start()
+        self.gh_path = self.base_url + "/repos/getsentry/sentry/pulls/{pull_number}"
+        installation = self.integration.get_installation(organization_id=self.organization.id)
+        self.gh_client = installation.get_client()
+        responses.add(
+            responses.POST,
+            self.base_url
+            + f"/app/installations/{self.gh_client._get_installation_id()}/access_tokens",
+            json={"token": access_token, "expires_at": expires_at},
+        )
+
+    @responses.activate
+    def test_simple(self):
+        responses.add(
+            responses.GET,
+            self.gh_path.format(pull_number=self.pr.key),
+            status=200,
+            json={"changed_files": 5, "additions": 100, "deletions": 100},
+        )
+
+        assert safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+
+    @responses.activate
+    def test_error__rate_limited(self):
+        responses.add(
+            responses.GET,
+            self.gh_path.format(pull_number=self.pr.key),
+            status=429,
+            json={
+                "message": "API rate limit exceeded",
+                "documentation_url": "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting",
+            },
+        )
+
+        with pytest.raises(ApiError):
+            safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.api_error", tags={"type": "gh_rate_limited", "code": 429}
+        )
+
+    @responses.activate
+    def test_error__missing_pr(self):
+        responses.add(
+            responses.GET, self.gh_path.format(pull_number=self.pr.key), status=404, json={}
+        )
+
+        with pytest.raises(ApiError):
+            safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.api_error",
+            tags={"type": "missing_gh_pull_request", "code": 404},
+        )
+
+    @responses.activate
+    def test_error__api_error(self):
+        responses.add(
+            responses.GET, self.gh_path.format(pull_number=self.pr.key), status=400, json={}
+        )
+
+        with pytest.raises(ApiError):
+            safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.api_error", tags={"type": "unknown_api_error", "code": 400}
+        )
+
+    @responses.activate
+    def test_too_many_files(self):
+        responses.add(
+            responses.GET,
+            self.gh_path.format(pull_number=self.pr.key),
+            status=200,
+            json={"changed_files": 11, "additions": 100, "deletions": 100},
+        )
+
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.rejected_comment", tags={"reason": "too_many_files"}
+        )
+
+    @responses.activate
+    def test_too_many_lines(self):
+        responses.add(
+            responses.GET,
+            self.gh_path.format(pull_number=self.pr.key),
+            status=200,
+            json={"changed_files": 5, "additions": 300, "deletions": 300},
+        )
+
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.rejected_comment", tags={"reason": "too_many_lines"}
+        )
+
+    @responses.activate
+    def test_too_many_files_and_lines(self):
+        responses.add(
+            responses.GET,
+            self.gh_path.format(pull_number=self.pr.key),
+            status=200,
+            json={"changed_files": 11, "additions": 300, "deletions": 300},
+        )
+
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_any_call(
+            "github_open_pr_comment.rejected_comment", tags={"reason": "too_many_lines"}
+        )
+        self.mock_metrics.incr.assert_any_call(
+            "github_open_pr_comment.rejected_comment", tags={"reason": "too_many_files"}
+        )


### PR DESCRIPTION
We only want to comment on open PRs that have <= 500 lines modified and <= 10 files modified. The lines modified and files modified constraints can be changed in the future. The reasoning for having these two additional checks is that

1. The more lines modified, the less relevant individual issues in functions become.
2. Similar to above, the more files modified, the harder it will be to find relevant issues.

For ER-1804