### PR TITLE
chore(hybrid-cloud): Split db for deletion tests

### DIFF
--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -2,6 +2,8 @@ import logging
 import re
 
 from sentry.constants import ObjectStatus
+from sentry.services.hybrid_cloud.user.model import RpcUser
+from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.utils import metrics
 from sentry.utils.query import bulk_delete_objects
 
@@ -237,14 +239,9 @@ class ModelDeletionTask(BaseDeletionTask):
                     },
                 )
 
-    def get_actor(self):
-        from sentry.models import User
-
+    def get_actor(self) -> RpcUser:
         if self.actor_id:
-            try:
-                return User.objects.get_from_cache(id=self.actor_id)
-            except User.DoesNotExist:
-                pass
+            return user_service.get_user(user_id=self.actor_id)
         return None
 
     def mark_deletion_in_progress(self, instance_list):

--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import re
 
@@ -239,7 +241,7 @@ class ModelDeletionTask(BaseDeletionTask):
                     },
                 )
 
-    def get_actor(self) -> RpcUser:
+    def get_actor(self) -> RpcUser | None:
         if self.actor_id:
             return user_service.get_user(user_id=self.actor_id)
         return None

--- a/src/sentry/deletions/defaults/organizationintegration.py
+++ b/src/sentry/deletions/defaults/organizationintegration.py
@@ -1,4 +1,6 @@
 from sentry.constants import ObjectStatus
+from sentry.models.integrations.organization_integration import OrganizationIntegration
+from sentry.services.hybrid_cloud.repository import repository_service
 
 from ..base import ModelDeletionTask, ModelRelation
 
@@ -18,22 +20,10 @@ class OrganizationIntegrationDeletionTask(ModelDeletionTask):
 
         return relations
 
-    def delete_instance(self, instance):
-        from sentry.models import ProjectCodeOwners, Repository, RepositoryProjectPathConfig
-
-        # Dissociate repos from the integration being deleted. integration
-        Repository.objects.filter(
-            organization_id=instance.organization_id, integration_id=instance.integration_id
-        ).update(integration_id=None)
-
-        # Delete Code Owners with a Code Mapping using the OrganizationIntegration
-        ProjectCodeOwners.objects.filter(
-            repository_project_path_config__in=RepositoryProjectPathConfig.objects.filter(
-                organization_integration_id=instance.id
-            ).values_list("id", flat=True)
-        ).delete()
-
-        # Delete the Code Mappings
-        RepositoryProjectPathConfig.objects.filter(organization_integration_id=instance.id).delete()
-
+    def delete_instance(self, instance: OrganizationIntegration):
+        repository_service.disassociate_organization_integration(
+            organization_id=instance.organization_id,
+            organization_integration_id=instance.id,
+            integration_id=instance.integration_id,
+        )
         return super().delete_instance(instance)

--- a/src/sentry/models/integrations/organization_integration.py
+++ b/src/sentry/models/integrations/organization_integration.py
@@ -55,7 +55,7 @@ class OrganizationIntegration(DefaultFieldsModel):
         ):
             for outbox in self.outboxes_for_update():
                 outbox.save()
-            super().delete(*args, **kwds)
+            return super().delete(*args, **kwds)
 
     @staticmethod
     def services_in(config: Mapping[str, Any]) -> List[PagerDutyServiceDict]:

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -260,12 +260,12 @@ class NotificationsManager(BaseManager["NotificationSetting"]):  # noqa: F821
         self._filter(team_ids=[team.id], provider=provider, type=type).delete()
 
     def remove_for_project(
-        self, project: Project, type: NotificationSettingTypes | None = None
+        self, project_id: int, type: NotificationSettingTypes | None = None
     ) -> None:
         """Bulk delete all Notification Settings for a PROJECT, optionally by type."""
         self._filter(
             scope_type=NotificationScopeType.PROJECT,
-            scope_identifier=project.id,
+            scope_identifier=project_id,
             type=type,
         ).delete()
 

--- a/src/sentry/services/hybrid_cloud/notifications/impl.py
+++ b/src/sentry/services/hybrid_cloud/notifications/impl.py
@@ -175,6 +175,9 @@ class DatabaseBackedNotificationsService(NotificationsService):
         assert organization_id, "organization_id must be a positive integer"
         NotificationSetting.objects.remove_for_organization(organization_id=organization_id)
 
+    def remove_notification_settings_for_project(self, *, project_id: int) -> None:
+        NotificationSetting.objects.remove_for_project(project_id=project_id)
+
     def serialize_many(
         self,
         *,

--- a/src/sentry/services/hybrid_cloud/notifications/service.py
+++ b/src/sentry/services/hybrid_cloud/notifications/service.py
@@ -130,6 +130,11 @@ class NotificationsService(RpcService):
     def remove_notification_settings_for_organization(self, *, organization_id: int) -> None:
         pass
 
+    @rpc_method
+    @abstractmethod
+    def remove_notification_settings_for_project(self, *, project_id: int) -> None:
+        pass
+
 
 notifications_service: NotificationsService = cast(
     NotificationsService, NotificationsService.create_delegation()

--- a/src/sentry/services/hybrid_cloud/repository/service.py
+++ b/src/sentry/services/hybrid_cloud/repository/service.py
@@ -81,5 +81,19 @@ class RepositoryService(RpcService):
         """
         pass
 
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def disassociate_organization_integration(
+        self,
+        *,
+        organization_id: int,
+        organization_integration_id: int,
+        integration_id: int,
+    ) -> None:
+        """
+        Disassociates all repositories, code owners, and code mapping associated with the given organization integration.
+        """
+        pass
+
 
 repository_service = cast(RepositoryService, RepositoryService.create_delegation())

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1100,7 +1100,7 @@ class Factories:
         }
 
     @staticmethod
-    @assume_test_silo_mode(SiloMode.CONTROL)
+    @assume_test_silo_mode(SiloMode.REGION)
     def create_service_hook(actor=None, org=None, project=None, events=None, url=None, **kwargs):
         if not actor:
             actor = Factories.create_user()

--- a/src/sentry/testutils/hybrid_cloud.py
+++ b/src/sentry/testutils/hybrid_cloud.py
@@ -4,7 +4,7 @@ import contextlib
 import functools
 import os
 import threading
-from typing import Any, Callable, Iterator, List, Set, TypedDict
+from typing import Any, Callable, Iterator, List, Set, Type, TypedDict
 
 from django.db import connections, transaction
 from django.db.backends.base.base import BaseDatabaseWrapper
@@ -12,11 +12,16 @@ from django.db.backends.base.base import BaseDatabaseWrapper
 from sentry.db.postgres.transactions import in_test_transaction_enforcement
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
+from sentry.models.scheduledeletion import BaseScheduledDeletion, get_regional_scheduled_deletion
 from sentry.silo import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
 
 
 class HybridCloudTestMixin:
+    @property
+    def ScheduledDeletion(self) -> Type[BaseScheduledDeletion]:
+        return get_regional_scheduled_deletion(SiloMode.get_current_mode())
+
     @assume_test_silo_mode(SiloMode.CONTROL)
     def assert_org_member_mapping(self, org_member: OrganizationMember, expected=None):
         org_member.refresh_from_db()

--- a/tests/sentry/deletions/test_apiapplication.py
+++ b/tests/sentry/deletions/test_apiapplication.py
@@ -1,12 +1,16 @@
-from sentry.models import ApiApplication, ApiGrant, ApiToken, ScheduledDeletion, ServiceHook
+from sentry.models import ApiApplication, ApiGrant, ApiToken, ServiceHook
 from sentry.models.apiapplication import ApiApplicationStatus
+from sentry.silo import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
-from sentry.tasks.deletion.scheduled import run_deletion
+from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import TransactionTestCase
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
-class DeleteApiApplicationTest(TransactionTestCase):
+@control_silo_test(stable=True)
+class DeleteApiApplicationTest(TransactionTestCase, HybridCloudTestMixin):
     def test_simple(self):
         app = ApiApplication.objects.create(
             owner=self.user, status=ApiApplicationStatus.pending_deletion
@@ -18,21 +22,22 @@ class DeleteApiApplicationTest(TransactionTestCase):
         service_hook = self.create_service_hook(application=app)
         sh_id = service_hook.id
 
-        deletion = ScheduledDeletion.schedule(app, days=0)
-        deletion.update(in_progress=True)
+        self.ScheduledDeletion.schedule(instance=app, days=0)
 
         with self.tasks(), outbox_runner():
-            run_deletion(deletion.id)
+            run_scheduled_deletions()
 
         assert not ApiApplication.objects.filter(id=app.id).exists()
         assert not ApiGrant.objects.filter(application=app).exists()
         assert not ApiToken.objects.filter(application=app).exists()
-        assert ServiceHook.objects.filter(id=sh_id).exists()
+        with assume_test_silo_mode(SiloMode.REGION):
+            assert ServiceHook.objects.filter(id=sh_id).exists()
 
-        with self.tasks():
+        with self.tasks(), assume_test_silo_mode(SiloMode.MONOLITH):
             schedule_hybrid_cloud_foreign_key_jobs()
 
-        assert not ServiceHook.objects.filter(id=sh_id).exists()
+        with assume_test_silo_mode(SiloMode.REGION):
+            assert not ServiceHook.objects.filter(id=sh_id).exists()
 
     def test_skip_active(self):
         app = ApiApplication.objects.create(owner=self.user, status=ApiApplicationStatus.active)
@@ -41,11 +46,10 @@ class DeleteApiApplicationTest(TransactionTestCase):
             application=app, user=self.user, scopes=0, redirect_uri="http://example.com"
         )
 
-        deletion = ScheduledDeletion.schedule(app, days=0)
-        deletion.update(in_progress=True)
+        self.ScheduledDeletion.schedule(instance=app, days=0)
 
-        with self.tasks():
-            run_deletion(deletion.id)
+        with self.tasks(), outbox_runner():
+            run_scheduled_deletions()
 
         assert ApiApplication.objects.filter(id=app.id).exists()
         assert ApiGrant.objects.filter(application=app).exists()

--- a/tests/sentry/deletions/test_monitor.py
+++ b/tests/sentry/deletions/test_monitor.py
@@ -1,4 +1,4 @@
-from sentry.models import Environment, Project, ScheduledDeletion
+from sentry.models import Environment, Project
 from sentry.monitors.models import (
     CheckInStatus,
     Monitor,
@@ -7,13 +7,14 @@ from sentry.monitors.models import (
     MonitorType,
     ScheduleType,
 )
-from sentry.tasks.deletion.scheduled import run_deletion
+from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import APITestCase, TransactionTestCase
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
-class DeleteMonitorTest(APITestCase, TransactionTestCase):
+@region_silo_test(stable=True)
+class DeleteMonitorTest(APITestCase, TransactionTestCase, HybridCloudTestMixin):
     def test_simple(self):
         project = self.create_project(name="test")
         env = Environment.objects.create(organization_id=project.organization_id, name="foo")
@@ -36,11 +37,10 @@ class DeleteMonitorTest(APITestCase, TransactionTestCase):
             status=CheckInStatus.OK,
         )
 
-        deletion = ScheduledDeletion.schedule(monitor, days=0)
-        deletion.update(in_progress=True)
+        self.ScheduledDeletion.schedule(instance=monitor, days=0)
 
         with self.tasks():
-            run_deletion(deletion.id)
+            run_scheduled_deletions()
 
         assert not Monitor.objects.filter(id=monitor.id).exists()
         assert not MonitorEnvironment.objects.filter(id=monitor_env.id).exists()

--- a/tests/sentry/deletions/test_monitor_environment.py
+++ b/tests/sentry/deletions/test_monitor_environment.py
@@ -1,4 +1,4 @@
-from sentry.models import Environment, Project, ScheduledDeletion
+from sentry.models import Environment, Project
 from sentry.monitors.models import (
     CheckInStatus,
     Monitor,
@@ -7,13 +7,14 @@ from sentry.monitors.models import (
     MonitorType,
     ScheduleType,
 )
-from sentry.tasks.deletion.scheduled import run_deletion
+from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import APITestCase, TransactionTestCase
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
-class DeleteMonitorEnvironmentTest(APITestCase, TransactionTestCase):
+@region_silo_test(stable=True)
+class DeleteMonitorEnvironmentTest(APITestCase, TransactionTestCase, HybridCloudTestMixin):
     def test_simple(self):
         project = self.create_project(name="test")
         env = Environment.objects.create(organization_id=project.organization_id, name="foo")
@@ -48,11 +49,10 @@ class DeleteMonitorEnvironmentTest(APITestCase, TransactionTestCase):
             status=CheckInStatus.OK,
         )
 
-        deletion = ScheduledDeletion.schedule(monitor_env, days=0)
-        deletion.update(in_progress=True)
+        self.ScheduledDeletion.schedule(instance=monitor_env, days=0)
 
         with self.tasks():
-            run_deletion(deletion.id)
+            run_scheduled_deletions()
 
         assert not MonitorEnvironment.objects.filter(id=monitor_env.id).exists()
         assert not MonitorCheckIn.objects.filter(id=checkin.id).exists()

--- a/tests/sentry/deletions/test_rule.py
+++ b/tests/sentry/deletions/test_rule.py
@@ -1,19 +1,14 @@
 from sentry.constants import ObjectStatus
-from sentry.models import (
-    GroupRuleStatus,
-    RegionScheduledDeletion,
-    Rule,
-    RuleActivity,
-    RuleActivityType,
-)
+from sentry.models import GroupRuleStatus, Rule, RuleActivity, RuleActivityType
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import TestCase
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test(stable=True)
-class DeleteRuleTest(TestCase):
+class DeleteRuleTest(TestCase, HybridCloudTestMixin):
     def test_simple(self):
         project = self.create_project()
         rule = self.create_project_rule(project)
@@ -27,7 +22,7 @@ class DeleteRuleTest(TestCase):
         )
         rule_activity = RuleActivity.objects.create(rule=rule, type=RuleActivityType.CREATED.value)
 
-        RegionScheduledDeletion.schedule(rule, days=0)
+        self.ScheduledDeletion.schedule(instance=rule, days=0)
 
         with self.tasks():
             run_scheduled_deletions()

--- a/tests/sentry/deletions/test_sentry_installation_tokens.py
+++ b/tests/sentry/deletions/test_sentry_installation_tokens.py
@@ -1,8 +1,10 @@
 from sentry import deletions
 from sentry.models import ApiToken, SentryAppInstallation, SentryAppInstallationToken
 from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
 
 
+@control_silo_test(stable=True)
 class TestSentryInstallationTokenDeletionTask(TestCase):
     def setUp(self):
         self.user = self.create_user()

--- a/tests/sentry/deletions/test_team.py
+++ b/tests/sentry/deletions/test_team.py
@@ -1,13 +1,13 @@
-from sentry.models import Project, RegionScheduledDeletion, Rule, Team
+from sentry.models import Project, Rule, Team
 from sentry.models.projectteam import ProjectTeam
-from sentry.silo import SiloMode
-from sentry.tasks.deletion.scheduled import run_deletion
+from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import TestCase
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test(stable=True)
-class DeleteTeamTest(TestCase):
+class DeleteTeamTest(TestCase, HybridCloudTestMixin):
     def test_simple(self):
         team = self.create_team(name="test")
         project1 = self.create_project(teams=[team], name="test1")
@@ -15,11 +15,10 @@ class DeleteTeamTest(TestCase):
         assert project1.teams.first() == team
         assert project2.teams.first() == team
 
-        deletion = RegionScheduledDeletion.schedule(team, days=0)
-        deletion.update(in_progress=True)
+        self.ScheduledDeletion.schedule(instance=team, days=0)
 
         with self.tasks():
-            run_deletion(deletion.id, silo_mode=str(SiloMode.REGION))
+            run_scheduled_deletions()
 
         assert not Team.objects.filter(id=team.id).exists()
         assert Project.objects.filter(id=project1.id).exists()
@@ -33,11 +32,10 @@ class DeleteTeamTest(TestCase):
         alert_rule = self.create_alert_rule(
             name="test alert rule", owner=team.actor.get_actor_tuple(), projects=[project]
         )
-        deletion = RegionScheduledDeletion.schedule(team, days=0)
-        deletion.update(in_progress=True)
+        self.ScheduledDeletion.schedule(team, days=0)
 
         with self.tasks():
-            run_deletion(deletion.id, silo_mode=str(SiloMode.REGION))
+            run_scheduled_deletions()
 
         assert not Team.objects.filter(id=team.id).exists()
         assert Project.objects.filter(id=project.id).exists()


### PR DESCRIPTION
This prepares the deletion tasks for the hybrid cloud world, and to get tests passing for the split silo database world.