### PR TITLE
feat(backup): Support foreign key remapping

### DIFF
--- a/fixtures/backup/user-pk-mapping.json
+++ b/fixtures/backup/user-pk-mapping.json
@@ -1,0 +1,65 @@
+[
+    {
+      "model": "sentry.email",
+      "pk": 34,
+      "fields": {
+        "email": "testing@example.com",
+        "date_added": "2023-06-22T00:00:00.123Z"
+      }
+    },
+    {
+      "model": "sentry.user",
+      "pk": 12,
+      "fields": {
+        "password": "pbkdf2_sha256$150000$iEvdIknqYjTr$+QsGn0tfIJ1FZLxQI37mVU1gL2KbL/wqjMtG/dFhsMA=",
+        "last_login": null,
+        "username": "testing@example.com",
+        "name": "",
+        "email": "testing@example.com",
+        "is_staff": true,
+        "is_active": true,
+        "is_superuser": true,
+        "is_managed": false,
+        "is_sentry_app": null,
+        "is_password_expired": false,
+        "last_password_change": "2023-06-22T22:59:57.023Z",
+        "flags": "0",
+        "session_nonce": null,
+        "date_joined": "2023-06-22T22:59:55.488Z",
+        "last_active": "2023-06-22T22:59:55.489Z",
+        "avatar_type": 0,
+        "avatar_url": null
+      }
+    },
+    {
+      "model": "sentry.useremail",
+      "pk": 56,
+      "fields": {
+        "user": 12,
+        "email": "testing@example.com",
+        "validation_hash": "mCnWesSVvYQcq7qXQ36AZHwosAd6cghE",
+        "date_hash_added": "2023-06-22T00:00:00.456Z",
+        "is_verified": false
+      }
+    },
+    {
+      "model": "sentry.userrole",
+      "pk": 78,
+      "fields": {
+        "date_updated": "2023-06-22T23:00:00.123Z",
+        "date_added": "2023-06-22T22:54:27.960Z",
+        "name": "Super Admin",
+        "permissions": "['broadcasts.admin', 'users.admin', 'options.admin']"
+      }
+    },
+    {
+      "model": "sentry.userroleuser",
+      "pk": 90,
+      "fields": {
+        "date_updated": "2023-06-22T23:00:00.123Z",
+        "date_added": "2023-06-22T22:59:57.000Z",
+        "user": 12,
+        "role": 78
+      }
+    }
+  ]

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -7,7 +7,9 @@ import click
 from django.apps import apps
 from django.core import management, serializers
 from django.db import IntegrityError, connection, transaction
+from django.forms import model_to_dict
 
+from sentry.backup.dependencies import PrimaryKeyMap, dependencies, normalize_model_name
 from sentry.backup.helpers import EXCLUDED_APPS
 
 
@@ -27,16 +29,79 @@ class OldImportConfig(NamedTuple):
 
 
 def imports(src, old_config: OldImportConfig, printer=click.echo):
-    """CLI command wrapping the `exec_import` functionality."""
+    """Imports core data for the Sentry installation."""
+
+    # TODO(hybrid-cloud): actor refactor. Remove this import when done.
+    from sentry.models.actor import Actor
 
     try:
         # Import / export only works in monolith mode with a consolidated db.
         with transaction.atomic("default"):
+            pk_map = PrimaryKeyMap()
+            deps = dependencies()
+
             for obj in serializers.deserialize(
                 "json", src, stream=True, use_natural_keys=old_config.use_natural_foreign_keys
             ):
                 if obj.object._meta.app_label not in EXCLUDED_APPS:
-                    obj.save()
+                    # TODO(getsentry/team-ospo#183): This conditional should be removed once we want
+                    # to roll out the new API to self-hosted.
+                    if old_config.use_update_instead_of_create:
+                        obj.save()
+                    else:
+                        o = obj.object
+                        label = o._meta.label_lower
+                        model_name = normalize_model_name(o)
+                        for field, model_relation in deps[model_name].foreign_keys.items():
+                            field_id = f"{field}_id"
+                            fk = getattr(o, field_id, None)
+                            if fk is not None:
+                                new_pk = pk_map.get(normalize_model_name(model_relation.model), fk)
+                                # TODO(getsentry/team-ospo#167): Will allow missing items when we
+                                # implement org-based filtering.
+                                setattr(o, field_id, new_pk)
+
+                        old_pk = o.pk
+                        o.pk = None
+                        o.id = None
+
+                        # TODO(hybrid-cloud): actor refactor. Remove this conditional when done.
+                        #
+                        # `Actor` and `Team` have a direct circular dependency between them for the
+                        # time being due to an ongoing refactor (that is, `Actor` foreign keys
+                        # directly into `Team`, and `Team` foreign keys directly into `Actor`). If
+                        # we use `INSERT` database calls naively, they will always fail, because one
+                        # half of the cycle will always be missing.
+                        #
+                        # Because `Actor` ends up first in the dependency sorting (see:
+                        # fixtures/backup/model_dependencies/sorted.json), a viable solution here is
+                        # to always null out the `team_id` field of the `Actor` when we write it,
+                        # and then make sure to circle back and update the relevant actor after we
+                        # create the `Team` models later on (see snippet at the end of this scope).
+                        if label == "sentry.actor":
+                            o.team_id = None
+
+                        # TODO(getsentry/team-ospo#181): what's up with email/useremail here? Seems
+                        # like both gets added with `sentry.user` simultaneously? Will need to make
+                        # more robust user handling logic, and to test what happens when a UserEmail
+                        # already exists.
+                        if label == "sentry.useremail":
+                            (o, _) = o.__class__.objects.get_or_create(
+                                user=o.user, email=o.email, defaults=model_to_dict(o)
+                            )
+                            pk_map.insert(model_name, old_pk, o.pk)
+                            continue
+
+                        obj.save(force_insert=True)
+                        pk_map.insert(model_name, old_pk, o.pk)
+
+                        # TODO(hybrid-cloud): actor refactor. Remove this conditional when done.
+                        if label == "sentry.team":
+                            if o.actor_id is not None:
+                                actor = Actor.objects.get(pk=o.actor_id)
+                                actor.team_id = o.pk
+                                actor.save()
+
     # For all database integrity errors, let's warn users to follow our
     # recommended backup/restore workflow before reraising exception. Most of
     # these errors come from restoring on a different version of Sentry or not restoring

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -3,26 +3,27 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
+from django.apps import apps
 from django.core.management import call_command
+from django.db import connections, router, transaction
 
 from sentry.backup.comparators import ComparatorMap
+from sentry.backup.dependencies import sorted_dependencies
 from sentry.backup.exports import OldExportConfig, exports
 from sentry.backup.findings import ComparatorFindings
-from sentry.backup.helpers import get_exportable_final_derivations_of, get_final_derivations_of
 from sentry.backup.imports import OldImportConfig, imports
 from sentry.backup.validate import validate
+from sentry.models.integrations.sentry_app import SentryApp
 from sentry.silo import unguarded_write
 from sentry.testutils.factories import get_fixture_path
 from sentry.utils import json
 from sentry.utils.json import JSONData
 
 __all__ = [
-    "ValidationError",
     "export_to_file",
-    "get_final_derivations_of",
-    "get_exportable_final_derivations_of",
     "import_export_then_validate",
     "import_export_from_fixture_then_validate",
+    "ValidationError",
 ]
 
 NOOP_PRINTER = lambda *args, **kwargs: None
@@ -46,7 +47,30 @@ def export_to_file(path: Path) -> JSONData:
     return output
 
 
-def import_export_then_validate(method_name: str) -> JSONData:
+REVERSED_DEPENDENCIES = sorted_dependencies()
+REVERSED_DEPENDENCIES.reverse()
+
+
+def clear_database_but_keep_sequences():
+    """Deletes all models we care about from the database, in a sequence that ensures we get no
+    foreign key errors."""
+
+    with unguarded_write(using="default"), transaction.atomic(using="default"):
+        for model in REVERSED_DEPENDENCIES:
+            # For some reason, the tables for `SentryApp*` models don't get deleted properly here
+            # when using `model.objects.all().delete()`, so we have to call out to Postgres
+            # manually.
+            connection = connections[router.db_for_write(SentryApp)]
+            with connection.cursor() as cursor:
+                table = model._meta.db_table
+                cursor.execute(f"DELETE FROM {table:s};")
+
+        # Clear remaining tables that are not explicitly in Sentry's own model dependency graph.
+        for model in set(apps.get_models()) - set(REVERSED_DEPENDENCIES):
+            model.objects.all().delete()
+
+
+def import_export_then_validate(method_name: str, *, reset_pks: bool = True) -> JSONData:
     """Test helper that validates that dat imported from an export of the current state of the test
     database correctly matches the actual outputted export data."""
 
@@ -60,10 +84,14 @@ def import_export_then_validate(method_name: str) -> JSONData:
 
         # Write the contents of the "expected" JSON file into the now clean database.
         # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
-        with unguarded_write(using="default"), open(tmp_expect) as tmp_file:
-            # Reset the Django database.
-            call_command("flush", verbosity=0, interactive=False)
-            imports(tmp_file, OldImportConfig(), NOOP_PRINTER)
+        with unguarded_write(using="default"):
+            if reset_pks:
+                call_command("flush", verbosity=0, interactive=False)
+            else:
+                clear_database_but_keep_sequences()
+
+            with open(tmp_expect) as tmp_file:
+                imports(tmp_file, OldImportConfig(), NOOP_PRINTER)
 
         # Validate that the "expected" and "actual" JSON matches.
         actual = export_to_file(tmp_actual)

--- a/tests/sentry/backup/test_models.py
+++ b/tests/sentry/backup/test_models.py
@@ -4,10 +4,10 @@ from datetime import datetime, timedelta
 from typing import Literal, Type
 from uuid import uuid4
 
-from django.core.management import call_command
 from django.utils import timezone
 from sentry_relay.auth import generate_key_pair
 
+from sentry.backup.helpers import get_exportable_final_derivations_of
 from sentry.db.models import BaseModel
 from sentry.incidents.models import (
     AlertRule,
@@ -85,11 +85,10 @@ from sentry.monitors.models import (
     ScheduleType,
 )
 from sentry.sentry_apps.apps import SentryAppUpdater
-from sentry.silo import unguarded_write
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers.backups import (
-    get_exportable_final_derivations_of,
+    clear_database_but_keep_sequences,
     import_export_then_validate,
 )
 from sentry.utils.json import JSONData
@@ -126,13 +125,11 @@ class ModelBackupTests(TransactionTestCase):
     comparators."""
 
     def setUp(self):
-        # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
-        with unguarded_write(using="default"):
-            # Reset the Django database.
-            call_command("flush", verbosity=0, interactive=False)
+        # Empty the database without resetting primary keys.
+        clear_database_but_keep_sequences()
 
     def import_export_then_validate(self) -> JSONData:
-        return import_export_then_validate(self._testMethodName)
+        return import_export_then_validate(self._testMethodName, reset_pks=False)
 
     def create_dashboard(self):
         """Re-usable dashboard object for test cases."""

--- a/tests/sentry/backup/test_roundtrip.py
+++ b/tests/sentry/backup/test_roundtrip.py
@@ -4,6 +4,7 @@ from sentry.backup.comparators import DEFAULT_COMPARATORS
 from sentry.backup.findings import ComparatorFindingKind, InstanceID
 from sentry.testutils.helpers.backups import (
     ValidationError,
+    clear_database_but_keep_sequences,
     import_export_from_fixture_then_validate,
 )
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -26,15 +27,19 @@ def test_bad_unequal_json(tmp_path):
         import_export_from_fixture_then_validate(tmp_path, "fresh-install.json")
     findings = execinfo.value.info.findings
 
-    assert len(findings) == 2
+    assert len(findings) == 3
     assert findings[0].kind == ComparatorFindingKind.UnequalJSON
-    assert findings[0].on == InstanceID("sentry.userrole", 1)
+    assert findings[0].on == InstanceID("sentry.useremail", 1)
     assert findings[0].left_pk == 1
     assert findings[0].right_pk == 1
     assert findings[1].kind == ComparatorFindingKind.UnequalJSON
-    assert findings[1].on == InstanceID("sentry.userroleuser", 1)
+    assert findings[1].on == InstanceID("sentry.userrole", 1)
     assert findings[1].left_pk == 1
     assert findings[1].right_pk == 1
+    assert findings[2].kind == ComparatorFindingKind.UnequalJSON
+    assert findings[2].on == InstanceID("sentry.userroleuser", 1)
+    assert findings[2].left_pk == 1
+    assert findings[2].right_pk == 1
 
 
 @run_backup_tests_only_on_single_db
@@ -56,3 +61,22 @@ def test_date_updated_with_unzeroed_milliseconds(tmp_path):
     assert findings[0].right_pk == 1
     assert """-  "last_updated": "2023-06-22T00:00:00Z",""" in findings[0].reason
     assert """+  "last_updated": "2023-06-22T00:00:00.000Z",""" in findings[0].reason
+
+
+@django_db_all(transaction=True, reset_sequences=True)
+def test_good_continuing_sequences(tmp_path):
+    # Populate once to set the sequences.
+    import_export_from_fixture_then_validate(tmp_path, "fresh-install.json", DEFAULT_COMPARATORS)
+
+    # Empty the database without resetting primary keys.
+    clear_database_but_keep_sequences()
+
+    # Test that foreign keys are properly re-pointed to newly allocated primary keys as they are
+    # assigned.
+    import_export_from_fixture_then_validate(tmp_path, "fresh-install.json", DEFAULT_COMPARATORS)
+
+
+# User models are unique and important enough that we target them with a specific test case.
+@django_db_all(transaction=True)
+def test_user_pk_mapping(tmp_path):
+    import_export_from_fixture_then_validate(tmp_path, "user-pk-mapping.json", DEFAULT_COMPARATORS)


### PR DESCRIPTION
When importing into a database that is not entirely flushed, sequences and all, we run into a problem: the foriegn keys in the source JSON file will not match the primary keys of the newly `INSERT`ed models we will be importing. This will cause downstream imports that depend on upstream imports to fail.

To resolve this, we maintain a `PrimaryKeyMap` of old pks to new pks for every model. As we import models, we take note of their new pks, so that when foreign key references to these models are encountered later on, we can perform a simple replacement.

This generally works well enough, but because we have a circular dependency between `Actor` and `Team`, we must take care to do the appropriate set of dance moves to avoid writing `Actor`s with (necessarily) non-existent `Team` references.

To test these changes, I've modified all of `test_models` to *not* reset sequences between database uploads. This should ensure that every such test will produce two JSON files with differing pks, which should give us fairly thorough coverage.

Issue: getsentry/team-ospo#170
Issue: getsentry/team-ospo#171