### PR TITLE
feat(on-demand): configurable spec limit

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1471,7 +1471,7 @@ register(
 register(
     "on_demand.max_alert_specs",
     default=50,
-    flags=FLAG_MODIFIABLE_RATE,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1477,5 +1477,5 @@ register(
 register(
     "on_demand.max_widget_specs",
     default=100,
-    flags=FLAG_MODIFIABLE_RATE,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1470,7 +1470,7 @@ register(
 
 register(
     "on_demand.max_alert_specs",
-    default=100,
+    default=50,
     flags=FLAG_MODIFIABLE_RATE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1467,3 +1467,15 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "on_demand.max_alert_specs",
+    default=100,
+    flags=FLAG_MODIFIABLE_RATE,
+)
+
+register(
+    "on_demand.max_widget_specs",
+    default=100,
+    flags=FLAG_MODIFIABLE_RATE,
+)

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -33,8 +33,8 @@ _METRIC_EXTRACTION_VERSION = 1
 
 # Maximum number of custom metrics that can be extracted for alerts and widgets with
 # advanced filter expressions.
-_MAX_ON_DEMAND_ALERTS = 100
-_MAX_ON_DEMAND_WIDGETS = 300
+_MAX_ON_DEMAND_ALERTS = 50
+_MAX_ON_DEMAND_WIDGETS = 100
 
 HashMetricSpec = Tuple[str, MetricSpec]
 


### PR DESCRIPTION
Adds an option to dynamically set number of on demand specs generated