### PR TITLE
fix(replay): Catch errors when breadcrumbs are messed up and return defaults instead

### DIFF
--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -285,7 +285,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame) => Details> = {
   }),
 };
 
-const MAPPER_DEFAULT = frame => ({
+const MAPPER_DEFAULT = (frame): Details => ({
   color: 'gray300',
   description: frame.message ?? '',
   tabKey: TabKey.CONSOLE,
@@ -296,7 +296,11 @@ const MAPPER_DEFAULT = frame => ({
 export default function getFrameDetails(frame: ReplayFrame): Details {
   const key = getFrameOpOrCategory(frame);
   const fn = MAPPER_FOR_FRAME[key] ?? MAPPER_DEFAULT;
-  return fn(frame);
+  try {
+    return fn(frame);
+  } catch (error) {
+    return MAPPER_DEFAULT(frame);
+  }
 }
 
 function defaultTitle(frame: ReplayFrame) {
@@ -307,7 +311,7 @@ function defaultTitle(frame: ReplayFrame) {
   if ('message' in frame) {
     return frame.message as string; // TODO(replay): Included for backwards compat
   }
-  return frame.description;
+  return frame.description ?? '';
 }
 
 function stringifyNodeAttributes(node: SlowClickFrame['data']['node']) {


### PR DESCRIPTION
I thought about also logging to sentry, but I didn't since i believe that users/sdk's can mess up breadcrumbs on their own, so not a tonne we can do about it. 

The specific instance of this bug looks like it's caused by the customer emitting a custom breadcrumb which has the same name 'navigation' as what the sdk emits. 
Before they were seeing an error message instead of the timeline, and when they scroll through the breadcrumb list it would also error out when that crumb rendered.

Now they
| Before (timeline) | After (breadcrumbs) |
| --- | --- |
| ![SCR-20230808-jxvp](https://github.com/getsentry/sentry/assets/187460/95cfa0d4-42d8-46fb-ad89-d3f1803d7e95) | ![SCR-20230808-kbuc](https://github.com/getsentry/sentry/assets/187460/62427e19-f09d-4f52-986f-a6fb2b3c181e) |


Fixes https://github.com/getsentry/sentry/issues/54378
