### PR TITLE
feat(alerts): on demand alert support for apdex and failure rate

### DIFF
--- a/static/app/views/alerts/rules/metric/utils/onDemandMetricAlert.tsx
+++ b/static/app/views/alerts/rules/metric/utils/onDemandMetricAlert.tsx
@@ -11,13 +11,8 @@ export function isValidOnDemandMetricAlert(
     return true;
   }
 
-  const unsupportedAggregates = [
-    AggregationKey.PERCENTILE,
-    AggregationKey.APDEX,
-    AggregationKey.FAILURE_RATE,
-  ];
-
-  return !unsupportedAggregates.some(agg => aggregate.includes(agg));
+  // On demand metric alerts do not support generic percentile aggregations
+  return !aggregate.includes(AggregationKey.PERCENTILE);
 }
 
 /**


### PR DESCRIPTION
Removes validation check for `apdex` and `failure_rate` functions for on-demand alerts. Requires #54017 