### PR TITLE
fix(hybrid-cloud): Override get_from_cache and get_many_from_cache with silo limits

### DIFF
--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -524,6 +524,12 @@ def create_silo_limited_copy(self: BaseManager[M], limit: SiloLimit) -> BaseMana
         "select_for_update": limit.create_override(cls.select_for_update),
         "update": limit.create_override(cls.update),
         "update_or_create": limit.create_override(cls.update_or_create),
+        "get_from_cache": limit.create_override(cls.get_from_cache)
+        if hasattr(cls, "get_from_cache")
+        else None,
+        "get_many_from_cache": limit.create_override(cls.get_many_from_cache)
+        if hasattr(cls, "get_many_from_cache")
+        else None,
     }
     manager_subclass = type(cls.__name__, (cls,), overrides)
     manager_instance = manager_subclass()


### PR DESCRIPTION
We do not plan to have a shared redis cache cluster between the region silos and the control silo.

Hence, we shouldn't be able to call `get_from_cache()` and `get_many_from_cache()` on models in silos that they're not available in.