### PR TITLE
fix(custom-metrics) Fix bug in custom metrics estimation endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
@@ -149,7 +149,7 @@ def estimate_volume(
 
 
 def _get_value(elm: MetricVolumeRow) -> float:
-    return cast(List[CountResult], elm[1])[0]["count"]
+    return cast(List[CountResult], elm[1])[0].get("count", 0.0)
 
 
 def _set_value(elm: MetricVolumeRow, value: float) -> None:


### PR DESCRIPTION
This PR fixes a bug in the estimation metrics endpoint.
When the count of a metric was None the endpoint crashed.