### PR TITLE
ref(crons): Use redis GETSET over a lock for synchronization

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -180,7 +180,9 @@ def _try_handle_high_volume_task_trigger(ts: datetime):
     reference_datetime = ts.replace(second=0, microsecond=0)
     reference_ts = int(reference_datetime.timestamp())
 
-    last_ts = redis_client.get(HIGH_VOLUME_LAST_TRIGGER_TS_KEY)
+    # Since GETSET is atomic this acts as a guard against another consumer
+    # picking up the minute rollover
+    last_ts = redis_client.getset(HIGH_VOLUME_LAST_TRIGGER_TS_KEY, reference_ts)
     if last_ts is not None:
         last_ts = int(last_ts)
 
@@ -188,29 +190,22 @@ def _try_handle_high_volume_task_trigger(ts: datetime):
     if last_ts == reference_ts:
         return
 
-    try:
-        lock = locks.get("sentry.monitors.task_trigger", duration=5)
-        with lock.acquire():
-            # Track the delay from the true time, ideally this should be pretty
-            # close, but in the case of a backlog, this will be much higher
-            total_delay = reference_ts - datetime.now().timestamp()
+    # Track the delay from the true time, ideally this should be pretty
+    # close, but in the case of a backlog, this will be much higher
+    total_delay = reference_ts - datetime.now().timestamp()
 
-            metrics.incr("monitors.task.triggered_via_high_volume_clock")
-            metrics.gauge("monitors.task.high_volume_clock_delay", total_delay)
+    metrics.incr("monitors.task.triggered_via_high_volume_clock")
+    metrics.gauge("monitors.task.high_volume_clock_delay", total_delay)
 
-            # If more than exactly a minute has passed then we've skipped a
-            # task run, report that to sentry, it is a problem.
-            if last_ts is not None and last_ts + 60 != reference_ts:
-                with sentry_sdk.push_scope() as scope:
-                    scope.set_extra("last_ts", last_ts)
-                    scope.set_extra("reference_ts", reference_ts)
-                    sentry_sdk.capture_message("Monitor task dispatch minute skipped")
+    # If more than exactly a minute has passed then we've skipped a
+    # task run, report that to sentry, it is a problem.
+    if last_ts is not None and last_ts + 60 != reference_ts:
+        with sentry_sdk.push_scope() as scope:
+            scope.set_extra("last_ts", last_ts)
+            scope.set_extra("reference_ts", reference_ts)
+            sentry_sdk.capture_message("Monitor task dispatch minute skipped")
 
-            _dispatch_tasks(ts)
-            redis_client.set(HIGH_VOLUME_LAST_TRIGGER_TS_KEY, reference_ts)
-    except UnableToAcquireLock:
-        # Another message processor is handling this. Nothing to do
-        pass
+    _dispatch_tasks(ts)
 
 
 def _process_message(ts: datetime, wrapper: CheckinMessage) -> None:


### PR DESCRIPTION
Instead of taking a lock when ticking the monitor tasks trigger clock,
we can use redis' `GETSET` command to retrieve the current value and set
a new value atomically.

This addresses @fpacifici's feedback here https://github.com/getsentry/sentry/issues/53661#issuecomment-1668622515