### PR TITLE
feat(crons): Add option to toggle consumer driven task dispatch

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -961,14 +961,8 @@ CELERYBEAT_SCHEDULE_REGION = {
         "schedule": timedelta(seconds=30),
         "options": {"expires": 30},
     },
-    "check-monitors-missing": {
-        "task": "sentry.monitors.tasks.check_missing",
-        # Run every 1 minute
-        "schedule": crontab(minute="*/1"),
-        "options": {"expires": 60},
-    },
-    "check-monitors-timeout": {
-        "task": "sentry.monitors.tasks.check_timeout",
+    "monitors-temp-task-dispatcher": {
+        "task": "sentry.monitors.tasks.temp_task_dispatcher",
         # Run every 1 minute
         "schedule": crontab(minute="*/1"),
         "options": {"expires": 60},

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -17,7 +17,7 @@ from django.db import router, transaction
 from django.utils.text import slugify
 from typing_extensions import NotRequired
 
-from sentry import ratelimits
+from sentry import options, ratelimits
 from sentry.constants import ObjectStatus
 from sentry.killswitches import killswitch_matches_context
 from sentry.models import Project
@@ -32,6 +32,7 @@ from sentry.monitors.models import (
     MonitorLimitsExceeded,
     MonitorType,
 )
+from sentry.monitors.tasks import check_missing, check_timeout
 from sentry.monitors.utils import (
     get_new_timeout_at,
     get_timeout_at,
@@ -155,9 +156,7 @@ def _ensure_monitor_with_config(
 
 def _dispatch_tasks(ts: datetime):
     """
-    Dispatch monitor tasks triggered by the consumer clock. These will run
-    after the MONITOR_TASK_DELAY (in seconds), This is to give some breathing
-    room for check-ins to start and not be EXACTLY on the minute
+    Dispatch monitor tasks triggered by the consumer clock.
 
     These tasks are triggered via the consumer processing check-ins. This
     allows the monitor tasks to be synchronized to any backlog of check-ins
@@ -171,12 +170,11 @@ def _dispatch_tasks(ts: datetime):
     sentry.io, when we deploy we restart the celery beat worker and it will
     skip any tasks it missed)
     """
-    # For now we're going to have this do nothing. We want to validate that
-    # we're not going to be skipping any check-ins
-    return
+    if not options.get("monitors.use_consumer_clock_task_triggers"):
+        return
 
-    # check_missing.delay(current_datetime=ts)
-    # check_timeout.delay(current_datetime=ts)
+    check_missing.delay(current_datetime=ts)
+    check_timeout.delay(current_datetime=ts)
 
 
 def _try_monitor_tasks_trigger(ts: datetime):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1461,3 +1461,9 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "monitors.use_consumer_clock_task_triggers",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
allows us to switch over the monitors tasks to be driven via the clock