### PR TITLE
chore(github): add open PR comments toggle and org option

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -137,6 +137,12 @@ ORG_OPTIONS = (
         bool,
         org_serializers.GITHUB_PR_BOT_DEFAULT,
     ),
+    (
+        "githubOpenPRComments",
+        "sentry:github_open_pr_comments",
+        bool,
+        org_serializers.GITHUB_OPEN_PR_COMMENTS_DEFAULT,
+    ),
 )
 
 DELETION_STATUSES = frozenset(
@@ -180,6 +186,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     isEarlyAdopter = serializers.BooleanField(required=False)
     aiSuggestedSolution = serializers.BooleanField(required=False)
     codecovAccess = serializers.BooleanField(required=False)
+    githubOpenPRComments = serializers.BooleanField(required=False)
     githubPRBot = serializers.BooleanField(required=False)
     require2FA = serializers.BooleanField(required=False)
     requireEmailVerification = serializers.BooleanField(required=False)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -42,6 +42,7 @@ from sentry.constants import (
     ATTACHMENTS_ROLE_DEFAULT,
     DEBUG_FILES_ROLE_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
+    GITHUB_OPEN_PR_COMMENTS_DEFAULT,
     GITHUB_PR_BOT_DEFAULT,
     JOIN_REQUESTS_DEFAULT,
     PROJECT_RATE_LIMIT_DEFAULT,
@@ -417,6 +418,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     codecovAccess: bool
     aiSuggestedSolution: bool
     githubPRBot: bool
+    githubOpenPRComments: bool
     isDynamicallySampled: bool
 
 
@@ -523,6 +525,11 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                     obj.get_option("sentry:ai_suggested_solution", AI_SUGGESTED_SOLUTION)
                 ),
                 "githubPRBot": bool(obj.get_option("sentry:github_pr_bot", GITHUB_PR_BOT_DEFAULT)),
+                "githubOpenPRComments": bool(
+                    obj.get_option(
+                        "sentry:github_open_pr_comments", GITHUB_OPEN_PR_COMMENTS_DEFAULT
+                    )
+                ),
             }
         )
 

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -633,6 +633,7 @@ JOIN_REQUESTS_DEFAULT = True
 APDEX_THRESHOLD_DEFAULT = 300
 AI_SUGGESTED_SOLUTION = True
 GITHUB_PR_BOT_DEFAULT = True
+GITHUB_OPEN_PR_COMMENTS_DEFAULT = True
 
 # `sentry:events_member_admin` - controls whether the 'member' role gets the event:admin scope
 EVENTS_MEMBER_ADMIN_DEFAULT = True

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -17,6 +17,7 @@ export interface OrganizationSummary {
   codecovAccess: boolean;
   dateCreated: string;
   features: string[];
+  githubOpenPRComments: boolean;
   githubPRBot: boolean;
   id: string;
   isEarlyAdopter: boolean;

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -331,7 +331,15 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
     const hasIntegration = configurations ? configurations.length > 0 : false;
     const endpoint = `/organizations/${organization.slug}/`;
     const hasOrgWrite = organization.access.includes('org:write');
-
+    let openPRDisabledReason = t(
+      'You must have a GitHub integration to enable this feature.'
+    );
+    if (
+      hasIntegration &&
+      !organization.features.includes('integrations-open-pr-comment')
+    ) {
+      openPRDisabledReason = t("This feature isn't available to you yet.");
+    }
     const forms: JsonFormObject[] = [
       {
         fields: [
@@ -347,12 +355,23 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
               'You must have a GitHub integration to enable this feature.'
             ),
           },
+          {
+            name: 'githubOpenPRComments',
+            type: 'boolean',
+            label: t('Enable Open PR Comments'),
+            help: t('Allow Sentry to comment on open PRs.'),
+            disabled:
+              !hasIntegration ||
+              !organization.features.includes('integrations-open-pr-comment'),
+            disabledReason: openPRDisabledReason,
+          },
         ],
       },
     ];
 
     const initialData = {
       githubPRBot: organization.githubPRBot,
+      githubOpenPRComments: organization.githubOpenPRComments,
     };
 
     return (

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -334,10 +334,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
     let openPRDisabledReason = t(
       'You must have a GitHub integration to enable this feature.'
     );
-    if (
-      hasIntegration &&
-      !organization.features.includes('integrations-open-pr-comment')
-    ) {
+    if (!organization.features.includes('integrations-open-pr-comment')) {
       openPRDisabledReason = t("This feature isn't available to you yet.");
     }
     const forms: JsonFormObject[] = [
@@ -346,9 +343,9 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
           {
             name: 'githubPRBot',
             type: 'boolean',
-            label: t('Enable Pull Request Bot'),
+            label: t('Enable Comments on Suspect Pull Requests'),
             help: t(
-              'Allow Sentry to comment on pull requests about issues impacting your app.'
+              'Allow Sentry to comment on recent pull requests suspected of causing issues.'
             ),
             disabled: !hasIntegration,
             disabledReason: t(
@@ -358,8 +355,10 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
           {
             name: 'githubOpenPRComments',
             type: 'boolean',
-            label: t('Enable Open PR Comments'),
-            help: t('Allow Sentry to comment on open PRs.'),
+            label: t('Enable Comments on Open Pull Requests'),
+            help: t(
+              'Allow Sentry to comment on open pull requests to show recent error and performance issues for the code being changed.'
+            ),
             disabled:
               !hasIntegration ||
               !organization.features.includes('integrations-open-pr-comment'),


### PR DESCRIPTION
Add a toggle for open PR comments.
- Org is not under feature flag: toggle is disabled
<img width="1512" alt="Screenshot 2023-08-14 at 10 58 44 AM" src="https://github.com/getsentry/sentry/assets/83109586/53776ca9-948e-41df-988a-bb4b23eaba0d">
- Org is under feature flag but doesn't have integration installed: toggle is disabled
<img width="1512" alt="Screenshot 2023-08-14 at 10 58 16 AM" src="https://github.com/getsentry/sentry/assets/83109586/e68fd1c1-7327-4913-abcd-a7df13a7c27b">
- Org is under feature flag and has integration installed: toggle is enabled
<img width="1512" alt="Toggle enabled" src="https://github.com/getsentry/sentry/assets/83109586/533061fc-0479-4204-be23-83c94656e733">

