### PR TITLE
fix(issues): Remove legacy group id redirect

### DIFF
--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -1,5 +1,3 @@
-import {browserHistory} from 'react-router';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -227,24 +225,6 @@ describe('groupDetails', () => {
     );
 
     expect(await screen.findByText('environment: staging')).toBeInTheDocument();
-  });
-
-  /**
-   * This is legacy code that I'm not even sure still happens
-   */
-  it('redirects to new issue if params id !== id returned from API request', async function () {
-    MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/`,
-      body: {...group, id: 'new-id'},
-    });
-    createWrapper();
-    expect(screen.queryByText('Group Details Mock')).not.toBeInTheDocument();
-    await waitFor(() => {
-      expect(browserHistory.push).toHaveBeenCalledTimes(1);
-    });
-    expect(browserHistory.push).toHaveBeenCalledWith(
-      '/organizations/org-slug/issues/new-id/?foo=bar#hash'
-    );
   });
 
   it('renders issue event error', async function () {

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -684,21 +684,6 @@ function GroupDetailsContent({
 
   useTrackView({group, event, project, tab: currentTab});
 
-  useEffect(() => {
-    if (
-      currentTab === Tab.DETAILS &&
-      group &&
-      event &&
-      group.id !== event?.groupID &&
-      !eventError
-    ) {
-      // if user pastes only the event id into the url, but it's from another group, redirect to correct group/event
-      const redirectUrl = `/organizations/${organization.slug}/issues/${event.groupID}/events/${event.id}/`;
-
-      router.push(normalizeUrl(redirectUrl));
-    }
-  }, [currentTab, event, eventError, group, organization.slug, router]);
-
   const childProps = {
     environments,
     group,


### PR DESCRIPTION
If someone manually changed the event id and it did not match the current group we tried to redirect to the correct group id. However, this is currently causing a race condition when navigating between linked issues AND the redirect no longer properly works since the event api returns the group id that was provided in the request (which would be the wrong one).

examples - the same event but with different group ids. https://sentry.sentry.io/api/0/issues/4372262661/events/1569a6ed4c854587b3b294e87aed6c0d/?collapse=fullRelease https://sentry.sentry.io/api/0/issues/3935139508/events/1569a6ed4c854587b3b294e87aed6c0d/?collapse=fullRelease&query=is%3Aunresolved

on the backend we aren't hitting snuba to get the group id https://github.com/getsentry/sentry/blob/329991b4a66ae847b5c83978e79504030ed09461/src/sentry/eventstore/snuba/backend.py#L326-L330
