### PR TITLE
feat(starfish): Display project avatar on span sample page

### DIFF
--- a/static/app/components/avatar/projectAvatar.tsx
+++ b/static/app/components/avatar/projectAvatar.tsx
@@ -5,6 +5,7 @@ import {AvatarProject} from 'sentry/types';
 
 type Props = {
   project: AvatarProject;
+  direction?: 'left' | 'right';
 } & BaseAvatar['props'];
 
 function ProjectAvatar({project, hasTooltip, tooltip, ...props}: Props) {

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -67,6 +67,7 @@ function SpanSummaryPage({params, location}: Props) {
     [
       SpanMetricsFields.SPAN_OP,
       SpanMetricsFields.SPAN_GROUP,
+      SpanMetricsFields.PROJECT_ID,
       `${StarfishFunctions.SPS}()`,
     ],
     'api.starfish.span-summary-page-metrics'
@@ -137,6 +138,7 @@ function SpanSummaryPage({params, location}: Props) {
 
                 <SampleList
                   groupId={span[SpanMetricsFields.SPAN_GROUP]}
+                  projectId={spanMetrics[SpanMetricsFields.PROJECT_ID]}
                   transactionName={transaction}
                   transactionMethod={transactionMethod}
                 />

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -89,7 +89,13 @@ export function SampleList({
         onOpen={onOpenDetailPanel}
       >
         {project && (
-          <SpanSummaryProjectAvatar project={project} direction="left" size={40} />
+          <SpanSummaryProjectAvatar
+            project={project}
+            direction="left"
+            size={40}
+            hasTooltip
+            tooltip={project.slug}
+          />
         )}
         <h3>
           <Link to={link}>{label}</Link>


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/54738 we made some updates to the span sample drawer. This PR builds on top of it, specifically re: passing down projects.

The PR removes the usage of pagefilters in favour of injected project id props and then adds a project avatar on the span sample page

![image](https://github.com/getsentry/sentry/assets/18689448/3eb48d1d-22a1-499b-b406-3af6d92166cf)