### PR TITLE
fix(discover): Show sampling alert if DS is active

### DIFF
--- a/fixtures/js-stubs/organization.js
+++ b/fixtures/js-stubs/organization.js
@@ -35,6 +35,7 @@ export function Organization(params = {}) {
     onboardingTasks: [],
     teams: [],
     projects: [],
+    isDynamicallySampled: true,
     ...params,
 
     orgRoleList: OrgRoleList(),

--- a/static/app/views/discover/sampleDataAlert.spec.tsx
+++ b/static/app/views/discover/sampleDataAlert.spec.tsx
@@ -34,4 +34,19 @@ describe('SampleDataAlert', function () {
     const {container} = render(<SampleDataAlert />);
     expect(container).toBeEmptyDOMElement();
   });
+
+  it("doesn't render when there's no dynamic sampling", function () {
+    const dismiss = jest.fn();
+    mockUseDismissAlert.mockImplementation(() => {
+      return {
+        dismiss,
+        isDismissed: false,
+      };
+    });
+    const {container} = render(<SampleDataAlert />, {
+      organization: {...TestStubs.Organization, isDynamicallySampled: false},
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/static/app/views/discover/sampleDataAlert.tsx
+++ b/static/app/views/discover/sampleDataAlert.tsx
@@ -11,13 +11,13 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 export function SampleDataAlert() {
   const user = ConfigStore.get('user');
-  const organization = useOrganization();
+  const {slug, isDynamicallySampled} = useOrganization();
 
   const {dismiss, isDismissed} = useDismissAlert({
-    key: `${organization.slug}-${user.id}:sample-data-alert-dismissed`,
+    key: `${slug}-${user.id}:sample-data-alert-dismissed`,
   });
 
-  if (isDismissed) {
+  if (isDismissed || !isDynamicallySampled) {
     return null;
   }
 


### PR DESCRIPTION
This PR fixes the condition of sampling alert in Discover.
We want to show it only if dynamic sampling is active (am2 and base sample rate lower than 100%).

<img width="1512" alt="image" src="https://github.com/getsentry/sentry/assets/9060071/fca36c2e-cf55-42ef-81c6-a2245ec00dd6">
