### PR TITLE
ref(starfish): Split up span summary page components

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/block.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/block.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import {space} from 'sentry/styles/space';
+
+interface Props {
+  children: React.ReactNode;
+  description?: React.ReactNode;
+  title?: React.ReactNode;
+}
+
+export function Block({title, description, children}: Props) {
+  return (
+    <BlockWrapper>
+      {title && (
+        <BlockTitle>
+          {title}
+          {description && (
+            <BlockTooltipContainer>
+              <QuestionTooltip size="sm" position="right" title={description} />
+            </BlockTooltipContainer>
+          )}
+        </BlockTitle>
+      )}
+      <BlockContent>{children}</BlockContent>
+    </BlockWrapper>
+  );
+}
+
+export const BlockContainer = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${space(2)};
+`;
+
+const BlockWrapper = styled('div')`
+  flex-grow: 1;
+  min-width: 0;
+  word-break: break-word;
+  padding-bottom: ${space(2)};
+`;
+
+const BlockTitle = styled('h3')`
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin: 0;
+  margin-bottom: ${space(1)};
+  white-space: nowrap;
+  display: flex;
+  height: ${space(3)};
+`;
+
+const BlockContent = styled('h4')`
+  margin: 0;
+  font-weight: normal;
+`;
+
+const BlockTooltipContainer = styled('span')`
+  margin-left: ${space(1)};
+`;

--- a/static/app/views/starfish/views/spanSummaryPage/getSpanOperationDescription.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/getSpanOperationDescription.tsx
@@ -1,0 +1,29 @@
+import {t} from 'sentry/locale';
+
+export function getSpanOperationDescription(spanOp: string) {
+  if (spanOp?.startsWith('http')) {
+    return t('URL Request');
+  }
+
+  if (spanOp === 'db.redis') {
+    return t('Cache Query');
+  }
+
+  if (spanOp?.startsWith('db')) {
+    return t('Database Query');
+  }
+
+  if (spanOp?.startsWith('task')) {
+    return t('Application Task');
+  }
+
+  if (spanOp?.startsWith('serialize')) {
+    return t('Serializer');
+  }
+
+  if (spanOp?.startsWith('middleware')) {
+    return t('Middleware');
+  }
+
+  return t('Span');
+}

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -1,75 +1,58 @@
 import {RouteComponentProps} from 'react-router';
-import styled from '@emotion/styled';
 import {Location} from 'history';
 import * as qs from 'query-string';
 
 import Breadcrumbs, {Crumb} from 'sentry/components/breadcrumbs';
 import * as Layout from 'sentry/components/layouts/thirds';
-import QuestionTooltip from 'sentry/components/questionTooltip';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
+import {t} from 'sentry/locale';
 import {fromSorts} from 'sentry/utils/discover/eventView';
-import {RateUnits, Sort} from 'sentry/utils/discover/fields';
-import {formatRate} from 'sentry/utils/formatters';
+import {Sort} from 'sentry/utils/discover/fields';
 import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import {AVG_COLOR, ERRORS_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
-import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
-import ChartPanel from 'sentry/views/starfish/components/chartPanel';
-import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
-import {SpanDescription} from 'sentry/views/starfish/components/spanDescription';
 import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
-import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
-import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
-import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
-import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
-import {useFullSpanFromTrace} from 'sentry/views/starfish/queries/useFullSpanFromTrace';
 import {
   SpanSummaryQueryFilters,
   useSpanMetrics,
 } from 'sentry/views/starfish/queries/useSpanMetrics';
-import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
-import {
-  DataTitles,
-  getThroughputChartTitle,
-  getThroughputTitle,
-} from 'sentry/views/starfish/views/spans/types';
+import {getSpanOperationDescription} from 'sentry/views/starfish/views/spanSummaryPage/getSpanOperationDescription';
 import {SampleList} from 'sentry/views/starfish/views/spanSummaryPage/sampleList';
+import {SpanSummaryView} from 'sentry/views/starfish/views/spanSummaryPage/spanSummaryView';
 import {
   isAValidSort,
   SpanTransactionsTable,
 } from 'sentry/views/starfish/views/spanSummaryPage/spanTransactionsTable';
 
-const DEFAULT_SORT: Sort = {
-  kind: 'desc',
-  field: 'time_spent_percentage(local)',
+type Query = {
+  endpoint: string;
+  endpointMethod: string;
+  transaction: string;
+  transactionMethod: string;
+  [QueryParameterNames.SORT]: string;
 };
 
-const CHART_HEIGHT = 160;
-
 type Props = {
-  location: Location;
-} & RouteComponentProps<{groupId: string}, {transaction: string}>;
+  location: Location<Query>;
+} & RouteComponentProps<Query, {groupId: string}>;
 
 function SpanSummaryPage({params, location}: Props) {
   const organization = useOrganization();
   const {groupId} = params;
-  const {transaction, transactionMethod, endpoint, endpointMethod} = location.query;
 
-  const {data: fullSpan} = useFullSpanFromTrace(groupId);
+  const {transaction, transactionMethod, endpoint, endpointMethod} = location.query;
 
   const queryFilter: SpanSummaryQueryFilters = endpoint
     ? {transactionName: endpoint, 'transaction.method': endpointMethod}
     : {};
+
   const sort =
     fromSorts(location.query[QueryParameterNames.SORT]).filter(isAValidSort)[0] ??
     DEFAULT_SORT; // We only allow one sort on this table in this view
@@ -83,49 +66,21 @@ function SpanSummaryPage({params, location}: Props) {
     queryFilter,
     [
       SpanMetricsFields.SPAN_OP,
-      SpanMetricsFields.SPAN_DESCRIPTION,
-      SpanMetricsFields.SPAN_ACTION,
-      SpanMetricsFields.SPAN_DOMAIN,
-      'count()',
-      'spm()',
-      `sum(${SpanMetricsFields.SPAN_SELF_TIME})`,
-      `avg(${SpanMetricsFields.SPAN_SELF_TIME})`,
-      'time_spent_percentage()',
-      'http_error_count()',
+      SpanMetricsFields.SPAN_GROUP,
+      `${StarfishFunctions.SPS}()`,
     ],
     'api.starfish.span-summary-page-metrics'
   );
 
   const span = {
-    ...spanMetrics,
+    [SpanMetricsFields.SPAN_OP]: spanMetrics[SpanMetricsFields.SPAN_OP],
     [SpanMetricsFields.SPAN_GROUP]: groupId,
-  } as {
-    [SpanMetricsFields.SPAN_OP]: string;
-    [SpanMetricsFields.SPAN_DESCRIPTION]: string;
-    [SpanMetricsFields.SPAN_ACTION]: string;
-    [SpanMetricsFields.SPAN_DOMAIN]: string;
-    [SpanMetricsFields.SPAN_GROUP]: string;
   };
 
-  const {isLoading: areSpanMetricsSeriesLoading, data: spanMetricsSeriesData} =
-    useSpanMetricsSeries(
-      groupId,
-      queryFilter,
-      [`avg(${SpanMetricsFields.SPAN_SELF_TIME})`, 'spm()', 'http_error_count()'],
-      'api.starfish.span-summary-page-metrics-chart'
-    );
-
-  useSynchronizeCharts([!areSpanMetricsSeriesLoading]);
-
-  const spanMetricsThroughputSeries = {
-    seriesName: span?.[SpanMetricsFields.SPAN_OP]?.startsWith('db')
-      ? 'Queries'
-      : 'Requests',
-    data: spanMetricsSeriesData?.['spm()'].data,
-  };
-
-  const title = getDescriptionLabel(span[SpanMetricsFields.SPAN_OP], true);
-  const spanDescriptionCardTitle = getDescriptionLabel(span[SpanMetricsFields.SPAN_OP]);
+  const title = [
+    getSpanOperationDescription(span[SpanMetricsFields.SPAN_OP]),
+    t('Summary'),
+  ].join(' ');
 
   const crumbs: Crumb[] = [];
   crumbs.push({
@@ -168,137 +123,8 @@ function SpanSummaryPage({params, location}: Props) {
             <Layout.Body>
               <Layout.Main fullWidth>
                 <PageErrorAlert />
-                <HeaderContainer>
-                  <FilterOptionsContainer>
-                    <StarfishDatePicker />
-                  </FilterOptionsContainer>
-                  <BlockContainer>
-                    {span?.[SpanMetricsFields.SPAN_OP]?.startsWith('db') &&
-                      span?.[SpanMetricsFields.SPAN_OP] !== 'db.redis' && (
-                        <Block title={t('Table')}>
-                          {span?.[SpanMetricsFields.SPAN_DOMAIN]}
-                        </Block>
-                      )}
-                    <Block
-                      title={getThroughputTitle(span?.[SpanMetricsFields.SPAN_OP])}
-                      description={tct('Throughput of this [spanType] per minute', {
-                        spanType: spanDescriptionCardTitle,
-                      })}
-                    >
-                      <ThroughputCell
-                        rate={spanMetrics?.['spm()']}
-                        unit={RateUnits.PER_MINUTE}
-                      />
-                    </Block>
-                    <Block
-                      title={DataTitles.avg}
-                      description={tct(
-                        'The average duration of [spanType] in the selected period',
-                        {
-                          spanType: spanDescriptionCardTitle.endsWith('y')
-                            ? `${spanDescriptionCardTitle.slice(0, -1)}ies`
-                            : `${spanDescriptionCardTitle}s`,
-                        }
-                      )}
-                    >
-                      <DurationCell
-                        milliseconds={
-                          spanMetrics?.[`avg(${SpanMetricsFields.SPAN_SELF_TIME})`]
-                        }
-                      />
-                    </Block>
-                    {span?.[SpanMetricsFields.SPAN_OP]?.startsWith('http') && (
-                      <Block
-                        title={t('5XX Responses')}
-                        description={t('5XX responses in this span')}
-                      >
-                        <CountCell count={spanMetrics?.[`http_error_count()`]} />
-                      </Block>
-                    )}
-                    <Block
-                      title={t('Time Spent')}
-                      description={t(
-                        'Time spent in this span as a proportion of total application time'
-                      )}
-                    >
-                      <TimeSpentCell
-                        percentage={spanMetrics?.['time_spent_percentage()']}
-                        total={spanMetrics?.[`avg(${SpanMetricsFields.SPAN_SELF_TIME})`]}
-                      />
-                    </Block>
-                  </BlockContainer>
-                </HeaderContainer>
 
-                {span?.[SpanMetricsFields.SPAN_DESCRIPTION] && (
-                  <DescriptionContainer>
-                    <SpanDescription
-                      span={{
-                        ...span,
-                        [SpanMetricsFields.SPAN_DESCRIPTION]:
-                          fullSpan?.description ??
-                          spanMetrics?.[SpanMetricsFields.SPAN_DESCRIPTION],
-                      }}
-                    />
-                  </DescriptionContainer>
-                )}
-
-                <BlockContainer>
-                  <Block>
-                    <ChartPanel
-                      title={getThroughputChartTitle(span?.[SpanMetricsFields.SPAN_OP])}
-                    >
-                      <Chart
-                        height={CHART_HEIGHT}
-                        data={[spanMetricsThroughputSeries]}
-                        loading={areSpanMetricsSeriesLoading}
-                        utc={false}
-                        chartColors={[THROUGHPUT_COLOR]}
-                        isLineChart
-                        definedAxisTicks={4}
-                        aggregateOutputFormat="rate"
-                        rateUnit={RateUnits.PER_MINUTE}
-                        tooltipFormatterOptions={{
-                          valueFormatter: value =>
-                            formatRate(value, RateUnits.PER_MINUTE),
-                        }}
-                      />
-                    </ChartPanel>
-                  </Block>
-
-                  <Block>
-                    <ChartPanel title={DataTitles.avg}>
-                      <Chart
-                        height={CHART_HEIGHT}
-                        data={[
-                          spanMetricsSeriesData?.[
-                            `avg(${SpanMetricsFields.SPAN_SELF_TIME})`
-                          ],
-                        ]}
-                        loading={areSpanMetricsSeriesLoading}
-                        utc={false}
-                        chartColors={[AVG_COLOR]}
-                        isLineChart
-                        definedAxisTicks={4}
-                      />
-                    </ChartPanel>
-                  </Block>
-
-                  {span?.[SpanMetricsFields.SPAN_OP]?.startsWith('http') && (
-                    <Block>
-                      <ChartPanel title={DataTitles.errorCount}>
-                        <Chart
-                          height={CHART_HEIGHT}
-                          data={[spanMetricsSeriesData?.[`http_error_count()`]]}
-                          loading={areSpanMetricsSeriesLoading}
-                          utc={false}
-                          chartColors={[ERRORS_COLOR]}
-                          isLineChart
-                          definedAxisTicks={4}
-                        />
-                      </ChartPanel>
-                    </Block>
-                  )}
-                </BlockContainer>
+                <SpanSummaryView groupId={groupId} />
 
                 {span && (
                   <SpanTransactionsTable
@@ -323,106 +149,9 @@ function SpanSummaryPage({params, location}: Props) {
   );
 }
 
-const FilterOptionsContainer = styled('div')`
-  display: flex;
-  flex-direction: row;
-  gap: ${space(1)};
-  align-items: center;
-  padding-bottom: ${space(2)};
-`;
-
-type BlockProps = {
-  children: React.ReactNode;
-  description?: React.ReactNode;
-  title?: React.ReactNode;
-};
-
-export function Block({title, description, children}: BlockProps) {
-  return (
-    <BlockWrapper>
-      {title && (
-        <BlockTitle>
-          {title}
-          {description && (
-            <BlockTooltipContainer>
-              <QuestionTooltip size="sm" position="right" title={description} />
-            </BlockTooltipContainer>
-          )}
-        </BlockTitle>
-      )}
-      <BlockContent>{children}</BlockContent>
-    </BlockWrapper>
-  );
-}
-
-const BlockTitle = styled('h3')`
-  color: ${p => p.theme.gray300};
-  font-size: ${p => p.theme.fontSizeMedium};
-  margin: 0;
-  margin-bottom: ${space(1)};
-  white-space: nowrap;
-  display: flex;
-  height: ${space(3)};
-`;
-
-const BlockContent = styled('h4')`
-  margin: 0;
-  font-weight: normal;
-`;
-
-const BlockTooltipContainer = styled('span')`
-  margin-left: ${space(1)};
-`;
-
-export const BlockContainer = styled('div')`
-  display: flex;
-  & > div:last-child {
-    padding-right: ${space(1)};
-  }
-  flex-wrap: wrap;
-`;
-
-export const HeaderContainer = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-`;
-
-const DescriptionContainer = styled('div')`
-  width: 100%;
-  margin-bottom: ${space(4)};
-  font-size: 1rem;
-  line-height: 1.2;
-`;
-
-const BlockWrapper = styled('div')`
-  padding-right: ${space(4)};
-  flex-grow: 1;
-  min-width: 0;
-  word-break: break-word;
-  padding-bottom: ${space(2)};
-`;
-
 export default SpanSummaryPage;
 
-const getDescriptionLabel = (spanOp: string, title?: boolean) => {
-  if (spanOp?.startsWith('http')) {
-    return title ? t('URL Request Summary') : t('URL Request');
-  }
-  if (spanOp === 'db.redis') {
-    return title ? t('Cache Query Summary') : t('Cache Query');
-  }
-  if (spanOp?.startsWith('db')) {
-    return title ? t('Database Query Summary') : t('Database Query');
-  }
-  if (spanOp?.startsWith('task')) {
-    return title ? t('Application Task Summary') : t('Application Task');
-  }
-  if (spanOp?.startsWith('serialize')) {
-    return title ? t('Serializer Summary') : t('Serializer');
-  }
-  if (spanOp?.startsWith('middleware')) {
-    return title ? t('Middleware Summary') : t('Middleware');
-  }
-  return title ? t('Request Summary') : t('Request');
+const DEFAULT_SORT: Sort = {
+  kind: 'desc',
+  field: 'time_spent_percentage(local)',
 };

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -62,6 +62,7 @@ export function SampleList({groupId, transactionName, transactionMethod}: Props)
       >
         <h3>{`${transactionMethod} ${transactionName}`}</h3>
         <PageErrorAlert />
+
         <SampleInfo
           groupId={groupId}
           transactionName={transactionName}

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -7,7 +7,7 @@ import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughp
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {SpanMetricsFields} from 'sentry/views/starfish/types';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
-import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage';
+import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 
 const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsFields;
 

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -21,7 +21,7 @@ import {
   useSpanMetrics,
 } from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types';
 import {
   DataTitles,
   getThroughputChartTitle,
@@ -66,11 +66,11 @@ export function SpanSummaryView({groupId}: Props) {
       SpanMetricsFields.SPAN_ACTION,
       SpanMetricsFields.SPAN_DOMAIN,
       'count()',
-      'spm()',
+      `${StarfishFunctions.SPM}()`,
       `sum(${SpanMetricsFields.SPAN_SELF_TIME})`,
       `avg(${SpanMetricsFields.SPAN_SELF_TIME})`,
-      'time_spent_percentage()',
-      'http_error_count()',
+      `${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`,
+      `${StarfishFunctions.HTTP_ERROR_COUNT}()`,
     ],
     'api.starfish.span-summary-page-metrics'
   );

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -53,10 +53,6 @@ export function SpanSummaryView({groupId}: Props) {
     ? {transactionName: endpoint, 'transaction.method': endpointMethod}
     : {};
 
-  if (endpointMethod && queryFilter) {
-    queryFilter['transaction.method'] = endpointMethod;
-  }
-
   const {data: spanMetrics} = useSpanMetrics(
     groupId,
     queryFilter,

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -1,0 +1,257 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {RateUnits} from 'sentry/utils/discover/fields';
+import {formatRate} from 'sentry/utils/formatters';
+import {useLocation} from 'sentry/utils/useLocation';
+import {AVG_COLOR, ERRORS_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
+import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
+import ChartPanel from 'sentry/views/starfish/components/chartPanel';
+import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
+import {SpanDescription} from 'sentry/views/starfish/components/spanDescription';
+import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
+import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
+import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
+import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
+import {useFullSpanFromTrace} from 'sentry/views/starfish/queries/useFullSpanFromTrace';
+import {
+  SpanSummaryQueryFilters,
+  useSpanMetrics,
+} from 'sentry/views/starfish/queries/useSpanMetrics';
+import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
+import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {
+  DataTitles,
+  getThroughputChartTitle,
+  getThroughputTitle,
+} from 'sentry/views/starfish/views/spans/types';
+import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
+import {getSpanOperationDescription} from 'sentry/views/starfish/views/spanSummaryPage/getSpanOperationDescription';
+
+const CHART_HEIGHT = 160;
+
+interface Props {
+  groupId: string;
+}
+
+type Query = {
+  endpoint: string;
+  endpointMethod: string;
+  transaction: string;
+  transactionMethod: string;
+};
+
+export function SpanSummaryView({groupId}: Props) {
+  const location = useLocation<Query>();
+  const {endpoint, endpointMethod} = location.query;
+
+  const {data: fullSpan} = useFullSpanFromTrace(groupId);
+
+  const queryFilter: SpanSummaryQueryFilters = endpoint
+    ? {transactionName: endpoint, 'transaction.method': endpointMethod}
+    : {};
+
+  if (endpointMethod && queryFilter) {
+    queryFilter['transaction.method'] = endpointMethod;
+  }
+
+  const {data: spanMetrics} = useSpanMetrics(
+    groupId,
+    queryFilter,
+    [
+      SpanMetricsFields.SPAN_OP,
+      SpanMetricsFields.SPAN_DESCRIPTION,
+      SpanMetricsFields.SPAN_ACTION,
+      SpanMetricsFields.SPAN_DOMAIN,
+      'count()',
+      'spm()',
+      `sum(${SpanMetricsFields.SPAN_SELF_TIME})`,
+      `avg(${SpanMetricsFields.SPAN_SELF_TIME})`,
+      'time_spent_percentage()',
+      'http_error_count()',
+    ],
+    'api.starfish.span-summary-page-metrics'
+  );
+
+  const span = {
+    ...spanMetrics,
+    [SpanMetricsFields.SPAN_GROUP]: groupId,
+  } as {
+    [SpanMetricsFields.SPAN_OP]: string;
+    [SpanMetricsFields.SPAN_DESCRIPTION]: string;
+    [SpanMetricsFields.SPAN_ACTION]: string;
+    [SpanMetricsFields.SPAN_DOMAIN]: string;
+    [SpanMetricsFields.SPAN_GROUP]: string;
+  };
+
+  const {isLoading: areSpanMetricsSeriesLoading, data: spanMetricsSeriesData} =
+    useSpanMetricsSeries(
+      groupId,
+      queryFilter,
+      [`avg(${SpanMetricsFields.SPAN_SELF_TIME})`, 'spm()', 'http_error_count()'],
+      'api.starfish.span-summary-page-metrics-chart'
+    );
+
+  useSynchronizeCharts([!areSpanMetricsSeriesLoading]);
+
+  const spanMetricsThroughputSeries = {
+    seriesName: span?.[SpanMetricsFields.SPAN_OP]?.startsWith('db')
+      ? 'Queries'
+      : 'Requests',
+    data: spanMetricsSeriesData?.['spm()'].data,
+  };
+
+  const spanOperationDescription = getSpanOperationDescription(
+    span[SpanMetricsFields.SPAN_OP]
+  );
+
+  return (
+    <React.Fragment>
+      <HeaderContainer>
+        <FilterOptionsContainer>
+          <StarfishDatePicker />
+        </FilterOptionsContainer>
+
+        <BlockContainer>
+          {span?.[SpanMetricsFields.SPAN_OP]?.startsWith('db') &&
+            span?.[SpanMetricsFields.SPAN_OP] !== 'db.redis' && (
+              <Block title={t('Table')}>{span?.[SpanMetricsFields.SPAN_DOMAIN]}</Block>
+            )}
+
+          <Block
+            title={getThroughputTitle(span?.[SpanMetricsFields.SPAN_OP])}
+            description={tct('Throughput of this [spanType] per minute', {
+              spanType: spanOperationDescription,
+            })}
+          >
+            <ThroughputCell rate={spanMetrics?.['spm()']} unit={RateUnits.PER_MINUTE} />
+          </Block>
+
+          <Block
+            title={DataTitles.avg}
+            description={tct(
+              'The average duration of [spanType] in the selected period',
+              {
+                spanType: spanOperationDescription.endsWith('y')
+                  ? `${spanOperationDescription.slice(0, -1)}ies`
+                  : `${spanOperationDescription}s`,
+              }
+            )}
+          >
+            <DurationCell
+              milliseconds={spanMetrics?.[`avg(${SpanMetricsFields.SPAN_SELF_TIME})`]}
+            />
+          </Block>
+
+          {span?.[SpanMetricsFields.SPAN_OP]?.startsWith('http') && (
+            <Block
+              title={t('5XX Responses')}
+              description={t('5XX responses in this span')}
+            >
+              <CountCell count={spanMetrics?.[`http_error_count()`]} />
+            </Block>
+          )}
+
+          <Block
+            title={t('Time Spent')}
+            description={t(
+              'Time spent in this span as a proportion of total application time'
+            )}
+          >
+            <TimeSpentCell
+              percentage={spanMetrics?.['time_spent_percentage()']}
+              total={spanMetrics?.[`sum(${SpanMetricsFields.SPAN_SELF_TIME})`]}
+            />
+          </Block>
+        </BlockContainer>
+      </HeaderContainer>
+
+      {span?.[SpanMetricsFields.SPAN_DESCRIPTION] && (
+        <DescriptionContainer>
+          <SpanDescription
+            span={{
+              ...span,
+              [SpanMetricsFields.SPAN_DESCRIPTION]:
+                fullSpan?.description ??
+                spanMetrics?.[SpanMetricsFields.SPAN_DESCRIPTION],
+            }}
+          />
+        </DescriptionContainer>
+      )}
+
+      <BlockContainer>
+        <Block>
+          <ChartPanel title={getThroughputChartTitle(span?.[SpanMetricsFields.SPAN_OP])}>
+            <Chart
+              height={CHART_HEIGHT}
+              data={[spanMetricsThroughputSeries]}
+              loading={areSpanMetricsSeriesLoading}
+              utc={false}
+              chartColors={[THROUGHPUT_COLOR]}
+              isLineChart
+              definedAxisTicks={4}
+              aggregateOutputFormat="rate"
+              rateUnit={RateUnits.PER_MINUTE}
+              tooltipFormatterOptions={{
+                valueFormatter: value => formatRate(value, RateUnits.PER_MINUTE),
+              }}
+            />
+          </ChartPanel>
+        </Block>
+
+        <Block>
+          <ChartPanel title={DataTitles.avg}>
+            <Chart
+              height={CHART_HEIGHT}
+              data={[spanMetricsSeriesData?.[`avg(${SpanMetricsFields.SPAN_SELF_TIME})`]]}
+              loading={areSpanMetricsSeriesLoading}
+              utc={false}
+              chartColors={[AVG_COLOR]}
+              isLineChart
+              definedAxisTicks={4}
+            />
+          </ChartPanel>
+        </Block>
+
+        {span?.[SpanMetricsFields.SPAN_OP]?.startsWith('http') && (
+          <Block>
+            <ChartPanel title={DataTitles.errorCount}>
+              <Chart
+                height={CHART_HEIGHT}
+                data={[spanMetricsSeriesData?.[`http_error_count()`]]}
+                loading={areSpanMetricsSeriesLoading}
+                utc={false}
+                chartColors={[ERRORS_COLOR]}
+                isLineChart
+                definedAxisTicks={4}
+              />
+            </ChartPanel>
+          </Block>
+        )}
+      </BlockContainer>
+    </React.Fragment>
+  );
+}
+
+const FilterOptionsContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(1)};
+  align-items: center;
+  padding-bottom: ${space(2)};
+`;
+
+const HeaderContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+`;
+
+const DescriptionContainer = styled('div')`
+  width: 100%;
+  margin-bottom: ${space(2)};
+  font-size: 1rem;
+  line-height: 1.2;
+`;

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -37,8 +37,6 @@ import {
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 
-const {SPAN_OP} = SpanMetricsFields;
-
 type Row = {
   'avg(span.self_time)': number;
   'spm()': number;
@@ -235,7 +233,7 @@ const getColumnOrder = (
   },
   {
     key: 'spm()',
-    name: getThroughputTitle(span[SPAN_OP]),
+    name: getThroughputTitle(span[SpanIndexedFields.SPAN_OP]),
     width: COL_WIDTH_UNDEFINED,
   },
   {


### PR DESCRIPTION
This one ended up bigger than I hoped, since it's such a ball of yarn. Splitting up the huge span summary view component so I can use the pieces separately when I move things out of Starfish. This is more of a setup for later work.

Also clarified some weirdly complicated functions, and fixed a couple of typos.
