### PR TITLE
feat(hybrid-cloud): Update tombstone service to be an RPC service

### DIFF
--- a/src/sentry/receivers/outbox/__init__.py
+++ b/src/sentry/receivers/outbox/__init__.py
@@ -65,7 +65,6 @@ def maybe_process_tombstone(model: Type[T], object_identifier: int) -> T | None:
     if instance := model.objects.filter(id=object_identifier).last():
         return instance
 
-    tombstone_service.record_remote_tombstone(
-        RpcTombstone(table_name=model._meta.db_table, identifier=object_identifier)
-    )
+    tombstone = RpcTombstone(table_name=model._meta.db_table, identifier=object_identifier)
+    tombstone_service.record_remote_tombstone(tombstone=tombstone)
     return None

--- a/src/sentry/services/hybrid_cloud/tombstone/service.py
+++ b/src/sentry/services/hybrid_cloud/tombstone/service.py
@@ -2,11 +2,9 @@
 #     from __future__ import annotations
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
-import abc
 from abc import abstractmethod
 from typing import cast
 
-from sentry.services.hybrid_cloud import silo_mode_delegation
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.services.hybrid_cloud.tombstone import RpcTombstone
 from sentry.silo import SiloMode

--- a/src/sentry/services/hybrid_cloud/tombstone/service.py
+++ b/src/sentry/services/hybrid_cloud/tombstone/service.py
@@ -4,8 +4,10 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 import abc
 from abc import abstractmethod
+from typing import cast
 
 from sentry.services.hybrid_cloud import silo_mode_delegation
+from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.services.hybrid_cloud.tombstone import RpcTombstone
 from sentry.silo import SiloMode
 
@@ -14,9 +16,21 @@ from sentry.silo import SiloMode
 # logic.  Basically, if you record a remote tombstone, you are implying the destination table_name exists, remotely.
 # Implementors should, thus, _not_ constraint these entries and gracefully handle version drift cases when the "mapping"
 # of who owns what models changes independent of the rollout of logic.
-class TombstoneService(abc.ABC):
+class TombstoneService(RpcService):
+    key = "tombstone_service"
+    local_mode = SiloMode.CONTROL
+
+    @classmethod
+    def get_local_implementation(cls) -> RpcService:
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            return region_impl()
+        elif SiloMode.get_current_mode() == SiloMode.CONTROL:
+            return control_impl()
+        return monolith_impl()
+
+    @rpc_method
     @abstractmethod
-    def record_remote_tombstone(self, tombstone: RpcTombstone) -> None:
+    def record_remote_tombstone(self, *, tombstone: RpcTombstone) -> None:
         pass
 
 
@@ -38,10 +52,4 @@ def monolith_impl() -> TombstoneService:
     return MonolithTombstoneService()
 
 
-tombstone_service: TombstoneService = silo_mode_delegation(
-    {
-        SiloMode.MONOLITH: monolith_impl,
-        SiloMode.REGION: region_impl,
-        SiloMode.CONTROL: control_impl,
-    }
-)
+tombstone_service: TombstoneService = cast(TombstoneService, TombstoneService.create_delegation())

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -14,10 +14,12 @@ from sentry.models import (
 from sentry.models.notificationsetting import NotificationSetting
 from sentry.models.projectteam import ProjectTeam
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
 
 
@@ -86,6 +88,7 @@ class TeamTest(TestCase):
             team.save()
 
 
+@region_silo_test(stable=True)
 class TransferTest(TestCase):
     def test_simple(self):
         user = self.create_user()
@@ -181,23 +184,28 @@ class TransferTest(TestCase):
         ).exists()
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class TeamDeletionTest(TestCase):
     def test_hybrid_cloud_deletion(self):
-        team = self.create_team(self.organization)
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.ALWAYS,
-            team_id=team.id,
-        )
+        org = self.create_organization()
+        team = self.create_team(org)
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.ALWAYS,
+                team_id=team.id,
+            )
 
         assert Team.objects.filter(id=team.id).exists()
-        assert NotificationSetting.objects.find_settings(
-            provider=ExternalProviders.EMAIL,
-            type=NotificationSettingTypes.ISSUE_ALERTS,
-            team_id=team.id,
-        ).exists()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert NotificationSetting.objects.find_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.ISSUE_ALERTS,
+                team_id=team.id,
+            ).exists()
 
         team_id = team.id
         with outbox_runner():
@@ -205,15 +213,25 @@ class TeamDeletionTest(TestCase):
 
         assert not Team.objects.filter(id=team_id).exists()
 
-        with self.tasks():
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            # cascade is asynchronous, ensure there is still related search,
+            assert NotificationSetting.objects.find_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.ISSUE_ALERTS,
+                team_id=team_id,
+            ).exists()
+
+        # Assume monolith silo mode to ensure all tasks are run correctly
+        with self.tasks(), assume_test_silo_mode(SiloMode.MONOLITH):
             schedule_hybrid_cloud_foreign_key_jobs()
 
         assert not Team.objects.filter(id=team_id).exists()
-        assert not NotificationSetting.objects.find_settings(
-            provider=ExternalProviders.EMAIL,
-            type=NotificationSettingTypes.ISSUE_ALERTS,
-            team_id=team_id,
-        ).exists()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert not NotificationSetting.objects.find_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.ISSUE_ALERTS,
+                team_id=team_id,
+            ).exists()
 
     def test_cannot_delete_last_owner_team(self):
         org = self.create_organization()

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -18,7 +18,6 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
 


### PR DESCRIPTION
1. Update tombstone service to be an RPC service.
2. Stabilize tests in `tests/sentry/models/test_team.py` and have them pass with `SENTRY_USE_SPLIT_DBS=1`.