### PR TITLE
ref(replay): Move `toPercent` into the utils folder

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -8,7 +8,6 @@ import ClippedBox from 'sentry/components/clippedBox';
 import {getSpanInfoFromTransactionEvent} from 'sentry/components/events/interfaces/performance/utils';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import Link from 'sentry/components/links/link';
-import {toRoundedPercent} from 'sentry/components/performance/waterfall/utils';
 import {t} from 'sentry/locale';
 import {
   Entry,
@@ -23,6 +22,7 @@ import {
 } from 'sentry/types';
 import {formatBytesBase2} from 'sentry/utils';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
+import toRoundedPercent from 'sentry/utils/number/toRoundedPercent';
 import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 import useOrganization from 'sentry/utils/useOrganization';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';

--- a/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
+++ b/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
@@ -1,10 +1,7 @@
 import {Component, createContext, createRef} from 'react';
 
-import {
-  clamp,
-  rectOfContent,
-  toPercent,
-} from 'sentry/components/performance/waterfall/utils';
+import {clamp, rectOfContent} from 'sentry/components/performance/waterfall/utils';
+import toPercent from 'sentry/utils/number/toPercent';
 import {setBodyUserSelect, UserSelectValues} from 'sentry/utils/userselect';
 
 // divider handle is positioned at 50% width from the left-hand side

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -18,13 +18,13 @@ import {
   getHumanDuration,
   pickBarColor,
   rectOfContent,
-  toPercent,
 } from 'sentry/components/performance/waterfall/utils';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
+import toPercent from 'sentry/utils/number/toPercent';
 import theme from 'sentry/utils/theme';
 import {ProfileContext} from 'sentry/views/profiling/profilesProvider';
 

--- a/static/app/components/events/interfaces/spans/measurementsPanel.tsx
+++ b/static/app/components/events/interfaces/spans/measurementsPanel.tsx
@@ -1,10 +1,10 @@
 import {Component, createRef} from 'react';
 import styled from '@emotion/styled';
 
-import {toPercent} from 'sentry/components/performance/waterfall/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import toPercent from 'sentry/utils/number/toPercent';
 import {VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {Vital} from 'sentry/utils/performance/vitals/types';
 

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -13,10 +13,10 @@ import * as DividerHandlerManager from 'sentry/components/events/interfaces/span
 import {OpsLine} from 'sentry/components/events/opsBreakdown';
 import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import {DividerSpacer} from 'sentry/components/performance/waterfall/miniHeader';
-import {toPercent} from 'sentry/components/performance/waterfall/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {formatBytesBase10} from 'sentry/utils';
+import toPercent from 'sentry/utils/number/toPercent';
 
 import * as CursorGuideHandler from './cursorGuideHandler';
 

--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -4,12 +4,9 @@ import {
   TOGGLE_BORDER_BOX,
   TOGGLE_BUTTON_MAX_WIDTH,
 } from 'sentry/components/performance/waterfall/treeConnector';
-import {
-  clamp,
-  rectOfContent,
-  toPercent,
-} from 'sentry/components/performance/waterfall/utils';
+import {clamp, rectOfContent} from 'sentry/components/performance/waterfall/utils';
 import getDisplayName from 'sentry/utils/getDisplayName';
+import toPercent from 'sentry/utils/number/toPercent';
 import {setBodyUserSelect, UserSelectValues} from 'sentry/utils/userselect';
 
 import {DragManagerChildrenProps} from './dragManager';

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -39,7 +39,6 @@ import {
   getDurationDisplay,
   getHumanDuration,
   lightenBarColor,
-  toPercent,
 } from 'sentry/components/performance/waterfall/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconWarning} from 'sentry/icons';
@@ -50,6 +49,7 @@ import {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
+import toPercent from 'sentry/utils/number/toPercent';
 import {
   QuickTraceContext,
   QuickTraceContextChildrenProps,

--- a/static/app/components/events/interfaces/spans/spanBarCursorGuide.tsx
+++ b/static/app/components/events/interfaces/spans/spanBarCursorGuide.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {toPercent} from 'sentry/components/performance/waterfall/utils';
+import toPercent from 'sentry/utils/number/toPercent';
 
 import * as CursorGuideHandler from './cursorGuideHandler';
 

--- a/static/app/components/events/interfaces/spans/spanDescendantGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanDescendantGroupBar.tsx
@@ -15,10 +15,10 @@ import {
 import {
   getDurationDisplay,
   getHumanDuration,
-  toPercent,
 } from 'sentry/components/performance/waterfall/utils';
 import {t} from 'sentry/locale';
 import {EventTransaction} from 'sentry/types/event';
+import toPercent from 'sentry/utils/number/toPercent';
 
 import {SpanGroupBar} from './spanGroupBar';
 import {EnhancedSpan, ProcessedSpanType, TreeDepthType} from './types';

--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -34,9 +34,9 @@ import {
   TreeToggle,
   TreeToggleContainer,
 } from 'sentry/components/performance/waterfall/treeConnector';
-import {toPercent} from 'sentry/components/performance/waterfall/utils';
 import {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
+import toPercent from 'sentry/utils/number/toPercent';
 import {PerformanceInteraction} from 'sentry/utils/performanceForSentry';
 
 import * as DividerHandlerManager from './dividerHandlerManager';

--- a/static/app/components/events/interfaces/spans/spanRectangle.tsx
+++ b/static/app/components/events/interfaces/spans/spanRectangle.tsx
@@ -5,7 +5,7 @@ import {
   SpanBarType,
 } from 'sentry/components/performance/waterfall/constants';
 import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
-import {toPercent} from 'sentry/components/performance/waterfall/utils';
+import toPercent from 'sentry/utils/number/toPercent';
 
 import {EnhancedSpan} from './types';
 import {SpanViewBoundsType} from './utils';

--- a/static/app/components/events/interfaces/spans/spanRectangleOverlay.tsx
+++ b/static/app/components/events/interfaces/spans/spanRectangleOverlay.tsx
@@ -3,8 +3,8 @@ import {DurationPill, RowRectangle} from 'sentry/components/performance/waterfal
 import {
   getDurationDisplay,
   getHumanDuration,
-  toPercent,
 } from 'sentry/components/performance/waterfall/utils';
+import toPercent from 'sentry/utils/number/toPercent';
 
 import {EnhancedSpan} from './types';
 import {getSpanGroupTimestamps, SpanViewBoundsType} from './utils';

--- a/static/app/components/performance/waterfall/row.tsx
+++ b/static/app/components/performance/waterfall/row.tsx
@@ -2,11 +2,9 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {ROW_HEIGHT} from 'sentry/components/performance/waterfall/constants';
-import {
-  getBackgroundColor,
-  toPercent,
-} from 'sentry/components/performance/waterfall/utils';
+import {getBackgroundColor} from 'sentry/components/performance/waterfall/utils';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import toPercent from 'sentry/utils/number/toPercent';
 
 interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
   cursor?: 'pointer' | 'default';

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -189,10 +189,6 @@ export const getHumanDuration = (duration: number): string => {
   })}ms`;
 };
 
-export const toPercent = (value: number) => `${(value * 100).toFixed(3)}%`;
-
-export const toRoundedPercent = (value: number) => `${Math.round(value * 100)}%`;
-
 type Rect = {
   height: number;
   width: number;

--- a/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
@@ -1,4 +1,4 @@
-import {memo} from 'react';
+import {memo, useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import CountTooltipContent from 'sentry/components/replays/countTooltipContent';
@@ -7,6 +7,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
+import toPercent from 'sentry/utils/number/toPercent';
 import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import type {SpanFrame} from 'sentry/utils/replays/types';
 
@@ -35,9 +36,12 @@ type Props = {
 function ReplayTimelineSpans({className, durationMs, frames, startTimestampMs}: Props) {
   const flattened = flattenFrames(frames);
   const {setActiveTab} = useActiveReplayTab();
+  const isDark = ConfigStore.get('theme') === 'dark';
+
+  const handleClick = useCallback(() => setActiveTab('network'), [setActiveTab]);
 
   return (
-    <Spans className={className}>
+    <Spans isDark={isDark} className={className}>
       {flattened.map((span, i) => {
         const sinceStart = span.startTimestamp - startTimestampMs;
         const startPct = divide(sinceStart, durationMs);
@@ -59,10 +63,11 @@ function ReplayTimelineSpans({className, durationMs, frames, startTimestampMs}: 
             position="bottom"
           >
             <Span
-              isDark={ConfigStore.get('theme') === 'dark'}
-              startPct={startPct}
-              widthPct={widthPct}
-              onClick={() => setActiveTab('network')}
+              style={{
+                left: toPercent(startPct),
+                width: toPercent(widthPct),
+              }}
+              onClick={handleClick}
             />
           </Tooltip>
         );
@@ -71,7 +76,7 @@ function ReplayTimelineSpans({className, durationMs, frames, startTimestampMs}: 
   );
 }
 
-const Spans = styled('ul')`
+const Spans = styled('ul')<{isDark: boolean}>`
   /* Reset defaults for <ul> */
   list-style: none;
   margin: 0;
@@ -81,17 +86,18 @@ const Spans = styled('ul')`
   margin-bottom: ${space(0.5)};
   position: relative;
   pointer-events: none;
+
+  & > li {
+    background: ${p => (p.isDark ? p.theme.charts.colors[5] : p.theme.charts.colors[0])};
+  }
 `;
 
-const Span = styled('li')<{isDark: boolean; startPct: number; widthPct: number}>`
+const Span = styled('li')`
   cursor: pointer;
   display: block;
   position: absolute;
-  left: ${p => p.startPct * 100}%;
   min-width: 1px;
-  width: ${p => p.widthPct * 100}%;
   height: 100%;
-  background: ${p => (p.isDark ? p.theme.charts.colors[5] : p.theme.charts.colors[0])};
   border-radius: 2px;
   pointer-events: auto;
 `;

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -14,7 +14,7 @@ import UserBadge from 'sentry/components/idBadge/userBadge';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
-import {pickBarColor, toPercent} from 'sentry/components/performance/waterfall/utils';
+import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import UserMisery from 'sentry/components/userMisery';
 import Version from 'sentry/components/version';
@@ -38,6 +38,7 @@ import {
 import {getShortEventId} from 'sentry/utils/events';
 import {formatFloat, formatPercentage, formatRate} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import toPercent from 'sentry/utils/number/toPercent';
 import Projects from 'sentry/utils/projects';
 import toArray from 'sentry/utils/toArray';
 import {QuickContextHoverWrapper} from 'sentry/views/discover/table/quickContext/quickContextWrapper';

--- a/static/app/utils/number/toPercent.spec.tsx
+++ b/static/app/utils/number/toPercent.spec.tsx
@@ -1,0 +1,7 @@
+import toPercent from 'sentry/utils/number/toPercent';
+
+describe('toPercent', () => {
+  it('should format a decimal into to percent', () => {
+    expect(toPercent(0.5)).toBe('50.000%');
+  });
+});

--- a/static/app/utils/number/toPercent.tsx
+++ b/static/app/utils/number/toPercent.tsx
@@ -1,0 +1,8 @@
+/**
+ * Format a fraction (0...1) into a percent, fixed & rounded to 3 decimal places.
+ *
+ * toPercent(0.42) === '42.000%'
+ */
+export default function toPercent(value: number) {
+  return `${(value * 100).toFixed(3)}%`;
+}

--- a/static/app/utils/number/toRoundedPercent.spec.tsx
+++ b/static/app/utils/number/toRoundedPercent.spec.tsx
@@ -1,0 +1,7 @@
+import toRoundedPercent from 'sentry/utils/number/toRoundedPercent';
+
+describe('toRoundedPercent', () => {
+  it('should format a decimal into to percent', () => {
+    expect(toRoundedPercent(0.666)).toBe('67%');
+  });
+});

--- a/static/app/utils/number/toRoundedPercent.tsx
+++ b/static/app/utils/number/toRoundedPercent.tsx
@@ -1,0 +1,8 @@
+/**
+ * Format a fraction (0...1) into a percent, rounded to the nearest decimal place.
+ *
+ * toRoundedPercent(0.42555) === '42%'
+ */
+export default function toRoundedPercent(value: number) {
+  return `${Math.round(value * 100)}%`;
+}

--- a/static/app/views/performance/traceDetails/traceView.tsx
+++ b/static/app/views/performance/traceDetails/traceView.tsx
@@ -18,11 +18,12 @@ import {
   VirtualScrollbar,
   VirtualScrollbarGrip,
 } from 'sentry/components/performance/waterfall/miniHeader';
-import {pickBarColor, toPercent} from 'sentry/components/performance/waterfall/utils';
+import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import {tct} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
+import toPercent from 'sentry/utils/number/toPercent';
 import {
   TraceError,
   TraceFullDetailed,

--- a/static/app/views/performance/traceDetails/transactionBar.tsx
+++ b/static/app/views/performance/traceDetails/transactionBar.tsx
@@ -46,12 +46,12 @@ import {
 import {
   getDurationDisplay,
   getHumanDuration,
-  toPercent,
 } from 'sentry/components/performance/waterfall/utils';
 import {generateIssueEventTarget} from 'sentry/components/quickTrace/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {Organization} from 'sentry/types';
 import {defined} from 'sentry/utils';
+import toPercent from 'sentry/utils/number/toPercent';
 import {TraceError, TraceFullDetailed} from 'sentry/utils/performance/quickTrace/types';
 import {
   isTraceError,

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsTable.tsx
@@ -10,7 +10,7 @@ import SortLink from 'sentry/components/gridEditable/sortLink';
 import Link from 'sentry/components/links/link';
 import Pagination from 'sentry/components/pagination';
 import {DurationPill, RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
-import {pickBarColor, toPercent} from 'sentry/components/performance/waterfall/utils';
+import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import PerformanceDuration from 'sentry/components/performanceDuration';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
@@ -20,6 +20,7 @@ import {defined} from 'sentry/utils';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {ColumnType, fieldAlignment} from 'sentry/utils/discover/fields';
 import {formatPercentage} from 'sentry/utils/formatters';
+import toPercent from 'sentry/utils/number/toPercent';
 import {
   ExampleTransaction,
   SuspectSpan,


### PR DESCRIPTION
Turns out that `toPercent` is used in a few spots outside the trace/waterfall folder. Lets make it a real first-class util that's hopefully still easy to find.


