### PR TITLE
Fix slackbot

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1456,9 +1456,8 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# flag for turning on/off the options_automator_slack_webhook.
 register(
-    "options_automator_slack_webhook",
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+    "options_automator_slack_webhook_enabled",
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1455,3 +1455,11 @@ register(
     default=[],
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# flag for turning on/off the options_automator_slack_webhook.
+register(
+    "options_automator_slack_webhook",
+    type=bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1459,7 +1459,6 @@ register(
 # flag for turning on/off the options_automator_slack_webhook.
 register(
     "options_automator_slack_webhook",
-    type=bool,
     default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/runner/commands/presenters/presenterdelegator.py
+++ b/src/sentry/runner/commands/presenters/presenterdelegator.py
@@ -1,4 +1,3 @@
-from sentry import options
 from sentry.runner.commands.presenters.consolepresenter import ConsolePresenter
 from sentry.runner.commands.presenters.slackpresenter import SlackPresenter
 
@@ -8,7 +7,7 @@ class PresenterDelegator:
         self._consolepresenter = ConsolePresenter()
 
         self._slackpresenter = None
-        if options.get("options_automator_slack_webhook") and SlackPresenter.is_slack_enabled():
+        if SlackPresenter.is_slack_enabled():
             self._slackpresenter = SlackPresenter()
 
     def __getattr__(self, attr: str):

--- a/src/sentry/runner/commands/presenters/presenterdelegator.py
+++ b/src/sentry/runner/commands/presenters/presenterdelegator.py
@@ -1,3 +1,4 @@
+from sentry import options
 from sentry.runner.commands.presenters.consolepresenter import ConsolePresenter
 from sentry.runner.commands.presenters.slackpresenter import SlackPresenter
 
@@ -7,7 +8,7 @@ class PresenterDelegator:
         self._consolepresenter = ConsolePresenter()
 
         self._slackpresenter = None
-        if SlackPresenter.is_slack_enabled():
+        if options.get("options_automator_slack_webhook") and SlackPresenter.is_slack_enabled():
             self._slackpresenter = SlackPresenter()
 
     def __getattr__(self, attr: str):

--- a/src/sentry/runner/commands/presenters/slackpresenter.py
+++ b/src/sentry/runner/commands/presenters/slackpresenter.py
@@ -37,7 +37,7 @@ class SlackPresenter(OptionsPresenter):
                 "updated_options": [],
                 "set_options": [],
                 "unset_options": [],
-                "not_writable": [],
+                "not_writable_options": [],
                 "unregistered_options": [],
                 "invalid_type_options": [],
             }

--- a/src/sentry/runner/commands/presenters/slackpresenter.py
+++ b/src/sentry/runner/commands/presenters/slackpresenter.py
@@ -29,9 +29,6 @@ class SlackPresenter(OptionsPresenter):
 
     @staticmethod
     def is_slack_enabled():
-        import logging
-
-        logger = logging.getLogger("sentry.options_automator")
 
         if not settings.OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL:
             return False
@@ -58,9 +55,9 @@ class SlackPresenter(OptionsPresenter):
             )
             if response.status_code == 200:
                 return True
-            logger.error(f"Slack integration webhook failed. Status code: {response.status_code}")
-            return False
-
+            raise ConnectionError(
+                f"Slack integration webhook failed. Status code: {response.status_code}"
+            )
         except Exception:
             raise
 

--- a/src/sentry/runner/commands/presenters/slackpresenter.py
+++ b/src/sentry/runner/commands/presenters/slackpresenter.py
@@ -3,6 +3,7 @@ from typing import List, Tuple
 import requests
 from django.conf import settings
 
+from sentry import options
 from sentry.runner.commands.presenters.optionspresenter import OptionsPresenter
 from sentry.utils import json
 
@@ -30,7 +31,10 @@ class SlackPresenter(OptionsPresenter):
     @staticmethod
     def is_slack_enabled():
 
-        if not settings.OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL:
+        if not (
+            options.get("options_automator_slack_webhook_enabled")
+            and settings.OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL
+        ):
             return False
         try:
             test_payload: dict = {

--- a/src/sentry/runner/commands/presenters/slackpresenter.py
+++ b/src/sentry/runner/commands/presenters/slackpresenter.py
@@ -29,6 +29,10 @@ class SlackPresenter(OptionsPresenter):
 
     @staticmethod
     def is_slack_enabled():
+        import logging
+
+        logger = logging.getLogger("sentry.options_automator")
+
         if not settings.OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL:
             return False
         try:
@@ -54,9 +58,9 @@ class SlackPresenter(OptionsPresenter):
             )
             if response.status_code == 200:
                 return True
-            raise ConnectionError(
-                f"Slack integration webhook failed. Status code: {response.status_code}"
-            )
+            logger.error(f"Slack integration webhook failed. Status code: {response.status_code}")
+            return False
+
         except Exception:
             raise
 

--- a/tests/sentry/runner/commands/presenters/test_slackpresenter.py
+++ b/tests/sentry/runner/commands/presenters/test_slackpresenter.py
@@ -16,6 +16,7 @@ class TestSlackPresenter:
     def test_is_slack_enabled(self):
         responses.add(responses.POST, "https://test/", status=200)
 
+        assert self.slackPresenter.is_slack_enabled()
         self.slackPresenter.set("option1", "value1")
         self.slackPresenter.set("option2", "value2")
 
@@ -75,5 +76,5 @@ class TestSlackPresenter:
             ],
         }
 
-        assert responses.calls[0].response.status_code == 200
-        assert expected_json_data == json.loads(responses.calls[0].request.body)
+        assert responses.calls[1].response.status_code == 200
+        assert expected_json_data == json.loads(responses.calls[1].request.body)


### PR DESCRIPTION
Typo in the payload being sent to the webhook, hence the 400 status code error. 
I added better testing, as well as not raising an error (as to keep the automator running in case this fails again). 