### PR TITLE
chore(statistical-detectors): Add separate queue for profiling

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -878,6 +878,7 @@ CELERY_QUEUES_REGION = [
     Queue("weekly_escalating_forecast", routing_key="weekly_escalating_forecast"),
     Queue("recap_servers", routing_key="recap_servers"),
     Queue("performance.statistical_detector", routing_key="performance.statistical_detector"),
+    Queue("profiling.statistical_detector", routing_key="profiling.statistical_detector"),
     CELERY_ISSUE_STATES_QUEUE,
 ]
 


### PR DESCRIPTION
This introduces a new celery queue for profiling statistical detectors. This allows us to separate the 2 use cases into different worker pools so they do not affect each other.