### PR TITLE
fix(github-growth): exclude empty owner emails in missing members API

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -63,12 +63,14 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
         # if a member has user_email=None, then they have yet to accept an invite
         org_owners = organization.get_members_with_org_roles(
             roles=[roles.get_top_dog().id]
-        ).exclude(user_email=None)
+        ).exclude(Q(user_email=None) | Q(user_email=""))
 
         def _get_email_domain(email: str) -> str:
             return Address(addr_spec=email).domain
 
-        owner_email_domains = {_get_email_domain(owner.user_email) for owner in org_owners}
+        owner_email_domains = {
+            _get_email_domain(owner.user_email) for owner in org_owners if owner.user_email
+        }
 
         # all owners have the same email domain
         if len(owner_email_domains) == 1:

--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -68,9 +68,7 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
         def _get_email_domain(email: str) -> str:
             return Address(addr_spec=email).domain
 
-        owner_email_domains = {
-            _get_email_domain(owner.user_email) for owner in org_owners if owner.user_email
-        }
+        owner_email_domains = {_get_email_domain(owner.user_email) for owner in org_owners}
 
         # all owners have the same email domain
         if len(owner_email_domains) == 1:


### PR DESCRIPTION
[This issue](https://sentry.sentry.io/issues/4386565348/?project=1) is coming up because we are trying to get the email domain from an email that is an empty string. We should filter out owners with emails that are empty strings when trying to determine if all owners in an org have a common email domain.