### PR TITLE
Fix(partnership): URL for users with multiple sentry orgs

### DIFF
--- a/src/sentry/web/frontend/auth_channel_login.py
+++ b/src/sentry/web/frontend/auth_channel_login.py
@@ -39,12 +39,25 @@ class AuthChannelLoginView(AuthOrganizationLoginView):
         if organization_context is None:
             return self.redirect(reverse("sentry-login"))
 
+        next_uri = self.get_next_uri(request)
+        # If user has an active session within the same organization skip login
         if request.user.is_authenticated:
-            next_uri = self.get_next_uri(request)
-            if is_valid_redirect(next_uri, allowed_hosts=(request.get_host())):
-                return self.redirect(next_uri)
-            return self.redirect(Organization.get_url(slug=organization_context.organization.slug))
+            if self.active_organization is not None:
+                if self.active_organization.organization.id == organization_id:
+                    if is_valid_redirect(next_uri, allowed_hosts=(request.get_host())):
+                        return self.redirect(next_uri)
+                    return self.redirect(
+                        Organization.get_url(slug=organization_context.organization.slug)
+                    )
 
-        return self.redirect(
-            reverse("sentry-auth-organization", args=[organization_context.organization.slug])
+        # If user doesn't have active session within the same organization redirect to login for the
+        # organization in the url
+        org_auth_url = reverse(
+            "sentry-auth-organization", args=[organization_context.organization.slug]
         )
+        redirect_url = (
+            org_auth_url + "?next=" + next_uri
+            if is_valid_redirect(next_uri, allowed_hosts=(request.get_host()))
+            else org_auth_url
+        )
+        return self.redirect(redirect_url)


### PR DESCRIPTION
This PR fixes a bug for users hitting sentry.io/auth/channel/fly/{org-X-fly-id} while they're logged in another org.
Before:
1. User logs in org-Y
2. User hits sentry.io/auth/channel/fly/{org-X-fly-id}/?next/issues/?project={org-X-project}
3. User gets page not found because we redirect them to org Y and org-X-project doesn't exist

After:
3. User gets log in page for Org X
4. After login will redirect to Org-X-project issues page

