### PR TITLE
Add periodic task to backfill artifact bundle indexes

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -760,6 +760,7 @@ CELERY_IMPORTS = (
     "sentry.tasks.check_am2_compatibility",
     "sentry.dynamic_sampling.tasks.collect_orgs",
     "sentry.tasks.statistical_detectors",
+    "sentry.debug_files.tasks",
 )
 
 default_exchange = Exchange("default", type="direct")
@@ -1131,6 +1132,11 @@ CELERYBEAT_SCHEDULE_REGION = {
     "statistical-detectors-detect-regressions": {
         "task": "sentry.tasks.statistical_detectors.run_detection",
         "schedule": crontab(minute=0, hour="*/1"),
+    },
+    "backfill-artifact-bundle-index": {
+        "task": "sentry.debug_files.tasks.backfill_artifact_index_updates",
+        "schedule": crontab(minute="*/1"),
+        "options": {"expires": 60},
     },
 }
 

--- a/src/sentry/debug_files/tasks.py
+++ b/src/sentry/debug_files/tasks.py
@@ -1,0 +1,15 @@
+from sentry.tasks.base import instrumented_task
+
+
+@instrumented_task(
+    name="sentry.debug_files.tasks.backfill_artifact_index_updates",
+    queue="assemble",
+)
+def backfill_artifact_index_updates():
+    from .artifact_bundle_indexing import backfill_artifact_index_updates as do_backfill
+
+    # If we hit our batch size, immediately schedule the task again to continue backfilling.
+    # Otherwise, only relying on a timer would mean we would accumulate a backlog over time.
+    hit_batch_size = do_backfill()
+    if hit_batch_size:
+        backfill_artifact_index_updates.delay()

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -772,8 +772,8 @@ class ArtifactBundlePostAssembler(PostAssembler):
                 )
                 if not was_indexed:
                     metrics.incr("artifact_bundle_flat_file_indexing.indexing.would_block")
-                    # TODO: spawn an async task to backfill the indexing
-                    pass
+                    # NOTE: the `backfill_artifact_index_updates` will pick this up automatically,
+                    # no need to explicitly spawn any backfill task for this
             except Exception as e:
                 metrics.incr("artifact_bundle_flat_file_indexing.error_when_indexing")
                 sentry_sdk.capture_exception(e)


### PR DESCRIPTION
This is on top of https://github.com/getsentry/sentry/pull/54442,

This introduces a periodic task. This task will merge artifact bundles into the respective index they have been marked for, but not yet indexed. At the same time, it will also apply any removed that were scheduled for backfilling.