### PR TITLE
fix: Signed urls and unsubscribe used wrong url prefix

### DIFF
--- a/src/sentry/utils/linksign.py
+++ b/src/sentry/utils/linksign.py
@@ -51,14 +51,12 @@ def process_signature(request, max_age=60 * 60 * 24 * 10):
     if not sig or sig.count(":") < 2:
         return None
 
-    request_absolute_uri = request.build_absolute_uri("/").rstrip("/")
+    url_prefix = options.get("system.url-prefix")
     request_path = request.path
-    signed_data = f"{request_absolute_uri}|{request_path}|{sig}"
+    signed_data = f"{url_prefix}|{request_path}|{sig}"
     try:
         data = get_signer().unsign(signed_data, max_age=max_age)
     except signing.BadSignature as e:
-        # We should plan on removing this after debugging the current issue -- it is an 'expected' exception and not
-        # actually exceptional.
         capture_exception(e)
         return None
 

--- a/tests/sentry/utils/test_linksign.py
+++ b/tests/sentry/utils/test_linksign.py
@@ -20,6 +20,14 @@ class LinkSignTestCase(TestCase):
         assert signed_user
         assert signed_user.id == self.user.id
 
+        with self.options({"system.url-prefix": "https://sentry.io"}):
+            url = linksign.generate_signed_link(self.user, "sentry")
+            assert url.startswith("https://")
+            req = rf.get("/" + url.split("/", 3)[-1])
+            signed_user = linksign.process_signature(req)
+            assert signed_user
+            assert signed_user.id == self.user.id
+
         req = rf.get("/what" + url.split("/", 3)[-1])
         signed_user = linksign.process_signature(req)
         assert signed_user is None


### PR DESCRIPTION
As revealed by https://sentry.sentry.io/issues/4384482676/?query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=8 

We have been signing our urls with `http` but then unsigning them with `https` due to differing helpers producing the base url.

Test added that reproduces the issue along with fix.