### PR TITLE
feat(perf-issues): Improve span evidence UI for detector

### DIFF
--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -87,6 +87,12 @@ export enum SpanSubTimingMark {
   HTTP_RESPONSE_START = 'http.request.response_start',
 }
 
+export enum SpanSubTimingName {
+  WAIT_TIME = 'Wait Time',
+  REQUEST_TIME = 'Request Time',
+  RESPONSE_TIME = 'Response Time',
+}
+
 const HTTP_DATA_KEYS = [
   'http.request.redirect_start',
   'http.request.fetch_start',
@@ -345,19 +351,19 @@ const SPAN_SUB_TIMINGS: Record<string, SubTimingDefinition[]> = {
     {
       startMark: SpanSubTimingMark.SPAN_START,
       endMark: SpanSubTimingMark.HTTP_REQUEST_START,
-      name: 'Wait Time',
+      name: SpanSubTimingName.WAIT_TIME,
       colorLighten: 0.5,
     },
     {
       startMark: SpanSubTimingMark.HTTP_REQUEST_START,
       endMark: SpanSubTimingMark.HTTP_RESPONSE_START,
-      name: 'Request Time',
+      name: SpanSubTimingName.REQUEST_TIME,
       colorLighten: 0.25,
     },
     {
       startMark: SpanSubTimingMark.HTTP_RESPONSE_START,
       endMark: SpanSubTimingMark.SPAN_END,
-      name: 'Response Time',
+      name: SpanSubTimingName.RESPONSE_TIME,
       colorLighten: 0,
     },
   ],

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -71,6 +71,7 @@ export enum IssueType {
   PERFORMANCE_RENDER_BLOCKING_ASSET = 'performance_render_blocking_asset_span',
   PERFORMANCE_UNCOMPRESSED_ASSET = 'performance_uncompressed_assets',
   PERFORMANCE_LARGE_HTTP_PAYLOAD = 'performance_large_http_payload',
+  PERFORMANCE_HTTP_OVERHEAD = 'performance_http_overhead',
 
   // Profile
   PROFILE_FILE_IO_MAIN_THREAD = 'profile_file_io_main_thread',
@@ -93,6 +94,7 @@ export const getIssueTypeFromOccurenceType = (
     1012: IssueType.PERFORMANCE_UNCOMPRESSED_ASSET,
     1013: IssueType.PERFORMANCE_DB_MAIN_THREAD,
     1015: IssueType.PERFORMANCE_LARGE_HTTP_PAYLOAD,
+    1016: IssueType.PERFORMANCE_HTTP_OVERHEAD,
   };
   if (!typeId) {
     return null;


### PR DESCRIPTION
### Summary
Previously it only had the transaction name, this adds a max queue time so the user doesn't have to dig around in all the affected spans.

![Screenshot 2023-08-08 at 10 15 13 AM](https://github.com/getsentry/sentry/assets/6111995/f947b357-d9aa-4b08-b848-24e65b34fda2)


