### PR TITLE
fix(perf-issues): Allow http timings small drift

### DIFF
--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -397,10 +397,19 @@ export function getSpanSubTimings(span: ProcessedSpanType): SubTimingInfo[] | nu
   const spanStart = subTimingMarkToTime(span, SpanSubTimingMark.SPAN_START);
   const spanEnd = subTimingMarkToTime(span, SpanSubTimingMark.SPAN_END);
 
+  const TEN_MS = 0.001;
+
   for (const def of timingDefinitions) {
     const start = subTimingMarkToTime(span, def.startMark);
     const end = subTimingMarkToTime(span, def.endMark);
-    if (!start || !end || !spanStart || !spanEnd || start < spanStart || end > spanEnd) {
+    if (
+      !start ||
+      !end ||
+      !spanStart ||
+      !spanEnd ||
+      start < spanStart - TEN_MS ||
+      end > spanEnd + TEN_MS
+    ) {
       return null;
     }
     timings.push({


### PR DESCRIPTION
### Summary
It seems there are times where the http timings are slightly off from span duration, in the millisecond range. This is likely due to the differences between timing the fetch operations and how PerformanceNetworkTiming works, but for now we can ease off the exit condition by a few milliseconds so we get subtimings when it's really close.

#### Screenshots
Timings won't get generated if they are outside the bounds of the span at all currently.
![Screenshot 2023-08-10 at 10 07 46 AM](https://github.com/getsentry/sentry/assets/6111995/82ab6c85-0941-435d-b0e8-c4b43caf6437)

