### PR TITLE
feat(statistical-detectors): Add option to control query batch size

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1457,7 +1457,7 @@ register(
 )
 register(
     "statistical_detectors.query.batch_size",
-    type=int,
+    type=Int,
     default=100,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1455,6 +1455,12 @@ register(
     default=[],
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "statistical_detectors.query.batch_size",
+    type=int,
+    default=100,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "options_automator_slack_webhook_enabled",


### PR DESCRIPTION
This option will control the number of projects we batch into a single query. Should max out at 100 as 100 projects x 100 results per project maxes out the 10,000 rows allowed in the results.