### PR TITLE
chore(profiling): Tie profiling feature to performance feature

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -331,7 +331,7 @@ function Sidebar({location, organization}: Props) {
   const profiling = hasOrganization && (
     <Feature
       hookName="feature-disabled:profiling-sidebar-item"
-      features={['profiling']}
+      features={['performance-view', 'profiling']}
       organization={organization}
       requireAll={false}
     >

--- a/static/app/views/profiling/index.tsx
+++ b/static/app/views/profiling/index.tsx
@@ -15,13 +15,14 @@ function ProfilingContainer({children}: Props) {
   return (
     <Feature
       hookName="feature-disabled:profiling-page"
-      features={['profiling']}
+      features={['performance-view', 'profiling']}
       organization={organization}
       renderDisabled={() => (
         <Layout.Page withPadding>
           <Alert type="warning">{t("You don't have access to this feature")}</Alert>
         </Layout.Page>
       )}
+      requireAll={false}
     >
       <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
     </Feature>


### PR DESCRIPTION
In preparation to tie the profiling feature to the subscription plans, here we tie it to the performance feature. This is because whenever the performance views are visible, the profiling views should be visible as well.

Long term, this is not ideal. The better fix is to have a standalone profiling flag with a proper hook overriding the disabled state.