### PR TITLE
fix(replay): Fix displaying Response headers in Network tab

### DIFF
--- a/static/app/views/replays/detail/network/details/sections.tsx
+++ b/static/app/views/replays/detail/network/details/sections.tsx
@@ -86,7 +86,7 @@ export function ResponseHeadersSection({item}: SectionProps) {
   const data = isRequestFrame(item) ? item.data : {};
   return (
     <SectionItem title={t('Response Headers')}>
-      {keyValueTableOrNotFound(data.request?.headers, t('Headers not captured'))}
+      {keyValueTableOrNotFound(data.response?.headers, t('Headers not captured'))}
     </SectionItem>
   );
 }


### PR DESCRIPTION
We were rendering request headers twice
