### PR TITLE
fix(starfish): Allow parsing @ signs in SQL

### DIFF
--- a/static/app/views/starfish/utils/sqlish/SQLishParser.spec.tsx
+++ b/static/app/views/starfish/utils/sqlish/SQLishParser.spec.tsx
@@ -21,6 +21,7 @@ describe('SQLishParser', function () {
       'LIMIT $2', // PHP-style II
       'created >= %s', // Python-style
       'created >= $1', // Rails-style
+      '@@ to_tsquery', // Postgres full-text search
     ])('Parses %s', sql => {
       expect(() => {
         parser.parse(sql);

--- a/static/app/views/starfish/utils/sqlish/sqlish.pegjs
+++ b/static/app/views/starfish/utils/sqlish/sqlish.pegjs
@@ -36,4 +36,4 @@ Whitespace
   = Whitespace:[\n\t ]+ { return { type: 'Whitespace', content: Whitespace.join("") } }
 
 GenericToken
-  = GenericToken:[a-zA-Z0-9"'`_\-.=><:,*;!\[\]?$%|/]+ { return { type: 'GenericToken', content: GenericToken.join('') } }
+  = GenericToken:[a-zA-Z0-9"'`_\-.=><:,*;!\[\]?$%|/@]+ { return { type: 'GenericToken', content: GenericToken.join('') } }


### PR DESCRIPTION
`@` is a valid symbol in lots of SQL dialects for lots of reasons. Closes JAVASCRIPT-2NHT
