### PR TITLE
feat(github): add frontend toggle for open PR comments

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -17,6 +17,7 @@ export interface OrganizationSummary {
   codecovAccess: boolean;
   dateCreated: string;
   features: string[];
+  githubOpenPRBot: boolean;
   githubPRBot: boolean;
   id: string;
   isEarlyAdopter: boolean;

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -224,7 +224,11 @@ describe('IntegrationDetailedView', function () {
     await userEvent.click(screen.getByText('features'));
 
     expect(
-      screen.getByRole('checkbox', {name: /Enable Pull Request Bot/})
+      screen.getByRole('checkbox', {name: /Enable Comments on Suspect Pull Requests/})
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole('checkbox', {name: /Enable Comments on Open Pull Requests/})
     ).toBeDisabled();
   });
 });

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -1,3 +1,4 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import IntegrationDetailedView from 'sentry/views/settings/organizationIntegrations/integrationDetailedView';
@@ -201,6 +202,12 @@ describe('IntegrationDetailedView', function () {
   });
 
   it('cannot enable PR bot without GitHub integration', async function () {
+    const {routerContext, organization} = initializeOrg({
+      organization: {
+        features: ['integrations-open-pr-comment'],
+      },
+    });
+
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/config/integrations/?provider_key=github`,
       body: {
@@ -216,9 +223,10 @@ describe('IntegrationDetailedView', function () {
       <IntegrationDetailedView
         {...TestStubs.routeComponentProps()}
         params={{integrationSlug: 'github'}}
-        organization={org}
+        organization={organization}
         location={TestStubs.location({query: {}})}
-      />
+      />,
+      {context: routerContext}
     );
 
     await userEvent.click(screen.getByText('features'));

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -246,27 +246,7 @@ describe('IntegrationDetailedView', function () {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/integrations/?provider_key=github&includeConfig=0`,
-      body: [
-        {
-          accountType: null,
-          configData: {},
-          configOrganization: [],
-          domainName: 'github.com/%7Bfb715533-bbd7-4666-aa57-01dc93dd9cc0%7D',
-          icon: 'https://secure.gravatar.com/avatar/8b4cb68e40b74c90427d8262256bd1c8?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNN-0.png',
-          id: '4',
-          name: '{fb715533-bbd7-4666-aa57-01dc93dd9cc0}',
-          provider: {
-            aspects: {},
-            canAdd: true,
-            canDisable: false,
-            features: ['commits', 'issue-basic'],
-            key: 'github',
-            name: 'GitHub',
-            slug: 'github',
-          },
-          status: 'active',
-        },
-      ],
+      body: [TestStubs.GitHubIntegration()],
     });
     render(
       <IntegrationDetailedView

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -338,14 +338,27 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
           {
             name: 'githubPRBot',
             type: 'boolean',
-            label: t('Enable Pull Request Bot'),
+            label: t('Enable Comments on Suspect Pull Requests'),
             help: t(
-              'Allow Sentry to comment on pull requests about issues impacting your app.'
+              'Allow Sentry to comment on recent pull requests suspected of causing issues.'
             ),
             disabled: !hasIntegration,
             disabledReason: t(
               'You must have a GitHub integration to enable this feature.'
             ),
+          },
+          {
+            name: 'githubOpenPRBot',
+            type: 'boolean',
+            label: t('Enable Comments on Open Pull Requests'),
+            help: t(
+              'Allow Sentry to comment on open pull requests to show recent error and performance issues for the code being changed.'
+            ),
+            disabled: !hasIntegration,
+            disabledReason: t(
+              'You must have a GitHub integration to enable this feature.'
+            ),
+            visible: ({features}) => features.includes('integrations-open-pr-comment'),
           },
         ],
       },
@@ -353,6 +366,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
 
     const initialData = {
       githubPRBot: organization.githubPRBot,
+      githubOpenPRBot: organization.githubOpenPRBot,
     };
 
     return (


### PR DESCRIPTION
Option is not visible if org is not under feature flag. Cannot toggle if Github integration is not installed.
Requires #54714 

<img width="1042" alt="Screenshot 2023-08-14 at 3 00 52 PM" src="https://github.com/getsentry/sentry/assets/83109586/09cd744d-eb48-49c1-84bf-9c372baf153a">

Not under feature flag:
<img width="1512" alt="Screenshot 2023-08-14 at 3 00 01 PM" src="https://github.com/getsentry/sentry/assets/83109586/b427a1fe-9bd3-45f0-ba55-7ef4c2764d62">

Integration not installed:
<img width="1512" alt="Screenshot 2023-08-14 at 2 59 32 PM" src="https://github.com/getsentry/sentry/assets/83109586/33086854-1914-4cec-875e-33c9e6b9cce4">


Fixes ER-1838. 

