### PR TITLE
 feat(perf-issues): Improve http overhead detector logic

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -306,6 +306,7 @@ class PerformanceHTTPOverheadGroupType(PerformanceGroupTypeDefaults, GroupType):
     type_id = 1016
     slug = "performance_http_overhead"
     description = "HTTP/1.1 Overhead"
+    noise_config = NoiseConfig(ignore_limit=100)
     category = GroupCategory.PERFORMANCE.value
 
 

--- a/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
@@ -25,12 +25,10 @@ from ..types import Span
 class ProblemIndicator:
     """
     Keep span data that will be used to store the problem together.
-    Has a monotonic queue depth to know if spans hit the parallel limit without walking all spans again.
     """
 
     span: Span
     delay: float
-    queue_depth: int = 0
 
 
 class HTTPOverheadDetector(PerformanceDetector):
@@ -85,28 +83,25 @@ class HTTPOverheadDetector(PerformanceDetector):
             # shouldn't be possible, but these values are browser reported
             return
 
-        indicators = self.location_to_indicators[location]
-        recent_beginning_of_chain = next(
-            filter(lambda i: i.queue_depth == 0, reversed(indicators)), None
-        )
-        recent_end_of_chain = indicators[-1] if indicators else None
+        indicator_chains = self.location_to_indicators[location]
+        if len(indicator_chains) == 0:
+            indicator_chains += [[]]
+        recent_chain = indicator_chains[-1]
+        recent_beginning_of_chain = recent_chain[0] if len(recent_chain) > 0 else None
 
         if not recent_beginning_of_chain:
-            self.location_to_indicators[location] += [ProblemIndicator(span, request_delay, 0)]
+            recent_chain += [ProblemIndicator(span, request_delay)]
             return
 
         previous_delay = recent_beginning_of_chain.delay
         previous_span = recent_beginning_of_chain.span
-        previous_monotonic = recent_end_of_chain.queue_depth if recent_end_of_chain else 0
 
         is_overlapping = does_overlap_previous_span(previous_span, span)
-        new_monotonic = (
-            previous_monotonic + 1 if request_delay >= previous_delay and is_overlapping else 0
-        )
+        if request_delay < previous_delay or not is_overlapping:
+            recent_chain = []
+            indicator_chains += [recent_chain]
 
-        self.location_to_indicators[location] += [
-            ProblemIndicator(span, request_delay, new_monotonic)
-        ]
+        recent_chain += [ProblemIndicator(span, request_delay)]
 
     def _is_span_eligible(self, span: Span) -> bool:
         span_op = span.get("op", None)
@@ -122,21 +117,24 @@ class HTTPOverheadDetector(PerformanceDetector):
     def _store_performance_problem(self, location: str) -> None:
         delay_threshold = self.settings.get("http_request_delay_threshold")
 
-        # This isn't a threshold, it reduces noise in offending spans.
-        indicators = [
-            indicator
-            for indicator in self.location_to_indicators[location]
-            if indicator.delay > 100
-        ]
+        max_delay = -1
+        chain = None
+        for indicator_chain in self.location_to_indicators[location]:
+            # Browsers queue past 4-6 connections.
+            if len(indicator_chain) < 6:
+                continue
 
-        location_spans = [indicator.span for indicator in indicators]
-        meets_min_queued = any(
-            indicator.queue_depth >= 5 for indicator in indicators
-        )  # Browsers queue past 4-6 connections.
-        exceeds_delay_threshold = any(indicator.delay > delay_threshold for indicator in indicators)
+            end_of_chain = indicator_chain[-1]
+            exceeds_delay_threshold = end_of_chain.delay > delay_threshold
+            if end_of_chain.delay > max_delay and exceeds_delay_threshold:
+                max_delay = end_of_chain.delay
+                chain = indicator_chain
 
-        if not exceeds_delay_threshold or not meets_min_queued or not location_spans:
+        if not chain:
             return
+
+        # Remove any offending spans below 100ms for display purposes
+        location_spans = [indicator.span for indicator in chain if indicator.delay > 100]
 
         fingerprint = f"1-{PerformanceHTTPOverheadGroupType.type_id}-{location}"
         example_span = location_spans[0]

--- a/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
+++ b/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
@@ -20,19 +20,23 @@ from sentry.utils.performance_issues.performance_detection import (
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
 
 
-def overhead_span(duration: float, request_start: float, url: str) -> dict[str, Any]:
+def overhead_span(
+    duration: float, request_start: float, url: str, span_start=1.0, span_id="b" * 16
+) -> dict[str, Any]:
+    span = create_span(
+        "http.client",
+        desc=url,
+        duration=duration,
+        data={
+            "url": url,
+            "network.protocol.version": "1.1",
+            "http.request.request_start": request_start / 1000.0,
+        },
+    )
+    span["span_id"] = span_id
     return modify_span_start(
-        create_span(
-            "http.client",
-            desc=url,
-            duration=duration,
-            data={
-                "url": url,
-                "network.protocol.version": "1.1",
-                "http.request.request_start": request_start / 1000.0,
-            },
-        ),
-        1,
+        span,
+        span_start,
     )
 
 
@@ -141,9 +145,54 @@ class HTTPOverheadDetectorTest(TestCase):
         ]
 
         assert len(self.find_problems(event)) == 1
+
         trigger_span["data"]["network.protocol.version"] = "h3"
 
         assert len(self.find_problems(event)) == 0
+
+    def test_non_overlapping_not_included_evidence(self):
+        url = "https://example.com/api/endpoint/123"
+        event = _valid_http_overhead_event(url)
+        event["spans"] = [
+            overhead_span(1000, 1, url),
+            overhead_span(1000, 2, url),
+            overhead_span(1000, 3, url),
+            overhead_span(1000, 4, url),
+            overhead_span(1000, 5, url),
+            overhead_span(1000, 502, url, 1, "c" * 16),
+            overhead_span(1000, 2001, url, 2000),
+            overhead_span(1000, 2002, url, 2000),
+            overhead_span(1000, 2003, url, 2000),
+            overhead_span(1000, 2104, url, 2000),
+            overhead_span(1000, 2105, url, 2000),
+            overhead_span(1000, 2502, url, 2000, "d" * 16),  # Separated group
+        ]
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1016-example.com",
+                op="http",
+                desc="/api/endpoint/123",
+                type=PerformanceHTTPOverheadGroupType,
+                parent_span_ids=None,
+                cause_span_ids=[],
+                offender_span_ids=[
+                    "bbbbbbbbbbbbbbbb",
+                    "bbbbbbbbbbbbbbbb",
+                    "dddddddddddddddd",
+                ],
+                evidence_data={
+                    "op": "http",
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": [
+                        "bbbbbbbbbbbbbbbb",
+                        "bbbbbbbbbbbbbbbb",
+                        "dddddddddddddddd",
+                    ],
+                },
+                evidence_display=[],
+            )
+        ]
 
     def test_detect_other_location(self):
         url = "https://example.com/api/endpoint/123"


### PR DESCRIPTION
### Summary
This changes the http overhead detector logic to only include offending spans from the longest chain of http overhead (instead of all "slow" spans), 

Before            |  After
:-------------------------:|:-------------------------:
![Screenshot 2023-08-08 at 10 09 00 AM](https://github.com/getsentry/sentry/assets/6111995/c6a17c9c-15c4-4910-b0d7-9bab7c3e4675) |  ![Screenshot 2023-08-08 at 10 12 58 AM](https://github.com/getsentry/sentry/assets/6111995/27584a63-08e0-47c6-9042-6edf181cc7cf)



#### Other:
- Needed to have its noise limit bumped since it's a browser detector.

