### PR TITLE
chore(scim): Remove beta tag from API docs

### DIFF
--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -82,7 +82,7 @@ OPENAPI_TAGS = [
     },
     {
         "name": "SCIM",
-        "x-sidebar-name": "SCIM (Beta)",
+        "x-sidebar-name": "SCIM",
         "description": "System for Cross-Domain Identity Management ([SCIM](http://www.simplecloud.info/)) is a standard implemented by Identity Providers and applications in order to facilitate federated identity management. Through these APIs you can add and delete members as well as teams. Sentry SaaS customers must be on a Business Plan with SAML2 Enabled. SCIM uses a bearer token for authentication that is created when SCIM is enabled. For how to enable SCIM, see our docs [here](/product/accounts/sso/#scim-provisioning).\n Sentry's SCIM API does not currently support syncing passwords, or setting any User attributes other than `active`.",
         "x-display-description": True,
         "externalDocs": {


### PR DESCRIPTION
This set of APIs follow the SCIM standard and they will not have major changes.