### PR TITLE
fix(crons): Add className parameter to timeline components

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
@@ -56,9 +56,9 @@ function getTimeMarkers(end: Date, timeWindow: TimeWindow, width: number): TimeM
   return times;
 }
 
-export function GridLineTimeLabels({end, timeWindow, width}: Props) {
+export function GridLineTimeLabels({end, timeWindow, width, className}: Props) {
   return (
-    <LabelsContainer>
+    <LabelsContainer className={className}>
       {getTimeMarkers(end, timeWindow, width).map(({date, position}) => (
         <TimeLabelContainer key={date.getTime()} left={position}>
           <TimeLabel date={date} {...timeWindowConfig[timeWindow].dateTimeProps} />
@@ -74,6 +74,7 @@ export function GridLineOverlay({
   width,
   showCursor,
   stickyCursor,
+  className,
 }: Props) {
   const {cursorLabelFormat} = timeWindowConfig[timeWindow];
 
@@ -94,7 +95,7 @@ export function GridLineOverlay({
   });
 
   return (
-    <Overlay ref={cursorContainerRef}>
+    <Overlay ref={cursorContainerRef} className={className}>
       {timelineCursor}
       <GridLineContainer>
         {getTimeMarkers(end, timeWindow, width).map(({date, position}) => (


### PR DESCRIPTION
Need to forward the css from `styled` down to these components. Not sure how I missed this before since `className` was already in the Props type 😵‍💫 