### PR TITLE
ref(crons): Remove option monitors.use_consumer_clock_task_triggers

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1469,12 +1469,6 @@ register(
 )
 
 register(
-    "monitors.use_consumer_clock_task_triggers",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
     "on_demand.max_alert_specs",
     default=50,
     flags=FLAG_AUTOMATOR_MODIFIABLE,


### PR DESCRIPTION
After this merges we can remove the option from the options automator https://github.com/getsentry/sentry-options-automator/pull/177