### PR TITLE
ref(backup): Swap include_in_exports -> relocation_scope (4/4)

### DIFF
--- a/src/sentry/data_export/models.py
+++ b/src/sentry/data_export/models.py
@@ -31,7 +31,6 @@ class ExportedData(Model):
     Stores references to asynchronous data export jobs
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization = FlexibleForeignKey("sentry.Organization")
@@ -154,7 +153,6 @@ class ExportedData(Model):
 
 @region_silo_only_model
 class ExportedDataBlob(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     data_export = FlexibleForeignKey("sentry.ExportedData")

--- a/src/sentry/discover/models.py
+++ b/src/sentry/discover/models.py
@@ -23,7 +23,6 @@ MAX_TEAM_KEY_TRANSACTIONS = 100
 
 @region_silo_only_model
 class DiscoverSavedQueryProject(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
@@ -41,7 +40,6 @@ class DiscoverSavedQuery(Model):
     A saved Discover query
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     projects = models.ManyToManyField("sentry.Project", through=DiscoverSavedQueryProject)
@@ -138,7 +136,6 @@ class TeamKeyTransactionModelManager(BaseManager):
 
 @region_silo_only_model
 class TeamKeyTransaction(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     # max_length here is based on the maximum for transactions in relay

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -32,7 +32,6 @@ from sentry.utils.retries import TimedRetryPolicy
 
 @region_silo_only_model
 class IncidentProject(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", db_index=False, db_constraint=False)
@@ -46,7 +45,6 @@ class IncidentProject(Model):
 
 @region_silo_only_model
 class IncidentSeen(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     incident = FlexibleForeignKey("sentry.Incident")
@@ -170,7 +168,6 @@ INCIDENT_STATUS = {
 
 @region_silo_only_model
 class Incident(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     objects = IncidentManager()
@@ -218,7 +215,6 @@ class Incident(Model):
 
 @region_silo_only_model
 class PendingIncidentSnapshot(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     incident = OneToOneCascadeDeletes("sentry.Incident", db_constraint=False)
@@ -232,7 +228,6 @@ class PendingIncidentSnapshot(Model):
 
 @region_silo_only_model
 class IncidentSnapshot(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     incident = OneToOneCascadeDeletes("sentry.Incident", db_constraint=False)
@@ -248,7 +243,6 @@ class IncidentSnapshot(Model):
 
 @region_silo_only_model
 class TimeSeriesSnapshot(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     start = models.DateTimeField()
@@ -271,7 +265,6 @@ class IncidentActivityType(Enum):
 
 @region_silo_only_model
 class IncidentActivity(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     incident = FlexibleForeignKey("sentry.Incident")
@@ -290,7 +283,6 @@ class IncidentActivity(Model):
 
 @region_silo_only_model
 class IncidentSubscription(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     incident = FlexibleForeignKey("sentry.Incident", db_index=False)
@@ -374,7 +366,6 @@ class AlertRuleManager(BaseManager):
 
 @region_silo_only_model
 class AlertRuleExcludedProjects(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     alert_rule = FlexibleForeignKey("sentry.AlertRule", db_index=False)
@@ -389,7 +380,6 @@ class AlertRuleExcludedProjects(Model):
 
 @region_silo_only_model
 class AlertRule(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     objects = AlertRuleManager()
@@ -481,7 +471,6 @@ class IncidentTriggerManager(BaseManager):
 
 @region_silo_only_model
 class IncidentTrigger(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     objects = IncidentTriggerManager()
@@ -530,7 +519,6 @@ class AlertRuleTriggerManager(BaseManager):
 
 @region_silo_only_model
 class AlertRuleTrigger(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     alert_rule = FlexibleForeignKey("sentry.AlertRule")
@@ -553,7 +541,6 @@ class AlertRuleTrigger(Model):
 
 @region_silo_only_model
 class AlertRuleTriggerExclusion(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     alert_rule_trigger = FlexibleForeignKey("sentry.AlertRuleTrigger", related_name="exclusions")
@@ -573,10 +560,8 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
     typically some sort of notification.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
-    # Aliases from NotificationAction
     Type = ActionService
     TargetType = ActionTarget
 
@@ -680,7 +665,6 @@ class AlertRuleActivityType(Enum):
 
 @region_silo_only_model
 class AlertRuleActivity(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     alert_rule = FlexibleForeignKey("sentry.AlertRule")

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -87,7 +87,6 @@ class ActivityManager(BaseManager):
 
 @region_silo_only_model
 class Activity(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -102,7 +102,6 @@ def actor_type_to_string(type: int) -> str | None:
 
 @region_silo_only_model
 class Actor(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     type = models.PositiveSmallIntegerField(

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -39,7 +39,6 @@ class ApiApplicationStatus:
 
 @control_silo_only_model
 class ApiApplication(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     client_id = models.CharField(max_length=64, unique=True, default=generate_token)

--- a/src/sentry/models/apiauthorization.py
+++ b/src/sentry/models/apiauthorization.py
@@ -15,7 +15,6 @@ class ApiAuthorization(Model, HasApiScopes):
     overall approved applications (vs individual tokens).
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     # users can generate tokens without being application-bound

--- a/src/sentry/models/apigrant.py
+++ b/src/sentry/models/apigrant.py
@@ -28,7 +28,6 @@ class ApiGrant(Model):
     of the OAuth 2 spec.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     user = FlexibleForeignKey("sentry.User")

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -24,7 +24,6 @@ class ApiKeyStatus:
 
 @control_silo_only_model
 class ApiKey(Model, HasApiScopes):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     organization_id = HybridCloudForeignKey("sentry.Organization", on_delete="cascade")

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -31,7 +31,6 @@ def generate_token():
 
 @control_silo_only_model
 class ApiToken(Model, HasApiScopes):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     # users can generate tokens without being application-bound

--- a/src/sentry/models/appconnectbuilds.py
+++ b/src/sentry/models/appconnectbuilds.py
@@ -24,7 +24,6 @@ class AppConnectBuild(Model):
     bundle_short_version, bundle_version).
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)

--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -66,7 +66,6 @@ class ArtifactBundleIndexingState(Enum):
 
 @region_silo_only_model
 class ArtifactBundle(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
@@ -140,7 +139,6 @@ indexstore = LazyServiceWrapper(
 
 @region_silo_only_model
 class ArtifactBundleFlatFileIndex(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField(db_index=True)
@@ -179,7 +177,6 @@ class ArtifactBundleFlatFileIndex(Model):
 
 @region_silo_only_model
 class FlatFileIndexState(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     flat_file_index = FlexibleForeignKey("sentry.ArtifactBundleFlatFileIndex")
@@ -212,7 +209,6 @@ class FlatFileIndexState(Model):
 
 @region_silo_only_model
 class ArtifactBundleIndex(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
@@ -236,7 +232,6 @@ class ArtifactBundleIndex(Model):
 
 @region_silo_only_model
 class ReleaseArtifactBundle(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
@@ -258,7 +253,6 @@ class ReleaseArtifactBundle(Model):
 
 @region_silo_only_model
 class DebugIdArtifactBundle(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
@@ -276,7 +270,6 @@ class DebugIdArtifactBundle(Model):
 
 @region_silo_only_model
 class ProjectArtifactBundle(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/assistant.py
+++ b/src/sentry/models/assistant.py
@@ -15,7 +15,6 @@ from sentry.db.models import (
 class AssistantActivity(Model):
     """Records user interactions with the assistant guides."""
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL, null=False)

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -40,7 +40,6 @@ def format_scim_token_actor_name(actor):
 
 @control_silo_only_model
 class AuditLogEntry(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = HybridCloudForeignKey("sentry.Organization", on_delete="CASCADE")

--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -140,7 +140,6 @@ class AuthenticatorConfig(PickledObjectField):
 
 @control_silo_only_model
 class Authenticator(BaseModel):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.User
 
     id = BoundedAutoField(primary_key=True)

--- a/src/sentry/models/authidentity.py
+++ b/src/sentry/models/authidentity.py
@@ -11,7 +11,6 @@ from sentry.db.models.fields.jsonfield import JSONField
 
 @control_silo_only_model
 class AuthIdentity(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     # NOTE: not a fk to sentry user

--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -32,7 +32,6 @@ SCIM_INTERNAL_INTEGRATION_OVERVIEW = (
 @control_silo_only_model
 class AuthProviderDefaultTeams(Model):
     # Completely defunct model.
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     authprovider_id = BoundedBigIntegerField()
@@ -46,7 +45,6 @@ class AuthProviderDefaultTeams(Model):
 
 @control_silo_only_model
 class AuthProvider(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     organization_id = HybridCloudForeignKey("sentry.Organization", on_delete="cascade", unique=True)

--- a/src/sentry/models/avatars/base.py
+++ b/src/sentry/models/avatars/base.py
@@ -26,7 +26,6 @@ class AvatarBase(Model):
     avatar preferences/files. If extending this class, ensure the model has avatar_type.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     ALLOWED_SIZES: ClassVar[tuple[int, ...]] = (20, 32, 36, 48, 52, 64, 80, 96, 120)

--- a/src/sentry/models/broadcast.py
+++ b/src/sentry/models/broadcast.py
@@ -13,7 +13,6 @@ def default_expiration():
 
 @control_silo_only_model
 class Broadcast(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     upstream_id = models.CharField(max_length=32, null=True, blank=True)
@@ -34,7 +33,6 @@ class Broadcast(Model):
 
 @control_silo_only_model
 class BroadcastSeen(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     broadcast = FlexibleForeignKey("sentry.Broadcast")

--- a/src/sentry/models/commit.py
+++ b/src/sentry/models/commit.py
@@ -34,7 +34,6 @@ class CommitManager(BaseManager):
 
 @region_silo_only_model
 class Commit(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/commitauthor.py
+++ b/src/sentry/models/commitauthor.py
@@ -24,7 +24,6 @@ class CommitAuthorManager(BaseManager):
 
 @region_silo_only_model
 class CommitAuthor(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/commitfilechange.py
+++ b/src/sentry/models/commitfilechange.py
@@ -23,7 +23,6 @@ class CommitFileChangeManager(BaseManager):
 
 @region_silo_only_model
 class CommitFileChange(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -19,7 +19,6 @@ from sentry.silo import SiloMode, unguarded_write
 
 @region_silo_only_model
 class Counter(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey("sentry.Project", unique=True)

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -14,7 +14,6 @@ from sentry.db.models.fields.jsonfield import JSONField
 
 @region_silo_only_model
 class DashboardProject(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
@@ -32,7 +31,6 @@ class Dashboard(Model):
     A dashboard.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     title = models.CharField(max_length=255)
@@ -81,7 +79,6 @@ class DashboardTombstone(Model):
     has been replaced or deleted for an organization.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     slug = models.CharField(max_length=255)

--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -80,7 +80,6 @@ class DashboardWidgetQuery(Model):
     A query in a dashboard widget.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     widget = FlexibleForeignKey("sentry.DashboardWidget")
@@ -116,7 +115,6 @@ class DashboardWidget(Model):
     A dashboard widget.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     dashboard = FlexibleForeignKey("sentry.Dashboard")

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -135,7 +135,6 @@ class ProjectDebugFileManager(BaseManager):
 
 @region_silo_only_model
 class ProjectDebugFile(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     file = FlexibleForeignKey("sentry.File")
@@ -368,7 +367,6 @@ def _analyze_progard_filename(filename: str) -> Optional[str]:
 
 @region_silo_only_model
 class ProguardArtifactRelease(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField()

--- a/src/sentry/models/deletedentry.py
+++ b/src/sentry/models/deletedentry.py
@@ -6,7 +6,6 @@ from sentry.db.models import BoundedBigIntegerField, Model
 
 
 class DeletedEntry(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     actor_label = models.CharField(max_length=64, null=True)

--- a/src/sentry/models/deploy.py
+++ b/src/sentry/models/deploy.py
@@ -23,7 +23,6 @@ from sentry.utils.retries import TimedRetryPolicy
 
 @region_silo_only_model
 class Deploy(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/distribution.py
+++ b/src/sentry/models/distribution.py
@@ -13,7 +13,6 @@ from sentry.db.models import (
 
 @region_silo_only_model
 class Distribution(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/email.py
+++ b/src/sentry/models/email.py
@@ -13,7 +13,6 @@ class Email(Model):
     UserEmail represents whether a given user account has access to that email.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.User
 
     email = CIEmailField(_("email address"), unique=True, max_length=75)

--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -22,7 +22,6 @@ OK_NAME_PATTERN = re.compile(ENVIRONMENT_NAME_PATTERN)
 
 @region_silo_only_model
 class EnvironmentProject(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey("sentry.Project")
@@ -37,7 +36,6 @@ class EnvironmentProject(Model):
 
 @region_silo_only_model
 class Environment(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     organization_id = BoundedBigIntegerField()

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -33,7 +33,6 @@ def event_attachment_screenshot_filter(queryset):
 
 @region_silo_only_model
 class EventAttachment(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField()

--- a/src/sentry/models/eventuser.py
+++ b/src/sentry/models/eventuser.py
@@ -25,7 +25,6 @@ KEYWORD_MAP = BidirectionalMapping(
 
 @region_silo_only_model
 class EventUser(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/featureadoption.py
+++ b/src/sentry/models/featureadoption.py
@@ -226,7 +226,6 @@ class FeatureAdoptionManager(BaseManager):
 
 @region_silo_only_model
 class FeatureAdoption(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization = FlexibleForeignKey("sentry.Organization")

--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -196,7 +196,6 @@ class ChunkedFileBlobIndexWrapper:
 
 
 class AbstractFile(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     name = models.TextField()

--- a/src/sentry/models/files/abstractfileblob.py
+++ b/src/sentry/models/files/abstractfileblob.py
@@ -30,7 +30,6 @@ MULTI_BLOB_UPLOAD_CONCURRENCY = 8
 
 
 class AbstractFileBlob(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     path = models.TextField(null=True)

--- a/src/sentry/models/files/abstractfileblobindex.py
+++ b/src/sentry/models/files/abstractfileblobindex.py
@@ -3,7 +3,6 @@ from sentry.db.models import BoundedPositiveIntegerField, Model
 
 
 class AbstractFileBlobIndex(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     offset = BoundedPositiveIntegerField()

--- a/src/sentry/models/files/abstractfileblobowner.py
+++ b/src/sentry/models/files/abstractfileblobowner.py
@@ -3,7 +3,6 @@ from sentry.db.models import BoundedBigIntegerField, Model
 
 
 class AbstractFileBlobOwner(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/files/control_fileblobindex.py
+++ b/src/sentry/models/files/control_fileblobindex.py
@@ -8,7 +8,6 @@ from sentry.models.files.abstractfileblobindex import AbstractFileBlobIndex
 
 @control_silo_only_model
 class ControlFileBlobIndex(AbstractFileBlobIndex):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     file = FlexibleForeignKey("sentry.ControlFile")

--- a/src/sentry/models/files/control_fileblobowner.py
+++ b/src/sentry/models/files/control_fileblobowner.py
@@ -6,7 +6,6 @@ from sentry.models.files.abstractfileblobowner import AbstractFileBlobOwner
 
 @control_silo_only_model
 class ControlFileBlobOwner(AbstractFileBlobOwner):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     blob = FlexibleForeignKey("sentry.ControlFileBlob")

--- a/src/sentry/models/files/fileblobindex.py
+++ b/src/sentry/models/files/fileblobindex.py
@@ -8,7 +8,6 @@ from sentry.models.files.abstractfileblobindex import AbstractFileBlobIndex
 
 @region_silo_only_model
 class FileBlobIndex(AbstractFileBlobIndex):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     file = FlexibleForeignKey("sentry.File")

--- a/src/sentry/models/files/fileblobowner.py
+++ b/src/sentry/models/files/fileblobowner.py
@@ -6,7 +6,6 @@ from sentry.models.files.abstractfileblobowner import AbstractFileBlobOwner
 
 @region_silo_only_model
 class FileBlobOwner(AbstractFileBlobOwner):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     blob = FlexibleForeignKey("sentry.FileBlob")

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -475,7 +475,6 @@ class Group(Model):
     Aggregated message which summarizes a set of Events.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -151,7 +151,6 @@ class GroupAssignee(Model):
     aggregated event (Group).
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     objects = GroupAssigneeManager()

--- a/src/sentry/models/groupbookmark.py
+++ b/src/sentry/models/groupbookmark.py
@@ -20,7 +20,6 @@ class GroupBookmark(Model):
     aggregated event (Group).
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", related_name="bookmark_set")

--- a/src/sentry/models/groupcommitresolution.py
+++ b/src/sentry/models/groupcommitresolution.py
@@ -11,7 +11,6 @@ class GroupCommitResolution(Model):
     When a Group is referenced via a commit, its association is stored here.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     group_id = BoundedBigIntegerField()

--- a/src/sentry/models/groupemailthread.py
+++ b/src/sentry/models/groupemailthread.py
@@ -20,7 +20,6 @@ class GroupEmailThread(Model):
     for email threading.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     email = models.EmailField(max_length=75)

--- a/src/sentry/models/groupenvironment.py
+++ b/src/sentry/models/groupenvironment.py
@@ -9,7 +9,6 @@ from sentry.utils.cache import cache
 
 @region_silo_only_model
 class GroupEnvironment(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     group = FlexibleForeignKey("sentry.Group", db_constraint=False)

--- a/src/sentry/models/grouphash.py
+++ b/src/sentry/models/grouphash.py
@@ -12,7 +12,6 @@ from sentry.db.models import (
 
 @region_silo_only_model
 class GroupHash(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     class State:

--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -164,7 +164,6 @@ class GroupHistory(Model):
     - Issue Activity/Status over time breakdown (i.e. for each of the last 14 days, how many new, resolved, regressed, unignored, etc. issues were there?)
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     objects = GroupHistoryManager()

--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -53,7 +53,6 @@ class GroupInbox(Model):
     A Group that is in the inbox.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     group = FlexibleForeignKey("sentry.Group", unique=True, db_constraint=False)

--- a/src/sentry/models/grouplink.py
+++ b/src/sentry/models/grouplink.py
@@ -43,7 +43,6 @@ class GroupLink(Model):
     Link a group with an external resource like a commit, issue, or pull request
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     class Relationship:

--- a/src/sentry/models/groupmeta.py
+++ b/src/sentry/models/groupmeta.py
@@ -92,7 +92,6 @@ class GroupMeta(Model):
     provided by plugins.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     group = FlexibleForeignKey("sentry.Group")

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -55,7 +55,6 @@ class GroupOwner(Model):
     Tracks the "owners" or "suggested assignees" of a group.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     group = FlexibleForeignKey("sentry.Group", db_constraint=False)

--- a/src/sentry/models/groupredirect.py
+++ b/src/sentry/models/groupredirect.py
@@ -11,7 +11,6 @@ class GroupRedirect(Model):
     deleted) to the group that superseded it.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(null=True)

--- a/src/sentry/models/grouprelease.py
+++ b/src/sentry/models/grouprelease.py
@@ -18,7 +18,6 @@ from sentry.utils.hashlib import md5_text
 
 @region_silo_only_model
 class GroupRelease(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/groupresolution.py
+++ b/src/sentry/models/groupresolution.py
@@ -23,7 +23,6 @@ class GroupResolution(Model):
     Describes when a group was marked as resolved.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     class Type:

--- a/src/sentry/models/grouprulestatus.py
+++ b/src/sentry/models/grouprulestatus.py
@@ -7,7 +7,6 @@ from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, 
 
 @region_silo_only_model
 class GroupRuleStatus(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     ACTIVE = 0

--- a/src/sentry/models/groupseen.py
+++ b/src/sentry/models/groupseen.py
@@ -13,7 +13,6 @@ class GroupSeen(Model):
     Track when a group is last seen by a user.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/models/groupshare.py
+++ b/src/sentry/models/groupshare.py
@@ -25,7 +25,6 @@ class GroupShare(Model):
     A Group that was shared publicly.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -37,7 +37,6 @@ class GroupSnooze(Model):
     NOTE: `window` and `user_window` are specified in minutes
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     group = FlexibleForeignKey("sentry.Group", unique=True)

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -174,7 +174,6 @@ class GroupSubscription(Model):
     Identifies a subscription relationship between a user and an issue.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", related_name="subscription_set")

--- a/src/sentry/models/grouptombstone.py
+++ b/src/sentry/models/grouptombstone.py
@@ -18,7 +18,6 @@ TOMBSTONE_FIELDS_FROM_GROUP = ("project_id", "level", "message", "culprit", "dat
 
 @region_silo_only_model
 class GroupTombstone(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     previous_group_id = BoundedBigIntegerField(unique=True)

--- a/src/sentry/models/identity.py
+++ b/src/sentry/models/identity.py
@@ -49,7 +49,6 @@ class IdentityProvider(Model):
     acme-org.onelogin.com.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     type = models.CharField(max_length=64)
@@ -192,7 +191,6 @@ class Identity(Model):
     A verified link between a user and a third party identity.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     idp = FlexibleForeignKey("sentry.IdentityProvider")

--- a/src/sentry/models/integrations/doc_integration.py
+++ b/src/sentry/models/integrations/doc_integration.py
@@ -11,7 +11,6 @@ class DocIntegration(Model):
     Document based integrations can be found in Sentry, but are installed via code change.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     name = models.CharField(max_length=64)

--- a/src/sentry/models/integrations/external_actor.py
+++ b/src/sentry/models/integrations/external_actor.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 
 @region_silo_only_model
 class ExternalActor(DefaultFieldsModel):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     actor = FlexibleForeignKey("sentry.Actor", db_index=True, on_delete=models.CASCADE)

--- a/src/sentry/models/integrations/external_issue.py
+++ b/src/sentry/models/integrations/external_issue.py
@@ -70,7 +70,6 @@ class ExternalIssueManager(BaseManager):
 
 @region_silo_only_model
 class ExternalIssue(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     # The foreign key here is an `int`, not `bigint`.

--- a/src/sentry/models/integrations/integration.py
+++ b/src/sentry/models/integrations/integration.py
@@ -46,7 +46,6 @@ class Integration(DefaultFieldsModel):
     workspace, a single GH org, etc.), which can be shared by multiple Sentry orgs.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     provider = models.CharField(max_length=64)

--- a/src/sentry/models/integrations/integration_external_project.py
+++ b/src/sentry/models/integrations/integration_external_project.py
@@ -7,7 +7,6 @@ from sentry.db.models import BoundedPositiveIntegerField, Model, control_silo_on
 
 @control_silo_only_model
 class IntegrationExternalProject(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_integration_id = BoundedPositiveIntegerField(db_index=True)

--- a/src/sentry/models/integrations/integration_feature.py
+++ b/src/sentry/models/integrations/integration_feature.py
@@ -180,7 +180,6 @@ class IntegrationFeatureManager(BaseManager):
 
 @control_silo_only_model
 class IntegrationFeature(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     objects = IntegrationFeatureManager()

--- a/src/sentry/models/integrations/organization_integration.py
+++ b/src/sentry/models/integrations/organization_integration.py
@@ -20,7 +20,6 @@ from sentry.types.region import find_regions_for_orgs
 
 @control_silo_only_model
 class OrganizationIntegration(DefaultFieldsModel):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = HybridCloudForeignKey("sentry.Organization", on_delete="cascade")

--- a/src/sentry/models/integrations/project_integration.py
+++ b/src/sentry/models/integrations/project_integration.py
@@ -11,7 +11,6 @@ class ProjectIntegration(Model):
      Project Integrations.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/models/integrations/repository_project_path_config.py
+++ b/src/sentry/models/integrations/repository_project_path_config.py
@@ -16,7 +16,6 @@ from sentry.models.integrations.organization_integrity_backfill_mixin import (
 
 @region_silo_only_model
 class RepositoryProjectPathConfig(OrganizationIntegrityBackfillMixin, DefaultFieldsModel):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     repository = FlexibleForeignKey("sentry.Repository")

--- a/src/sentry/models/integrations/sentry_app.py
+++ b/src/sentry/models/integrations/sentry_app.py
@@ -108,7 +108,6 @@ class SentryAppManager(ParanoidManager):
 
 @control_silo_only_model
 class SentryApp(ParanoidModel, HasApiScopes):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     application = models.OneToOneField(

--- a/src/sentry/models/integrations/sentry_app_component.py
+++ b/src/sentry/models/integrations/sentry_app_component.py
@@ -7,7 +7,6 @@ from sentry.db.models.fields.jsonfield import JSONField
 
 @control_silo_only_model
 class SentryAppComponent(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     uuid = UUIDField(unique=True, auto_add=True)

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -98,7 +98,6 @@ class SentryAppInstallationForProviderManager(ParanoidManager):
 
 @control_silo_only_model
 class SentryAppInstallation(ParanoidModel):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     sentry_app = FlexibleForeignKey("sentry.SentryApp", related_name="installations")

--- a/src/sentry/models/integrations/sentry_app_installation_for_provider.py
+++ b/src/sentry/models/integrations/sentry_app_installation_for_provider.py
@@ -9,7 +9,6 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 class SentryAppInstallationForProvider(DefaultFieldsModel):
     """Connects a sentry app installation to an organization and a provider."""
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     sentry_app_installation = FlexibleForeignKey("sentry.SentryAppInstallation")

--- a/src/sentry/models/integrations/sentry_app_installation_token.py
+++ b/src/sentry/models/integrations/sentry_app_installation_token.py
@@ -61,7 +61,6 @@ class SentryAppInstallationTokenManager(BaseManager):
 
 @control_silo_only_model
 class SentryAppInstallationToken(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     api_token = FlexibleForeignKey("sentry.ApiToken")

--- a/src/sentry/models/latestappconnectbuildscheck.py
+++ b/src/sentry/models/latestappconnectbuildscheck.py
@@ -20,7 +20,6 @@ class LatestAppConnectBuildsCheck(DefaultFieldsModel):
     specific appconnect source in a project.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)

--- a/src/sentry/models/latestreporeleaseenvironment.py
+++ b/src/sentry/models/latestreporeleaseenvironment.py
@@ -9,7 +9,6 @@ class LatestRepoReleaseEnvironment(Model):
     commits in the given repo.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     repository_id = BoundedBigIntegerField()

--- a/src/sentry/models/lostpasswordhash.py
+++ b/src/sentry/models/lostpasswordhash.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
 @control_silo_only_model
 class LostPasswordHash(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL, unique=True)

--- a/src/sentry/models/notificationaction.py
+++ b/src/sentry/models/notificationaction.py
@@ -152,7 +152,6 @@ class TriggerGenerator:
 
 @region_silo_only_model
 class NotificationActionProject(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     project = FlexibleForeignKey("sentry.Project")
@@ -206,7 +205,6 @@ class NotificationAction(AbstractNotificationAction):
     Generic notification action model to programmatically route depending on the trigger (or source) for the notification
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
     __repr__ = sane_repr("id", "trigger_type", "service_type", "target_display")
 

--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -33,7 +33,6 @@ class NotificationSetting(Model):
     and the value is ("value").
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     @property

--- a/src/sentry/models/notificationsettingbase.py
+++ b/src/sentry/models/notificationsettingbase.py
@@ -8,7 +8,6 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 
 
 class NotificationSettingBase(DefaultFieldsModel):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     scope_type = models.CharField(max_length=32, null=False)

--- a/src/sentry/models/notificationsettingoption.py
+++ b/src/sentry/models/notificationsettingoption.py
@@ -8,7 +8,6 @@ from .notificationsettingbase import NotificationSettingBase
 
 @control_silo_only_model
 class NotificationSettingOption(NotificationSettingBase):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     class Meta:

--- a/src/sentry/models/notificationsettingprovider.py
+++ b/src/sentry/models/notificationsettingprovider.py
@@ -8,7 +8,6 @@ from .notificationsettingbase import NotificationSettingBase
 
 @control_silo_only_model
 class NotificationSettingProvider(NotificationSettingBase):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     provider = models.CharField(max_length=32, null=False)

--- a/src/sentry/models/options/option.py
+++ b/src/sentry/models/options/option.py
@@ -28,8 +28,6 @@ class BaseOption(Model):
     their key. e.g. key='myplugin:optname'
     """
 
-    __include_in_export__ = True
-
     # Subclasses should overwrite the relocation scope as appropriate.
     __relocation_scope__ = RelocationScope.Excluded
 
@@ -49,7 +47,6 @@ class BaseOption(Model):
 
 @region_silo_only_model
 class Option(BaseOption):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     class Meta:
@@ -61,7 +58,6 @@ class Option(BaseOption):
 
 @control_silo_only_model
 class ControlOption(BaseOption):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     class Meta:

--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -99,7 +99,6 @@ class OrganizationOption(Model):
     value: { updated: datetime }
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     organization = FlexibleForeignKey("sentry.Organization")

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -145,7 +145,6 @@ class ProjectOption(Model):
     their key. e.g. key='myplugin:optname'
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/models/options/user_option.py
+++ b/src/sentry/models/options/user_option.py
@@ -186,7 +186,6 @@ class UserOption(Model):
         - unused
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.User
 
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL)

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -165,7 +165,6 @@ class Organization(Model, OptionMixin, OrganizationAbsoluteUrlMixin, SnowflakeId
     An organization represents a group of individuals which maintain ownership of projects.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
     name = models.CharField(max_length=64)
     slug: models.Field[str, str] = models.SlugField(unique=True)

--- a/src/sentry/models/organizationaccessrequest.py
+++ b/src/sentry/models/organizationaccessrequest.py
@@ -11,7 +11,6 @@ from sentry.services.hybrid_cloud.user.service import user_service
 
 @region_silo_only_model
 class OrganizationAccessRequest(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     team = FlexibleForeignKey("sentry.Team")

--- a/src/sentry/models/organizationmapping.py
+++ b/src/sentry/models/organizationmapping.py
@@ -21,8 +21,6 @@ class OrganizationMapping(Model):
     * Safely reserve organization slugs via an eventually consistent cross silo workflow
     """
 
-    __include_in_export__ = True
-
     # This model is "autocreated" via an outbox write from the regional `Organization` it
     # references, so there is no need to explicitly include it in the export.
     __relocation_scope__ = RelocationScope.Excluded

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -197,7 +197,6 @@ class OrganizationMember(Model):
     be set to ownership.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     objects = OrganizationMemberManager()

--- a/src/sentry/models/organizationmembermapping.py
+++ b/src/sentry/models/organizationmembermapping.py
@@ -19,8 +19,6 @@ class OrganizationMemberMapping(Model):
     - map a user or an email to a specific organization to indicate an organization membership
     """
 
-    __include_in_export__ = False
-
     # This model is "autocreated" via an outbox write from the regional `Organization` it
     # references, so there is no need to explicitly include it in the export.
     __relocation_scope__ = RelocationScope.Excluded

--- a/src/sentry/models/organizationmemberteam.py
+++ b/src/sentry/models/organizationmemberteam.py
@@ -21,7 +21,6 @@ class OrganizationMemberTeam(BaseModel):
     Identifies relationships between organization members and the teams they are on.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     id = BoundedAutoField(primary_key=True)

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -82,7 +82,6 @@ class AbstractOnboardingTask(Model):
     which allows for the creation of tasks that are unique to users instead of organizations.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     STATUS_CHOICES = (

--- a/src/sentry/models/orgauthtoken.py
+++ b/src/sentry/models/orgauthtoken.py
@@ -27,7 +27,6 @@ def validate_scope_list(value):
 
 @control_silo_only_model
 class OrgAuthToken(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     organization_id = HybridCloudForeignKey("sentry.Organization", null=False, on_delete="CASCADE")

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -209,7 +209,6 @@ class OutboxBase(Model):
     class Meta:
         abstract = True
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     # Different shard_scope, shard_identifier pairings of messages are always deliverable in parallel

--- a/src/sentry/models/platformexternalissue.py
+++ b/src/sentry/models/platformexternalissue.py
@@ -10,7 +10,6 @@ from sentry.db.models.fields.foreignkey import FlexibleForeignKey
 
 @region_silo_only_model
 class PlatformExternalIssue(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     group = FlexibleForeignKey("sentry.Group", db_constraint=False, db_index=False)

--- a/src/sentry/models/processingissue.py
+++ b/src/sentry/models/processingissue.py
@@ -125,7 +125,6 @@ class ProcessingIssueManager(BaseManager):
 
 @region_silo_only_model
 class ProcessingIssue(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", db_index=True)
@@ -154,7 +153,6 @@ class ProcessingIssue(Model):
 
 @region_silo_only_model
 class EventProcessingIssue(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     raw_event = FlexibleForeignKey("sentry.RawEvent")

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -212,7 +212,6 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
     are the top level entry point for all data.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     slug = models.SlugField(null=True)

--- a/src/sentry/models/projectbookmark.py
+++ b/src/sentry/models/projectbookmark.py
@@ -20,7 +20,6 @@ class ProjectBookmark(Model):
     Identifies a bookmark relationship between a user and a project
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey(Project, blank=True, null=True, db_constraint=False)

--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -22,7 +22,6 @@ READ_CACHE_DURATION = 3600
 @region_silo_only_model
 class ProjectCodeOwners(Model):
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
     # no db constraint to prevent locks on the Project table
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -50,7 +50,6 @@ class ProjectKeyManager(BaseManager):
 
 @region_silo_only_model
 class ProjectKey(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey("sentry.Project", related_name="key_set")

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -33,7 +33,6 @@ _Everyone = enum.Enum("_Everyone", "EVERYONE")
 
 @region_silo_only_model
 class ProjectOwnership(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey("sentry.Project", unique=True)

--- a/src/sentry/models/projectplatform.py
+++ b/src/sentry/models/projectplatform.py
@@ -13,7 +13,6 @@ class ProjectPlatform(Model):
     Note: This model is used solely for analytics.
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField()

--- a/src/sentry/models/projectredirect.py
+++ b/src/sentry/models/projectredirect.py
@@ -7,7 +7,6 @@ from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model
 
 @region_silo_only_model
 class ProjectRedirect(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     redirect_slug = models.SlugField(db_index=True)

--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -39,7 +39,6 @@ class ProjectTeamManager(BaseManager):
 
 @region_silo_only_model
 class ProjectTeam(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/models/promptsactivity.py
+++ b/src/sentry/models/promptsactivity.py
@@ -17,7 +17,6 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 class PromptsActivity(Model):
     """Records user interaction with various feature prompts in product"""
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -51,7 +51,6 @@ class PullRequestManager(BaseManager):
 
 @region_silo_only_model
 class PullRequest(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
@@ -83,7 +82,6 @@ class PullRequest(Model):
 
 @region_silo_only_model
 class PullRequestCommit(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
     pull_request = FlexibleForeignKey("sentry.PullRequest")
     commit = FlexibleForeignKey("sentry.Commit")
@@ -105,7 +103,6 @@ class CommentType:
 
 @region_silo_only_model
 class PullRequestComment(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     external_id = BoundedBigIntegerField()

--- a/src/sentry/models/rawevent.py
+++ b/src/sentry/models/rawevent.py
@@ -13,7 +13,6 @@ def ref_func(x):
 
 @region_silo_only_model
 class RawEvent(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/models/recentsearch.py
+++ b/src/sentry/models/recentsearch.py
@@ -17,7 +17,6 @@ class RecentSearch(Model):
     Searches run by users recently.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     organization = FlexibleForeignKey("sentry.Organization")

--- a/src/sentry/models/relay.py
+++ b/src/sentry/models/relay.py
@@ -9,7 +9,6 @@ from sentry.db.models import Model, region_silo_only_model
 
 @region_silo_only_model
 class RelayUsage(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     relay_id = models.CharField(max_length=64)
@@ -26,7 +25,6 @@ class RelayUsage(Model):
 
 @region_silo_only_model
 class Relay(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     relay_id = models.CharField(max_length=64, unique=True)

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -98,7 +98,6 @@ class ReleaseProjectModelManager(BaseManager):
 
 @region_silo_only_model
 class ReleaseProject(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
@@ -460,7 +459,6 @@ class Release(Model):
     A commit is generally a git commit. See also releasecommit.py
     """
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization = FlexibleForeignKey("sentry.Organization")

--- a/src/sentry/models/releaseactivity.py
+++ b/src/sentry/models/releaseactivity.py
@@ -13,7 +13,6 @@ from sentry.types.releaseactivity import CHOICES
 
 @region_silo_only_model
 class ReleaseActivity(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     release = FlexibleForeignKey("sentry.Release", db_index=True)

--- a/src/sentry/models/releasecommit.py
+++ b/src/sentry/models/releasecommit.py
@@ -11,7 +11,6 @@ from sentry.db.models import (
 
 @region_silo_only_model
 class ReleaseCommit(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/releaseenvironment.py
+++ b/src/sentry/models/releaseenvironment.py
@@ -17,7 +17,6 @@ from sentry.utils.cache import cache
 
 @region_silo_only_model
 class ReleaseEnvironment(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization = FlexibleForeignKey("sentry.Organization", db_index=True, db_constraint=False)

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -66,7 +66,6 @@ class ReleaseFile(Model):
     The ident of the file should be sha1(name) or
     sha1(name '\x00\x00' dist.name) and must be unique per release.
     """
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField()

--- a/src/sentry/models/releaseheadcommit.py
+++ b/src/sentry/models/releaseheadcommit.py
@@ -11,7 +11,6 @@ from sentry.db.models import (
 
 @region_silo_only_model
 class ReleaseHeadCommit(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/releaseprojectenvironment.py
+++ b/src/sentry/models/releaseprojectenvironment.py
@@ -24,7 +24,6 @@ class ReleaseStages(str, Enum):
 
 @region_silo_only_model
 class ReleaseProjectEnvironment(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     release = FlexibleForeignKey("sentry.Release")

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -21,7 +21,6 @@ from sentry.signals import pending_delete
 
 @region_silo_only_model
 class Repository(Model, PendingDeletionMixin):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     organization_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/reprocessingreport.py
+++ b/src/sentry/models/reprocessingreport.py
@@ -13,7 +13,6 @@ from sentry.db.models import (
 
 @region_silo_only_model
 class ReprocessingReport(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/models/rule.py
+++ b/src/sentry/models/rule.py
@@ -33,7 +33,6 @@ class RuleSource(IntEnum):
 
 @region_silo_only_model
 class Rule(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     DEFAULT_CONDITION_MATCH = "all"  # any, all
@@ -121,7 +120,6 @@ class RuleActivityType(Enum):
 
 @region_silo_only_model
 class RuleActivity(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     rule = FlexibleForeignKey("sentry.Rule")

--- a/src/sentry/models/rulefirehistory.py
+++ b/src/sentry/models/rulefirehistory.py
@@ -8,7 +8,6 @@ from sentry.db.models import CharField, FlexibleForeignKey, Model, region_silo_o
 
 @region_silo_only_model
 class RuleFireHistory(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)

--- a/src/sentry/models/rulesnooze.py
+++ b/src/sentry/models/rulesnooze.py
@@ -33,7 +33,6 @@ class RuleSnooze(Model):
     Null `user_id` value means snoozed for all users.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     user_id = HybridCloudForeignKey("sentry.User", on_delete="CASCADE", null=True)

--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -55,7 +55,6 @@ class SavedSearch(Model):
     A saved search query.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
     organization = FlexibleForeignKey("sentry.Organization", null=True)
     type = models.PositiveSmallIntegerField(default=SearchType.ISSUE.value, null=True)

--- a/src/sentry/models/scheduledeletion.py
+++ b/src/sentry/models/scheduledeletion.py
@@ -47,7 +47,6 @@ class BaseScheduledDeletion(Model):
     class Meta:
         abstract = True
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     guid = models.CharField(max_length=32, unique=True, default=default_guid)

--- a/src/sentry/models/sentryfunction.py
+++ b/src/sentry/models/sentryfunction.py
@@ -19,7 +19,6 @@ class SentryFunctionManager(BaseManager):
 
 @region_silo_only_model
 class SentryFunction(DefaultFieldsModel):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     organization = FlexibleForeignKey("sentry.Organization")

--- a/src/sentry/models/servicehook.py
+++ b/src/sentry/models/servicehook.py
@@ -32,7 +32,6 @@ SERVICE_HOOK_EVENTS = [
 
 @region_silo_only_model
 class ServiceHookProject(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     service_hook = FlexibleForeignKey("sentry.ServiceHook")
@@ -52,7 +51,6 @@ def generate_secret():
 
 @region_silo_only_model
 class ServiceHook(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Global
 
     guid = models.CharField(max_length=32, unique=True, null=True)

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -157,7 +157,6 @@ class Team(Model, SnowflakeIdMixin):
     A team represents a group of individuals which maintain ownership of projects.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     organization = FlexibleForeignKey("sentry.Organization")

--- a/src/sentry/models/tombstone.py
+++ b/src/sentry/models/tombstone.py
@@ -29,7 +29,6 @@ class TombstoneBase(Model):
         abstract = True
         unique_together = ("table_name", "object_identifier")
 
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     table_name = models.CharField(max_length=48, null=False)

--- a/src/sentry/models/transaction_threshold.py
+++ b/src/sentry/models/transaction_threshold.py
@@ -53,7 +53,6 @@ def _filter_and_cache(cls, cache_key, project_ids, organization_id, order_by, va
 
 @region_silo_only_model
 class ProjectTransactionThresholdOverride(DefaultFieldsModel):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     # max_length here is based on the maximum for transactions in relay
@@ -84,7 +83,6 @@ class ProjectTransactionThresholdOverride(DefaultFieldsModel):
 
 @region_silo_only_model
 class ProjectTransactionThreshold(DefaultFieldsModel):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", unique=True, db_constraint=False)

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -69,7 +69,6 @@ class UserManager(BaseManager, DjangoUserManager):
 
 @control_silo_only_model
 class User(BaseModel, AbstractBaseUser):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.User
 
     id = BoundedBigAutoField(primary_key=True)

--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -45,7 +45,6 @@ class UserEmailManager(BaseManager):
 
 @control_silo_only_model
 class UserEmail(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.User
 
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL, related_name="emails")

--- a/src/sentry/models/userip.py
+++ b/src/sentry/models/userip.py
@@ -15,7 +15,6 @@ from sentry.utils.geo import geo_by_addr
 
 @control_silo_only_model
 class UserIP(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.User
 
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL)

--- a/src/sentry/models/userpermission.py
+++ b/src/sentry/models/userpermission.py
@@ -14,7 +14,6 @@ class UserPermission(Model):
     Generally speaking, they should only apply to active superuser sessions.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.User
 
     user = FlexibleForeignKey("sentry.User")

--- a/src/sentry/models/userreport.py
+++ b/src/sentry/models/userreport.py
@@ -7,7 +7,6 @@ from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_mod
 
 @region_silo_only_model
 class UserReport(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/userrole.py
+++ b/src/sentry/models/userrole.py
@@ -16,7 +16,6 @@ class UserRole(DefaultFieldsModel):
     Roles are applied to administrative users and apply a set of `UserPermission`.
     """
 
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.User
 
     name = models.CharField(max_length=32, unique=True)
@@ -43,7 +42,6 @@ class UserRole(DefaultFieldsModel):
 
 @control_silo_only_model
 class UserRoleUser(DefaultFieldsModel):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.User
 
     user = FlexibleForeignKey("sentry.User")

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -208,7 +208,6 @@ class ScheduleType:
 
 @region_silo_only_model
 class Monitor(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     guid = UUIDField(unique=True, auto_add=True)
@@ -358,7 +357,6 @@ def check_organization_monitor_limits(sender, instance, **kwargs):
 
 @region_silo_only_model
 class MonitorCheckIn(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     guid = UUIDField(unique=True, auto_add=True)
@@ -454,7 +452,6 @@ class MonitorCheckIn(Model):
 
 @region_silo_only_model
 class MonitorLocation(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     guid = UUIDField(unique=True, auto_add=True)
@@ -493,7 +490,6 @@ class MonitorEnvironmentManager(BaseManager):
 
 @region_silo_only_model
 class MonitorEnvironment(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     monitor = FlexibleForeignKey("sentry.Monitor")

--- a/src/sentry/nodestore/django/models.py
+++ b/src/sentry/nodestore/django/models.py
@@ -7,7 +7,6 @@ from sentry.db.models import BaseModel, region_silo_only_model, sane_repr
 
 @region_silo_only_model
 class Node(BaseModel):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     id = models.CharField(max_length=40, primary_key=True)

--- a/src/sentry/replays/models.py
+++ b/src/sentry/replays/models.py
@@ -10,7 +10,6 @@ from sentry.db.models.fields.bounded import BoundedIntegerField, BoundedPositive
 # Based heavily on EventAttachment
 @region_silo_only_model
 class ReplayRecordingSegment(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField()

--- a/src/sentry/sentry_metrics/indexer/postgres/models.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/models.py
@@ -18,7 +18,6 @@ from typing import Mapping, Type
 
 @region_silo_only_model
 class MetricsKeyIndexer(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     string = models.CharField(max_length=200)
@@ -61,7 +60,6 @@ class BaseIndexer(Model):
 
 @region_silo_only_model
 class StringIndexer(BaseIndexer):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     class Meta:
@@ -74,7 +72,6 @@ class StringIndexer(BaseIndexer):
 
 @region_silo_only_model
 class PerfStringIndexer(BaseIndexer):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
     use_case_id = models.CharField(max_length=120)
 

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -23,7 +23,6 @@ query_aggregation_to_snuba = {
 
 @region_silo_only_model
 class SnubaQuery(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     class Type(Enum):
@@ -52,7 +51,6 @@ class SnubaQuery(Model):
 
 @region_silo_only_model
 class SnubaQueryEventType(Model):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     class EventType(Enum):
@@ -75,7 +73,6 @@ class SnubaQueryEventType(Model):
 
 @region_silo_only_model
 class QuerySubscription(DefaultFieldsModel):
-    __include_in_export__ = True
     __relocation_scope__ = RelocationScope.Organization
 
     class Status(Enum):

--- a/tests/sentry/db/models/fields/test_bounded.py
+++ b/tests/sentry/db/models/fields/test_bounded.py
@@ -14,7 +14,6 @@ from sentry.testutils.cases import TestCase
 # There's a good chance this model wont get created in the db, so avoid
 # assuming it exists in these tests.
 class DummyModel(Model):
-    __include_in_export__ = False
     __relocation_scope__ = RelocationScope.Excluded
 
     foo = models.CharField(max_length=32)

--- a/tests/sentry/models/test_base.py
+++ b/tests/sentry/models/test_base.py
@@ -11,7 +11,6 @@ from sentry.testutils.cases import TestCase
 
 class AvailableOnTest(TestCase):
     class TestModel(Model):
-        __include_in_export__ = False
         __relocation_scope__ = RelocationScope.Excluded
 
         class Meta:


### PR DESCRIPTION
This PR squashes a 4-step migration process, wherein we replace all 
use of `__include_in_export__` with the more specific and useful
`__relocation_scope__`:

1. Define the new `ReloationScope` enum.
2. Add the appropriate enum value to `__relocation_scope__` on all
   models
3. Replace all code that interacts with `__include_in_export__` with
   code that uses `__relocation_scope__` in the same way.
4. Remove all uses of `__include_in_export__`.

The end result of this work is to have more granular specifications for
what to do with a model during relocation than merely "do we include
this or not".

Issue: getsentry/team-ospo#166