### PR TITLE
ref(replays): Show project name on replay pages

### DIFF
--- a/src/sentry/integrations/example/repository.py
+++ b/src/sentry/integrations/example/repository.py
@@ -1,5 +1,5 @@
-from sentry.models import Integration
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import IntegrationError
 
 
@@ -8,9 +8,9 @@ class ExampleRepositoryProvider(IntegrationRepositoryProvider):
     repo_provider = "example"
 
     def compare_commits(self, repo, start_sha, end_sha):
-        installation = Integration.objects.get(id=repo.integration_id).get_installation(
-            repo.organization_id
-        )
+        installation = integration_service.get_integration(
+            integration_id=repo.integration_id
+        ).get_installation(organization_id=repo.organization_id)
 
         try:
             raise IntegrationError("{'error': 'Repository not found'}")

--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -42,9 +42,18 @@ function DetailsPageBreadcrumbs({orgSlug, replayRecord}: Props) {
         {
           label: (
             <Fragment>
-              {<BaseBadge displayName={labelTitle} project={project} avatarSize={16} />}
+              {
+                <BaseBadge
+                  displayName={project?.name}
+                  project={project}
+                  avatarSize={16}
+                />
+              }
             </Fragment>
           ),
+        },
+        {
+          label: labelTitle,
         },
       ]}
     />

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -138,6 +138,9 @@ export function ReplayCell({
       <Row gap={1}>
         <Row gap={0.5}>
           {project ? <Avatar size={12} project={project} /> : null}
+          {project ? project.name : null}
+        </Row>
+        <Row gap={0.5}>
           <Link to={detailsTab} onClick={trackNavigationEvent}>
             {getShortEventId(replay.id)}
           </Link>


### PR DESCRIPTION
Updates the replay details page to show the project name in the chevron area and the list items page to show the project name in the bottom row.

Closes #53473
