### PR TITLE
ref(replays): update tooltip wording to include SDK information

### DIFF
--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -1,5 +1,7 @@
-import {t} from 'sentry/locale';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
 import type {Sort} from 'sentry/utils/discover/fields';
+import {MIN_DEAD_RAGE_CLICK_SDK} from 'sentry/views/replays/replayTable';
 import SortableHeader from 'sentry/views/replays/replayTable/sortableHeader';
 import {ReplayColumn} from 'sentry/views/replays/replayTable/types';
 
@@ -31,8 +33,12 @@ function HeaderCell({column, sort}: Props) {
           sort={sort}
           fieldName="count_dead_clicks"
           label={t('Dead clicks')}
-          tooltip={t(
-            'A dead click is a user click that does not result in any page activity after 7 seconds.'
+          tooltip={tct(
+            'A dead click is a user click that does not result in any page activity after 7 seconds. Requires SDK version >= [minSDK]. [link:Learn more.]',
+            {
+              minSDK: MIN_DEAD_RAGE_CLICK_SDK,
+              link: <ExternalLink href="https://docs.sentry.io/platforms/javascript/" />,
+            }
           )}
         />
       );
@@ -46,8 +52,12 @@ function HeaderCell({column, sort}: Props) {
           sort={sort}
           fieldName="count_rage_clicks"
           label={t('Rage clicks')}
-          tooltip={t(
-            'A rage click is 5 or more clicks on a dead element, which exhibits no page activity after 7 seconds.'
+          tooltip={tct(
+            'A rage click is 5 or more clicks on a dead element, which exhibits no page activity after 7 seconds. Requires SDK version >= [minSDK]. [link:Learn more.]',
+            {
+              minSDK: MIN_DEAD_RAGE_CLICK_SDK,
+              link: <ExternalLink href="https://docs.sentry.io/platforms/javascript/" />,
+            }
           )}
         />
       );

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -31,7 +31,7 @@ import {
 import {ReplayColumn} from 'sentry/views/replays/replayTable/types';
 import type {ReplayListRecord} from 'sentry/views/replays/types';
 
-const MIN_DEAD_RAGE_CLICK_SDK = '7.60.1';
+export const MIN_DEAD_RAGE_CLICK_SDK = '7.60.1';
 
 type Props = {
   fetchError: undefined | Error;

--- a/static/app/views/replays/replayTable/sortableHeader.tsx
+++ b/static/app/views/replays/replayTable/sortableHeader.tsx
@@ -1,3 +1,4 @@
+import {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import Link from 'sentry/components/links/link';
@@ -13,14 +14,14 @@ import {ReplayRecordNestedFieldName} from 'sentry/views/replays/types';
 
 type NotSortable = {
   label: string;
-  tooltip?: string;
+  tooltip?: string | ReactNode;
 };
 
 type Sortable = {
   fieldName: ReplayRecordNestedFieldName;
   label: string;
   sort: undefined | Sort;
-  tooltip?: string;
+  tooltip?: string | ReactNode;
 };
 
 type Props = NotSortable | Sortable;

--- a/static/app/views/replays/replayTable/sortableHeader.tsx
+++ b/static/app/views/replays/replayTable/sortableHeader.tsx
@@ -36,7 +36,7 @@ function SortableHeader(props: Props) {
       <Header>
         {label}
         {tooltip ? (
-          <StyledQuestionTooltip size="xs" position="top" title={tooltip} />
+          <StyledQuestionTooltip size="xs" position="top" title={tooltip} isHoverable />
         ) : null}
       </Header>
     );
@@ -84,7 +84,7 @@ function SortableHeader(props: Props) {
         {label} {sort?.field === fieldName && sortArrow}
       </SortLink>
       {tooltip ? (
-        <StyledQuestionTooltip size="xs" position="top" title={tooltip} />
+        <StyledQuestionTooltip size="xs" position="top" title={tooltip} isHoverable />
       ) : null}
     </Header>
   );


### PR DESCRIPTION
<img width="263" alt="SCR-20230809-jkkk" src="https://github.com/getsentry/sentry/assets/56095982/04ccca63-a4f4-4d9a-b9cd-8f66871a6b4c">
<img width="267" alt="SCR-20230809-jlkx" src="https://github.com/getsentry/sentry/assets/56095982/0ff3a058-b1f4-49cd-ba07-6d9f1aa3a48d">
