### PR TITLE
chore(statistical-detectors): Move profiling statistical detectors to…

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -79,7 +79,7 @@ def detect_transaction_trends(project_ids: List[int], **kwargs) -> None:
 
 @instrumented_task(
     name="sentry.tasks.statistical_detectors.detect_function_trends",
-    queue="performance.statistical_detector",
+    queue="profiling.statistical_detector",
     max_retries=0,
 )
 def detect_function_trends(project_ids: List[int], start: datetime, **kwargs) -> None:


### PR DESCRIPTION
… new queue

To decouple profiling and performance statistical detectors, move the profiling statistical detectors into its own queue.