### PR TITLE
ref(backup): Swap include_in_exports -> relocation_scope (2/4)

### DIFF
--- a/src/sentry/data_export/models.py
+++ b/src/sentry/data_export/models.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_str
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -31,6 +32,7 @@ class ExportedData(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization = FlexibleForeignKey("sentry.Organization")
     user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, null=True, on_delete="SET_NULL")
@@ -153,6 +155,7 @@ class ExportedData(Model):
 @region_silo_only_model
 class ExportedDataBlob(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     data_export = FlexibleForeignKey("sentry.ExportedData")
     blob_id = BoundedBigIntegerField()

--- a/src/sentry/discover/models.py
+++ b/src/sentry/discover/models.py
@@ -3,6 +3,7 @@ from django.db.models import Q, UniqueConstraint
 from django.utils import timezone
 
 from sentry import features
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
@@ -23,6 +24,7 @@ MAX_TEAM_KEY_TRANSACTIONS = 100
 @region_silo_only_model
 class DiscoverSavedQueryProject(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
     discover_saved_query = FlexibleForeignKey("sentry.DiscoverSavedQuery")
@@ -40,6 +42,7 @@ class DiscoverSavedQuery(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     projects = models.ManyToManyField("sentry.Project", through=DiscoverSavedQueryProject)
     organization = FlexibleForeignKey("sentry.Organization")
@@ -136,6 +139,7 @@ class TeamKeyTransactionModelManager(BaseManager):
 @region_silo_only_model
 class TeamKeyTransaction(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     # max_length here is based on the maximum for transactions in relay
     transaction = models.CharField(max_length=200)

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -9,6 +9,7 @@ from django.db import IntegrityError, models, router, transaction
 from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     ArrayField,
     FlexibleForeignKey,
@@ -32,6 +33,7 @@ from sentry.utils.retries import TimedRetryPolicy
 @region_silo_only_model
 class IncidentProject(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", db_index=False, db_constraint=False)
     incident = FlexibleForeignKey("sentry.Incident")
@@ -45,6 +47,7 @@ class IncidentProject(Model):
 @region_silo_only_model
 class IncidentSeen(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     incident = FlexibleForeignKey("sentry.Incident")
     user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE", db_index=False)
@@ -168,6 +171,7 @@ INCIDENT_STATUS = {
 @region_silo_only_model
 class Incident(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     objects = IncidentManager()
 
@@ -215,6 +219,7 @@ class Incident(Model):
 @region_silo_only_model
 class PendingIncidentSnapshot(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     incident = OneToOneCascadeDeletes("sentry.Incident", db_constraint=False)
     target_run_date = models.DateTimeField(db_index=True, default=timezone.now)
@@ -228,6 +233,7 @@ class PendingIncidentSnapshot(Model):
 @region_silo_only_model
 class IncidentSnapshot(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     incident = OneToOneCascadeDeletes("sentry.Incident", db_constraint=False)
     event_stats_snapshot = FlexibleForeignKey("sentry.TimeSeriesSnapshot", db_constraint=False)
@@ -243,6 +249,7 @@ class IncidentSnapshot(Model):
 @region_silo_only_model
 class TimeSeriesSnapshot(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     start = models.DateTimeField()
     end = models.DateTimeField()
@@ -265,6 +272,7 @@ class IncidentActivityType(Enum):
 @region_silo_only_model
 class IncidentActivity(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     incident = FlexibleForeignKey("sentry.Incident")
     user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE", null=True)
@@ -283,6 +291,7 @@ class IncidentActivity(Model):
 @region_silo_only_model
 class IncidentSubscription(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     incident = FlexibleForeignKey("sentry.Incident", db_index=False)
     user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE")
@@ -366,6 +375,7 @@ class AlertRuleManager(BaseManager):
 @region_silo_only_model
 class AlertRuleExcludedProjects(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     alert_rule = FlexibleForeignKey("sentry.AlertRule", db_index=False)
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)
@@ -380,6 +390,7 @@ class AlertRuleExcludedProjects(Model):
 @region_silo_only_model
 class AlertRule(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     objects = AlertRuleManager()
     objects_with_snapshots = BaseManager()
@@ -471,6 +482,7 @@ class IncidentTriggerManager(BaseManager):
 @region_silo_only_model
 class IncidentTrigger(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     objects = IncidentTriggerManager()
 
@@ -519,6 +531,7 @@ class AlertRuleTriggerManager(BaseManager):
 @region_silo_only_model
 class AlertRuleTrigger(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     alert_rule = FlexibleForeignKey("sentry.AlertRule")
     label = models.TextField()
@@ -541,6 +554,7 @@ class AlertRuleTrigger(Model):
 @region_silo_only_model
 class AlertRuleTriggerExclusion(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     alert_rule_trigger = FlexibleForeignKey("sentry.AlertRuleTrigger", related_name="exclusions")
     query_subscription = FlexibleForeignKey("sentry.QuerySubscription")
@@ -560,6 +574,7 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     # Aliases from NotificationAction
     Type = ActionService
@@ -666,6 +681,7 @@ class AlertRuleActivityType(Enum):
 @region_silo_only_model
 class AlertRuleActivity(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     alert_rule = FlexibleForeignKey("sentry.AlertRule")
     previous_alert_rule = FlexibleForeignKey(

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -9,6 +9,7 @@ from django.db.models import F
 from django.db.models.signals import post_save
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedPositiveIntegerField,
@@ -87,6 +88,7 @@ class ActivityManager(BaseManager):
 @region_silo_only_model
 class Activity(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
     group = FlexibleForeignKey("sentry.Group", null=True)

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -9,6 +9,7 @@ from django.db import IntegrityError, models, router, transaction
 from django.db.models.signals import post_save
 from rest_framework import serializers
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, region_silo_only_model
 from sentry.db.models.fields.foreignkey import FlexibleForeignKey
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
@@ -102,6 +103,7 @@ def actor_type_to_string(type: int) -> str | None:
 @region_silo_only_model
 class Actor(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     type = models.PositiveSmallIntegerField(
         choices=(

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -7,6 +7,7 @@ from django.db import models, router, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedPositiveIntegerField,
@@ -39,6 +40,7 @@ class ApiApplicationStatus:
 @control_silo_only_model
 class ApiApplication(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     client_id = models.CharField(max_length=64, unique=True, default=generate_token)
     client_secret = models.TextField(default=generate_token)

--- a/src/sentry/models/apiauthorization.py
+++ b/src/sentry/models/apiauthorization.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, control_silo_only_model, sane_repr
 from sentry.models.apiscopes import HasApiScopes
 
@@ -15,6 +16,7 @@ class ApiAuthorization(Model, HasApiScopes):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     # users can generate tokens without being application-bound
     application = FlexibleForeignKey("sentry.ApiApplication", null=True)

--- a/src/sentry/models/apigrant.py
+++ b/src/sentry/models/apigrant.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.utils import timezone
 
 from bitfield import typed_dict_bitfield
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import ArrayField, FlexibleForeignKey, Model, control_silo_only_model
 
 DEFAULT_EXPIRATION = timedelta(minutes=10)
@@ -28,6 +29,7 @@ class ApiGrant(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     user = FlexibleForeignKey("sentry.User")
     application = FlexibleForeignKey("sentry.ApiApplication")

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedPositiveIntegerField,
@@ -24,6 +25,7 @@ class ApiKeyStatus:
 @control_silo_only_model
 class ApiKey(Model, HasApiScopes):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     organization_id = HybridCloudForeignKey("sentry.Organization", on_delete="cascade")
     label = models.CharField(max_length=64, blank=True, default="Default")

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -7,6 +7,7 @@ from django.db import models, router, transaction
 from django.utils import timezone
 from django.utils.encoding import force_str
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import SentryAppStatus
 from sentry.db.models import (
     BaseManager,
@@ -31,6 +32,7 @@ def generate_token():
 @control_silo_only_model
 class ApiToken(Model, HasApiScopes):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     # users can generate tokens without being application-bound
     application = FlexibleForeignKey("sentry.ApiApplication", null=True)

--- a/src/sentry/models/appconnectbuilds.py
+++ b/src/sentry/models/appconnectbuilds.py
@@ -1,3 +1,4 @@
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import region_silo_only_model
 
 """Database models to keep track of the App Store Connect builds for a project.
@@ -24,6 +25,7 @@ class AppConnectBuild(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)
 

--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import SymbolicError
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -66,6 +67,7 @@ class ArtifactBundleIndexingState(Enum):
 @region_silo_only_model
 class ArtifactBundle(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     # We use 00000000-00000000-00000000-00000000 in place of NULL because the uniqueness constraint doesn't play well
@@ -139,6 +141,7 @@ indexstore = LazyServiceWrapper(
 @region_silo_only_model
 class ArtifactBundleFlatFileIndex(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField(db_index=True)
     release_name = models.CharField(max_length=250)
@@ -177,6 +180,7 @@ class ArtifactBundleFlatFileIndex(Model):
 @region_silo_only_model
 class FlatFileIndexState(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     flat_file_index = FlexibleForeignKey("sentry.ArtifactBundleFlatFileIndex")
     artifact_bundle = FlexibleForeignKey("sentry.ArtifactBundle")
@@ -209,6 +213,7 @@ class FlatFileIndexState(Model):
 @region_silo_only_model
 class ArtifactBundleIndex(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     artifact_bundle = FlexibleForeignKey("sentry.ArtifactBundle")
@@ -232,6 +237,7 @@ class ArtifactBundleIndex(Model):
 @region_silo_only_model
 class ReleaseArtifactBundle(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     release_name = models.CharField(max_length=250)
@@ -253,6 +259,7 @@ class ReleaseArtifactBundle(Model):
 @region_silo_only_model
 class DebugIdArtifactBundle(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     debug_id = models.UUIDField()
@@ -270,6 +277,7 @@ class DebugIdArtifactBundle(Model):
 @region_silo_only_model
 class ProjectArtifactBundle(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     project_id = BoundedBigIntegerField()

--- a/src/sentry/models/assistant.py
+++ b/src/sentry/models/assistant.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
@@ -15,6 +16,7 @@ class AssistantActivity(Model):
     """Records user interactions with the assistant guides."""
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL, null=False)
     guide_id = BoundedPositiveIntegerField()

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -40,6 +41,7 @@ def format_scim_token_actor_name(actor):
 @control_silo_only_model
 class AuditLogEntry(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = HybridCloudForeignKey("sentry.Organization", on_delete="CASCADE")
     actor_label = models.CharField(max_length=MAX_ACTOR_LABEL_LENGTH, null=True, blank=True)

--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -17,6 +17,7 @@ from sentry.auth.authenticators import (
     available_authenticators,
 )
 from sentry.auth.authenticators.base import EnrollmentStatus
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BaseModel,
@@ -140,6 +141,7 @@ class AuthenticatorConfig(PickledObjectField):
 @control_silo_only_model
 class Authenticator(BaseModel):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.User
 
     id = BoundedAutoField(primary_key=True)
     user = FlexibleForeignKey("sentry.User", db_index=True)

--- a/src/sentry/models/authidentity.py
+++ b/src/sentry/models/authidentity.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, control_silo_only_model, sane_repr
 from sentry.db.models.fields.jsonfield import JSONField
 
@@ -11,6 +12,7 @@ from sentry.db.models.fields.jsonfield import JSONField
 @control_silo_only_model
 class AuthIdentity(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     # NOTE: not a fk to sentry user
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL)

--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.utils import timezone
 
 from bitfield import TypedClassBitField
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -32,6 +33,7 @@ SCIM_INTERNAL_INTEGRATION_OVERVIEW = (
 class AuthProviderDefaultTeams(Model):
     # Completely defunct model.
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     authprovider_id = BoundedBigIntegerField()
     team_id = BoundedBigIntegerField()
@@ -45,6 +47,7 @@ class AuthProviderDefaultTeams(Model):
 @control_silo_only_model
 class AuthProvider(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     organization_id = HybridCloudForeignKey("sentry.Organization", on_delete="cascade", unique=True)
     provider = models.CharField(max_length=128)

--- a/src/sentry/models/avatars/base.py
+++ b/src/sentry/models/avatars/base.py
@@ -10,6 +10,7 @@ from django.utils.encoding import force_bytes
 from PIL import Image
 from typing_extensions import Self
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model
 from sentry.models.files.file import File
 from sentry.silo import SiloMode
@@ -26,6 +27,7 @@ class AvatarBase(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     ALLOWED_SIZES: ClassVar[tuple[int, ...]] = (20, 32, 36, 48, 52, 64, 80, 96, 120)
 

--- a/src/sentry/models/broadcast.py
+++ b/src/sentry/models/broadcast.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, control_silo_only_model, sane_repr
 
 
@@ -13,6 +14,7 @@ def default_expiration():
 @control_silo_only_model
 class Broadcast(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     upstream_id = models.CharField(max_length=32, null=True, blank=True)
     title = models.CharField(max_length=32)
@@ -33,6 +35,7 @@ class Broadcast(Model):
 @control_silo_only_model
 class BroadcastSeen(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     broadcast = FlexibleForeignKey("sentry.Broadcast")
     user = FlexibleForeignKey("sentry.User")

--- a/src/sentry/models/commit.py
+++ b/src/sentry/models/commit.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.db.models.query import QuerySet
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedBigIntegerField,
@@ -34,6 +35,7 @@ class CommitManager(BaseManager):
 @region_silo_only_model
 class Commit(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     repository_id = BoundedPositiveIntegerField()

--- a/src/sentry/models/commitauthor.py
+++ b/src/sentry/models/commitauthor.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, List
 
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_model, sane_repr
 from sentry.db.models.manager import BaseManager
 
@@ -24,6 +25,7 @@ class CommitAuthorManager(BaseManager):
 @region_silo_only_model
 class CommitAuthor(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     name = models.CharField(max_length=128, null=True)

--- a/src/sentry/models/commitfilechange.py
+++ b/src/sentry/models/commitfilechange.py
@@ -3,6 +3,7 @@ from typing import Any, Iterable
 from django.db import models, router, transaction
 from django.db.models.signals import post_save
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedBigIntegerField,
@@ -23,6 +24,7 @@ class CommitFileChangeManager(BaseManager):
 @region_silo_only_model
 class CommitFileChange(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     commit = FlexibleForeignKey("sentry.Commit")

--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -5,6 +5,7 @@ from django.db import connections, transaction
 from django.db.models.signals import post_migrate
 
 from sentry import options
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     FlexibleForeignKey,
@@ -19,6 +20,7 @@ from sentry.silo import SiloMode, unguarded_write
 @region_silo_only_model
 class Counter(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey("sentry.Project", unique=True)
     value = BoundedBigIntegerField()

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -5,6 +5,7 @@ from typing import Any
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.bounded import BoundedBigIntegerField
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
@@ -14,6 +15,7 @@ from sentry.db.models.fields.jsonfield import JSONField
 @region_silo_only_model
 class DashboardProject(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
     dashboard = FlexibleForeignKey("sentry.Dashboard")
@@ -31,6 +33,7 @@ class Dashboard(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     title = models.CharField(max_length=255)
     created_by_id = HybridCloudForeignKey("sentry.User", on_delete="CASCADE")
@@ -79,6 +82,7 @@ class DashboardTombstone(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     slug = models.CharField(max_length=255)
     organization = FlexibleForeignKey("sentry.Organization")

--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -6,6 +6,7 @@ from django.contrib.postgres.fields import ArrayField as DjangoArrayField
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     ArrayField,
     BoundedPositiveIntegerField,
@@ -80,6 +81,7 @@ class DashboardWidgetQuery(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     widget = FlexibleForeignKey("sentry.DashboardWidget")
     name = models.CharField(max_length=255)
@@ -115,6 +117,7 @@ class DashboardWidget(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     dashboard = FlexibleForeignKey("sentry.Dashboard")
     order = BoundedPositiveIntegerField()

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -34,6 +34,7 @@ from symbolic.debuginfo import Archive, BcSymbolMap, Object, UuidMapping, normal
 from symbolic.exceptions import ObjectErrorUnsupportedObject, SymbolicError
 
 from sentry import options
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import KNOWN_DIF_FORMATS
 from sentry.db.models import (
     BaseManager,
@@ -135,6 +136,7 @@ class ProjectDebugFileManager(BaseManager):
 @region_silo_only_model
 class ProjectDebugFile(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     file = FlexibleForeignKey("sentry.File")
     checksum = models.CharField(max_length=40, null=True, db_index=True)
@@ -367,6 +369,7 @@ def _analyze_progard_filename(filename: str) -> Optional[str]:
 @region_silo_only_model
 class ProguardArtifactRelease(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField()
     project_id = BoundedBigIntegerField()

--- a/src/sentry/models/deletedentry.py
+++ b/src/sentry/models/deletedentry.py
@@ -1,11 +1,13 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model
 
 
 class DeletedEntry(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     actor_label = models.CharField(max_length=64, null=True)
     # if the entry was created via a user

--- a/src/sentry/models/deploy.py
+++ b/src/sentry/models/deploy.py
@@ -1,3 +1,4 @@
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import region_silo_only_model
 
 """
@@ -23,6 +24,7 @@ from sentry.utils.retries import TimedRetryPolicy
 @region_silo_only_model
 class Deploy(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     release = FlexibleForeignKey("sentry.Release")

--- a/src/sentry/models/distribution.py
+++ b/src/sentry/models/distribution.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     FlexibleForeignKey,
@@ -13,6 +14,7 @@ from sentry.db.models import (
 @region_silo_only_model
 class Distribution(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     release = FlexibleForeignKey("sentry.Release")

--- a/src/sentry/models/email.py
+++ b/src/sentry/models/email.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import CIEmailField, Model, control_silo_only_model, sane_repr
 
 
@@ -13,6 +14,7 @@ class Email(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.User
 
     email = CIEmailField(_("email address"), unique=True, max_length=75)
     date_added = models.DateTimeField(default=timezone.now)

--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -4,6 +4,7 @@ from urllib.parse import unquote
 from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import ENVIRONMENT_NAME_MAX_LENGTH, ENVIRONMENT_NAME_PATTERN
 from sentry.db.models import (
     BoundedBigIntegerField,
@@ -22,6 +23,7 @@ OK_NAME_PATTERN = re.compile(ENVIRONMENT_NAME_PATTERN)
 @region_silo_only_model
 class EnvironmentProject(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey("sentry.Project")
     environment = FlexibleForeignKey("sentry.Environment")
@@ -36,6 +38,7 @@ class EnvironmentProject(Model):
 @region_silo_only_model
 class Environment(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     organization_id = BoundedBigIntegerField()
     projects = models.ManyToManyField("sentry.Project", through=EnvironmentProject)

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.functional import cached_property
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_model, sane_repr
 
 # Attachment file types that are considered a crash report (PII relevant)
@@ -33,6 +34,7 @@ def event_attachment_screenshot_filter(queryset):
 @region_silo_only_model
 class EventAttachment(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField()
     group_id = BoundedBigIntegerField(null=True, db_index=True)

--- a/src/sentry/models/eventuser.py
+++ b/src/sentry/models/eventuser.py
@@ -4,6 +4,7 @@ from operator import or_
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import MAX_EMAIL_FIELD_LENGTH
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_model, sane_repr
 from sentry.utils.datastructures import BidirectionalMapping
@@ -25,6 +26,7 @@ KEYWORD_MAP = BidirectionalMapping(
 @region_silo_only_model
 class EventUser(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField(db_index=True)
     hash = models.CharField(max_length=32)

--- a/src/sentry/models/featureadoption.py
+++ b/src/sentry/models/featureadoption.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from sentry.adoption import manager
 from sentry.adoption.manager import UnknownFeature
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
@@ -226,6 +227,7 @@ class FeatureAdoptionManager(BaseManager):
 @region_silo_only_model
 class FeatureAdoption(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization = FlexibleForeignKey("sentry.Organization")
     feature_id = models.PositiveIntegerField(choices=[(f.id, str(f.name)) for f in manager.all()])

--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -15,6 +15,7 @@ from django.core.files.base import File as FileObj
 from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.celery import SentryTask
 from sentry.db.models import BoundedPositiveIntegerField, JSONField, Model
 from sentry.models.files.abstractfileblob import AbstractFileBlob
@@ -196,6 +197,7 @@ class ChunkedFileBlobIndexWrapper:
 
 class AbstractFile(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     name = models.TextField()
     type = models.CharField(max_length=64)

--- a/src/sentry/models/files/abstractfileblob.py
+++ b/src/sentry/models/files/abstractfileblob.py
@@ -10,6 +10,7 @@ from django.db import IntegrityError, models, router
 from django.utils import timezone
 from typing_extensions import Self
 
+from sentry.backup.scopes import RelocationScope
 from sentry.celery import SentryTask
 from sentry.db.models import BoundedPositiveIntegerField, Model
 from sentry.locks import locks
@@ -30,6 +31,7 @@ MULTI_BLOB_UPLOAD_CONCURRENCY = 8
 
 class AbstractFileBlob(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     path = models.TextField(null=True)
     size = BoundedPositiveIntegerField(null=True)

--- a/src/sentry/models/files/abstractfileblobindex.py
+++ b/src/sentry/models/files/abstractfileblobindex.py
@@ -1,8 +1,10 @@
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedPositiveIntegerField, Model
 
 
 class AbstractFileBlobIndex(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     offset = BoundedPositiveIntegerField()
 

--- a/src/sentry/models/files/abstractfileblobowner.py
+++ b/src/sentry/models/files/abstractfileblobowner.py
@@ -1,8 +1,10 @@
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model
 
 
 class AbstractFileBlobOwner(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
 

--- a/src/sentry/models/files/control_fileblobindex.py
+++ b/src/sentry/models/files/control_fileblobindex.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey
 from sentry.db.models.base import control_silo_only_model
 from sentry.models.files.abstractfileblobindex import AbstractFileBlobIndex
@@ -8,6 +9,7 @@ from sentry.models.files.abstractfileblobindex import AbstractFileBlobIndex
 @control_silo_only_model
 class ControlFileBlobIndex(AbstractFileBlobIndex):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     file = FlexibleForeignKey("sentry.ControlFile")
     blob = FlexibleForeignKey("sentry.ControlFileBlob", on_delete=models.PROTECT)

--- a/src/sentry/models/files/control_fileblobowner.py
+++ b/src/sentry/models/files/control_fileblobowner.py
@@ -1,3 +1,4 @@
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey
 from sentry.db.models.base import control_silo_only_model
 from sentry.models.files.abstractfileblobowner import AbstractFileBlobOwner
@@ -6,6 +7,7 @@ from sentry.models.files.abstractfileblobowner import AbstractFileBlobOwner
 @control_silo_only_model
 class ControlFileBlobOwner(AbstractFileBlobOwner):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     blob = FlexibleForeignKey("sentry.ControlFileBlob")
 

--- a/src/sentry/models/files/fileblobindex.py
+++ b/src/sentry/models/files/fileblobindex.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey
 from sentry.db.models.base import region_silo_only_model
 from sentry.models.files.abstractfileblobindex import AbstractFileBlobIndex
@@ -8,6 +9,7 @@ from sentry.models.files.abstractfileblobindex import AbstractFileBlobIndex
 @region_silo_only_model
 class FileBlobIndex(AbstractFileBlobIndex):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     file = FlexibleForeignKey("sentry.File")
     blob = FlexibleForeignKey("sentry.FileBlob", on_delete=models.PROTECT)

--- a/src/sentry/models/files/fileblobowner.py
+++ b/src/sentry/models/files/fileblobowner.py
@@ -1,3 +1,4 @@
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey
 from sentry.db.models.base import region_silo_only_model
 from sentry.models.files.abstractfileblobowner import AbstractFileBlobOwner
@@ -6,6 +7,7 @@ from sentry.models.files.abstractfileblobowner import AbstractFileBlobOwner
 @region_silo_only_model
 class FileBlobOwner(AbstractFileBlobOwner):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     blob = FlexibleForeignKey("sentry.FileBlob")
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -22,6 +22,7 @@ from django.utils.translation import gettext_lazy as _
 from snuba_sdk import Column, Condition, Op
 
 from sentry import eventstore, eventtypes, tagstore
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS, MAX_CULPRIT_LENGTH
 from sentry.db.models import (
     BaseManager,
@@ -475,6 +476,7 @@ class Group(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
     logger = models.CharField(

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.db import models, router, transaction
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
@@ -151,6 +152,7 @@ class GroupAssignee(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     objects = GroupAssigneeManager()
 

--- a/src/sentry/models/groupbookmark.py
+++ b/src/sentry/models/groupbookmark.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
@@ -20,6 +21,7 @@ class GroupBookmark(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", related_name="bookmark_set")
     group = FlexibleForeignKey("sentry.Group", related_name="bookmark_set")

--- a/src/sentry/models/groupcommitresolution.py
+++ b/src/sentry/models/groupcommitresolution.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_model, sane_repr
 
 
@@ -11,6 +12,7 @@ class GroupCommitResolution(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     group_id = BoundedBigIntegerField()
     commit_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/groupemailthread.py
+++ b/src/sentry/models/groupemailthread.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
@@ -20,6 +21,7 @@ class GroupEmailThread(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     email = models.EmailField(max_length=75)
     project = FlexibleForeignKey("sentry.Project", related_name="groupemail_set")

--- a/src/sentry/models/groupenvironment.py
+++ b/src/sentry/models/groupenvironment.py
@@ -2,6 +2,7 @@ from django.db.models import DO_NOTHING, DateTimeField
 from django.db.models.signals import post_delete
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.utils.cache import cache
 
@@ -9,6 +10,7 @@ from sentry.utils.cache import cache
 @region_silo_only_model
 class GroupEnvironment(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     group = FlexibleForeignKey("sentry.Group", db_constraint=False)
     environment = FlexibleForeignKey("sentry.Environment", db_constraint=False)

--- a/src/sentry/models/grouphash.py
+++ b/src/sentry/models/grouphash.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
@@ -12,6 +13,7 @@ from sentry.db.models import (
 @region_silo_only_model
 class GroupHash(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     class State:
         UNLOCKED = None

--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -5,6 +5,7 @@ from django.db.models import SET_NULL, Q
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedPositiveIntegerField,
@@ -164,6 +165,7 @@ class GroupHistory(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     objects = GroupHistoryManager()
 

--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -5,6 +5,7 @@ import jsonschema
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, JSONField, Model, region_silo_only_model
 from sentry.models import Activity
 from sentry.models.grouphistory import (
@@ -53,6 +54,7 @@ class GroupInbox(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     group = FlexibleForeignKey("sentry.Group", unique=True, db_constraint=False)
     project = FlexibleForeignKey("sentry.Project", null=True, db_constraint=False)

--- a/src/sentry/models/grouplink.py
+++ b/src/sentry/models/grouplink.py
@@ -7,6 +7,7 @@ from django.db.models import QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedBigIntegerField,
@@ -43,6 +44,7 @@ class GroupLink(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     class Relationship:
         unknown = 0

--- a/src/sentry/models/groupmeta.py
+++ b/src/sentry/models/groupmeta.py
@@ -4,6 +4,7 @@ from celery.signals import task_postrun
 from django.core.signals import request_finished
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.manager import BaseManager
 from sentry.exceptions import CacheNotPopulated
@@ -92,6 +93,7 @@ class GroupMeta(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     group = FlexibleForeignKey("sentry.Group")
     key = models.CharField(max_length=64)

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.fields.jsonfield import JSONField
@@ -55,6 +56,7 @@ class GroupOwner(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     group = FlexibleForeignKey("sentry.Group", db_constraint=False)
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)

--- a/src/sentry/models/groupredirect.py
+++ b/src/sentry/models/groupredirect.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_model, sane_repr
 
 
@@ -11,6 +12,7 @@ class GroupRedirect(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(null=True)
     group_id = BoundedBigIntegerField(db_index=True)

--- a/src/sentry/models/grouprelease.py
+++ b/src/sentry/models/grouprelease.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -18,6 +19,7 @@ from sentry.utils.hashlib import md5_text
 @region_silo_only_model
 class GroupRelease(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField(db_index=True)
     group_id = BoundedBigIntegerField()

--- a/src/sentry/models/groupresolution.py
+++ b/src/sentry/models/groupresolution.py
@@ -5,6 +5,7 @@ from sentry_relay.exceptions import RelayError
 from sentry_relay.processing import compare_version as compare_version_relay
 from sentry_relay.processing import parse_release
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
@@ -23,6 +24,7 @@ class GroupResolution(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     class Type:
         in_release = 0

--- a/src/sentry/models/grouprulestatus.py
+++ b/src/sentry/models/grouprulestatus.py
@@ -1,12 +1,14 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 
 
 @region_silo_only_model
 class GroupRuleStatus(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     ACTIVE = 0
     INACTIVE = 1

--- a/src/sentry/models/groupseen.py
+++ b/src/sentry/models/groupseen.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 
@@ -13,6 +14,7 @@ class GroupSeen(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
     group = FlexibleForeignKey("sentry.Group")

--- a/src/sentry/models/groupshare.py
+++ b/src/sentry/models/groupshare.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
@@ -25,6 +26,7 @@ class GroupShare(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
     group = FlexibleForeignKey("sentry.Group", unique=True)

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedPositiveIntegerField,
@@ -37,6 +38,7 @@ class GroupSnooze(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     group = FlexibleForeignKey("sentry.Group", unique=True)
     until = models.DateTimeField(null=True)

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedPositiveIntegerField,
@@ -174,6 +175,7 @@ class GroupSubscription(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", related_name="subscription_set")
     group = FlexibleForeignKey("sentry.Group", related_name="subscription_set")

--- a/src/sentry/models/grouptombstone.py
+++ b/src/sentry/models/grouptombstone.py
@@ -2,6 +2,7 @@ import logging
 
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import LOG_LEVELS, MAX_CULPRIT_LENGTH
 from sentry.db.models import (
     BoundedBigIntegerField,
@@ -18,6 +19,7 @@ TOMBSTONE_FIELDS_FROM_GROUP = ("project_id", "level", "message", "culprit", "dat
 @region_silo_only_model
 class GroupTombstone(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     previous_group_id = BoundedBigIntegerField(unique=True)
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/models/identity.py
+++ b/src/sentry/models/identity.py
@@ -9,6 +9,7 @@ from django.db.models import Q, QuerySet
 from django.utils import timezone
 
 from sentry import analytics
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     ArrayField,
     BaseManager,
@@ -49,6 +50,7 @@ class IdentityProvider(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     type = models.CharField(max_length=64)
     config = JSONField()
@@ -191,6 +193,7 @@ class Identity(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     idp = FlexibleForeignKey("sentry.IdentityProvider")
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL)

--- a/src/sentry/models/integrations/doc_integration.py
+++ b/src/sentry/models/integrations/doc_integration.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, control_silo_only_model
 from sentry.db.models.fields.jsonfield import JSONField
 
@@ -11,6 +12,7 @@ class DocIntegration(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     name = models.CharField(max_length=64)
     slug = models.CharField(max_length=64, unique=True)

--- a/src/sentry/models/integrations/external_actor.py
+++ b/src/sentry/models/integrations/external_actor.py
@@ -3,6 +3,7 @@ import logging
 from django.db import models, router, transaction
 from django.db.models.signals import post_delete, post_save
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
     DefaultFieldsModel,
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 @region_silo_only_model
 class ExternalActor(DefaultFieldsModel):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     actor = FlexibleForeignKey("sentry.Actor", db_index=True, on_delete=models.CASCADE)
     team = FlexibleForeignKey("sentry.Team", null=True, db_index=True, on_delete=models.CASCADE)

--- a/src/sentry/models/integrations/external_issue.py
+++ b/src/sentry/models/integrations/external_issue.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.db.models import QuerySet
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
@@ -70,6 +71,7 @@ class ExternalIssueManager(BaseManager):
 @region_silo_only_model
 class ExternalIssue(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     # The foreign key here is an `int`, not `bigint`.
     organization = FlexibleForeignKey("sentry.Organization", db_constraint=False)

--- a/src/sentry/models/integrations/integration.py
+++ b/src/sentry/models/integrations/integration.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, List
 
 from django.db import IntegrityError, models, router, transaction
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
     BoundedPositiveIntegerField,
@@ -46,6 +47,7 @@ class Integration(DefaultFieldsModel):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     provider = models.CharField(max_length=64)
     external_id = models.CharField(max_length=64)

--- a/src/sentry/models/integrations/integration_external_project.py
+++ b/src/sentry/models/integrations/integration_external_project.py
@@ -1,12 +1,14 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedPositiveIntegerField, Model, control_silo_only_model
 
 
 @control_silo_only_model
 class IntegrationExternalProject(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_integration_id = BoundedPositiveIntegerField(db_index=True)
     date_updated = models.DateTimeField(default=timezone.now)

--- a/src/sentry/models/integrations/integration_feature.py
+++ b/src/sentry/models/integrations/integration_feature.py
@@ -7,6 +7,7 @@ from typing import List, Union
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -180,6 +181,7 @@ class IntegrationFeatureManager(BaseManager):
 @control_silo_only_model
 class IntegrationFeature(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     objects = IntegrationFeatureManager()
 

--- a/src/sentry/models/integrations/organization_integration.py
+++ b/src/sentry/models/integrations/organization_integration.py
@@ -4,6 +4,7 @@ from typing import Any, List, Mapping, TypedDict
 
 from django.db import models, router, transaction
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
     BoundedPositiveIntegerField,
@@ -20,6 +21,7 @@ from sentry.types.region import find_regions_for_orgs
 @control_silo_only_model
 class OrganizationIntegration(DefaultFieldsModel):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = HybridCloudForeignKey("sentry.Organization", on_delete="cascade")
     integration = FlexibleForeignKey("sentry.Integration")

--- a/src/sentry/models/integrations/project_integration.py
+++ b/src/sentry/models/integrations/project_integration.py
@@ -1,3 +1,4 @@
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.fields.jsonfield import JSONField
@@ -11,6 +12,7 @@ class ProjectIntegration(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
     integration_id = HybridCloudForeignKey("sentry.Integration", on_delete="CASCADE")

--- a/src/sentry/models/integrations/repository_project_path_config.py
+++ b/src/sentry/models/integrations/repository_project_path_config.py
@@ -1,6 +1,7 @@
 from django.db import models, router, transaction
 from django.db.models.signals import post_save
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     DefaultFieldsModel,
@@ -16,6 +17,7 @@ from sentry.models.integrations.organization_integrity_backfill_mixin import (
 @region_silo_only_model
 class RepositoryProjectPathConfig(OrganizationIntegrityBackfillMixin, DefaultFieldsModel):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     repository = FlexibleForeignKey("sentry.Repository")
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)

--- a/src/sentry/models/integrations/sentry_app.py
+++ b/src/sentry/models/integrations/sentry_app.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from django.utils.text import slugify
 from rest_framework.request import Request
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import (
     SENTRY_APP_SLUG_MAX_LENGTH,
     SentryAppInstallationStatus,
@@ -108,6 +109,7 @@ class SentryAppManager(ParanoidManager):
 @control_silo_only_model
 class SentryApp(ParanoidModel, HasApiScopes):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     application = models.OneToOneField(
         "sentry.ApiApplication", null=True, on_delete=models.SET_NULL, related_name="sentry_app"

--- a/src/sentry/models/integrations/sentry_app_component.py
+++ b/src/sentry/models/integrations/sentry_app_component.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, UUIDField, control_silo_only_model
 from sentry.db.models.fields.jsonfield import JSONField
 
@@ -7,6 +8,7 @@ from sentry.db.models.fields.jsonfield import JSONField
 @control_silo_only_model
 class SentryAppComponent(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     uuid = UUIDField(unique=True, auto_add=True)
     sentry_app = FlexibleForeignKey("sentry.SentryApp", related_name="components")

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -8,6 +8,7 @@ from django.db import models, router, transaction
 from django.db.models import OuterRef, QuerySet, Subquery
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import SentryAppInstallationStatus
 from sentry.db.models import (
     BoundedPositiveIntegerField,
@@ -98,6 +99,7 @@ class SentryAppInstallationForProviderManager(ParanoidManager):
 @control_silo_only_model
 class SentryAppInstallation(ParanoidModel):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     sentry_app = FlexibleForeignKey("sentry.SentryApp", related_name="installations")
 

--- a/src/sentry/models/integrations/sentry_app_installation_for_provider.py
+++ b/src/sentry/models/integrations/sentry_app_installation_for_provider.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, control_silo_only_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 
@@ -9,6 +10,7 @@ class SentryAppInstallationForProvider(DefaultFieldsModel):
     """Connects a sentry app installation to an organization and a provider."""
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     sentry_app_installation = FlexibleForeignKey("sentry.SentryAppInstallation")
     organization_id = HybridCloudForeignKey("sentry.Organization", on_delete="CASCADE")

--- a/src/sentry/models/integrations/sentry_app_installation_token.py
+++ b/src/sentry/models/integrations/sentry_app_installation_token.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from django.db.models import QuerySet
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BaseManager, FlexibleForeignKey, Model, control_silo_only_model
 from sentry.models import ApiToken
 
@@ -61,6 +62,7 @@ class SentryAppInstallationTokenManager(BaseManager):
 @control_silo_only_model
 class SentryAppInstallationToken(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     api_token = FlexibleForeignKey("sentry.ApiToken")
     sentry_app_installation = FlexibleForeignKey("sentry.SentryAppInstallation")

--- a/src/sentry/models/latestappconnectbuildscheck.py
+++ b/src/sentry/models/latestappconnectbuildscheck.py
@@ -1,3 +1,4 @@
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import region_silo_only_model
 
 """Database models to keep track of the App Store Connect builds for a project.
@@ -20,6 +21,7 @@ class LatestAppConnectBuildsCheck(DefaultFieldsModel):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)
 

--- a/src/sentry/models/latestreporeleaseenvironment.py
+++ b/src/sentry/models/latestreporeleaseenvironment.py
@@ -1,3 +1,4 @@
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_model, sane_repr
 
 
@@ -9,6 +10,7 @@ class LatestRepoReleaseEnvironment(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     repository_id = BoundedBigIntegerField()
     # 0 for 'all environments'

--- a/src/sentry/models/lostpasswordhash.py
+++ b/src/sentry/models/lostpasswordhash.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.urls import reverse
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, control_silo_only_model, sane_repr
 from sentry.utils.http import absolute_uri
 from sentry.utils.security import get_secure_token
@@ -17,6 +18,7 @@ if TYPE_CHECKING:
 @control_silo_only_model
 class LostPasswordHash(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL, unique=True)
     hash = models.CharField(max_length=32)

--- a/src/sentry/models/notificationaction.py
+++ b/src/sentry/models/notificationaction.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, MutableMapping, Opti
 
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, sane_repr
 from sentry.db.models.base import region_silo_only_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
@@ -152,6 +153,7 @@ class TriggerGenerator:
 @region_silo_only_model
 class NotificationActionProject(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     project = FlexibleForeignKey("sentry.Project")
     action = FlexibleForeignKey("sentry.NotificationAction")
@@ -205,6 +207,7 @@ class NotificationAction(AbstractNotificationAction):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
     __repr__ = sane_repr("id", "trigger_type", "service_type", "target_display")
 
     _trigger_types: tuple[tuple[int, str], ...] = ActionTrigger.as_choices()

--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -2,6 +2,7 @@ import sentry_sdk
 from django.conf import settings
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -33,6 +34,7 @@ class NotificationSetting(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     @property
     def scope_str(self) -> str:

--- a/src/sentry/models/notificationsettingbase.py
+++ b/src/sentry/models/notificationsettingbase.py
@@ -2,12 +2,14 @@ import sentry_sdk
 from django.conf import settings
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, DefaultFieldsModel, FlexibleForeignKey
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 
 
 class NotificationSettingBase(DefaultFieldsModel):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     scope_type = models.CharField(max_length=32, null=False)
     scope_identifier = BoundedBigIntegerField(null=False)

--- a/src/sentry/models/notificationsettingoption.py
+++ b/src/sentry/models/notificationsettingoption.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import control_silo_only_model, sane_repr
 
 from .notificationsettingbase import NotificationSettingBase
@@ -8,6 +9,7 @@ from .notificationsettingbase import NotificationSettingBase
 @control_silo_only_model
 class NotificationSettingOption(NotificationSettingBase):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/notificationsettingprovider.py
+++ b/src/sentry/models/notificationsettingprovider.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import control_silo_only_model, sane_repr
 
 from .notificationsettingbase import NotificationSettingBase
@@ -8,6 +9,7 @@ from .notificationsettingbase import NotificationSettingBase
 @control_silo_only_model
 class NotificationSettingProvider(NotificationSettingBase):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     provider = models.CharField(max_length=32, null=False)
 

--- a/src/sentry/models/options/option.py
+++ b/src/sentry/models/options/option.py
@@ -5,6 +5,7 @@ import abc
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     Model,
     OptionManager,
@@ -29,6 +30,9 @@ class BaseOption(Model):
 
     __include_in_export__ = True
 
+    # Subclasses should overwrite the relocation scope as appropriate.
+    __relocation_scope__ = RelocationScope.Excluded
+
     key = models.CharField(max_length=128, unique=True)
     last_updated = models.DateTimeField(default=timezone.now)
     last_updated_by = models.CharField(
@@ -46,6 +50,7 @@ class BaseOption(Model):
 @region_silo_only_model
 class Option(BaseOption):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     class Meta:
         app_label = "sentry"
@@ -57,6 +62,7 @@ class Option(BaseOption):
 @control_silo_only_model
 class ControlOption(BaseOption):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.picklefield import PickledObjectField
 from sentry.db.models.manager import OptionManager, ValidateFunction, Value
@@ -99,6 +100,7 @@ class OrganizationOption(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     organization = FlexibleForeignKey("sentry.Organization")
     key = models.CharField(max_length=64)

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Sequence
 from django.db import models
 
 from sentry import projectoptions
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields import PickledObjectField
 from sentry.db.models.manager import OptionManager, ValidateFunction, Value
@@ -145,6 +146,7 @@ class ProjectOption(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey("sentry.Project")
     key = models.CharField(max_length=64)

--- a/src/sentry/models/options/user_option.py
+++ b/src/sentry/models/options/user_option.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 from django.conf import settings
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, control_silo_only_model, sane_repr
 from sentry.db.models.fields import PickledObjectField
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
@@ -186,6 +187,7 @@ class UserOption(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.User
 
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL)
     project_id = HybridCloudForeignKey("sentry.Project", null=True, on_delete="CASCADE")

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -14,6 +14,7 @@ from typing_extensions import override
 from bitfield import TypedClassBitField
 from sentry import features, roles
 from sentry.app import env
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import (
     ALERTS_MEMBER_WRITE_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
@@ -165,6 +166,7 @@ class Organization(Model, OptionMixin, OrganizationAbsoluteUrlMixin, SnowflakeId
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
     name = models.CharField(max_length=64)
     slug: models.Field[str, str] = models.SlugField(unique=True)
     status = BoundedPositiveIntegerField(

--- a/src/sentry/models/organizationaccessrequest.py
+++ b/src/sentry/models/organizationaccessrequest.py
@@ -3,6 +3,7 @@ from django.db.models import Q
 from django.urls import reverse
 
 from sentry import roles
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.services.hybrid_cloud.user.service import user_service
@@ -11,6 +12,7 @@ from sentry.services.hybrid_cloud.user.service import user_service
 @region_silo_only_model
 class OrganizationAccessRequest(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     team = FlexibleForeignKey("sentry.Team")
     member = FlexibleForeignKey("sentry.OrganizationMember")

--- a/src/sentry/models/organizationmapping.py
+++ b/src/sentry/models/organizationmapping.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.utils import timezone
 
 from sentry import roles
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model, sane_repr
 from sentry.db.models.base import control_silo_only_model
 from sentry.models.organization import OrganizationStatus
@@ -21,6 +22,10 @@ class OrganizationMapping(Model):
     """
 
     __include_in_export__ = True
+
+    # This model is "autocreated" via an outbox write from the regional `Organization` it
+    # references, so there is no need to explicitly include it in the export.
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True, unique=True)
     slug = models.SlugField(unique=True)

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -20,6 +20,7 @@ from structlog import get_logger
 
 from bitfield.models import typed_dict_bitfield
 from sentry import features, roles
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
@@ -197,6 +198,7 @@ class OrganizationMember(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     objects = OrganizationMemberManager()
 

--- a/src/sentry/models/organizationmembermapping.py
+++ b/src/sentry/models/organizationmembermapping.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, FlexibleForeignKey, Model, sane_repr
 from sentry.db.models.base import control_silo_only_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
@@ -19,6 +20,10 @@ class OrganizationMemberMapping(Model):
     """
 
     __include_in_export__ = False
+
+    # This model is "autocreated" via an outbox write from the regional `Organization` it
+    # references, so there is no need to explicitly include it in the export.
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = HybridCloudForeignKey("sentry.Organization", on_delete="CASCADE")
     organizationmember_id = BoundedBigIntegerField(db_index=True, null=True)

--- a/src/sentry/models/organizationmemberteam.py
+++ b/src/sentry/models/organizationmemberteam.py
@@ -3,6 +3,7 @@ from typing import FrozenSet
 from django.db import models
 
 from sentry import features, roles
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseModel,
     BoundedAutoField,
@@ -21,6 +22,7 @@ class OrganizationMemberTeam(BaseModel):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     id = BoundedAutoField(primary_key=True)
     team = FlexibleForeignKey("sentry.Team")

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedPositiveIntegerField,
@@ -82,6 +83,7 @@ class AbstractOnboardingTask(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     STATUS_CHOICES = (
         (OnboardingTaskStatus.COMPLETE, "complete"),

--- a/src/sentry/models/orgauthtoken.py
+++ b/src/sentry/models/orgauthtoken.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.encoding import force_str
 
+from sentry.backup.scopes import RelocationScope
 from sentry.conf.server import SENTRY_SCOPES
 from sentry.db.models import (
     ArrayField,
@@ -27,6 +28,7 @@ def validate_scope_list(value):
 @control_silo_only_model
 class OrgAuthToken(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     organization_id = HybridCloudForeignKey("sentry.Organization", null=False, on_delete="CASCADE")
     # The JWT token in hashed form

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -19,6 +19,7 @@ from django.utils import timezone
 from sentry_sdk.tracing import Span
 from typing_extensions import Self
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -209,6 +210,7 @@ class OutboxBase(Model):
         abstract = True
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     # Different shard_scope, shard_identifier pairings of messages are always deliverable in parallel
     shard_scope = BoundedPositiveIntegerField(choices=OutboxScope.as_choices(), null=False)

--- a/src/sentry/models/platformexternalissue.py
+++ b/src/sentry/models/platformexternalissue.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.foreignkey import FlexibleForeignKey
 
@@ -10,6 +11,7 @@ from sentry.db.models.fields.foreignkey import FlexibleForeignKey
 @region_silo_only_model
 class PlatformExternalIssue(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     group = FlexibleForeignKey("sentry.Group", db_constraint=False, db_index=False)
     project = FlexibleForeignKey("sentry.Project", null=True, db_constraint=False)

--- a/src/sentry/models/processingissue.py
+++ b/src/sentry/models/processingissue.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.db.models.aggregates import Count
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
@@ -125,6 +126,7 @@ class ProcessingIssueManager(BaseManager):
 @region_silo_only_model
 class ProcessingIssue(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", db_index=True)
     checksum = models.CharField(max_length=40, db_index=True)
@@ -153,6 +155,7 @@ class ProcessingIssue(Model):
 @region_silo_only_model
 class EventProcessingIssue(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     raw_event = FlexibleForeignKey("sentry.RawEvent")
     processing_issue = FlexibleForeignKey("sentry.ProcessingIssue")

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -18,6 +18,7 @@ from django.utils.translation import gettext_lazy as _
 
 from bitfield import TypedClassBitField
 from sentry import projectoptions
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import RESERVED_PROJECT_SLUGS, ObjectStatus
 from sentry.db.mixin import PendingDeletionMixin, delete_pending_deletion_option
 from sentry.db.models import (
@@ -212,6 +213,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     slug = models.SlugField(null=True)
     # DEPRECATED do not use, prefer slug

--- a/src/sentry/models/projectbookmark.py
+++ b/src/sentry/models/projectbookmark.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
@@ -20,6 +21,7 @@ class ProjectBookmark(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey(Project, blank=True, null=True, db_constraint=False)
     user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE")

--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
 from sentry import analytics
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, JSONField, Model, region_silo_only_model, sane_repr
 from sentry.models.organization import Organization
 from sentry.ownership.grammar import convert_codeowners_syntax, create_schema_from_issue_owners
@@ -22,6 +23,7 @@ READ_CACHE_DURATION = 3600
 class ProjectCodeOwners(Model):
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
     # no db constraint to prevent locks on the Project table
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)
     # repository_project_path_config ⇒ use this to transform CODEOWNERS paths to stacktrace paths

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_lazy as _
 
 from bitfield import TypedClassBitField
 from sentry import features, options
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedPositiveIntegerField,
@@ -50,6 +51,7 @@ class ProjectKeyManager(BaseManager):
 @region_silo_only_model
 class ProjectKey(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey("sentry.Project", related_name="key_set")
     label = models.CharField(max_length=64, blank=True, null=True)

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -9,6 +9,7 @@ from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
 from sentry import features
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields import FlexibleForeignKey, JSONField
 from sentry.models import Activity, ActorTuple
@@ -33,6 +34,7 @@ _Everyone = enum.Enum("_Everyone", "EVERYONE")
 @region_silo_only_model
 class ProjectOwnership(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey("sentry.Project", unique=True)
     raw = models.TextField(null=True)

--- a/src/sentry/models/projectplatform.py
+++ b/src/sentry/models/projectplatform.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_model, sane_repr
 
 
@@ -13,6 +14,7 @@ class ProjectPlatform(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField()
     platform = models.CharField(max_length=64)

--- a/src/sentry/models/projectredirect.py
+++ b/src/sentry/models/projectredirect.py
@@ -1,12 +1,14 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model
 
 
 @region_silo_only_model
 class ProjectRedirect(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     redirect_slug = models.SlugField(db_index=True)
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Sequence
 from django.db import router, transaction
 from django.db.models.signals import post_delete, post_save
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
     BaseManager,
@@ -39,6 +40,7 @@ class ProjectTeamManager(BaseManager):
 @region_silo_only_model
 class ProjectTeam(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     project = FlexibleForeignKey("sentry.Project")
     team = FlexibleForeignKey("sentry.Team")

--- a/src/sentry/models/promptsactivity.py
+++ b/src/sentry/models/promptsactivity.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     JSONField,
@@ -17,6 +18,7 @@ class PromptsActivity(Model):
     """Records user interaction with various feature prompts in product"""
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     # Not a Foreign Key because it's no longer safe to take out lock on Project table in Prod

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedBigIntegerField,
@@ -51,6 +52,7 @@ class PullRequestManager(BaseManager):
 @region_silo_only_model
 class PullRequest(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     repository_id = BoundedPositiveIntegerField()
@@ -82,6 +84,7 @@ class PullRequest(Model):
 @region_silo_only_model
 class PullRequestCommit(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
     pull_request = FlexibleForeignKey("sentry.PullRequest")
     commit = FlexibleForeignKey("sentry.Commit")
 
@@ -103,6 +106,7 @@ class CommentType:
 @region_silo_only_model
 class PullRequestComment(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     external_id = BoundedBigIntegerField()
     pull_request = FlexibleForeignKey("sentry.PullRequest")

--- a/src/sentry/models/rawevent.py
+++ b/src/sentry/models/rawevent.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, NodeField, region_silo_only_model, sane_repr
 from sentry.db.models.manager import BaseManager
 from sentry.utils.canonical import CanonicalKeyView
@@ -13,6 +14,7 @@ def ref_func(x):
 @region_silo_only_model
 class RawEvent(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
     event_id = models.CharField(max_length=32, null=True)

--- a/src/sentry/models/recentsearch.py
+++ b/src/sentry/models/recentsearch.py
@@ -3,6 +3,7 @@ from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.utils.hashlib import md5_text
@@ -17,6 +18,7 @@ class RecentSearch(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     organization = FlexibleForeignKey("sentry.Organization")
     user_id = HybridCloudForeignKey("sentry.User", db_index=False, on_delete="CASCADE")

--- a/src/sentry/models/relay.py
+++ b/src/sentry/models/relay.py
@@ -3,12 +3,14 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from sentry_relay.auth import PublicKey
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, region_silo_only_model
 
 
 @region_silo_only_model
 class RelayUsage(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     relay_id = models.CharField(max_length=64)
     version = models.CharField(max_length=32, default="0.0.1")
@@ -25,6 +27,7 @@ class RelayUsage(Model):
 @region_silo_only_model
 class Relay(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     relay_id = models.CharField(max_length=64, unique=True)
     public_key = models.CharField(max_length=200)

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -18,6 +18,7 @@ from sentry_relay.exceptions import RelayError
 from sentry_relay.processing import parse_release
 
 from sentry import features
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import BAD_RELEASE_CHARS, COMMIT_RANGE_DELIMITER, ObjectStatus
 from sentry.db.models import (
     ArrayField,
@@ -98,6 +99,7 @@ class ReleaseProjectModelManager(BaseManager):
 @region_silo_only_model
 class ReleaseProject(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
     release = FlexibleForeignKey("sentry.Release")
@@ -459,6 +461,7 @@ class Release(Model):
     """
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization = FlexibleForeignKey("sentry.Organization")
     projects = models.ManyToManyField(

--- a/src/sentry/models/releaseactivity.py
+++ b/src/sentry/models/releaseactivity.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
@@ -13,6 +14,7 @@ from sentry.types.releaseactivity import CHOICES
 @region_silo_only_model
 class ReleaseActivity(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     release = FlexibleForeignKey("sentry.Release", db_index=True)
     type = BoundedPositiveIntegerField(null=False, choices=CHOICES)

--- a/src/sentry/models/releasecommit.py
+++ b/src/sentry/models/releasecommit.py
@@ -1,3 +1,4 @@
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -11,6 +12,7 @@ from sentry.db.models import (
 @region_silo_only_model
 class ReleaseCommit(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     # DEPRECATED

--- a/src/sentry/models/releaseenvironment.py
+++ b/src/sentry/models/releaseenvironment.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     FlexibleForeignKey,
@@ -17,6 +18,7 @@ from sentry.utils.cache import cache
 @region_silo_only_model
 class ReleaseEnvironment(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization = FlexibleForeignKey("sentry.Organization", db_index=True, db_constraint=False)
     # DEPRECATED

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -16,6 +16,7 @@ from django.core.files.base import File as FileObj
 from django.db import models, router
 
 from sentry import options
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedBigIntegerField,
@@ -66,6 +67,7 @@ class ReleaseFile(Model):
     sha1(name '\x00\x00' dist.name) and must be unique per release.
     """
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField()
     # DEPRECATED

--- a/src/sentry/models/releaseheadcommit.py
+++ b/src/sentry/models/releaseheadcommit.py
@@ -1,3 +1,4 @@
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -11,6 +12,7 @@ from sentry.db.models import (
 @region_silo_only_model
 class ReleaseHeadCommit(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
     repository_id = BoundedPositiveIntegerField()

--- a/src/sentry/models/releaseprojectenvironment.py
+++ b/src/sentry/models/releaseprojectenvironment.py
@@ -4,6 +4,7 @@ from enum import Enum
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
@@ -24,6 +25,7 @@ class ReleaseStages(str, Enum):
 @region_silo_only_model
 class ReleaseProjectEnvironment(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     release = FlexibleForeignKey("sentry.Release")
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.db.models.signals import pre_delete
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.mixin import PendingDeletionMixin, delete_pending_deletion_option
 from sentry.db.models import (
@@ -21,6 +22,7 @@ from sentry.signals import pending_delete
 @region_silo_only_model
 class Repository(Model, PendingDeletionMixin):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     organization_id = BoundedBigIntegerField(db_index=True)
     name = models.CharField(max_length=200)

--- a/src/sentry/models/reprocessingreport.py
+++ b/src/sentry/models/reprocessingreport.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
@@ -13,6 +14,7 @@ from sentry.db.models import (
 @region_silo_only_model
 class ReprocessingReport(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")
     event_id = models.CharField(max_length=32, null=True)

--- a/src/sentry/models/rule.py
+++ b/src/sentry/models/rule.py
@@ -4,6 +4,7 @@ from typing import Sequence, Tuple
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
     BoundedPositiveIntegerField,
@@ -33,6 +34,7 @@ class RuleSource(IntEnum):
 @region_silo_only_model
 class Rule(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     DEFAULT_CONDITION_MATCH = "all"  # any, all
     DEFAULT_FILTER_MATCH = "all"  # match to apply on filters
@@ -120,6 +122,7 @@ class RuleActivityType(Enum):
 @region_silo_only_model
 class RuleActivity(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     rule = FlexibleForeignKey("sentry.Rule")
     user_id = HybridCloudForeignKey("sentry.User", on_delete="SET_NULL", null=True)

--- a/src/sentry/models/rulefirehistory.py
+++ b/src/sentry/models/rulefirehistory.py
@@ -2,12 +2,14 @@ from django.db.models import DateTimeField, Index
 from django.db.models.fields import UUIDField
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import CharField, FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 
 
 @region_silo_only_model
 class RuleFireHistory(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)
     rule = FlexibleForeignKey("sentry.Rule")

--- a/src/sentry/models/rulesnooze.py
+++ b/src/sentry/models/rulesnooze.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.db.models import CheckConstraint, Q, UniqueConstraint
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
@@ -33,6 +34,7 @@ class RuleSnooze(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     user_id = HybridCloudForeignKey("sentry.User", on_delete="CASCADE", null=True)
     owner_id = HybridCloudForeignKey("sentry.User", on_delete="SET_NULL", null=True)

--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -5,6 +5,7 @@ from django.db.models import Q, UniqueConstraint
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.fields.text import CharField
@@ -55,6 +56,7 @@ class SavedSearch(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
     organization = FlexibleForeignKey("sentry.Organization", null=True)
     type = models.PositiveSmallIntegerField(default=SearchType.ISSUE.value, null=True)
     name = models.CharField(max_length=128)

--- a/src/sentry/models/scheduledeletion.py
+++ b/src/sentry/models/scheduledeletion.py
@@ -9,6 +9,7 @@ from django.apps import apps
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     JSONField,
@@ -47,6 +48,7 @@ class BaseScheduledDeletion(Model):
         abstract = True
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     guid = models.CharField(max_length=32, unique=True, default=default_guid)
     app_label = models.CharField(max_length=64)

--- a/src/sentry/models/sentryfunction.py
+++ b/src/sentry/models/sentryfunction.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     DefaultFieldsModel,
@@ -19,6 +20,7 @@ class SentryFunctionManager(BaseManager):
 @region_silo_only_model
 class SentryFunction(DefaultFieldsModel):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     organization = FlexibleForeignKey("sentry.Organization")
     name = models.TextField()

--- a/src/sentry/models/servicehook.py
+++ b/src/sentry/models/servicehook.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
     ArrayField,
@@ -32,6 +33,7 @@ SERVICE_HOOK_EVENTS = [
 @region_silo_only_model
 class ServiceHookProject(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     service_hook = FlexibleForeignKey("sentry.ServiceHook")
     project_id = BoundedBigIntegerField(db_index=True)
@@ -51,6 +53,7 @@ def generate_secret():
 @region_silo_only_model
 class ServiceHook(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Global
 
     guid = models.CharField(max_length=32, unique=True, null=True)
     # hooks may be bound to an api application, or simply registered by a user

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from sentry.app import env
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
     BaseManager,
@@ -157,6 +158,7 @@ class Team(Model, SnowflakeIdMixin):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     organization = FlexibleForeignKey("sentry.Organization")
     slug = models.SlugField()

--- a/src/sentry/models/tombstone.py
+++ b/src/sentry/models/tombstone.py
@@ -5,6 +5,7 @@ from typing import Type
 from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     Model,
@@ -29,6 +30,7 @@ class TombstoneBase(Model):
         unique_together = ("table_name", "object_identifier")
 
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     table_name = models.CharField(max_length=48, null=False)
     object_identifier = BoundedBigIntegerField(null=False)

--- a/src/sentry/models/transaction_threshold.py
+++ b/src/sentry/models/transaction_threshold.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo_only_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.utils.cache import cache
@@ -53,6 +54,7 @@ def _filter_and_cache(cls, cache_key, project_ids, organization_id, order_by, va
 @region_silo_only_model
 class ProjectTransactionThresholdOverride(DefaultFieldsModel):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     # max_length here is based on the maximum for transactions in relay
     transaction = models.CharField(max_length=200)
@@ -83,6 +85,7 @@ class ProjectTransactionThresholdOverride(DefaultFieldsModel):
 @region_silo_only_model
 class ProjectTransactionThreshold(DefaultFieldsModel):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", unique=True, db_constraint=False)
     organization = FlexibleForeignKey("sentry.Organization")

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -15,6 +15,7 @@ from django.utils.translation import gettext_lazy as _
 
 from bitfield import TypedClassBitField
 from sentry.auth.authenticators import available_authenticators
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     BaseModel,
@@ -69,6 +70,7 @@ class UserManager(BaseManager, DjangoUserManager):
 @control_silo_only_model
 class User(BaseModel, AbstractBaseUser):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.User
 
     id = BoundedBigAutoField(primary_key=True)
     username = models.CharField(_("username"), max_length=128, unique=True)

--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
@@ -45,6 +46,7 @@ class UserEmailManager(BaseManager):
 @control_silo_only_model
 class UserEmail(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.User
 
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL, related_name="emails")
     email = models.EmailField(_("email address"), max_length=75)

--- a/src/sentry/models/userip.py
+++ b/src/sentry/models/userip.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, control_silo_only_model, sane_repr
 from sentry.models import User
 from sentry.services.hybrid_cloud.log import UserIpEvent, log_service
@@ -15,6 +16,7 @@ from sentry.utils.geo import geo_by_addr
 @control_silo_only_model
 class UserIP(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.User
 
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL)
     ip_address = models.GenericIPAddressField()

--- a/src/sentry/models/userpermission.py
+++ b/src/sentry/models/userpermission.py
@@ -2,6 +2,7 @@ from typing import FrozenSet
 
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, control_silo_only_model, sane_repr
 
 
@@ -14,6 +15,7 @@ class UserPermission(Model):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.User
 
     user = FlexibleForeignKey("sentry.User")
     # permissions should be in the form of 'service-name.permission-name'

--- a/src/sentry/models/userreport.py
+++ b/src/sentry/models/userreport.py
@@ -1,12 +1,14 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_model, sane_repr
 
 
 @region_silo_only_model
 class UserReport(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField(db_index=True)
     group_id = BoundedBigIntegerField(null=True, db_index=True)

--- a/src/sentry/models/userrole.py
+++ b/src/sentry/models/userrole.py
@@ -3,6 +3,7 @@ from typing import FrozenSet
 from django.conf import settings
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import ArrayField, DefaultFieldsModel, control_silo_only_model, sane_repr
 from sentry.db.models.fields.foreignkey import FlexibleForeignKey
 from sentry.signals import post_upgrade
@@ -16,6 +17,7 @@ class UserRole(DefaultFieldsModel):
     """
 
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.User
 
     name = models.CharField(max_length=32, unique=True)
     permissions = ArrayField()
@@ -42,6 +44,7 @@ class UserRole(DefaultFieldsModel):
 @control_silo_only_model
 class UserRoleUser(DefaultFieldsModel):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.User
 
     user = FlexibleForeignKey("sentry.User")
     role = FlexibleForeignKey("sentry.UserRole")

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -14,6 +14,7 @@ from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
     BaseManager,
@@ -208,6 +209,7 @@ class ScheduleType:
 @region_silo_only_model
 class Monitor(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     guid = UUIDField(unique=True, auto_add=True)
     slug = models.SlugField()
@@ -357,6 +359,7 @@ def check_organization_monitor_limits(sender, instance, **kwargs):
 @region_silo_only_model
 class MonitorCheckIn(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     guid = UUIDField(unique=True, auto_add=True)
     project_id = BoundedBigIntegerField(db_index=True)
@@ -452,6 +455,7 @@ class MonitorCheckIn(Model):
 @region_silo_only_model
 class MonitorLocation(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     guid = UUIDField(unique=True, auto_add=True)
     name = models.CharField(max_length=128)
@@ -490,6 +494,7 @@ class MonitorEnvironmentManager(BaseManager):
 @region_silo_only_model
 class MonitorEnvironment(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     monitor = FlexibleForeignKey("sentry.Monitor")
     environment = FlexibleForeignKey("sentry.Environment")

--- a/src/sentry/nodestore/django/models.py
+++ b/src/sentry/nodestore/django/models.py
@@ -1,12 +1,14 @@
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BaseModel, region_silo_only_model, sane_repr
 
 
 @region_silo_only_model
 class Node(BaseModel):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     id = models.CharField(max_length=40, primary_key=True)
     # TODO(dcramer): this being pickle and not JSON has the ability to cause

--- a/src/sentry/replays/models.py
+++ b/src/sentry/replays/models.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.bounded import BoundedIntegerField, BoundedPositiveIntegerField
 
@@ -10,6 +11,7 @@ from sentry.db.models.fields.bounded import BoundedIntegerField, BoundedPositive
 @region_silo_only_model
 class ReplayRecordingSegment(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     project_id = BoundedBigIntegerField()
     replay_id = models.CharField(max_length=32, db_index=True)

--- a/src/sentry/sentry_metrics/indexer/postgres/models.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/models.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.db import connections, models, router
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, region_silo_only_model
 from sentry.db.models.fields.bounded import BoundedBigIntegerField
 from sentry.db.models.manager.base import BaseManager
@@ -18,6 +19,7 @@ from typing import Mapping, Type
 @region_silo_only_model
 class MetricsKeyIndexer(Model):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     string = models.CharField(max_length=200)
     date_added = models.DateTimeField(default=timezone.now)
@@ -60,6 +62,7 @@ class BaseIndexer(Model):
 @region_silo_only_model
 class StringIndexer(BaseIndexer):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     class Meta:
         db_table = "sentry_stringindexer"
@@ -72,6 +75,7 @@ class StringIndexer(BaseIndexer):
 @region_silo_only_model
 class PerfStringIndexer(BaseIndexer):
     __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
     use_case_id = models.CharField(max_length=120)
 
     class Meta:

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -4,6 +4,7 @@ from enum import Enum
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model
 from sentry.db.models.base import DefaultFieldsModel
 from sentry.db.models.manager import BaseManager
@@ -23,6 +24,7 @@ query_aggregation_to_snuba = {
 @region_silo_only_model
 class SnubaQuery(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     class Type(Enum):
         ERROR = 0
@@ -51,6 +53,7 @@ class SnubaQuery(Model):
 @region_silo_only_model
 class SnubaQueryEventType(Model):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     class EventType(Enum):
         ERROR = 0
@@ -73,6 +76,7 @@ class SnubaQueryEventType(Model):
 @region_silo_only_model
 class QuerySubscription(DefaultFieldsModel):
     __include_in_export__ = True
+    __relocation_scope__ = RelocationScope.Organization
 
     class Status(Enum):
         ACTIVE = 0

--- a/tests/sentry/db/models/fields/test_bounded.py
+++ b/tests/sentry/db/models/fields/test_bounded.py
@@ -1,6 +1,7 @@
 import pytest
 from django.db import models
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedIntegerField,
@@ -13,7 +14,8 @@ from sentry.testutils.cases import TestCase
 # There's a good chance this model wont get created in the db, so avoid
 # assuming it exists in these tests.
 class DummyModel(Model):
-    __include_in_export__ = False  # needs defined for Sentry to not yell at you
+    __include_in_export__ = False
+    __relocation_scope__ = RelocationScope.Excluded
 
     foo = models.CharField(max_length=32)
     normint = BoundedIntegerField(null=True)

--- a/tests/sentry/models/test_base.py
+++ b/tests/sentry/models/test_base.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 from django.test import override_settings
 from pytest import raises
 
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models.base import Model, ModelSiloLimit, get_model_if_available
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
@@ -11,6 +12,7 @@ from sentry.testutils.cases import TestCase
 class AvailableOnTest(TestCase):
     class TestModel(Model):
         __include_in_export__ = False
+        __relocation_scope__ = RelocationScope.Excluded
 
         class Meta:
             abstract = True


### PR DESCRIPTION
This is part of a 4-step migration process, wherein we replace all use of `__include_in_export__` with the more specific and useful `__relocation_scope__`:

1. Define the new `ReloationScope` enum.
2. Add the appropriate enum value to `__relocation_scope__` on all models (<- you are here)
3. Replace all code that interacts with `__include_in_export__` with code that uses `__relocation_scope__` in the same way.
4. Remove all uses of `__include_in_export__`.

Issue: getsentry/team-ospo#166