### PR TITLE
Fix granularity adjustment for TimeseriesQueryBuilder

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -220,7 +220,10 @@ class MetricsQueryBuilder(QueryBuilder):
         with sentry_sdk.start_span(op="QueryBuilder", description="resolve_granularity"):
             # Needs to happen before params and after time conditions since granularity can change start&end
             self.granularity = self.resolve_granularity()
-            self.start = adjust_datetime_to_granularity(self.start, self.granularity.granularity)
+            if self.start is not None:
+                self.start = adjust_datetime_to_granularity(
+                    self.start, self.granularity.granularity
+                )
 
         # Resolutions that we will perform only in case the query is not on demand. The reasoning for this is that
         # for building an on demand query we only require a time interval and granularity. All the other fields are

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -1232,7 +1232,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
         # the start time should be at granularity boundary (otherwse we'll miss data between the start time and the
         # next granularity boundary, e.g. if start time is 10:20 and granularity 1h we'll miss all data between
         # 10:20 and 11:00 since the timestamp for our data will be 10:00--> so we need to).
-        self.start = adjust_datetime_to_granularity(self.start, self.interval)
+        self.start = adjust_datetime_to_granularity(self.start, granularity)
         return Granularity(granularity)
 
     def resolve_split_granularity(self) -> Tuple[List[Condition], Optional[Granularity]]:

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 
 import sentry_sdk
 from django.utils.functional import cached_property
@@ -30,6 +30,7 @@ from sentry.search.events import constants, fields
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.builder.utils import (
     adjust_datetime_to_granularity,
+    optimal_granularity_for_date_range,
     remove_hours,
     remove_minutes,
 )
@@ -219,6 +220,7 @@ class MetricsQueryBuilder(QueryBuilder):
         with sentry_sdk.start_span(op="QueryBuilder", description="resolve_granularity"):
             # Needs to happen before params and after time conditions since granularity can change start&end
             self.granularity = self.resolve_granularity()
+            self.start = adjust_datetime_to_granularity(self.start, self.granularity.granularity)
 
         # Resolutions that we will perform only in case the query is not on demand. The reasoning for this is that
         # for building an on demand query we only require a time interval and granularity. All the other fields are
@@ -312,58 +314,8 @@ class MetricsQueryBuilder(QueryBuilder):
 
         if self.end is None or self.start is None:
             raise ValueError("skip_time_conditions must be False when calling this method")
-        duration = (self.end - self.start).total_seconds()
 
-        near_midnight: Callable[[datetime], bool] = lambda time: (
-            time.minute <= 30 and time.hour == 0
-        ) or (time.minute >= 30 and time.hour == 23)
-        near_hour: Callable[[datetime], bool] = lambda time: time.minute <= 15 or time.minute >= 45
-
-        if (
-            # precisely going hour to hour
-            self.start.minute
-            == self.end.minute
-            == self.start.second
-            == self.end.second
-            == duration % 3600
-            == 0
-        ):
-            # we're going from midnight -> midnight which aligns with our daily buckets
-            if self.start.hour == self.end.hour == duration % 86400 == 0:
-                granularity = 86400
-            # we're roughly going from start of hour -> next which aligns with our hourly buckets
-            else:
-                granularity = 3600
-        elif (
-            # Its over 30d, just use the daily granularity
-            duration
-            >= 86400 * 30
-        ):
-            self.start = self.start.replace(hour=0, minute=0, second=0, microsecond=0)
-            granularity = 86400
-        elif (
-            # more than 3 days
-            duration
-            >= 86400 * 3
-        ):
-            # Allow 30 minutes for the daily buckets
-            if near_midnight(self.start) and near_midnight(self.end):
-                self.start = self.start.replace(hour=0, minute=0, second=0, microsecond=0)
-                granularity = 86400
-            else:
-                self.start = self.start.replace(minute=0, second=0, microsecond=0)
-                granularity = 3600
-        elif (
-            # more than 12 hours
-            (duration >= 3600 * 12)
-            # Allow 15 minutes for the hourly buckets
-            and near_hour(self.start)
-            and near_hour(self.end)
-        ):
-            self.start = self.start.replace(minute=0, second=0, microsecond=0)
-            granularity = 3600
-        else:
-            granularity = 60
+        granularity = optimal_granularity_for_date_range(self.start, self.end)
         return Granularity(granularity)
 
     def resolve_split_granularity(self) -> Tuple[List[Condition], Optional[Granularity]]:
@@ -1220,19 +1172,20 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
         """Find the largest granularity that is smaller than the interval"""
         for available_granularity in constants.METRICS_GRANULARITIES:
             if available_granularity <= self.interval:
-                granularity = available_granularity
+                max_granularity = available_granularity
                 break
         else:
             # if we are here the user requested an interval smaller than the smallest granularity available.
             # We'll force the interval to be the smallest granularity (since we don't have data at the requested interval)
             # and return the smallest granularity
             self.interval = constants.METRICS_GRANULARITIES[-1]
-            granularity = self.interval
+            max_granularity = self.interval
 
-        # the start time should be at granularity boundary (otherwse we'll miss data between the start time and the
-        # next granularity boundary, e.g. if start time is 10:20 and granularity 1h we'll miss all data between
-        # 10:20 and 11:00 since the timestamp for our data will be 10:00--> so we need to).
-        self.start = adjust_datetime_to_granularity(self.start, granularity)
+        optimal_granularity = optimal_granularity_for_date_range(self.start, self.end)
+
+        # get the minimum granularity between the optimal granularity and the max granularity
+        granularity = min(optimal_granularity, max_granularity)
+
         return Granularity(granularity)
 
     def resolve_split_granularity(self) -> Tuple[List[Condition], Optional[Granularity]]:

--- a/src/sentry/search/events/builder/utils.py
+++ b/src/sentry/search/events/builder/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import Callable
 
 
 def remove_minutes(timestamp, floor=True):
@@ -42,3 +43,56 @@ def adjust_datetime_to_granularity(timestamp: datetime, granularity_seconds: int
         return timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
     else:
         raise NotImplementedError(f"Granularity {granularity_seconds} not supported")
+
+
+def optimal_granularity_for_date_range(start: datetime, end: datetime) -> int:
+    duration = (end - start).total_seconds()
+
+    near_midnight: Callable[[datetime], bool] = lambda time: (
+        time.minute <= 30 and time.hour == 0
+    ) or (time.minute >= 30 and time.hour == 23)
+    near_hour: Callable[[datetime], bool] = lambda time: time.minute <= 15 or time.minute >= 45
+
+    if (
+        # precisely going hour to hour
+        start.minute
+        == end.minute
+        == start.second
+        == end.second
+        == duration % 3600
+        == 0
+    ):
+        # we're going from midnight -> midnight which aligns with our daily buckets
+        if start.hour == end.hour == duration % 86400 == 0:
+            granularity = 86400
+        # we're roughly going from start of hour -> next which aligns with our hourly buckets
+        else:
+            granularity = 3600
+    elif (
+        # Its over 30d, just use the daily granularity
+        duration
+        >= 86400 * 30
+    ):
+        granularity = 86400
+    elif (
+        # more than 3 days
+        duration
+        >= 86400 * 3
+    ):
+        # Allow 30 minutes for the daily buckets
+        if near_midnight(start) and near_midnight(end):
+            granularity = 86400
+        else:
+            granularity = 3600
+    elif (
+        # more than 12 hours
+        (duration >= 3600 * 12)
+        # Allow 15 minutes for the hourly buckets
+        and near_hour(start)
+        and near_hour(end)
+    ):
+        granularity = 3600
+    else:
+        granularity = 60
+
+    return granularity

--- a/src/sentry/search/events/builder/utils.py
+++ b/src/sentry/search/events/builder/utils.py
@@ -15,3 +15,30 @@ def remove_hours(timestamp, floor=True):
         return datetime(timestamp.year, timestamp.month, timestamp.day)
     else:
         return datetime(timestamp.year, timestamp.month, timestamp.day) + timedelta(days=1)
+
+
+def adjust_datetime_to_granularity(timestamp: datetime, granularity_seconds: int):
+    """
+    Adjusts a datetime (down) to the boundary of a specified granularity.
+
+    When storing events at a certain granularity the timestamp is truncated to the specified granularity.
+    For example, if we store events at a granularity of 1 hour, the timestamp will be truncated to the beginning of the
+    hour.
+
+    In a query we might need to adjust the start/end interval to match the granularity of the query.
+    This function returns the timestamp adjusted down to the specified granularity
+
+    Examples:
+        12 May 10:25:20, minute -> 12 May 10:25:00
+        12 May 10:25:20, hour -> 12 May 10:00:00
+        12 May 10:25:20, day -> 12 May 00:00:00
+    """
+
+    if granularity_seconds == 60:
+        return timestamp.replace(second=0, microsecond=0)
+    elif granularity_seconds == 3600:
+        return timestamp.replace(minute=0, second=0, microsecond=0)
+    elif granularity_seconds == 86400:
+        return timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
+    else:
+        raise NotImplementedError(f"Granularity {granularity_seconds} not supported")


### PR DESCRIPTION
This PR implements the granularity adjustment i.e. `resolve_granularity` for `TimeseriesMetricsQueryBuilder`.
Previously we were using the implementation from the parent `MetricsQueryBuilder` but that does not honour the requested interval and adjusts the granularity with respect to only the start / end time ( trying to create an efficient query, but ignoring the necessity to keep the required interval ).

Details and explanations:
MetricsQueryBuilder resolved granularity by looking at start and end dates.
TimeseriesMetricsQueryBuilder needs to also take in account the interval in addition to the start & end dates.
Refactor `MetricsQueryBuilder` so we can re-use the granularity logic from there and combine it with the interval granularity logic in `TimeseriesMetricsQueryBuilder`.

Fixes: https://github.com/getsentry/sentry/issues/53839