### PR TITLE
ref(alerts): Use OrganizationAlertRuleDetailsEndpoint 

### DIFF
--- a/static/app/views/alerts/list/rules/index.tsx
+++ b/static/app/views/alerts/list/rules/index.tsx
@@ -95,8 +95,10 @@ class AlertRulesList extends DeprecatedAsyncComponent<
     ownerValue: string
   ) => {
     const {organization} = this.props;
-    const alertPath = rule.type === 'alert_rule' ? 'alert-rules' : 'rules';
-    const endpoint = `/projects/${organization.slug}/${projectId}/${alertPath}/${rule.id}/`;
+    const endpoint =
+      rule.type === 'alert_rule'
+        ? `/organizations/${organization.slug}/alert-rules/${rule.id}`
+        : `/projects/${organization.slug}/${projectId}/rules/${rule.id}/`;
     const updatedRule = {...rule, owner: ownerValue};
 
     this.api.request(endpoint, {

--- a/static/app/views/alerts/rules/metric/actions.tsx
+++ b/static/app/views/alerts/rules/metric/actions.tsx
@@ -17,13 +17,12 @@ function isSavedRule(rule: MetricRule): rule is SavedMetricRule {
 export function addOrUpdateRule(
   api: Client,
   orgId: string,
-  projectId: string,
   rule: MetricRule,
   query?: object | any
 ) {
   const isExisting = isSavedRule(rule);
   const endpoint = isExisting
-    ? `/projects/${orgId}/${projectId}/alert-rules/${rule.id}/`
+    ? `/organizations/${orgId}/alert-rules/${rule.id}/`
     : `/organizations/${orgId}/alert-rules/`;
   const method = isExisting ? 'PUT' : 'POST';
 

--- a/static/app/views/alerts/rules/metric/edit.spec.tsx
+++ b/static/app/views/alerts/rules/metric/edit.spec.tsx
@@ -71,7 +71,7 @@ describe('MetricRulesEdit', function () {
     });
 
     const editRule = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/project-slug/alert-rules/${rule.id}/`,
+      url: `/organizations/${organization.slug}/alert-rules/${rule.id}/`,
       method: 'PUT',
       body: rule,
     });
@@ -167,7 +167,7 @@ describe('MetricRulesEdit', function () {
     });
 
     const editRule = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/project-slug/alert-rules/${rule.id}/`,
+      url: `/organizations/${organization.slug}/alert-rules/${rule.id}/`,
       method: 'PUT',
       body: rule,
     });

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -297,7 +297,7 @@ describe('Incident Rules Form', () => {
 
     beforeEach(() => {
       editRule = MockApiClient.addMockResponse({
-        url: `/projects/org-slug/project-slug/alert-rules/${rule.id}/`,
+        url: `/organizations/org-slug/alert-rules/${rule.id}/`,
         method: 'PUT',
         body: rule,
       });
@@ -449,7 +449,7 @@ describe('Incident Rules Form', () => {
     it('success status updates the rule', async () => {
       const alertRule = TestStubs.MetricRule({name: 'Slack Alert Rule'});
       MockApiClient.addMockResponse({
-        url: `/projects/org-slug/project-slug/alert-rules/${alertRule.id}/`,
+        url: `/organizations/org-slug/alert-rules/${alertRule.id}/`,
         method: 'PUT',
         body: {uuid},
         statusCode: 202,
@@ -496,7 +496,7 @@ describe('Incident Rules Form', () => {
     it('pending status keeps loading true', () => {
       const alertRule = TestStubs.MetricRule({name: 'Slack Alert Rule'});
       MockApiClient.addMockResponse({
-        url: `/projects/org-slug/project-slug/alert-rules/${alertRule.id}/`,
+        url: `/organizations/org-slug/alert-rules/${alertRule.id}/`,
         method: 'PUT',
         body: {uuid},
         statusCode: 202,
@@ -522,7 +522,7 @@ describe('Incident Rules Form', () => {
     it('failed status renders error message', async () => {
       const alertRule = TestStubs.MetricRule({name: 'Slack Alert Rule'});
       MockApiClient.addMockResponse({
-        url: `/projects/org-slug/project-slug/alert-rules/${alertRule.id}/`,
+        url: `/organizations/org-slug/alert-rules/${alertRule.id}/`,
         method: 'PUT',
         body: {uuid},
         statusCode: 202,

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -630,7 +630,6 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       const [data, , resp] = await addOrUpdateRule(
         this.api,
         organization.slug,
-        project.slug,
         {
           ...rule,
           ...model.getTransformedData(),


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/54003 and a follow up to https://github.com/getsentry/sentry/pull/54152 to replace the usages we have of the `ProjectAlertRuleDetailsEndpoint` PUT method with the `OrganizationAlertRuleDetailsEndpoint` one.