### PR TITLE
ref(scopes): Add comment w/context for OIDC scopes

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2128,7 +2128,7 @@ SENTRY_SCOPES = {
     "event:admin",
     "alerts:write",
     "alerts:read",
-    # The following three scopes aren't prefixed to maintain compliance with the OIDC spec.
+    # openid, profile, and email aren't prefixed to maintain compliance with the OIDC spec.
     # https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes.
     "openid",
     "profile",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2128,6 +2128,8 @@ SENTRY_SCOPES = {
     "event:admin",
     "alerts:write",
     "alerts:read",
+    # The following three scopes aren't prefixed to maintain compliance with the OIDC spec.
+    # https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes.
     "openid",
     "profile",
     "email",


### PR DESCRIPTION
These scope names need to be exact in order to maintain compliance with the OpenId Connect (OIDC) protocol ([source](https://openid.net/specs/openid-connect-basic-1_0.html)). For this reason we won't be prefixing them - these comments explain that so future developers won't come in and wonder why these aren't prefixed.
