### PR TITLE
feat(hybridcloud) Introduce separate queues for control silo tasks

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -777,13 +777,16 @@ CELERY_QUEUES_ALL = [
 
 CELERY_QUEUES_CONTROL = [
     Queue("app_platform.control", routing_key="app_platform.control", exchange=control_exchange),
-    Queue("auth", routing_key="auth", exchange=control_exchange),
-    Queue("integrations", routing_key="integrations", exchange=control_exchange),
+    Queue("auth.control", routing_key="auth.control", exchange=control_exchange),
+    Queue("cleanup.control", routing_key="cleanup.control", exchange=control_exchange),
+    Queue("integrations.control", routing_key="integrations.control", exchange=control_exchange),
+    Queue("files.delete.control", routing_key="files.delete.control", exchange=control_exchange),
     Queue(
         "hybrid_cloud.control_repair",
         routing_key="hybrid_cloud.control_repair",
         exchange=control_exchange,
     ),
+    Queue("options.control", routing_key="options.control", exchange=control_exchange),
 ]
 
 CELERY_ISSUE_STATES_QUEUE = Queue(
@@ -792,6 +795,7 @@ CELERY_ISSUE_STATES_QUEUE = Queue(
 
 CELERY_QUEUES_REGION = [
     Queue("activity.notify", routing_key="activity.notify"),
+    Queue("auth", routing_key="auth"),
     Queue("alerts", routing_key="alerts"),
     Queue("app_platform", routing_key="app_platform"),
     Queue("appstoreconnect", routing_key="sentry.tasks.app_store_connect.#"),
@@ -837,6 +841,7 @@ CELERY_QUEUES_REGION = [
         "group_owners.process_suspect_commits", routing_key="group_owners.process_suspect_commits"
     ),
     Queue("group_owners.process_commit_context", routing_key="group_owners.process_commit_context"),
+    Queue("integrations", routing_key="integrations"),
     Queue(
         "releasemonitor",
         routing_key="releasemonitor",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -769,12 +769,6 @@ if USE_SILOS:
     control_exchange = Exchange("control", type="direct")
 
 
-CELERY_QUEUES_ALL = [
-    Queue("options", routing_key="options"),
-    Queue("files.copy", routing_key="files.copy"),
-    Queue("files.delete", routing_key="files.delete"),
-]
-
 CELERY_QUEUES_CONTROL = [
     Queue("app_platform.control", routing_key="app_platform.control", exchange=control_exchange),
     Queue("auth.control", routing_key="auth.control", exchange=control_exchange),
@@ -837,6 +831,8 @@ CELERY_QUEUES_REGION = [
         "events.symbolicate_js_event_low_priority",
         routing_key="events.symbolicate_js_event_low_priority",
     ),
+    Queue("files.copy", routing_key="files.copy"),
+    Queue("files.delete", routing_key="files.delete"),
     Queue(
         "group_owners.process_suspect_commits", routing_key="group_owners.process_suspect_commits"
     ),
@@ -854,6 +850,7 @@ CELERY_QUEUES_REGION = [
     Queue("incident_snapshots", routing_key="incident_snapshots"),
     Queue("incidents", routing_key="incidents"),
     Queue("merge", routing_key="merge"),
+    Queue("options", routing_key="options"),
     Queue("post_process_errors", routing_key="post_process_errors"),
     Queue("post_process_issue_platform", routing_key="post_process_issue_platform"),
     Queue("post_process_transactions", routing_key="post_process_transactions"),
@@ -1143,17 +1140,17 @@ CELERYBEAT_SCHEDULE_REGION = {
 if SILO_MODE == "CONTROL":
     CELERYBEAT_SCHEDULE_FILENAME = os.path.join(tempfile.gettempdir(), "sentry-celerybeat-control")
     CELERYBEAT_SCHEDULE = CELERYBEAT_SCHEDULE_CONTROL
-    CELERY_QUEUES = CELERY_QUEUES_CONTROL + CELERY_QUEUES_ALL
+    CELERY_QUEUES = CELERY_QUEUES_CONTROL
 
 elif SILO_MODE == "REGION":
     CELERYBEAT_SCHEDULE_FILENAME = os.path.join(tempfile.gettempdir(), "sentry-celerybeat-region")
     CELERYBEAT_SCHEDULE = CELERYBEAT_SCHEDULE_REGION
-    CELERY_QUEUES = CELERY_QUEUES_REGION + CELERY_QUEUES_ALL
+    CELERY_QUEUES = CELERY_QUEUES_REGION
 
 else:
     CELERYBEAT_SCHEDULE = {**CELERYBEAT_SCHEDULE_CONTROL, **CELERYBEAT_SCHEDULE_REGION}
     CELERYBEAT_SCHEDULE_FILENAME = os.path.join(tempfile.gettempdir(), "sentry-celerybeat")
-    CELERY_QUEUES = CELERY_QUEUES_REGION + CELERY_QUEUES_CONTROL + CELERY_QUEUES_ALL
+    CELERY_QUEUES = CELERY_QUEUES_REGION + CELERY_QUEUES_CONTROL
 
 for queue in CELERY_QUEUES:
     queue.durable = False


### PR DESCRIPTION
In order to gradually bring up siloed worker pools we need separate queues. Having separate queues allows us to be certain that a control silo worker will not receive work intended for a region silo.

With these queues defined, my next steps are to update worker assignments in k8s and then update task definitions.

Refs HC-839
