### PR TITLE
ref(github-invite): filter out commit authors missing GH username

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -42,7 +42,7 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
             )
         )
         nonmember_authors = CommitAuthor.objects.filter(organization_id=organization.id).exclude(
-            email__in=member_emails
+            Q(email__in=member_emails) | Q(external_id=None)
         )
 
         # currently for Github only

--- a/tests/sentry/api/test_organization_missing_members.py
+++ b/tests/sentry/api/test_organization_missing_members.py
@@ -95,6 +95,22 @@ class OrganizationMissingMembersTestCase(APITestCase):
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
         ]
 
+    def test_filters_authors_with_no_external_id(self):
+        no_external_id_author = self.create_commit_author(
+            project=self.project, email="e@example.com"
+        )
+        self.create_commit(
+            repo=self.repo,
+            author=no_external_id_author,
+        )
+
+        response = self.get_success_response(self.organization.slug)
+        assert response.data[0]["integration"] == "github"
+        assert response.data[0]["users"] == [
+            {"email": "c@example.com", "externalId": "c", "commitCount": 2},
+            {"email": "d@example.com", "externalId": "d", "commitCount": 1},
+        ]
+
     def test_no_authors(self):
         org = self.create_organization(owner=self.create_user())
         self.create_member(user=self.user, organization=org, role="manager")


### PR DESCRIPTION
When fetching missing members, some commit authors may have `external_id=None` aka their GitHub username is not attached to the commit author.

We should filter these authors out when rendering the invite banner and modal because we want to show org owners and managers that the missing members are actual GitHub users that are not in their organization.