### PR TITLE
chore(hybrid-cloud): Prepare OrganizationAlertRuleAvailableActionIndexEndpoint for split db

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -67,17 +67,16 @@ def build_action_response(
 
     elif sentry_app_installation:
         action_response["sentryAppName"] = sentry_app_installation.sentry_app.name
-        action_response["sentryAppId"] = sentry_app_installation.sentry_app_id
+        action_response["sentryAppId"] = sentry_app_installation.sentry_app.id
         action_response["sentryAppInstallationUuid"] = sentry_app_installation.uuid
         action_response["status"] = SentryAppStatus.as_str(
             sentry_app_installation.sentry_app.status
         )
 
         # Sentry Apps can be alertable but not have an Alert Rule UI Component
-        # TODO: fix for hybrid cloud
-        component = sentry_app_installation.prepare_sentry_app_components("alert-rule-action")
+        component = sentry_app_installation.app_component
         if component:
-            action_response["settings"] = component.schema.get("settings", {})
+            action_response["settings"] = component.app_schema.get("settings", {})
 
     return action_response
 
@@ -111,7 +110,9 @@ class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
             # Add all alertable SentryApps to the list.
             elif registered_type.type == AlertRuleTriggerAction.Type.SENTRY_APP:
                 app_installations = app_service.get_installed_for_organization(
-                    organization_id=organization.id, is_alertable=True
+                    organization_id=organization.id,
+                    is_alertable=True,
+                    prepare_sentry_app_components_type="alert-rule-action",
                 )
                 actions += [
                     build_action_response(registered_type, sentry_app_installation=install)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 
 from rest_framework import status
@@ -17,10 +19,18 @@ from sentry.incidents.logic import (
 from sentry.incidents.models import AlertRuleTriggerAction
 from sentry.incidents.serializers import ACTION_TARGET_TYPE_TO_STRING
 from sentry.models import SentryAppInstallation
+from sentry.models.organization import Organization
+from sentry.services.hybrid_cloud.app.model import RpcSentryAppInstallation
+from sentry.services.hybrid_cloud.integration.model import RpcIntegration
+from sentry.services.hybrid_cloud.util import region_silo_function
 
 
+@region_silo_function
 def build_action_response(
-    registered_type, integration=None, organization=None, sentry_app_installation=None
+    registered_type,
+    integration: RpcIntegration | None = None,
+    organization: Organization | None = None,
+    sentry_app_installation: RpcSentryAppInstallation | None = None,
 ):
     """
     Build the "available action" objects for the API. Each one can have different fields.
@@ -72,7 +82,7 @@ def build_action_response(
 
 @region_silo_endpoint
 class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Fetches actions that an alert rule can perform for an organization
         """

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -35,7 +35,7 @@ from sentry.incidents.models import (
     IncidentTrigger,
     TriggerStatus,
 )
-from sentry.models import Actor, Integration, PagerDutyService, Project
+from sentry.models import Actor, PagerDutyService, Project
 from sentry.models.notificationaction import ActionService, ActionTarget
 from sentry.models.organization import Organization
 from sentry.search.events.builder import QueryBuilder

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -191,7 +191,7 @@ class SentryAppInstallation(ParanoidModel):
             for region_name in find_regions_for_orgs([self.organization_id])
         ]
 
-    def prepare_sentry_app_components(self, component_type, project=None, values=None):
+    def prepare_sentry_app_components(self, component_type: str, project=None, values=None):
         from sentry.models import SentryAppComponent
 
         try:

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -191,7 +191,7 @@ class SentryAppInstallation(ParanoidModel):
             for region_name in find_regions_for_orgs([self.organization_id])
         ]
 
-    def prepare_sentry_app_components(self, component_type: str, project=None, values=None):
+    def prepare_sentry_app_components(self, component_type: str):
         from sentry.models import SentryAppComponent
 
         try:
@@ -201,7 +201,7 @@ class SentryAppInstallation(ParanoidModel):
         except SentryAppComponent.DoesNotExist:
             return None
 
-        return self.prepare_ui_component(component, project, values)
+        return self.prepare_ui_component(component=component)
 
     def prepare_ui_component(self, component, project=None, values=None):
         return prepare_ui_component(

--- a/src/sentry/services/hybrid_cloud/app/impl.py
+++ b/src/sentry/services/hybrid_cloud/app/impl.py
@@ -70,11 +70,19 @@ class DatabaseBackedAppService(AppService):
             return None
 
     def get_installed_for_organization(
-        self, *, organization_id: int
+        self,
+        *,
+        organization_id: int,
+        is_alertable: Optional[bool] = None,
     ) -> List[RpcSentryAppInstallation]:
         installations = SentryAppInstallation.objects.get_installed_for_organization(
             organization_id
         ).select_related("sentry_app")
+        if is_alertable is not None:
+            installations = installations.filter(
+                sentry_app__is_alertable=is_alertable,
+            )
+
         fq = self._AppServiceFilterQuery()
         return [fq.serialize_rpc(i) for i in installations]
 

--- a/src/sentry/services/hybrid_cloud/app/model.py
+++ b/src/sentry/services/hybrid_cloud/app/model.py
@@ -48,7 +48,7 @@ class RpcSentryApp(RpcModel):
     is_unpublished: bool = False
     is_internal: bool = True
     is_publish_request_inprogress: bool = False
-    status: str = ""
+    status: int = 0
 
     def show_auth_info(self, access: Any) -> bool:
         encoded_scopes = set({"%s" % scope for scope in list(access.scopes)})

--- a/src/sentry/services/hybrid_cloud/app/model.py
+++ b/src/sentry/services/hybrid_cloud/app/model.py
@@ -72,6 +72,13 @@ class RpcSentryApp(RpcModel):
         return self.slug
 
 
+class RpcSentryAppComponent(RpcModel):
+    uuid: str = ""
+    sentry_app_id: int = -1
+    type: str = ""
+    app_schema: Mapping[str, Any] = Field(default_factory=dict)
+
+
 class RpcSentryAppInstallation(RpcModel):
     id: int = -1
     organization_id: int = -1
@@ -79,13 +86,7 @@ class RpcSentryAppInstallation(RpcModel):
     sentry_app: RpcSentryApp = Field(default_factory=lambda: RpcSentryApp())
     date_deleted: Optional[datetime.datetime] = None
     uuid: str = ""
-
-
-class RpcSentryAppComponent(RpcModel):
-    uuid: str = ""
-    sentry_app_id: int = -1
-    type: str = ""
-    app_schema: Mapping[str, Any] = Field(default_factory=dict)
+    app_component: Optional[RpcSentryAppComponent] = None
 
 
 class RpcAlertRuleActionResult(RpcModel):

--- a/src/sentry/services/hybrid_cloud/app/service.py
+++ b/src/sentry/services/hybrid_cloud/app/service.py
@@ -63,6 +63,7 @@ class AppService(RpcService):
         self,
         *,
         organization_id: int,
+        is_alertable: Optional[bool] = None,
     ) -> List[RpcSentryAppInstallation]:
         pass
 

--- a/src/sentry/services/hybrid_cloud/app/service.py
+++ b/src/sentry/services/hybrid_cloud/app/service.py
@@ -64,6 +64,7 @@ class AppService(RpcService):
         *,
         organization_id: int,
         is_alertable: Optional[bool] = None,
+        prepare_sentry_app_components_type: Optional[str] = None,
     ) -> List[RpcSentryAppInstallation]:
         pass
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -68,6 +68,7 @@ from sentry.incidents.models import (
 )
 from sentry.models import ActorTuple, Integration, OrganizationIntegration, PagerDutyService
 from sentry.models.actor import get_actor_id_for_user
+from sentry.services.hybrid_cloud.integration.serial import serialize_integration
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
@@ -1771,14 +1772,18 @@ class GetAvailableActionIntegrationsForOrgTest(TestCase):
     def test_registered(self):
         integration = Integration.objects.create(external_id="1", provider="slack")
         integration.add_organization(self.organization)
-        assert list(get_available_action_integrations_for_org(self.organization)) == [integration]
+        assert list(get_available_action_integrations_for_org(self.organization)) == [
+            serialize_integration(integration)
+        ]
 
     def test_mixed(self):
         integration = Integration.objects.create(external_id="1", provider="slack")
         integration.add_organization(self.organization)
         other_integration = Integration.objects.create(external_id="12345", provider="random")
         other_integration.add_organization(self.organization)
-        assert list(get_available_action_integrations_for_org(self.organization)) == [integration]
+        assert list(get_available_action_integrations_for_org(self.organization)) == [
+            serialize_integration(integration)
+        ]
 
     def test_disabled_integration(self):
         integration = Integration.objects.create(


### PR DESCRIPTION
1. Relevant tests pass in split database mode with `SENTRY_USE_SPLIT_DBS=1`.
2. Updated `OrganizationAlertRuleAvailableActionIndexEndpoint` endpoint to be region silo only.
3. Add serializer for `RpcSentryAppComponent`.
4. Add `app_component` attribute to `RpcSentryAppInstallation` to potentially reduce RPC calls.
5. Update `app_service.get_installed_for_organization` to prefetch and serialize `SentryAppComponent`.