### PR TITLE
fix(dynamic-sampling): Keep track of interval in on-demand metric query

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -138,10 +138,12 @@ class MetricsQueryBuilder(QueryBuilder):
             limit = Limit(1)
             alias = "count"
             include_series = True
+            interval = self.interval
         else:
             limit = self.limit or Limit(1)
             alias = spec.mri
             include_series = False
+            interval = None
 
         # Since the query builder is very convoluted, we first try to get the start and end from the validated
         # parameters but in case it's none it can be that the `skip_time_conditions` was True, thus in that case we
@@ -169,6 +171,7 @@ class MetricsQueryBuilder(QueryBuilder):
             limit=limit,
             offset=self.offset,
             granularity=self.granularity,
+            interval=interval,
             is_alerts_query=True,
             org_id=self.params.organization.id,
             project_ids=[p.id for p in self.params.projects],
@@ -1154,6 +1157,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
                 if granularity <= interval:
                     self.granularity = Granularity(granularity)
                     break
+        self.interval = interval
 
         self.time_column = self.resolve_time_column(interval)
         self.limit = None if limit is None else Limit(limit)

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -375,8 +375,14 @@ class MetricsQuery(MetricsQueryValidationRunner):
         if ONE_DAY % self.granularity.granularity != 0:
             raise InvalidParams("The interval should divide one day without a remainder.")
 
+        # see what's our effective interval (either the one passed in or the one from the granularity)
+        if self.interval is None:
+            interval = self.granularity.granularity
+        else:
+            interval = self.interval
+
         if self.start and self.end and self.include_series:
-            if (self.end - self.start).total_seconds() / self.granularity.granularity > MAX_POINTS:
+            if (self.end - self.start).total_seconds() / interval > MAX_POINTS:
                 raise InvalidParams(
                     "Your interval and date range would create too many results. "
                     "Use a larger interval, or a smaller date range."


### PR DESCRIPTION
This PR fixes a bug in the event-stats endpoint when using the metric query builder.
We were "forgetting" about the interval and falling back to granularity, which sometimes
resulted in exceeding the max results returned by snuba

fixes: [#53839](https://github.com/getsentry/sentry/issues/53839)