### PR TITLE
fix(starfish): Remove duplicate method from span summary page

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -203,9 +203,10 @@ type CellProps = {
 };
 
 function TransactionCell({row, project}: CellProps) {
-  const label = row.transactionMethod
-    ? `${row.transactionMethod} ${row.transaction}`
-    : row.transaction;
+  const label =
+    row.transactionMethod && !row.transaction.startsWith(row.transactionMethod)
+      ? `${row.transactionMethod} ${row.transaction}`
+      : row.transaction;
 
   const link = `/performance/summary/?${qs.stringify({
     project,


### PR DESCRIPTION
A table I missed!

### Before

<img width="1251" alt="image" src="https://github.com/getsentry/sentry/assets/18689448/b67d50d3-6459-4c8d-8962-adcc54c08980">

### After

<img width="1269" alt="image" src="https://github.com/getsentry/sentry/assets/18689448/cb37a67d-8bc5-45bf-ad5c-cfd8e31ed193">

