### PR TITLE
ref: use datetime.timezone.utc instead of pytz.utc / pytz.UTC

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ sentry =
 # Currently, the black formatter doesn't wrap long strings: https://github.com/psf/black/issues/182#issuecomment-385325274
 # We already have a lot of E501's - these are lines black didn't wrap.
 # But rather than append # noqa: E501 to all of them, we just ignore E501 for now.
-extend-ignore = E203,E501,E402,E731,B007,B009,B010,B011,B020,B023,B024,B026,B027
+extend-ignore = E203,E501,E402,E731,B007,B009,B010,B011,B020,B023,B024,B026,B027,S008
 
 per-file-ignores =
     # these scripts must have minimal dependencies so opt out of the usual sentry rules

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Iterable, List, Mapping, Optional, Tuple, Type
 from urllib.parse import quote as urlquote
 
@@ -12,7 +12,6 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.http.request import HttpRequest
 from django.views.decorators.csrf import csrf_exempt
-from pytz import utc
 from rest_framework import status
 from rest_framework.authentication import BaseAuthentication, SessionAuthentication
 from rest_framework.exceptions import ParseError
@@ -538,7 +537,7 @@ class StatsMixin:
             if end:
                 end = to_datetime(float(end))
             else:
-                end = datetime.utcnow().replace(tzinfo=utc)
+                end = datetime.utcnow().replace(tzinfo=timezone.utc)
         except ValueError:
             raise ParseError(detail="until must be a numeric timestamp.")
 

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -1,13 +1,12 @@
 import logging
 from copy import copy
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from django.db import IntegrityError, models, router, transaction
 from django.db.models.query_utils import DeferredAttribute
 from django.urls import reverse
-from django.utils import timezone
-from pytz import UTC
+from django.utils import timezone as django_timezone
 from rest_framework import serializers, status
 
 from bitfield.types import BitHandler
@@ -295,7 +294,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         return attrs
 
     def save_trusted_relays(self, incoming, changed_data, organization):
-        timestamp_now = datetime.utcnow().replace(tzinfo=UTC).isoformat()
+        timestamp_now = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
         option_key = "sentry:trusted-relays"
         try:
             # get what we already have
@@ -701,7 +700,7 @@ def send_delete_confirmation(delete_confirmation_args: DeleteConfirmationArgs):
         "username": username,
         "user_ip_address": user_ip_address,
         "deletion_datetime": deletion_datetime,
-        "eta": timezone.now() + timedelta(seconds=countdown),
+        "eta": django_timezone.now() + timedelta(seconds=countdown),
         "url": url,
     }
 

--- a/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
@@ -1,10 +1,8 @@
 import re
 from collections import namedtuple
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable, Dict, List, Optional, Tuple
-
-from pytz import UTC
 
 from sentry.dynamic_sampling.rules.helpers.time_to_adoptions import Platform
 from sentry.dynamic_sampling.rules.utils import BOOSTED_RELEASES_LIMIT, get_redis_client_for_ds
@@ -87,7 +85,7 @@ class BoostedReleases:
         # We get release models in order to have all the information to extend the releases we get from the cache.
         models = self._get_releases_models()
 
-        current_timestamp = datetime.utcnow().replace(tzinfo=UTC).timestamp()
+        current_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
 
         extended_boosted_releases = []
         expired_boosted_releases = []
@@ -155,7 +153,7 @@ class ProjectBoostedReleases:
         self.redis_client.hset(
             cache_key,
             self._generate_cache_key_for_boosted_release(release_id, environment),
-            datetime.utcnow().replace(tzinfo=UTC).timestamp(),
+            datetime.utcnow().replace(tzinfo=timezone.utc).timestamp(),
         )
         # In order to avoid having the boosted releases hash in memory for an indefinite amount of time, we will expire
         # it after a specific timeout.
@@ -210,7 +208,7 @@ class ProjectBoostedReleases:
         """
         cache_key = self._generate_cache_key_for_boosted_releases_hash()
         boosted_releases = self.redis_client.hgetall(cache_key)
-        current_timestamp = datetime.utcnow().replace(tzinfo=UTC).timestamp()
+        current_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
 
         LRBRelease = namedtuple("LRBRelease", ["key", "timestamp"])
         lrb_release = None

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -8,7 +8,7 @@ import re
 import time
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from typing import (
     TYPE_CHECKING,
@@ -32,7 +32,6 @@ from django.db import IntegrityError, OperationalError, connection, router, tran
 from django.db.models import Func
 from django.db.models.signals import post_save
 from django.utils.encoding import force_str
-from pytz import UTC
 
 from sentry import (
     eventstore,
@@ -1286,7 +1285,7 @@ def _tsdb_record_all_metrics(jobs: Sequence[Job]) -> None:
 
 @metrics.wraps("save_event.nodestore_save_many")
 def _nodestore_save_many(jobs: Sequence[Job]) -> None:
-    inserted_time = datetime.utcnow().replace(tzinfo=UTC).timestamp()
+    inserted_time = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
     for job in jobs:
         # Write the event to Nodestore
         subkeys = {}
@@ -2210,7 +2209,7 @@ def save_attachment(
     if start_time is not None:
         timestamp = to_datetime(start_time)
     else:
-        timestamp = datetime.utcnow().replace(tzinfo=UTC)
+        timestamp = datetime.utcnow().replace(tzinfo=timezone.utc)
 
     try:
         data = attachment.data

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timezone
 from typing import Any, Iterable, Mapping, MutableMapping
 from urllib.parse import urlencode
 
@@ -115,17 +116,16 @@ class AlertRuleNotification(ProjectNotification):
     def get_recipient_context(
         self, recipient: RpcActor, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
-        timezone = pytz.timezone("UTC")
-
+        tz = timezone.utc
         if recipient.actor_type == ActorType.USER:
             user_tz = UserOption.objects.get_value(user=recipient, key="timezone", default="UTC")
             try:
-                timezone = pytz.timezone(user_tz)
+                tz = pytz.timezone(user_tz)
             except pytz.UnknownTimeZoneError:
                 pass
         return {
             **super().get_recipient_context(recipient, extra_context),
-            "timezone": timezone,
+            "timezone": tz,
         }
 
     def get_context(self) -> MutableMapping[str, Any]:

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from time import time
 from typing import Any, List, Mapping, MutableMapping, Optional, Tuple
 
 import msgpack
 import sentry_sdk
 from django.conf import settings
-from pytz import UTC
 from symbolic.proguard import ProguardMapper
 
 from sentry import quotas
@@ -703,7 +702,7 @@ def _track_outcome(
         key_id=None,
         outcome=outcome,
         reason=reason,
-        timestamp=datetime.utcnow().replace(tzinfo=UTC),
+        timestamp=datetime.utcnow().replace(tzinfo=timezone.utc),
         event_id=event_id,
         category=DataCategory.PROFILE_INDEXED,
         quantity=1,

--- a/src/sentry/projectoptions/manager.py
+++ b/src/sentry/projectoptions/manager.py
@@ -1,8 +1,6 @@
 import bisect
 import uuid
-from datetime import datetime
-
-from pytz import utc
+from datetime import datetime, timezone
 
 from sentry.utils import json
 
@@ -78,7 +76,7 @@ class ProjectOptionsManager:
         ProjectOption.objects.set_value(
             project,
             "sentry:relay-rev-lastchange",
-            json.datetime_to_str(datetime.utcnow().replace(tzinfo=utc)),
+            json.datetime_to_str(datetime.utcnow().replace(tzinfo=timezone.utc)),
         )
 
     def register(self, key, default=None, epoch_defaults=None):

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
-import pytz
 from django.db.models import F
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
 from sentry import analytics
 from sentry.models import (
@@ -47,7 +46,7 @@ logger = logging.getLogger("sentry")
 # Used to determine if we should or not record an analytic data
 # for a first event of a project with a minified stack trace
 START_DATE_TRACKING_FIRST_EVENT_WITH_MINIFIED_STACK_TRACE_PER_PROJ = datetime(
-    2022, 12, 14, tzinfo=pytz.UTC
+    2022, 12, 14, tzinfo=timezone.utc
 )
 
 
@@ -238,7 +237,7 @@ def record_first_replay(project, **kwargs):
         organization_id=project.organization_id,
         task=OnboardingTask.SESSION_REPLAY,
         status=OnboardingTaskStatus.COMPLETE,
-        date_completed=timezone.now(),
+        date_completed=django_timezone.now(),
     )
 
     if success:
@@ -306,7 +305,7 @@ def record_member_joined(organization_id: int, organization_member_id: int, **kw
         status=OnboardingTaskStatus.PENDING,
         values={
             "status": OnboardingTaskStatus.COMPLETE,
-            "date_completed": timezone.now(),
+            "date_completed": django_timezone.now(),
             "data": {"invited_member_id": organization_member_id},
         },
     )
@@ -491,7 +490,7 @@ def record_alert_rule_created(user, project, rule, rule_type, **kwargs):
             "status": OnboardingTaskStatus.COMPLETE,
             "user_id": user.id if user else None,
             "project_id": project.id,
-            "date_completed": timezone.now(),
+            "date_completed": django_timezone.now(),
         },
     )
 
@@ -509,7 +508,7 @@ def record_issue_tracker_used(plugin, project, user, **kwargs):
             "status": OnboardingTaskStatus.COMPLETE,
             "user_id": user.id,
             "project_id": project.id,
-            "date_completed": timezone.now(),
+            "date_completed": django_timezone.now(),
             "data": {"plugin": plugin.slug},
         },
     )
@@ -563,7 +562,7 @@ def record_integration_added(
         if task.status != OnboardingTaskStatus.COMPLETE:
             task.status = OnboardingTaskStatus.COMPLETE
             task.user_id = user_id
-            task.date_completed = timezone.now()
+            task.date_completed = django_timezone.now()
         task.save()
     else:
         task = OrganizationOnboardingTask.objects.create(

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -16,7 +16,6 @@ from typing import (
 )
 
 import sentry_sdk
-from pytz import utc
 from sentry_sdk import Hub, capture_exception
 
 from sentry import features, killswitches, quotas, utils
@@ -321,7 +320,7 @@ def _get_project_config(
     public_keys = get_public_key_configs(project, full_config, project_keys=project_keys)
 
     with Hub.current.start_span(op="get_public_config"):
-        now = datetime.utcnow().replace(tzinfo=utc)
+        now = datetime.utcnow().replace(tzinfo=timezone.utc)
         cfg = {
             "disabled": False,
             "slug": project.slug,

--- a/src/sentry/runner/commands/tsdb.py
+++ b/src/sentry/runner/commands/tsdb.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import click
-import pytz
 from dateutil.parser import parse
 
 from sentry.runner.decorators import configuration
@@ -26,7 +25,7 @@ class DateTimeParamType(click.ParamType):
             # TODO: We should probably warn about this? Also note that this
             # doesn't use the Django specified timezone, since settings haven't
             # been configured yet.
-            result = result.replace(tzinfo=pytz.utc)
+            result = result.replace(tzinfo=timezone.utc)
 
         return result
 

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -3,11 +3,11 @@ import os
 import re
 from collections import defaultdict
 from collections.abc import Iterable
+from datetime import timezone
 from typing import Any, Dict, Optional, Sequence
 
 from dateutil.parser import parse as parse_datetime
 from django.core.cache import cache
-from pytz import UTC
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 from snuba_sdk import Column, Condition, Direction, Entity, Function, Op, OrderBy, Query, Request
 
@@ -93,7 +93,7 @@ def is_fuzzy_numeric_key(key):
 def fix_tag_value_data(data):
     for key, transformer in tag_value_data_transformers.items():
         if key in data:
-            data[key] = transformer(data[key]).replace(tzinfo=UTC)
+            data[key] = transformer(data[key]).replace(tzinfo=timezone.utc)
     return data
 
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1,49 +1,11 @@
 from __future__ import annotations
 
-import responses
-import sentry_kafka_schemas
-
-from sentry.sentry_metrics.aggregation_option_registry import AggregationOption
-from sentry.sentry_metrics.configuration import UseCaseKey
-from sentry.sentry_metrics.use_case_id_registry import METRIC_PATH_MAPPING, UseCaseID
-
-__all__ = (
-    "TestCase",
-    "TransactionTestCase",
-    "APITestCase",
-    "TwoFactorAPITestCase",
-    "AuthProviderTestCase",
-    "RuleTestCase",
-    "PermissionTestCase",
-    "PluginTestCase",
-    "CliTestCase",
-    "AcceptanceTestCase",
-    "IntegrationTestCase",
-    "SnubaTestCase",
-    "BaseMetricsTestCase",
-    "BaseMetricsLayerTestCase",
-    "BaseIncidentsTest",
-    "IntegrationRepositoryTestCase",
-    "ReleaseCommitPatchTest",
-    "SetRefsTestCase",
-    "OrganizationDashboardWidgetTestCase",
-    "SCIMTestCase",
-    "SCIMAzureTestCase",
-    "MetricsEnhancedPerformanceTestCase",
-    "MetricsAPIBaseTestCase",
-    "OrganizationMetricMetaIntegrationTestCase",
-    "ProfilesSnubaTestCase",
-    "ReplaysAcceptanceTestCase",
-    "ReplaysSnubaTestCase",
-    "MonitorTestCase",
-    "MonitorIngestTestCase",
-)
 import hashlib
 import inspect
 import os.path
 import time
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from typing import Dict, List, Literal, Optional, Sequence, Union
 from unittest import mock
@@ -52,8 +14,9 @@ from uuid import uuid4
 from zlib import compress
 
 import pytest
-import pytz
 import requests
+import responses
+import sentry_kafka_schemas
 from click.testing import CliRunner
 from django.conf import settings
 from django.contrib.auth import login
@@ -68,7 +31,7 @@ from django.test import TransactionTestCase as DjangoTransactionTestCase
 from django.test import override_settings
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 from django.utils.functional import cached_property
 from pkg_resources import iter_entry_points
 from rest_framework import status
@@ -139,6 +102,9 @@ from sentry.search.events.constants import (
     SPAN_METRICS_MAP,
 )
 from sentry.sentry_metrics import indexer
+from sentry.sentry_metrics.aggregation_option_registry import AggregationOption
+from sentry.sentry_metrics.configuration import UseCaseKey
+from sentry.sentry_metrics.use_case_id_registry import METRIC_PATH_MAPPING, UseCaseID
 from sentry.silo import SiloMode
 from sentry.snuba.metrics.datasource import get_series
 from sentry.tagstore.snuba import SnubaTagStorage
@@ -173,6 +139,38 @@ from .fixtures import Fixtures
 from .helpers import AuthProvider, Feature, TaskRunner, override_options, parse_queries
 from .silo import assume_test_silo_mode
 from .skips import requires_snuba
+
+__all__ = (
+    "TestCase",
+    "TransactionTestCase",
+    "APITestCase",
+    "TwoFactorAPITestCase",
+    "AuthProviderTestCase",
+    "RuleTestCase",
+    "PermissionTestCase",
+    "PluginTestCase",
+    "CliTestCase",
+    "AcceptanceTestCase",
+    "IntegrationTestCase",
+    "SnubaTestCase",
+    "BaseMetricsTestCase",
+    "BaseMetricsLayerTestCase",
+    "BaseIncidentsTest",
+    "IntegrationRepositoryTestCase",
+    "ReleaseCommitPatchTest",
+    "SetRefsTestCase",
+    "OrganizationDashboardWidgetTestCase",
+    "SCIMTestCase",
+    "SCIMAzureTestCase",
+    "MetricsEnhancedPerformanceTestCase",
+    "MetricsAPIBaseTestCase",
+    "OrganizationMetricMetaIntegrationTestCase",
+    "ProfilesSnubaTestCase",
+    "ReplaysAcceptanceTestCase",
+    "ReplaysSnubaTestCase",
+    "MonitorTestCase",
+    "MonitorIngestTestCase",
+)
 
 DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
 
@@ -1449,7 +1447,7 @@ class BaseMetricsLayerTestCase(BaseMetricsTestCase):
     # This time has been specifically chosen to be 10:00:00 so that all tests will automatically have the data inserted
     # and queried with automatically inferred timestamps (e.g., usage of - 1 second, get_date_range()...) without
     # incurring into problems.
-    MOCK_DATETIME = (timezone.now() - timedelta(days=1)).replace(
+    MOCK_DATETIME = (django_timezone.now() - timedelta(days=1)).replace(
         hour=10, minute=0, second=0, microsecond=0
     )
 
@@ -1828,7 +1826,7 @@ class BaseIncidentsTest(SnubaTestCase):
 
     @cached_property
     def now(self):
-        return timezone.now().replace(minute=0, second=0, microsecond=0)
+        return django_timezone.now().replace(minute=0, second=0, microsecond=0)
 
 
 @pytest.mark.snuba
@@ -1947,7 +1945,7 @@ class ReplaysSnubaTestCase(TestCase):
 # AcceptanceTestCase and TestCase are mutually exclusive base classses
 class ReplaysAcceptanceTestCase(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        self.now = datetime.utcnow().replace(tzinfo=pytz.utc)
+        self.now = datetime.utcnow().replace(tzinfo=timezone.utc)
         super().setUp()
         self.drop_replays()
         patcher = mock.patch("django.utils.timezone.now", return_value=self.now)
@@ -2339,7 +2337,7 @@ class ActivityTestCase(TestCase):
         release = Release.objects.create(
             version=name * 40,
             organization_id=self.project.organization_id,
-            date_released=timezone.now(),
+            date_released=django_timezone.now(),
         )
         release.add_project(self.project)
         release.add_project(self.project2)

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -1,8 +1,7 @@
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping, Optional, Tuple, Union, overload
 
-import pytz
 from dateutil.parser import parse
 from django.http.request import HttpRequest
 from django.utils.timezone import is_aware, make_aware
@@ -10,7 +9,7 @@ from django.utils.timezone import is_aware, make_aware
 from sentry import quotas
 from sentry.constants import MAX_ROLLUP_POINTS
 
-epoch = datetime(1970, 1, 1, tzinfo=pytz.utc)
+epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
 def ensure_aware(value: datetime) -> datetime:
@@ -65,7 +64,7 @@ def floor_to_utc_day(value: datetime) -> datetime:
     """
     Floors a given datetime to UTC midnight.
     """
-    return value.astimezone(pytz.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    return value.astimezone(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
 
 
 def parse_date(datestr: str, timestr: str) -> Optional[datetime]:
@@ -90,7 +89,7 @@ def parse_timestamp(value: Any) -> Optional[datetime]:
     if isinstance(value, datetime):
         return value
     elif isinstance(value, (int, float)):
-        return datetime.utcfromtimestamp(value).replace(tzinfo=pytz.utc)
+        return datetime.utcfromtimestamp(value).replace(tzinfo=timezone.utc)
     value = (value or "").rstrip("Z").encode("ascii", "replace").split(b".", 1)
     if not value:
         return None
@@ -103,7 +102,7 @@ def parse_timestamp(value: Any) -> Optional[datetime]:
             rv = rv.replace(microsecond=int(value[1].ljust(6, b"0")[:6]))
         except ValueError:
             return None
-    return rv.replace(tzinfo=pytz.utc)
+    return rv.replace(tzinfo=timezone.utc)
 
 
 def parse_stats_period(period: str) -> Optional[timedelta]:
@@ -192,7 +191,7 @@ def outside_retention_with_modified_start(
 
     # Need to support timezone-aware and naive datetimes since
     # Snuba API only deals in naive UTC
-    now = datetime.utcnow().astimezone(pytz.utc) if start.tzinfo else datetime.utcnow()
+    now = datetime.utcnow().astimezone(timezone.utc) if start.tzinfo else datetime.utcnow()
     start = max(start, now - timedelta(days=retention))
 
     return start > end, start

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -1,5 +1,6 @@
-import pytz
-from django.utils import timezone
+from datetime import timezone
+
+from django.utils import timezone as django_timezone
 
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models import IncidentStatus, IncidentStatusMethod
@@ -9,7 +10,7 @@ from sentry.testutils.silo import no_silo_test
 
 FEATURE_NAME = ["organizations:incidents", "organizations:performance-view"]
 
-event_time = before_now(days=3).replace(tzinfo=pytz.utc)
+event_time = before_now(days=3).replace(tzinfo=timezone.utc)
 
 
 @no_silo_test(stable=True)
@@ -30,8 +31,8 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
         incident = self.create_incident(
             self.organization,
             title="Incident #1",
-            date_started=timezone.now(),
-            date_detected=timezone.now(),
+            date_started=django_timezone.now(),
+            date_detected=django_timezone.now(),
             projects=[self.project],
             alert_rule=alert_rule,
         )

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -1,15 +1,12 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
-
-import pytz
-from django.utils import timezone
 
 from fixtures.page_objects.issue_details import IssueDetailsPage
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.silo import no_silo_test
 from sentry.utils.samples import load_data
 
-now = datetime.utcnow().replace(tzinfo=pytz.utc)
+now = datetime.utcnow().replace(tzinfo=timezone.utc)
 
 
 @no_silo_test(stable=True)

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -1,10 +1,9 @@
 import copy
-from datetime import timedelta
+from datetime import timedelta, timezone
 from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytest
-import pytz
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
@@ -184,7 +183,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_all_events_query(self, mock_now):
-        now = before_now().replace(tzinfo=pytz.utc)
+        now = before_now().replace(tzinfo=timezone.utc)
         mock_now.return_value = now
         five_mins_ago = iso_format(now - timedelta(minutes=5))
         ten_mins_ago = iso_format(now - timedelta(minutes=10))
@@ -245,7 +244,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_errors_query(self, mock_now):
-        now = before_now().replace(tzinfo=pytz.utc)
+        now = before_now().replace(tzinfo=timezone.utc)
         mock_now.return_value = now
         ten_mins_ago = iso_format(now - timedelta(minutes=10))
         self.store_event(
@@ -301,7 +300,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_transactions_query(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         event_data = generate_transaction()
 
@@ -317,7 +316,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_all_events(self, mock_now):
-        now = before_now().replace(tzinfo=pytz.utc)
+        now = before_now().replace(tzinfo=timezone.utc)
         mock_now.return_value = now
         ten_mins_ago = iso_format(now - timedelta(minutes=10))
 
@@ -355,7 +354,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_errors_view(self, mock_now):
-        now = before_now().replace(tzinfo=pytz.utc)
+        now = before_now().replace(tzinfo=timezone.utc)
         mock_now.return_value = now
 
         event_data = load_data("javascript")
@@ -391,7 +390,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_transactions_query(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         event_data = generate_transaction(trace="a" * 32, span="ab" * 8)
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
@@ -440,7 +439,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_transactions_query_siblings(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         event_data = generate_transaction(trace="a" * 32, span="ab" * 8)
 
@@ -528,7 +527,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_transaction_event_detail_view_ops_filtering(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         event_data = generate_transaction(trace="a" * 32, span="ab" * 8)
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
@@ -678,7 +677,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     @pytest.mark.skip(reason="causing timeouts in github actions and travis")
     @patch("django.utils.timezone.now")
     def test_drilldown_result(self, mock_now):
-        now = before_now().replace(tzinfo=pytz.utc)
+        now = before_now().replace(tzinfo=timezone.utc)
         mock_now.return_value = now
         ten_mins_ago = iso_format(now - timedelta(minutes=10))
         events = (
@@ -717,7 +716,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     @pytest.mark.skip(reason="not done")
     @patch("django.utils.timezone.now")
     def test_usage(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         # TODO: load events
 

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -1,9 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
-import pytz
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
 from fixtures.page_objects.issue_details import IssueDetailsPage
 from fixtures.page_objects.issue_list import IssueListPage
@@ -11,7 +10,7 @@ from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import no_silo_test
 
-event_time = before_now(days=3).replace(tzinfo=pytz.utc)
+event_time = before_now(days=3).replace(tzinfo=timezone.utc)
 
 
 @no_silo_test(stable=True)
@@ -68,7 +67,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
 
     def test_global_selection_header_dropdown(self):
         self.dismiss_assistant()
-        self.project.update(first_event=timezone.now())
+        self.project.update(first_event=django_timezone.now())
         self.issues_list.visit_issue_list(
             self.org.slug, query="?query=assigned%3Ame&project=" + str(self.project_1.id)
         )
@@ -283,7 +282,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         "My Projects" in issues list.
         """
         with self.feature("organizations:global-views"):
-            mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+            mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
             self.create_issues()
             self.issues_list.visit_issue_list(self.org.slug)
             self.issues_list.wait_for_issue()
@@ -316,7 +315,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         If user has a project defined in URL, if they visit an issue and then
         return back to issues list, that project id should still exist in URL
         """
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
         self.create_issues()
         self.issues_list.visit_issue_list(self.org.slug, query=f"?project={self.project_2.id}")
         self.issues_list.wait_for_issue()
@@ -350,7 +349,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         When navigating back to issues stream, should keep environment and project in context.
         """
 
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
         self.create_issues()
         self.issue_details.visit_issue_in_environment(self.org.slug, self.issue_2.group.id, "prod")
 
@@ -381,7 +380,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         """
 
         with self.feature("organizations:global-views"):
-            mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+            mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
             self.create_issues()
             self.issue_details.visit_issue_in_environment(
                 self.org.slug, self.issue_2.group.id, "prod"

--- a/tests/acceptance/test_performance_issues.py
+++ b/tests/acceptance/test_performance_issues.py
@@ -1,10 +1,8 @@
 import random
 import string
-from datetime import timedelta
+from datetime import timedelta, timezone
 from unittest import mock
 from unittest.mock import patch
-
-import pytz
 
 from fixtures.page_objects.issue_details import IssueDetailsPage
 from sentry import options
@@ -70,7 +68,7 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase, PerformanceIssueT
 
     @patch("django.utils.timezone.now")
     def test_with_one_performance_issue(self, mock_now):
-        mock_now.return_value = before_now(minutes=5).replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now(minutes=5).replace(tzinfo=timezone.utc)
         event_data = self.create_sample_event(
             "n-plus-one-in-django-new-view", mock_now.return_value.timestamp()
         )
@@ -93,7 +91,7 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase, PerformanceIssueT
 
     @patch("django.utils.timezone.now")
     def test_multiple_events_with_one_cause_are_grouped(self, mock_now):
-        mock_now.return_value = before_now(minutes=5).replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now(minutes=5).replace(tzinfo=timezone.utc)
         event_data = self.create_sample_event(
             "n-plus-one-in-django-new-view", mock_now.return_value.timestamp()
         )
@@ -104,7 +102,7 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase, PerformanceIssueT
 
     @patch("django.utils.timezone.now")
     def test_n_one_api_call_performance_issue(self, mock_now):
-        mock_now.return_value = before_now(minutes=5).replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now(minutes=5).replace(tzinfo=timezone.utc)
         event_data = self.create_sample_event(
             "n-plus-one-api-calls/n-plus-one-api-calls-in-issue-stream",
             mock_now.return_value.timestamp(),
@@ -129,7 +127,7 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase, PerformanceIssueT
 
     @patch("django.utils.timezone.now")
     def test_multiple_events_with_multiple_causes_are_not_grouped(self, mock_now):
-        mock_now.return_value = before_now(minutes=5).replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now(minutes=5).replace(tzinfo=timezone.utc)
 
         # Create identical events with different parent spans
         for _ in range(3):

--- a/tests/acceptance/test_performance_landing.py
+++ b/tests/acceptance/test_performance_landing.py
@@ -1,6 +1,6 @@
+from datetime import timezone
 from unittest.mock import patch
 
-import pytz
 from django.db.models import F
 
 from fixtures.page_objects.base import BasePage
@@ -33,7 +33,7 @@ class PerformanceLandingTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         event = load_data("transaction", timestamp=before_now(minutes=10))
         self.store_event(data=event, project_id=self.project.id)
@@ -52,7 +52,7 @@ class PerformanceLandingTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_data_and_new_widget_designs(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         event = load_data("transaction", timestamp=before_now(minutes=10))
         self.store_event(data=event, project_id=self.project.id)

--- a/tests/acceptance/test_performance_overview.py
+++ b/tests/acceptance/test_performance_overview.py
@@ -1,6 +1,6 @@
+from datetime import timezone
 from unittest.mock import patch
 
-import pytz
 from django.db.models import F
 
 from fixtures.page_objects.base import BasePage
@@ -33,7 +33,7 @@ class PerformanceOverviewTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_onboarding(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.path)
@@ -42,7 +42,7 @@ class PerformanceOverviewTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         event = load_data("transaction", timestamp=before_now(minutes=10))
         self.store_event(data=event, project_id=self.project.id)

--- a/tests/acceptance/test_performance_span_summary.py
+++ b/tests/acceptance/test_performance_span_summary.py
@@ -1,9 +1,8 @@
-from datetime import timedelta
+from datetime import timedelta, timezone
 from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytest
-import pytz
 
 from fixtures.page_objects.base import BasePage
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
@@ -92,7 +91,7 @@ class PerformanceSpanSummaryTest(AcceptanceTestCase, SnubaTestCase):
     @pytest.mark.skip(reason="Has been flaky lately.")
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         self.create_event()
 

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -1,7 +1,6 @@
+from datetime import timezone
 from unittest.mock import patch
 from urllib.parse import urlencode
-
-import pytz
 
 from fixtures.page_objects.transaction_summary import TransactionSummaryPage
 from sentry.models import AssistantActivity
@@ -43,7 +42,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         # Create a transaction
         event = make_event(load_data("transaction", timestamp=before_now(minutes=3)))
@@ -68,7 +67,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_view_details_from_summary(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         event = make_event(
             load_data(
@@ -88,7 +87,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_tags_page(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         tags_path = "/organizations/{}/performance/summary/tags/?{}".format(
             self.org.slug,
@@ -108,7 +107,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_transaction_vitals(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         vitals_path = "/organizations/{}/performance/summary/vitals/?{}".format(
             self.org.slug,
@@ -131,7 +130,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_transaction_vitals_filtering(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         vitals_path = "/organizations/{}/performance/summary/vitals/?{}".format(
             self.org.slug,
@@ -195,7 +194,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_transaction_threshold_modal(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         # Create a transaction
         event = make_event(load_data("transaction", timestamp=before_now(minutes=3)))

--- a/tests/acceptance/test_performance_trace_detail.py
+++ b/tests/acceptance/test_performance_trace_detail.py
@@ -1,8 +1,6 @@
-from datetime import timedelta
+from datetime import timedelta, timezone
 from unittest.mock import patch
 from uuid import uuid4
-
-import pytz
 
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -191,7 +189,7 @@ class PerformanceTraceDetailTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.path)

--- a/tests/acceptance/test_performance_trends.py
+++ b/tests/acceptance/test_performance_trends.py
@@ -1,7 +1,7 @@
+from datetime import timezone
 from unittest.mock import patch
 from urllib.parse import urlencode
 
-import pytz
 from django.db.models import F
 
 from fixtures.page_objects.base import BasePage
@@ -59,7 +59,7 @@ class PerformanceTrendsTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
         values = range(1, 100, 5)
 
         self.make_trend("improvement", [v for v in reversed(values)])

--- a/tests/acceptance/test_performance_vital_detail.py
+++ b/tests/acceptance/test_performance_vital_detail.py
@@ -1,7 +1,7 @@
+from datetime import timezone
 from unittest.mock import patch
 from urllib.parse import urlencode
 
-import pytz
 from django.db.models import F
 
 from fixtures.page_objects.base import BasePage
@@ -35,7 +35,7 @@ class PerformanceVitalDetailsTest(AcceptanceTestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
 
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
 
         event = load_data("transaction", timestamp=before_now(minutes=10))
         self.store_event(data=event, project_id=self.project.id)

--- a/tests/acceptance/test_project_tags_settings.py
+++ b/tests/acceptance/test_project_tags_settings.py
@@ -1,14 +1,12 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
-
-import pytz
 
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import no_silo_test
 
-event_time = before_now(days=3).replace(tzinfo=pytz.utc)
-current_time = datetime.utcnow().replace(tzinfo=pytz.utc)
+event_time = before_now(days=3).replace(tzinfo=timezone.utc)
+current_time = datetime.utcnow().replace(tzinfo=timezone.utc)
 
 
 @no_silo_test(stable=True)

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1,11 +1,10 @@
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from unittest.mock import patch
 
-import pytz
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
 from sentry.api.endpoints.organization_releases import ReleaseSerializerWithProjects
 from sentry.api.serializers.rest_framework.release import ReleaseHeadCommitSerializer
@@ -462,14 +461,14 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
             project_id=self.project.id,
             release_id=adopted_release.id,
             environment_id=self.environment.id,
-            adopted=timezone.now(),
+            adopted=django_timezone.now(),
         )
         ReleaseProjectEnvironment.objects.create(
             project_id=self.project.id,
             release_id=replaced_release.id,
             environment_id=self.environment.id,
-            adopted=timezone.now() - timedelta(minutes=5),
-            unadopted=timezone.now(),
+            adopted=django_timezone.now() - timedelta(minutes=5),
+            unadopted=django_timezone.now(),
         )
         ReleaseProjectEnvironment.objects.create(
             project_id=self.project.id,
@@ -528,7 +527,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         self.assert_expected_versions(
             response, [adopted_release, replaced_release, not_adopted_release]
         )
-        adopted_rpe.update(adopted=timezone.now() - timedelta(minutes=15))
+        adopted_rpe.update(adopted=django_timezone.now() - timedelta(minutes=15))
 
         # Replaced should come first now.
         response = self.get_success_response(
@@ -575,7 +574,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         prev_cursor = self.get_cursor_headers(response)[0]
         self.assert_expected_versions(response, [replaced_release])
 
-        adopted_rpe.update(adopted=timezone.now() - timedelta(minutes=15))
+        adopted_rpe.update(adopted=django_timezone.now() - timedelta(minutes=15))
 
         response = self.get_success_response(
             self.organization.slug,
@@ -773,22 +772,22 @@ class OrganizationReleasesStatsTest(APITestCase):
         release1 = Release.objects.create(
             organization_id=self.organization.id,
             version="1",
-            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=pytz.UTC),
+            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=timezone.utc),
         )
         release1.add_project(self.project1)
 
         release2 = Release.objects.create(
             organization_id=self.organization.id,
             version="2",
-            date_added=datetime(2013, 8, 12, 3, 8, 24, 880386, tzinfo=pytz.UTC),
-            date_released=datetime(2013, 8, 15, 3, 8, 24, 880386, tzinfo=pytz.UTC),
+            date_added=datetime(2013, 8, 12, 3, 8, 24, 880386, tzinfo=timezone.utc),
+            date_released=datetime(2013, 8, 15, 3, 8, 24, 880386, tzinfo=timezone.utc),
         )
         release2.add_project(self.project2)
 
         release3 = Release.objects.create(
             organization_id=self.organization.id,
             version="3",
-            date_added=datetime(2013, 8, 14, 3, 8, 24, 880386, tzinfo=pytz.UTC),
+            date_added=datetime(2013, 8, 14, 3, 8, 24, 880386, tzinfo=timezone.utc),
         )
         release3.add_project(self.project3)
 
@@ -946,14 +945,14 @@ class OrganizationReleasesStatsTest(APITestCase):
             project_id=self.project.id,
             release_id=adopted_release.id,
             environment_id=self.environment.id,
-            adopted=timezone.now(),
+            adopted=django_timezone.now(),
         )
         ReleaseProjectEnvironment.objects.create(
             project_id=self.project.id,
             release_id=replaced_release.id,
             environment_id=self.environment.id,
-            adopted=timezone.now(),
-            unadopted=timezone.now(),
+            adopted=django_timezone.now(),
+            unadopted=django_timezone.now(),
         )
         ReleaseProjectEnvironment.objects.create(
             project_id=self.project.id,
@@ -1029,13 +1028,13 @@ class OrganizationReleasesStatsTest(APITestCase):
             project_id=project2.id,
             release_id=multi_project_release.id,
             environment_id=self.environment.id,
-            adopted=timezone.now(),
+            adopted=django_timezone.now(),
         )
         ReleaseProjectEnvironment.objects.create(
             project_id=self.project.id,
             release_id=single_project_release.id,
             environment_id=self.environment.id,
-            adopted=timezone.now(),
+            adopted=django_timezone.now(),
         )
 
         # Filtering to self.environment.name and self.project with release.stage:adopted should NOT return multi_project_release.
@@ -2238,7 +2237,7 @@ class ReleaseSerializerWithProjectsTest(TestCase):
         assert result["owner"].username == self.user.username
         assert result["ref"] == self.ref
         assert result["url"] == self.url
-        assert result["dateReleased"] == datetime(1000, 10, 10, 6, 6, tzinfo=pytz.UTC)
+        assert result["dateReleased"] == datetime(1000, 10, 10, 6, 6, tzinfo=timezone.utc)
         assert result["commits"] == self.commits
         assert result["headCommits"] == self.headCommits
         assert result["refs"] == self.refs

--- a/tests/sentry/api/endpoints/test_project_artifact_lookup.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_lookup.py
@@ -5,7 +5,6 @@ from hashlib import sha1
 from io import BytesIO
 from uuid import uuid4
 
-import pytz
 from django.core.files.base import ContentFile
 from django.urls import reverse
 from freezegun import freeze_time
@@ -461,10 +460,10 @@ class ArtifactLookupTest(APITestCase):
         for days_before, expected_date_added, debug_id in (
             (
                 2,
-                datetime.now(tz=pytz.UTC) - timedelta(days=2),
+                datetime.now(tz=timezone.utc) - timedelta(days=2),
                 "2432d9ad-fe87-4f77-938d-50cc9b2b2e2a",
             ),
-            (35, datetime.now(tz=pytz.UTC), "ef88bc3e-d334-4809-9723-5c5dbc8bd4e9"),
+            (35, datetime.now(tz=timezone.utc), "ef88bc3e-d334-4809-9723-5c5dbc8bd4e9"),
         ):
             file_zip = make_compressed_zip_file(
                 {
@@ -480,7 +479,7 @@ class ArtifactLookupTest(APITestCase):
             )
             file = make_file("bundle_c.zip", file_zip)
             bundle_id = uuid4()
-            date_added = datetime.now(tz=pytz.UTC) - timedelta(days=days_before)
+            date_added = datetime.now(tz=timezone.utc) - timedelta(days=days_before)
 
             artifact_bundle = ArtifactBundle.objects.create(
                 organization_id=self.organization.id,
@@ -544,14 +543,14 @@ class ArtifactLookupTest(APITestCase):
         for days_before, expected_date_added, release in (
             (
                 2,
-                datetime.now(tz=pytz.UTC) - timedelta(days=2),
+                datetime.now(tz=timezone.utc) - timedelta(days=2),
                 self.create_release(version="1.0"),
             ),
-            (35, datetime.now(tz=pytz.UTC), self.create_release(version="2.0")),
+            (35, datetime.now(tz=timezone.utc), self.create_release(version="2.0")),
         ):
             dist = release.add_dist("android")
             bundle_id = uuid4()
-            date_added = datetime.now(tz=pytz.UTC) - timedelta(days=days_before)
+            date_added = datetime.now(tz=timezone.utc) - timedelta(days=days_before)
 
             artifact_bundle = ArtifactBundle.objects.create(
                 organization_id=self.organization.id,

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
 
-import pytz
 from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
@@ -735,7 +734,7 @@ class ReleaseSerializerTest(TestCase):
         assert result["owner"].username == self.user.username
         assert result["ref"] == self.ref
         assert result["url"] == self.url
-        assert result["dateReleased"] == datetime(1000, 10, 10, 6, 6, tzinfo=pytz.UTC)
+        assert result["dateReleased"] == datetime(1000, 10, 10, 6, 6, tzinfo=timezone.utc)
         assert result["commits"] == self.commits
 
     def test_fields_not_required(self):

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Mapping
 from unittest import mock
 from unittest.mock import call, patch
@@ -8,7 +8,6 @@ from unittest.mock import call, patch
 import pytest
 import responses
 from freezegun import freeze_time
-from pytz import UTC
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.slack.utils.channel import strip_channel_name
@@ -251,7 +250,7 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
         response = self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, expand=["lastTriggered"]
         )
-        assert response.data["lastTriggered"] == datetime.now().replace(tzinfo=UTC)
+        assert response.data["lastTriggered"] == datetime.now().replace(tzinfo=timezone.utc)
 
     def test_with_jira_action_error(self):
         conditions = [

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -1,10 +1,9 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Callable
 from unittest.mock import patch
 
 import pytest
-import pytz
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 from freezegun import freeze_time
 
 from sentry.dynamic_sampling import RuleType, generate_rules, get_redis_client_for_ds
@@ -35,7 +34,7 @@ from sentry.dynamic_sampling.tasks.sliding_window_org import sliding_window_org
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.testutils.cases import BaseMetricsLayerTestCase, SnubaTestCase, TestCase
 
-MOCK_DATETIME = (timezone.now() - timedelta(days=1)).replace(
+MOCK_DATETIME = (django_timezone.now() - timedelta(days=1)).replace(
     hour=0, minute=0, second=0, microsecond=0
 )
 
@@ -43,7 +42,7 @@ MOCK_DATETIME = (timezone.now() - timedelta(days=1)).replace(
 class TasksTestCase(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
     @staticmethod
     def old_date():
-        return datetime.now(tz=pytz.UTC) - timedelta(minutes=NEW_MODEL_THRESHOLD_IN_MINUTES + 1)
+        return datetime.now(tz=timezone.utc) - timedelta(minutes=NEW_MODEL_THRESHOLD_IN_MINUTES + 1)
 
     @staticmethod
     def disable_all_biases(project):

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -1,12 +1,11 @@
-from datetime import timedelta
+from datetime import timedelta, timezone
 from functools import cached_property
 from unittest import mock
 from unittest.mock import Mock, call, patch
 
 import pytest
-import pytz
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 from freezegun import freeze_time
 
 from sentry.incidents.logic import (
@@ -247,7 +246,7 @@ class TestHandleSubscriptionMetricsLogger(TestCase):
         return create_snuba_subscription(self.project, SUBSCRIPTION_METRICS_LOGGER, snuba_query)
 
     def build_subscription_update(self):
-        timestamp = timezone.now().replace(tzinfo=pytz.utc, microsecond=0)
+        timestamp = django_timezone.now().replace(tzinfo=timezone.utc, microsecond=0)
         data = {
             "count": 100,
             "crashed": 2.0,
@@ -288,7 +287,7 @@ class TestHandleSubscriptionMetricsLoggerV1(TestHandleSubscriptionMetricsLogger)
     """
 
     def build_subscription_update(self):
-        timestamp = timezone.now().replace(tzinfo=pytz.utc, microsecond=0)
+        timestamp = django_timezone.now().replace(tzinfo=timezone.utc, microsecond=0)
         values = {
             "data": [
                 {

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1,6 +1,6 @@
 import uuid
 from collections import Counter
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from typing import Mapping, Sequence
 from unittest import mock
@@ -10,7 +10,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
 from django.db.models import F
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.userreport import UserReportWithGroupSerializer
@@ -550,8 +550,8 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
         """
         from django.template.defaultfilters import date
 
-        timestamp = datetime.now(tz=pytz.utc)
-        local_timestamp_s = timezone.localtime(timestamp, pytz.timezone("Europe/Vienna"))
+        timestamp = datetime.now(tz=timezone.utc)
+        local_timestamp_s = django_timezone.localtime(timestamp, pytz.timezone("Europe/Vienna"))
         local_timestamp = date(local_timestamp_s, "N j, Y, g:i:s a e")
 
         UserOption.objects.create(user=self.user, key="timezone", value="Europe/Vienna")
@@ -785,8 +785,8 @@ class MailAdapterNotifyIssueOwnersTest(BaseMailAdapterTest):
         )
         self.create_member(user=user2, organization=organization, teams=[team])
         self.group = self.create_group(
-            first_seen=timezone.now(),
-            last_seen=timezone.now(),
+            first_seen=django_timezone.now(),
+            last_seen=django_timezone.now(),
             project=project,
             message="hello  world",
             logger="root",
@@ -1183,7 +1183,7 @@ class MailAdapterGetDigestSubjectTest(BaseMailAdapterTest):
             get_digest_subject(
                 mock.Mock(qualified_short_id="BAR-1"),
                 Counter({mock.sentinel.group: 3}),
-                datetime(2016, 9, 19, 1, 2, 3, tzinfo=pytz.utc),
+                datetime(2016, 9, 19, 1, 2, 3, tzinfo=timezone.utc),
             )
             == "BAR-1 - 1 new alert since Sept. 19, 2016, 1:02 a.m. UTC"
         )

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -1,9 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
-import pytz
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
 from sentry.api.invite_helper import ApiInviteHelper
 from sentry.models import (
@@ -46,7 +45,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
 
     def test_no_existing_task(self):
-        now = timezone.now()
+        now = django_timezone.now()
         project = self.create_project(first_event=now)
         event = self.store_event(data={}, project_id=project.id)
         first_event_received.send(project=project, event=event, sender=type(project))
@@ -59,7 +58,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         assert task.date_completed == project.first_event
 
     def test_existing_pending_task(self):
-        now = timezone.now()
+        now = django_timezone.now()
         project = self.create_project(first_event=now)
 
         first_event_pending.send(project=project, user=self.user, sender=type(project))
@@ -83,7 +82,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         assert task.date_completed == project.first_event
 
     def test_existing_complete_task(self):
-        now = timezone.now()
+        now = django_timezone.now()
         project = self.create_project(first_event=now)
         task = OrganizationOnboardingTask.objects.create(
             organization=project.organization,
@@ -100,7 +99,7 @@ class OrganizationOnboardingTaskTest(TestCase):
 
     # Tests on the receivers
     def test_event_processed(self):
-        now = timezone.now()
+        now = django_timezone.now()
         project = self.create_project(first_event=now)
         event = self.store_event(
             data={
@@ -156,7 +155,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         assert task is not None
 
     def test_project_created(self):
-        now = timezone.now()
+        now = django_timezone.now()
         project = self.create_project(first_event=now)
         project_created.send(project=project, user=self.user, sender=type(project))
 
@@ -168,7 +167,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         assert task is not None
 
     def test_first_event_pending(self):
-        now = timezone.now()
+        now = django_timezone.now()
         project = self.create_project(first_event=now)
         first_event_pending.send(project=project, user=self.user, sender=type(project))
 
@@ -180,7 +179,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         assert task is not None
 
     def test_first_event_received(self):
-        now = timezone.now()
+        now = django_timezone.now()
         project = self.create_project(first_event=now)
         project_created.send(project=project, user=self.user, sender=type(project))
         event = self.store_event(
@@ -430,7 +429,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         assert task is not None
 
     def test_onboarding_complete(self):
-        now = timezone.now()
+        now = django_timezone.now()
         user = self.create_user(email="test@example.org")
         project = self.create_project(first_event=now)
         second_project = self.create_project(first_event=now)
@@ -542,7 +541,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         Test that an analytics event is NOT recorded when
         there no event with minified stack trace is received
         """
-        now = timezone.now()
+        now = django_timezone.now()
         project = self.create_project(first_event=now)
         project_created.send(project=project, user=self.user, sender=type(project))
         data = load_data("javascript")
@@ -567,7 +566,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         Test that an analytics event is recorded when
         a first event with minified stack trace is received
         """
-        now = timezone.now()
+        now = django_timezone.now()
         project = self.create_project(first_event=now, platform="VueJS")
         project_created.send(project=project, user=self.user, sender=type(project))
         url = "http://localhost:3000"
@@ -623,7 +622,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         Test that an analytic event is triggered only once when
         multiple events with minified stack trace are received
         """
-        now = timezone.now()
+        now = django_timezone.now()
         project = self.create_project(first_event=now)
         project_created.send(project=project, user=self.user, sender=type(project))
         url = "http://localhost:3000"
@@ -683,7 +682,7 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         In this test we also check  if the has_minified_stack_trace is being set to "True" in old projects
         """
-        old_date = datetime(2022, 12, 10, tzinfo=pytz.UTC)
+        old_date = datetime(2022, 12, 10, tzinfo=timezone.utc)
         project = self.create_project(first_event=old_date, date_added=old_date)
         project_created.send(project=project, user=self.user, sender=type(project))
         url = "http://localhost:3000"

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -9,7 +9,6 @@ from unittest import mock
 
 import freezegun
 import pytest
-import pytz
 import sentry_sdk
 from django.utils.datastructures import MultiValueDict
 from freezegun import freeze_time
@@ -335,8 +334,8 @@ def test_exclusive_end():
     start, end, interval = get_date_range(
         {"start": "2021-02-24T00:00:00", "end": "2021-02-25T00:00:00", "interval": "1h"},
     )
-    assert start == datetime(2021, 2, 24, tzinfo=pytz.utc)
-    assert end == datetime(2021, 2, 25, 0, tzinfo=pytz.utc)
+    assert start == datetime(2021, 2, 24, tzinfo=timezone.utc)
+    assert end == datetime(2021, 2, 25, 0, tzinfo=timezone.utc)
 
 
 @freeze_time("2020-12-18T11:14:17.105Z")
@@ -779,8 +778,8 @@ def test_build_snuba_query_orderby(mock_now, mock_now2):
         where=[
             Condition(Column("org_id"), Op.EQ, 1),
             Condition(Column("project_id"), Op.IN, [1]),
-            Condition(Column("timestamp"), Op.GTE, datetime(2021, 8, 24, 23, tzinfo=pytz.utc)),
-            Condition(Column("timestamp"), Op.LT, datetime(2021, 8, 26, 0, tzinfo=pytz.utc)),
+            Condition(Column("timestamp"), Op.GTE, datetime(2021, 8, 24, 23, tzinfo=timezone.utc)),
+            Condition(Column("timestamp"), Op.LT, datetime(2021, 8, 26, 0, tzinfo=timezone.utc)),
             Condition(
                 Column(resolve_tag_key(use_case_id, org_id, "release"), entity=None),
                 Op.IN,
@@ -808,8 +807,8 @@ def test_build_snuba_query_orderby(mock_now, mock_now2):
         where=[
             Condition(Column("org_id"), Op.EQ, 1),
             Condition(Column("project_id"), Op.IN, [1]),
-            Condition(Column("timestamp"), Op.GTE, datetime(2021, 8, 24, 23, tzinfo=pytz.utc)),
-            Condition(Column("timestamp"), Op.LT, datetime(2021, 8, 26, 0, tzinfo=pytz.utc)),
+            Condition(Column("timestamp"), Op.GTE, datetime(2021, 8, 24, 23, tzinfo=timezone.utc)),
+            Condition(Column("timestamp"), Op.LT, datetime(2021, 8, 26, 0, tzinfo=timezone.utc)),
             Condition(
                 Column(resolve_tag_key(use_case_id, org_id, "release"), entity=None),
                 Op.IN,
@@ -897,8 +896,8 @@ def test_build_snuba_query_with_derived_alias(mock_now, mock_now2):
         where=[
             Condition(Column("org_id"), Op.EQ, 1),
             Condition(Column("project_id"), Op.IN, [1]),
-            Condition(Column("timestamp"), Op.GTE, datetime(2021, 8, 24, 23, tzinfo=pytz.utc)),
-            Condition(Column("timestamp"), Op.LT, datetime(2021, 8, 26, 0, tzinfo=pytz.utc)),
+            Condition(Column("timestamp"), Op.GTE, datetime(2021, 8, 24, 23, tzinfo=timezone.utc)),
+            Condition(Column("timestamp"), Op.LT, datetime(2021, 8, 26, 0, tzinfo=timezone.utc)),
             Condition(
                 Column(resolve_tag_key(use_case_id, org_id, "release"), entity=None),
                 Op.IN,
@@ -927,8 +926,8 @@ def test_build_snuba_query_with_derived_alias(mock_now, mock_now2):
         where=[
             Condition(Column("org_id"), Op.EQ, 1),
             Condition(Column("project_id"), Op.IN, [1]),
-            Condition(Column("timestamp"), Op.GTE, datetime(2021, 8, 24, 23, tzinfo=pytz.utc)),
-            Condition(Column("timestamp"), Op.LT, datetime(2021, 8, 26, 0, tzinfo=pytz.utc)),
+            Condition(Column("timestamp"), Op.GTE, datetime(2021, 8, 24, 23, tzinfo=timezone.utc)),
+            Condition(Column("timestamp"), Op.LT, datetime(2021, 8, 26, 0, tzinfo=timezone.utc)),
             Condition(
                 Column(resolve_tag_key(use_case_id, org_id, "release"), entity=None),
                 Op.IN,

--- a/tests/sentry/tsdb/test_base.py
+++ b/tests/sentry/tsdb/test_base.py
@@ -2,7 +2,6 @@ import itertools
 from datetime import datetime, timedelta, timezone
 from unittest import TestCase
 
-import pytz
 from freezegun import freeze_time
 
 from sentry.tsdb.base import ONE_DAY, ONE_HOUR, ONE_MINUTE, BaseTSDB
@@ -22,7 +21,7 @@ class BaseTSDBTest(TestCase):
         )
 
     def test_normalize_to_epoch(self):
-        timestamp = datetime(2013, 5, 18, 15, 13, 58, 132928, tzinfo=pytz.UTC)
+        timestamp = datetime(2013, 5, 18, 15, 13, 58, 132928, tzinfo=timezone.utc)
         normalize_to_epoch = self.tsdb.normalize_to_epoch
 
         result = normalize_to_epoch(timestamp, 60)
@@ -41,7 +40,7 @@ class BaseTSDBTest(TestCase):
         assert post_results[1] == [[1368889200, 15], [1368892800, 7]]
 
     def test_calculate_expiry(self):
-        timestamp = datetime(2013, 5, 18, 15, 13, 58, 132928, tzinfo=pytz.UTC)
+        timestamp = datetime(2013, 5, 18, 15, 13, 58, 132928, tzinfo=timezone.utc)
         result = self.tsdb.calculate_expiry(10, 30, timestamp)
         assert result == 1368890330
 
@@ -86,8 +85,8 @@ class BaseTSDBTest(TestCase):
         assert self.tsdb.get_optimal_rollup_series(start, rollup=10) == (
             10,
             [
-                to_timestamp(datetime(2016, 8, 1, 0, 0, 0, tzinfo=pytz.utc)),
-                to_timestamp(datetime(2016, 8, 1, 0, 0, 10, tzinfo=pytz.utc)),
+                to_timestamp(datetime(2016, 8, 1, 0, 0, 0, tzinfo=timezone.utc)),
+                to_timestamp(datetime(2016, 8, 1, 0, 0, 10, tzinfo=timezone.utc)),
             ],
         )
 
@@ -95,14 +94,14 @@ class BaseTSDBTest(TestCase):
         start = now - timedelta(seconds=ONE_MINUTE - 1)
         assert self.tsdb.get_optimal_rollup_series(start, rollup=ONE_MINUTE) == (
             ONE_MINUTE,
-            [to_timestamp(datetime(2016, 8, 1, 0, 0, 0, tzinfo=pytz.utc))],
+            [to_timestamp(datetime(2016, 8, 1, 0, 0, 0, tzinfo=timezone.utc))],
         )
 
         now = datetime.now(timezone.utc) + timedelta(hours=11, seconds=45)
         start = now - timedelta(seconds=ONE_DAY - 1)
         assert self.tsdb.get_optimal_rollup_series(start, rollup=ONE_DAY) == (
             ONE_DAY,
-            [to_timestamp(datetime(2016, 8, 1, 0, tzinfo=pytz.utc))],
+            [to_timestamp(datetime(2016, 8, 1, 0, tzinfo=timezone.utc))],
         )
 
     @freeze_time("2016-08-01")

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -1,10 +1,9 @@
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import pytest
-import pytz
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
 from sentry.models import GroupRelease, Project, Release
 from sentry.snuba.dataset import Dataset
@@ -24,7 +23,7 @@ from sentry.utils.snuba import (
 class SnubaUtilsTest(TestCase):
     def setUp(self):
         self.now = datetime.utcnow().replace(
-            hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.UTC
+            hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc
         )
         self.proj1 = self.create_project()
         self.proj1env1 = self.create_environment(project=self.proj1, name="prod")
@@ -298,7 +297,7 @@ class PrepareQueryParamsTest(TestCase):
 
 class QuantizeTimeTest(unittest.TestCase):
     def setUp(self):
-        self.now = timezone.now().replace(microsecond=0)
+        self.now = django_timezone.now().replace(microsecond=0)
 
     def test_cache_suffix_time(self):
         starting_key = quantize_time(self.now, 0)

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -1,14 +1,13 @@
 import math
 import uuid
-from datetime import timedelta
+from datetime import timedelta, timezone
 from unittest import mock
 
 import pytest
 from django.test import override_settings
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 from freezegun import freeze_time
-from pytz import utc
 from snuba_sdk.column import Column
 from snuba_sdk.function import Function
 
@@ -1296,13 +1295,13 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         replaced_release = self.create_release(
             version="replaced_release",
             environments=[self.environment],
-            adopted=timezone.now(),
-            unadopted=timezone.now(),
+            adopted=django_timezone.now(),
+            unadopted=django_timezone.now(),
         )
         adopted_release = self.create_release(
             version="adopted_release",
             environments=[self.environment],
-            adopted=timezone.now(),
+            adopted=django_timezone.now(),
         )
         self.create_release(version="not_adopted_release", environments=[self.environment])
 
@@ -4132,7 +4131,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
     @mock.patch("sentry.utils.snuba.quantize_time")
     def test_quantize_dates(self, mock_quantize):
         self.create_project()
-        mock_quantize.return_value = before_now(days=1).replace(tzinfo=utc)
+        mock_quantize.return_value = before_now(days=1).replace(tzinfo=timezone.utc)
 
         # Don't quantize short time periods
         query = {"statsPeriod": "1h", "query": "", "field": ["id", "timestamp"]}

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -1,11 +1,10 @@
-from datetime import timedelta
+from datetime import timedelta, timezone
 from unittest import mock
 from uuid import uuid4
 
 import requests
 from django.urls import reverse
-from django.utils import timezone
-from pytz import utc
+from django.utils import timezone as django_timezone
 from rest_framework.exceptions import ParseError
 
 from sentry.testutils.cases import APITestCase, SnubaTestCase
@@ -272,7 +271,7 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
         self.store_event(
             data={
                 "event_id": uuid4().hex,
-                "timestamp": iso_format(timezone.now()),
+                "timestamp": iso_format(django_timezone.now()),
                 "tags": {"color": "red"},
             },
             project_id=self.project2.id,
@@ -603,7 +602,7 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
 
     @mock.patch("sentry.utils.snuba.quantize_time")
     def test_quantize_dates(self, mock_quantize):
-        mock_quantize.return_value = before_now(days=1).replace(tzinfo=utc)
+        mock_quantize.return_value = before_now(days=1).replace(tzinfo=timezone.utc)
         with self.feature("organizations:discover-basic"):
             # Don't quantize short time periods
             self.client.get(

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import pytest
 from django.urls import reverse
-from pytz import utc
 from rest_framework.exceptions import ParseError
 
 from sentry.issues.grouptype import ProfileFileIOGroupType
@@ -182,7 +181,7 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase, SearchIssueTest
 
     @mock.patch("sentry.utils.snuba.quantize_time")
     def test_quantize_dates(self, mock_quantize):
-        mock_quantize.return_value = before_now(days=1).replace(tzinfo=utc)
+        mock_quantize.return_value = before_now(days=1).replace(tzinfo=timezone.utc)
         with self.feature(self.features):
             # Don't quantize short time periods
             self.client.get(

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1,12 +1,11 @@
 import uuid
-from datetime import timedelta
+from datetime import timedelta, timezone
 from unittest import mock
 from uuid import uuid4
 
 import pytest
 from dateutil.parser import parse as parse_date
 from django.urls import reverse
-from pytz import utc
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.function import Function
@@ -99,7 +98,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=utc),
+            self.day_ago.replace(tzinfo=timezone.utc),
         )
         assert group_info is not None
         self.store_search_issue(
@@ -107,14 +106,14 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=utc) + timedelta(hours=1, minutes=1),
+            self.day_ago.replace(tzinfo=timezone.utc) + timedelta(hours=1, minutes=1),
         )
         self.store_search_issue(
             self.project.id,
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=utc) + timedelta(hours=1, minutes=2),
+            self.day_ago.replace(tzinfo=timezone.utc) + timedelta(hours=1, minutes=2),
         )
         with self.feature(
             [
@@ -142,7 +141,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=utc) + timedelta(minutes=1),
+            self.day_ago.replace(tzinfo=timezone.utc) + timedelta(minutes=1),
         )
         assert group_info is not None
         self.store_search_issue(
@@ -150,14 +149,14 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=utc) + timedelta(minutes=1),
+            self.day_ago.replace(tzinfo=timezone.utc) + timedelta(minutes=1),
         )
         self.store_search_issue(
             self.project.id,
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=utc) + timedelta(minutes=2),
+            self.day_ago.replace(tzinfo=timezone.utc) + timedelta(minutes=2),
         )
         with self.feature(
             [
@@ -842,7 +841,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
 
     @mock.patch("sentry.utils.snuba.quantize_time")
     def test_quantize_dates(self, mock_quantize):
-        mock_quantize.return_value = before_now(days=1).replace(tzinfo=utc)
+        mock_quantize.return_value = before_now(days=1).replace(tzinfo=timezone.utc)
         # Don't quantize short time periods
         self.do_request(
             data={"statsPeriod": "1h", "query": "", "interval": "30m", "yAxis": "count()"},

--- a/tests/snuba/api/serializers/test_group_stream.py
+++ b/tests/snuba/api/serializers/test_group_stream.py
@@ -1,9 +1,8 @@
 import time
-from datetime import timedelta
+from datetime import timedelta, timezone
 from unittest import mock
 
-import pytz
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.api.serializers import serialize
@@ -210,8 +209,8 @@ class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):
                 environment_ids=[dev_environment.id],
                 stats_period="14d",
                 expand=["sessions"],
-                start=timezone.now() - timedelta(days=30),
-                end=timezone.now() - timedelta(days=15),
+                start=django_timezone.now() - timedelta(days=30),
+                end=django_timezone.now() - timedelta(days=15),
                 organization_id=organization_id,
             ),
         )
@@ -225,7 +224,7 @@ class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):
         )
         data = {
             "fingerprint": ["meow"],
-            "timestamp": iso_format(timezone.now()),
+            "timestamp": iso_format(django_timezone.now()),
             "type": "error",
             "exception": [{"type": "Foo"}],
         }
@@ -253,22 +252,22 @@ class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):
                 SearchFilter(
                     SearchKey("timestamp"),
                     ">",
-                    SearchValue(before_now(hours=1).replace(tzinfo=pytz.UTC)),
+                    SearchValue(before_now(hours=1).replace(tzinfo=timezone.utc)),
                 ),
                 SearchFilter(
                     SearchKey("timestamp"),
                     "<",
-                    SearchValue(before_now(seconds=1).replace(tzinfo=pytz.UTC)),
+                    SearchValue(before_now(seconds=1).replace(tzinfo=timezone.utc)),
                 ),
                 SearchFilter(
                     SearchKey("date"),
                     ">",
-                    SearchValue(before_now(hours=1).replace(tzinfo=pytz.UTC)),
+                    SearchValue(before_now(hours=1).replace(tzinfo=timezone.utc)),
                 ),
                 SearchFilter(
                     SearchKey("date"),
                     "<",
-                    SearchValue(before_now(seconds=1).replace(tzinfo=pytz.UTC)),
+                    SearchValue(before_now(seconds=1).replace(tzinfo=timezone.utc)),
                 ),
             ]
         )

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -1,10 +1,9 @@
 import time
 from copy import deepcopy
-from datetime import timedelta
+from datetime import timedelta, timezone
 from unittest.mock import patch
 from uuid import uuid4
 
-import pytz
 from django.utils.timezone import now
 from freezegun import freeze_time
 
@@ -82,8 +81,8 @@ class PerfIssuePlatformEventMixin(PerformanceIssueTestCase):
         )
         event_data = load_data(
             "transaction-n-plus-one",
-            timestamp=timestamp.replace(tzinfo=pytz.utc),
-            start_timestamp=timestamp.replace(tzinfo=pytz.utc),
+            timestamp=timestamp.replace(tzinfo=timezone.utc),
+            start_timestamp=timestamp.replace(tzinfo=timezone.utc),
             fingerprint=[fingerprint],
         )
         event_data["user"] = {"id": uuid4().hex}

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1,13 +1,12 @@
 import time
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest import mock
 
 import pytest
-import pytz
 import urllib3
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 from sentry_kafka_schemas.schema_types.group_attributes_v1 import GroupAttributesSnapshot
 
 from sentry import options
@@ -124,7 +123,7 @@ class EventsDatasetTestSetup(SharedSnubaMixin):
 
     def setUp(self):
         super().setUp()
-        self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
+        self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=timezone.utc)
 
         event1_timestamp = iso_format(self.base_datetime - timedelta(days=21))
         self.event1 = self.store_event(
@@ -1844,7 +1843,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
 
         assert (
             self.make_query(
-                search_filter_query="last_seen:>%s" % date_to_query_format(timezone.now()),
+                search_filter_query="last_seen:>%s" % date_to_query_format(django_timezone.now()),
                 sort_by="date",
             ).results
             == []
@@ -1860,7 +1859,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
 
         assert (
             self.make_query(
-                search_filter_query="last_seen:>%s" % date_to_query_format(timezone.now()),
+                search_filter_query="last_seen:>%s" % date_to_query_format(django_timezone.now()),
                 sort_by="date",
             ).results
             == []
@@ -1876,7 +1875,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
 
         assert (
             self.make_query(
-                search_filter_query="last_seen:>%s" % date_to_query_format(timezone.now()),
+                search_filter_query="last_seen:>%s" % date_to_query_format(django_timezone.now()),
                 sort_by="date",
             ).results
             == []
@@ -1917,7 +1916,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             options.set("snuba.search.pre-snuba-candidates-optimizer", prev_optimizer_enabled)
 
     def test_search_out_of_range(self):
-        the_date = datetime(2000, 1, 1, 0, 0, 0, tzinfo=pytz.utc)
+        the_date = datetime(2000, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         results = self.make_query(
             search_filter_query=f"event.timestamp:>{the_date} event.timestamp:<{the_date}",
             date_from=the_date,
@@ -2636,7 +2635,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
     def test_priority_sort_old_and_new_events(self):
         """Test that an issue with only one old event is ranked lower than an issue with only one new event"""
         new_project = self.create_project(organization=self.project.organization)
-        base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
+        base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=timezone.utc)
 
         recent_event = self.store_event(
             data={
@@ -2686,7 +2685,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
     def test_priority_sort_v2(self):
         """Test that the v2 formula works."""
         new_project = self.create_project(organization=self.project.organization)
-        base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
+        base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=timezone.utc)
 
         recent_event = self.store_event(
             data={
@@ -2735,7 +2734,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
 
     def test_priority_log_level_results(self):
         """Test that the scoring results change when we pass in different log level weights"""
-        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=pytz.utc)
+        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=timezone.utc)
         event1 = self.store_event(
             data={
                 "fingerprint": ["put-me-in-group1"],
@@ -2811,7 +2810,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
 
     def test_priority_has_stacktrace_results(self):
         """Test that the scoring results change when we pass in different has_stacktrace weights"""
-        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=pytz.utc)
+        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=timezone.utc)
         agg_kwargs = {
             "priority": {
                 "log_level": 0,
@@ -2893,7 +2892,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
 
     def test_priority_event_halflife_results(self):
         """Test that the scoring results change when we pass in different event halflife weights"""
-        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=pytz.utc)
+        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=timezone.utc)
         event1 = self.store_event(
             data={
                 "fingerprint": ["put-me-in-group1"],
@@ -2966,7 +2965,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         assert group1_score_after < group2_score_after
 
     def test_priority_mixed_group_types(self):
-        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=pytz.utc)
+        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=timezone.utc)
 
         error_event = self.store_event(
             data={
@@ -3040,7 +3039,7 @@ class EventsTransactionsSnubaSearchTest(TestCase, SharedSnubaMixin):
 
     def setUp(self):
         super().setUp()
-        self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
+        self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=timezone.utc)
 
         transaction_event_data = {
             "level": "info",
@@ -3411,7 +3410,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
 
     def setUp(self):
         super().setUp()
-        self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
+        self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=timezone.utc)
 
         event_id_1 = uuid.uuid4().hex
         _, group_info = process_event_and_issue_occurrence(
@@ -3697,7 +3696,7 @@ class CdcEventsSnubaSearchTest(TestCase, SharedSnubaMixin):
 
     def setUp(self):
         super().setUp()
-        self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
+        self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=timezone.utc)
 
         self.event1 = self.store_event(
             data={

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1,10 +1,8 @@
 import time
-from datetime import datetime, timedelta
-from datetime import timezone as dt_timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
-import pytz
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
 from sentry.release_health.base import OverviewStat
 from sentry.release_health.metrics import MetricsReleaseHealthBackend
@@ -46,7 +44,7 @@ def format_timestamp(dt):
 
 
 def make_24h_stats(ts, adjust_start=False):
-    ret_val = _make_stats(datetime.utcfromtimestamp(ts).replace(tzinfo=pytz.utc), 3600, 24)
+    ret_val = _make_stats(datetime.utcfromtimestamp(ts).replace(tzinfo=timezone.utc), 3600, 24)
 
     if adjust_start:
         # HACK this adds another interval at the beginning in accordance with the new way of calculating intervals
@@ -495,7 +493,7 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         }
 
     def test_get_crash_free_breakdown(self):
-        start = timezone.now() - timedelta(days=4)
+        start = django_timezone.now() - timedelta(days=4)
 
         # it should work with and without environments
         for environments in [None, ["prod"]]:
@@ -508,7 +506,7 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
 
             # Last returned date is generated within function, should be close to now:
             last_date = data[-1].pop("date")
-            assert timezone.now() - last_date < timedelta(seconds=1)
+            assert django_timezone.now() - last_date < timedelta(seconds=1)
 
             assert data == [
                 {
@@ -654,7 +652,7 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
     def _test_get_project_release_stats(
         self, stat: OverviewStat, release: str, expected_series, expected_totals
     ):
-        end = timezone.now()
+        end = django_timezone.now()
         start = end - timedelta(days=4)
         stats, totals = self.backend.get_project_release_stats(
             self.project.id,
@@ -1080,7 +1078,7 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
             )
 
     def test_get_current_and_previous_crash_free_rates(self):
-        now = timezone.now().replace(minute=15, second=23)
+        now = django_timezone.now().replace(minute=15, second=23)
         last_24h_start = now - 24 * timedelta(hours=1)
         last_48h_start = now - 2 * 24 * timedelta(hours=1)
 
@@ -1104,7 +1102,7 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
         }
 
     def test_get_current_and_previous_crash_free_rates_with_zero_sessions(self):
-        now = timezone.now().replace(minute=15, second=23)
+        now = django_timezone.now().replace(minute=15, second=23)
         last_48h_start = now - 2 * 24 * timedelta(hours=1)
         last_72h_start = now - 3 * 24 * timedelta(hours=1)
         last_96h_start = now - 4 * 24 * timedelta(hours=1)
@@ -1274,7 +1272,7 @@ class CheckNumberOfSessions(TestCase, SnubaTestCase):
 
         # now_dt should be set to 17:40 of some day not in the future and (system time - now_dt)
         # must be less than 90 days for the metrics DB TTL
-        ONE_DAY_AGO = datetime.now(tz=dt_timezone.utc) - timedelta(days=1)
+        ONE_DAY_AGO = datetime.now(tz=timezone.utc) - timedelta(days=1)
         self.now_dt = ONE_DAY_AGO.replace(hour=17, minute=40, second=0)
         self._5_min_ago_dt = self.now_dt - timedelta(minutes=5)
         self._30_min_ago_dt = self.now_dt - timedelta(minutes=30)
@@ -1628,7 +1626,7 @@ class InitWithoutUserTestCase(TestCase, SnubaTestCase):
         assert inner["total_project_users_24h"] == 3
 
     def test_get_crash_free_breakdown(self):
-        start = timezone.now() - timedelta(days=4)
+        start = django_timezone.now() - timedelta(days=4)
         data = self.backend.get_crash_free_breakdown(
             project_id=self.project.id,
             release=self.session_release,
@@ -1639,7 +1637,7 @@ class InitWithoutUserTestCase(TestCase, SnubaTestCase):
         # Last returned date is generated within function, should be close to now:
         last_date = data[-1].pop("date")
 
-        assert timezone.now() - last_date < timedelta(seconds=1)
+        assert django_timezone.now() - last_date < timedelta(seconds=1)
 
         assert data == [
             {
@@ -1665,7 +1663,7 @@ class InitWithoutUserTestCase(TestCase, SnubaTestCase):
         ]
 
     def test_get_project_release_stats_users(self):
-        end = timezone.now()
+        end = django_timezone.now()
         start = end - timedelta(days=4)
         stats, totals = self.backend.get_project_release_stats(
             self.project.id,

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -8,8 +8,6 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
-import pytz
-
 from sentry import eventstream, tagstore, tsdb
 from sentry.eventstore.models import Event
 from sentry.models import Environment, Group, GroupHash, GroupRelease, Release, UserReport
@@ -168,7 +166,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
 
     @with_feature("projects:similarity-indexing")
     def test_unmerge(self):
-        now = before_now(minutes=5).replace(microsecond=0, tzinfo=pytz.utc)
+        now = before_now(minutes=5).replace(microsecond=0, tzinfo=timezone.utc)
 
         def time_from_now(offset=0):
             return now + timedelta(seconds=offset)

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
-import pytz
 from snuba_sdk import Limit
 
 from sentry.issues.grouptype import ProfileFileIOGroupType
@@ -58,7 +57,7 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
 
         self.db = SnubaTSDB()
         self.now = (datetime.utcnow() - timedelta(hours=4)).replace(
-            hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.UTC
+            hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc
         )
         self.proj1 = self.create_project()
         env1 = "test"
@@ -630,7 +629,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
 
         self.db = SnubaTSDB()
         self.now = (datetime.utcnow() - timedelta(hours=4)).replace(
-            hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.UTC
+            hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc
         )
         self.proj1 = self.create_project()
 
@@ -710,7 +709,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
 
     def test_range_groups_mult(self):
         now = (datetime.utcnow() - timedelta(days=1)).replace(
-            hour=10, minute=0, second=0, microsecond=0, tzinfo=pytz.UTC
+            hour=10, minute=0, second=0, microsecond=0, tzinfo=timezone.utc
         )
         dts = [now + timedelta(hours=i) for i in range(4)]
         project = self.create_project()
@@ -747,7 +746,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
     def test_range_groups_simple(self):
         project = self.create_project()
         now = (datetime.utcnow() - timedelta(days=1)).replace(
-            hour=10, minute=0, second=0, microsecond=0, tzinfo=pytz.UTC
+            hour=10, minute=0, second=0, microsecond=0, tzinfo=timezone.utc
         )
         group_fingerprint = f"{ProfileFileIOGroupType.type_id}-group5"
         ids = [1, 2, 3, 4, 5]
@@ -905,12 +904,12 @@ class AddJitterToSeriesTest(TestCase):
         self.db = SnubaTSDB()
 
     def run_test(self, end, interval, jitter, expected_start, expected_end):
-        end = end.replace(tzinfo=pytz.UTC)
+        end = end.replace(tzinfo=timezone.utc)
         start = end - interval
         rollup, rollup_series = self.db.get_optimal_rollup_series(start, end)
         series = self.db._add_jitter_to_series(rollup_series, start, rollup, jitter)
-        assert to_datetime(series[0]) == expected_start.replace(tzinfo=pytz.UTC)
-        assert to_datetime(series[-1]) == expected_end.replace(tzinfo=pytz.UTC)
+        assert to_datetime(series[0]) == expected_start.replace(tzinfo=timezone.utc)
+        assert to_datetime(series[-1]) == expected_end.replace(tzinfo=timezone.utc)
 
     def test(self):
         self.run_test(

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import ast
 
+import pytest
+
 from tools.flake8_plugin import SentryCheck
 
 
@@ -132,3 +134,17 @@ import sentry.testutils.outbox as outbox_utils
     assert errors == [
         "t.py:1:0: S007 Do not import sentry.testutils into production code.",
     ]
+
+
+@pytest.mark.parametrize(
+    "src",
+    (
+        "from pytz import utc",
+        "from pytz import UTC",
+        "pytz.utc",
+        "pytz.UTC",
+    ),
+)
+def test_S008(src):
+    expected = ["t.py:1:0: S008 Use stdlib datetime.timezone.utc instead of pytz.utc / pytz.UTC"]
+    assert _run(src) == expected


### PR DESCRIPTION
django 4.x switches to zoneinfo-based timezones -- this gets us mostly off of pytz for non-user timezones