### PR TITLE
ref(github-comments): use 14 day PR window

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -38,7 +38,7 @@ DEBOUNCE_CACHE_KEY = lambda group_id: f"process-commit-context-{group_id}"
 DEBOUNCE_PR_COMMENT_CACHE_KEY = lambda pullrequest_id: f"pr-comment-{pullrequest_id}"
 DEBOUNCE_PR_COMMENT_LOCK_KEY = lambda pullrequest_id: f"queue_comment_task:{pullrequest_id}"
 PR_COMMENT_TASK_TTL = timedelta(minutes=5).total_seconds()
-PR_COMMENT_WINDOW = 7  # days
+PR_COMMENT_WINDOW = 14  # days
 
 logger = logging.getLogger(__name__)
 

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -14,7 +14,7 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import PullRequestCommit
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.snuba.sessions_v2 import isoformat_z
-from sentry.tasks.commit_context import process_commit_context
+from sentry.tasks.commit_context import PR_COMMENT_WINDOW, process_commit_context
 from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
@@ -616,8 +616,8 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
     @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate
     def test_gh_comment_pr_too_old(self, get_jwt, mock_comment_workflow):
-        """No comment on pr that's older than 30 days"""
-        self.pull_request.date_added = iso_format(before_now(days=8))
+        """No comment on pr that's older than PR_COMMENT_WINDOW"""
+        self.pull_request.date_added = iso_format(before_now(days=PR_COMMENT_WINDOW + 1))
         self.pull_request.save()
 
         self.add_responses()


### PR DESCRIPTION
Up the age of the merged PRs we comment on to a maximum of 14 days.

For ER-1679