### PR TITLE
feat(on-demand): Add feature flags for prefilling

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1701,6 +1701,10 @@ SENTRY_FEATURES = {
     "projects:custom-inbound-filters": False,
     # Enable the new flat file indexing system for sourcemaps.
     "organizations:sourcemaps-bundle-flat-file-indexing": False,
+    # Signals that the organization supports the on demand metrics prefill.
+    "organizations:on-demand-metrics-prefill": False,
+    # Signals that the organization can start prefilling on demand metrics.
+    "organizations:enable-on-demand-metrics-prefill": False,
     # Enable data forwarding functionality for projects.
     "projects:data-forwarding": True,
     # Enable functionality to discard groups.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -268,6 +268,8 @@ default_manager.add("organizations:slack-fatal-disable-on-broken", OrganizationF
 default_manager.add("organizations:sourcemaps-bundle-flat-file-indexing", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:recap-server", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:detailed-alert-logging", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:on-demand-metrics-prefill", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:enable-on-demand-metrics-prefill", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 
 # Project scoped features
 default_manager.add("projects:alert-filters", ProjectFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
This PR adds two new feature flags for an upcoming prefilling behavior that will start to prefill on demand metrics for all customers. The new flags are used for a granular control of the behavior:
* `organizations:on-demand-metrics-prefill` is used to mark whether the organization is eligible for the prefilling.
* `organizations:enable-on-demand-metrics-prefill` is used to mark whether we actually want to enable prefilling for that org.