### PR TITLE
fix(replay): Fix console data render

### DIFF
--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -82,7 +82,11 @@ export function getFrameOpOrCategory(frame: ReplayFrame) {
 }
 
 export function isConsoleFrame(frame: BreadcrumbFrame): frame is ConsoleFrame {
-  return frame.category === 'console';
+  if (frame.category === 'console') {
+    frame.data = frame.data ?? {};
+    return true;
+  }
+  return false;
 }
 
 export function isDeadClick(frame: SlowClickFrame) {

--- a/static/app/views/replays/detail/console/messageFormatter.spec.tsx
+++ b/static/app/views/replays/detail/console/messageFormatter.spec.tsx
@@ -23,6 +23,26 @@ describe('MessageFormatter', () => {
     expect(screen.getByText('This is a test')).toBeInTheDocument();
   });
 
+  it('Should print console message without data', () => {
+    const [frame] = hydrateBreadcrumbs(TestStubs.ReplayRecord(), [
+      TestStubs.Replay.ConsoleFrame({
+        level: BreadcrumbLevelType.LOG,
+        message: 'This is only a test',
+        timestamp: new Date('2022-06-22T20:00:39.959Z'),
+      }),
+    ]);
+
+    // Manually delete `data` from the mock.
+    // This is reasonable because the type, at this point, `frame` is of type
+    // `BreadcrumbFrame` and not `ConsoleFrame`.
+    // When the type is narrowed to `ConsoleFrame` the `data` field is forced to exist.
+    delete frame.data;
+
+    render(<MessageFormatter frame={frame} />);
+
+    expect(screen.getByText('This is only a test')).toBeInTheDocument();
+  });
+
   it('Should print console message with objects correctly', () => {
     const [frame] = hydrateBreadcrumbs(TestStubs.ReplayRecord(), [
       TestStubs.Replay.ConsoleFrame({

--- a/static/app/views/replays/detail/console/messageFormatter.tsx
+++ b/static/app/views/replays/detail/console/messageFormatter.tsx
@@ -44,10 +44,10 @@ function UnmemoizedMessageFormatter({frame, expandPaths, onExpand}: Props) {
     );
   }
 
-  const args = isConsoleFrame(frame) ? frame.data.arguments : undefined;
+  const args = frame.data.arguments;
 
   // Turn this back into an Error object so <Format> can pretty print it
-  if (args && isConsoleFrame(frame) && isSerializedError(frame)) {
+  if (args && isSerializedError(frame)) {
     // Sometimes message can include stacktrace
     const splitMessage = frame.message.split('\n');
     const errorMessagePiece = splitMessage[0].trim();


### PR DESCRIPTION
Fix a bug where, if console breadcrumbs are missing the `data` field rendering would break. It looked like this:

![259424884-3df312a4-8298-44e6-9253-137a4f68286f](https://github.com/getsentry/sentry/assets/187460/006392ec-dcb0-4c34-9296-d45b89e4f885)

Now the console rows render fine, they show only the `message` field, no arguments, no string interpolation.

Fixes https://github.com/getsentry/team-replay/issues/136