### PR TITLE
Rework Symbolicator Polling

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3225,20 +3225,15 @@ MIGRATIONS_LOCKFILE_APP_WHITELIST = (
 # Where to write the lockfile to.
 MIGRATIONS_LOCKFILE_PATH = os.path.join(PROJECT_ROOT, os.path.pardir, os.path.pardir)
 
-# Log error and abort processing (without dropping event) when process_event is
-# taking more than n seconds to process event
-SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT = 600
+# Log error and abort processing (without dropping event, but marking it as failed to process)
+# when `symbolicate_event` is taking more than n seconds to process an event.
+SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT = 15 * 60
 
-# Log warning when process_event is taking more than n seconds to process event
-SYMBOLICATOR_PROCESS_EVENT_WARN_TIMEOUT = 120
+# Log warning when `symbolicate_event` is taking more than n seconds to process an event.
+SYMBOLICATOR_PROCESS_EVENT_WARN_TIMEOUT = 2 * 60
 
-# Block symbolicate_event for this many seconds to wait for a initial response
-# from symbolicator after the task submission.
+# Block `symbolicate_event` for this many seconds to wait for a response from Symbolicator.
 SYMBOLICATOR_POLL_TIMEOUT = 5
-
-# When retrying symbolication requests or querying for the result this set the
-# max number of second to wait between subsequent attempts.
-SYMBOLICATOR_MAX_RETRY_AFTER = 2
 
 # The `url` of the different Symbolicator pools.
 # We want to route different workloads to a different set of Symbolicator pools.
@@ -3360,7 +3355,7 @@ SENTRY_ENABLE_AUTO_LOW_PRIORITY_QUEUE = False
 # See `RealtimeMetricsStore.record_project_duration` for an explanation of how
 # this works.
 # The "regular interval" at which symbolication time is submitted is defined by
-# a combination of `SYMBOLICATOR_POLL_TIMEOUT` and `SYMBOLICATOR_MAX_RETRY_AFTER`.
+# `SYMBOLICATOR_POLL_TIMEOUT`.
 #
 # This value is already adjusted according to the
 # `symbolicate-event.low-priority.metrics.submission-rate` option.

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import dataclasses
 import logging
 import time
 import uuid
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Callable
 from urllib.parse import urljoin
 
 import sentry_sdk
@@ -12,7 +14,6 @@ from django.conf import settings
 from requests.exceptions import RequestException
 
 from sentry import options
-from sentry.cache import default_cache
 from sentry.lang.native.sources import (
     get_bundle_index_urls,
     get_internal_artifact_lookup_source,
@@ -23,13 +24,8 @@ from sentry.net.http import Session
 from sentry.utils import json, metrics
 
 MAX_ATTEMPTS = 3
-REQUEST_CACHE_TIMEOUT = 3600
 
 logger = logging.getLogger(__name__)
-
-
-def _task_id_cache_key_for_event(project_id, event_id):
-    return f"symbolicator:{event_id}:{project_id}"
 
 
 @dataclass(frozen=True)
@@ -38,10 +34,10 @@ class SymbolicatorTaskKind:
     is_low_priority: bool = False
     is_reprocessing: bool = False
 
-    def with_low_priority(self, is_low_priority: bool) -> "SymbolicatorTaskKind":
+    def with_low_priority(self, is_low_priority: bool) -> SymbolicatorTaskKind:
         return dataclasses.replace(self, is_low_priority=is_low_priority)
 
-    def with_js(self, is_js: bool) -> "SymbolicatorTaskKind":
+    def with_js(self, is_js: bool) -> SymbolicatorTaskKind:
         return dataclasses.replace(self, is_js=is_js)
 
 
@@ -53,7 +49,13 @@ class SymbolicatorPools(Enum):
 
 
 class Symbolicator:
-    def __init__(self, task_kind: SymbolicatorTaskKind, project: Project, event_id: str):
+    def __init__(
+        self,
+        task_kind: SymbolicatorTaskKind,
+        on_request: Callable[[], None],
+        project: Project,
+        event_id: str,
+    ):
         URLS = settings.SYMBOLICATOR_POOL_URLS
         pool = SymbolicatorPools.default.value
         if task_kind.is_low_priority:
@@ -72,59 +74,70 @@ class Symbolicator:
         base_url = base_url.rstrip("/")
         assert base_url
 
+        self.base_url = base_url
+        self.on_request = on_request
         self.project = project
-        self.sess = SymbolicatorSession(
-            url=base_url,
-            project_id=str(project.id),
-            event_id=str(event_id),
-            timeout=settings.SYMBOLICATOR_POLL_TIMEOUT,
-        )
-        self.task_id_cache_key = _task_id_cache_key_for_event(project.id, event_id)
+        self.event_id = event_id
 
     def _process(self, task_name: str, path: str, **kwargs):
-        task_id = default_cache.get(self.task_id_cache_key)
+        """
+        This function will submit a symbolication task to a Symbolicator and handle
+        polling it using the `SymbolicatorSession`.
+        It will also correctly handle `TaskIdNotFound` and `ServiceUnavailable` errors.
+        """
+        session = SymbolicatorSession(
+            url=self.base_url,
+            project_id=str(self.project.id),
+            event_id=str(self.event_id),
+            timeout=settings.SYMBOLICATOR_POLL_TIMEOUT,
+        )
+
+        task_id: str | None = None
         json_response = None
 
-        with self.sess:
-            try:
-                if task_id:
-                    # Processing has already started and we need to poll
-                    # symbolicator for an update. This in turn may put us back into
-                    # the queue.
-                    json_response = self.sess.query_task(task_id)
+        with session:
+            while True:
+                try:
+                    if not task_id:
+                        # We are submitting a new task to Symbolicator
+                        json_response = session.create_task(path, **kwargs)
+                    else:
+                        # The task has already been submitted to Symbolicator and we are polling
+                        json_response = session.query_task(task_id)
+                except TaskIdNotFound:
+                    # We have started a task on Symbolicator and are polling, but the task went away.
+                    # This can happen when Symbolicator was restarted or the load balancer routing changed in some way.
+                    # We can just re-submit the task using the same `session` and try again. We use the same `session`
+                    # to avoid the likelihood of this happening again. When Symbolicators are restarted due to a deploy
+                    # in a staggered fashion, we do not want to create a new `session`, being assigned a different
+                    # Symbolicator instance just to it restarted next.
+                    task_id = None
+                    continue
+                except ServiceUnavailable:
+                    # This error means that the Symbolicator instance bound to our `session` is not healthy.
+                    # By resetting the `worker_id`, the load balancer will route us to a different
+                    # Symbolicator instance.
+                    session.reset_worker_id()
+                    task_id = None
+                    continue
+                finally:
+                    self.on_request()
 
-                if json_response is None:
-                    # This is a new task, so we compute all request parameters
-                    # (potentially expensive if we need to pull minidumps), and then
-                    # upload all information to symbolicator. It will likely not
-                    # have a response ready immediately, so we start polling after
-                    # some timeout.
-                    json_response = self.sess.create_task(path, **kwargs)
-            except ServiceUnavailable:
-                # 503 can indicate that symbolicator is restarting. Wait for a
-                # reboot, then try again. This overrides the default behavior of
-                # retrying after just a second.
-                #
-                # If there is no response attached, it's a connection error.
-                raise RetrySymbolication(retry_after=settings.SYMBOLICATOR_MAX_RETRY_AFTER)
-
-            metrics.incr(
-                "events.symbolicator.response",
-                tags={"response": json_response.get("status") or "null", "task_name": task_name},
-            )
-
-            # Symbolication is still in progress. Bail out and try again
-            # after some timeout. Symbolicator keeps the response for the
-            # first one to poll it.
-            if json_response["status"] == "pending":
-                default_cache.set(
-                    self.task_id_cache_key, json_response["request_id"], REQUEST_CACHE_TIMEOUT
+                metrics.incr(
+                    "events.symbolicator.response",
+                    tags={
+                        "response": json_response.get("status") or "null",
+                        "task_name": task_name,
+                    },
                 )
-                raise RetrySymbolication(retry_after=json_response["retry_after"])
-            else:
-                # Once we arrive here, we are done processing. Clean up the
-                # task id from the cache.
-                default_cache.delete(self.task_id_cache_key)
+
+                if json_response["status"] == "pending":
+                    # Symbolicator was not able to process the whole task within one timeout period.
+                    # Start polling using the `request_id`/`task_id`.
+                    task_id = json_response["request_id"]
+                    continue
+
+                # Otherwise, we are done processing, yay
                 return json_response
 
     def process_minidump(self, minidump):
@@ -208,25 +221,30 @@ class ServiceUnavailable(Exception):
     pass
 
 
-class RetrySymbolication(Exception):
-    def __init__(self, retry_after: Optional[int] = None) -> None:
-        self.retry_after = retry_after
-
-
 class SymbolicatorSession:
+    """
+    The `SymbolicatorSession` is a glorified HTTP request wrapper that does the following things:
 
-    # used in x-sentry-worker-id http header
-    # to keep it static for celery worker process keep it as class attribute
+    - Maintains a `worker_id` which is used downstream in the load balancer for routing.
+    - Maintains `timeout` parameters which are passed to Symbolicator.
+    - Converts 404 and 503 errors into proper classes so they can be handled upstream.
+    - Otherwise, it retries failed requests.
+    """
+
+    # Used as the `x-sentry-worker-id` HTTP header which is the routing key of
+    # the Symbolicator load balancer.
     _worker_id = None
 
     def __init__(
-        self, url=None, sources=None, project_id=None, event_id=None, timeout=None, options=None
+        self,
+        url=None,
+        project_id=None,
+        event_id=None,
+        timeout=None,
     ):
         self.url = url
         self.project_id = project_id
         self.event_id = event_id
-        self.sources = sources or []
-        self.options = options or None
         self.timeout = timeout
         self.session = None
 
@@ -265,9 +283,7 @@ class SymbolicatorSession:
                 with metrics.timer(
                     "events.symbolicator.session.request", tags={"attempt": attempts}
                 ):
-                    response = self.session.request(
-                        method, url, timeout=settings.SYMBOLICATOR_POLL_TIMEOUT + 1, **kwargs
-                    )
+                    response = self.session.request(method, url, timeout=self.timeout + 1, **kwargs)
 
                 metrics.incr(
                     "events.symbolicator.status_code",
@@ -283,7 +299,7 @@ class SymbolicatorSession:
                     # expected to happen when we're currently deploying
                     # symbolicator (which will clear all of its state). Re-send
                     # the symbolication task.
-                    return None
+                    raise TaskIdNotFound()
 
                 if response.status_code in (502, 503):
                     raise ServiceUnavailable()
@@ -326,6 +342,7 @@ class SymbolicatorSession:
 
     def create_task(self, path, **kwargs):
         params = {"timeout": self.timeout, "scope": self.project_id}
+
         with metrics.timer(
             "events.symbolicator.create_task",
             tags={"path": path},
@@ -333,18 +350,11 @@ class SymbolicatorSession:
             return self._request(method="post", path=path, params=params, **kwargs)
 
     def query_task(self, task_id):
+        params = {"timeout": self.timeout, "scope": self.project_id}
         task_url = f"requests/{task_id}"
-
-        params = {
-            "timeout": 0,  # Only wait when creating, but not when querying tasks
-            "scope": self.project_id,
-        }
 
         with metrics.timer("events.symbolicator.query_task"):
             return self._request("get", task_url, params=params)
-
-    def healthcheck(self):
-        return self._request("get", "healthcheck")
 
     @classmethod
     def get_worker_id(cls):
@@ -353,3 +363,7 @@ class SymbolicatorSession:
             # %5000 to reduce cardinality of metrics tagging with worker id
             cls._worker_id = str(uuid.uuid4().int % 5000)
         return cls._worker_id
+
+    @classmethod
+    def reset_worker_id(cls):
+        cls._worker_id = None

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from datetime import datetime
-from time import sleep, time
+from time import time
 from typing import Any, List, Mapping, MutableMapping, Optional, Tuple
 
 import msgpack
@@ -15,7 +15,7 @@ from sentry import quotas
 from sentry.constants import DataCategory
 from sentry.lang.javascript.processing import _handles_frame as is_valid_javascript_frame
 from sentry.lang.javascript.processing import generate_scraping_config
-from sentry.lang.native.symbolicator import RetrySymbolication, Symbolicator, SymbolicatorTaskKind
+from sentry.lang.native.symbolicator import Symbolicator, SymbolicatorTaskKind
 from sentry.models import EventError, Organization, Project, ProjectDebugFile
 from sentry.profiles.device import classify_device
 from sentry.profiles.java import deobfuscate_signature
@@ -337,6 +337,10 @@ def symbolicate(
     )
 
 
+class SymbolicationTimeout(Exception):
+    pass
+
+
 @metrics.wraps("process_profile.symbolicate.request")
 def run_symbolicate(
     project: Project,
@@ -344,57 +348,55 @@ def run_symbolicate(
     modules: List[Any],
     stacktraces: List[Any],
 ) -> Tuple[List[Any], List[Any], bool]:
-    symbolicator = Symbolicator(SymbolicatorTaskKind(), project, profile["event_id"])
     symbolication_start_time = time()
 
-    while True:
-        try:
-            with sentry_sdk.start_span(op="task.profiling.symbolicate.process_payload"):
-                response = symbolicate(
-                    symbolicator=symbolicator,
-                    profile=profile,
-                    stacktraces=stacktraces,
-                    modules=modules,
-                )
+    def on_symbolicator_request():
+        duration = time() - symbolication_start_time
+        if duration > settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT:
+            raise SymbolicationTimeout
 
-                if not response:
-                    profile["symbolicator_error"] = {
-                        "type": EventError.NATIVE_INTERNAL_FAILURE,
-                    }
-                    return modules, stacktraces, False
-                elif response["status"] == "completed":
-                    return (
-                        response.get("modules", modules),
-                        response.get("stacktraces", stacktraces),
-                        True,
-                    )
-                elif response["status"] == "failed":
-                    profile["symbolicator_error"] = {
-                        "type": EventError.NATIVE_SYMBOLICATOR_FAILED,
-                        "status": response.get("status"),
-                        "message": response.get("message"),
-                    }
-                    return modules, stacktraces, False
-                else:
-                    profile["symbolicator_error"] = {
-                        "status": response.get("status"),
-                        "type": EventError.NATIVE_INTERNAL_FAILURE,
-                    }
-                    return modules, stacktraces, False
-        except RetrySymbolication as e:
-            if (
-                time() - symbolication_start_time
-            ) > settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT:
-                metrics.incr("process_profile.symbolicate.timeout", sample_rate=1.0)
-                break
-            else:
-                sleep_time = (
-                    settings.SYMBOLICATOR_MAX_RETRY_AFTER
-                    if e.retry_after is None
-                    else min(e.retry_after, settings.SYMBOLICATOR_MAX_RETRY_AFTER)
+    symbolicator = Symbolicator(
+        task_kind=SymbolicatorTaskKind(),
+        on_request=on_symbolicator_request,
+        project=project,
+        event_id=profile["event_id"],
+    )
+
+    try:
+        with sentry_sdk.start_span(op="task.profiling.symbolicate.process_payload"):
+            response = symbolicate(
+                symbolicator=symbolicator,
+                profile=profile,
+                stacktraces=stacktraces,
+                modules=modules,
+            )
+
+            if not response:
+                profile["symbolicator_error"] = {
+                    "type": EventError.NATIVE_INTERNAL_FAILURE,
+                }
+                return modules, stacktraces, False
+            elif response["status"] == "completed":
+                return (
+                    response.get("modules", modules),
+                    response.get("stacktraces", stacktraces),
+                    True,
                 )
-                sleep(sleep_time)
-                continue
+            elif response["status"] == "failed":
+                profile["symbolicator_error"] = {
+                    "type": EventError.NATIVE_SYMBOLICATOR_FAILED,
+                    "status": response.get("status"),
+                    "message": response.get("message"),
+                }
+                return modules, stacktraces, False
+            else:
+                profile["symbolicator_error"] = {
+                    "status": response.get("status"),
+                    "type": EventError.NATIVE_INTERNAL_FAILURE,
+                }
+                return modules, stacktraces, False
+    except SymbolicationTimeout:
+        metrics.incr("process_profile.symbolicate.timeout", sample_rate=1.0)
 
     # returns the unsymbolicated data to avoid errors later
     return modules, stacktraces, False

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -1,6 +1,6 @@
 import logging
 import random
-from time import sleep, time
+from time import time
 from typing import Any, Callable, Optional, Tuple
 
 import sentry_sdk
@@ -11,7 +11,7 @@ from sentry.eventstore import processing
 from sentry.eventstore.processing.base import Event
 from sentry.killswitches import killswitch_matches_context
 from sentry.lang.javascript.processing import process_js_stacktraces
-from sentry.lang.native.symbolicator import RetrySymbolication, Symbolicator, SymbolicatorTaskKind
+from sentry.lang.native.symbolicator import Symbolicator, SymbolicatorTaskKind
 from sentry.models import Organization, Project
 from sentry.processing import realtime_metrics
 from sentry.silo import SiloMode
@@ -23,11 +23,6 @@ from sentry.utils.sdk import set_current_event_project
 
 error_logger = logging.getLogger("sentry.errors.events")
 info_logger = logging.getLogger("sentry.symbolication")
-
-# Is reprocessing on or off by default?
-REPROCESSING_DEFAULT = False
-
-SYMBOLICATOR_MAX_RETRY_AFTER: int = settings.SYMBOLICATOR_MAX_RETRY_AFTER
 
 # The maximum number of times an event will be moved between the normal
 # and low priority queues
@@ -100,6 +95,10 @@ def get_symbolication_function(
         return False, get_native_symbolication_function(data)
 
 
+class SymbolicationTimeout(Exception):
+    pass
+
+
 def _do_symbolicate_event(
     cache_key: str,
     start_time: Optional[int],
@@ -120,7 +119,7 @@ def _do_symbolicate_event(
         return
 
     data = CanonicalKeyDict(data)
-    event_id = data["event_id"]
+    event_id = str(data["event_id"])
     project_id = data["project"]
     has_changed = False
 
@@ -222,81 +221,63 @@ def _do_symbolicate_event(
             "organization", Organization.objects.get_from_cache(id=project.organization_id)
         )
 
-    symbolicator = Symbolicator(task_kind, project, data["event_id"])
+    def on_symbolicator_request():
+        duration = record_symbolication_duration()
+        if duration > settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT:
+            raise SymbolicationTimeout
+        elif duration > settings.SYMBOLICATOR_PROCESS_EVENT_WARN_TIMEOUT:
+            error_logger.warning(
+                "symbolicate.slow",
+                extra={"project_id": project_id, "event_id": event_id},
+            )
 
-    with sentry_sdk.start_span(op="tasks.store.symbolicate_event.symbolication") as span:
-        span.set_data("symbolication_function", symbolication_function_name)
-        with metrics.timer(
-            "tasks.store.symbolicate_event.symbolication",
-            tags={"symbolication_function": symbolication_function_name},
-        ):
-            while True:
-                try:
-                    with sentry_sdk.start_span(
-                        op="tasks.store.symbolicate_event.%s" % symbolication_function_name
-                    ) as span:
-                        symbolicated_data = symbolication_function(symbolicator, data)
-                        span.set_data("symbolicated_data", bool(symbolicated_data))
+    symbolicator = Symbolicator(
+        task_kind=task_kind,
+        on_request=on_symbolicator_request,
+        project=project,
+        event_id=event_id,
+    )
 
-                    if symbolicated_data:
-                        data = symbolicated_data
-                        has_changed = True
+    with metrics.timer(
+        "tasks.store.symbolicate_event.symbolication",
+        tags={"symbolication_function": symbolication_function_name},
+    ), sentry_sdk.start_span(
+        op=f"tasks.store.symbolicate_event.{symbolication_function_name}"
+    ) as span:
+        try:
+            symbolicated_data = symbolication_function(symbolicator, data)
+            span.set_data("symbolicated_data", bool(symbolicated_data))
 
-                    record_symbolication_duration()
-                    break
-                except RetrySymbolication as e:
-                    duration = record_symbolication_duration()
-                    if duration > settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT:
-                        # Do not drop event but actually continue with rest of pipeline
-                        # (persisting unsymbolicated event)
-                        metrics.incr(
-                            "tasks.store.symbolicate_event.fatal",
-                            tags={
-                                "reason": "timeout",
-                                "symbolication_function": symbolication_function_name,
-                            },
-                        )
-                        error_logger.exception(
-                            "symbolicate.failed.infinite_retry",
-                            extra={"project_id": project_id, "event_id": event_id},
-                        )
-                        data.setdefault("_metrics", {})["flag.processing.error"] = True
-                        data.setdefault("_metrics", {})["flag.processing.fatal"] = True
-                        has_changed = True
-                        break
-                    else:
-                        if duration > settings.SYMBOLICATOR_PROCESS_EVENT_WARN_TIMEOUT:
-                            error_logger.warning(
-                                "symbolicate.slow",
-                                extra={"project_id": project_id, "event_id": event_id},
-                            )
-                        # sleep for `retry_after` but max 5 seconds and try again
-                        metrics.incr(
-                            "tasks.store.symbolicate_event.retry",
-                            tags={"symbolication_function": symbolication_function_name},
-                        )
-                        sleep_time = (
-                            SYMBOLICATOR_MAX_RETRY_AFTER
-                            if e.retry_after is None
-                            else min(e.retry_after, SYMBOLICATOR_MAX_RETRY_AFTER)
-                        )
-                        sleep(sleep_time)
-                        continue
-                except Exception:
-                    metrics.incr(
-                        "tasks.store.symbolicate_event.fatal",
-                        tags={
-                            "reason": "error",
-                            "symbolication_function": symbolication_function_name,
-                        },
-                    )
-                    error_logger.exception("tasks.store.symbolicate_event.symbolication")
-                    data.setdefault("_metrics", {})["flag.processing.error"] = True
-                    data.setdefault("_metrics", {})["flag.processing.fatal"] = True
-                    has_changed = True
-
-                    record_symbolication_duration()
-                    break
+            if symbolicated_data:
+                data = symbolicated_data
+                has_changed = True
+        except SymbolicationTimeout:
+            metrics.incr(
+                "tasks.store.symbolicate_event.fatal",
+                tags={
+                    "reason": "timeout",
+                    "symbolication_function": symbolication_function_name,
+                },
+            )
+            error_logger.exception(
+                "symbolicate.failed.infinite_retry",
+                extra={"project_id": project_id, "event_id": event_id},
+            )
+            data.setdefault("_metrics", {})["flag.processing.error"] = True
+            data.setdefault("_metrics", {})["flag.processing.fatal"] = True
+            has_changed = True
+        except Exception:
+            metrics.incr(
+                "tasks.store.symbolicate_event.fatal",
+                tags={
+                    "reason": "error",
+                    "symbolication_function": symbolication_function_name,
+                },
+            )
+            error_logger.exception("tasks.store.symbolicate_event.symbolication")
+            data.setdefault("_metrics", {})["flag.processing.error"] = True
+            data.setdefault("_metrics", {})["flag.processing.fatal"] = True
+            has_changed = True
 
     # We cannot persist canonical types in the cache, so we need to
     # downgrade this.


### PR DESCRIPTION
The existing implementation of how Symbolicator polling works had some major flaws:
- The `symbolication_function` was executed multiple times when polling, and the state across calls was being persisted in Redis.
- The `worker_id` pinning meant that a task could never make any progress when it was hitting an unhealthy Symbolicator.

The whole logic was cleaned up and reworked in such a way:
- The task is now calling into the `symbolication_function` just a single time.
- Handling of "lost task"s was improved to just re-submit right away.
- Handling of unhealthy Symbolicators will create a new `SymbolicationSession` which has a higher likelihood of being routed to a healthy Symbolicator.
- Related, the worker to Symbolicator pinning was removed in favor of creating a new routing key for each task.
- Timeout and LPQ handling was moved to a callback pattern that is hooked up in the celery tasks themselves.