### PR TITLE
feat(github): backend for open PR comments

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -135,13 +135,13 @@ ORG_OPTIONS = (
         "githubPRBot",
         "sentry:github_pr_bot",
         bool,
-        org_serializers.GITHUB_PR_BOT_DEFAULT,
+        org_serializers.GITHUB_COMMENT_BOT_DEFAULT,
     ),
     (
         "githubOpenPRBot",
         "sentry:github_open_pr_bot",
         bool,
-        org_serializers.GITHUB_OPEN_PR_BOT_DEFAULT,
+        org_serializers.GITHUB_COMMENT_BOT_DEFAULT,
     ),
 )
 

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -137,6 +137,12 @@ ORG_OPTIONS = (
         bool,
         org_serializers.GITHUB_PR_BOT_DEFAULT,
     ),
+    (
+        "githubOpenPRBot",
+        "sentry:github_open_pr_bot",
+        bool,
+        org_serializers.GITHUB_OPEN_PR_BOT_DEFAULT,
+    ),
 )
 
 DELETION_STATUSES = frozenset(
@@ -180,6 +186,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     isEarlyAdopter = serializers.BooleanField(required=False)
     aiSuggestedSolution = serializers.BooleanField(required=False)
     codecovAccess = serializers.BooleanField(required=False)
+    githubOpenPRBot = serializers.BooleanField(required=False)
     githubPRBot = serializers.BooleanField(required=False)
     require2FA = serializers.BooleanField(required=False)
     requireEmailVerification = serializers.BooleanField(required=False)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -42,8 +42,7 @@ from sentry.constants import (
     ATTACHMENTS_ROLE_DEFAULT,
     DEBUG_FILES_ROLE_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
-    GITHUB_OPEN_PR_BOT_DEFAULT,
-    GITHUB_PR_BOT_DEFAULT,
+    GITHUB_COMMENT_BOT_DEFAULT,
     JOIN_REQUESTS_DEFAULT,
     PROJECT_RATE_LIMIT_DEFAULT,
     REQUIRE_SCRUB_DATA_DEFAULT,
@@ -524,9 +523,11 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 "aiSuggestedSolution": bool(
                     obj.get_option("sentry:ai_suggested_solution", AI_SUGGESTED_SOLUTION)
                 ),
-                "githubPRBot": bool(obj.get_option("sentry:github_pr_bot", GITHUB_PR_BOT_DEFAULT)),
+                "githubPRBot": bool(
+                    obj.get_option("sentry:github_pr_bot", GITHUB_COMMENT_BOT_DEFAULT)
+                ),
                 "githubOpenPRBot": bool(
-                    obj.get_option("sentry:github_open_pr_bot", GITHUB_OPEN_PR_BOT_DEFAULT)
+                    obj.get_option("sentry:github_open_pr_bot", GITHUB_COMMENT_BOT_DEFAULT)
                 ),
             }
         )

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -42,6 +42,7 @@ from sentry.constants import (
     ATTACHMENTS_ROLE_DEFAULT,
     DEBUG_FILES_ROLE_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
+    GITHUB_OPEN_PR_BOT_DEFAULT,
     GITHUB_PR_BOT_DEFAULT,
     JOIN_REQUESTS_DEFAULT,
     PROJECT_RATE_LIMIT_DEFAULT,
@@ -417,6 +418,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     codecovAccess: bool
     aiSuggestedSolution: bool
     githubPRBot: bool
+    githubOpenPRBot: bool
     isDynamicallySampled: bool
 
 
@@ -523,6 +525,9 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                     obj.get_option("sentry:ai_suggested_solution", AI_SUGGESTED_SOLUTION)
                 ),
                 "githubPRBot": bool(obj.get_option("sentry:github_pr_bot", GITHUB_PR_BOT_DEFAULT)),
+                "githubOpenPRBot": bool(
+                    obj.get_option("sentry:github_open_pr_bot", GITHUB_OPEN_PR_BOT_DEFAULT)
+                ),
             }
         )
 

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -632,8 +632,7 @@ TRUSTED_RELAYS_DEFAULT = None
 JOIN_REQUESTS_DEFAULT = True
 APDEX_THRESHOLD_DEFAULT = 300
 AI_SUGGESTED_SOLUTION = True
-GITHUB_PR_BOT_DEFAULT = True
-GITHUB_OPEN_PR_BOT_DEFAULT = True
+GITHUB_COMMENT_BOT_DEFAULT = True
 
 # `sentry:events_member_admin` - controls whether the 'member' role gets the event:admin scope
 EVENTS_MEMBER_ADMIN_DEFAULT = True

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -633,6 +633,7 @@ JOIN_REQUESTS_DEFAULT = True
 APDEX_THRESHOLD_DEFAULT = 300
 AI_SUGGESTED_SOLUTION = True
 GITHUB_PR_BOT_DEFAULT = True
+GITHUB_OPEN_PR_BOT_DEFAULT = True
 
 # `sentry:events_member_admin` - controls whether the 'member' role gets the event:admin scope
 EVENTS_MEMBER_ADMIN_DEFAULT = True

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -368,6 +368,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             "isEarlyAdopter": True,
             "codecovAccess": True,
             "aiSuggestedSolution": False,
+            "githubOpenPRBot": False,
             "githubPRBot": False,
             "allowSharedIssues": False,
             "enhancedPrivacy": True,
@@ -439,6 +440,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "to {}".format(data["alertsMemberWrite"]) in log.data["alertsMemberWrite"]
         assert "to {}".format(data["aiSuggestedSolution"]) in log.data["aiSuggestedSolution"]
         assert "to {}".format(data["githubPRBot"]) in log.data["githubPRBot"]
+        assert "to {}".format(data["githubOpenPRBot"]) in log.data["githubOpenPRBot"]
 
     @responses.activate
     @patch(


### PR DESCRIPTION
Add org option to enable/disable the Github Open PR Comment Bot. Separating toggle PR into FE and BE.
