### PR TITLE
ref(hybrid-cloud): Stabilizes org model tests in region silo mode

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -36,6 +36,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox, outbox_context
 from sentry.models.team import Team
 from sentry.roles.manager import Role
+from sentry.services.hybrid_cloud.notifications import notifications_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.types.organization import OrganizationAbsoluteUrlMixin
@@ -273,13 +274,11 @@ class Organization(Model, OptionMixin, OrganizationAbsoluteUrlMixin, SnowflakeId
         return generate_snowflake_id(cls.snowflake_redis_key)
 
     def delete(self, **kwargs):
-        from sentry.models import NotificationSetting
-
         if self.is_default:
             raise Exception("You cannot delete the the default organization.")
 
-        # There is no foreign key relationship so we have to manually cascade.
-        NotificationSetting.objects.remove_for_organization(self)
+        # There is no foreign key relationship, so we have to manually cascade.
+        notifications_service.remove_notification_settings_for_organization(organization_id=self.id)
 
         with outbox_context(transaction.atomic(router.db_for_write(Organization)), flush=False):
             Organization.outbox_for_update(self.id).save()

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -270,12 +270,12 @@ class NotificationsManager(BaseManager["NotificationSetting"]):  # noqa: F821
         ).delete()
 
     def remove_for_organization(
-        self, organization: Organization, type: NotificationSettingTypes | None = None
+        self, organization_id: int, type: NotificationSettingTypes | None = None
     ) -> None:
         """Bulk delete all Notification Settings for an ENTIRE ORGANIZATION, optionally by type."""
         self._filter(
             scope_type=NotificationScopeType.ORGANIZATION,
-            scope_identifier=organization.id,
+            scope_identifier=organization_id,
             type=type,
         ).delete()
 

--- a/src/sentry/services/hybrid_cloud/notifications/impl.py
+++ b/src/sentry/services/hybrid_cloud/notifications/impl.py
@@ -171,6 +171,10 @@ class DatabaseBackedNotificationsService(NotificationsService):
     def get_many(self, *, filter: NotificationSettingFilterArgs) -> List[RpcNotificationSetting]:
         return self._FQ.get_many(filter)
 
+    def remove_notification_settings_for_organization(self, *, organization_id: int) -> None:
+        assert organization_id
+        NotificationSetting.objects.remove_for_organization(organization_id=organization_id)
+
     def serialize_many(
         self,
         *,

--- a/src/sentry/services/hybrid_cloud/notifications/impl.py
+++ b/src/sentry/services/hybrid_cloud/notifications/impl.py
@@ -172,7 +172,7 @@ class DatabaseBackedNotificationsService(NotificationsService):
         return self._FQ.get_many(filter)
 
     def remove_notification_settings_for_organization(self, *, organization_id: int) -> None:
-        assert organization_id
+        assert organization_id, "organization_id must be a positive integer"
         NotificationSetting.objects.remove_for_organization(organization_id=organization_id)
 
     def serialize_many(

--- a/src/sentry/services/hybrid_cloud/notifications/service.py
+++ b/src/sentry/services/hybrid_cloud/notifications/service.py
@@ -125,6 +125,11 @@ class NotificationsService(RpcService):
     ) -> List[OpaqueSerializedResponse]:
         pass
 
+    @rpc_method
+    @abstractmethod
+    def remove_notification_settings_for_organization(self, *, organization_id: int) -> None:
+        pass
+
 
 notifications_service: NotificationsService = cast(
     NotificationsService, NotificationsService.create_delegation()

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -15,18 +15,26 @@ from sentry.auth.authenticators.totp import TotpInterface
 from sentry.models import (
     ApiKey,
     AuditLogEntry,
+    NotificationSetting,
     Organization,
     OrganizationMember,
     OrganizationOption,
     User,
     UserOption,
 )
+from sentry.notifications.types import (
+    NotificationScopeType,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
+)
+from sentry.silo import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import control_silo_test, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.types.integrations import ExternalProviders
 
 
 @region_silo_test(stable=True)
@@ -174,11 +182,12 @@ class OrganizationTest(TestCase, HybridCloudTestMixin):
         self.assertFalse(has_changed(inst, "name"))
 
 
-@control_silo_test
+@region_silo_test(stable=True)
 class Require2fa(TestCase, HybridCloudTestMixin):
     def setUp(self):
         self.owner = self.create_user("foo@example.com")
-        TotpInterface().enroll(self.owner)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            TotpInterface().enroll(self.owner)
         self.org = self.create_organization(owner=self.owner)
         self.request = self.make_request(user=self.owner)
 
@@ -190,13 +199,16 @@ class Require2fa(TestCase, HybridCloudTestMixin):
     def _create_user_and_member(self, has_2fa=False, has_user_email=True):
         user = self._create_user(has_email=has_user_email)
         if has_2fa:
-            TotpInterface().enroll(user)
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                TotpInterface().enroll(user)
         member = self.create_member(organization=self.org, user=user)
         return user, member
 
     def is_organization_member(self, user_id, member_id):
         member = OrganizationMember.objects.get(id=member_id)
-        user = User.objects.get(id=user_id)
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            user = User.objects.get(id=user_id)
         assert not member.is_pending
         assert not member.email
         assert member.user_id == user.id
@@ -204,7 +216,8 @@ class Require2fa(TestCase, HybridCloudTestMixin):
     def is_pending_organization_member(self, user_id, member_id, was_booted=True):
         member = OrganizationMember.objects.get(id=member_id)
         if user_id:
-            assert User.objects.filter(id=user_id).exists()
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                assert User.objects.filter(id=user_id).exists()
         assert member.is_pending
         assert member.email
         if was_booted:
@@ -235,11 +248,12 @@ class Require2fa(TestCase, HybridCloudTestMixin):
         assert len(mail.outbox) == 1
         assert mail.outbox[0].to == [non_compliant_user.email]
 
-        audit_logs = AuditLogEntry.objects.filter(
-            event=audit_log.get_event_id("MEMBER_PENDING"),
-            organization_id=self.org.id,
-            actor=self.owner,
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            audit_logs = AuditLogEntry.objects.filter(
+                event=audit_log.get_event_id("MEMBER_PENDING"),
+                organization_id=self.org.id,
+                actor=self.owner,
+            )
         assert audit_logs.count() == 1
         assert audit_logs[0].data["email"] == non_compliant_user.email
         assert audit_logs[0].target_user_id == non_compliant_user.id
@@ -257,11 +271,13 @@ class Require2fa(TestCase, HybridCloudTestMixin):
             self.is_organization_member(user.id, member.id)
 
         assert len(mail.outbox) == 0
-        assert not AuditLogEntry.objects.filter(
-            event=audit_log.get_event_id("MEMBER_PENDING"),
-            organization_id=self.org.id,
-            actor=self.owner,
-        ).exists()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert not AuditLogEntry.objects.filter(
+                event=audit_log.get_event_id("MEMBER_PENDING"),
+                organization_id=self.org.id,
+                actor=self.owner,
+            ).exists()
 
     def test_handle_2fa_required__non_compliant_members(self):
         non_compliant = []
@@ -280,11 +296,12 @@ class Require2fa(TestCase, HybridCloudTestMixin):
             self.assert_org_member_mapping(org_member=member)
 
         assert len(mail.outbox) == len(non_compliant)
-        assert AuditLogEntry.objects.filter(
-            event=audit_log.get_event_id("MEMBER_PENDING"),
-            organization_id=self.org.id,
-            actor=self.owner,
-        ).count() == len(non_compliant)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert AuditLogEntry.objects.filter(
+                event=audit_log.get_event_id("MEMBER_PENDING"),
+                organization_id=self.org.id,
+                actor=self.owner,
+            ).count() == len(non_compliant)
 
     def test_handle_2fa_required__pending_member__ok(self):
         member = self.create_member(organization=self.org, email="bob@zombo.com")
@@ -295,16 +312,21 @@ class Require2fa(TestCase, HybridCloudTestMixin):
         self.is_pending_organization_member(user_id=None, member_id=member.id, was_booted=False)
 
         assert len(mail.outbox) == 0
-        assert not AuditLogEntry.objects.filter(
-            event=audit_log.get_event_id("MEMBER_PENDING"),
-            organization_id=self.org.id,
-            actor=self.owner,
-        ).exists()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert not AuditLogEntry.objects.filter(
+                event=audit_log.get_event_id("MEMBER_PENDING"),
+                organization_id=self.org.id,
+                actor=self.owner,
+            ).exists()
 
     @mock.patch("sentry.tasks.auth.logger")
     def test_handle_2fa_required__no_email__warning(self, auth_log):
         user, member = self._create_user_and_member(has_user_email=False)
-        assert not user.has_2fa()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert not user.has_2fa()
+
         assert not user.email
         assert not member.email
 
@@ -326,10 +348,11 @@ class Require2fa(TestCase, HybridCloudTestMixin):
         with self.options(
             {"system.url-prefix": "http://example.com"}
         ), self.tasks(), outbox_runner():
-            api_key = ApiKey.objects.create(
-                organization_id=self.org.id,
-                scope_list=["org:read", "org:write", "member:read", "member:write"],
-            )
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                api_key = ApiKey.objects.create(
+                    organization_id=self.org.id,
+                    scope_list=["org:read", "org:write", "member:read", "member:write"],
+                )
             request = copy.deepcopy(self.request)
             request.user = None
             request.auth = api_key
@@ -338,15 +361,17 @@ class Require2fa(TestCase, HybridCloudTestMixin):
         self.assert_org_member_mapping(org_member=member)
 
         assert len(mail.outbox) == 1
-        assert (
-            AuditLogEntry.objects.filter(
-                event=audit_log.get_event_id("MEMBER_PENDING"),
-                organization_id=self.org.id,
-                actor=None,
-                actor_key=api_key,
-            ).count()
-            == 1
-        )
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert (
+                AuditLogEntry.objects.filter(
+                    event=audit_log.get_event_id("MEMBER_PENDING"),
+                    organization_id=self.org.id,
+                    actor=None,
+                    actor_key=api_key,
+                ).count()
+                == 1
+            )
 
     @mock.patch("sentry.tasks.auth.logger")
     def test_handle_2fa_required__no_ip_address__ok(self, auth_log):
@@ -363,16 +388,18 @@ class Require2fa(TestCase, HybridCloudTestMixin):
         self.assert_org_member_mapping(org_member=member)
 
         assert len(mail.outbox) == 1
-        assert (
-            AuditLogEntry.objects.filter(
-                event=audit_log.get_event_id("MEMBER_PENDING"),
-                organization_id=self.org.id,
-                actor=self.owner,
-                actor_key=None,
-                ip_address=None,
-            ).count()
-            == 1
-        )
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert (
+                AuditLogEntry.objects.filter(
+                    event=audit_log.get_event_id("MEMBER_PENDING"),
+                    organization_id=self.org.id,
+                    actor=self.owner,
+                    actor_key=None,
+                    ip_address=None,
+                ).count()
+                == 1
+            )
 
     def test_get_audit_log_data(self):
         org = self.create_organization()
@@ -400,23 +427,60 @@ class Require2fa(TestCase, HybridCloudTestMixin):
         assert url == "http://acme.testserver/issues/?project=123#ref"
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class OrganizationDeletionTest(TestCase):
+    def add_org_notification_settings(self, org: Organization, user: User):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            NotificationSetting.objects.create(
+                scope_type=NotificationScopeType.ORGANIZATION.value,
+                target_id=user.id,
+                provider=ExternalProviders.EMAIL.value,
+                type=NotificationSettingTypes.DEPLOY.value,
+                scope_identifier=org.id,
+                user=user,
+                value=NotificationSettingOptionValues.NEVER.value,
+            )
+
+            assert NotificationSetting.objects.filter(
+                scope_type=NotificationScopeType.ORGANIZATION.value, scope_identifier=org.id
+            ).exists()
+
     def test_hybrid_cloud_deletion(self):
         org = self.create_organization()
         user = self.create_user()
-        UserOption.objects.set_value(user, "cool_key", "Hello!", organization_id=org.id)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            UserOption.objects.set_value(user, "cool_key", "Hello!", organization_id=org.id)
         org_id = org.id
+
+        self.add_org_notification_settings(org, user)
+
+        # Set up another org + notification settings to validate that this is unaffected by org deletion
+        unaffected_user = self.create_user()
+        unaffected_org = self.create_organization(owner=unaffected_user)
+        self.add_org_notification_settings(unaffected_org, unaffected_user)
 
         with outbox_runner():
             org.delete()
 
         assert not Organization.objects.filter(id=org_id).exists()
 
-        # cascade is asynchronous, ensure there is still related search,
-        assert UserOption.objects.filter(organization_id=org_id).exists()
-        with self.tasks():
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            # cascade is asynchronous, ensure there is still related search,
+            assert UserOption.objects.filter(organization_id=org_id).exists()
+
+        # Assume monolith silo mode to ensure all tasks are run correctly
+        with self.tasks(), assume_test_silo_mode(SiloMode.MONOLITH):
             schedule_hybrid_cloud_foreign_key_jobs()
 
-        # Ensure they are all now gone.
-        assert not UserOption.objects.filter(organization_id=org_id).exists()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            # Ensure they are all now gone.
+            assert not UserOption.objects.filter(organization_id=org_id).exists()
+
+            assert NotificationSetting.objects.filter(
+                scope_type=NotificationScopeType.ORGANIZATION.value,
+                scope_identifier=unaffected_org.id,
+            ).exists()
+
+            assert not NotificationSetting.objects.filter(
+                scope_type=NotificationScopeType.ORGANIZATION.value, scope_identifier=org_id
+            ).exists()


### PR DESCRIPTION
- Updates Org member query code to hide RPC call when retrieving an unpopulated email
- Adds new RPC method in `notification_service` allowing bulk deletion of organization notification settings
- Marks remaining organization model tests as region-silo stable
- Updates Organization deletion logic to use the new `notification_service` bulk notification setting deletion method
