### PR TITLE
feat(github-invite): use carousel and update banner copy

### DIFF
--- a/static/app/components/carousel.spec.tsx
+++ b/static/app/components/carousel.spec.tsx
@@ -3,7 +3,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import Carousel from 'sentry/components/carousel';
 import Placeholder from 'sentry/components/placeholder';
 
-function setIntersectionObserver(
+export function setIntersectionObserver(
   entries: {isIntersecting: boolean; target: {id: string}}[]
 ) {
   (() => {

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -31,6 +31,23 @@ describe('inviteBanner', function () {
         snoozed_ts: undefined,
       },
     });
+
+    (() => {
+      return (global.IntersectionObserver = class IntersectionObserver {
+        [x: string]: any;
+        constructor(cb: any) {
+          this.cb = cb;
+        }
+        observe() {
+          this.cb([
+            {target: {id: 'left-anchor'}, isIntersecting: true},
+            {target: {id: 'right-anchor'}, isIntersecting: true},
+          ]);
+        }
+        unobserve() {}
+        disconnect() {}
+      } as any);
+    })();
   });
 
   it('render banners with feature flag', async function () {

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -2,6 +2,7 @@ import moment from 'moment';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {setIntersectionObserver} from 'sentry/components/carousel.spec';
 import {DEFAULT_SNOOZE_PROMPT_DAYS} from 'sentry/utils/promptIsDismissed';
 import {InviteBanner} from 'sentry/views/settings/organizationMembers/inviteBanner';
 
@@ -32,22 +33,10 @@ describe('inviteBanner', function () {
       },
     });
 
-    (() => {
-      return (global.IntersectionObserver = class IntersectionObserver {
-        [x: string]: any;
-        constructor(cb: any) {
-          this.cb = cb;
-        }
-        observe() {
-          this.cb([
-            {target: {id: 'left-anchor'}, isIntersecting: true},
-            {target: {id: 'right-anchor'}, isIntersecting: true},
-          ]);
-        }
-        unobserve() {}
-        disconnect() {}
-      } as any);
-    })();
+    setIntersectionObserver([
+      {target: {id: 'left-anchor'}, isIntersecting: true},
+      {target: {id: 'right-anchor'}, isIntersecting: true},
+    ]);
   });
 
   it('render banners with feature flag', async function () {

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {promptsCheck, promptsUpdate} from 'sentry/actionCreators/prompts';
 import {Button} from 'sentry/components/button';
 import Card from 'sentry/components/card';
+import Carousel from 'sentry/components/carousel';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu, MenuItemProps} from 'sentry/components/dropdownMenu';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -122,11 +123,13 @@ export function InviteBanner({missingMembers, onSendInvite, organization}: Props
         <CardTitleContent>
           <CardTitle>{t('Bring your full GitHub team on board in Sentry')}</CardTitle>
           <Subtitle>
-            {tct('[missingMemberCount] missing members that are active in your GitHub', {
+            {tct('[missingMemberCount] missing members', {
               missingMemberCount: users.length,
             })}
             <QuestionTooltip
-              title={t('Based on the last 30 days of commit data')}
+              title={t(
+                "Based on the last 30 days of GitHub commit data, there are team members committing code to Sentry projects that aren't in your Sentry organization"
+              )}
               size="xs"
             />
           </Subtitle>
@@ -150,7 +153,7 @@ export function InviteBanner({missingMembers, onSendInvite, organization}: Props
           />
         </ButtonContainer>
       </CardTitleContainer>
-      <MemberCardsContainer>{cards}</MemberCardsContainer>
+      <Carousel>{cards}</Carousel>
     </StyledCard>
   );
 }
@@ -192,12 +195,14 @@ function SeeMoreCard({missingUsers}: SeeMoreCardProps) {
 const StyledCard = styled(Card)`
   display: flex;
   padding: ${space(2)};
+  padding-bottom: ${space(1.5)};
   overflow: hidden;
 `;
 
 const CardTitleContainer = styled('div')`
   display: flex;
   justify-content: space-between;
+  margin-bottom: ${space(1)};
 `;
 
 const CardTitleContent = styled('div')`
@@ -240,12 +245,6 @@ const MemberCard = styled(Card)`
   padding: ${space(2)} 18px;
   justify-content: center;
   align-items: center;
-`;
-
-const MemberCardsContainer = styled('div')`
-  position: relative;
-  display: flex;
-  overflow-x: scroll;
 `;
 
 const MemberCardContent = styled('div')`

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -11,6 +11,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {setIntersectionObserver} from 'sentry/components/carousel.spec';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -166,6 +167,10 @@ describe('OrganizationMembersList', function () {
         snoozed_ts: undefined,
       },
     });
+    setIntersectionObserver([
+      {target: {id: 'left-anchor'}, isIntersecting: true},
+      {target: {id: 'right-anchor'}, isIntersecting: true},
+    ]);
     (browserHistory.push as jest.Mock).mockReset();
     OrganizationsStore.load([organization]);
   });


### PR DESCRIPTION
<img width="1188" alt="Screenshot 2023-08-14 at 09 03 43" src="https://github.com/getsentry/sentry/assets/70817427/f3e689f1-31c3-4ca4-9038-ff4ff8354a5d">

<img width="1199" alt="Screenshot 2023-08-14 at 09 04 03" src="https://github.com/getsentry/sentry/assets/70817427/85ebeea9-757d-40ad-94fd-4f9e3ca41499">

See the carousel #54433