### PR TITLE
ref(hc): Remove get_orgs()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -405,7 +405,6 @@ module = [
     "sentry.discover.endpoints.serializers",
     "sentry.eventstore.models",
     "sentry.features.handler",
-    "sentry.features.helpers",
     "sentry.features.manager",
     "sentry.filestore.gcs",
     "sentry.filestore.s3",

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -16,11 +16,15 @@ from sentry.api.permissions import SentryPermission
 from sentry.auth.superuser import is_active_superuser
 from sentry.coreapi import APIError
 from sentry.middleware.stats import add_request_metric_tags
-from sentry.models import Organization
+from sentry.models import OrganizationMemberMapping
 from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.organization import OrganizationStatus
 from sentry.services.hybrid_cloud.app import RpcSentryApp, app_service
-from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.services.hybrid_cloud.organization import (
+    RpcUserOrganizationContext,
+    organization_service,
+)
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.utils.sdk import configure_scope
 from sentry.utils.strings import to_single_line_str
@@ -87,7 +91,12 @@ class SentryAppsPermission(SentryPermission):
             return True
 
         # User must be a part of the Org they're trying to create the app in.
-        if organization not in request.user.get_orgs():
+        if (
+            organization.status != OrganizationStatus.ACTIVE
+            or not OrganizationMemberMapping.objects.filter(
+                user_id=request.user.id, organization_id=organization.id
+            ).exists()
+        ):
             raise Http404
 
         return ensure_scoped_permission(request, self.scope_map.get(request.method))
@@ -109,27 +118,36 @@ class SentryAppsBaseEndpoint(IntegrationPlatformEndpoint):
             raise ValidationError({"organization": to_single_line_str(error_message)})
         return organization_slug
 
-    def _get_organization_for_superuser(self, organization_slug):
-        try:
-            return Organization.objects.get(slug=organization_slug)
-        except Organization.DoesNotExist:
+    def _get_organization_for_superuser(
+        self, user: RpcUser, organization_slug: str
+    ) -> RpcUserOrganizationContext:
+        context = organization_service.get_organization_by_slug(
+            slug=organization_slug, only_visible=False, user_id=user.id
+        )
+
+        if context is None:
             error_message = f"Organization '{organization_slug}' does not exist."
             raise ValidationError({"organization": to_single_line_str(error_message)})
 
-    def _get_organization_for_user(self, user, organization_slug):
-        try:
-            return user.get_orgs().get(slug=organization_slug)
-        except Organization.DoesNotExist:
+        return context
+
+    def _get_organization_for_user(
+        self, user: RpcUser, organization_slug: str
+    ) -> RpcUserOrganizationContext:
+        context = organization_service.get_organization_by_slug(
+            slug=organization_slug, only_visible=True, user_id=user.id
+        )
+        if context is None or context.member is None:
             error_message = f"User does not belong to the '{organization_slug}' organization."
             raise PermissionDenied(to_single_line_str(error_message))
+        return context
 
-    def _get_organization(self, request: Request):
+    def _get_org_context(self, request: Request) -> RpcUserOrganizationContext:
         organization_slug = self._get_organization_slug(request)
         if is_active_superuser(request):
-            return self._get_organization_for_superuser(organization_slug)
+            return self._get_organization_for_superuser(request.user, organization_slug)
         else:
-            user = request.user
-            return self._get_organization_for_user(user, organization_slug)
+            return self._get_organization_for_user(request.user, organization_slug)
 
     def convert_args(self, request: Request, *args, **kwargs):
         """
@@ -154,9 +172,9 @@ class SentryAppsBaseEndpoint(IntegrationPlatformEndpoint):
         if not request.json_body:
             return (args, kwargs)
 
-        organization = self._get_organization(request)
-        self.check_object_permissions(request, organization)
-        kwargs["organization"] = organization
+        context = self._get_org_context(request)
+        self.check_object_permissions(request, context)
+        kwargs["organization"] = context.organization
 
         return (args, kwargs)
 

--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from rest_framework.request import Request
 
 from sentry.api.base import Endpoint
@@ -6,10 +8,11 @@ from sentry.api.permissions import SentryPermission
 from sentry.auth.superuser import is_active_superuser
 from sentry.auth.system import is_system_auth
 from sentry.models import Organization, OrganizationStatus, User
+from sentry.services.hybrid_cloud.user import RpcUser
 
 
 class UserPermission(SentryPermission):
-    def has_object_permission(self, request: Request, view, user=None):
+    def has_object_permission(self, request: Request, view, user: User | RpcUser | None = None):
         if user is None:
             user = request.user
         if request.user.id == user.id:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/index.py
@@ -12,7 +12,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import SentryAppSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import SentryAppStatus
-from sentry.models import SentryApp
+from sentry.models import Organization, SentryApp
 from sentry.sentry_apps.apps import SentryAppCreator
 from sentry.utils import json
 
@@ -30,11 +30,19 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
         elif status == "unpublished":
             queryset = SentryApp.objects.filter(status=SentryAppStatus.UNPUBLISHED)
             if not is_active_superuser(request):
-                queryset = queryset.filter(owner_id__in=[o.id for o in request.user.get_orgs()])
+                queryset = queryset.filter(
+                    owner_id__in=[
+                        o.id for o in Organization.objects.get_for_user_ids({request.user.id})
+                    ]
+                )
         elif status == "internal":
             queryset = SentryApp.objects.filter(status=SentryAppStatus.INTERNAL)
             if not is_active_superuser(request):
-                queryset = queryset.filter(owner_id__in=[o.id for o in request.user.get_orgs()])
+                queryset = queryset.filter(
+                    owner_id__in=[
+                        o.id for o in Organization.objects.get_for_user_ids({request.user.id})
+                    ]
+                )
         else:
             if is_active_superuser(request):
                 queryset = SentryApp.objects.all()

--- a/src/sentry/api/endpoints/integrations/sentry_apps/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/index.py
@@ -12,8 +12,9 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import SentryAppSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import SentryAppStatus
-from sentry.models import Organization, SentryApp
+from sentry.models import SentryApp
 from sentry.sentry_apps.apps import SentryAppCreator
+from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.utils import json
 
 logger = logging.getLogger(__name__)
@@ -32,7 +33,10 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             if not is_active_superuser(request):
                 queryset = queryset.filter(
                     owner_id__in=[
-                        o.id for o in Organization.objects.get_for_user_ids({request.user.id})
+                        o.organization_id
+                        for o in user_service.get_organizations(
+                            user_id=request.user.id, only_visible=True
+                        )
                     ]
                 )
         elif status == "internal":
@@ -40,7 +44,10 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             if not is_active_superuser(request):
                 queryset = queryset.filter(
                     owner_id__in=[
-                        o.id for o in Organization.objects.get_for_user_ids({request.user.id})
+                        o.organization_id
+                        for o in user_service.get_organizations(
+                            user_id=request.user.id, only_visible=True
+                        )
                     ]
                 )
         else:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/index.py
@@ -33,7 +33,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             if not is_active_superuser(request):
                 queryset = queryset.filter(
                     owner_id__in=[
-                        o.organization_id
+                        o.id
                         for o in user_service.get_organizations(
                             user_id=request.user.id, only_visible=True
                         )
@@ -44,7 +44,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             if not is_active_superuser(request):
                 queryset = queryset.filter(
                     owner_id__in=[
-                        o.organization_id
+                        o.id
                         for o in user_service.get_organizations(
                             user_id=request.user.id, only_visible=True
                         )

--- a/src/sentry/api/endpoints/user_organizations.py
+++ b/src/sentry/api/endpoints/user_organizations.py
@@ -1,22 +1,44 @@
+from __future__ import annotations
+
 from django.db.models import Q
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.base import control_silo_endpoint
-from sentry.api.bases.user import UserEndpoint
+from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.bases.user import UserPermission
+from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import OrganizationMapping, OrganizationMemberMapping, OrganizationStatus, User
+from sentry.models import Organization, User
+from sentry.services.hybrid_cloud.user import RpcUser
+from sentry.services.hybrid_cloud.user.service import user_service
 
 
-@control_silo_endpoint
-class UserOrganizationsEndpoint(UserEndpoint):
-    def get(self, request: Request, user: User) -> Response:
-        org_ids = OrganizationMemberMapping.objects.filter(user_id=user.id)
-        queryset = OrganizationMapping.objects.filter(
-            id__in=org_ids,
-            status=OrganizationStatus.ACTIVE,
-        )
+@region_silo_endpoint
+class UserOrganizationsEndpoint(Endpoint):
+    permission_classes = (UserPermission,)
+
+    def convert_args(self, request: Request, user_id: int, *args, **kwargs):
+        user: RpcUser | User | None = None
+
+        if user_id == "me":
+            if not request.user.is_authenticated:
+                raise ResourceDoesNotExist
+            if isinstance(request.user, User) or isinstance(request.user, RpcUser):
+                user = request.user
+        else:
+            user = user_service.get_user(user_id=user_id)
+
+        if not user:
+            raise ResourceDoesNotExist
+
+        self.check_object_permissions(request, user)
+
+        kwargs["user"] = user
+        return args, kwargs
+
+    def get(self, request: Request, user: RpcUser) -> Response:
+        queryset = Organization.objects.get_for_user_ids({user.id})
 
         query = request.GET.get("query")
         if query:

--- a/src/sentry/api/endpoints/user_organizations.py
+++ b/src/sentry/api/endpoints/user_organizations.py
@@ -6,12 +6,17 @@ from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.models import OrganizationMapping, OrganizationMemberMapping, OrganizationStatus, User
 
 
 @control_silo_endpoint
 class UserOrganizationsEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
-        queryset = user.get_orgs()
+    def get(self, request: Request, user: User) -> Response:
+        org_ids = OrganizationMemberMapping.objects.filter(user_id=user.id)
+        queryset = OrganizationMapping.objects.filter(
+            id__in=org_ids,
+            status=OrganizationStatus.ACTIVE,
+        )
 
         query = request.GET.get("query")
         if query:

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -82,9 +82,7 @@ class SentryAppSerializer(Serializer):
         user_org_ids = attrs["user_org_ids"]
 
         if owner:
-            if (env.request and is_active_superuser(env.request)) or (
-                hasattr(user, "get_orgs") and owner.id in user_org_ids
-            ):
+            if (env.request and is_active_superuser(env.request)) or owner.id in user_org_ids:
                 client_secret = (
                     obj.application.client_secret if obj.show_auth_info(access) else MASKED_VALUE
                 )

--- a/src/sentry/features/helpers.py
+++ b/src/sentry/features/helpers.py
@@ -45,7 +45,9 @@ def requires_feature(
             # flag enabled.
             if any_org:
                 if not any_organization_has_feature(
-                    feature, request.user.get_orgs(), actor=request.user
+                    feature,
+                    Organization.objects.get_for_user_ids({request.user.id}),
+                    actor=request.user,
                 ):
                     return Response(status=404)
 

--- a/src/sentry/features/helpers.py
+++ b/src/sentry/features/helpers.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -18,16 +18,11 @@ def any_organization_has_feature(
     return any([features.has(feature, organization, **kwargs) for organization in organizations])
 
 
-def requires_feature(
-    feature: str, any_org: Optional[bool] = None
-) -> Callable[[EndpointFunc], EndpointFunc]:
+def requires_feature(feature: str) -> Callable[[EndpointFunc], EndpointFunc]:
     """
     Require a feature flag to access an endpoint.
 
-    If ``any_org`` is ``True``, this will check all of the request User's
-    Organizations for the flag. If any are flagged in, the endpoint is accessible.
-
-    Without ``any_org=True``, the endpoint must resolve an Organization via
+    The endpoint must resolve an Organization via
     ``convert_args`` (and therefor be in ``kwargs``). The resolved Org must have
     the passed feature.
 
@@ -41,26 +36,13 @@ def requires_feature(
 
     def decorator(func: EndpointFunc) -> EndpointFunc:
         def wrapped(self: Any, request: Request, *args: Any, **kwargs: Any) -> Response:
-            # The endpoint is accessible if any of the User's Orgs have the feature
-            # flag enabled.
-            if any_org:
-                if not any_organization_has_feature(
-                    feature,
-                    Organization.objects.get_for_user_ids({request.user.id}),
-                    actor=request.user,
-                ):
-                    return Response(status=404)
+            if "organization" not in kwargs:
+                return Response(status=404)
 
-                return func(self, request, *args, **kwargs)
-            # The Org in scope for the request must have the feature flag enabled.
-            else:
-                if "organization" not in kwargs:
-                    return Response(status=404)
+            if not features.has(feature, kwargs["organization"], actor=request.user):
+                return Response(status=404)
 
-                if not features.has(feature, kwargs["organization"], actor=request.user):
-                    return Response(status=404)
-
-                return func(self, request, *args, **kwargs)
+            return func(self, request, *args, **kwargs)
 
         return wrapped
 

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -356,16 +356,6 @@ class User(BaseModel, AbstractBaseUser):
         if request is not None:
             request.session["_nonce"] = self.session_nonce
 
-    def get_orgs(self):
-        from sentry.models import Organization
-
-        return Organization.objects.get_for_user_ids({self.id})
-
-    def get_projects(self):
-        from sentry.models import Project
-
-        return Project.objects.get_for_user_ids({self.id})
-
     def get_orgs_require_2fa(self):
         from sentry.models import Organization, OrganizationStatus
 

--- a/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
+++ b/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
@@ -60,7 +60,9 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
     method = "put"
 
     def test_update_invalid_project(self):
-        self.get_error_response("me", "alerts", status_code=403, **{"123": 1})
+        # We do not validate project / organization ids!  Due to the silo split we accept these at face value rather than fan out
+        # across all silos to validate them.
+        self.get_response("me", "alerts", **{"123": 1})
 
     def test_invalid_id_value(self):
         self.get_error_response("me", "alerts", status_code=400, **{"nope": 1})
@@ -270,9 +272,6 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
         assert not UserOption.objects.filter(
             user=self.user, organization_id=new_org.id, key="reports"
         ).exists()
-
-        data = {str(new_project.id): 1}
-        self.get_error_response("me", "alerts", status_code=403, **data)
 
         value = NotificationSetting.objects.get_settings(
             ExternalProviders.EMAIL,

--- a/tests/sentry/features/test_helpers.py
+++ b/tests/sentry/features/test_helpers.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.features.base import OrganizationFeature
 from sentry.features.helpers import any_organization_has_feature, requires_feature
+from sentry.models import Organization
 from sentry.testutils.cases import TestCase
 
 
@@ -22,9 +23,13 @@ class TestFeatureHelpers(TestCase):
         features.add("foo", OrganizationFeature)
 
     def test_any_organization_has_feature(self):
-        assert not any_organization_has_feature("foo", self.user.get_orgs())
+        assert not any_organization_has_feature(
+            "foo", Organization.objects.get_for_user_ids({self.user.id})
+        )
         with org_with_feature(self.org, "foo"):
-            assert any_organization_has_feature("foo", self.user.get_orgs())
+            assert any_organization_has_feature(
+                "foo", Organization.objects.get_for_user_ids({self.user.id})
+            )
 
     def test_org_missing_from_request_fails(self):
         @requires_feature("foo")

--- a/tests/sentry/features/test_helpers.py
+++ b/tests/sentry/features/test_helpers.py
@@ -24,11 +24,11 @@ class TestFeatureHelpers(TestCase):
 
     def test_any_organization_has_feature(self):
         assert not any_organization_has_feature(
-            "foo", Organization.objects.get_for_user_ids({self.user.id})
+            "foo", list(Organization.objects.get_for_user_ids({self.user.id}).all())
         )
         with org_with_feature(self.org, "foo"):
             assert any_organization_has_feature(
-                "foo", Organization.objects.get_for_user_ids({self.user.id})
+                "foo", list(Organization.objects.get_for_user_ids({self.user.id}))
             )
 
     def test_org_missing_from_request_fails(self):

--- a/tests/sentry/features/test_helpers.py
+++ b/tests/sentry/features/test_helpers.py
@@ -56,19 +56,6 @@ class TestFeatureHelpers(TestCase):
             response = get(None, self.request, organization=self.org)
             assert response.status_code == 200
 
-    def test_any_org_true_when_users_other_org_has_flag_succeeds(self):
-        # The Org in scope of the request does not have the flag, but another
-        # Org the User belongs to does.
-        #
-        with org_with_feature(self.out_of_scope_org, "foo"):
-
-            @requires_feature("foo", any_org=True)
-            def get(self, request, *args, **kwargs):
-                return Response()
-
-            response = get(None, self.request, organization=self.org)
-            assert response.status_code == 200
-
     def test_any_org_false_when_users_other_org_has_flag_fails(self):
         with org_with_feature(self.out_of_scope_org, "foo"):
 

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -1,7 +1,9 @@
 from sentry.models import (
     Authenticator,
+    Organization,
     OrganizationMember,
     OrganizationMemberTeam,
+    Project,
     SavedSearch,
     User,
     UserEmail,
@@ -22,7 +24,7 @@ class UserTest(TestCase, HybridCloudTestMixin):
         member = OrganizationMember.objects.get(user_id=user.id, organization=org)
         OrganizationMemberTeam.objects.create(organizationmember=member, team=team)
 
-        organizations = user.get_orgs()
+        organizations = Organization.objects.get_for_user_ids({user.id})
         assert {_.id for _ in organizations} == {org.id}
 
     def test_hybrid_cloud_deletion(self):
@@ -51,7 +53,7 @@ class UserTest(TestCase, HybridCloudTestMixin):
         OrganizationMemberTeam.objects.create(organizationmember=member, team=team)
         project = self.create_project(teams=[team], name="name")
 
-        projects = user.get_projects()
+        projects = Project.objects.get_for_user_ids({user.id})
         assert {_.id for _ in projects} == {project.id}
 
     def test_get_full_name(self):

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -12,7 +12,7 @@ from django.test import override_settings
 from sentry.app import env
 from sentry.middleware.auth import AuthenticationMiddleware
 from sentry.middleware.placeholder import placeholder_get_response
-from sentry.models import AuthIdentity, AuthProvider
+from sentry.models import AuthIdentity, AuthProvider, Organization
 from sentry.silo import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -83,7 +83,7 @@ def make_user_request_from_non_existant_org(org=None):
 
 def make_user_request_from_org_with_auth_identities(org=None):
     request, user = make_user_request_from_org(org)
-    org = user.get_orgs()[0]
+    org = Organization.objects.get_for_user_ids({user.id})[0]
     provider = AuthProvider.objects.create(
         organization_id=org.id, provider="google", config={"domain": "olddomain.com"}
     )


### PR DESCRIPTION
user.get_orgs() is problematic, because the Organization objects associated to a user via OrganizationMember can only ever be *per region*, and not contain all organizations a user belongs to globally.

This PR attempts to use separate means of getting the same question answered but with more specific implementations, so we can extract the `user.get_orgs()` which is ambiguous. 

For instance, `Organization.get_for_user_ids` can only mean *within a region scope*.  but `user_service.get_organizations` will include global organizations.