### PR TITLE
fix(ui): Reimplement align access button

### DIFF
--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -284,13 +284,14 @@ export default withApi(AllTeamsRow);
 
 export const GRID_TEMPLATE = `
   display: grid;
-  grid-template-columns: minmax(150px, 4fr) minmax(0px, 100px) 125px 110px;
+  grid-template-columns: minmax(150px, 4fr) minmax(0px, 100px) 125px minmax(110px 1fr);
   gap: ${space(1)};
 `;
 
 const TeamPanelItem = styled(PanelItem)`
   ${GRID_TEMPLATE}
   align-items: center;
+  display: flex;
 
   > div:last-child {
     margin-left: auto;

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -284,14 +284,13 @@ export default withApi(AllTeamsRow);
 
 export const GRID_TEMPLATE = `
   display: grid;
-  grid-template-columns: minmax(150px, 4fr) minmax(0px, 100px) 125px minmax(110px 1fr);
+  grid-template-columns: minmax(150px, 4fr) minmax(0px, 100px) 125px minmax(110px, 1fr);
   gap: ${space(1)};
 `;
 
 const TeamPanelItem = styled(PanelItem)`
   ${GRID_TEMPLATE}
   align-items: center;
-  display: flex;
 
   > div:last-child {
     margin-left: auto;

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -284,7 +284,7 @@ export default withApi(AllTeamsRow);
 
 export const GRID_TEMPLATE = `
   display: grid;
-  grid-template-columns: minmax(150px, 4fr) minmax(0px, 100px) 125px minmax(110px, 1fr);
+  grid-template-columns: minmax(150px, 4fr) minmax(0px, 100px) 125px minmax(150px, 1fr);
   gap: ${space(1)};
 `;
 


### PR DESCRIPTION
## Before
<img width="1240" alt="Screenshot 2023-08-07 at 2 27 50 PM" src="https://github.com/getsentry/sentry/assets/67301797/8f47f041-3982-4856-a5ef-85db910e2167">

## After
<img width="1219" alt="Screenshot 2023-08-07 at 2 26 40 PM" src="https://github.com/getsentry/sentry/assets/67301797/f086ffb4-c664-49b4-9b5a-54383d0c9554">

## When shrunk
<img width="560" alt="Screenshot 2023-08-07 at 2 34 08 PM" src="https://github.com/getsentry/sentry/assets/67301797/21d003fe-e787-47dd-991e-aeb374b090e8">