### PR TITLE
ref(starfish): Extract `SpanMetricsRibbon` component

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
@@ -1,0 +1,74 @@
+import {t, tct} from 'sentry/locale';
+import {RateUnits} from 'sentry/utils/discover/fields';
+import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
+import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
+import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
+import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
+import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
+import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
+import {getSpanOperationDescription} from 'sentry/views/starfish/views/spanSummaryPage/getSpanOperationDescription';
+
+interface Props {
+  spanMetrics: {
+    [SpanMetricsFields.SPAN_OP]: string;
+    [SpanMetricsFields.SPAN_DESCRIPTION]: string;
+    [SpanMetricsFields.SPAN_ACTION]: string;
+    [SpanMetricsFields.SPAN_DOMAIN]: string;
+    [SpanMetricsFields.SPAN_GROUP]: string;
+  };
+}
+
+export function SpanMetricsRibbon({spanMetrics}: Props) {
+  const op = spanMetrics?.[SpanMetricsFields.SPAN_OP] ?? '';
+  const opDescription = getSpanOperationDescription(op);
+
+  return (
+    <BlockContainer>
+      {op.startsWith('db') && op !== 'db.redis' && (
+        <Block title={t('Table')}>{spanMetrics?.[SpanMetricsFields.SPAN_DOMAIN]}</Block>
+      )}
+
+      <Block
+        title={getThroughputTitle(op)}
+        description={tct('Throughput of this [opDescription] span per minute', {
+          opDescription,
+        })}
+      >
+        <ThroughputCell rate={spanMetrics?.['spm()']} unit={RateUnits.PER_MINUTE} />
+      </Block>
+
+      <Block
+        title={DataTitles.avg}
+        description={tct(
+          'The average duration of [opDescription] spans in the selected period',
+          {
+            opDescription,
+          }
+        )}
+      >
+        <DurationCell
+          milliseconds={spanMetrics?.[`avg(${SpanMetricsFields.SPAN_SELF_TIME})`]}
+        />
+      </Block>
+
+      {op.startsWith('http') && (
+        <Block title={t('5XX Responses')} description={t('5XX responses in this span')}>
+          <CountCell count={spanMetrics?.[`http_error_count()`]} />
+        </Block>
+      )}
+
+      <Block
+        title={t('Time Spent')}
+        description={t(
+          'Time spent in this span as a proportion of total application time'
+        )}
+      >
+        <TimeSpentCell
+          percentage={spanMetrics?.['time_spent_percentage()']}
+          total={spanMetrics?.[`sum(${SpanMetricsFields.SPAN_SELF_TIME})`]}
+        />
+      </Block>
+    </BlockContainer>
+  );
+}

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
@@ -11,11 +11,11 @@ import {getSpanOperationDescription} from 'sentry/views/starfish/views/spanSumma
 
 interface Props {
   spanMetrics: {
-    [SpanMetricsFields.SPAN_OP]: string;
-    [SpanMetricsFields.SPAN_DESCRIPTION]: string;
-    [SpanMetricsFields.SPAN_ACTION]: string;
-    [SpanMetricsFields.SPAN_DOMAIN]: string;
-    [SpanMetricsFields.SPAN_GROUP]: string;
+    [SpanMetricsFields.SPAN_OP]?: string;
+    [SpanMetricsFields.SPAN_DESCRIPTION]?: string;
+    [SpanMetricsFields.SPAN_ACTION]?: string;
+    [SpanMetricsFields.SPAN_DOMAIN]?: string;
+    [SpanMetricsFields.SPAN_GROUP]?: string;
   };
 }
 

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
@@ -4,7 +4,7 @@ import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
 import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
 import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 import {getSpanOperationDescription} from 'sentry/views/starfish/views/spanSummaryPage/getSpanOperationDescription';
@@ -35,7 +35,10 @@ export function SpanMetricsRibbon({spanMetrics}: Props) {
           opDescription,
         })}
       >
-        <ThroughputCell rate={spanMetrics?.['spm()']} unit={RateUnits.PER_MINUTE} />
+        <ThroughputCell
+          rate={spanMetrics?.[`${StarfishFunctions.SPM}()`]}
+          unit={RateUnits.PER_MINUTE}
+        />
       </Block>
 
       <Block
@@ -54,7 +57,7 @@ export function SpanMetricsRibbon({spanMetrics}: Props) {
 
       {op.startsWith('http') && (
         <Block title={t('5XX Responses')} description={t('5XX responses in this span')}>
-          <CountCell count={spanMetrics?.[`http_error_count()`]} />
+          <CountCell count={spanMetrics?.[`${StarfishFunctions.HTTP_ERROR_COUNT}()`]} />
         </Block>
       )}
 
@@ -65,7 +68,7 @@ export function SpanMetricsRibbon({spanMetrics}: Props) {
         )}
       >
         <TimeSpentCell
-          percentage={spanMetrics?.['time_spent_percentage()']}
+          percentage={spanMetrics?.[`${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`]}
           total={spanMetrics?.[`sum(${SpanMetricsFields.SPAN_SELF_TIME})`]}
         />
       </Block>

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {RateUnits} from 'sentry/utils/discover/fields';
 import {formatRate} from 'sentry/utils/formatters';
@@ -11,10 +10,6 @@ import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/char
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
 import {SpanDescription} from 'sentry/views/starfish/components/spanDescription';
-import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
-import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
-import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
-import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {useFullSpanFromTrace} from 'sentry/views/starfish/queries/useFullSpanFromTrace';
 import {
   SpanSummaryQueryFilters,
@@ -25,10 +20,9 @@ import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types'
 import {
   DataTitles,
   getThroughputChartTitle,
-  getThroughputTitle,
 } from 'sentry/views/starfish/views/spans/types';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
-import {getSpanOperationDescription} from 'sentry/views/starfish/views/spanSummaryPage/getSpanOperationDescription';
+import {SpanMetricsRibbon} from 'sentry/views/starfish/views/spanSummaryPage/spanMetricsRibbon';
 
 const CHART_HEIGHT = 160;
 
@@ -99,10 +93,6 @@ export function SpanSummaryView({groupId}: Props) {
     data: spanMetricsSeriesData?.['spm()'].data,
   };
 
-  const spanOperationDescription = getSpanOperationDescription(
-    span[SpanMetricsFields.SPAN_OP]
-  );
-
   return (
     <React.Fragment>
       <HeaderContainer>
@@ -110,58 +100,7 @@ export function SpanSummaryView({groupId}: Props) {
           <StarfishDatePicker />
         </FilterOptionsContainer>
 
-        <BlockContainer>
-          {span?.[SpanMetricsFields.SPAN_OP]?.startsWith('db') &&
-            span?.[SpanMetricsFields.SPAN_OP] !== 'db.redis' && (
-              <Block title={t('Table')}>{span?.[SpanMetricsFields.SPAN_DOMAIN]}</Block>
-            )}
-
-          <Block
-            title={getThroughputTitle(span?.[SpanMetricsFields.SPAN_OP])}
-            description={tct('Throughput of this [spanType] per minute', {
-              spanType: spanOperationDescription,
-            })}
-          >
-            <ThroughputCell rate={spanMetrics?.['spm()']} unit={RateUnits.PER_MINUTE} />
-          </Block>
-
-          <Block
-            title={DataTitles.avg}
-            description={tct(
-              'The average duration of [spanType] in the selected period',
-              {
-                spanType: spanOperationDescription.endsWith('y')
-                  ? `${spanOperationDescription.slice(0, -1)}ies`
-                  : `${spanOperationDescription}s`,
-              }
-            )}
-          >
-            <DurationCell
-              milliseconds={spanMetrics?.[`avg(${SpanMetricsFields.SPAN_SELF_TIME})`]}
-            />
-          </Block>
-
-          {span?.[SpanMetricsFields.SPAN_OP]?.startsWith('http') && (
-            <Block
-              title={t('5XX Responses')}
-              description={t('5XX responses in this span')}
-            >
-              <CountCell count={spanMetrics?.[`http_error_count()`]} />
-            </Block>
-          )}
-
-          <Block
-            title={t('Time Spent')}
-            description={t(
-              'Time spent in this span as a proportion of total application time'
-            )}
-          >
-            <TimeSpentCell
-              percentage={spanMetrics?.['time_spent_percentage()']}
-              total={spanMetrics?.[`sum(${SpanMetricsFields.SPAN_SELF_TIME})`]}
-            />
-          </Block>
-        </BlockContainer>
+        <SpanMetricsRibbon spanMetrics={span} />
       </HeaderContainer>
 
       {span?.[SpanMetricsFields.SPAN_DESCRIPTION] && (


### PR DESCRIPTION
Continuing the block-u-lation of Starfish view components. This gives me more leverage when deciding whether to specialize components, or use the blocks they're made of.
