### PR TITLE
feat(automator) Fix exit code when the configfile is invalid

### DIFF
--- a/src/sentry/runner/commands/configoptions.py
+++ b/src/sentry/runner/commands/configoptions.py
@@ -195,11 +195,11 @@ def patch(ctx) -> None:
     if invalid_options:
         status = "update_failed"
         amount = 2
-        ret_val = 1
+        ret_val = 2
     elif ctx.obj["drifted_options"]:
         status = "drift"
         amount = 2
-        ret_val = 1
+        ret_val = 2
     else:
         status = "success"
         amount = 1
@@ -282,11 +282,11 @@ def sync(ctx):
     if invalid_options:
         status = "update_failed"
         amount = 2
-        ret_val = 1
+        ret_val = 2
     elif drift_found:
         status = "drift"
         amount = 2
-        ret_val = 1
+        ret_val = 2
     else:
         status = "success"
         amount = 1

--- a/src/sentry/runner/commands/configoptions.py
+++ b/src/sentry/runner/commands/configoptions.py
@@ -195,12 +195,15 @@ def patch(ctx) -> None:
     if invalid_options:
         status = "update_failed"
         amount = 2
+        ret_val = 1
     elif ctx.obj["drifted_options"]:
         status = "drift"
         amount = 2
+        ret_val = 1
     else:
         status = "success"
         amount = 1
+        ret_val = 0
 
     metrics.incr(
         "options_automator.run",
@@ -208,6 +211,7 @@ def patch(ctx) -> None:
         tags={"status": status},
         sample_rate=1.0,
     )
+    exit(ret_val)
 
 
 @configoptions.command()
@@ -278,12 +282,15 @@ def sync(ctx):
     if invalid_options:
         status = "update_failed"
         amount = 2
+        ret_val = 1
     elif drift_found:
         status = "drift"
         amount = 2
+        ret_val = 1
     else:
         status = "success"
         amount = 1
+        ret_val = 0
 
     presenter_delegator.flush()
 
@@ -293,3 +300,5 @@ def sync(ctx):
         tags={"status": status},
         sample_rate=1.0,
     )
+
+    exit(ret_val)

--- a/tests/sentry/runner/commands/test_configoptions.py
+++ b/tests/sentry/runner/commands/test_configoptions.py
@@ -81,7 +81,7 @@ class ConfigOptionsTest(CliTestCase):
             assert not options.isset("list_option")
 
         def assert_output(rv):
-            assert rv.exit_code == 1, rv.output
+            assert rv.exit_code == 2, rv.output
 
             # The script produces log lines when DRIFT is detected. This
             # makes it easier to surface these as Sentry errors.
@@ -137,7 +137,7 @@ class ConfigOptionsTest(CliTestCase):
             ).read_text(),
         )
 
-        assert rv.exit_code == 1
+        assert rv.exit_code == 2
         assert options.get("int_option") == 40
         assert options.get("str_option") == "new value"
         assert options.get("map_option") == {
@@ -153,7 +153,7 @@ class ConfigOptionsTest(CliTestCase):
             "tests/sentry/runner/commands/valid_patch.yaml",
             "sync",
         )
-        assert rv.exit_code == 1, rv.output
+        assert rv.exit_code == 2, rv.output
         expected_output = "\n".join(
             [
                 ConsolePresenter.DRIFT_MSG % "drifted_option",
@@ -190,7 +190,7 @@ class ConfigOptionsTest(CliTestCase):
             "patch",
         )
 
-        assert rv.exit_code == 1, rv.output
+        assert rv.exit_code == 2, rv.output
 
         assert ConsolePresenter.SET_MSG % ("int_option", 50) in rv.output
         assert (

--- a/tests/sentry/runner/commands/test_configoptions.py
+++ b/tests/sentry/runner/commands/test_configoptions.py
@@ -81,7 +81,7 @@ class ConfigOptionsTest(CliTestCase):
             assert not options.isset("list_option")
 
         def assert_output(rv):
-            assert rv.exit_code == 0, rv.output
+            assert rv.exit_code == 1, rv.output
 
             # The script produces log lines when DRIFT is detected. This
             # makes it easier to surface these as Sentry errors.
@@ -137,7 +137,7 @@ class ConfigOptionsTest(CliTestCase):
             ).read_text(),
         )
 
-        assert rv.exit_code == 0
+        assert rv.exit_code == 1
         assert options.get("int_option") == 40
         assert options.get("str_option") == "new value"
         assert options.get("map_option") == {
@@ -153,7 +153,7 @@ class ConfigOptionsTest(CliTestCase):
             "tests/sentry/runner/commands/valid_patch.yaml",
             "sync",
         )
-        assert rv.exit_code == 0, rv.output
+        assert rv.exit_code == 1, rv.output
         expected_output = "\n".join(
             [
                 ConsolePresenter.DRIFT_MSG % "drifted_option",
@@ -190,7 +190,7 @@ class ConfigOptionsTest(CliTestCase):
             "patch",
         )
 
-        assert rv.exit_code == 0, rv.output
+        assert rv.exit_code == 1, rv.output
 
         assert ConsolePresenter.SET_MSG % ("int_option", 50) in rv.output
         assert (


### PR DESCRIPTION
Allow the caller to tell whether the config file was applied cleanly or not.
exit code = 0 -> it was clean
exit code = 2 -> invalid file. Some options have been applied but there are errors. Find them on stderr.
others -> script failed.