### PR TITLE
feat(perf): Use p50 instead of avg

### DIFF
--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -243,7 +243,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
             'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
           sort: 'trend_percentage()',
           statsPeriod: '14d',
-          trendFunction: 'avg(transaction.duration)',
+          trendFunction: 'p50(transaction.duration)',
           trendType: 'improved',
         }),
       })
@@ -838,7 +838,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
             'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
           sort: 'trend_percentage()',
           statsPeriod: '7d',
-          trendFunction: 'avg(transaction.duration)',
+          trendFunction: 'p50(transaction.duration)',
           trendType: 'improved',
         }),
       })
@@ -874,7 +874,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
             'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
           sort: '-trend_percentage()',
           statsPeriod: '7d',
-          trendFunction: 'avg(transaction.duration)',
+          trendFunction: 'p50(transaction.duration)',
           trendType: 'regression',
         }),
       })

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -68,7 +68,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
       ? TrendChangeType.IMPROVED
       : TrendChangeType.REGRESSION;
   const derivedTrendChangeType = withBreakpoint ? TrendChangeType.ANY : trendChangeType;
-  const trendFunctionField = TrendFunctionField.AVG; // Average is the easiest chart to understand.
+  const trendFunctionField = TrendFunctionField.P50; // Setting p50 to match trends page
 
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
 


### PR DESCRIPTION
To match Trends, use p50 on the landing page widgets.