### PR TITLE
fix(crons): Reset cursor on search

### DIFF
--- a/static/app/views/monitors/overview.tsx
+++ b/static/app/views/monitors/overview.tsx
@@ -72,7 +72,7 @@ export default function Monitors() {
   const monitorListPageLinks = monitorListHeaders?.('Link');
 
   const handleSearch = (query: string) => {
-    const currentQuery = router.location.query ?? {};
+    const currentQuery = {...(router.location.query ?? {}), cursor: undefined};
     router.push({
       pathname: location.pathname,
       query: normalizeDateTimeParams({...currentQuery, query}),


### PR DESCRIPTION
When using the search bar on the crons listing page, reset the cursor to show first page of results