### PR TITLE
feat(sentryapps): change timeout to 3 from 5

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1426,7 +1426,7 @@ register("dynamic-sampling.tasks.collect_orgs", default=False, flags=FLAG_MODIFI
 # Sets the timeout for webhooks
 register(
     "sentry-apps.webhook.timeout.sec",
-    default=5.0,
+    default=3.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 


### PR DESCRIPTION
Lowering timeout to 3 seconds for sentry apps.