### PR TITLE
fix(sentryapp):  sentryapp disabled email new subject line

### DIFF
--- a/src/sentry/integrations/notify_disable.py
+++ b/src/sentry/integrations/notify_disable.py
@@ -36,6 +36,10 @@ def get_subject(integration_name: str) -> str:
     return f"Action required: re-authenticate or fix your {integration_name} integration"
 
 
+def get_sentry_app_subject(integration_name: str) -> str:
+    return f"Action required: fix your {integration_name} integration"
+
+
 def notify_disable(
     organization: Organization,
     integration_name: str,
@@ -52,15 +56,17 @@ def notify_disable(
     )
 
     referrer = (
-        "?referrer=disabled-sentry-app/"
+        "?referrer=disabled-sentry-app"
         if "sentry-app" in redis_key
-        else "?referrer=disabled-integration/"
+        else "?referrer=disabled-integration"
     )
 
     for user in organization.get_owners():
 
         msg = MessageBuilder(
-            subject=get_subject(integration_name.title()),
+            subject=get_sentry_app_subject(integration_name.title())
+            if "sentry-app" in redis_key
+            else get_subject(integration_name.title()),
             context={
                 "integration_name": integration_name.title(),
                 "integration_link": f"{integration_link}{referrer}",

--- a/src/sentry/integrations/notify_disable.py
+++ b/src/sentry/integrations/notify_disable.py
@@ -37,7 +37,7 @@ def get_subject(integration_name: str) -> str:
 
 
 def get_sentry_app_subject(integration_name: str) -> str:
-    return f"Action required: fix your {integration_name} integration"
+    return f"Action required: Fix your {integration_name} integration"
 
 
 def notify_disable(

--- a/src/sentry/templates/sentry/integrations/sentry-app-notify-disable.html
+++ b/src/sentry/templates/sentry/integrations/sentry-app-notify-disable.html
@@ -8,7 +8,7 @@
 </p><p>
     We’ve received multiple <a href={{dashboard_link}}/>request errors</a> from your webhook: <a href={{webhook_url}}>{{webhook_url}}</a> for the custom {{ integration_name }} integration, and have unsubscribed the webhook from receiving events.
 </p><p>
-    To continue using your custom integration, please fix your webhook: <a href={{webhook_url}}>{{webhook_url}}</a> and re-enable the webhook subscriptions <a href={{integration_link}}>here</a>.
+    To continue using your custom integration, please fix your webhook and re-enable the webhook subscriptions <a href={{integration_link}}>here</a>.
 </p><p>
   </p>
   <p>

--- a/tests/sentry/integrations/slack/test_disable.py
+++ b/tests/sentry/integrations/slack/test_disable.py
@@ -89,7 +89,7 @@ class SlackClientDisable(TestCase):
         )
         assert (
             self.organization.absolute_url(
-                f"/settings/{self.organization.slug}/integrations/{self.integration.provider}/?referrer=disabled-integration/"
+                f"/settings/{self.organization.slug}/integrations/{self.integration.provider}/?referrer=disabled-integration"
             )
             in msg.body
         )

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -912,10 +912,7 @@ class TestWebhookRequests(TestCase):
             )
         assert len(mail.outbox) == 1
         msg = mail.outbox[0]
-        assert (
-            msg.subject
-            == f"Action required: re-authenticate or fix your {self.sentry_app.name} integration"
-        )
+        assert msg.subject == f"Action required: Fix your {self.sentry_app.name} integration"
         assert (
             self.organization.absolute_url(
                 f"/settings/{self.organization.slug}/developer-settings/{self.sentry_app.slug}"


### PR DESCRIPTION
Changing subject line for Sentry apps from "Action required: re-authenticate or fix your {integration_name} integration"
 to  "Action required: fix your {integration_name} integration" and other small email improvements