### PR TITLE
ref(statistical-detectors): Generalize statistical detector helpers

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -7,9 +7,9 @@ from django.utils import timezone
 
 from sentry import options
 from sentry.models.project import Project
-from sentry.profiles.statistical_detectors import TrendPayload
 from sentry.snuba import functions
 from sentry.snuba.referrer import Referrer
+from sentry.statistical_detectors.detector import TrendPayload
 from sentry.tasks.base import instrumented_task
 
 logger = logging.getLogger("sentry.tasks.statistical_detectors")

--- a/tests/sentry/statistical_detectors/test_detector.py
+++ b/tests/sentry/statistical_detectors/test_detector.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from sentry.profiles.statistical_detectors import TrendPayload, TrendState, compute_new_trend_states
+from sentry.statistical_detectors.detector import TrendPayload, TrendState, compute_new_trend_states
 
 
 @pytest.mark.parametrize(
@@ -100,7 +100,7 @@ def test_trend_state(data, expected):
         ),
     ],
 )
-def test_run_functions_trend_detection(initial, p95s, regressed_indices, improved_indices):
+def test_run_trend_detection(initial, p95s, regressed_indices, improved_indices):
     states = [initial]
     all_regressed = []
     all_improved = []


### PR DESCRIPTION
These are no longer profiling specific and can be reused by performance as well. Move them out of the profiling folders.