### PR TITLE
chore(plugins): Rename pagerduty plugin client

### DIFF
--- a/src/sentry_plugins/pagerduty/client.py
+++ b/src/sentry_plugins/pagerduty/client.py
@@ -5,7 +5,7 @@ from sentry_plugins.client import ApiClient
 INTEGRATION_API_URL = "https://events.pagerduty.com/generic/2010-04-15/create_event.json"
 
 
-class PagerDutyProxyClient(ApiClient):
+class PagerDutyPluginClient(ApiClient):
     client = "sentry"
     plugin_name = "pagerduty"
     allow_redirects = False

--- a/src/sentry_plugins/pagerduty/plugin.py
+++ b/src/sentry_plugins/pagerduty/plugin.py
@@ -4,7 +4,7 @@ from sentry.utils.http import absolute_uri
 from sentry_plugins.base import CorePluginMixin
 from sentry_plugins.utils import get_secret_field_config
 
-from .client import PagerDutyProxyClient
+from .client import PagerDutyPluginClient
 
 
 class PagerDutyPlugin(CorePluginMixin, NotifyPlugin):
@@ -100,7 +100,7 @@ class PagerDutyPlugin(CorePluginMixin, NotifyPlugin):
                 service_key = route_service_key
                 break
 
-        client = PagerDutyProxyClient(service_key=service_key)
+        client = PagerDutyPluginClient(service_key=service_key)
         try:
             response = client.trigger_incident(
                 description=description,


### PR DESCRIPTION
I think the client was renamed by accident since it doesn't proxy anything (plugins do not have to)