### PR TITLE
feat(issues): Remove issue-alert-fallback frontend

### DIFF
--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -314,8 +314,7 @@ function RuleNode({
 
     if (
       data.id === NOTIFY_EMAIL_ACTION &&
-      data.targetType !== MailActionTargetType.ISSUE_OWNERS &&
-      organization.features.includes('issue-alert-fallback-targeting')
+      data.targetType !== MailActionTargetType.ISSUE_OWNERS
     ) {
       // Hide the fallback options when targeting team or member
       label = 'Send a notification to {targetType}';
@@ -413,8 +412,7 @@ function RuleNode({
 
     if (
       data.id === NOTIFY_EMAIL_ACTION &&
-      data.targetType === MailActionTargetType.ISSUE_OWNERS &&
-      !organization.features.includes('issue-alert-fallback-targeting')
+      data.targetType === MailActionTargetType.ISSUE_OWNERS
     ) {
       return (
         <MarginlessAlert type="warning">

--- a/static/app/views/projectInstall/issueAlertOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.spec.tsx
@@ -115,14 +115,13 @@ describe('IssueAlertOptions', function () {
     expect(screen.getByTestId('range-input')).toHaveValue(null);
   });
 
-  it('should provide fallthroughType with issue action for issue-alert-fallback-targeting', async () => {
+  it('should provide fallthroughType with issue action', async () => {
     MockApiClient.addMockResponse({
       url: URL,
       body: TestStubs.MOCK_RESP_VERBOSE,
     });
-    const org = {...organization, features: ['issue-alert-fallback-targeting']};
 
-    render(<IssueAlertOptions {...props} organization={org} />);
+    render(<IssueAlertOptions {...props} />);
     await userEvent.click(screen.getByLabelText(/When there are more than/i));
     expect(props.onChange).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -39,6 +39,7 @@ const ISSUE_ALERT_DEFAULT_ACTION: Omit<
 > = {
   id: 'sentry.mail.actions.NotifyEmailAction',
   targetType: 'IssueOwners',
+  fallthroughType: 'ActiveMembers',
 };
 
 const METRIC_CONDITION_MAP = {
@@ -231,14 +232,7 @@ class IssueAlertOptions extends DeprecatedAsyncComponent<Props, State> {
               ),
             ]
           : undefined,
-      actions: [
-        {
-          ...ISSUE_ALERT_DEFAULT_ACTION,
-          ...(this.props.organization.features.includes('issue-alert-fallback-targeting')
-            ? {fallthroughType: 'ActiveMembers'}
-            : {}),
-        },
-      ],
+      actions: [ISSUE_ALERT_DEFAULT_ACTION],
       actionMatch: 'all',
       frequency: 5,
     };

--- a/static/app/views/settings/project/projectOwnership/index.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.spec.tsx
@@ -137,16 +137,12 @@ describe('Project Ownership', () => {
       });
     });
 
-    it('should hide issue owners for issue-alert-fallback-targeting flag', () => {
-      const org = {
-        ...organization,
-        features: ['issue-alert-fallback-targeting'],
-      };
+    it('should hide issue owners', () => {
       render(
         <ProjectOwnership
           {...routerProps}
           params={{projectId: project.slug}}
-          organization={org}
+          organization={organization}
           project={project}
         />
       );

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -281,21 +281,6 @@ tags.sku_class:enterprise #enterprise`;
                       ],
                       disabled,
                     },
-                    ...(organization.features.includes('issue-alert-fallback-targeting')
-                      ? []
-                      : [
-                          {
-                            name: 'fallthrough',
-                            type: 'boolean' as const,
-                            label: t(
-                              'Send alert to project members if there’s no assigned owner'
-                            ),
-                            help: t(
-                              'Alerts will be sent to all users who have access to this project.'
-                            ),
-                            disabled,
-                          },
-                        ]),
                     {
                       name: 'codeownersAutoSync',
                       type: 'boolean',


### PR DESCRIPTION
feature has been in GA for a while. This is the flag that moved the issue alert fallback setting - into the issue alert itself