### PR TITLE
fix(hybrid-cloud): Fix commit task and update it for split db

### DIFF
--- a/src/sentry/integrations/example/repository.py
+++ b/src/sentry/integrations/example/repository.py
@@ -1,5 +1,5 @@
-from sentry.models import Integration
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import IntegrationError
 
 
@@ -8,9 +8,9 @@ class ExampleRepositoryProvider(IntegrationRepositoryProvider):
     repo_provider = "example"
 
     def compare_commits(self, repo, start_sha, end_sha):
-        installation = Integration.objects.get(id=repo.integration_id).get_installation(
-            repo.organization_id
-        )
+        installation = integration_service.get_integration(
+            integration_id=repo.integration_id
+        ).get_installation(organization_id=repo.organization_id)
 
         try:
             raise IntegrationError("{'error': 'Repository not found'}")


### PR DESCRIPTION
Fixes SENTRY-1405

1. Fixes [SENTRY-1405](https://sentry.sentry.io/issues/4337300531/) such that we only care about _active_ repositories. Note that repositories may be disabled due to removal of or disabling of the associated integration such as the GitHub integration.
2. Update and stabilize associated tests for split db.