### PR TITLE
ref(alerts): Prevent name data from being saved to db

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -171,7 +171,12 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
 
             trigger_sentry_app_action_creators_for_issues(actions=kwargs.get("actions"))
 
-            if rule.data["conditions"] != kwargs["conditions"]:
+            condition_data = rule.data["conditions"].copy()
+            for condition in condition_data:
+                if condition.get("name"):
+                    del condition["name"]
+
+            if condition_data != kwargs["conditions"]:
                 metrics.incr("sentry.issue_alert.conditions.edited", sample_rate=1.0)
             updated_rule = project_rules.Updater.run(rule=rule, request=request, **kwargs)
 

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -31,7 +31,6 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.signals import alert_rule_edited
 from sentry.tasks.integrations.slack import find_channel_id_for_rule
-from sentry.utils import metrics
 from sentry.web.decorators import transaction_start
 
 
@@ -171,13 +170,6 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
 
             trigger_sentry_app_action_creators_for_issues(actions=kwargs.get("actions"))
 
-            condition_data = rule.data["conditions"].copy()
-            for condition in condition_data:
-                if condition.get("name"):
-                    del condition["name"]
-
-            if condition_data != kwargs["conditions"]:
-                metrics.incr("sentry.issue_alert.conditions.edited", sample_rate=1.0)
             updated_rule = project_rules.Updater.run(rule=rule, request=request, **kwargs)
 
             RuleActivity.objects.create(

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -148,6 +148,13 @@ class RuleSerializer(RuleSetSerializer):
 
         return environment
 
+    def validate_conditions(self, conditions):
+        for condition in conditions:
+            if condition.get("name"):
+                del condition["name"]
+
+        return conditions
+
     def validate(self, attrs):
         return super().validate(validate_actions(attrs))
 
@@ -181,6 +188,8 @@ def validate_actions(attrs):
     # project_rule(_details) endpoints by setting it on attrs
     actions = attrs.get("actions", tuple())
     for action in actions:
+        if action.get("name"):
+            del action["name"]
         # XXX(colleen): For ticket rules we need to ensure the user has
         # at least done minimal configuration
         if action["id"] in TICKET_ACTIONS:

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -228,11 +228,9 @@ def create_alert_rule_data(project: Project, user: User, monitor: Monitor, alert
         "conditions": [
             {
                 "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
-                "name": "A new issue is created",
             },
             {
                 "id": "sentry.rules.conditions.regression_event.RegressionEventCondition",
-                "name": "The issue changes state from resolved to unresolved",
             },
         ],
         "createdBy": {
@@ -248,7 +246,6 @@ def create_alert_rule_data(project: Project, user: User, monitor: Monitor, alert
                 "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
                 "key": "monitor.slug",
                 "match": "eq",
-                "name": f"The event's tags match monitor.slug contains {monitor.slug}",
                 "value": monitor.slug,
             }
         ],
@@ -265,7 +262,6 @@ def create_alert_rule_data(project: Project, user: User, monitor: Monitor, alert
 
         action = {
             "id": "sentry.mail.actions.NotifyEmailAction",
-            "name": f"Send a notification to {target_type}",
             "targetIdentifier": target_identifier,
             "targetType": target_type,
         }
@@ -282,7 +278,6 @@ def update_alert_rule(request: Request, project: Project, alert_rule: Rule, aler
 
         action = {
             "id": "sentry.mail.actions.NotifyEmailAction",
-            "name": f"Send a notification to {target_type}",
             "targetIdentifier": target_identifier,
             "targetType": target_type,
         }

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Any, Mapping
-from unittest import mock
-from unittest.mock import call, patch
+from unittest.mock import patch
 
-import pytest
 import responses
 from freezegun import freeze_time
 
@@ -318,11 +316,6 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
 
 @region_silo_test(stable=True)
 class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
-    @pytest.fixture(autouse=True)
-    def _setup_metric_patch(self):
-        with mock.patch("sentry.api.endpoints.project_rule_details.metrics") as self.metrics:
-            yield
-
     method = "PUT"
 
     @patch("sentry.signals.alert_rule_edited.send_robust")
@@ -745,10 +738,6 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
         )
-        assert (
-            call("sentry.issue_alert.conditions.edited", sample_rate=1.0)
-            in self.metrics.incr.call_args_list
-        )
 
     def test_edit_non_condition_metric(self):
         payload = {
@@ -761,10 +750,6 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         }
         self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
-        )
-        assert (
-            call("sentry.issue_alert.conditions.edited", sample_rate=1.0)
-            not in self.metrics.incr.call_args_list
         )
 
 


### PR DESCRIPTION
Backend piece to https://github.com/getsentry/sentry/pull/54739/ to make sure we aren't saving the `name` field to the `Rule` table's `data` column. 