### PR TITLE
ref(code-snippet): Introduce the prop 'disableUserSelection'

### DIFF
--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import Prism from 'prismjs';
 
 import {Button} from 'sentry/components/button';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -15,6 +16,10 @@ interface CodeSnippetProps {
   dark?: boolean;
   filename?: string;
   hideCopyButton?: boolean;
+  /**
+   * Weather the code snippet or parts of it, it is currently being loaded
+   */
+  loading?: boolean;
   onCopy?: (copiedCode: string) => void;
   /**
    * Fired when the user selects and copies code snippet manually
@@ -31,6 +36,7 @@ export function CodeSnippet({
   onCopy,
   className,
   onSelectAndCopy,
+  loading,
 }: CodeSnippetProps) {
   const ref = useRef<HTMLModElement | null>(null);
 
@@ -73,7 +79,7 @@ export function CodeSnippet({
     <Wrapper className={`${dark ? 'prism-dark ' : ''}${className ?? ''}`}>
       <Header hasFileName={!!filename}>
         {filename && <FileName>{filename}</FileName>}
-        {!hideCopyButton && (
+        {!hideCopyButton && !loading && (
           <CopyButton
             type="button"
             size="xs"
@@ -90,13 +96,15 @@ export function CodeSnippet({
       </Header>
 
       <pre className={`language-${String(language)}`}>
-        <code
+        <Code
           ref={ref}
           className={`language-${String(language)}`}
           onCopy={onSelectAndCopy}
+          isLoading={loading}
         >
           {children}
-        </code>
+        </Code>
+        {loading && <Loading mini />}
       </pre>
     </Wrapper>
   );
@@ -158,4 +166,15 @@ const CopyButton = styled(Button)`
   &.focus-visible {
     opacity: 1;
   }
+`;
+
+const Code = styled('code')<{isLoading?: boolean}>`
+  visibility: ${p => (p.isLoading ? 'hidden' : 'visible')};
+`;
+
+const Loading = styled(LoadingIndicator)`
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  position: absolute;
 `;

--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -18,7 +18,7 @@ interface CodeSnippetProps {
    * Userful when loading parts of a code snippet, and
    * we wish to avoid users copying them manually.
    */
-  disabledUserSelection?: boolean;
+  disableUserSelection?: boolean;
   filename?: string;
   hideCopyButton?: boolean;
   onCopy?: (copiedCode: string) => void;
@@ -37,7 +37,7 @@ export function CodeSnippet({
   onCopy,
   className,
   onSelectAndCopy,
-  disabledUserSelection,
+  disableUserSelection,
 }: CodeSnippetProps) {
   const ref = useRef<HTMLModElement | null>(null);
 
@@ -101,7 +101,7 @@ export function CodeSnippet({
           ref={ref}
           className={`language-${String(language)}`}
           onCopy={onSelectAndCopy}
-          disabledUserSelection={disabledUserSelection}
+          disableUserSelection={disableUserSelection}
         >
           {children}
         </Code>
@@ -168,6 +168,6 @@ const CopyButton = styled(Button)`
   }
 `;
 
-const Code = styled('code')<{disabledUserSelection?: boolean}>`
-  user-select: ${p => (p.disabledUserSelection ? 'none' : 'auto')};
+const Code = styled('code')<{disableUserSelection?: boolean}>`
+  user-select: ${p => (p.disableUserSelection ? 'none' : 'auto')};
 `;

--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import Prism from 'prismjs';
 
 import {Button} from 'sentry/components/button';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -14,12 +13,14 @@ interface CodeSnippetProps {
   language: string;
   className?: string;
   dark?: boolean;
+  /**
+   * Makes the text of the element and its sub-elements is not selectable.
+   * Userful when loading parts of a code snippet, and
+   * we wish to avoid users copying them manually.
+   */
+  disabledUserSelection?: boolean;
   filename?: string;
   hideCopyButton?: boolean;
-  /**
-   * Weather the code snippet or parts of it, it is currently being loaded
-   */
-  loading?: boolean;
   onCopy?: (copiedCode: string) => void;
   /**
    * Fired when the user selects and copies code snippet manually
@@ -36,7 +37,7 @@ export function CodeSnippet({
   onCopy,
   className,
   onSelectAndCopy,
-  loading,
+  disabledUserSelection,
 }: CodeSnippetProps) {
   const ref = useRef<HTMLModElement | null>(null);
 
@@ -79,7 +80,7 @@ export function CodeSnippet({
     <Wrapper className={`${dark ? 'prism-dark ' : ''}${className ?? ''}`}>
       <Header hasFileName={!!filename}>
         {filename && <FileName>{filename}</FileName>}
-        {!hideCopyButton && !loading && (
+        {!hideCopyButton && (
           <CopyButton
             type="button"
             size="xs"
@@ -100,11 +101,10 @@ export function CodeSnippet({
           ref={ref}
           className={`language-${String(language)}`}
           onCopy={onSelectAndCopy}
-          isLoading={loading}
+          disabledUserSelection={disabledUserSelection}
         >
           {children}
         </Code>
-        {loading && <Loading mini />}
       </pre>
     </Wrapper>
   );
@@ -168,13 +168,6 @@ const CopyButton = styled(Button)`
   }
 `;
 
-const Code = styled('code')<{isLoading?: boolean}>`
-  visibility: ${p => (p.isLoading ? 'hidden' : 'visible')};
-`;
-
-const Loading = styled(LoadingIndicator)`
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  position: absolute;
+const Code = styled('code')<{disabledUserSelection?: boolean}>`
+  user-select: ${p => (p.disabledUserSelection ? 'none' : 'auto')};
 `;

--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -14,7 +14,7 @@ interface CodeSnippetProps {
   className?: string;
   dark?: boolean;
   /**
-   * Makes the text of the element and its sub-elements is not selectable.
+   * Makes the text of the element and its sub-elements not selectable.
    * Userful when loading parts of a code snippet, and
    * we wish to avoid users copying them manually.
    */


### PR DESCRIPTION
~This PR adds a new prop called "loading" to the code snippet component. This change ensures that when specific parts of the code snippet are still being fetched asynchronously, users won't be able to copy the incomplete code. The entire code snippet will also be blocked until all the necessary parts are ready. This change is being used in the https://github.com/getsentry/sentry/pull/54675. (there is a video showing case how the feature works)~

This PR adds a new prop called "disableUserSelection" to the code snippet component. This change ensures that when specific parts of the code snippet are still being fetched asynchronously, users won't be able to copy the incomplete code manually. 

