### PR TITLE
ref(crons): Use translucent border on sticky timeline header

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
@@ -123,7 +123,6 @@ const GridLineContainer = styled('div')`
 const LabelsContainer = styled('div')`
   position: relative;
   align-self: stretch;
-  border-bottom: 1px solid ${p => p.theme.border};
 `;
 
 const Gridline = styled('div')<{left: number}>`

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -100,10 +100,10 @@ const MonitorListPanel = styled(Panel)`
 const StickyResolutionSelector = styled(Sticky)`
   z-index: 1;
   padding: ${space(1.5)} ${space(2)};
-  border-bottom: 1px solid ${p => p.theme.border};
   grid-column: 1/3;
   background: ${p => p.theme.background};
   border-top-left-radius: ${p => p.theme.panelBorderRadius};
+  box-shadow: 0 1px ${p => p.theme.translucentBorder};
 
   &[data-stuck] {
     border-radius: 0;
@@ -119,6 +119,7 @@ const StickyGridLineTimeLabels = styled(Sticky)`
   z-index: 1;
   background: ${p => p.theme.background};
   border-top-right-radius: ${p => p.theme.panelBorderRadius};
+  box-shadow: 0 1px ${p => p.theme.translucentBorder};
 
   &[data-stuck] {
     border-radius: 0;


### PR DESCRIPTION
Tiny change, but translucent borders work better than solid borders on floating elements.

**Before ——**
<img width="638" alt="Screenshot 2023-08-08 at 12 54 02 PM" src="https://github.com/getsentry/sentry/assets/44172267/50e040da-1c3f-41a3-a4c0-8d1f99f83e10">


**After ——**
<img width="638" alt="Screenshot 2023-08-08 at 12 52 02 PM" src="https://github.com/getsentry/sentry/assets/44172267/1363b1b1-50b2-4f0a-85ab-4d83bc38a601">
