### PR TITLE
feat(replays): add electron replay onboarding sidebar

### DIFF
--- a/static/app/components/replaysOnboarding/utils.tsx
+++ b/static/app/components/replaysOnboarding/utils.tsx
@@ -4,7 +4,12 @@ import {PlatformKey, replayPlatforms} from 'sentry/data/platformCategories';
 import {PlatformIntegration, Project} from 'sentry/types';
 
 export function generateDocKeys(platform: PlatformKey): string[] {
-  return ['1-install', '2-configure'].map(key => `${platform}-replay-onboarding-${key}`);
+  const platformKey = platform.startsWith('javascript')
+    ? platform
+    : 'javascript-' + platform;
+  return ['1-install', '2-configure'].map(
+    key => `${platformKey}-replay-onboarding-${key}`
+  );
 }
 
 export function isPlatformSupported(platform: undefined | PlatformIntegration) {

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -312,9 +312,13 @@ export const releaseHealth: PlatformKey[] = [
 ];
 
 export const replayPlatforms: readonly PlatformKey[] = [
+  'capacitor',
+  'electron',
   'javascript-angular',
   // 'javascript-angularjs', // Unsupported, angularjs requires the v6.x core SDK
   'javascript-backbone',
+  'javascript-capacitor',
+  'javascript-electron',
   'javascript-ember',
   'javascript-gatsby',
   'javascript-nextjs',
@@ -333,9 +337,13 @@ export const replayPlatforms: readonly PlatformKey[] = [
  * See: https://github.com/getsentry/sentry-docs/tree/master/src/wizard/javascript/replay-onboarding
  */
 export const replayOnboardingPlatforms: readonly PlatformKey[] = [
+  'capacitor',
+  'electron',
   'javascript-angular',
   // 'javascript-angularjs', // Unsupported, angularjs requires the v6.x core SDK
   // 'javascript-backbone', // No docs yet
+  'javascript-capacitor',
+  'javascript-electron',
   'javascript-ember',
   'javascript-gatsby',
   'javascript-nextjs',

--- a/static/app/utils/replays/projectSupportsReplay.spec.tsx
+++ b/static/app/utils/replays/projectSupportsReplay.spec.tsx
@@ -18,6 +18,7 @@ describe('projectSupportsReplay & projectCanLinkToReplay', () => {
     'javascript-nextjs' as PlatformKey,
     'javascript-react' as PlatformKey,
     'javascript' as PlatformKey,
+    'electron' as PlatformKey,
   ])('should SUPPORT & LINK frontend platform %s', platform => {
     const project = mockProject(platform);
     expect(projectSupportsReplay(project)).toBeTruthy();
@@ -47,7 +48,6 @@ describe('projectSupportsReplay & projectCanLinkToReplay', () => {
 
   it.each([
     'apple-macos' as PlatformKey,
-    'electron' as PlatformKey,
     'flutter' as PlatformKey,
     'unity' as PlatformKey,
   ])('should FAIL for Desktop framework %s', platform => {


### PR DESCRIPTION
Integrated onboarding for `electron` platform:
<img width="580" alt="SCR-20230814-nzgq" src="https://github.com/getsentry/sentry/assets/56095982/4845d7da-5721-4cd5-ab55-b3b53e459054">


Integrated onboarding for `capacitor` platform as well:
<img width="567" alt="SCR-20230814-maip" src="https://github.com/getsentry/sentry/assets/56095982/c94b6ac3-b67e-4ff0-8b23-7072f7054764">


Closes https://github.com/getsentry/sentry/issues/49595