### PR TITLE
feat(tracing-w/o-performance): Trace Navigator for orphanerrors and moving adopted error flameicons to parent rectangle.

### DIFF
--- a/static/app/components/performance/waterfall/rowDivider.tsx
+++ b/static/app/components/performance/waterfall/rowDivider.tsx
@@ -49,7 +49,7 @@ export const DividerLineGhostContainer = styled('div')`
   height: 100%;
 `;
 
-export const BadgeBorder = styled('div')<{
+const BadgeBorder = styled('div')<{
   color: Color | keyof Aliases;
   fillBackground?: boolean;
 }>`

--- a/static/app/components/performance/waterfall/rowDivider.tsx
+++ b/static/app/components/performance/waterfall/rowDivider.tsx
@@ -49,7 +49,7 @@ export const DividerLineGhostContainer = styled('div')`
   height: 100%;
 `;
 
-const BadgeBorder = styled('div')<{
+export const BadgeBorder = styled('div')<{
   color: Color | keyof Aliases;
   fillBackground?: boolean;
 }>`

--- a/static/app/components/quickTrace/index.tsx
+++ b/static/app/components/quickTrace/index.tsx
@@ -78,16 +78,23 @@ export default function QuickTrace({
   transactionDest,
 }: QuickTraceProps) {
   let parsedQuickTrace;
+  const noTrace = <Fragment>{'\u2014'}</Fragment>;
   try {
     if (quickTrace.orphanErrors && quickTrace.orphanErrors.length > 0) {
+      const orphanError = quickTrace.orphanErrors.find(e => e.event_id === event.id);
+
+      if (!orphanError) {
+        return noTrace;
+      }
+
       parsedQuickTrace = {
-        current: quickTrace.orphanErrors.find(e => e.event_id === event.id),
+        current: orphanError,
       };
     } else {
       parsedQuickTrace = parseQuickTrace(quickTrace, event, organization);
     }
   } catch (error) {
-    return <Fragment>{'\u2014'}</Fragment>;
+    return noTrace;
   }
 
   const traceLength =

--- a/static/app/components/quickTrace/index.tsx
+++ b/static/app/components/quickTrace/index.tsx
@@ -162,7 +162,7 @@ export default function QuickTrace({
       anchor={anchor}
       nodeKey="current"
       errorDest={errorDest}
-      isOrphanErrorNode={isTraceError(current)}
+      isOrphanErrorNode={traceLength === 1 && isTraceError(current)}
       transactionDest={transactionDest}
     />
   );

--- a/static/app/components/quickTrace/index.tsx
+++ b/static/app/components/quickTrace/index.tsx
@@ -614,7 +614,7 @@ class MissingServiceNode extends Component<MissingServiceProps, MissingServiceSt
         : `https://docs.sentry.io/platforms/${docPlatform}/performance/connect-services`;
     return (
       <Fragment>
-        {connectorSide === 'left' && <TraceConnector />}
+        {connectorSide === 'left' && <TraceConnector dashed />}
         <DropdownContainer>
           <DropdownLink
             caret={false}
@@ -637,7 +637,7 @@ class MissingServiceNode extends Component<MissingServiceProps, MissingServiceSt
             </DropdownItem>
           </DropdownLink>
         </DropdownContainer>
-        {connectorSide === 'right' && <TraceConnector />}
+        {connectorSide === 'right' && <TraceConnector dashed />}
       </Fragment>
     );
   }

--- a/static/app/components/quickTrace/styles.tsx
+++ b/static/app/components/quickTrace/styles.tsx
@@ -56,9 +56,9 @@ export const EventNode = styled(Tag)`
   }
 `;
 
-export const TraceConnector = styled('div')`
+export const TraceConnector = styled('div')<{dashed?: boolean}>`
   width: ${space(1)};
-  border-top: 1px solid ${p => p.theme.textColor};
+  border-top: 1px ${p => (p.dashed ? 'dashed' : 'solid')} ${p => p.theme.textColor};
 `;
 
 /**

--- a/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
+++ b/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
@@ -80,7 +80,7 @@ export default function QuickTraceQuery({children, event, ...props}: QueryProps)
               if (orphanError) {
                 return children({
                   ...traceFullResults,
-                  trace: null,
+                  trace: [],
                   orphanErrors: [orphanError],
                   currentEvent: orphanError,
                 });

--- a/static/app/utils/performance/quickTrace/types.tsx
+++ b/static/app/utils/performance/quickTrace/types.tsx
@@ -32,6 +32,7 @@ export type TraceError = {
   project_slug: string;
   span: string;
   title: string;
+  event_type?: string;
   generation?: number;
   timestamp?: number;
 };
@@ -99,16 +100,19 @@ export type TraceRequestProps = DiscoverQueryProps & TraceProps;
 export type EmptyQuickTrace = {
   trace: QuickTraceEvent[];
   type: 'empty' | 'missing';
+  orphanErrors?: TraceError[];
 };
 
 export type PartialQuickTrace = {
   trace: QuickTraceEvent[] | null;
   type: 'partial';
+  orphanErrors?: TraceError[];
 };
 
 export type FullQuickTrace = {
   trace: QuickTraceEvent[] | null;
   type: 'full';
+  orphanErrors?: TraceError[];
 };
 
 export type BaseTraceChildrenProps = Omit<
@@ -120,7 +124,7 @@ export type QuickTrace = EmptyQuickTrace | PartialQuickTrace | FullQuickTrace;
 
 export type QuickTraceQueryChildrenProps = BaseTraceChildrenProps &
   QuickTrace & {
-    currentEvent: QuickTraceEvent | null;
+    currentEvent: QuickTraceEvent | TraceError | null;
   };
 
 export type TraceMeta = {

--- a/static/app/utils/performance/quickTrace/utils.tsx
+++ b/static/app/utils/performance/quickTrace/utils.tsx
@@ -314,7 +314,7 @@ export function isTraceTransaction<U extends TraceFull | TraceFullDetailed>(
 }
 
 export function isTraceError(
-  transaction: TraceRoot | TraceError | TraceFullDetailed
+  transaction: TraceRoot | TraceError | TraceFullDetailed | QuickTraceEvent
 ): transaction is TraceError {
   return 'event_type' in transaction && transaction.event_type === 'error';
 }

--- a/static/app/utils/performance/quickTrace/utils.tsx
+++ b/static/app/utils/performance/quickTrace/utils.tsx
@@ -316,7 +316,7 @@ export function isTraceTransaction<U extends TraceFull | TraceFullDetailed>(
 export function isTraceError(
   transaction: TraceRoot | TraceError | TraceFullDetailed
 ): transaction is TraceError {
-  return 'level' in transaction;
+  return 'event_type' in transaction && transaction.event_type === 'error';
 }
 
 export function isTraceRoot(

--- a/static/app/views/issueDetails/quickTrace/issueQuickTrace.tsx
+++ b/static/app/views/issueDetails/quickTrace/issueQuickTrace.tsx
@@ -22,8 +22,8 @@ function IssueQuickTrace({event, location, organization, quickTrace}: Props) {
   const isTraceMissing =
     !quickTrace ||
     quickTrace.error ||
-    !defined(quickTrace.trace) ||
-    quickTrace.trace.length === 0;
+    ((!defined(quickTrace.trace) || quickTrace.trace.length === 0) &&
+      (!quickTrace.orphanErrors || quickTrace.orphanErrors?.length === 0));
 
   useRouteAnalyticsParams({
     trace_status: isTraceMissing

--- a/static/app/views/performance/traceDetails/transactionBar.tsx
+++ b/static/app/views/performance/traceDetails/transactionBar.tsx
@@ -25,6 +25,7 @@ import {
 } from 'sentry/components/performance/waterfall/row';
 import {DurationPill, RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {
+  BadgeBorder,
   DividerContainer,
   DividerLine,
   DividerLineGhostContainer,
@@ -501,7 +502,7 @@ class TransactionBar extends Component<Props, State> {
     const widthPercentage = duration / delta;
 
     return (
-      <RowRectangle
+      <StyledRowRectangle
         style={{
           backgroundColor: barColor,
           left: `min(${toPercent(startPercentage || 0)}, calc(100% - 1px))`,
@@ -512,17 +513,20 @@ class TransactionBar extends Component<Props, State> {
         {isTraceError(transaction) ? (
           <ErrorBadge />
         ) : (
-          <DurationPill
-            durationDisplay={getDurationDisplay({
-              left: startPercentage,
-              width: widthPercentage,
-            })}
-            showDetail={showDetail}
-          >
-            {getHumanDuration(duration)}
-          </DurationPill>
+          <Fragment>
+            {this.renderErrorBadge()}
+            <DurationPill
+              durationDisplay={getDurationDisplay({
+                left: startPercentage,
+                width: widthPercentage,
+              })}
+              showDetail={showDetail}
+            >
+              {getHumanDuration(duration)}
+            </DurationPill>
+          </Fragment>
         )}
-      </RowRectangle>
+      </StyledRowRectangle>
     );
   }
 
@@ -562,7 +566,7 @@ class TransactionBar extends Component<Props, State> {
     dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps;
     scrollbarManagerChildrenProps: ScrollbarManager.ScrollbarManagerChildrenProps;
   }) {
-    const {hasGuideAnchor, index, transaction} = this.props;
+    const {hasGuideAnchor, index} = this.props;
     const {showDetail} = this.state;
     const {dividerPosition} = dividerHandlerChildrenProps;
 
@@ -585,7 +589,6 @@ class TransactionBar extends Component<Props, State> {
         </RowCell>
         <DividerContainer>
           {this.renderDivider(dividerHandlerChildrenProps)}
-          {this.renderErrorBadge()}
         </DividerContainer>
         <RowCell
           data-test-id="transaction-row-duration"
@@ -594,8 +597,7 @@ class TransactionBar extends Component<Props, State> {
           style={{
             width: `calc(${toPercent(1 - dividerPosition)} - 0.5px)`,
             paddingTop: 0,
-            alignItems: isTraceError(transaction) ? 'normal' : 'center',
-            overflow: isTraceError(transaction) ? 'visible' : 'hidden',
+            overflow: 'visible',
           }}
           showDetail={showDetail}
           onClick={this.toggleDisplayDetail}
@@ -688,4 +690,10 @@ const StyledRow = styled(Row)`
 
 const ErrorLink = styled(Link)`
   color: ${p => p.theme.error};
+`;
+
+const StyledRowRectangle = styled(RowRectangle)`
+  ${BadgeBorder} {
+    top: -4px;
+  }
 `;

--- a/static/app/views/performance/traceDetails/transactionBar.tsx
+++ b/static/app/views/performance/traceDetails/transactionBar.tsx
@@ -25,7 +25,6 @@ import {
 } from 'sentry/components/performance/waterfall/row';
 import {DurationPill, RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {
-  BadgeBorder,
   DividerContainer,
   DividerLine,
   DividerLineGhostContainer,
@@ -693,7 +692,6 @@ const ErrorLink = styled(Link)`
 `;
 
 const StyledRowRectangle = styled(RowRectangle)`
-  ${BadgeBorder} {
-    top: -4px;
-  }
+  display: flex;
+  align-items: center;
 `;

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -63,7 +63,11 @@ export default function QuickTraceMeta({
   let body: React.ReactNode;
   let footer: React.ReactNode;
 
-  if (!traceId || !quickTrace || quickTrace.trace === null) {
+  if (
+    !traceId ||
+    !quickTrace ||
+    (quickTrace.trace === null && !quickTrace.orphanErrors)
+  ) {
     // this platform doesn't support performance don't show anything here
     if (docsLink === null) {
       return null;
@@ -83,10 +87,7 @@ export default function QuickTraceMeta({
         <ErrorBoundary mini>
           <QuickTrace
             event={event}
-            quickTrace={{
-              type: quickTrace.type,
-              trace: quickTrace.trace,
-            }}
+            quickTrace={quickTrace}
             location={location}
             organization={organization}
             anchor={anchor}


### PR DESCRIPTION
This PR aims to display trace navigator for orphan errors under the flag `organizations:performance-tracing-without-performance` and moves flame icons for representing errors and performanceissues to the rectangle representing their parent transaction in trace views.

Changes: 
- Issue Detail Trace navigator:
<img width="634" alt="Screenshot 2023-08-15 at 4 17 51 PM" src="https://github.com/getsentry/sentry/assets/60121741/e5d40509-35a8-47d5-b275-81d90b01f5cb">

- Discover Event Details navigator: 
<img width="1133" alt="Screenshot 2023-08-15 at 4 19 06 PM" src="https://github.com/getsentry/sentry/assets/60121741/0bfdc0a4-caa6-4b1b-a93d-225adef5ab1a">

Testing with yarn dev-ui:
- Issue details trace navigator: [link](https://sentry.dev.getsentry.net:7999/issues/4389116230/?project=1&query=is%3Aunresolved&referrer=issue-stream&stream_index=6)
- Discover event details trace navigator: [link](https://sentry.dev.getsentry.net:7999/discover/sentry:a303a329c9ed4e41ac05b41eae505f0f/?field=title&field=release&field=environment&field=user.display&field=timestamp&name=Integration+does+not+exist.&project=1&query=issue%3ASENTRY-14WC&sort=-timestamp&statsPeriod=90d&yAxis=count%28%29)
- Moving adopted error flame icon to parent rectangle: [link](https://sentry.dev.getsentry.net:7999/performance/trace/b076f03758d487bace9a2bffb31f3542/?pageEnd=2023-07-20T06%3A11%3A14.247&pageStart=2023-07-19T06%3A11%3A14.247)

Note:
- `QuickTraceQuery` component falls back to 'event-trace-light' results when request to 'event-trace' fails/can't be flattened to a form that's usable by `QuickTrace` component.
- 'event-trace-light` endpoint hasn't been modified to handle the case for orphan errors yet. Will be handling this in the next PR.

Context:
- We are now adding views for orphan errors in trace views.
- Part of [Tracing without performance concept.](https://www.notion.so/sentry/Tracing-without-performance-efab307eb7f64e71a04f09dc72722530)
- Performance Views for tracing without performance: [link](https://getsentry.atlassian.net/browse/PERF-2052)