### PR TITLE
feat(performance-detector-thresholds-configs): Returning superuser-required code with 403 response.

### DIFF
--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -205,14 +205,21 @@ class ProjectPerformanceIssueSettingsEndpoint(ProjectEndpoint):
         )
         if body_has_invalid_options:
             return Response(
-                {"detail": "Invalid settings option"},
+                {
+                    "detail": "Invalid settings option",
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
         body_has_admin_options = any([option in request.data for option in internal_only_settings])
         if body_has_admin_options and not is_active_superuser(request):
             return Response(
-                {"detail": "Passed options are only modifiable internally"},
+                {
+                    "detail": {
+                        "message": "Passed options are only modifiable internally",
+                        "code": "superuser-required",
+                    },
+                },
                 status=status.HTTP_403_FORBIDDEN,
             )
 

--- a/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
+++ b/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
@@ -161,7 +161,12 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
             )
 
         assert response.status_code == 403, response.content
-        assert response.data == {"detail": "Passed options are only modifiable internally"}
+        assert response.data == {
+            "detail": {
+                "message": "Passed options are only modifiable internally",
+                "code": "superuser-required",
+            },
+        }
 
     def test_put_super_user_updates_detection_setting(self):
         with self.feature(PERFORMANCE_ISSUE_FEATURES):


### PR DESCRIPTION
There is a mismatch between the frontend and backend checks for active-superusers. Returning "superuser-required" code with the 403 response opens up the sudo modal, allowing people who see the internal detection enabling/disabling ui to quickly re-authenticate as an active super user and make a change. 
<img width="624" alt="Screenshot 2023-08-10 at 4 17 27 PM" src="https://github.com/getsentry/sentry/assets/60121741/9071febb-2bf0-4399-9613-c8164af8d467">
<img width="658" alt="Screenshot 2023-08-10 at 4 15 42 PM" src="https://github.com/getsentry/sentry/assets/60121741/163a17c3-6099-4b59-a06b-6feeda25867e">

For project: [Detector Threshold Configurations](https://www.notion.so/sentry/Detector-Threshold-Configuration-f8cb07e7cceb42388cedb09ea05fc116)