### PR TITLE
ref(backup): Swap include_in_exports -> relocation_scope (3/4)

### DIFF
--- a/fixtures/backup/fresh-install.json
+++ b/fixtures/backup/fresh-install.json
@@ -94,21 +94,6 @@
   }
 },
 {
-  "model": "sentry.organizationmapping",
-  "pk": 1,
-  "fields": {
-    "organization_id": 1,
-    "slug": "testing",
-    "name": "Testing",
-    "date_created": "2023-06-22T22:54:29.123Z",
-    "customer_id": null,
-    "verified": true,
-    "idempotency_key": "",
-    "region_name": "--monolith--",
-    "status": 0
-  }
-},
-{
   "model": "sentry.relayusage",
   "pk": 1,
   "fields": {

--- a/src/sentry/backup/helpers.py
+++ b/src/sentry/backup/helpers.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from enum import Enum
 from typing import Type
 
+from sentry.backup.scopes import RelocationScope
+
 # Django apps we take care to never import or export from.
 EXCLUDED_APPS = frozenset(("auth", "contenttypes", "fixtures"))
 
@@ -24,11 +26,11 @@ def get_final_derivations_of(model: Type) -> set[Type]:
 
 def get_exportable_final_derivations_of(model: Type) -> set[Type]:
     """Like `get_final_derivations_of`, except that it further filters the results to include only
-    `__include_in_export__ = True`."""
+    `__relocation_scope__ != RelocationScope.Excluded`."""
 
     return set(
         filter(
-            lambda c: getattr(c, "__include_in_export__") is True,
+            lambda c: getattr(c, "__relocation_scope__") is not RelocationScope.Excluded,
             get_final_derivations_of(model),
         )
     )

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -129,9 +129,9 @@ def __model_class_prepared(sender: Any, **kwargs: Any) -> None:
     if not issubclass(sender, BaseModel):
         return
 
-    if not hasattr(sender, "__include_in_export__"):
+    if not hasattr(sender, "__relocation_scope__"):
         raise ValueError(
-            f"{sender!r} model has not defined __include_in_export__. This is used to determine "
+            f"{sender!r} model has not defined __relocation_scope__. This is used to determine "
             f"which models we export from sentry as part of our migration workflow: \n"
             f"https://docs.sentry.io/product/sentry-basics/migration/#3-export-your-data.\n"
             f"This should be True for core, low volume models used to configure Sentry. Things like "

--- a/tests/sentry/backup/__init__.py
+++ b/tests/sentry/backup/__init__.py
@@ -13,7 +13,7 @@ def targets(expected_models: list[Type]):
     """A helper decorator that checks that every model that a test "targeted" was actually seen in
     the output, ensuring that we're actually testing the thing we think we are. Additionally, this
     decorator is easily legible to static analysis, which allows for static checks to ensure that
-    all `__include_in_export__ = True` models are being tested.
+    all `__relocation_scope__ != RelocationScope.Excluded` models are being tested.
 
     To be considered a proper "testing" of a given target type, the resulting output must contain at
     least one instance of that type with all of its fields present and set to non-default values."""

--- a/tests/sentry/backup/test_invariants.py
+++ b/tests/sentry/backup/test_invariants.py
@@ -11,7 +11,7 @@ from sentry.db.models import BaseModel
 def test_all_final_derivations_of_django_model_set_included_in_export():
     missing = set(
         filter(
-            lambda c: not hasattr(c, "__include_in_export__"),
+            lambda c: not hasattr(c, "__relocation_scope__"),
             get_final_derivations_of(BaseModel),
         )
     )


### PR DESCRIPTION
This is part of a 4-step migration process, wherein we replace all use of `__include_in_export__` with the more specific and useful `__relocation_scope__`:

1. Define the new `ReloationScope` enum.
2. Add the appropriate enum value to `__relocation_scope__` on all models
3. Replace all code that interacts with `__include_in_export__` with code that uses `__relocation_scope__` in the same way. (<- you are here)
4. Remove all uses of `__include_in_export__`.

Issue: getsentry/team-ospo#166