### PR TITLE
fix(github-comments): use first() instead of get() when fetching PRs

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -78,7 +78,9 @@ def queue_comment_task_if_needed(
     merge_commit_sha = response[0]["merge_commit_sha"]
 
     pr_query = PullRequest.objects.filter(
-        organization_id=commit.organization_id, merge_commit_sha=merge_commit_sha
+        organization_id=commit.organization_id,
+        repository_id=commit.repository_id,
+        merge_commit_sha=merge_commit_sha,
     )
     if not pr_query.exists():
         logger.info(

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -93,7 +93,7 @@ def queue_comment_task_if_needed(
         )
         return
 
-    pr = pr_query[0]
+    pr = pr_query.first()
     if pr.date_added >= datetime.now(tz=timezone.utc) - timedelta(days=PR_COMMENT_WINDOW) and (
         not pr.pullrequestcomment_set.exists()
         or group_owner.group_id not in pr.pullrequestcomment_set.get().group_ids

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -91,7 +91,7 @@ def queue_comment_task_if_needed(
         )
         return
 
-    pr = pr_query.get()
+    pr = pr_query[0]
     if pr.date_added >= datetime.now(tz=timezone.utc) - timedelta(days=PR_COMMENT_WINDOW) and (
         not pr.pullrequestcomment_set.exists()
         or group_owner.group_id not in pr.pullrequestcomment_set.get().group_ids


### PR DESCRIPTION
We are currently seeing [this issue](https://sentry.sentry.io/issues/4299414147/?project=1) when we try to fetch a `PullRequest` for an `organization_id` + `merge_commit_sha` combo. It would be good to also filter by `repository_id` since we have that information from the commit, and fetch the first `PullRequest` if the query does return duplicates instead of calling `get()`.

I believe this is causing collisions because somehow multiple (probably duplicate) PRs have the same `merge_commit_shas` for a single organization. We currently only have a uniqueness constraint on the `PullRequest` table for `repository_id` + `key`. To add a uniqueness constraint on `organization_id` + `repository_id` + `key` we'd have to delete the duplicate rows first.