### PR TITLE
Feat/opt automator add region

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3662,7 +3662,9 @@ OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL: Optional[str] = None
 
 # This setting is specific to the options automator. It gets the current region or
 # customer in the case of single tenant.
-SENTRY_REGION_OR_CUSTOMER: str = os.environ.get("SENTRY_REGION") or os.environ.get("CUSTOMER_ID")
+SENTRY_REGION_OR_CUSTOMER: Optional[str] = (
+    os.environ.get("SENTRY_REGION") or os.environ.get("CUSTOMER_ID") or None
+)
 
 SENTRY_METRICS_INTERFACE_BACKEND = "sentry.sentry_metrics.client.snuba.SnubaMetricsBackend"
 SENTRY_METRICS_INTERFACE_BACKEND_OPTIONS: dict[str, Any] = {}

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3660,9 +3660,7 @@ BROKEN_TIMEOUT_THRESHOLD = 1000
 # are changed by sentry configoptions.
 OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL: Optional[str] = None
 
-SENTRY_REGION_OR_CUSTOMER: Optional[str] = os.environ.get("SENTRY_REGION") or os.environ.get(
-    "CUSTOMER_ID"
-)
+SENTRY_REGION_OR_CUSTOMER: str = os.environ.get("SENTRY_REGION") or os.environ.get("CUSTOMER_ID")
 
 SENTRY_METRICS_INTERFACE_BACKEND = "sentry.sentry_metrics.client.snuba.SnubaMetricsBackend"
 SENTRY_METRICS_INTERFACE_BACKEND_OPTIONS: dict[str, Any] = {}

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3660,11 +3660,5 @@ BROKEN_TIMEOUT_THRESHOLD = 1000
 # are changed by sentry configoptions.
 OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL: Optional[str] = None
 
-# This setting is specific to the options automator. It gets the current region or
-# customer in the case of single tenant.
-SENTRY_REGION_OR_CUSTOMER: Optional[str] = (
-    os.environ.get("SENTRY_REGION") or os.environ.get("CUSTOMER_ID") or None
-)
-
 SENTRY_METRICS_INTERFACE_BACKEND = "sentry.sentry_metrics.client.snuba.SnubaMetricsBackend"
 SENTRY_METRICS_INTERFACE_BACKEND_OPTIONS: dict[str, Any] = {}

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -632,6 +632,9 @@ SILO_MODE = os.environ.get("SENTRY_SILO_MODE", None)
 # If this instance is a region silo, which region is it running in?
 SENTRY_REGION = os.environ.get("SENTRY_REGION", None)
 
+# Returns the customer single tenant ID.
+CUSTOMER_ID = os.environ.get("CUSTOMER_ID", None)
+
 # Enable siloed development environment.
 USE_SILOS = os.environ.get("SENTRY_USE_SILOS", None)
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3660,6 +3660,8 @@ BROKEN_TIMEOUT_THRESHOLD = 1000
 # are changed by sentry configoptions.
 OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL: Optional[str] = None
 
+# This setting is specific to the options automator. It gets the current region or
+# customer in the case of single tenant.
 SENTRY_REGION_OR_CUSTOMER: str = os.environ.get("SENTRY_REGION") or os.environ.get("CUSTOMER_ID")
 
 SENTRY_METRICS_INTERFACE_BACKEND = "sentry.sentry_metrics.client.snuba.SnubaMetricsBackend"

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3660,5 +3660,9 @@ BROKEN_TIMEOUT_THRESHOLD = 1000
 # are changed by sentry configoptions.
 OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL: Optional[str] = None
 
+SENTRY_REGION_OR_CUSTOMER: Optional[str] = os.environ.get("SENTRY_REGION") or os.environ.get(
+    "CUSTOMER_ID"
+)
+
 SENTRY_METRICS_INTERFACE_BACKEND = "sentry.sentry_metrics.client.snuba.SnubaMetricsBackend"
 SENTRY_METRICS_INTERFACE_BACKEND_OPTIONS: dict[str, Any] = {}

--- a/src/sentry/runner/commands/configoptions.py
+++ b/src/sentry/runner/commands/configoptions.py
@@ -2,7 +2,7 @@ import sys
 from typing import Any, Optional, Set
 
 import click
-from yaml import safe_dump, safe_load
+from yaml import safe_load
 
 from sentry.runner.commands.presenters.presenterdelegator import PresenterDelegator
 from sentry.runner.decorators import configuration, log_options
@@ -31,7 +31,7 @@ def _attempt_update(
         if hide_drift:
             presenter_delegator.drift(key, "")
         else:
-            presenter_delegator.drift(key, safe_dump(db_value_to_print))
+            presenter_delegator.drift(key, db_value_to_print)
         return
 
     last_update_channel = options.get_last_update_channel(key)

--- a/src/sentry/runner/commands/presenters/consolepresenter.py
+++ b/src/sentry/runner/commands/presenters/consolepresenter.py
@@ -1,6 +1,7 @@
 from typing import Any, List, Tuple
 
 import click
+from yaml import safe_dump
 
 from sentry.runner.commands.presenters.optionspresenter import OptionsPresenter
 
@@ -47,7 +48,7 @@ class ConsolePresenter(OptionsPresenter):
                 # This is yaml instead of the python representation as the
                 # expected flow, in this case, is to use the output of this
                 # line to copy paste it in the config map.
-                click.echo(db_value)
+                click.echo(safe_dump(db_value))
 
         for key in self.channel_updated_options:
             click.echo(self.CHANNEL_UPDATE_MSG % key)

--- a/src/sentry/runner/commands/presenters/slackpresenter.py
+++ b/src/sentry/runner/commands/presenters/slackpresenter.py
@@ -1,5 +1,4 @@
-import os
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple
 
 import requests
 from django.conf import settings
@@ -67,11 +66,9 @@ class SlackPresenter(OptionsPresenter):
             raise
 
     def flush(self) -> None:
-
-        region = settings.SENTRY_REGION
-
+        region: Optional[str] = settings.SENTRY_REGION
         if not region:
-            region = os.environ.get("CUSTOMER_ID")
+            region = settings.CUSTOMER_ID
 
         json_data = {
             "region": region,

--- a/src/sentry/runner/commands/presenters/slackpresenter.py
+++ b/src/sentry/runner/commands/presenters/slackpresenter.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, List, Tuple
 
 import requests
@@ -67,7 +68,10 @@ class SlackPresenter(OptionsPresenter):
 
     def flush(self) -> None:
 
-        region = settings.SENTRY_REGION_OR_CUSTOMER
+        region = settings.SENTRY_REGION
+
+        if not region:
+            region = os.environ.get("CUSTOMER_ID")
 
         json_data = {
             "region": region,

--- a/src/sentry/runner/commands/presenters/slackpresenter.py
+++ b/src/sentry/runner/commands/presenters/slackpresenter.py
@@ -66,7 +66,11 @@ class SlackPresenter(OptionsPresenter):
             raise
 
     def flush(self) -> None:
+
+        region = settings.SENTRY_REGION_OR_CUSTOMER
+
         json_data = {
+            "region": region,
             "drifted_options": [
                 {"option_name": key, "option_value": self.truncate_value(value)}
                 for key, value in self.drifted_options

--- a/tests/sentry/runner/commands/presenters/test_slackpresenter.py
+++ b/tests/sentry/runner/commands/presenters/test_slackpresenter.py
@@ -11,6 +11,7 @@ class TestSlackPresenter:
     def setup(self):
         self.slackPresenter = SlackPresenter()
         settings.OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL = "https://test/"
+        settings.SENTRY_REGION_OR_CUSTOMER = "test_region"
 
     @responses.activate
     def test_is_slack_enabled(self):
@@ -44,6 +45,7 @@ class TestSlackPresenter:
         self.slackPresenter.flush()
 
         expected_json_data = {
+            "region": "test_region",
             "drifted_options": [
                 {"option_name": "option9", "option_value": "db_value9"},
                 {"option_name": "option10", "option_value": "db_value10"},
@@ -97,6 +99,7 @@ class TestSlackPresenter:
         self.slackPresenter.flush()
 
         expected_json_data = {
+            "region": "test_region",
             "drifted_options": [{"option_name": "drifted", "option_value": "{'key': 'value'}"}],
             "updated_options": [{"option_name": "updated", "db_value": "1.0", "value": "0.0"}],
             "set_options": [

--- a/tests/sentry/runner/commands/presenters/test_slackpresenter.py
+++ b/tests/sentry/runner/commands/presenters/test_slackpresenter.py
@@ -11,7 +11,7 @@ class TestSlackPresenter:
     def setup(self):
         self.slackPresenter = SlackPresenter()
         settings.OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL = "https://test/"
-        settings.SENTRY_REGION_OR_CUSTOMER = "test_region"
+        settings.SENTRY_REGION = "test_region"
 
     @responses.activate
     def test_is_slack_enabled(self):


### PR DESCRIPTION
Added region to the options automator. 
for STs "SENTRY_REGION" doesn't work so I'm calling it from "CUSTOMER_ID". 
If theres a better way to get the ST region I'm open to it. 