### PR TITLE
ref(hc): Make it easier to deprecate pager duty services on getsentry

### DIFF
--- a/src/sentry/services/hybrid_cloud/integration/serial.py
+++ b/src/sentry/services/hybrid_cloud/integration/serial.py
@@ -20,7 +20,10 @@ def serialize_integration(integration: Integration) -> RpcIntegration:
 
 def serialize_organization_integration(oi: OrganizationIntegration) -> RpcOrganizationIntegration:
     config: Dict[str, Any] = dict(**oi.config)
-    if oi.integration.provider == ExternalProviders.PAGERDUTY.name:
+    if (
+        oi.integration.provider == ExternalProviders.PAGERDUTY.name
+        and "pagerduty_services" not in config
+    ):
         config["pagerduty_services"] = [
             pds.as_dict()
             for pds in PagerDutyService.objects.filter(organization_integration_id=oi.id)


### PR DESCRIPTION
One more change necessary for https://github.com/getsentry/getsentry/pull/11412 which enables https://github.com/getsentry/sentry/pull/54530

Basically, need getsentry to swap write behavior while also retaining read behavior before I can swap the write behavior on the sentry side to be consistent through getsentry on the read behavior.  Ungh.