### PR TITLE
feat(performance): add suspect functions to list in performance change explorer

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -92,6 +92,12 @@ export type PerformanceEventParameters = {
     project_platforms: string;
   };
   'performance_views.overview.search': {};
+  'performance_views.performance_change_explorer.function_link_clicked': {
+    function: string;
+    package: string;
+    profile_id: string;
+    transaction: string;
+  };
   'performance_views.performance_change_explorer.open': {
     transaction: string;
   };
@@ -341,6 +347,8 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
   'performance_views.landing.table.unparameterized':
     'Performance Views: Landing Page - Table Unparameterized',
   'performance_views.landing.table.seen': 'Performance Views: Landing Page - Table Seen',
+  'performance_views.performance_change_explorer.function_link_clicked':
+    'Performance Views: Performance Change Explorer - Link to Function',
   'performance_views.performance_change_explorer.open':
     'Performance Views: Performance Change Explorer - Opened',
   'performance_views.performance_change_explorer.span_link_clicked':

--- a/static/app/views/performance/trends/changeExplorer.spec.tsx
+++ b/static/app/views/performance/trends/changeExplorer.spec.tsx
@@ -6,13 +6,17 @@ import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {SuspectSpans} from 'sentry/utils/performance/suspectSpans/types';
+import {EventsResultsDataRow} from 'sentry/utils/profiling/hooks/types';
 import {PerformanceChangeExplorer} from 'sentry/views/performance/trends/changeExplorer';
 import {
   COLUMNS,
   MetricsTable,
   renderBodyCell,
 } from 'sentry/views/performance/trends/changeExplorerUtils/metricsTable';
-import {SpansList} from 'sentry/views/performance/trends/changeExplorerUtils/spansList';
+import {
+  FunctionsField,
+  SpansList,
+} from 'sentry/views/performance/trends/changeExplorerUtils/spansList';
 import {
   NormalizedTrendsTransaction,
   TrendChangeType,
@@ -195,6 +199,97 @@ const spanResults: SuspectSpans = [
   },
 ];
 
+const functionResults: EventsResultsDataRow<FunctionsField>[] = [
+  {
+    'count()': 234,
+    'examples()': ['serw8r9s', 'aeo4i2u38'],
+    function: 'f1',
+    'p75()': 4239847,
+    package: 'p1',
+    'sum()': 2304823908,
+  },
+  {
+    'count()': 234,
+    'examples()': ['serw8r9s', 'aeo4i2u38'],
+    function: 'f2',
+    'p75()': 4239847,
+    package: 'p2',
+    'sum()': 2304823908,
+  },
+  {
+    'count()': 234,
+    'examples()': ['serw8r9s', 'aeo4i2u38'],
+    function: 'f3',
+    'p75()': 4239847,
+    package: 'p3',
+    'sum()': 2304823908,
+  },
+  {
+    'count()': 234,
+    'examples()': ['serw8r9s', 'aeo4i2u38'],
+    function: 'f4',
+    'p75()': 4239847,
+    package: 'p4',
+    'sum()': 2304823908,
+  },
+  {
+    'count()': 234,
+    'examples()': ['serw8r9s', 'aeo4i2u38'],
+    function: 'f5',
+    'p75()': 4239847,
+    package: 'p5',
+    'sum()': 2304823908,
+  },
+  {
+    'count()': 234,
+    'examples()': ['serw8r9s', 'aeo4i2u38'],
+    function: 'f5',
+    'p75()': 4239847,
+    package: 'p5',
+    'sum()': 2304823908,
+  },
+  {
+    'count()': 234,
+    'examples()': ['serw8r9s', 'aeo4i2u38'],
+    function: 'f7',
+    'p75()': 4239847,
+    package: 'p7',
+    'sum()': 2304823908,
+  },
+  {
+    'count()': 234,
+    'examples()': ['serw8r9s', 'aeo4i2u38'],
+    function: 'f8',
+    'p75()': 4239847,
+    package: 'p8',
+    'sum()': 2304823908,
+  },
+  {
+    'count()': 234,
+    'examples()': ['serw8r9s', 'aeo4i2u38'],
+    function: 'f9',
+    'p75()': 4239847,
+    package: 'p9',
+    'sum()': 2304823908,
+  },
+  {
+    'count()': 234,
+    'examples()': ['serw8r9s', 'aeo4i2u38'],
+    function: 'f10',
+    'p75()': 4239847,
+    package: 'p10',
+    'sum()': 2304823908,
+  },
+  {
+    'count()': 234,
+    'examples()': ['serw8r9s', 'aeo4i2u38'],
+    function: 'f11',
+    'p75()': 4239847,
+    package: 'p11',
+    'sum()': 2304823908,
+  },
+];
+
 describe('Performance > Trends > Performance Change Explorer', function () {
   let eventsMockBefore;
   let spansMock;
@@ -208,6 +303,7 @@ describe('Performance > Trends > Performance Change Explorer', function () {
             'p50()': 47.34580982348902,
             'tps()': 3.7226926286168966,
             'count()': 345,
+            'examples()': ['dkwj4w8sdjk', 'asdi389a8'],
           },
         ],
         meta: {
@@ -216,12 +312,14 @@ describe('Performance > Trends > Performance Change Explorer', function () {
             '950()': 'duration',
             'tps()': 'number',
             'count()': 'number',
+            'examples()': 'Array',
           },
           units: {
             'p95()': 'millisecond',
             'p50()': 'millisecond',
             'tps()': null,
             'count()': null,
+            'examples()': null,
           },
           isMetricsData: true,
           tips: {},
@@ -282,7 +380,7 @@ describe('Performance > Trends > Performance Change Explorer', function () {
       expect(screen.getAllByTestId('pce-metrics-chart-row-before')).toHaveLength(4);
       expect(screen.getAllByTestId('pce-metrics-chart-row-after')).toHaveLength(4);
       expect(screen.getAllByTestId('pce-metrics-chart-row-change')).toHaveLength(4);
-      expect(screen.getByTestId('spans-no-results')).toBeInTheDocument();
+      expect(screen.getByTestId('list-item')).toBeInTheDocument();
     });
   });
 
@@ -467,6 +565,10 @@ describe('Performance > Trends > Performance Change Explorer', function () {
 
   it('renders spans list with no results', async () => {
     const data = initializeData();
+    const emptyEventsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {},
+    });
 
     render(
       <SpansList
@@ -480,6 +582,8 @@ describe('Performance > Trends > Performance Change Explorer', function () {
     );
 
     await waitForMockCall(spansMock);
+    await waitForMockCall(emptyEventsMock);
+
     await waitFor(() => {
       expect(screen.getByTestId('empty-state')).toBeInTheDocument();
       expect(screen.getByTestId('spans-no-results')).toBeInTheDocument();
@@ -489,6 +593,10 @@ describe('Performance > Trends > Performance Change Explorer', function () {
   it('renders spans list with error message', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-spans-performance/',
+      statusCode: 504,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
       statusCode: 504,
     });
     const data = initializeData();
@@ -513,6 +621,13 @@ describe('Performance > Trends > Performance Change Explorer', function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-spans-performance/',
       body: spanResults,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: functionResults,
+        meta: {},
+      },
     });
     const data = initializeData();
 

--- a/static/app/views/performance/trends/changeExplorer.spec.tsx
+++ b/static/app/views/performance/trends/changeExplorer.spec.tsx
@@ -8,16 +8,16 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import {SuspectSpans} from 'sentry/utils/performance/suspectSpans/types';
 import {EventsResultsDataRow} from 'sentry/utils/profiling/hooks/types';
 import {PerformanceChangeExplorer} from 'sentry/views/performance/trends/changeExplorer';
-import {FunctionsList} from 'sentry/views/performance/trends/changeExplorerUtils/functionsList';
+import {
+  FunctionsField,
+  FunctionsList,
+} from 'sentry/views/performance/trends/changeExplorerUtils/functionsList';
 import {
   COLUMNS,
   MetricsTable,
   renderBodyCell,
 } from 'sentry/views/performance/trends/changeExplorerUtils/metricsTable';
-import {
-  FunctionsField,
-  SpansList,
-} from 'sentry/views/performance/trends/changeExplorerUtils/spansList';
+import {SpansList} from 'sentry/views/performance/trends/changeExplorerUtils/spansList';
 import {
   NormalizedTrendsTransaction,
   TrendChangeType,

--- a/static/app/views/performance/trends/changeExplorer.spec.tsx
+++ b/static/app/views/performance/trends/changeExplorer.spec.tsx
@@ -8,6 +8,7 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import {SuspectSpans} from 'sentry/utils/performance/suspectSpans/types';
 import {EventsResultsDataRow} from 'sentry/utils/profiling/hooks/types';
 import {PerformanceChangeExplorer} from 'sentry/views/performance/trends/changeExplorer';
+import {FunctionsList} from 'sentry/views/performance/trends/changeExplorerUtils/functionsList';
 import {
   COLUMNS,
   MetricsTable,
@@ -571,22 +572,33 @@ describe('Performance > Trends > Performance Change Explorer', function () {
     });
 
     render(
-      <SpansList
-        location={data.location}
-        organization={data.organization}
-        trendView={data.eventView}
-        breakpoint={transaction.breakpoint!}
-        transaction={transaction}
-        trendChangeType={TrendChangeType.REGRESSION}
-      />
+      <div>
+        <SpansList
+          location={data.location}
+          organization={data.organization}
+          trendView={data.eventView}
+          breakpoint={transaction.breakpoint!}
+          transaction={transaction}
+          trendChangeType={TrendChangeType.REGRESSION}
+        />
+        <FunctionsList
+          location={data.location}
+          organization={data.organization}
+          trendView={data.eventView}
+          breakpoint={transaction.breakpoint!}
+          transaction={transaction}
+          trendChangeType={TrendChangeType.REGRESSION}
+        />
+      </div>
     );
 
     await waitForMockCall(spansMock);
     await waitForMockCall(emptyEventsMock);
 
     await waitFor(() => {
-      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+      expect(screen.getAllByTestId('empty-state')).toHaveLength(2);
       expect(screen.getByTestId('spans-no-results')).toBeInTheDocument();
+      expect(screen.getByTestId('functions-no-results')).toBeInTheDocument();
     });
   });
 
@@ -602,18 +614,29 @@ describe('Performance > Trends > Performance Change Explorer', function () {
     const data = initializeData();
 
     render(
-      <SpansList
-        location={data.location}
-        organization={data.organization}
-        trendView={data.eventView}
-        breakpoint={transaction.breakpoint!}
-        transaction={transaction}
-        trendChangeType={TrendChangeType.REGRESSION}
-      />
+      <div>
+        <SpansList
+          location={data.location}
+          organization={data.organization}
+          trendView={data.eventView}
+          breakpoint={transaction.breakpoint!}
+          transaction={transaction}
+          trendChangeType={TrendChangeType.REGRESSION}
+        />
+        <FunctionsList
+          location={data.location}
+          organization={data.organization}
+          trendView={data.eventView}
+          breakpoint={transaction.breakpoint!}
+          transaction={transaction}
+          trendChangeType={TrendChangeType.REGRESSION}
+        />
+      </div>
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('error-indicator')).toBeInTheDocument();
+      expect(screen.getByTestId('error-indicator-spans')).toBeInTheDocument();
+      expect(screen.getByTestId('error-indicator-functions')).toBeInTheDocument();
     });
   });
 
@@ -632,19 +655,30 @@ describe('Performance > Trends > Performance Change Explorer', function () {
     const data = initializeData();
 
     render(
-      <SpansList
-        location={data.location}
-        organization={data.organization}
-        trendView={data.eventView}
-        breakpoint={transaction.breakpoint!}
-        transaction={transaction}
-        trendChangeType={TrendChangeType.REGRESSION}
-      />
+      <div>
+        <SpansList
+          location={data.location}
+          organization={data.organization}
+          trendView={data.eventView}
+          breakpoint={transaction.breakpoint!}
+          transaction={transaction}
+          trendChangeType={TrendChangeType.REGRESSION}
+        />
+        <FunctionsList
+          location={data.location}
+          organization={data.organization}
+          trendView={data.eventView}
+          breakpoint={transaction.breakpoint!}
+          transaction={transaction}
+          trendChangeType={TrendChangeType.REGRESSION}
+        />
+      </div>
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+      expect(screen.getAllByTestId('empty-state')).toHaveLength(2);
       expect(screen.getByTestId('spans-no-changes')).toBeInTheDocument();
+      expect(screen.getByTestId('functions-no-changes')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/performance/trends/changeExplorer.tsx
+++ b/static/app/views/performance/trends/changeExplorer.tsx
@@ -17,6 +17,7 @@ import {
   DisplayModes,
   transactionSummaryRouteWithQuery,
 } from 'sentry/views/performance/transactionSummary/utils';
+import {FunctionsList} from 'sentry/views/performance/trends/changeExplorerUtils/functionsList';
 import {MetricsTable} from 'sentry/views/performance/trends/changeExplorerUtils/metricsTable';
 import {SpansList} from 'sentry/views/performance/trends/changeExplorerUtils/spansList';
 import {Chart} from 'sentry/views/performance/trends/chart';
@@ -174,6 +175,14 @@ function ExplorerBody(props: ExplorerBodyProps) {
         organization={organization}
       />
       <SpansList
+        location={location}
+        organization={organization}
+        trendView={trendView}
+        transaction={transaction}
+        breakpoint={transaction.breakpoint!}
+        trendChangeType={trendChangeType}
+      />
+      <FunctionsList
         location={location}
         organization={organization}
         trendView={trendView}

--- a/static/app/views/performance/trends/changeExplorerUtils/functionsList.tsx
+++ b/static/app/views/performance/trends/changeExplorerUtils/functionsList.tsx
@@ -223,29 +223,32 @@ export function FunctionsList(props: FunctionsListProps) {
   );
 
   return (
-    <NumberedFunctionsList
-      functions={
-        trendChangeType === TrendChangeType.REGRESSION
-          ? functionList
-          : functionList?.reverse()
-      }
-      project={projects.find(project => project.id === projectID)}
-      organization={organization}
-      transactionName={transaction.transaction}
-      limit={4}
-      isLoading={
-        transactionsLoadingBefore ||
-        transactionsLoadingAfter ||
-        beforeFunctionsQuery.isLoading ||
-        afterFunctionsQuery.isLoading
-      }
-      isError={
-        transactionsErrorBefore ||
-        transactionsErrorAfter ||
-        beforeFunctionsQuery.isError ||
-        afterFunctionsQuery.isError
-      }
-    />
+    <div>
+      <h6>{t('Relevant Suspect Functions')}</h6>
+      <NumberedFunctionsList
+        functions={
+          trendChangeType === TrendChangeType.REGRESSION
+            ? functionList
+            : functionList?.reverse()
+        }
+        project={projects.find(project => project.id === projectID)}
+        organization={organization}
+        transactionName={transaction.transaction}
+        limit={4}
+        isLoading={
+          transactionsLoadingBefore ||
+          transactionsLoadingAfter ||
+          beforeFunctionsQuery.isLoading ||
+          afterFunctionsQuery.isLoading
+        }
+        isError={
+          transactionsErrorBefore ||
+          transactionsErrorAfter ||
+          beforeFunctionsQuery.isError ||
+          afterFunctionsQuery.isError
+        }
+      />
+    </div>
   );
 }
 
@@ -431,10 +434,5 @@ export function NumberedFunctionsList(props: NumberedFunctionsListProps) {
     );
   }
 
-  return (
-    <div style={{marginTop: space(4)}}>
-      <h6>{t('Relevant Suspect Functions')}</h6>
-      <ol>{formattedFunctions}</ol>
-    </div>
-  );
+  return <ol>{formattedFunctions}</ol>;
 }

--- a/static/app/views/performance/trends/changeExplorerUtils/functionsList.tsx
+++ b/static/app/views/performance/trends/changeExplorerUtils/functionsList.tsx
@@ -1,0 +1,440 @@
+import {useMemo} from 'react';
+import {Location} from 'history';
+import moment from 'moment';
+
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {IconWarning} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {Organization, Project} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {parsePeriodToHours} from 'sentry/utils/dates';
+import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {EventsResultsDataRow, Sort} from 'sentry/utils/profiling/hooks/types';
+import {useProfileFunctions} from 'sentry/utils/profiling/hooks/useProfileFunctions';
+import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import useProjects from 'sentry/utils/useProjects';
+import {
+  getQueryParams,
+  relativeChange,
+} from 'sentry/views/performance/trends/changeExplorerUtils/metricsTable';
+import {
+  ErrorWrapper,
+  ListItemWrapper,
+  ListLink,
+} from 'sentry/views/performance/trends/changeExplorerUtils/spansList';
+import {
+  NormalizedTrendsTransaction,
+  TrendChangeType,
+  TrendView,
+} from 'sentry/views/performance/trends/types';
+import {getTrendProjectId} from 'sentry/views/performance/trends/utils';
+
+type FunctionsListProps = {
+  breakpoint: number;
+  location: Location;
+  organization: Organization;
+  transaction: NormalizedTrendsTransaction;
+  trendChangeType: TrendChangeType;
+  trendView: TrendView;
+};
+
+type AveragedSuspectFunction = EventsResultsDataRow<FunctionsField> & {
+  avgSumExclusiveTime: number;
+};
+
+type ChangedSuspectFunction = AveragedSuspectFunction & {
+  avgTimeDifference: number;
+  changeType: string;
+  percentChange: number;
+};
+
+type NumberedFunctionsListProps = {
+  isError: boolean;
+  isLoading: boolean;
+  limit: number;
+  organization: Organization;
+  transactionName: string;
+  functions?: ChangedSuspectFunction[];
+  project?: Project;
+};
+
+const functionsFields = [
+  'package',
+  'function',
+  'count()',
+  'p75()',
+  'sum()',
+  'examples()',
+] as const;
+
+export type FunctionsField = (typeof functionsFields)[number];
+
+export const FunctionChangeType = {
+  added: t('Added'),
+  removed: t('Removed'),
+  regressed: t('Regressed'),
+  improved: t('Improved'),
+};
+
+export function FunctionsList(props: FunctionsListProps) {
+  const {trendView, location, organization, breakpoint, transaction, trendChangeType} =
+    props;
+
+  const hours = trendView.statsPeriod ? parsePeriodToHours(trendView.statsPeriod) : 0;
+  const startTime = useMemo(
+    () =>
+      trendView.start ? trendView.start : moment().subtract(hours, 'h').toISOString(),
+    [hours, trendView.start]
+  );
+  const breakpointTime = breakpoint ? new Date(breakpoint * 1000).toISOString() : '';
+  const endTime = useMemo(
+    () => (trendView.end ? trendView.end : moment().toISOString()),
+    [trendView.end]
+  );
+
+  const {projects} = useProjects();
+  const projectID = getTrendProjectId(transaction, projects);
+
+  const functionsSort: Sort<FunctionsField> = {key: 'sum()', order: 'desc'};
+
+  const query = useMemo(() => {
+    const conditions = new MutableSearch('');
+    conditions.setFilterValues('transaction', [transaction.transaction]);
+    return conditions.formatString();
+  }, [transaction.transaction]);
+
+  const {
+    data: totalTransactionsBefore,
+    isLoading: transactionsLoadingBefore,
+    isError: transactionsErrorBefore,
+  } = useDiscoverQuery(
+    getQueryParams(
+      startTime,
+      breakpointTime,
+      ['count'],
+      'transaction',
+      DiscoverDatasets.METRICS,
+      organization,
+      trendView,
+      transaction.transaction,
+      location
+    )
+  );
+
+  const transactionCountBefore = totalTransactionsBefore?.data
+    ? (totalTransactionsBefore?.data[0]['count()'] as number)
+    : 0;
+
+  const {
+    data: totalTransactionsAfter,
+    isLoading: transactionsLoadingAfter,
+    isError: transactionsErrorAfter,
+  } = useDiscoverQuery(
+    getQueryParams(
+      breakpointTime,
+      endTime,
+      ['count'],
+      'transaction',
+      DiscoverDatasets.METRICS,
+      organization,
+      trendView,
+      transaction.transaction,
+      location
+    )
+  );
+
+  const transactionCountAfter = totalTransactionsAfter?.data
+    ? (totalTransactionsAfter?.data[0]['count()'] as number)
+    : 0;
+
+  const beforeFunctionsQuery = useProfileFunctions<FunctionsField>({
+    fields: functionsFields,
+    referrer: 'api.performance.performance-change-explorer',
+    sort: functionsSort,
+    query,
+    limit: 50,
+    datetime: {
+      end: breakpointTime,
+      start: startTime,
+      period: null,
+      utc: null,
+    },
+  });
+
+  const afterFunctionsQuery = useProfileFunctions<FunctionsField>({
+    fields: functionsFields,
+    referrer: 'api.performance.performance-change-explorer',
+    sort: functionsSort,
+    query,
+    limit: 50,
+    datetime: {
+      end: endTime,
+      start: breakpointTime,
+      period: null,
+      utc: null,
+    },
+  });
+
+  // need these averaged fields because comparing total self times may be inaccurate depending on
+  // where the breakpoint is
+  const functionsAveragedAfter = addAvgSumOfFunctions(
+    afterFunctionsQuery.data?.data,
+    transactionCountAfter
+  );
+  const functionsAveragedBefore = addAvgSumOfFunctions(
+    beforeFunctionsQuery.data?.data,
+    transactionCountBefore
+  );
+
+  const addedFunctions = addFunctionChangeFields(
+    findFunctionsNotIn(functionsAveragedAfter, functionsAveragedBefore),
+    true
+  );
+  const removedFunctions = addFunctionChangeFields(
+    findFunctionsNotIn(functionsAveragedBefore, functionsAveragedAfter),
+    false
+  );
+
+  const remainingFunctionsBefore = findFunctionsIn(
+    functionsAveragedBefore,
+    functionsAveragedAfter
+  );
+  const remainingFunctionsAfter = findFunctionsIn(
+    functionsAveragedAfter,
+    functionsAveragedBefore
+  );
+
+  const remainingFunctionsWithChange = addPercentChangeInFunctions(
+    remainingFunctionsBefore,
+    remainingFunctionsAfter
+  );
+
+  const allFunctionsUpdated = remainingFunctionsWithChange
+    ?.concat(addedFunctions ? addedFunctions : [])
+    .concat(removedFunctions ? removedFunctions : []);
+
+  // sorts all functions in descending order of avgTimeDifference (change in avg total self time)
+  const functionList = allFunctionsUpdated?.sort(
+    (a, b) => b.avgTimeDifference - a.avgTimeDifference
+  );
+
+  return (
+    <NumberedFunctionsList
+      functions={
+        trendChangeType === TrendChangeType.REGRESSION
+          ? functionList
+          : functionList?.reverse()
+      }
+      project={projects.find(project => project.id === projectID)}
+      organization={organization}
+      transactionName={transaction.transaction}
+      limit={4}
+      isLoading={
+        transactionsLoadingBefore ||
+        transactionsLoadingAfter ||
+        beforeFunctionsQuery.isLoading ||
+        afterFunctionsQuery.isLoading
+      }
+      isError={
+        transactionsErrorBefore ||
+        transactionsErrorAfter ||
+        beforeFunctionsQuery.isError ||
+        afterFunctionsQuery.isError
+      }
+    />
+  );
+}
+
+/**
+ *
+ * adds an average of the sum() time so it is more comparable when the breakpoint
+ * is not close to the middle of the timeseries
+ */
+function addAvgSumOfFunctions(
+  suspectFunctions: EventsResultsDataRow<FunctionsField>[] | undefined,
+  transactionCount: number
+) {
+  return suspectFunctions?.map(susFunc => {
+    return {
+      ...susFunc,
+      avgSumExclusiveTime: (susFunc['sum()'] as number)
+        ? (susFunc['sum()'] as number) / transactionCount
+        : 0,
+    };
+  });
+}
+
+function findFunctionsNotIn(
+  initialFunctions: AveragedSuspectFunction[] | undefined,
+  comparingFunctions: AveragedSuspectFunction[] | undefined
+) {
+  return initialFunctions?.filter(initialValue => {
+    const functionInComparingSet = comparingFunctions?.find(
+      comparingValue =>
+        comparingValue.function === initialValue.function &&
+        comparingValue.package === initialValue.package
+    );
+    return functionInComparingSet === undefined;
+  });
+}
+
+function findFunctionsIn(
+  initialFunctions: AveragedSuspectFunction[] | undefined,
+  comparingFunctions: AveragedSuspectFunction[] | undefined
+) {
+  return initialFunctions?.filter(initialValue => {
+    const functionInComparingSet = comparingFunctions?.find(
+      comparingValue =>
+        comparingValue.function === initialValue.function &&
+        comparingValue.package === initialValue.package
+    );
+    return functionInComparingSet !== undefined;
+  });
+}
+
+function addFunctionChangeFields(
+  functions: AveragedSuspectFunction[] | undefined,
+  added: boolean
+): ChangedSuspectFunction[] | undefined {
+  // percent change is hardcoded to pass the 1% change threshold,
+  // avoid infinite values and reflect correct change type
+  return functions?.map(func => {
+    if (added) {
+      return {
+        ...func,
+        percentChange: 100,
+        avgTimeDifference: func.avgSumExclusiveTime,
+        changeType: FunctionChangeType.added,
+      };
+    }
+    return {
+      ...func,
+      percentChange: -100,
+      avgTimeDifference: 0 - func.avgSumExclusiveTime,
+      changeType: FunctionChangeType.removed,
+    };
+  });
+}
+
+function addPercentChangeInFunctions(
+  before: AveragedSuspectFunction[] | undefined,
+  after: AveragedSuspectFunction[] | undefined
+) {
+  return after?.map(functionAfter => {
+    const functionBefore = before?.find(
+      beforeValue =>
+        functionAfter.function === beforeValue.function &&
+        functionAfter.package === beforeValue.package
+    );
+    const percentageChange =
+      relativeChange(
+        functionBefore?.avgSumExclusiveTime || 0,
+        functionAfter.avgSumExclusiveTime
+      ) * 100;
+    return {
+      ...functionAfter,
+      percentChange: percentageChange,
+      avgTimeDifference:
+        functionAfter.avgSumExclusiveTime - (functionBefore?.avgSumExclusiveTime || 0),
+      changeType:
+        percentageChange < 0 ? FunctionChangeType.improved : FunctionChangeType.regressed,
+    };
+  });
+}
+
+export function NumberedFunctionsList(props: NumberedFunctionsListProps) {
+  const {project, transactionName, organization, limit, isLoading, isError, functions} =
+    props;
+
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
+
+  if (isError) {
+    return (
+      <ErrorWrapper>
+        <IconWarning
+          data-test-id="error-indicator-functions"
+          color="gray200"
+          size="xxl"
+        />
+        <p>{t('There was an issue finding suspect functions for this transaction')}</p>
+      </ErrorWrapper>
+    );
+  }
+
+  if (functions?.length === 0 || !functions) {
+    return (
+      <EmptyStateWarning>
+        <p data-test-id="functions-no-results">
+          {t('No results found for suspect functions')}
+        </p>
+      </EmptyStateWarning>
+    );
+  }
+
+  // percent change of a function must be more than 1%
+  const formattedFunctions = functions
+    ?.filter(func => (functions.length > 10 ? Math.abs(func.percentChange) >= 1 : true))
+    .slice(0, limit)
+    .map((func, index) => {
+      const profiles = func['examples()'] as string[];
+
+      const functionSummaryView = generateProfileFlamechartRouteWithQuery({
+        orgSlug: organization.slug,
+        projectSlug: project?.slug || '',
+        profileId: profiles[0],
+        query: {
+          frameName: func.function as string,
+          framePackage: func.package as string,
+        },
+      });
+
+      const handleClickAnalytics = () => {
+        trackAnalytics(
+          'performance_views.performance_change_explorer.function_link_clicked',
+          {
+            organization,
+            transaction: transactionName,
+            package: func.package as string,
+            function: func.function as string,
+            profile_id: profiles[0],
+          }
+        );
+      };
+
+      return (
+        <li key={`list-item-${index}`}>
+          <ListItemWrapper data-test-id="list-item">
+            <p style={{marginLeft: space(2)}}>
+              {tct('[changeType] suspect function', {changeType: func.changeType})}
+            </p>
+            <ListLink to={functionSummaryView} onClick={handleClickAnalytics}>
+              {func.function}
+            </ListLink>
+          </ListItemWrapper>
+        </li>
+      );
+    });
+
+  if (formattedFunctions?.length === 0) {
+    return (
+      <EmptyStateWarning>
+        <p data-test-id="functions-no-changes">
+          {t('No sizable changes in suspect functions')}
+        </p>
+      </EmptyStateWarning>
+    );
+  }
+
+  return (
+    <div style={{marginTop: space(4)}}>
+      <h6>{t('Relevant Suspect Functions')}</h6>
+      <ol>{formattedFunctions}</ol>
+    </div>
+  );
+}

--- a/static/app/views/performance/trends/changeExplorerUtils/spansList.spec.tsx
+++ b/static/app/views/performance/trends/changeExplorerUtils/spansList.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {
   ChangedSuspectSpan,
-  NumberedList,
+  NumberedSpansList,
   SpanChangeType,
 } from 'sentry/views/performance/trends/changeExplorerUtils/spansList';
 import {NormalizedTrendsTransaction} from 'sentry/views/performance/trends/types';
@@ -303,7 +303,7 @@ describe('Performance > Trends > Performance Change Explorer > Spans List', func
     const data = initializeData();
 
     render(
-      <NumberedList
+      <NumberedSpansList
         spans={longSpanList}
         location={data.location}
         organization={data.organization}
@@ -334,7 +334,7 @@ describe('Performance > Trends > Performance Change Explorer > Spans List', func
     const data = initializeData();
 
     render(
-      <NumberedList
+      <NumberedSpansList
         spans={longSpanList.reverse()}
         location={data.location}
         organization={data.organization}
@@ -365,7 +365,7 @@ describe('Performance > Trends > Performance Change Explorer > Spans List', func
     const data = initializeData();
 
     render(
-      <NumberedList
+      <NumberedSpansList
         spans={shortSpanList}
         location={data.location}
         organization={data.organization}

--- a/static/app/views/performance/trends/changeExplorerUtils/spansList.tsx
+++ b/static/app/views/performance/trends/changeExplorerUtils/spansList.tsx
@@ -76,17 +76,6 @@ export const SpanChangeType = {
   improved: t('Improved'),
 };
 
-const functionsFields = [
-  'package',
-  'function',
-  'count()',
-  'p75()',
-  'sum()',
-  'examples()',
-] as const;
-
-export type FunctionsField = (typeof functionsFields)[number];
-
 export function SpansList(props: SpansListProps) {
   const {trendView, location, organization, breakpoint, transaction, trendChangeType} =
     props;

--- a/static/app/views/performance/trends/changeExplorerUtils/spansList.tsx
+++ b/static/app/views/performance/trends/changeExplorerUtils/spansList.tsx
@@ -256,30 +256,33 @@ export function SpansList(props: SpansListProps) {
               );
               // reverse the span list when trendChangeType is improvement so most negative (improved) change is first
               return (
-                <NumberedSpansList
-                  spans={
-                    trendChangeType === TrendChangeType.REGRESSION
-                      ? spanList
-                      : spanList?.reverse()
-                  }
-                  projectID={projectID}
-                  location={location}
-                  organization={organization}
-                  transactionName={transaction.transaction}
-                  limit={4}
-                  isLoading={
-                    transactionsLoadingBefore ||
-                    transactionsLoadingAfter ||
-                    spansLoadingBefore ||
-                    spansLoadingAfter
-                  }
-                  isError={
-                    transactionsErrorBefore ||
-                    transactionsErrorAfter ||
-                    hasSpansErrorBefore ||
-                    hasSpansErrorAfter
-                  }
-                />
+                <div style={{marginTop: space(4)}}>
+                  <h6>{t('Relevant Suspect Spans')}</h6>
+                  <NumberedSpansList
+                    spans={
+                      trendChangeType === TrendChangeType.REGRESSION
+                        ? spanList
+                        : spanList?.reverse()
+                    }
+                    projectID={projectID}
+                    location={location}
+                    organization={organization}
+                    transactionName={transaction.transaction}
+                    limit={4}
+                    isLoading={
+                      transactionsLoadingBefore ||
+                      transactionsLoadingAfter ||
+                      spansLoadingBefore ||
+                      spansLoadingAfter
+                    }
+                    isError={
+                      transactionsErrorBefore ||
+                      transactionsErrorAfter ||
+                      hasSpansErrorBefore ||
+                      hasSpansErrorAfter
+                    }
+                  />
+                </div>
               );
             }}
           </SuspectSpansQuery>
@@ -513,12 +516,7 @@ export function NumberedSpansList(props: NumberedSpansListProps) {
     );
   }
 
-  return (
-    <div style={{marginTop: space(4)}}>
-      <h6>{t('Relevant Suspect Spans')}</h6>
-      <ol>{formattedSpans}</ol>
-    </div>
-  );
+  return <ol>{formattedSpans}</ol>;
 }
 
 export const ListLink = styled(Link)`

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -261,6 +261,7 @@ describe('Performance > Trends', function () {
             'p95()': 1010.9232499999998,
             'p50()': 47.34580982348902,
             'tps()': 3.7226926286168966,
+            'examples()': ['djk3w308er', '3298a9ui3h'],
           },
         ],
         meta: {
@@ -268,11 +269,13 @@ describe('Performance > Trends', function () {
             'p95()': 'duration',
             '950()': 'duration',
             'tps()': 'number',
+            'examples()': 'Array',
           },
           units: {
             'p95()': 'millisecond',
             'p50()': 'millisecond',
             'tps()': null,
+            'examples()': null,
           },
           isMetricsData: true,
           tips: {},


### PR DESCRIPTION
I've added a list of suspect functions to the spans list on the Performance Change Explorer. Same concept of most regressed/improved/added/removed functions for the specified transaction. It's using the same logic to figure out what is most changed but applied onto the function data. (Also I updated tests)
![image](https://github.com/getsentry/sentry/assets/72356613/957920d7-a2ee-413a-9094-b3fb80af61ab)

