### PR TITLE
fix(source-map-debug): Fix doc links

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.spec.tsx
@@ -107,7 +107,7 @@ describe('SourceMapDebug', () => {
     expect(screen.getByText('Event missing Release tag')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Read Guide'})).toHaveAttribute(
       'href',
-      'https://docs.sentry.io/platforms/javascript/sourcemaps/#uploading-source-maps-to-sentry'
+      'https://docs.sentry.io/platforms/javascript/sourcemaps/#uploading-source-maps'
     );
   });
 
@@ -141,7 +141,7 @@ describe('SourceMapDebug', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Read Guide'})).toHaveAttribute(
       'href',
-      'https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/#verify-artifact-names-match-stack-trace-frames'
+      'https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/legacy-uploading-methods/#verify-artifact-names-match-stack-trace-frames'
     );
   });
 
@@ -177,7 +177,7 @@ describe('SourceMapDebug', () => {
     expect(screen.getByText(textWithMarkupMatcher(expandedMessage))).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Read Guide'})).toHaveAttribute(
       'href',
-      'https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/#verify-artifact-names-match-stack-trace-frames'
+      'https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/legacy-uploading-methods/#verify-artifact-names-match-stack-trace-frames'
     );
   });
 

--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
@@ -53,9 +53,12 @@ function getErrorMessage(
     if (docPlatform === 'react-native') {
       return 'https://docs.sentry.io/platforms/react-native/troubleshooting/#source-maps';
     }
-    return `${baseSourceMapDocsLink}troubleshooting_js/` + (section ? `#${section}` : '');
+    return (
+      `${baseSourceMapDocsLink}troubleshooting_js/legacy-uploading-methods/` +
+      (section ? `#${section}` : '')
+    );
   }
-  const defaultDocsLink = `${baseSourceMapDocsLink}#uploading-source-maps-to-sentry`;
+  const defaultDocsLink = `${baseSourceMapDocsLink}#uploading-source-maps`;
 
   switch (error.type) {
     case SourceMapProcessingIssueType.MISSING_RELEASE:


### PR DESCRIPTION
this pr fixes the doc links for our source map debugger. the previous links were broken due to the docs being moved into the legacy uploading section. 

Closes https://github.com/getsentry/sentry/issues/54409

