### PR TITLE
feat(starfish): Auto-indent SQL

### DIFF
--- a/static/app/views/starfish/utils/sqlish/SQLishFormatter.spec.tsx
+++ b/static/app/views/starfish/utils/sqlish/SQLishFormatter.spec.tsx
@@ -21,7 +21,13 @@ describe('SQLishFormatter', function () {
     it('Adds newlines for keywords in INSERTs', () => {
       expect(
         formatter.toString('INSERT INTO users (id, name) VALUES (:c0, :c1) RETURNING *')
-      ).toEqual('INSERT INTO users (id, name) \nVALUES (:c0, :c1) \nRETURNING *');
+      ).toEqual('INSERT INTO users (id, name) \nVALUES (\n  :c0, :c1\n) \nRETURNING *');
+    });
+
+    it('Adds indentation for keywords followed by parentheses', () => {
+      expect(formatter.toString('SELECT * FROM (SELECT * FROM users))')).toEqual(
+        'SELECT * \nFROM (\n  SELECT * \n  FROM users\n))'
+      );
     });
   });
 

--- a/static/app/views/starfish/utils/sqlish/SQLishFormatter.spec.tsx
+++ b/static/app/views/starfish/utils/sqlish/SQLishFormatter.spec.tsx
@@ -13,21 +13,36 @@ describe('SQLishFormatter', function () {
     });
 
     it('Adds newlines for keywords in SELECTs', () => {
-      expect(
-        formatter.toString('SELECT hello FROM users ORDER BY name DESC LIMIT 1;')
-      ).toEqual('SELECT hello \nFROM users \nORDER BY name DESC \nLIMIT 1;');
+      expect(formatter.toString('SELECT hello FROM users ORDER BY name DESC LIMIT 1;'))
+        .toMatchInlineSnapshot(`
+        "SELECT hello
+        FROM users
+        ORDER BY name DESC
+        LIMIT 1;"
+      `);
     });
 
     it('Adds newlines for keywords in INSERTs', () => {
       expect(
         formatter.toString('INSERT INTO users (id, name) VALUES (:c0, :c1) RETURNING *')
-      ).toEqual('INSERT INTO users (id, name) \nVALUES (\n  :c0, :c1\n) \nRETURNING *');
+      ).toMatchInlineSnapshot(`
+        "INSERT INTO users (id, name)
+        VALUES (
+          :c0, :c1
+        )
+        RETURNING *"
+      `);
     });
 
     it('Adds indentation for keywords followed by parentheses', () => {
-      expect(formatter.toString('SELECT * FROM (SELECT * FROM users))')).toEqual(
-        'SELECT * \nFROM (\n  SELECT * \n  FROM users\n))'
-      );
+      expect(formatter.toString('SELECT * FROM (SELECT * FROM users))'))
+        .toMatchInlineSnapshot(`
+        "SELECT *
+        FROM (
+          SELECT *
+          FROM users
+        ))"
+      `);
     });
   });
 
@@ -47,14 +62,14 @@ describe('SQLishFormatter', function () {
     });
 
     it('Capitalizes keywords', () => {
-      expect(getMarkup(formatter.toSimpleMarkup('select hello'))).toEqual(
-        '<b>SELECT</b><span> </span><span>hello</span>'
+      expect(getMarkup(formatter.toSimpleMarkup('select hello'))).toMatchInlineSnapshot(
+        `"<b>SELECT</b><span> </span><span>hello</span>"`
       );
     });
 
     it('Wraps every token in a `<span>` element', () => {
-      expect(getMarkup(formatter.toSimpleMarkup('SELECT hello;'))).toEqual(
-        '<b>SELECT</b><span> </span><span>hello;</span>'
+      expect(getMarkup(formatter.toSimpleMarkup('SELECT hello;'))).toMatchInlineSnapshot(
+        `"<b>SELECT</b><span> </span><span>hello;</span>"`
       );
     });
   });

--- a/static/app/views/starfish/utils/sqlish/SQLishFormatter.spec.tsx
+++ b/static/app/views/starfish/utils/sqlish/SQLishFormatter.spec.tsx
@@ -44,6 +44,29 @@ describe('SQLishFormatter', function () {
         ))"
       `);
     });
+
+    it('Adds indentation for SELECTS in conditions', () => {
+      expect(
+        formatter.toString(
+          'SELECT * FROM "sentry_users" WHERE (id IN (SELECT VO."id" FROM "sentry_vips" VO LIMIT 1)) AND (id IN (SELECT V1."id" FROM "sentry_currentusers" V1 LIMIT 1)) LIMIT 1'
+        )
+      ).toMatchInlineSnapshot(`
+        "SELECT *
+        FROM "sentry_users"
+        WHERE (
+          id IN (
+            SELECT VO."id"
+            FROM "sentry_vips" VO
+            LIMIT 1
+          )
+        ) AND (id IN (
+          SELECT V1."id"
+          FROM "sentry_currentusers" V1
+          LIMIT 1
+        ))
+        LIMIT 1"
+      `);
+    });
   });
 
   describe('SQLishFormatter.toSimpleMarkup()', () => {

--- a/static/app/views/starfish/utils/sqlish/SQLishFormatter.tsx
+++ b/static/app/views/starfish/utils/sqlish/SQLishFormatter.tsx
@@ -34,6 +34,16 @@ export class SQLishFormatter {
   toFormat(sql: string, format: Format) {
     let tokens;
 
+    const sentryTransaction = Sentry.getCurrentHub().getScope()?.getTransaction();
+
+    const sentrySpan = sentryTransaction?.startChild({
+      op: 'function',
+      description: 'SQLishFormatter.toFormat',
+      data: {
+        format,
+      },
+    });
+
     try {
       tokens = this.parser.parse(sql);
     } catch (error) {
@@ -42,6 +52,9 @@ export class SQLishFormatter {
       return sql;
     }
 
-    return FORMATTERS[format](tokens);
+    const formattedString = FORMATTERS[format](tokens);
+    sentrySpan?.finish();
+
+    return formattedString;
   }
 }

--- a/static/app/views/starfish/utils/sqlish/SQLishParser.spec.tsx
+++ b/static/app/views/starfish/utils/sqlish/SQLishParser.spec.tsx
@@ -48,17 +48,19 @@ describe('SQLishParser', function () {
     });
 
     it('Detects whitespace between generic tokens and JOIN commands', () => {
-      expect(parser.parse('table1 INNER JOIN table2')).toEqual([
+      expect(parser.parse('sentry_users INNER JOIN sentry_messages')).toEqual([
         {
           type: 'GenericToken',
-          content: 'table1',
+          content: 'sentry_users',
         },
         {type: 'Whitespace', content: ' '},
-        {type: 'Keyword', content: 'INNER JOIN'},
+        {type: 'Keyword', content: 'INNER'},
+        {type: 'Whitespace', content: ' '},
+        {type: 'Keyword', content: 'JOIN'},
         {type: 'Whitespace', content: ' '},
         {
           type: 'GenericToken',
-          content: 'table2',
+          content: 'sentry_messages',
         },
       ]);
     });

--- a/static/app/views/starfish/utils/sqlish/formatters/simpleMarkup.tsx
+++ b/static/app/views/starfish/utils/sqlish/formatters/simpleMarkup.tsx
@@ -3,19 +3,19 @@ import type {Token} from 'sentry/views/starfish/utils/sqlish/types';
 export function simpleMarkup(tokens: Token[]): React.ReactElement[] {
   const accumulator: React.ReactElement[] = [];
 
-  function contentize(content: Token): void {
-    if (Array.isArray(content.content)) {
-      content.content.forEach(contentize);
+  function contentize(token: Token): void {
+    if (Array.isArray(token.content)) {
+      token.content.forEach(contentize);
       return;
     }
 
-    if (typeof content.content === 'string') {
-      if (content.type === 'Keyword') {
-        accumulator.push(<b>{content.content.toUpperCase()}</b>);
-      } else if (content.type === 'Whitespace') {
+    if (typeof token.content === 'string') {
+      if (token.type === 'Keyword') {
+        accumulator.push(<b>{token.content.toUpperCase()}</b>);
+      } else if (token.type === 'Whitespace') {
         accumulator.push(<span> </span>);
       } else {
-        accumulator.push(<span>{content.content}</span>);
+        accumulator.push(<span>{token.content}</span>);
       }
     }
 

--- a/static/app/views/starfish/utils/sqlish/formatters/string.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/string.ts
@@ -3,24 +3,73 @@ import type {Token} from 'sentry/views/starfish/utils/sqlish/types';
 export function string(tokens: Token[]): string {
   let accumulator = '';
 
+  let precedingNonWhitespaceToken: Token | undefined = undefined;
+  let indentation: number = 0; // Track the current indent level
+  let parenthesisLevel: number = 0; // Tracks the current parenthesis nesting level
+  const indentationLevels: number[] = []; // Tracks the parenthesis nesting levels at which we've incremented the indentation
+
   function contentize(token: Token): void {
     if (Array.isArray(token.content)) {
       token.content.forEach(contentize);
       return;
     }
 
+    if (token.type === 'LeftParenthesis') {
+      parenthesisLevel += 1;
+      accumulator += '(';
+
+      // If the previous legible token is a meaningful keyword that triggers a
+      // newline, increase the current indentation level and note the parenthesis level where this happened
+      if (
+        precedingNonWhitespaceToken &&
+        typeof precedingNonWhitespaceToken.content === 'string' &&
+        PARENTHESIS_NEWLINE_KEYWORDS.has(precedingNonWhitespaceToken.content)
+      ) {
+        accumulator += '\n';
+
+        indentation += 1;
+        indentationLevels.push(parenthesisLevel);
+      }
+    }
+
+    if (token.type === 'RightParenthesis') {
+      // If this right parenthesis closes a left parenthesis at a level where
+      // we incremented the indentation, decrement the indentation
+      if (indentationLevels.at(-1) === parenthesisLevel) {
+        accumulator += '\n';
+        indentation -= 1;
+        accumulator += INDENTATION.repeat(indentation);
+        indentationLevels.pop();
+      }
+
+      parenthesisLevel -= 1;
+      accumulator += ')';
+    }
+
     if (typeof token.content === 'string') {
       if (token.type === 'Keyword' && NEWLINE_KEYWORDS.has(token.content)) {
-        accumulator += '\n';
+        if (!accumulator.endsWith('\n')) {
+          accumulator += '\n';
+        }
+
+        accumulator += INDENTATION.repeat(indentation);
         accumulator += token.content;
       } else if (token.type === 'Whitespace') {
         // Convert all whitespace to single spaces
         accumulator += ' ';
+      } else if (['LeftParenthesis', 'RightParenthesis'].includes(token.type)) {
+        // Parenthesis contents are appended above, so we can skip them here
+        accumulator += '';
       } else {
+        if (accumulator.endsWith('\n')) {
+          accumulator += INDENTATION.repeat(indentation);
+        }
         accumulator += token.content;
       }
+    }
 
-      return;
+    if (token.type !== 'Whitespace') {
+      precedingNonWhitespaceToken = token;
     }
 
     return;
@@ -30,17 +79,25 @@ export function string(tokens: Token[]): string {
   return accumulator.trim();
 }
 
+const INDENTATION = '  ';
+
+// Keywords that always trigger a newline
 const NEWLINE_KEYWORDS = new Set([
   'DELETE',
   'FROM',
   'GROUP',
+  'INNER',
   'INSERT',
+  'LEFT',
   'LIMIT',
   'OFFSET',
-  'ON',
   'ORDER',
   'RETURNING',
+  'RIGHT',
   'SELECT',
   'VALUES',
   'WHERE',
 ]);
+
+// Keywords that may or may not trigger a newline, but they always trigger a newlines if followed by a parenthesis
+const PARENTHESIS_NEWLINE_KEYWORDS = new Set([...NEWLINE_KEYWORDS, ...['IN']]);

--- a/static/app/views/starfish/utils/sqlish/formatters/string.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/string.ts
@@ -4,7 +4,7 @@ export function string(tokens: Token[]): string {
   const accumulator = new StringAccumulator();
 
   let precedingNonWhitespaceToken: Token | undefined = undefined;
-  let indentation: number = 0; // Track the current indent level
+  let indentation: number = 0; // Tracks the current indent level
   let parenthesisLevel: number = 0; // Tracks the current parenthesis nesting level
   const indentationLevels: number[] = []; // Tracks the parenthesis nesting levels at which we've incremented the indentation
 

--- a/static/app/views/starfish/utils/sqlish/formatters/string.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/string.ts
@@ -21,8 +21,7 @@ export function string(tokens: Token[]): string {
       // If the previous legible token is a meaningful keyword that triggers a
       // newline, increase the current indentation level and note the parenthesis level where this happened
       if (
-        precedingNonWhitespaceToken &&
-        typeof precedingNonWhitespaceToken.content === 'string' &&
+        typeof precedingNonWhitespaceToken?.content === 'string' &&
         PARENTHESIS_NEWLINE_KEYWORDS.has(precedingNonWhitespaceToken.content)
       ) {
         accumulator += '\n';

--- a/static/app/views/starfish/utils/sqlish/formatters/string.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/string.ts
@@ -10,8 +10,7 @@ export function string(tokens: Token[]): string {
     }
 
     if (typeof content.content === 'string') {
-      if (content.type === 'Keyword') {
-        // Break up the string on newlines
+      if (content.type === 'Keyword' && NEWLINE_KEYWORDS.has(content.content)) {
         accumulator += '\n';
         accumulator += content.content;
       } else if (content.type === 'Whitespace') {
@@ -30,3 +29,18 @@ export function string(tokens: Token[]): string {
   tokens.forEach(contentize);
   return accumulator.trim();
 }
+
+const NEWLINE_KEYWORDS = new Set([
+  'DELETE',
+  'FROM',
+  'GROUP',
+  'INSERT',
+  'LIMIT',
+  'OFFSET',
+  'ON',
+  'ORDER',
+  'RETURNING',
+  'SELECT',
+  'VALUES',
+  'WHERE',
+]);

--- a/static/app/views/starfish/utils/sqlish/formatters/string.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/string.ts
@@ -3,21 +3,21 @@ import type {Token} from 'sentry/views/starfish/utils/sqlish/types';
 export function string(tokens: Token[]): string {
   let accumulator = '';
 
-  function contentize(content: Token): void {
-    if (Array.isArray(content.content)) {
-      content.content.forEach(contentize);
+  function contentize(token: Token): void {
+    if (Array.isArray(token.content)) {
+      token.content.forEach(contentize);
       return;
     }
 
-    if (typeof content.content === 'string') {
-      if (content.type === 'Keyword' && NEWLINE_KEYWORDS.has(content.content)) {
+    if (typeof token.content === 'string') {
+      if (token.type === 'Keyword' && NEWLINE_KEYWORDS.has(token.content)) {
         accumulator += '\n';
-        accumulator += content.content;
-      } else if (content.type === 'Whitespace') {
+        accumulator += token.content;
+      } else if (token.type === 'Whitespace') {
         // Convert all whitespace to single spaces
         accumulator += ' ';
       } else {
-        accumulator += content.content;
+        accumulator += token.content;
       }
 
       return;

--- a/static/app/views/starfish/utils/sqlish/formatters/string.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/string.ts
@@ -24,7 +24,7 @@ export function string(tokens: Token[]): string {
         typeof precedingNonWhitespaceToken?.content === 'string' &&
         PARENTHESIS_NEWLINE_KEYWORDS.has(precedingNonWhitespaceToken.content)
       ) {
-        accumulator += '\n';
+        accumulator += NEWLINE;
 
         indentation += 1;
         indentationLevels.push(parenthesisLevel);
@@ -35,7 +35,7 @@ export function string(tokens: Token[]): string {
       // If this right parenthesis closes a left parenthesis at a level where
       // we incremented the indentation, decrement the indentation
       if (indentationLevels.at(-1) === parenthesisLevel) {
-        accumulator += '\n';
+        accumulator += NEWLINE;
         indentation -= 1;
         accumulator += INDENTATION.repeat(indentation);
         indentationLevels.pop();
@@ -47,8 +47,8 @@ export function string(tokens: Token[]): string {
 
     if (typeof token.content === 'string') {
       if (token.type === 'Keyword' && NEWLINE_KEYWORDS.has(token.content)) {
-        if (!accumulator.endsWith('\n')) {
-          accumulator += '\n';
+        if (!accumulator.endsWith(NEWLINE)) {
+          accumulator += NEWLINE;
         }
 
         accumulator += INDENTATION.repeat(indentation);
@@ -60,7 +60,7 @@ export function string(tokens: Token[]): string {
         // Parenthesis contents are appended above, so we can skip them here
         accumulator += '';
       } else {
-        if (accumulator.endsWith('\n')) {
+        if (accumulator.endsWith(NEWLINE)) {
           accumulator += INDENTATION.repeat(indentation);
         }
         accumulator += token.content;
@@ -79,6 +79,7 @@ export function string(tokens: Token[]): string {
 }
 
 const INDENTATION = '  ';
+const NEWLINE = '\n';
 
 // Keywords that always trigger a newline
 const NEWLINE_KEYWORDS = new Set([

--- a/static/app/views/starfish/utils/sqlish/sqlish.pegjs
+++ b/static/app/views/starfish/utils/sqlish/sqlish.pegjs
@@ -11,7 +11,7 @@ RightParenthesis
   = ")" { return { type: 'RightParenthesis', content: ')' } }
 
 Keyword
-  = Keyword:("SELECT"i / "INSERT"i / "DELETE"i / "FROM"i / "ON"i / "WHERE"i / "AND"i / "ORDER BY"i / "LIMIT"i / "GROUP BY"i / "OFFSET"i / "VALUES"i / "RETURNING"i / JoinKeyword) {
+  = Keyword:("ADD"i / "ALL"i / "ALTER"i / "AND"i / "ANY"i / "AS"i / "ASC"i / "BACKUP"i / "BETWEEN"i / "BY"i / "CASE"i / "CHECK"i / "COLUMN"i / "CONSTRAINT"i / "COUNT"i / "CREATE"i / "DATABASE"i / "DEFAULT"i / "DELETE"i / "DESC"i / "DISTINCT"i / "DROP"i / "EXEC"i / "EXISTS"i / "FOREIGN"i / "FROM"i / "FROM"i / "FULL"i / "GROUP"i / "HAVING"i / "INNER"i / "INSERT"i / "JOIN"i / "KEY"i / "LEFT"i / "LIMIT"i / "OFFSET"i / "ON"i / "ORDER"i / "OUTER"i / "RETURNING"i / "RIGHT"i / "SELECT"i / "SELECT"i / "TABLE"i / "UPDATE"i / "VALUES"i / "WHERE"i / JoinKeyword) {
   return { type: 'Keyword', content: Keyword }
 }
 

--- a/static/app/views/starfish/utils/sqlish/sqlish.pegjs
+++ b/static/app/views/starfish/utils/sqlish/sqlish.pegjs
@@ -2,7 +2,7 @@ Expression
    = tokens:Token*
 
 Token
-   = LeftParenthesis / RightParenthesis / Whitespace / Keyword / Parameter / CollapsedColumns / GenericToken
+  = LeftParenthesis / RightParenthesis / Whitespace / Keyword / Parameter / CollapsedColumns / GenericToken
 
 LeftParenthesis
   = "(" { return { type: 'LeftParenthesis', content: '(' } }
@@ -21,10 +21,10 @@ JoinKeyword
 }
 
 JoinDirection
- = "LEFT"i / "RIGHT"i / "FULL"i
+  = "LEFT"i / "RIGHT"i / "FULL"i
 
 JoinType
-= "OUTER"i / "INNER"i
+  = "OUTER"i / "INNER"i
 
 Parameter
   = Parameter:("%s" / ":c" [0-9]) { return { type: 'Parameter', content: Array.isArray(Parameter) ? Parameter.join('') : Parameter } }

--- a/static/app/views/starfish/utils/sqlish/sqlish.pegjs
+++ b/static/app/views/starfish/utils/sqlish/sqlish.pegjs
@@ -2,7 +2,13 @@ Expression
    = tokens:Token*
 
 Token
-   = Whitespace / Keyword / Parameter / CollapsedColumns / GenericToken
+   = LeftParenthesis / RightParenthesis / Whitespace / Keyword / Parameter / CollapsedColumns / GenericToken
+
+LeftParenthesis
+  = "(" { return { type: 'LeftParenthesis', content: '(' } }
+
+RightParenthesis
+  = ")" { return { type: 'RightParenthesis', content: ')' } }
 
 Keyword
   = Keyword:("SELECT"i / "INSERT"i / "DELETE"i / "FROM"i / "ON"i / "WHERE"i / "AND"i / "ORDER BY"i / "LIMIT"i / "GROUP BY"i / "OFFSET"i / "VALUES"i / "RETURNING"i / JoinKeyword) {
@@ -30,4 +36,4 @@ Whitespace
   = Whitespace:[\n\t ]+ { return { type: 'Whitespace', content: Whitespace.join("") } }
 
 GenericToken
-  = GenericToken:[a-zA-Z0-9"'`_\-.()=><:,*;!\[\]?$%|/]+ { return { type: 'GenericToken', content: GenericToken.join('') } }
+  = GenericToken:[a-zA-Z0-9"'`_\-.=><:,*;!\[\]?$%|/]+ { return { type: 'GenericToken', content: GenericToken.join('') } }

--- a/static/app/views/starfish/utils/sqlish/types.ts
+++ b/static/app/views/starfish/utils/sqlish/types.ts
@@ -1,4 +1,11 @@
 export interface Token {
-  type: 'Keyword' | 'Parameter' | 'CollapsedColumns' | 'Whitespace' | 'GenericToken';
+  type:
+    | 'LeftParenthesis'
+    | 'RightParenthesis'
+    | 'Whitespace'
+    | 'Keyword'
+    | 'Parameter'
+    | 'CollapsedColumns'
+    | 'GenericToken';
   content?: string | Token | Token[];
 }


### PR DESCRIPTION
Improves `SQLishFormatter` with an indentation heuristic. Manages auto-indenting by automatically incrementing indenting for expressions in parentheses that follow important keywords.

This ended up being a real rabbit hole. I first tried to do this by improving the PEG definition, but lazy/greedy behaviour in PEG can only be expressed recursively and the whole point was to keep the grammar simple so parsing is fast. Heuristics based on tokenized output are simpler (even though the code looks a little gross).

The instrumentation will help us suss out whether it's in fact fast. A good next step might be to auto-break long lines, but that feels much less important.

**Before:**
<img width="531" alt="Screenshot 2023-08-09 at 3 19 30 PM" src="https://github.com/getsentry/sentry/assets/989898/41fc5c4b-a1fa-48d6-a62d-c02d57717b02">

**After:**
<img width="678" alt="Screenshot 2023-08-09 at 3 24 32 PM" src="https://github.com/getsentry/sentry/assets/989898/27ef9b59-5113-42df-806d-292762bd7317">


## Changes

- Explicitly parse parentheses
- Fix indentation
- Only add newlines on specific keywords
- Add more keywords
- Rename ambiguous variable
- Add an indentation heuristic
- Add instrumentation
- Use an explicit accumulator class
