### PR TITLE
fix(perf): Improve SQL formatting IV

### DIFF
--- a/static/app/views/starfish/utils/sqlish/SQLishFormatter.spec.tsx
+++ b/static/app/views/starfish/utils/sqlish/SQLishFormatter.spec.tsx
@@ -45,6 +45,13 @@ describe('SQLishFormatter', function () {
       `);
     });
 
+    it('Capitalizes lowercase keywords', () => {
+      expect(formatter.toString('select * from users;')).toMatchInlineSnapshot(`
+        "SELECT *
+        FROM users;"
+      `);
+    });
+
     it('Adds indentation for SELECTS in conditions', () => {
       expect(
         formatter.toString(

--- a/static/app/views/starfish/utils/sqlish/SQLishParser.spec.tsx
+++ b/static/app/views/starfish/utils/sqlish/SQLishParser.spec.tsx
@@ -35,7 +35,7 @@ describe('SQLishParser', function () {
       expect(parser.parse('select ..')).toEqual([
         {
           type: 'Keyword',
-          content: 'select',
+          content: 'SELECT',
         },
         {
           type: 'Whitespace',

--- a/static/app/views/starfish/utils/sqlish/formatters/string.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/string.ts
@@ -58,7 +58,6 @@ export function string(tokens: Token[]): string {
         accumulator.space();
       } else if (['LeftParenthesis', 'RightParenthesis'].includes(token.type)) {
         // Parenthesis contents are appended above, so we can skip them here
-        accumulator.add('');
       } else {
         if (accumulator.endsWith(NEWLINE)) {
           accumulator.add(INDENTATION.repeat(indentation));
@@ -115,19 +114,24 @@ class StringAccumulator {
   }
 
   space() {
+    this.rtrim();
     this.tokens.push(SPACE);
   }
 
   break() {
-    if (this.tokens.at(-1) === SPACE) {
-      this.tokens.pop();
-    }
+    this.rtrim();
 
     this.tokens.push(NEWLINE);
   }
 
   indent(count: number = 1) {
     this.tokens.push(INDENTATION.repeat(count));
+  }
+
+  rtrim() {
+    while (this.tokens.at(-1)?.trim() === '') {
+      this.tokens.pop();
+    }
   }
 
   endsWith(token: string) {

--- a/static/app/views/starfish/utils/sqlish/sqlish.pegjs
+++ b/static/app/views/starfish/utils/sqlish/sqlish.pegjs
@@ -12,7 +12,7 @@ RightParenthesis
 
 Keyword
   = Keyword:("ADD"i / "ALL"i / "ALTER"i / "AND"i / "ANY"i / "AS"i / "ASC"i / "BACKUP"i / "BETWEEN"i / "BY"i / "CASE"i / "CHECK"i / "COLUMN"i / "CONSTRAINT"i / "COUNT"i / "CREATE"i / "DATABASE"i / "DEFAULT"i / "DELETE"i / "DESC"i / "DISTINCT"i / "DROP"i / "EXEC"i / "EXISTS"i / "FOREIGN"i / "FROM"i / "FROM"i / "FULL"i / "GROUP"i / "HAVING"i / "INNER"i / "INSERT"i / "JOIN"i / "KEY"i / "LEFT"i / "LIMIT"i / "OFFSET"i / "ON"i / "ORDER"i / "OUTER"i / "RETURNING"i / "RIGHT"i / "SELECT"i / "SELECT"i / "TABLE"i / "UPDATE"i / "VALUES"i / "WHERE"i / JoinKeyword) {
-  return { type: 'Keyword', content: Keyword }
+  return { type: 'Keyword', content: Keyword.toUpperCase() }
 }
 
 JoinKeyword


### PR DESCRIPTION
A few fixes to address what Performance folks found.

- Return all keywords as uppercase
- Add spec for capitalization
- Trim long strings of whitespace
