### PR TITLE
fix(trends): Filter out empty timeseries

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -135,7 +135,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             # about having exact counts.
             return metrics_query(
                 top_event_columns,
-                query="",
+                query=user_query,
                 params=params,
                 orderby=["-count()"],
                 limit=event_limit,


### PR DESCRIPTION
In cases when we exceed the data limit, we're getting empty timeseries. The microservice throws an error when that happens since it can't parse through the data. I'll look into how to prevent empty timeseries but, in the meantime, this is a fix to stop errors from happening.

Fixes SENTRY-14T2