### PR TITLE
feat(starfish): Change how span samples are accessed

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -1,7 +1,9 @@
 import {useCallback, useState} from 'react';
 import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
+import * as qs from 'query-string';
 
+import Link from 'sentry/components/links/link';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   PageErrorAlert,
@@ -9,6 +11,7 @@ import {
 } from 'sentry/utils/performance/contexts/pageError';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import DetailPanel from 'sentry/views/starfish/components/detailPanel';
 import DurationChart from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
@@ -41,12 +44,23 @@ export function SampleList({groupId, transactionName, transactionMethod}: Props)
 
   const organization = useOrganization();
   const {query} = useLocation();
+  const pageFilters = usePageFilters();
 
   const onOpenDetailPanel = useCallback(() => {
     if (query.transaction) {
       trackAnalytics('starfish.panel.open', {organization});
     }
   }, [organization, query.transaction]);
+
+  const label =
+    transactionMethod && !transactionName.startsWith(transactionMethod)
+      ? `${transactionMethod} ${transactionName}`
+      : transactionName;
+
+  const link = `/performance/summary/?${qs.stringify({
+    project: pageFilters.selection.projects[0],
+    transaction: transactionName,
+  })}`;
 
   return (
     <PageErrorProvider>
@@ -60,7 +74,9 @@ export function SampleList({groupId, transactionName, transactionMethod}: Props)
         }}
         onOpen={onOpenDetailPanel}
       >
-        <h3>{`${transactionMethod} ${transactionName}`}</h3>
+        <h3>
+          <Link to={link}>{label}</Link>
+        </h3>
         <PageErrorAlert />
 
         <SampleInfo


### PR DESCRIPTION
As per our newest set of requirements, update the span summary view table to now have the transaction name link to the span sample popout.

There is no longer anything linked to the average duration marker.

My only question is the usage of `pageFilter` hook to get project - should I query for the project instead given we are going to support querying multiple projects?

In the next PR I'm going to take a look at revamping the span sample chart based on design review given we want to change the triangles again.

<img width="1274" alt="image" src="https://github.com/getsentry/sentry/assets/18689448/b73f3202-ec26-4858-9ad3-c850b7c80068">