### PR TITLE
feat(escalating): Handle unmerge issue states

### DIFF
--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -274,13 +274,12 @@ def get_hourly_count_unmerged_group(group: Group) -> Optional[int]:
     groups involved in the unmerge to get accurate event counts due to a Clickhouse bug.
     """
     # Check if the group is a source groups involved in an unmerge in the last 24 hrs
+    org_id = group.project.organization.id
     project_id = group.project.id
-    source_key = f"source-groups:{project_id}"
-    source_ids = cache.get(source_key)
+    unmerge_key = f"unmerged-groups:{org_id}:{project_id}:{group.id}"
+    unmerge_groups_ids = cache.get(unmerge_key)
 
-    if source_ids and group.id in source_ids:
-        unmerge_key = f"unmerged-groups:{project_id}:{group.id}"
-        unmerge_groups_ids = cache.get(unmerge_key)
+    if unmerge_groups_ids:
         unmerge_groups = Group.objects.filter(project=group.project, id__in=unmerge_groups_ids)
         unmerge_groups_counts = query_groups_past_counts(unmerge_groups)
         parsed_unmerge_groups_counts = parse_groups_past_counts(unmerge_groups_counts)

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -763,6 +763,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
                 batch_size=5,
             )
         # Check unmerge counts
+        sleep(1)  # Sleep to allow snuba to update
         primary, dest = list(Group.objects.all())
         primary_unmerge_hour_count = get_group_hourly_count(primary)
         past_counts = query_groups_past_counts(list(Group.objects.all()))
@@ -870,6 +871,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
                 batch_size=5,
             )
         # Check unmerge counts
+        sleep(1)  # Sleep to allow snuba to update
         primary, new_child = list(Group.objects.all())
         primary_unmerge_hour_count = get_group_hourly_count(primary)
         past_counts = query_groups_past_counts(list(Group.objects.all()))


### PR DESCRIPTION
On unmerge we should:
- Recompute source group escalating forecast
- Compute child group escalating forecast
- Child group inherits GroupStatus and GroupInboxReason from source group
- Child group gets new entry in GroupHistory with new GroupStatus

Notes:
- There is currently a [Clickhouse bug](https://github.com/getsentry/snuba/issues/4558) that causes the queried source group event count to be incorrect if not all the groups involved in the unmerge event counts are queried at the same time
- This event count will be incorrect for 24 hours
- The workaround is to save the source ids and their associated unmerged group ids in cache for 24 hours, so that we can query all groups involved in the unmerge and get the correct event counts for those groups

closes https://github.com/getsentry/sentry/issues/49894