### PR TITLE
fix(source-map-debug) : Add context_line check for node

### DIFF
--- a/src/sentry/api/helpers/source_map_helper.py
+++ b/src/sentry/api/helpers/source_map_helper.py
@@ -37,8 +37,12 @@ def source_map_debug(project, event_id, exception_idx, frame_idx):
         # already mapped
         return SourceMapDebug()
 
+    if event.platform == "node" and frame.context_line:
+        return SourceMapDebug()
+
     # We can't demangle node's internal modules therefore we only process
     # user-land frames (starting with /) or those created by bundle/webpack internals.
+
     if event.platform == "node" and not abs_path.startswith(("/", "app:", "webpack:")):
         return SourceMapDebug()
 

--- a/tests/sentry/api/endpoints/test_source_map_debug.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug.py
@@ -352,6 +352,42 @@ class SourceMapDebugEndpointTestCase(APITestCase):
         )
         assert len(resp.data["errors"]) == 0
 
+    def test_skip_node_context_line(self):
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "platform": "node",
+                "exception": {
+                    "values": [
+                        {
+                            "type": "TypeError",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "abs_path": "/app",
+                                        "filename": "/static/js/main.fa8fe19f.js",
+                                        "lineno": 5,
+                                        "colno": 45,
+                                        "context_line": "throw new Error('foo')",
+                                    }
+                                ]
+                            },
+                        },
+                    ]
+                },
+            },
+            project_id=self.project.id,
+        )
+
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            event.event_id,
+            frame_idx=0,
+            exception_idx=0,
+        )
+        assert len(resp.data["errors"]) == 0
+
     def test_no_valid_url_skips_node(self):
         event = self.store_event(
             data={


### PR DESCRIPTION
this pr fixes a bug with node issues where we are falsely showing issues with sourcemaps when we shouldn't. We had this check for context_line in the past, but due to concerns about it preventing necessary alerts from being shown, it was removed. We are adding it back in just for events with node as the platform. 
