### PR TITLE
feat(sentryapps)-email-on-disable

### DIFF
--- a/src/sentry/integrations/notify_disable.py
+++ b/src/sentry/integrations/notify_disable.py
@@ -58,6 +58,9 @@ def notify_disable(
                 "integration_name": integration_name.title(),
                 "integration_link": integration_link,
                 "webhook_url": webhook_url if "sentry-app" in redis_key and webhook_url else "",
+                "dashboard_link": f"{integration_link}dashboard/"
+                if "sentry-app" in redis_key
+                else "",
             },
             html_template="sentry/integrations/sentry-app-notify-disable.html"
             if "sentry-app" in redis_key and integration_slug

--- a/src/sentry/integrations/notify_disable.py
+++ b/src/sentry/integrations/notify_disable.py
@@ -40,6 +40,7 @@ def notify_disable(
     integration_name: str,
     redis_key: str,
     integration_slug: Union[str, None] = None,
+    webhook_url: Union[str, None] = None,
     project: Union[str, None] = None,
 ):
 
@@ -56,8 +57,7 @@ def notify_disable(
             context={
                 "integration_name": integration_name.title(),
                 "integration_link": integration_link,
-                "webhook_url": redis_key,
-                "dashboard_link": "hold",
+                "webhook_url": webhook_url if "sentry-app" in redis_key and webhook_url else "",
             },
             html_template="sentry/integrations/sentry-app-notify-disable.html"
             if "sentry-app" in redis_key and integration_slug

--- a/src/sentry/integrations/notify_disable.py
+++ b/src/sentry/integrations/notify_disable.py
@@ -56,8 +56,14 @@ def notify_disable(
             context={
                 "integration_name": integration_name.title(),
                 "integration_link": integration_link,
+                "webhook_url": redis_key,
+                "dashboard_link": "hold",
             },
-            html_template="sentry/integrations/notify-disable.html",
-            template="sentry/integrations/notify-disable.txt",
+            html_template="sentry/integrations/sentry-app-notify-disable.html"
+            if "sentry-app" in redis_key and integration_slug
+            else "sentry/integrations/notify-disable.html",
+            template="sentry/integrations/sentry-app-notify-disable.txt"
+            if "sentry-app" in redis_key and integration_slug
+            else "sentry/integrations/notify-disable.txt",
         )
         msg.send_async([user.email])

--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -49,7 +49,7 @@
         <option value="mail/invite-request/">Invite Request</option>
         <option value="mail/integration-request/">Integration Request</option>
         <option value="mail/notify-disable/">Notify Disable</option>
-        <option value="mail/sentry-app-notify-disable/">Notify Disable</option>
+        <option value="mail/sentry-app-notify-disable/">Sentry App Notify Disable</option>
         <option value="mail/join-request/">Join Request</option>
       </optgroup>
       <optgroup label="Reports">

--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -49,6 +49,7 @@
         <option value="mail/invite-request/">Invite Request</option>
         <option value="mail/integration-request/">Integration Request</option>
         <option value="mail/notify-disable/">Notify Disable</option>
+        <option value="mail/sentry-app-notify-disable/">Notify Disable</option>
         <option value="mail/join-request/">Join Request</option>
       </optgroup>
       <optgroup label="Reports">

--- a/src/sentry/templates/sentry/integrations/sentry-app-notify-disable.html
+++ b/src/sentry/templates/sentry/integrations/sentry-app-notify-disable.html
@@ -1,0 +1,23 @@
+{% extends "sentry/emails/base.html" %}
+
+{% load i18n %}
+
+{% block main %}
+  <p>
+    Hi there,
+</p><p>
+    We’ve received multiple request errors {{ dashboard_link }} from your webhook: {{ webhook_url }} for the custom {{ integration_name }} integration, and have unsubscribed the webhook from receiving events.
+</p><p>
+    To continue using your custom integration, please fix your webhook: {{ webhook_url }}  and re-enable the webhook subscriptions <a href={{integration_link}}>here</a>.
+</p><p>
+  </p>
+  <p>
+  </p>
+  <p>If you need additional assistance, you can reach out to our support team at <a href=https://help.sentry.io/>help.sentry.io</a>.</p>
+  <p>Happy fixing,</p><p>
+    Sentry
+  </p>
+  <p class="via">
+    You are receiving this email because you’re listed as an organization Owner or Manager.</a>
+  </p>
+{% endblock %}

--- a/src/sentry/templates/sentry/integrations/sentry-app-notify-disable.html
+++ b/src/sentry/templates/sentry/integrations/sentry-app-notify-disable.html
@@ -6,7 +6,7 @@
   <p>
     Hi there,
 </p><p>
-    We’ve received multiple <a href={{integration_link}}dashboard/>request errors</a> from your webhook: <a href={{webhook_url}}>{{webhook_url}}</a> for the custom {{ integration_name }} integration, and have unsubscribed the webhook from receiving events.
+    We’ve received multiple <a href={{dashboard_link}}/>request errors</a> from your webhook: <a href={{webhook_url}}>{{webhook_url}}</a> for the custom {{ integration_name }} integration, and have unsubscribed the webhook from receiving events.
 </p><p>
     To continue using your custom integration, please fix your webhook: <a href={{webhook_url}}>{{webhook_url}}</a> and re-enable the webhook subscriptions <a href={{integration_link}}>here</a>.
 </p><p>

--- a/src/sentry/templates/sentry/integrations/sentry-app-notify-disable.html
+++ b/src/sentry/templates/sentry/integrations/sentry-app-notify-disable.html
@@ -6,9 +6,9 @@
   <p>
     Hi there,
 </p><p>
-    We’ve received multiple request errors {{ dashboard_link }} from your webhook: {{ webhook_url }} for the custom {{ integration_name }} integration, and have unsubscribed the webhook from receiving events.
+    We’ve received multiple <a href={{integration_link}}dashboard/>request errors</a> from your webhook: <a href={{webhook_url}}>{{webhook_url}}</a> for the custom {{ integration_name }} integration, and have unsubscribed the webhook from receiving events.
 </p><p>
-    To continue using your custom integration, please fix your webhook: {{ webhook_url }}  and re-enable the webhook subscriptions <a href={{integration_link}}>here</a>.
+    To continue using your custom integration, please fix your webhook: <a href={{webhook_url}}>{{webhook_url}}</a> and re-enable the webhook subscriptions <a href={{integration_link}}>here</a>.
 </p><p>
   </p>
   <p>

--- a/src/sentry/templates/sentry/integrations/sentry-app-notify-disable.txt
+++ b/src/sentry/templates/sentry/integrations/sentry-app-notify-disable.txt
@@ -1,6 +1,6 @@
 Hi there,
 
-    We’ve received multiple <a href={{integration_link}}dashboard/>request errors</a> from your webhook: <a href={{webhook_url}}>{{webhook_url}}</a> for the custom {{ integration_name }} integration,
+    We’ve received multiple <a href={{dashboard_link}}/>request errors</a> from your webhook: <a href={{webhook_url}}>{{webhook_url}}</a> for the custom {{ integration_name }} integration,
     and have unsubscribed the webhook from receiving events.
 
     To continue using your custom integration, please fix your webhook: <a href={{webhook_url}}>{{webhook_url}}</a> and re-enable the webhook subscriptions <a href={{integration_link}}>here</a>.

--- a/src/sentry/templates/sentry/integrations/sentry-app-notify-disable.txt
+++ b/src/sentry/templates/sentry/integrations/sentry-app-notify-disable.txt
@@ -1,0 +1,13 @@
+Hi there,
+
+    We’ve received multiple <a href={{integration_link}}dashboard/>request errors</a> from your webhook: <a href={{webhook_url}}>{{webhook_url}}</a> for the custom {{ integration_name }} integration,
+    and have unsubscribed the webhook from receiving events.
+
+    To continue using your custom integration, please fix your webhook: <a href={{webhook_url}}>{{webhook_url}}</a> and re-enable the webhook subscriptions <a href={{integration_link}}>here</a>.
+
+If you need additional assistance, you can reach out to our support team at <a href=https://help.sentry.io/>help.sentry.io</a>.
+
+Happy fixing,
+Sentry
+
+You are receiving this email because you’re listed as an organization Owner or Manager.

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -47,7 +47,7 @@ def check_broken(sentryapp: SentryApp, org_id: str):
         org = Organization.objects.get(id=org_id)
         if features.has("organizations:disable-sentryapps-on-broken", org):
             sentryapp._disable()
-            notify_disable(org, sentryapp.slug, redis_key)
+            notify_disable(org, sentryapp.name, redis_key, sentryapp.slug, sentryapp.webhook_url)
             buffer.clear()
 
         extra = {

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -57,6 +57,9 @@ from sentry.web.frontend.debug.debug_resolved_in_release_email import (
     DebugResolvedInReleaseEmailView,
     DebugResolvedInReleaseUpcomingEmailView,
 )
+from sentry.web.frontend.debug.debug_sentry_app_notify_disable import (
+    DebugSentryAppNotifyDisableView,
+)
 from sentry.web.frontend.debug.debug_setup_2fa_email import DebugSetup2faEmailView
 from sentry.web.frontend.debug.debug_sso_link_email import (
     DebugSsoLinkedEmailView,
@@ -151,4 +154,5 @@ urlpatterns = [
     re_path(r"^debug/oauth/authorize/error/$", DebugOAuthAuthorizeErrorView.as_view()),
     re_path(r"^debug/chart-renderer/$", DebugChartRendererView.as_view()),
     re_path(r"^debug/mail/notify-disable/$", DebugNotifyDisableView.as_view()),
+    re_path(r"^debug/mail/sentry-app-notify-disable/$", DebugSentryAppNotifyDisableView.as_view()),
 ]

--- a/src/sentry/web/frontend/debug/debug_notify_disable.py
+++ b/src/sentry/web/frontend/debug/debug_notify_disable.py
@@ -1,7 +1,6 @@
 from django.http import HttpRequest, HttpResponse
 from django.views.generic import View
 
-from sentry import integrations
 from sentry.integrations.notify_disable import get_provider_type, get_url
 from sentry.models import Integration, Organization
 
@@ -10,8 +9,9 @@ from .mail import MailPreview
 
 class DebugNotifyDisableView(View):
     def get(self, request: HttpRequest) -> HttpResponse:
-        self.integration = Integration.objects.create(
+        self.integration, _ = Integration.objects.get_or_create(
             provider="slack",
+            external_id="TXXXXXXX",
             name="Awesome Team",
             metadata={
                 "access_token": "xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
@@ -21,19 +21,18 @@ class DebugNotifyDisableView(View):
 
         self.organization = Organization(id=1, slug="organization", name="My Company")
 
-        provider = integrations.get(self.integration.provider)
-        integration_name = provider.name
+        integration_name = self.integration.provider
         integration_link = get_url(
             self.organization,
             get_provider_type(f"sentry-integration-error:{self.integration.external_id}"),
-            provider.name,
+            self.integration.provider,
         )
 
         return MailPreview(
             html_template="sentry/integrations/notify-disable.html",
             text_template="sentry/integrations/notify-disable.txt",
             context={
-                "integration_name": integration_name,
+                "integration_name": integration_name.title(),
                 "integration_link": integration_link,
             },
         ).render(request)

--- a/src/sentry/web/frontend/debug/debug_notify_disable.py
+++ b/src/sentry/web/frontend/debug/debug_notify_disable.py
@@ -13,7 +13,6 @@ class DebugNotifyDisableView(View):
         self.integration = Integration.objects.create(
             provider="slack",
             name="Awesome Team",
-            external_id="TXXXXXXX",
             metadata={
                 "access_token": "xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
                 "installation_type": "born_as_bot",

--- a/src/sentry/web/frontend/debug/debug_notify_disable.py
+++ b/src/sentry/web/frontend/debug/debug_notify_disable.py
@@ -2,14 +2,16 @@ from django.http import HttpRequest, HttpResponse
 from django.views.generic import View
 
 from sentry import integrations
+from sentry.constants import SentryAppStatus
 from sentry.integrations.notify_disable import get_provider_type, get_url
-from sentry.models import Integration, Organization
+from sentry.models import Integration, Organization, SentryApp
 
 from .mail import MailPreview
 
 
 class DebugNotifyDisableView(View):
     def get(self, request: HttpRequest) -> HttpResponse:
+
         self.integration = Integration.objects.create(
             provider="slack",
             name="Awesome Team",
@@ -19,20 +21,25 @@ class DebugNotifyDisableView(View):
                 "installation_type": "born_as_bot",
             },
         )
+        provider = integrations.get(self.integration.provider)
 
         self.organization = Organization(id=1, slug="organization", name="My Company")
+        self.sentry_app = SentryApp(
+            name="Test App",
+            events=["issue.resolved", "issue.ignored", "issue.assigned"],
+            status=SentryAppStatus.INTERNAL,
+        )
 
-        provider = integrations.get(self.integration.provider)
-        integration_name = provider.name
+        integration_name = self.sentry_app.name
         integration_link = get_url(
             self.organization,
-            get_provider_type(f"sentry-integration-error:{self.integration.external_id}"),
-            provider.name,
+            get_provider_type(f"sentry-app-error:{self.sentry_app.uuid}"),
+            self.sentry_app.slug,
         )
 
         return MailPreview(
-            html_template="sentry/integrations/notify-disable.html",
-            text_template="sentry/integrations/notify-disable.txt",
+            html_template="sentry/integrations/sentry-app-notify-disable.html",
+            text_template="sentry/integrations/sentry-app-notify-disable.txt",
             context={
                 "integration_name": integration_name,
                 "integration_link": integration_link,

--- a/src/sentry/web/frontend/debug/debug_notify_disable.py
+++ b/src/sentry/web/frontend/debug/debug_notify_disable.py
@@ -13,7 +13,7 @@ class DebugNotifyDisableView(View):
         self.integration = Integration.objects.create(
             provider="slack",
             name="Awesome Team",
-            external_id="TXXXXXXXZ",
+            external_id="TXXXXXXX",
             metadata={
                 "access_token": "xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
                 "installation_type": "born_as_bot",

--- a/src/sentry/web/frontend/debug/debug_notify_disable.py
+++ b/src/sentry/web/frontend/debug/debug_notify_disable.py
@@ -1,33 +1,21 @@
 from django.http import HttpRequest, HttpResponse
 from django.views.generic import View
 
-from sentry import integrations
 from sentry.constants import SentryAppStatus
 from sentry.integrations.notify_disable import get_provider_type, get_url
-from sentry.models import Integration, Organization, SentryApp
+from sentry.models import Organization, SentryApp
 
 from .mail import MailPreview
 
 
 class DebugNotifyDisableView(View):
     def get(self, request: HttpRequest) -> HttpResponse:
-
-        self.integration = Integration.objects.create(
-            provider="slack",
-            name="Awesome Team",
-            external_id="TXXXXXXXZ",
-            metadata={
-                "access_token": "xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
-                "installation_type": "born_as_bot",
-            },
-        )
-        provider = integrations.get(self.integration.provider)
-
         self.organization = Organization(id=1, slug="organization", name="My Company")
         self.sentry_app = SentryApp(
             name="Test App",
             events=["issue.resolved", "issue.ignored", "issue.assigned"],
             status=SentryAppStatus.INTERNAL,
+            webhook_url="https://broken-example.com/webhook",
         )
 
         integration_name = self.sentry_app.name
@@ -36,6 +24,7 @@ class DebugNotifyDisableView(View):
             get_provider_type(f"sentry-app-error:{self.sentry_app.uuid}"),
             self.sentry_app.slug,
         )
+        redis_key = f"sentry-app-error:{self.sentry_app.uuid}"
 
         return MailPreview(
             html_template="sentry/integrations/sentry-app-notify-disable.html",
@@ -43,5 +32,8 @@ class DebugNotifyDisableView(View):
             context={
                 "integration_name": integration_name,
                 "integration_link": integration_link,
+                "webhook_url": self.sentry_app.webhook_url
+                if "sentry-app" in redis_key and self.sentry_app.webhook_url
+                else "",
             },
         ).render(request)

--- a/src/sentry/web/frontend/debug/debug_sentry_app_notify_disable.py
+++ b/src/sentry/web/frontend/debug/debug_sentry_app_notify_disable.py
@@ -1,0 +1,40 @@
+from django.http import HttpRequest, HttpResponse
+from django.views.generic import View
+
+from sentry.constants import SentryAppStatus
+from sentry.integrations.notify_disable import get_provider_type, get_url
+from sentry.models import Organization, SentryApp
+
+from .mail import MailPreview
+
+
+class DebugSentryAppNotifyDisableView(View):
+    def get(self, request: HttpRequest) -> HttpResponse:
+
+        self.organization = Organization(id=1, slug="organization", name="My Company")
+        self.sentry_app = SentryApp(
+            name="Test App",
+            events=["issue.resolved", "issue.ignored", "issue.assigned"],
+            status=SentryAppStatus.INTERNAL,
+            webhook_url="https://broken-example.com/webhook",
+        )
+
+        integration_name = self.sentry_app.name
+        integration_link = get_url(
+            self.organization,
+            get_provider_type(f"sentry-app-error:{self.sentry_app.uuid}"),
+            self.sentry_app.slug,
+        )
+        redis_key = f"sentry-app-error:{self.sentry_app.uuid}"
+
+        return MailPreview(
+            html_template="sentry/integrations/sentry-app-notify-disable.html",
+            text_template="sentry/integrations/sentry-app-notify-disable.txt",
+            context={
+                "integration_name": integration_name,
+                "integration_link": integration_link,
+                "webhook_url": self.sentry_app.webhook_url
+                if "sentry-app" in redis_key and self.sentry_app.webhook_url
+                else "",
+            },
+        ).render(request)

--- a/src/sentry/web/frontend/debug/debug_sentry_app_notify_disable.py
+++ b/src/sentry/web/frontend/debug/debug_sentry_app_notify_disable.py
@@ -39,5 +39,6 @@ class DebugSentryAppNotifyDisableView(View):
                 "webhook_url": self.sentry_app.webhook_url
                 if "sentry-app" in redis_key and self.sentry_app.webhook_url
                 else "",
+                "dashboard_link": f"{integration_link}dashboard/",
             },
         ).render(request)

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -647,6 +647,7 @@ class TestWebhookRequests(TestCase):
             name="Test App",
             organization=self.organization,
             events=["issue.resolved", "issue.ignored", "issue.assigned"],
+            webhook_url="https://example.com",
         )
         self.sentry_app.update(status=SentryAppStatus.PUBLISHED)
 
@@ -904,6 +905,7 @@ class TestWebhookRequests(TestCase):
                 self.sentry_app.name,
                 get_redis_key(self.sentry_app, self.organization.id),
                 self.sentry_app.slug,
+                self.sentry_app.webhook_url,
             )
         assert len(mail.outbox) == 1
         msg = mail.outbox[0]
@@ -917,3 +919,10 @@ class TestWebhookRequests(TestCase):
             )
             in msg.body
         )
+        assert (
+            self.organization.absolute_url(
+                f"/settings/{self.organization.slug}/developer-settings/{self.sentry_app.slug}/dashboard"
+            )
+            in msg.body
+        )
+        assert (self.sentry_app.webhook_url) in msg.body


### PR DESCRIPTION
Implementing email notification when sentry app is detected to be broken and disabled.
Part of [Notify on Disabled Integration project](https://www.notion.so/sentry/Tech-Spec-Notify-on-Disabled-Integration-Spec-e7ea0f86ccd6419cb3e564067cf4a2ef?pvs=4)
Disabling and notifying implemented under feature flag "disable-sentryapps-on-broken".
<img width="775" alt="Screenshot 2023-08-07 at 4 48 19 PM" src="https://github.com/getsentry/sentry/assets/56209417/e5edd998-7130-4c53-913b-ec9bb1e342bb">
