### PR TITLE
ref: bucket tests by count rather than hashing

### DIFF
--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -3,8 +3,6 @@ import subprocess
 import sys
 import time
 
-from django.conf import settings
-
 from sentry.testutils.pytest.sentry import configure_split_db
 from sentry.utils import json
 
@@ -73,4 +71,4 @@ def pytest_configure(config):
             "Unable to run `yarn` -- make sure your development environment is setup correctly: https://docs.sentry.io/development/contribute/environment/#macos---nodejs"
         )
 
-    configure_split_db(settings)
+    configure_split_db()

--- a/tests/sentry/testutils/pytest/test_sentry.py
+++ b/tests/sentry/testutils/pytest/test_sentry.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import types
+from typing import Sequence
+from unittest import mock
+
+import pytest
+
+from sentry.testutils.pytest import sentry
+
+NODEIDS = (
+    "test1.py::test1",
+    "test1.py::test2",
+    "test1.py::test3",
+    "test1.py::MyTest::test",
+    "test1.py::MyTest::test2",
+    "test2.py::test",
+    "test3.py::test1",
+    "test3.py::test2",
+    "test3.py::test3",
+    "test3.py::test4",
+)
+
+strategies = pytest.mark.parametrize("strategy", ("scope", "roundrobin"))
+
+
+def _bucket(ids: Sequence[str], strategy: str) -> list[list[str]]:
+    ret = []
+    for i in range(3):
+        items = [types.SimpleNamespace(nodeid=nodeid) for nodeid in ids]
+        sentry.pytest_collection_modifyitems(
+            mock.Mock(),
+            items,
+            _total_groups=3,
+            _current_group=i,
+            _grouping_strategy=strategy,
+        )
+        ret.append([item.nodeid for item in items])
+    return ret
+
+
+@strategies
+def test_bucketing_includes_all_items(strategy: str) -> None:
+    all_items = [nodeid for bucket in _bucket(NODEIDS, strategy) for nodeid in bucket]
+    assert len(all_items) == len(NODEIDS)
+    assert set(all_items) == set(NODEIDS)
+
+
+@strategies
+def test_bucketing_independent_of_collection_order(strategy: str) -> None:
+    items_forward = _bucket(NODEIDS, strategy)
+    items_reversed = _bucket(NODEIDS[::-1], strategy)
+    assert items_forward == items_reversed
+
+
+def test_round_robin_bucketing():
+    assert _bucket(NODEIDS, "roundrobin") == [
+        ["test1.py::MyTest::test", "test1.py::test2", "test3.py::test1", "test3.py::test4"],
+        ["test1.py::MyTest::test2", "test1.py::test3", "test3.py::test2"],
+        ["test1.py::test1", "test2.py::test", "test3.py::test3"],
+    ]
+
+
+def test_scope_bucketing():
+    assert _bucket(NODEIDS, "scope") == [
+        ["test3.py::test1", "test3.py::test2", "test3.py::test3", "test3.py::test4"],
+        ["test1.py::test1", "test1.py::test2", "test1.py::test3"],
+        ["test1.py::MyTest::test", "test1.py::MyTest::test2", "test2.py::test"],
+    ]


### PR DESCRIPTION
this is similar to how xdist groups tests -- should give a more even distribution especially for files containing lots of tests


this does have a few downsides:
- tests will not always be scheduled to the same shard consistently
- tests will not always run in the same order

neither of these should be a problem -- though it may uncover some cases of test pollution that will need fixing