### PR TITLE
feat(apis): Track API owners

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -76,3 +76,4 @@ from .sso_enabled import *  # noqa: F401,F403
 from .team_created import *  # noqa: F401,F403
 from .user_created import *  # noqa: F401,F403
 from .user_signup import *  # noqa: F401,F403
+from .webhook_repository_created import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/webhook_repository_created.py
+++ b/src/sentry/analytics/events/webhook_repository_created.py
@@ -1,0 +1,14 @@
+from sentry import analytics
+
+
+class WebHookRepositoryCreatedEvent(analytics.Event):
+    type = "webhook.repository_created"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("repository_id"),
+        analytics.Attribute("integration"),
+    )
+
+
+analytics.register(WebHookRepositoryCreatedEvent)

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -2,5 +2,12 @@ from enum import Enum
 
 
 class ApiOwner(Enum):
-    UNOWNED = "unowned"
-    ENTERPRISE = "enterprise"
+    UNOWNED = "Unowned"
+    ENTERPRISE = "Enterprise"
+    REVENUE = "Revenue"
+    HYBRID_CLOUD = "Hybrid Cloud"
+    MDX = "Mobile Developer Experience"
+    WORKFLOW = "Workflow"
+    DISCOVER = "Discover"
+    PERFORMANCE = "Performance"
+    ISSUES = "Issues"

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class ApiOwner(Enum):
+    UNOWNED = "unowned"
+    ENTERPRISE = "enterprise"

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -23,6 +23,7 @@ from rest_framework.views import APIView
 from sentry_sdk import Scope
 
 from sentry import analytics, options, tsdb
+from sentry.api.api_owners import ApiOwner
 from sentry.apidocs.hooks import HTTP_METHODS_SET
 from sentry.auth import access
 from sentry.models import Environment
@@ -145,6 +146,7 @@ class Endpoint(APIView):
     cursor_name = "cursor"
 
     public: Optional[HTTP_METHODS_SET] = None
+    owner: ApiOwner = ApiOwner.UNOWNED
 
     rate_limits: RateLimitConfig | dict[
         str, dict[RateLimitCategory, RateLimit]

--- a/src/sentry/api/endpoints/experimental/enterprise/organization_projects_experiment.py
+++ b/src/sentry/api/endpoints/experimental/enterprise/organization_projects_experiment.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
 from sentry import audit_log, features
+from sentry.api.api_owners import ApiOwner
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.endpoints.team_projects import ProjectPostSerializer
@@ -52,6 +53,7 @@ class OrgProjectPermission(OrganizationPermission):
 class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
     permission_classes = (OrgProjectPermission,)
     logger = logging.getLogger("team-project.create")
+    owner = ApiOwner.ENTERPRISE
 
     def should_add_creator_to_team(self, request: Request):
         return request.user.is_authenticated

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1,6 +1,9 @@
 from django.conf.urls import include
 from django.urls import re_path
 
+from sentry.api.endpoints.experimental.enterprise.organization_projects_experiment import (
+    OrganizationProjectsExperimentEndpoint,
+)
 from sentry.api.endpoints.group_event_details import GroupEventDetailsEndpoint
 from sentry.api.endpoints.internal.integration_proxy import InternalIntegrationProxyEndpoint
 from sentry.api.endpoints.org_auth_token_details import OrgAuthTokenDetailsEndpoint
@@ -13,9 +16,6 @@ from sentry.api.endpoints.organization_events_root_cause_analysis import (
 )
 from sentry.api.endpoints.organization_events_starfish import OrganizationEventsStarfishEndpoint
 from sentry.api.endpoints.organization_missing_org_members import OrganizationMissingMembersEndpoint
-from sentry.api.endpoints.organization_projects_experiment import (
-    OrganizationProjectsExperimentEndpoint,
-)
 from sentry.api.utils import method_dispatch
 from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint

--- a/src/sentry/web/frontend/auth_channel_login.py
+++ b/src/sentry/web/frontend/auth_channel_login.py
@@ -40,11 +40,16 @@ class AuthChannelLoginView(AuthOrganizationLoginView):
             return self.redirect(reverse("sentry-login"))
 
         if request.user.is_authenticated:
-            next_uri = self.get_next_uri(request)
-            if is_valid_redirect(next_uri, allowed_hosts=(request.get_host())):
-                return self.redirect(next_uri)
-            return self.redirect(Organization.get_url(slug=organization_context.organization.slug))
+            if self.active_organization is not None:
+                if self.active_organization.organization.id == organization_id:
+                    next_uri = self.get_next_uri(request)
+                    if is_valid_redirect(next_uri, allowed_hosts=(request.get_host())):
+                        return self.redirect(next_uri)
+                    return self.redirect(
+                        Organization.get_url(slug=organization_context.organization.slug)
+                    )
 
         return self.redirect(
+            # TODO: Add next URI here as well
             reverse("sentry-auth-organization", args=[organization_context.organization.slug])
         )

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -51,6 +51,7 @@ class AuthOrganizationLoginView(AuthLoginView):
 
     @method_decorator(never_cache)
     def handle(self, request: Request, organization_slug) -> HttpResponse:
+        print("*******next", self.get_next_uri(request))
         org_context = organization_service.get_organization_by_slug(
             slug=organization_slug, only_visible=True
         )

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -148,7 +148,7 @@ class PushEventWebhookTest(APITestCase):
         assert repos[0].external_id == "35129377"
         assert repos[0].provider == "integrations:github"
         assert repos[0].name == "baxterthehacker/public-repo"
-        mock_metrics.incr.assert_called_with("github.webhook.create_repository")
+        mock_metrics.incr.assert_called_with("github.webhook.repository_created")
 
     @with_feature("organizations:integrations-auto-repo-linking")
     def test_ignores_hidden_repo(self):
@@ -316,7 +316,7 @@ class PushEventWebhookTest(APITestCase):
             assert repo.external_id == "35129377"
             assert repo.provider == "integrations:github"
             assert repo.name == "baxterthehacker/public-repo"
-        mock_metrics.incr.assert_called_with("github.webhook.create_repository")
+        mock_metrics.incr.assert_called_with("github.webhook.repository_created")
 
     @with_feature("organizations:integrations-auto-repo-linking")
     def test_multiple_orgs_ignores_hidden_repo(self):
@@ -440,7 +440,7 @@ class PullRequestEventWebhook(APITestCase):
         assert repos[0].external_id == "35129377"
         assert repos[0].provider == "integrations:github"
         assert repos[0].name == "baxterthehacker/public-repo"
-        mock_metrics.incr.assert_called_with("github.webhook.create_repository")
+        mock_metrics.incr.assert_called_with("github.webhook.repository_created")
 
     @with_feature("organizations:integrations-auto-repo-linking")
     def test_ignores_hidden_repo(self):
@@ -499,7 +499,7 @@ class PullRequestEventWebhook(APITestCase):
             assert repo.external_id == "35129377"
             assert repo.provider == "integrations:github"
             assert repo.name == "baxterthehacker/public-repo"
-        mock_metrics.incr.assert_called_with("github.webhook.create_repository")
+        mock_metrics.incr.assert_called_with("github.webhook.repository_created")
 
     @with_feature("organizations:integrations-auto-repo-linking")
     def test_multiple_orgs_ignores_hidden_repo(self):


### PR DESCRIPTION
Adding a field to Endpoint class to track the engineering team owning it. Also creating experimental and private folders to keep track of what endpoints are not documented because they're experimental or because they shouldn't be published.