### PR TITLE
fix(perf-issues): Use slowest span for http overhead description

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
@@ -137,7 +137,7 @@ class HTTPOverheadDetector(PerformanceDetector):
         location_spans = [indicator.span for indicator in chain if indicator.delay > 100]
 
         fingerprint = f"1-{PerformanceHTTPOverheadGroupType.type_id}-{location}"
-        example_span = location_spans[0]
+        example_span = location_spans[-1]
         desc: str = example_span.get("description", None)
 
         location_span_ids = [span.get("span_id", None) for span in location_spans]

--- a/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
+++ b/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
@@ -151,7 +151,6 @@ class HTTPOverheadDetectorTest(TestCase):
             )
         ]
 
-
     def test_does_not_detect_under_delay_threshold(self):
         url = "/api/endpoint/123"
         event = _valid_http_overhead_event(url)

--- a/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
+++ b/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
@@ -116,6 +116,42 @@ class HTTPOverheadDetectorTest(TestCase):
         event["spans"] = event["spans"][:5]
         assert self.find_problems(event) == []
 
+    def test_slowest_span_description_used(self):
+        url = "/api/endpoint/123"
+        event = _valid_http_overhead_event("/api/endpoint/123")
+        event["spans"] = [
+            overhead_span(1000, 1, url),
+            overhead_span(1000, 2, url),
+            overhead_span(1000, 3, url),
+            overhead_span(1000, 4, url),
+            overhead_span(1000, 5, url),
+            overhead_span(1000, 502, "/api/endpoint/slowest"),
+        ]
+
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1016-/",
+                op="http",
+                desc="/api/endpoint/slowest",
+                type=PerformanceHTTPOverheadGroupType,
+                parent_span_ids=None,
+                cause_span_ids=[],
+                offender_span_ids=[
+                    "bbbbbbbbbbbbbbbb",
+                ],
+                evidence_data={
+                    "op": "http",
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": [
+                        "bbbbbbbbbbbbbbbb",
+                    ],
+                },
+                evidence_display=[],
+            )
+        ]
+
+
     def test_does_not_detect_under_delay_threshold(self):
         url = "/api/endpoint/123"
         event = _valid_http_overhead_event(url)


### PR DESCRIPTION
### Summary
This uses the last (slowest) span instead of the first one for the span description, assuming it has the largest impact it should be what the user looks at first.

