### PR TITLE
feat(apis): Track API owners

### DIFF
--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class ApiOwner(Enum):
+    UNOWNED = "Unowned"
+    ENTERPRISE = "Enterprise"
+    REVENUE = "Revenue"
+    HYBRID_CLOUD = "Hybrid Cloud"
+    MDX = "Mobile Developer Experience"
+    WORKFLOW = "Workflow"
+    DISCOVER = "Discover"
+    PERFORMANCE = "Performance"
+    ISSUES = "Issues"

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -22,6 +22,7 @@ from rest_framework.views import APIView
 from sentry_sdk import Scope
 
 from sentry import analytics, options, tsdb
+from sentry.api.api_owners import ApiOwner
 from sentry.apidocs.hooks import HTTP_METHODS_SET
 from sentry.auth import access
 from sentry.models import Environment
@@ -145,6 +146,7 @@ class Endpoint(APIView):
     cursor_name = "cursor"
 
     public: Optional[HTTP_METHODS_SET] = None
+    owner: ApiOwner = ApiOwner.UNOWNED
 
     rate_limits: RateLimitConfig | dict[
         str, dict[RateLimitCategory, RateLimit]

--- a/src/sentry/api/endpoints/experimental/enterprise/organization_projects_experiment.py
+++ b/src/sentry/api/endpoints/experimental/enterprise/organization_projects_experiment.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
 from sentry import audit_log, features
+from sentry.api.api_owners import ApiOwner
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.endpoints.team_projects import ProjectPostSerializer
@@ -50,6 +51,7 @@ class OrgProjectPermission(OrganizationPermission):
 
 @region_silo_endpoint
 class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.ENTERPRISE
     permission_classes = (OrgProjectPermission,)
     logger = logging.getLogger("team-project.create")
 

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from django.conf.urls import include
 from django.urls import URLPattern, URLResolver, re_path
 
+from sentry.api.endpoints.experimental.enterprise.organization_projects_experiment import (
+    OrganizationProjectsExperimentEndpoint,
+)
 from sentry.api.endpoints.group_event_details import GroupEventDetailsEndpoint
 from sentry.api.endpoints.internal.integration_proxy import InternalIntegrationProxyEndpoint
 from sentry.api.endpoints.org_auth_token_details import OrgAuthTokenDetailsEndpoint
@@ -15,9 +18,6 @@ from sentry.api.endpoints.organization_events_root_cause_analysis import (
 )
 from sentry.api.endpoints.organization_events_starfish import OrganizationEventsStarfishEndpoint
 from sentry.api.endpoints.organization_missing_org_members import OrganizationMissingMembersEndpoint
-from sentry.api.endpoints.organization_projects_experiment import (
-    OrganizationProjectsExperimentEndpoint,
-)
 from sentry.api.utils import method_dispatch
 from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint

--- a/tests/sentry/api/endpoints/test_organization_projects_experiment.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_experiment.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from django.urls import reverse
 from django.utils.text import slugify
 
-from sentry.api.endpoints.organization_projects_experiment import (
+from sentry.api.endpoints.experimental.enterprise.organization_projects_experiment import (
     OrganizationProjectsExperimentEndpoint,
     fetch_slugifed_email_username,
 )


### PR DESCRIPTION
Adding a field to Endpoint class to track the engineering team owning it. Also creating experimental folder to keep track of what endpoints are not documented but will be soon. Will add one for private too but didn't have a good example now.