### PR TITLE
feat(integrations): create redis keys using integration_id

### DIFF
--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -63,7 +63,10 @@ class BitbucketApiClient(IntegrationProxyClient):
                 integration_id=integration.id, ctx_logger=logger
             )
         super().__init__(
-            org_integration_id=org_integration_id, verify_ssl=True, logging_context=None
+            integration_id=integration.id,
+            org_integration_id=org_integration_id,
+            verify_ssl=True,
+            logging_context=None,
         )
 
     @control_silo_function

--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -119,6 +119,7 @@ class BitbucketServerClient(IntegrationProxyClient):
         super().__init__(
             org_integration_id=org_integration_id,
             verify_ssl=integration.metadata["verify_ssl"],
+            integration_id=integration.id,
             logging_context=None,
         )
 

--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -40,7 +40,8 @@ class BitbucketServerSetupClient(ApiClient):
     authorize_url = "{}/plugins/servlet/oauth/authorize?oauth_token={}"
     integration_name = "bitbucket_server_setup"
 
-    def __init__(self, base_url, consumer_key, private_key, verify_ssl=True):
+    def __init__(self, base_url, consumer_key, private_key, verify_ssl=True, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.base_url = base_url
         self.consumer_key = consumer_key
         self.private_key = private_key

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -93,7 +93,7 @@ class GitLabProxyApiClient(IntegrationProxyClient):
         self.base_url = self.metadata["base_url"]
         org_integration_id = installation.org_integration.id
         super().__init__(
-            integration_id=installation.id,
+            integration_id=installation.model.id,
             org_integration_id=org_integration_id,
             verify_ssl=verify_ssl,
         )

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -92,7 +92,11 @@ class GitLabProxyApiClient(IntegrationProxyClient):
         self.refreshed_identity: RpcIdentity | None = None
         self.base_url = self.metadata["base_url"]
         org_integration_id = installation.org_integration.id
-        super().__init__(org_integration_id=org_integration_id, verify_ssl=verify_ssl)
+        super().__init__(
+            integration_id=installation.id,
+            org_integration_id=org_integration_id,
+            verify_ssl=verify_ssl,
+        )
 
     @property
     def identity(self) -> RpcIdentity:

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -383,7 +383,7 @@ class BaseApiClient(TrackResponseMixin):
                     ) = integration_service.get_organization_contexts(
                         integration_id=self.integration_id
                     )
-                    if rpc_integration.provider in ("github", "gitlab"):
+                    if rpc_integration.provider in ("github", "gitlab", "slack"):
                         extra = {
                             "integration_id": self.integration_id,
                             "buffer_record": buffer._get_all_from_buffer(),


### PR DESCRIPTION
Adding integration id's to integration clients to be used to create redis keys for the `IntegrationRequestBuffer` used to detect and disable integrations for the [Notify on Disabled Integration project](https://www.notion.so/sentry/Tech-Spec-Notify-on-Disabled-Integration-Spec-e7ea0f86ccd6419cb3e564067cf4a2ef?pvs=4)
