### PR TITLE
ref(api): Enable custom credentials

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -243,7 +243,10 @@ type ClientOptions = {
    * The base URL path to prepend to API request URIs.
    */
   baseUrl?: string;
-
+  /**
+   * Credentials policy to apply to each request
+   */
+  credentials?: RequestCredentials;
   /**
    * Base set of headers to apply to each request
    */
@@ -265,6 +268,7 @@ export class Client {
   baseUrl: string;
   activeRequests: Record<string, Request>;
   headers: HeadersInit;
+  credentials?: RequestCredentials;
 
   static JSON_HEADERS = {
     Accept: 'application/json; charset=utf-8',
@@ -275,6 +279,7 @@ export class Client {
     this.baseUrl = options.baseUrl ?? '/api/0';
     this.headers = options.headers ?? Client.JSON_HEADERS;
     this.activeRequests = {};
+    this.credentials = options.credentials ?? 'include';
   }
 
   wrapCallback<T extends any[]>(
@@ -459,7 +464,7 @@ export class Client {
       method,
       body,
       headers,
-      credentials: 'include',
+      credentials: this.credentials,
       signal: aborter?.signal,
     });
 


### PR DESCRIPTION
Update the api.tsx file by introducing the new optional prop `credentials`. This will allow us to include custom credentials, like omit, which is crucial for addressing an cross-origin issue when fetching Sentry's release registry. This solution has been implemented in the PR  https://github.com/getsentry/sentry/pull/54675. 