### PR TITLE
(fix): user creation for self-hosted clean installs

### DIFF
--- a/src/sentry/receivers/users.py
+++ b/src/sentry/receivers/users.py
@@ -3,13 +3,14 @@ import sys
 from sentry.models.user import User
 from sentry.signals import post_upgrade
 from sentry.silo import SiloMode
+from sentry.utils.settings import is_self_hosted
 
 
 def create_first_user(**kwargs):
     if User.objects.filter(is_superuser=True).exists():
         return
 
-    if not sys.stdin.isatty():
+    if not sys.stdin.isatty() and not is_self_hosted():
         return
 
     if not kwargs["interactive"]:


### PR DESCRIPTION
Tested locally, it works. Hacky, but it gets the job done