### PR TITLE
ref: use build_absolute_uri instead of deprecated get_raw_uri

### DIFF
--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -399,7 +399,7 @@ class ControlOutboxBase(OutboxBase):
         return OutboxWebhookPayload(
             method=request.method,
             path=request.get_full_path(),
-            uri=request.get_raw_uri(),
+            uri=request.build_absolute_uri(),
             headers={k: v for k, v in request.headers.items()},
             body=request.body.decode(encoding="utf-8"),
         )


### PR DESCRIPTION
this method is gone in django 4.x https://github.com/django/django/pull/14331