### PR TITLE
fix(starfish): Always link to span with correct project

### DIFF
--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -45,11 +45,12 @@ export function SpanDescriptionCell({
 
   const queryString = {
     ...location.query,
+    project: projectId,
     endpoint,
     endpointMethod,
   };
 
-  const sort: string | undefined = queryString?.[QueryParameterNames.SORT];
+  const sort: string | undefined = queryString[QueryParameterNames.SORT];
 
   // the spans page uses time_spent_percentage(local), so to persist the sort upon navigation we need to replace
   if (sort?.includes(`${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`)) {
@@ -76,9 +77,9 @@ export function SpanDescriptionCell({
         <OverflowEllipsisTextContainer>
           {group ? (
             <Link
-              to={`/starfish/${extractRoute(location) ?? 'spans'}/span/${group}${
-                queryString ? `?${qs.stringify(queryString)}` : ''
-              }`}
+              to={`/starfish/${
+                extractRoute(location) ?? 'spans'
+              }/span/${group}?${qs.stringify(queryString)}`}
             >
               {formattedDescription}
             </Link>

--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -20,6 +20,7 @@ import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 
 interface Props {
   moduleName: ModuleName;
+  projectId: number;
   description?: string;
   endpoint?: string;
   endpointMethod?: string;
@@ -34,6 +35,7 @@ export function SpanDescriptionCell({
   moduleName,
   endpoint,
   endpointMethod,
+  projectId,
 }: Props) {
   const location = useLocation();
 

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -10,12 +10,13 @@ import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
-const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, SPAN_DOMAIN} =
+const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, SPAN_DOMAIN, PROJECT_ID} =
   SpanMetricsFields;
 
 export type SpanMetrics = {
   'avg(span.self_time)': number;
   'http_error_count()': number;
+  'project.id': number;
   'span.description': string;
   'span.domain': string;
   'span.group': string;
@@ -78,6 +79,7 @@ function getEventView(
   ].join(' ');
 
   const fields = [
+    PROJECT_ID,
     SPAN_OP,
     SPAN_GROUP,
     SPAN_DESCRIPTION,

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -25,6 +25,7 @@ export enum SpanMetricsFields {
   SPAN_GROUP = 'span.group',
   SPAN_DURATION = 'span.duration',
   SPAN_SELF_TIME = 'span.self_time',
+  PROJECT_ID = 'project.id',
 }
 
 export type SpanMetricsFieldTypes = {

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -55,7 +55,7 @@ type Props = {
   spanCategory?: string;
 };
 
-const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_DOMAIN, SPAN_GROUP, SPAN_OP} =
+const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_DOMAIN, SPAN_GROUP, SPAN_OP, PROJECT_ID} =
   SpanMetricsFields;
 const {TIME_SPENT_PERCENTAGE, SPS, SPM, HTTP_ERROR_COUNT} = StarfishFunctions;
 
@@ -158,6 +158,7 @@ function renderBodyCell(
         moduleName={moduleName}
         description={row[SPAN_DESCRIPTION]}
         group={row[SPAN_GROUP]}
+        projectId={row[PROJECT_ID]}
         endpoint={endpoint}
         endpointMethod={endpointMethod}
       />


### PR DESCRIPTION
Preparing for a multi-project future. With this PR, the query list always links to the span details page with the correct project ID, which it fetches from the backend. This makes it possible to render a list of queries from multiple projects and still link to the correct one.

- Add project ID to metric fields
- Fetch project ID with span list data
- Remove unnecessary conditional
- Link span summary page with correct project
