### PR TITLE
feat(escalating-issues): Generate forecasts for ongoing issues

### DIFF
--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -2,11 +2,13 @@ import logging
 from datetime import datetime, timedelta
 from typing import Dict, List, TypedDict
 
+from django.db.models import Q
 from sentry_sdk.crons.decorator import monitor
 
+from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.issues.forecasts import generate_and_save_forecasts
-from sentry.models import Group, GroupStatus, Project
+from sentry.models import Group, GroupStatus, Organization, Project
 from sentry.tasks.base import instrumented_task, retry
 from sentry.types.group import GroupSubStatus
 from sentry.utils.iterators import chunked
@@ -36,16 +38,25 @@ def run_escalating_forecast() -> None:
     Run the escalating forecast algorithm on archived until escalating issues.
     """
     logger.info("Starting task for sentry.tasks.weekly_escalating_forecast.run_escalating_forecast")
+    for organization in RangeQuerySetWrapper(Organization.objects.all()):
+        for project_ids in chunked(
+            RangeQuerySetWrapper(
+                Project.objects.filter(
+                    status=ObjectStatus.ACTIVE, organization=organization
+                ).values_list("id", flat=True),
+                result_value_getter=lambda item: item,
+                step=ITERATOR_CHUNK,
+            ),
+            ITERATOR_CHUNK,
+        ):
+            if features.has("organizations:escalating-issues-v2", organization):
+                return generate_forecasts_for_projects.delay(
+                    project_ids=project_ids, forecast_for_ongoing=True
+                )
 
-    for project_ids in chunked(
-        RangeQuerySetWrapper(
-            Project.objects.filter(status=ObjectStatus.ACTIVE).values_list("id", flat=True),
-            result_value_getter=lambda item: item,
-            step=ITERATOR_CHUNK,
-        ),
-        ITERATOR_CHUNK,
-    ):
-        generate_forecasts_for_projects.delay(project_ids=project_ids)
+            return generate_forecasts_for_projects.delay(
+                project_ids=project_ids, forecast_for_ongoing=False
+            )
 
 
 @instrumented_task(
@@ -55,15 +66,24 @@ def run_escalating_forecast() -> None:
     default_retry_delay=60,
 )
 @retry
-def generate_forecasts_for_projects(project_ids: List[int]) -> None:
+def generate_forecasts_for_projects(project_ids: List[int], forecast_for_ongoing=False) -> None:
+    query_for_archived_until_escalating = Q(
+        status=GroupStatus.IGNORED, substatus=GroupSubStatus.UNTIL_ESCALATING
+    )
+    query_for_ongoing = Q(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING)
+
+    combined_query = (
+        (query_for_archived_until_escalating | query_for_ongoing)
+        if forecast_for_ongoing
+        else query_for_archived_until_escalating
+    )
+
     for until_escalating_groups in chunked(
         RangeQuerySetWrapper(
             Group.objects.filter(
-                status=GroupStatus.IGNORED,
-                substatus=GroupSubStatus.UNTIL_ESCALATING,
                 project_id__in=project_ids,
                 last_seen__gte=datetime.now() - timedelta(days=7),
-            ),
+            ).filter(combined_query),
             step=ITERATOR_CHUNK,
         ),
         ITERATOR_CHUNK,

--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -53,10 +53,10 @@ def run_escalating_forecast() -> None:
                 return generate_forecasts_for_projects.delay(
                     project_ids=project_ids, forecast_for_ongoing=True
                 )
-
-            return generate_forecasts_for_projects.delay(
-                project_ids=project_ids, forecast_for_ongoing=False
-            )
+            else:
+                return generate_forecasts_for_projects.delay(
+                    project_ids=project_ids, forecast_for_ongoing=False
+                )
 
 
 @instrumented_task(


### PR DESCRIPTION
## Objective:
All Ongoing Issues should be able to escalate. So in our cron task that generates the escalating forecasts, we will also query for Ongoing Issues. This is wrapped in the v2 feature flag.