### PR TITLE
feat(trends): Pass top events from the client

### DIFF
--- a/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
+++ b/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
@@ -16,6 +16,7 @@ import {
   generateTrendFunctionAsString,
   getCurrentTrendFunction,
   getCurrentTrendParameter,
+  getTopTrendingEvents,
 } from 'sentry/views/performance/trends/utils';
 
 export type TrendsRequest = {
@@ -63,6 +64,15 @@ export function getTrendsRequestPayload(props: RequestProps) {
   apiPayload.trendType = eventView?.trendType || props.trendChangeType;
   apiPayload.interval = eventView?.interval;
   apiPayload.middle = eventView?.middle;
+
+  // This enables configuring the top event count for trend analysis
+  // It's not necessary to set top event count unless
+  // it's done for experimentation
+  const topEventsCountAsString = getTopTrendingEvents(props.location);
+  if (topEventsCountAsString) {
+    apiPayload.topEvents = parseInt(topEventsCountAsString, 10);
+  }
+
   return apiPayload;
 }
 

--- a/static/app/views/performance/trends/types.tsx
+++ b/static/app/views/performance/trends/types.tsx
@@ -15,6 +15,7 @@ export type TrendsQuery = EventQuery &
   LocationQuery & {
     interval?: string;
     middle?: string;
+    topEvents?: number;
     trendFunction?: string;
     trendType?: TrendChangeType;
   };

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -454,3 +454,7 @@ export function modifyTransactionNameTrendsQuery(trendView: TrendView) {
   query.setFilterValues('tpm()', ['>0.1']);
   trendView.query = query.formatString();
 }
+
+export function getTopTrendingEvents(location: Location) {
+  return decodeScalar(location?.query?.topEvents);
+}


### PR DESCRIPTION
If `topEvents` query param is present, send it to the backend