### PR TITLE
sample-event: try synchronous kafka producing

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -161,6 +161,8 @@ class KafkaEventStream(SnubaProtocolEventStream):
                     "sample_event": True,
                 },
             )
+            kwargs["asynchronous"] = False
+
         super().insert(
             event,
             is_new,

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -215,6 +215,7 @@ class SnubaProtocolEventStream(EventStream):
                 },
             ),
             headers=headers,
+            asynchronous=kwargs.get("asynchronous", True),
             skip_semantic_partitioning=skip_semantic_partitioning,
             event_type=event_type,
         )


### PR DESCRIPTION
- when creating a sample event, try producing synchronously, since when done through the sample_event [endpoint](https://github.com/getsentry/sentry/blob/7e204dc42b2dd671aec955f108ea334dea72339e/src/sentry/api/endpoints/project_create_sample.py#L19), we may not finish flushing before the request thread is terminated.
- can test this on S4S to see if fixes issue, and quickly revert before it makes it to canary before it can cause problems, but I think it should be fine?


Note: my understanding of kafka / how Django uWSGI lifecycles work is not expert, so my analysis/assumptions here may be off.