### PR TITLE
feat(opsgenie): add button for plugin migration

### DIFF
--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -194,7 +194,6 @@ class ConfigureIntegration extends DeprecatedAsyncView<Props, State> {
       provider &&
       provider.key === 'opsgenie' &&
       (plugins || []).find(this.isInstalledOpsgeniePlugin);
-    // console.log(this.props.organization.features);
     const action =
       provider && provider.key === 'pagerduty' ? (
         <AddIntegration

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -186,6 +186,10 @@ class ConfigureIntegration extends DeprecatedAsyncView<Props, State> {
       ['jira', 'jira_server'].includes(provider.key) &&
       (plugins || []).find(({id}) => id === 'jira');
     const shouldMigrateOpsgeniePlugin =
+      // feature flag for now
+      this.props.organization.features.includes(
+        'organizations:integrations-opsgenie-migration'
+      ) &&
       provider &&
       provider.key === 'opsgenie' &&
       (plugins || []).find(this.isInstalledOpsgeniePlugin);

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -165,13 +165,30 @@ class ConfigureIntegration extends DeprecatedAsyncView<Props, State> {
       addErrorMessage(t('Something went wrong! Please try again.'));
     }
   };
+
+  handleOpsgenieMigration = () => {
+    this.setState(
+      {
+        plugins: (this.state.plugins || []).filter(({id}) => id === 'opsgenie'),
+      },
+      () => addSuccessMessage(t("This doesn't do anything yet!"))
+    );
+  };
+
+  isInstalledOpsgeniePlugin = (plugin: PluginWithProjectList) => {
+    return plugin.id === 'opsgenie' && plugin.projectList.length >= 1;
+  };
+
   getAction = (provider: IntegrationProvider | undefined) => {
     const {integration, plugins} = this.state;
     const shouldMigrateJiraPlugin =
       provider &&
       ['jira', 'jira_server'].includes(provider.key) &&
       (plugins || []).find(({id}) => id === 'jira');
-
+    const shouldMigrateOpsgeniePlugin =
+      provider &&
+      provider.key === 'opsgenie' &&
+      (plugins || []).find(this.isInstalledOpsgeniePlugin);
     const action =
       provider && provider.key === 'pagerduty' ? (
         <AddIntegration
@@ -235,6 +252,41 @@ class ConfigureIntegration extends DeprecatedAsyncView<Props, State> {
         >
           Open in Discord
         </LinkButton>
+      ) : shouldMigrateOpsgeniePlugin ? (
+        <Access access={['org:integrations']}>
+          {({hasAccess}) => (
+            <Confirm
+              disabled={!hasAccess}
+              header="Migrate API Keys and Alert Rules from Opsgenie"
+              renderMessage={() => (
+                <Fragment>
+                  <p>
+                    {t(
+                      'This will automatically associate all the API keys and Alert Rules of your Opsgenie Plugins to this integration.'
+                    )}
+                  </p>
+                  <p>
+                    {t(
+                      'API keys will be automatically named after one of the projects with which they were associated.'
+                    )}
+                  </p>
+                  <p>
+                    {t(
+                      'Once the migration is complete, your Opsgenie Plugins will be disabled.'
+                    )}
+                  </p>
+                </Fragment>
+              )}
+              onConfirm={() => {
+                this.handleOpsgenieMigration();
+              }}
+            >
+              <Button priority="primary" size="md" disabled={!hasAccess}>
+                {t('Migrate Plugin')}
+              </Button>
+            </Confirm>
+          )}
+        </Access>
       ) : null;
 
     return action;

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -176,7 +176,11 @@ class ConfigureIntegration extends DeprecatedAsyncView<Props, State> {
   };
 
   isInstalledOpsgeniePlugin = (plugin: PluginWithProjectList) => {
-    return plugin.id === 'opsgenie' && plugin.projectList.length >= 1;
+    return (
+      plugin.id === 'opsgenie' &&
+      plugin.projectList.length >= 1 &&
+      plugin.projectList.find(({enabled}) => enabled === true)
+    );
   };
 
   getAction = (provider: IntegrationProvider | undefined) => {
@@ -186,13 +190,11 @@ class ConfigureIntegration extends DeprecatedAsyncView<Props, State> {
       ['jira', 'jira_server'].includes(provider.key) &&
       (plugins || []).find(({id}) => id === 'jira');
     const shouldMigrateOpsgeniePlugin =
-      // feature flag for now
-      this.props.organization.features.includes(
-        'organizations:integrations-opsgenie-migration'
-      ) &&
+      this.props.organization.features.includes('integrations-opsgenie-migration') &&
       provider &&
       provider.key === 'opsgenie' &&
       (plugins || []).find(this.isInstalledOpsgeniePlugin);
+    // console.log(this.props.organization.features);
     const action =
       provider && provider.key === 'pagerduty' ? (
         <AddIntegration


### PR DESCRIPTION
Add the button for migrating from plugin to integration to the Opsgenie config page. It doesn't do anything right now.

<img width="1624" alt="Screenshot 2023-08-10 at 8 43 05 AM" src="https://github.com/getsentry/sentry/assets/83109586/1b7a3ee9-39bc-401b-bbf4-d289b2b5ff63">
<img width="1624" alt="Screenshot 2023-08-10 at 8 43 20 AM" src="https://github.com/getsentry/sentry/assets/83109586/8eadae79-8078-489c-931d-62ea8a3d1a6e">
<img width="1512" alt="Screenshot 2023-08-10 at 8 43 40 AM" src="https://github.com/getsentry/sentry/assets/83109586/bb41bd42-e5bc-4fd0-9b91-878b5450b243">

Fixes ER-1824