### PR TITLE
fix(proguard-mappings): UI not updating when using pagination

### DIFF
--- a/static/app/views/settings/projectProguard/index.tsx
+++ b/static/app/views/settings/projectProguard/index.tsx
@@ -44,12 +44,20 @@ function ProjectProguard({organization, location, router, params}: ProjectProgua
   } = useApiQuery<DebugFile[]>(
     [
       `/projects/${organization.slug}/${projectId}/files/dsyms/`,
-      {query: {query: location.query.query, file_formats: 'proguard'}},
+      {
+        query: {
+          query: location.query.query,
+          file_formats: 'proguard',
+          cursor: location.query.cursor,
+        },
+      },
     ],
     {
       staleTime: 0,
     }
   );
+
+  const mappingsPageLinks = getResponseHeader?.('Link');
 
   const associationsResults = useQueries({
     queries:
@@ -75,13 +83,11 @@ function ProjectProguard({organization, location, router, params}: ProjectProgua
 
   const associationsFetched = associationsResults.every(result => result.isFetched);
 
-  const mappingsPageLinks = getResponseHeader?.('Link');
-
   const handleSearch = useCallback(
     (query: string) => {
       router.push({
         ...location,
-        query: {...location.query, cursor: undefined, query},
+        query: {...location.query, cursor: undefined, query: query || undefined},
       });
     },
     [location, router]


### PR DESCRIPTION
the cursor was not being passed to the query, resulting in the UI not updating on page change. This PR fixes the issue 