### PR TITLE
fix(guides): Better link hover styles

### DIFF
--- a/static/app/components/assistant/guideAnchor.tsx
+++ b/static/app/components/assistant/guideAnchor.tsx
@@ -271,6 +271,12 @@ const GuideContainer = styled('div')`
   background-color: ${p => p.theme.purple300};
   border-color: ${p => p.theme.purple300};
   color: ${p => p.theme.white};
+
+  a {
+    :hover {
+      color: ${p => p.theme.white};
+    }
+  }
 `;
 
 const GuideContent = styled('div')`


### PR DESCRIPTION
Before:

<img width="203" alt="CleanShot 2023-08-09 at 16 40 45@2x" src="https://github.com/getsentry/sentry/assets/10888943/5265cb2b-680f-4e77-bac4-49eefd54d498">

After:

<img width="228" alt="CleanShot 2023-08-09 at 16 41 00@2x" src="https://github.com/getsentry/sentry/assets/10888943/fcb8aa38-1f7c-42a5-93f7-f87254dba701">
