### PR TITLE
feat(grouping): Add `in_app` vs `system` frame mix metric

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1641,6 +1641,18 @@ def _save_aggregate(
                     tags={"platform": event.platform or "unknown"},
                 )
 
+                # This only applies to events with stacktraces
+                frame_mix = event.get_event_metadata().get("in_app_frame_mix")
+                if frame_mix:
+                    metrics.incr(
+                        "grouping.in_app_frame_mix",
+                        sample_rate=1.0,
+                        tags={
+                            "platform": event.platform or "unknown",
+                            "frame_mix": frame_mix,
+                        },
+                    )
+
                 return GroupInfo(group, is_new, is_regression)
 
     group = Group.objects.get(id=existing_grouphash.group_id)

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 # Keys in the event payload we do not want to send to the event stream / snuba.
 EVENTSTREAM_PRUNED_KEYS = ("debug_meta", "_meta")
 # Keys in the event metadata we do not want to include in the event's `search_message`
-SEARCH_MESSAGE_SKIPPED_KEYS = frozenset([])
+SEARCH_MESSAGE_SKIPPED_KEYS = frozenset(["in_app_frame_mix"])
 
 if TYPE_CHECKING:
     from sentry.interfaces.user import User

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -197,6 +197,18 @@ def save_issue_from_occurrence(
                 tags={"platform": event.platform or "unknown", "type": occurrence.type.type_id},
             )
             group_info = GroupInfo(group=group, is_new=is_new, is_regression=is_regression)
+
+            # This only applies to events with stacktraces
+            frame_mix = event.get_event_metadata().get("in_app_frame_mix")
+            if is_new and frame_mix:
+                metrics.incr(
+                    "grouping.in_app_frame_mix",
+                    sample_rate=1.0,
+                    tags={
+                        "platform": event.platform or "unknown",
+                        "frame_mix": frame_mix,
+                    },
+                )
     else:
         group = existing_grouphash.group
         if group.issue_category.value != occurrence.type.category:

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -242,6 +242,42 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
             group_info = save_issue_from_occurrence(new_occurrence, new_event, None)
             assert group_info is not None
 
+    def test_frame_mix_metric_logged(self) -> None:
+        event = self.store_event(
+            data={"platform": "javascript"},
+            project_id=self.project.id,
+        )
+
+        # Normally this is done by `normalize_stacktraces_for_grouping`, but that can't be mocked
+        # because it's imported inside its calling function to avoid circular imports
+        event.data.setdefault("metadata", {})
+        event.data["metadata"]["in_app_frame_mix"] = "in-app-only"
+
+        with patch("sentry.issues.ingest.metrics.incr") as mock_metrics_incr:
+            occurrence = self.build_occurrence()
+            save_issue_from_occurrence(occurrence, event, None)
+
+            mock_metrics_incr.assert_any_call(
+                "grouping.in_app_frame_mix",
+                sample_rate=1.0,
+                tags={
+                    "platform": "javascript",
+                    "frame_mix": "in-app-only",
+                },
+            )
+
+    def test_frame_mix_metric_not_logged(self) -> None:
+        event = self.store_event(data={}, project_id=self.project.id)
+
+        assert event.get_event_metadata().get("in_app_frame_mix") is None
+
+        with patch("sentry.issues.ingest.metrics.incr") as mock_metrics_incr:
+            occurrence = self.build_occurrence()
+            save_issue_from_occurrence(occurrence, event, None)
+
+            metrics_logged = [call.args[0] for call in mock_metrics_incr.mock_calls]
+            assert "grouping.in_app_frame_mix" not in metrics_logged
+
 
 class CreateIssueKwargsTest(OccurrenceTestMixin, TestCase):
     def test(self) -> None:


### PR DESCRIPTION
This adds a DD metric, `grouping.in_app_frame_mix`, which fires each time a new group with at least one stacktrace is created and which tracks whether the event's stacktrace(s) contain only `in_app` frames, only `system` frames, or a mix of the two. (The presumption is that - assuming our `in_app` detection works correctly - most (if not close to all) stacktraces _should_ contain a mix of the two.)

To avoid looping through the frames an extra time, this data is collected in `_normalize_in_app`, where we're already looking at every frame. `_normalize_in_app` returns a frame mix for each stacktrace it examines, and then its caller, `normalize_stacktraces_for_grouping`, collects all stacktraces' frame mixes and uses them to determine a frame mix for the event, which it then stores in the event's `metadata` property. Later on in the ingest process, when we decide whether or not to create a new group, we then read that data and collect the metric when a new group is created. (We do this only when a group is created - rather than for each event - under the assumption that in a majority of cases, all events in a group will have the same stacktrace, and so it would both be redundant and a potential source of bias to collect the same information each time the group gets a new event.)

Note that by default, every non-boolean, non-numerical value in `event.metadata` is included in `event.search_message`, which is used both for search and for deciding if an event triggers an alert rule. Since the frame mix enum isn't something we're ever going to use for those purposes, it's excluded from the `search_message` value.

Ref https://github.com/getsentry/sentry/issues/54452