### PR TITLE
ref: make `sentry devservices down` idempotent

### DIFF
--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -449,7 +449,7 @@ def down(project: str, service: list[str]) -> None:
                 continue
             containers.append(container)
 
-        with ThreadPoolExecutor(max_workers=len(containers)) as executor:
+        with ThreadPoolExecutor(max_workers=len(containers) or 1) as executor:
             futures = []
             for container in containers:
                 futures.append(executor.submit(_down, container))


### PR DESCRIPTION
originally crashes with:
```
$ sentry devservices down
INFO:The Sentry runner will report development issues to Sentry.io. Use SENTRY_DEVENV_NO_REPORT to avoid reporting issues.
INFO:We have reported the error below to Sentry
Traceback (most recent call last):
  File "/Users/asottile/workspace/sentry/.venv/bin/sentry", line 33, in <module>
    sys.exit(load_entry_point('sentry', 'console_scripts', 'sentry')())
  File "/Users/asottile/workspace/sentry/src/sentry/runner/__init__.py", line 191, in main
    raise e
  File "/Users/asottile/workspace/sentry/src/sentry/runner/__init__.py", line 183, in main
    func(**kwargs)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/asottile/workspace/sentry/src/sentry/runner/commands/devservices.py", line 452, in down
    with ThreadPoolExecutor(max_workers=len(containers)) as executor:
  File "/Users/asottile/.pyenv/versions/3.8.16/lib/python3.8/concurrent/futures/thread.py", line 141, in __init__
    raise ValueError("max_workers must be greater than 0")
ValueError: max_workers must be greater than 0
```




<!-- Describe your PR here. -->