### PR TITLE
fix(search): minor cleanup of side query code

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -40,6 +40,7 @@ from sentry.search.events.constants import EQUALITY_OPERATORS, OPERATOR_TO_DJANG
 from sentry.search.snuba.executors import (
     AbstractQueryExecutor,
     CdcPostgresSnubaQueryExecutor,
+    InvalidQueryForExecutor,
     PostgresSnubaQueryExecutor,
     PrioritySortWeights,
 )
@@ -339,6 +340,11 @@ def _group_attributes_side_query(
                     "snuba.search.group_attributes_joined.events_compared",
                     tags={"comparison": comparison},
                 )
+        except InvalidQueryForExecutor:
+            logging.info(
+                "unsupported query received in GroupAttributesPostgresSnubaQueryExecutor",
+                exc_info=True,
+            )
         except Exception:
             logging.warning(
                 "failed to load side query from _group_attributes_side_query", exc_info=True

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2606,9 +2606,9 @@ class EventsJoinedGroupAttributesSnubaSearchTest(TransactionTestCase, EventsSnub
 
     @mock.patch("sentry.utils.metrics.timer")
     @mock.patch("sentry.utils.metrics.incr")
-    def test_empty_query_logs_metric(self, metrics_incr, metrics_timer):
-        results = self.make_query()
-        assert set(results) == {self.group1, self.group2}
+    def test_is_unresolved_query_logs_metric(self, metrics_incr, metrics_timer):
+        results = self.make_query(search_filter_query="is:unresolved")
+        assert set(results) == {self.group1}
 
         # introduce a slight delay so the async future has time to run and log the metric
         time.sleep(0.10)


### PR DESCRIPTION
Mostly fixing the test to verify the side query is properly running when a search query `is:unresolved` comes through. 