### PR TITLE
Stop special-casing symbolicate/assemble tasks

### DIFF
--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -21,8 +21,6 @@ LEGACY_PICKLE_TASKS = frozenset(
         "sentry.tasks.process_buffer.process_incr",
         "sentry.tasks.process_resource_change_bound",
         "sentry.tasks.sentry_apps.send_alert_event",
-        "sentry.tasks.store.symbolicate_event",
-        "sentry.tasks.store.symbolicate_event_low_priority",
         "sentry.tasks.unmerge",
         "src.sentry.notifications.utils.async_send_notification",
         # basic tasks that can already deal with primary keys passed

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -106,11 +106,8 @@ if settings.ADDITIONAL_SAMPLED_URLS:
 # tasks will not be sampled
 SAMPLED_TASKS = {
     "sentry.tasks.send_ping": settings.SAMPLED_DEFAULT_RATE,
-    "sentry.tasks.store.symbolicate_event": settings.SENTRY_SYMBOLICATE_EVENT_APM_SAMPLING,
-    "sentry.tasks.store.symbolicate_event_from_reprocessing": settings.SENTRY_SYMBOLICATE_EVENT_APM_SAMPLING,
     "sentry.tasks.store.process_event": settings.SENTRY_PROCESS_EVENT_APM_SAMPLING,
     "sentry.tasks.store.process_event_from_reprocessing": settings.SENTRY_PROCESS_EVENT_APM_SAMPLING,
-    "sentry.tasks.assemble.assemble_dif": 0.1,
     "sentry.tasks.app_store_connect.dsym_download": settings.SENTRY_APPCONNECT_APM_SAMPLING,
     "sentry.tasks.app_store_connect.refresh_all_builds": settings.SENTRY_APPCONNECT_APM_SAMPLING,
     "sentry.tasks.process_suspect_commits": settings.SENTRY_SUSPECT_COMMITS_APM_SAMPLING,


### PR DESCRIPTION
This removes some symbolicate tasks from celery and transaction sampling special-casing, along with assemble.