### PR TITLE
fix(org-tokens): Add org token url to python

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -597,6 +597,11 @@ urlpatterns += [
                     name="sentry-customer-domain-developer-settings-settings",
                 ),
                 re_path(
+                    r"^auth-tokens/",
+                    react_page_view,
+                    name="sentry-customer-domain-auth-token-settings",
+                ),
+                re_path(
                     r"^document-integrations/",
                     react_page_view,
                     name="sentry-customer-domain-document-integrations-settings",


### PR DESCRIPTION
Adding this new page here as well - I hope that helps to make redirects without an org work...?