### PR TITLE
fix(issue-details): Hide scraping event error

### DIFF
--- a/static/app/components/events/eventErrors.tsx
+++ b/static/app/components/events/eventErrors.tsx
@@ -37,6 +37,7 @@ const ERRORS_TO_HIDE = [
   JavascriptProcessingErrors.JS_INVALID_SOURCEMAP_LOCATION,
   JavascriptProcessingErrors.JS_TOO_MANY_REMOTE_SOURCES,
   JavascriptProcessingErrors.JS_INVALID_SOURCE_ENCODING,
+  JavascriptProcessingErrors.JS_SCRAPING_DISABLED,
   GenericSchemaErrors.UNKNOWN_ERROR,
   GenericSchemaErrors.MISSING_ATTRIBUTE,
   NativeProcessingErrors.NATIVE_NO_CRASHED_THREAD,

--- a/static/app/constants/eventErrors.tsx
+++ b/static/app/constants/eventErrors.tsx
@@ -10,6 +10,7 @@ export enum JavascriptProcessingErrors {
   JS_INVALID_SOURCEMAP_LOCATION = 'js_invalid_sourcemap_location',
   JS_TOO_LARGE = 'js_too_large',
   JS_FETCH_TIMEOUT = 'js_fetch_timeout',
+  JS_SCRAPING_DISABLED = 'js_scraping_disabled',
 }
 
 export enum HttpProcessingErrors {


### PR DESCRIPTION
this pr hides the js_scraping_disabled event error. since a user has to manually turn scraping off, we shouldn't show an error just to tell them that's its off after they turned it off. 