### PR TITLE
ref(backup): Encapsulate old import config

### DIFF
--- a/fixtures/backup/fresh-install.json
+++ b/fixtures/backup/fresh-install.json
@@ -134,9 +134,7 @@
   "model": "sentry.useremail",
   "pk": 1,
   "fields": {
-    "user": [
-      "testing@example.com"
-    ],
+    "user": 1,
     "email": "testing@example.com",
     "validation_hash": "mCnWesSVvYQcq7qXQ36AZHwosAd6cghE",
     "date_hash_added": "2023-06-22T22:59:55.521Z",
@@ -159,9 +157,7 @@
   "fields": {
     "date_updated": "2023-06-22T23:00:00.123Z",
     "date_added": "2023-06-22T22:59:57.000Z",
-    "user": [
-      "testing@example.com"
-    ],
+    "user": 1,
     "role": 1
   }
 },

--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -10,7 +10,6 @@ from django.db import models
 from sentry.backup.findings import ComparatorFinding, ComparatorFindingKind, InstanceID
 from sentry.backup.helpers import Side, get_exportable_final_derivations_of
 from sentry.db.models import BaseModel
-from sentry.db.models.fields.foreignkey import FlexibleForeignKey
 from sentry.utils.json import JSONData
 
 
@@ -304,12 +303,6 @@ def auto_assign_email_obfuscating_comparators(comps: ComparatorMap) -> None:
         assign = set()
         for f in fields:
             if isinstance(f, models.EmailField):
-                assign.add(f.name)
-            elif isinstance(f, FlexibleForeignKey) and f.related_model.__name__ == "User":
-                assign.add(f.name)
-            elif isinstance(f, models.OneToOneField) and f.related_model.__name__ == "User":
-                assign.add(f.name)
-            elif isinstance(f, models.ManyToManyField) and f.related_model.__name__ == "User":
                 assign.add(f.name)
 
         if len(assign):

--- a/src/sentry/backup/exports.py
+++ b/src/sentry/backup/exports.py
@@ -35,6 +35,10 @@ class OldExportConfig(NamedTuple):
     # option.
     excluded_models: set[str] = set()
 
+    # Old exports use "natural" foreign keys, which in practice only changes how foreign keys into
+    # `sentry.User` are represented.
+    use_natural_foreign_keys: bool = False
+
 
 def exports(dest, old_config: OldExportConfig, indent: int, printer=click.echo):
     """Exports core data for the Sentry installation."""
@@ -59,6 +63,6 @@ def exports(dest, old_config: OldExportConfig, indent: int, printer=click.echo):
         yield_objects(),
         indent=indent,
         stream=dest,
-        use_natural_foreign_keys=True,
+        use_natural_foreign_keys=old_config.use_natural_foreign_keys,
         cls=DatetimeSafeDjangoJSONEncoder,
     )

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import click
 
 from sentry.backup.exports import OldExportConfig, exports
-from sentry.backup.imports import imports
+from sentry.backup.imports import OldImportConfig, imports
 from sentry.runner.decorators import configuration
 
 
@@ -14,7 +14,14 @@ from sentry.runner.decorators import configuration
 def import_(src, silent):
     """Imports core data for a Sentry installation."""
 
-    imports(src, (lambda *args, **kwargs: None) if silent else click.echo)
+    imports(
+        src,
+        OldImportConfig(
+            use_update_instead_of_create=True,
+            use_natural_foreign_keys=True,
+        ),
+        (lambda *args, **kwargs: None) if silent else click.echo,
+    )
 
 
 @click.command()
@@ -38,6 +45,7 @@ def export(dest, silent, indent, exclude):
         OldExportConfig(
             include_non_sentry_models=True,
             excluded_models=set(exclude),
+            use_natural_foreign_keys=True,
         ),
         indent,
         (lambda *args, **kwargs: None) if silent else click.echo,

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -9,7 +9,7 @@ from sentry.backup.comparators import ComparatorMap
 from sentry.backup.exports import OldExportConfig, exports
 from sentry.backup.findings import ComparatorFindings
 from sentry.backup.helpers import get_exportable_final_derivations_of, get_final_derivations_of
-from sentry.backup.imports import imports
+from sentry.backup.imports import OldImportConfig, imports
 from sentry.backup.validate import validate
 from sentry.silo import unguarded_write
 from sentry.testutils.factories import get_fixture_path
@@ -63,7 +63,7 @@ def import_export_then_validate(method_name: str) -> JSONData:
         with unguarded_write(using="default"), open(tmp_expect) as tmp_file:
             # Reset the Django database.
             call_command("flush", verbosity=0, interactive=False)
-            imports(tmp_file, NOOP_PRINTER)
+            imports(tmp_file, OldImportConfig(), NOOP_PRINTER)
 
         # Validate that the "expected" and "actual" JSON matches.
         actual = export_to_file(tmp_actual)
@@ -91,7 +91,7 @@ def import_export_from_fixture_then_validate(
 
     # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
     with unguarded_write(using="default"), open(fixture_file_path) as fixture_file:
-        imports(fixture_file, NOOP_PRINTER)
+        imports(fixture_file, OldImportConfig(), NOOP_PRINTER)
 
     res = validate(expect, export_to_file(tmp_path.joinpath("tmp_test_file.json")), map)
     if res.findings:

--- a/tests/sentry/backup/test_correctness.py
+++ b/tests/sentry/backup/test_correctness.py
@@ -348,62 +348,44 @@ def test_auto_assign_email_obfuscating_comparator(tmp_path):
     with open(get_fixture_path("backup", "single-option.json")) as backup_file:
         left = json.load(backup_file)
     right = deepcopy(left)
-    useremail_left = json.loads(
+    email_left = json.loads(
         """
             {
-                "model": "sentry.useremail",
+                "model": "sentry.email",
                 "pk": 1,
                 "fields": {
-                    "user": [
-                        "testing@example.com"
-                    ],
                     "email": "testing@example.com",
-                    "validation_hash": "XXXXXXXX",
-                    "date_hash_added": "2023-06-22T00:00:00.000Z",
-                    "is_verified": false
+                    "date_added": "2023-06-22T00:00:00.000Z"
                 }
             }
         """
     )
-    useremail_right = json.loads(
+    email_right = json.loads(
         """
             {
-                "model": "sentry.useremail",
+                "model": "sentry.email",
                 "pk": 1,
                 "fields": {
-                    "user": [
-                        "foo@example.fake"
-                    ],
                     "email": "foo@example.fake",
-                    "validation_hash": "XXXXXXXX",
-                    "date_hash_added": "2023-06-22T00:00:00.000Z",
-                    "is_verified": false
+                    "date_added": "2023-06-22T00:00:00.000Z"
                 }
             }
         """
     )
-    left.append(useremail_left)
-    right.append(useremail_right)
+    left.append(email_left)
+    right.append(email_right)
     out = validate(left, right)
     findings = out.findings
 
-    assert len(findings) == 2
+    assert len(findings) == 1
 
     assert findings[0].kind == ComparatorFindingKind.EmailObfuscatingComparator
-    assert findings[0].on == InstanceID("sentry.useremail", 1)
+    assert findings[0].on == InstanceID("sentry.email", 1)
     assert findings[0].left_pk == 1
     assert findings[0].right_pk == 1
     assert """`email`""" in findings[0].reason
     assert """left value ("t...@...le.com")""" in findings[0].reason
     assert """right value ("f...@...e.fake")""" in findings[0].reason
-
-    assert findings[1].kind == ComparatorFindingKind.EmailObfuscatingComparator
-    assert findings[1].on == InstanceID("sentry.useremail", 1)
-    assert findings[0].left_pk == 1
-    assert findings[0].right_pk == 1
-    assert """`user`""" in findings[1].reason
-    assert """left value ("t...@...le.com")""" in findings[1].reason
-    assert """right value ("f...@...e.fake")""" in findings[1].reason
 
 
 def test_auto_assign_date_added_comparator(tmp_path):


### PR DESCRIPTION
There are a number of properties of the import system API that we'd like to eventually change. These include:

- Using `INSERT` rather than `INSERT_OR_UPDATE` semantics for import operations.
- Using natural foreign keys (currently only relevant to the `sentry.User` model).

To keep the original behavior export system intact until we debut these changes, this commit hides the behind `OldImportConfig`, which allows them to be toggled on (for tests) but left off for the actual CLI tool (for now).

Issue: getsentry/team-ospo#171
Issue: getsentry/team-ospo#184