### PR TITLE
Randomize `worker_id` used as routing key to Symbolicator

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import random
 import time
 import uuid
 from dataclasses import dataclass
@@ -247,6 +248,7 @@ class SymbolicatorSession:
         self.event_id = event_id
         self.timeout = timeout
         self.session = None
+        self.worker_id = self._get_worker_id()
 
     def __enter__(self):
         self.open()
@@ -273,7 +275,7 @@ class SymbolicatorSession:
         # required for load balancing
         kwargs.setdefault("headers", {})["x-sentry-project-id"] = self.project_id
         kwargs.setdefault("headers", {})["x-sentry-event-id"] = self.event_id
-        kwargs.setdefault("headers", {})["x-sentry-worker-id"] = self.get_worker_id()
+        kwargs.setdefault("headers", {})["x-sentry-worker-id"] = self.worker_id
 
         attempts = 0
         wait = 0.5
@@ -357,7 +359,10 @@ class SymbolicatorSession:
             return self._request("get", task_url, params=params)
 
     @classmethod
-    def get_worker_id(cls):
+    def _get_worker_id(cls) -> str:
+        if options.get("symbolicator.worker-id-randomization-sample-rate") <= random.random():
+            return uuid.uuid4().hex
+
         # as class attribute to keep it static for life of process
         if cls._worker_id is None:
             # %5000 to reduce cardinality of metrics tagging with worker id
@@ -365,5 +370,9 @@ class SymbolicatorSession:
         return cls._worker_id
 
     @classmethod
-    def reset_worker_id(cls):
+    def _reset_worker_id(cls):
         cls._worker_id = None
+
+    def reset_worker_id(self):
+        self._reset_worker_id()
+        self.worker_id = self._get_worker_id()

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -578,6 +578,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Percentage of events that generate a random `worker_id` for symbolicator load balancing
+register(
+    "symbolicator.worker-id-randomization-sample-rate",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Normalization after processors
 register("store.normalize-after-processing", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)  # unused
 register(


### PR DESCRIPTION
This is behind a sample rate option. Each event/session that is sampled gets a random `worker_id`, vs a stable per-worker id.

The goal is to see whether the routing to Symbolicator gets a more equal distribution with fully random IDs.