### PR TITLE
chore(api): Remove redundant sidebar descriptions

### DIFF
--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -106,7 +106,7 @@ OPENAPI_TAGS = [
         "name": "Crons",
         "x-sidebar-name": "Crons (Beta)",
         "description": "Endpoints for Crons",
-        "x-display-description": True,
+        "x-display-description": False,
         "externalDocs": {
             "description": "Found an error? Let us know.",
             "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/api/integration-platform/&template=api_error_template.md",
@@ -116,7 +116,7 @@ OPENAPI_TAGS = [
         "name": "Replays",
         "x-sidebar-name": "Replays",
         "description": "Endpoints for Replays",
-        "x-display-description": True,
+        "x-display-description": False,
         "externalDocs": {
             "description": "Found an error? Let us know.",
             "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/api/integration-platform/&template=api_error_template.md",


### PR DESCRIPTION
## Before
![Screenshot 2023-08-10 at 3 03 41 PM](https://github.com/getsentry/sentry/assets/67301797/830c8f6f-11d6-42eb-ae86-a011656f1447)

## After
![Screenshot 2023-08-10 at 3 03 56 PM](https://github.com/getsentry/sentry/assets/67301797/db7b870b-149f-4827-ac03-fb26fab160bf)
