### PR TITLE
fix(hybridcloud) Ignore fixtures/ from production code linting.

### DIFF
--- a/src/sentry/sentry_metrics/client/snuba.py
+++ b/src/sentry/sentry_metrics/client/snuba.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 from sentry import quotas
 from sentry.sentry_metrics.client.base import GenericMetricsBackend
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.testutils.cases import BaseMetricsTestCase
+from sentry.testutils.cases import BaseMetricsTestCase  # NOQA:S007
 
 
 def build_mri(metric_name: str, type: str, use_case_id: UseCaseID, unit: Optional[str]) -> str:

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -49,6 +49,7 @@ class SentryVisitor(ast.NodeVisitor):
                 self.errors.append((node.lineno, node.col_offset, S006_msg))
             elif (
                 "tests/" not in self.filename
+                and "fixtures/" not in self.filename
                 and "sentry/testutils/" not in self.filename
                 and "sentry.testutils" in node.module
             ):
@@ -62,6 +63,7 @@ class SentryVisitor(ast.NodeVisitor):
                 self.errors.append((node.lineno, node.col_offset, S003_msg))
             elif (
                 "tests/" not in self.filename
+                and "fixtures/" not in self.filename
                 and "sentry/testutils/" not in self.filename
                 and "sentry.testutils" in alias.name
             ):


### PR DESCRIPTION
Add an ignore to metrics code as well. Unwinding this testutils import doesn't seem straightforward and it would be better if the original team took on this work.
