### PR TITLE
styles(functions): Add x-axis to function trends widget

### DIFF
--- a/static/app/views/profiling/landing/functionTrendsWidget.tsx
+++ b/static/app/views/profiling/landing/functionTrendsWidget.tsx
@@ -432,7 +432,7 @@ function FunctionTrendsChart({func, trendFunction}: FunctionTrendsChartProps) {
       height: 150,
       grid: {
         top: '10px',
-        bottom: '0px',
+        bottom: '10px',
         left: '10px',
         right: '10px',
       },
@@ -443,7 +443,7 @@ function FunctionTrendsChart({func, trendFunction}: FunctionTrendsChartProps) {
         },
       },
       xAxis: {
-        show: false,
+        type: 'time' as const,
       },
       tooltip: {
         valueFormatter: (value: number) => tooltipFormatter(value, 'duration'),


### PR DESCRIPTION
Add the x-axis to the function trends widget to easily see the time.

# Screenshot

## Before

![image](https://github.com/getsentry/sentry/assets/10239353/e9692328-a4d6-45e5-8acd-5a823162332c)

## After

![image](https://github.com/getsentry/sentry/assets/10239353/6c77106f-5ad1-4a5f-a87b-9f40a7a95c94)
