### PR TITLE
fix(hybridcloud) Make BroadcastIndex extend ControlSiloEndpoint

### DIFF
--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from functools import reduce
 from operator import or_
@@ -7,13 +9,14 @@ from django.db.models import Q
 from django.utils import timezone
 
 from sentry.api.base import control_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import AdminBroadcastSerializer, BroadcastSerializer, serialize
 from sentry.api.validators import AdminBroadcastValidator, BroadcastValidator
 from sentry.db.models.query import in_icontains
 from sentry.models import Broadcast, BroadcastSeen
 from sentry.search.utils import tokenize_query
+from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 
 logger = logging.getLogger("sentry")
 
@@ -23,7 +26,7 @@ from rest_framework.response import Response
 
 
 @control_silo_endpoint
-class BroadcastIndexEndpoint(OrganizationEndpoint):
+class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
     permission_classes = (OrganizationPermission,)
 
     def _get_serializer(self, request: Request):
@@ -45,7 +48,7 @@ class BroadcastIndexEndpoint(OrganizationEndpoint):
 
         return (args, kwargs)
 
-    def get(self, request: Request, organization=None) -> Response:
+    def get(self, request: Request, organization: RpcOrganization | None = None) -> Response:
         if request.GET.get("show") == "all" and request.access.has_permission("broadcasts.admin"):
             # superusers can slice and dice
             queryset = Broadcast.objects.all().order_by("-date_added")

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -48,7 +48,9 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
 
         return (args, kwargs)
 
-    def get(self, request: Request, organization: RpcOrganization | None = None) -> Response:
+    def get(
+        self, request: Request, organization: RpcOrganization | None = None, **kwargs
+    ) -> Response:
         if request.GET.get("show") == "all" and request.access.has_permission("broadcasts.admin"):
             # superusers can slice and dice
             queryset = Broadcast.objects.all().order_by("-date_added")


### PR DESCRIPTION
- Change base classes to one that uses RPC services to read organization data fixing a potential silo boundary issue.
- Add more types.
