### PR TITLE
ref(replays): Update replay pages to show project name

### DIFF
--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -44,7 +44,7 @@ function DetailsPageBreadcrumbs({orgSlug, replayRecord}: Props) {
             <Fragment>
               {
                 <BaseBadge
-                  displayName={project?.name}
+                  displayName={project?.slug}
                   project={project}
                   avatarSize={16}
                 />

--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -42,9 +42,18 @@ function DetailsPageBreadcrumbs({orgSlug, replayRecord}: Props) {
         {
           label: (
             <Fragment>
-              {<BaseBadge displayName={labelTitle} project={project} avatarSize={16} />}
+              {
+                <BaseBadge
+                  displayName={project?.name}
+                  project={project}
+                  avatarSize={16}
+                />
+              }
             </Fragment>
           ),
+        },
+        {
+          label: labelTitle,
         },
       ]}
     />

--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 
 import Breadcrumbs from 'sentry/components/breadcrumbs';
-import BaseBadge from 'sentry/components/idBadge/baseBadge';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import HeaderPlaceholder from 'sentry/components/replays/header/headerPlaceholder';
 import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
@@ -42,13 +42,9 @@ function DetailsPageBreadcrumbs({orgSlug, replayRecord}: Props) {
         {
           label: (
             <Fragment>
-              {
-                <BaseBadge
-                  displayName={project?.slug}
-                  project={project}
-                  avatarSize={16}
-                />
-              }
+              {project ? (
+                <ProjectBadge disableLink project={project} avatarSize={16} />
+              ) : null}
             </Fragment>
           ),
         },

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -137,6 +137,7 @@ export function ReplayCell({
       {showUrl ? <StringWalker urls={replay.urls} /> : undefined}
       <Row gap={1}>
         <Row gap={0.5}>
+          {/* Avatar is used instead of ProjectBadge because using ProjectBadge increases spacing, which doesn't look as good */}
           {project ? <Avatar size={12} project={project} /> : null}
           {project ? project.slug : null}
           <Link to={detailsTab} onClick={trackNavigationEvent}>

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -138,7 +138,7 @@ export function ReplayCell({
       <Row gap={1}>
         <Row gap={0.5}>
           {project ? <Avatar size={12} project={project} /> : null}
-          {project ? project.name : null}
+          {project ? project.slug : null}
           <Link to={detailsTab} onClick={trackNavigationEvent}>
             {getShortEventId(replay.id)}
           </Link>

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -138,6 +138,7 @@ export function ReplayCell({
       <Row gap={1}>
         <Row gap={0.5}>
           {project ? <Avatar size={12} project={project} /> : null}
+          {project ? project.name : null}
           <Link to={detailsTab} onClick={trackNavigationEvent}>
             {getShortEventId(replay.id)}
           </Link>


### PR DESCRIPTION
Updates the replay index page to add the project name to the bottom of all table rows and updates the replay details page to add the project name to the chevron area at the top of the page.

Closes #53473
