### PR TITLE
chore(hybridcloud) Move and expand the codeowners for hybrid cloud

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -115,20 +115,31 @@ yarn.lock                                                @getsentry/owners-js-de
 /static/fonts/                                           @getsentry/design
 /static/images/                                          @getsentry/design
 
-## Crons
-/static/app/views/monitors                                   @getsentry/crons
-/src/sentry/monitors                                         @getsentry/crons
-/tests/sentry/monitors                                       @getsentry/crons
-/src/sentry/utils/monitors.py                                @getsentry/crons
-/tests/sentry/utils/test_monitors.py                         @getsentry/crons
-
-
 # Owners by product feature
 #
 # The following ownership rules are specific to particular features of the
 # Sentry product. These rules generally map to a signle team, but that may not
 # always be the case.
 
+## Crons
+/static/app/views/monitors                               @getsentry/crons
+/src/sentry/monitors                                     @getsentry/crons
+/tests/sentry/monitors                                   @getsentry/crons
+/src/sentry/utils/monitors.py                            @getsentry/crons
+/tests/sentry/utils/test_monitors.py                     @getsentry/crons
+## End Crons
+
+
+## Hybrid Cloud
+/src/sentry/silo/                                        @getsentry/hybrid-cloud
+/src/sentry/services/hybrid_cloud/                       @getsentry/hybrid-cloud
+/src/sentry/api_gateway/                                 @getsentry/hybrid-cloud
+/src/sentry/middleware/api_gateway.py                    @getsentry/hybrid-cloud
+/src/sentry/middleware/customer_domain.py                @getsentry/hybrid-cloud
+/src/sentry/middleware/subdomain.py                      @getsentry/hybrid-cloud
+/src/sentry/middleware/integration/                      @getsentry/hybrid-cloud
+/src/sentry/api/endpoints/rpc.py                         @getsentry/hybrid-cloud
+## End of Hybrid Cloud
 
 ## Workflow
 /static/app/views/settings/projectAlerts/                 @getsentry/issues
@@ -455,9 +466,3 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/api/endpoints/source_map_debug.py                @getsentry/issues
 /src/sentry/api/helpers/source_map_helper.py                  @getsentry/issues
 ## End of Issues
-
-
-## Hybrid Cloud
-/src/sentry/silo/                     @getsentry/hybrid-cloud
-/src/sentry/services/hybrid_cloud/    @getsentry/hybrid-cloud
-## End of Hybrid Cloud


### PR DESCRIPTION
- Add more files that should be triaged to the hybrid cloud team
- Move our ownership rules up in the file so that we don't have to triage as many issues as the last matching ownership rule wins.
