### PR TITLE
feat(celery): start recording timing of sentry app tasks

### DIFF
--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -1,4 +1,5 @@
 # XXX(mdtro): backwards compatible imports for celery 4.4.7, remove after upgrade to 5.2.7
+from datetime import datetime
 from itertools import chain
 
 import celery
@@ -82,6 +83,10 @@ def good_use_of_pickle_or_bad_use_of_pickle(task, args, kwargs):
 
 class SentryTask(Task):
     Request = "sentry.celery:SentryRequest"
+
+    def delay(self, *args, **kwargs):
+        kwargs["__start_time"] = datetime.now().timestamp()
+        return super().delay(*args, **kwargs)
 
     def apply_async(self, *args, **kwargs):
         # If intended detect bad uses of pickle and make the tasks fail in tests.  This should

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -47,6 +47,7 @@ TASK_OPTIONS = {
     "queue": "app_platform",
     "default_retry_delay": (60 * 5),  # Five minutes.
     "max_retries": 3,
+    "record_timing": True,
 }
 CONTROL_TASK_OPTIONS = {
     "queue": "app_platform.control",


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/54328