### PR TITLE
ref(backup): Lazily load expensive maps

### DIFF
--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from enum import Enum, auto, unique
+from functools import lru_cache
 from typing import NamedTuple, Type
 
 from django.db import models
@@ -106,6 +107,8 @@ class PrimaryKeyMap:
         self.mapping[model][old] = new
 
 
+# No arguments, so we lazily cache the result after the first calculation.
+@lru_cache(maxsize=1)
 def dependencies() -> dict[str, ModelRelations]:
     """Produce a dictionary mapping model type definitions to a `ModelDeps` describing their dependencies."""
 
@@ -185,6 +188,8 @@ def dependencies() -> dict[str, ModelRelations]:
     return model_dependencies_list
 
 
+# No arguments, so we lazily cache the result after the first calculation.
+@lru_cache(maxsize=1)
 def sorted_dependencies():
     """Produce a list of model definitions such that, for every item in the list, all of the other models it mentions in its fields and/or natural key (ie, its "dependencies") have already appeared in the list.
 

--- a/src/sentry/backup/validate.py
+++ b/src/sentry/backup/validate.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from difflib import unified_diff
 from typing import Dict, Tuple
 
-from sentry.backup.comparators import DEFAULT_COMPARATORS, ComparatorMap, ForeignKeyComparator
+from sentry.backup.comparators import ComparatorMap, ForeignKeyComparator, get_default_comparators
 from sentry.backup.dependencies import PrimaryKeyMap
 from sentry.backup.findings import (
     ComparatorFinding,
@@ -24,7 +24,7 @@ JSON_PRETTY_PRINTER = JSONEncoder(
 def validate(
     expect: JSONData,
     actual: JSONData,
-    comparators: ComparatorMap = DEFAULT_COMPARATORS,
+    comparators: ComparatorMap | None = None,
 ) -> ComparatorFindings:
     """Ensures that originally imported data correctly matches actual outputted data, and produces a
     list of reasons why not when it doesn't.
@@ -86,6 +86,9 @@ def validate(
         """Take a JSONData object and pretty-print it as JSON."""
 
         return JSON_PRETTY_PRINTER.encode(obj).splitlines()
+
+    if comparators is None:
+        comparators = get_default_comparators()
 
     # Because we may be scrubbing data from the objects as we compare them, we may (optionally) make
     # deep copies to start to avoid potentially mangling the input data.

--- a/tests/sentry/backup/test_roundtrip.py
+++ b/tests/sentry/backup/test_roundtrip.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sentry.backup.comparators import DEFAULT_COMPARATORS
+from sentry.backup.comparators import get_default_comparators
 from sentry.backup.findings import ComparatorFindingKind, InstanceID
 from sentry.testutils.helpers.backups import (
     ValidationError,
@@ -14,15 +14,18 @@ from tests.sentry.backup import run_backup_tests_only_on_single_db
 @run_backup_tests_only_on_single_db
 @django_db_all(transaction=True, reset_sequences=True)
 def test_good_fresh_install(tmp_path):
-    import_export_from_fixture_then_validate(tmp_path, "fresh-install.json", DEFAULT_COMPARATORS)
+    import_export_from_fixture_then_validate(
+        tmp_path, "fresh-install.json", get_default_comparators()
+    )
 
 
 @run_backup_tests_only_on_single_db
 @django_db_all(transaction=True, reset_sequences=True)
 def test_bad_unequal_json(tmp_path):
-    # Without the `DEFAULT_COMPARATORS`, the `date_updated` fields will not be compared using the
-    # special comparator logic, and will try to use (and fail on) simple JSON string comparison
-    # instead.
+    # Without calling `get_default_comparators()` as the third argument to
+    # `import_export_from_fixture_then_validate()`, the `date_updated` fields will not be compared
+    # using the special comparator logic, and will try to use (and fail on) simple JSON string
+    # comparison instead.
     with pytest.raises(ValidationError) as execinfo:
         import_export_from_fixture_then_validate(tmp_path, "fresh-install.json")
     findings = execinfo.value.info.findings
@@ -67,18 +70,24 @@ def test_date_updated_with_unzeroed_milliseconds(tmp_path):
 @django_db_all(transaction=True, reset_sequences=True)
 def test_good_continuing_sequences(tmp_path):
     # Populate once to set the sequences.
-    import_export_from_fixture_then_validate(tmp_path, "fresh-install.json", DEFAULT_COMPARATORS)
+    import_export_from_fixture_then_validate(
+        tmp_path, "fresh-install.json", get_default_comparators()
+    )
 
     # Empty the database without resetting primary keys.
     clear_database_but_keep_sequences()
 
     # Test that foreign keys are properly re-pointed to newly allocated primary keys as they are
     # assigned.
-    import_export_from_fixture_then_validate(tmp_path, "fresh-install.json", DEFAULT_COMPARATORS)
+    import_export_from_fixture_then_validate(
+        tmp_path, "fresh-install.json", get_default_comparators()
+    )
 
 
 # User models are unique and important enough that we target them with a specific test case.
 @run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_user_pk_mapping(tmp_path):
-    import_export_from_fixture_then_validate(tmp_path, "user-pk-mapping.json", DEFAULT_COMPARATORS)
+    import_export_from_fixture_then_validate(
+        tmp_path, "user-pk-mapping.json", get_default_comparators()
+    )

--- a/tests/sentry/backup/test_validate.py
+++ b/tests/sentry/backup/test_validate.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 
+from sentry.backup.comparators import get_default_comparators
 from sentry.backup.findings import ComparatorFindingKind, InstanceID
 from sentry.backup.validate import validate
 from sentry.testutils.factories import get_fixture_path
@@ -42,7 +43,9 @@ def test_good_ignore_differing_pks(tmp_path):
         """
         )
     )
-    out = validate(left, right)
+
+    # Test the explicit ssignment of `get_default_comparators()`
+    out = validate(left, right, get_default_comparators())
     findings = out.findings
     assert not findings
 
@@ -65,7 +68,7 @@ def test_bad_duplicate_entry(tmp_path):
         """
     )
     test_json.append(dupe)
-    out = validate(test_json, test_json)
+    out = validate(test_json, test_json, get_default_comparators())
     findings = out.findings
 
     assert len(findings) == 2


### PR DESCRIPTION
Previously, we were always doing the relatively involved calculations for `get_default_comparators()`, `dependencies()`, and `sorted_dependencies()` at init time. This is wasteful, and slows down the test of anyone who imports these modules. A better solution is to resolve this information lazily when needed, and to cache that result going forward. This ensures that we still only do the work once, but now only when it is actually needed, rather than as soon as possible.