### PR TITLE
feat(trends): Add top events query param

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -36,6 +36,7 @@ ANY = "any"
 TREND_TYPES = [IMPROVED, REGRESSION, ANY]
 
 DEFAULT_TOP_EVENTS_LIMIT = 45
+MAX_TOP_EVENTS_LIMIT = 1000
 EVENTS_PER_QUERY = 15
 DAY_GRANULARITY_IN_SECONDS = METRICS_GRANULARITIES[0]
 ONE_DAY_IN_SECONDS = 24 * 60 * 60  # 86,400 seconds
@@ -231,7 +232,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
         def get_event_stats_metrics(_, user_query, params, rollup, zerofill_results, __):
             top_event_limit = min(
                 int(request.GET.get("topEvents", DEFAULT_TOP_EVENTS_LIMIT)),
-                DEFAULT_TOP_EVENTS_LIMIT,
+                MAX_TOP_EVENTS_LIMIT,
             )
             # Fetch transactions names with the highest event count
             top_events = get_top_events(

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -35,7 +35,7 @@ REGRESSION = "regression"
 ANY = "any"
 TREND_TYPES = [IMPROVED, REGRESSION, ANY]
 
-TOP_EVENTS_LIMIT = 45
+DEFAULT_TOP_EVENTS_LIMIT = 45
 EVENTS_PER_QUERY = 15
 DAY_GRANULARITY_IN_SECONDS = METRICS_GRANULARITIES[0]
 ONE_DAY_IN_SECONDS = 24 * 60 * 60  # 86,400 seconds
@@ -233,7 +233,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             top_events = get_top_events(
                 user_query=user_query,
                 params=params,
-                event_limit=TOP_EVENTS_LIMIT,
+                event_limit=int(request.GET.get("topEvents", DEFAULT_TOP_EVENTS_LIMIT)),
                 referrer=Referrer.API_TRENDS_GET_EVENT_STATS_V2_TOP_EVENTS.value,
             )
 

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -229,11 +229,15 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             return formatted_results
 
         def get_event_stats_metrics(_, user_query, params, rollup, zerofill_results, __):
+            top_event_limit = min(
+                int(request.GET.get("topEvents", DEFAULT_TOP_EVENTS_LIMIT)),
+                DEFAULT_TOP_EVENTS_LIMIT,
+            )
             # Fetch transactions names with the highest event count
             top_events = get_top_events(
                 user_query=user_query,
                 params=params,
-                event_limit=int(request.GET.get("topEvents", DEFAULT_TOP_EVENTS_LIMIT)),
+                event_limit=top_event_limit,
                 referrer=Referrer.API_TRENDS_GET_EVENT_STATS_V2_TOP_EVENTS.value,
             )
 


### PR DESCRIPTION
If `topEvents` param is passed then it's used instead of the default top event count. This is done so that we can send a higher top event count for experiments.