### PR TITLE
ref(crons): Remove temp_task_dispatcher

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -968,12 +968,6 @@ CELERYBEAT_SCHEDULE_REGION = {
         "schedule": crontab(minute="*/1"),
         "options": {"expires": 60},
     },
-    "monitors-temp-task-dispatcher": {
-        "task": "sentry.monitors.tasks.temp_task_dispatcher",
-        # Run every 1 minute
-        "schedule": crontab(minute="*/1"),
-        "options": {"expires": 60},
-    },
     "clear-expired-snoozes": {
         "task": "sentry.tasks.clear_expired_snoozes",
         # Run every 5 minutes


### PR DESCRIPTION
This is no longer needed once tasks are correctly being dispatched by
the monitor consumer clock