### PR TITLE
dev: stop asking for a regular user and just create a canonical superuser

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -181,12 +181,13 @@ apply-migrations() {
     sentry upgrade --noinput
 }
 
-create-user() {
+create-superuser() {
     echo "--> Creating a superuser account"
     if [[ -n "${GITHUB_ACTIONS+x}" ]]; then
         sentry createuser --superuser --email foo@tbd.com --no-password --no-input
     else
-        sentry createuser --superuser
+        sentry createuser --superuser --email admin@sentry.io --password admin
+        echo "Password is admin."
     fi
 }
 
@@ -203,8 +204,8 @@ bootstrap() {
     run-dependent-services
     create-db
     apply-migrations
-    create-user
-    # Load mocks requires a super user to exist, thus, we execute after create-user
+    create-superuser
+    # Load mocks requires a superuser
     bin/load-mocks
     build-platform-assets
     echo "--> Finished bootstrapping. Have a nice day."
@@ -235,7 +236,7 @@ reset-db() {
     drop-db
     create-db
     apply-migrations
-    create-user
+    create-superuser
     echo "Finished resetting database. To load mock data, run `./bin/load-mocks`"
 }
 

--- a/src/sentry/receivers/users.py
+++ b/src/sentry/receivers/users.py
@@ -12,6 +12,9 @@ def create_first_user(**kwargs):
     if not sys.stdin.isatty():
         return
 
+    if not kwargs["interactive"]:
+        return
+
     import click
 
     if not click.confirm("\nWould you like to create a user account now?", default=True):

--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -68,7 +68,7 @@ def _upgrade(interactive, traceback, verbosity, repair, run_post_upgrade, with_n
         call_command("sentry.runner.commands.repair.repair")
 
     if run_post_upgrade:
-        post_upgrade.send(sender=SiloMode.get_current_mode())
+        post_upgrade.send(sender=SiloMode.get_current_mode(), interactive=interactive)
 
 
 @click.command()


### PR DESCRIPTION
rather than have people manually create a user AND a superuser, we should simplify and remove those 2 interactive steps by having a standard admin@sentry.io/`admin` superuser.

TODO: doc updates

https://getsentry.atlassian.net/jira/software/c/projects/DEVINFRA/issues/DEVINFRA-319
https://getsentry.atlassian.net/jira/software/c/projects/DEVINFRA/issues/DEVINFRA-324