### PR TITLE
chore(github-growth): auto repo linking analytics

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -76,3 +76,4 @@ from .sso_enabled import *  # noqa: F401,F403
 from .team_created import *  # noqa: F401,F403
 from .user_created import *  # noqa: F401,F403
 from .user_signup import *  # noqa: F401,F403
+from .webhook_repository_created import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/webhook_repository_created.py
+++ b/src/sentry/analytics/events/webhook_repository_created.py
@@ -1,0 +1,14 @@
+from sentry import analytics
+
+
+class WebHookRepositoryCreatedEvent(analytics.Event):
+    type = "webhook.repository_created"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("repository_id"),
+        analytics.Attribute("integration"),
+    )
+
+
+analytics.register(WebHookRepositoryCreatedEvent)

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -148,7 +148,7 @@ class PushEventWebhookTest(APITestCase):
         assert repos[0].external_id == "35129377"
         assert repos[0].provider == "integrations:github"
         assert repos[0].name == "baxterthehacker/public-repo"
-        mock_metrics.incr.assert_called_with("github.webhook.create_repository")
+        mock_metrics.incr.assert_called_with("github.webhook.repository_created")
 
     @with_feature("organizations:integrations-auto-repo-linking")
     def test_ignores_hidden_repo(self):
@@ -316,7 +316,7 @@ class PushEventWebhookTest(APITestCase):
             assert repo.external_id == "35129377"
             assert repo.provider == "integrations:github"
             assert repo.name == "baxterthehacker/public-repo"
-        mock_metrics.incr.assert_called_with("github.webhook.create_repository")
+        mock_metrics.incr.assert_called_with("github.webhook.repository_created")
 
     @with_feature("organizations:integrations-auto-repo-linking")
     def test_multiple_orgs_ignores_hidden_repo(self):
@@ -440,7 +440,7 @@ class PullRequestEventWebhook(APITestCase):
         assert repos[0].external_id == "35129377"
         assert repos[0].provider == "integrations:github"
         assert repos[0].name == "baxterthehacker/public-repo"
-        mock_metrics.incr.assert_called_with("github.webhook.create_repository")
+        mock_metrics.incr.assert_called_with("github.webhook.repository_created")
 
     @with_feature("organizations:integrations-auto-repo-linking")
     def test_ignores_hidden_repo(self):
@@ -499,7 +499,7 @@ class PullRequestEventWebhook(APITestCase):
             assert repo.external_id == "35129377"
             assert repo.provider == "integrations:github"
             assert repo.name == "baxterthehacker/public-repo"
-        mock_metrics.incr.assert_called_with("github.webhook.create_repository")
+        mock_metrics.incr.assert_called_with("github.webhook.repository_created")
 
     @with_feature("organizations:integrations-auto-repo-linking")
     def test_multiple_orgs_ignores_hidden_repo(self):


### PR DESCRIPTION
Emit an analytics event when a Github repository is automatically linked through a webhook.