### PR TITLE
feat(crons): Timeline in monitor details page

### DIFF
--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -22,7 +22,7 @@ import {
   MonitorBucketData,
   TimeWindow,
 } from 'sentry/views/monitors/components/overviewTimeline/types';
-import {timeWindowConfig} from 'sentry/views/monitors/components/overviewTimeline/utils';
+import {getConfigFromTimeRange} from 'sentry/views/monitors/components/overviewTimeline/utils';
 import {getTimeRangeFromEvent} from 'sentry/views/monitors/utils/getTimeRangeFromEvent';
 
 interface Props {
@@ -42,7 +42,8 @@ export function CronTimelineSection({event, organization}: Props) {
   const {start, end} = getTimeRangeFromEvent(event, nowRef.current, timeWindow);
   const {elementRef, width: timelineWidth} = useDimensions<HTMLDivElement>();
 
-  const elapsedMinutes = timeWindowConfig[timeWindow].elapsedMinutes;
+  const timeWindowConfig = getConfigFromTimeRange(start, end, timelineWidth);
+  const elapsedMinutes = timeWindowConfig.elapsedMinutes;
   const rollup = Math.floor((elapsedMinutes * 60) / timelineWidth);
 
   const monitorStatsQueryKey = `/organizations/${organization.slug}/monitors-stats/`;
@@ -82,13 +83,15 @@ export function CronTimelineSection({event, organization}: Props) {
       <TimelineContainer>
         <TimelineWidthTracker ref={elementRef} />
         <StyledGridLineTimeLabels
-          timeWindow={timeWindow}
+          timeWindowConfig={timeWindowConfig}
+          start={start}
           end={end}
           width={timelineWidth}
         />
         <StyledGridLineOverlay
           showCursor={!isLoading}
-          timeWindow={timeWindow}
+          timeWindowConfig={timeWindowConfig}
+          start={start}
           end={end}
           width={timelineWidth}
         />
@@ -104,7 +107,7 @@ export function CronTimelineSection({event, organization}: Props) {
                 bucketedData={monitorStats[monitorSlug]}
                 start={start}
                 end={end}
-                timeWindow={timeWindow}
+                timeWindowConfig={timeWindowConfig}
                 environment={environment ?? DEFAULT_ENVIRONMENT}
               />
             </FadeInContainer>

--- a/static/app/views/monitors/components/cronDetailsTimeline.tsx
+++ b/static/app/views/monitors/components/cronDetailsTimeline.tsx
@@ -1,0 +1,127 @@
+import {useRef} from 'react';
+import styled from '@emotion/styled';
+import moment from 'moment';
+
+import Panel from 'sentry/components/panels/panel';
+import Text from 'sentry/components/text';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
+import {parsePeriodToHours} from 'sentry/utils/dates';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useDimensions} from 'sentry/utils/useDimensions';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useRouter from 'sentry/utils/useRouter';
+import {
+  GridLineOverlay,
+  GridLineTimeLabels,
+} from 'sentry/views/monitors/components/overviewTimeline/gridLines';
+import {TimelineTableRow} from 'sentry/views/monitors/components/overviewTimeline/timelineTableRow';
+import {MonitorBucketData} from 'sentry/views/monitors/components/overviewTimeline/types';
+import {getConfigFromTimeRange} from 'sentry/views/monitors/components/overviewTimeline/utils';
+import {Monitor} from 'sentry/views/monitors/types';
+
+interface Props {
+  monitor: Monitor;
+  organization: Organization;
+}
+
+export function CronDetailsTimeline({monitor, organization}: Props) {
+  const {location} = useRouter();
+  const nowRef = useRef<Date>(new Date());
+  const {selection} = usePageFilters();
+  const {period} = selection.datetime;
+  let {end, start} = selection.datetime;
+
+  if (!start || !end) {
+    end = nowRef.current;
+    start = moment(end)
+      .subtract(parsePeriodToHours(period ?? '24h'), 'hour')
+      .toDate();
+  } else {
+    start = new Date(start);
+    end = new Date(end);
+  }
+
+  const {elementRef, width: timelineWidth} = useDimensions<HTMLDivElement>();
+  const config = getConfigFromTimeRange(start, end, timelineWidth);
+
+  const elapsedMinutes = config.elapsedMinutes;
+  const rollup = Math.floor((elapsedMinutes * 60) / timelineWidth);
+
+  const monitorStatsQueryKey = `/organizations/${organization.slug}/monitors-stats/`;
+  const {data: monitorStats, isLoading} = useApiQuery<Record<string, MonitorBucketData>>(
+    [
+      monitorStatsQueryKey,
+      {
+        query: {
+          until: Math.floor(end.getTime() / 1000),
+          since: Math.floor(start.getTime() / 1000),
+          monitor: monitor.slug,
+          resolution: `${rollup}s`,
+          ...location.query,
+        },
+      },
+    ],
+    {
+      staleTime: 0,
+      enabled: timelineWidth > 0,
+    }
+  );
+
+  return (
+    <TimelineContainer>
+      <TimelineWidthTracker ref={elementRef} />
+      <TimelineTitle>{t('Check-Ins')}</TimelineTitle>
+      <StyledGridLineTimeLabels
+        timeWindowConfig={config}
+        start={start}
+        end={end}
+        width={timelineWidth}
+      />
+      <StyledGridLineOverlay
+        showCursor={!isLoading}
+        timeWindowConfig={config}
+        start={start}
+        end={end}
+        width={timelineWidth}
+      />
+      <TimelineTableRow
+        monitor={monitor}
+        bucketedData={monitorStats?.[monitor.slug]}
+        timeWindowConfig={config}
+        end={end}
+        start={start}
+        width={timelineWidth}
+        singleMonitorView
+      />
+    </TimelineContainer>
+  );
+}
+
+const TimelineContainer = styled(Panel)`
+  display: grid;
+  grid-template-columns: 135px 1fr;
+  align-items: center;
+`;
+
+const StyledGridLineTimeLabels = styled(GridLineTimeLabels)`
+  grid-column: 2;
+`;
+
+const StyledGridLineOverlay = styled(GridLineOverlay)`
+  grid-column: 2;
+`;
+
+const TimelineWidthTracker = styled('div')`
+  position: absolute;
+  width: 100%;
+  grid-row: 1;
+  grid-column: 2;
+`;
+
+const TimelineTitle = styled(Text)`
+  ${p => p.theme.text.cardTitle};
+  border-bottom: 1px solid ${p => p.theme.border};
+  padding: ${space(2)};
+`;

--- a/static/app/views/monitors/components/monitorStats.tsx
+++ b/static/app/views/monitors/components/monitorStats.tsx
@@ -119,7 +119,7 @@ function MonitorStats({monitor, monitorEnvs, orgSlug}: Props) {
     <React.Fragment>
       <Panel>
         <PanelBody withPadding>
-          <StyledHeaderTitle>{t('Check-Ins')}</StyledHeaderTitle>
+          <StyledHeaderTitle>{t('Status')}</StyledHeaderTitle>
           {isLoading ? (
             <Placeholder height={`${height}px`} />
           ) : (

--- a/static/app/views/monitors/components/overviewTimeline/checkInTimeline.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/checkInTimeline.tsx
@@ -6,14 +6,14 @@ import {getAggregateStatus} from 'sentry/views/monitors/utils/getAggregateStatus
 import {mergeBuckets} from 'sentry/views/monitors/utils/mergeBuckets';
 
 import {JobTickTooltip} from './jobTickTooltip';
-import {MonitorBucketData, TimeWindow} from './types';
+import {MonitorBucketData, TimeWindowOptions} from './types';
 
 export interface CheckInTimelineProps {
   bucketedData: MonitorBucketData;
   end: Date;
   environment: string;
   start: Date;
-  timeWindow: TimeWindow;
+  timeWindowConfig: TimeWindowOptions;
   width: number;
 }
 
@@ -27,7 +27,7 @@ function getBucketedCheckInsPosition(
 }
 
 export function CheckInTimeline(props: CheckInTimelineProps) {
-  const {bucketedData, start, end, timeWindow, width, environment} = props;
+  const {bucketedData, start, end, timeWindowConfig, width, environment} = props;
 
   const elapsedMs = end.getTime() - start.getTime();
   const msPerPixel = elapsedMs / width;
@@ -50,7 +50,7 @@ export function CheckInTimeline(props: CheckInTimelineProps) {
         return (
           <JobTickTooltip
             jobTick={jobTick}
-            timeWindow={timeWindow}
+            timeWindowConfig={timeWindowConfig}
             skipWrapper
             key={startTs}
           >

--- a/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
@@ -4,31 +4,27 @@ import moment from 'moment';
 
 import DateTime from 'sentry/components/dateTime';
 import {space} from 'sentry/styles/space';
-import {TimeWindow} from 'sentry/views/monitors/components/overviewTimeline/types';
-import {
-  getStartFromTimeWindow,
-  timeWindowConfig,
-} from 'sentry/views/monitors/components/overviewTimeline/utils';
+import {TimeWindowOptions} from 'sentry/views/monitors/components/overviewTimeline/types';
 
 import {useTimelineCursor} from './timelineCursor';
 
 interface Props {
   end: Date;
-  timeWindow: TimeWindow;
+  start: Date;
+  timeWindowConfig: TimeWindowOptions;
   width: number;
   className?: string;
   showCursor?: boolean;
   stickyCursor?: boolean;
 }
 
-function clampTimeBasedOnResolution(date: moment.Moment, resolution: string) {
-  date.startOf('minute');
-  if (resolution === '1h') {
-    date.minute(date.minutes() - (date.minutes() % 10));
-  } else if (resolution === '30d') {
-    date.startOf('day');
-  } else {
+function alignTimeMarkersToStartOf(date: moment.Moment, timeMarkerInterval: number) {
+  if (timeMarkerInterval < 60) {
+    date.minute(date.minutes() - (date.minutes() % timeMarkerInterval));
+  } else if (timeMarkerInterval < 60 * 24) {
     date.startOf('hour');
+  } else {
+    date.startOf('day');
   }
 }
 
@@ -37,18 +33,21 @@ interface TimeMarker {
   position: number;
 }
 
-function getTimeMarkers(end: Date, timeWindow: TimeWindow, width: number): TimeMarker[] {
-  const {elapsedMinutes, timeMarkerInterval} = timeWindowConfig[timeWindow];
+function getTimeMarkersFromConfig(
+  start: Date,
+  end: Date,
+  config: TimeWindowOptions,
+  width: number
+) {
+  const {elapsedMinutes, timeMarkerInterval} = config;
   const msPerPixel = (elapsedMinutes * 60 * 1000) / width;
 
   const times: TimeMarker[] = [];
-  const start = getStartFromTimeWindow(end, timeWindow);
 
-  const firstTimeMark = moment(start);
-  clampTimeBasedOnResolution(firstTimeMark, timeWindow);
-  // Generate time markers which represent location of grid lines/time labels
+  const lastTimeMark = moment(end);
+  alignTimeMarkersToStartOf(lastTimeMark, timeMarkerInterval);
   for (let i = 1; i < elapsedMinutes / timeMarkerInterval; i++) {
-    const timeMark = moment(firstTimeMark).add(i * timeMarkerInterval, 'minute');
+    const timeMark = moment(lastTimeMark).subtract(i * timeMarkerInterval, 'minute');
     const position = (timeMark.valueOf() - start.valueOf()) / msPerPixel;
     times.push({date: timeMark.toDate(), position});
   }
@@ -56,36 +55,44 @@ function getTimeMarkers(end: Date, timeWindow: TimeWindow, width: number): TimeM
   return times;
 }
 
-export function GridLineTimeLabels({end, timeWindow, width, className}: Props) {
+export function GridLineTimeLabels({
+  width,
+  timeWindowConfig,
+  start,
+  end,
+  className,
+}: Props) {
   return (
     <LabelsContainer className={className}>
-      {getTimeMarkers(end, timeWindow, width).map(({date, position}) => (
-        <TimeLabelContainer key={date.getTime()} left={position}>
-          <TimeLabel date={date} {...timeWindowConfig[timeWindow].dateTimeProps} />
-        </TimeLabelContainer>
-      ))}
+      {getTimeMarkersFromConfig(start, end, timeWindowConfig, width).map(
+        ({date, position}) => (
+          <TimeLabelContainer key={date.getTime()} left={position}>
+            <TimeLabel date={date} {...timeWindowConfig.dateTimeProps} />
+          </TimeLabelContainer>
+        )
+      )}
     </LabelsContainer>
   );
 }
 
 export function GridLineOverlay({
   end,
-  timeWindow,
   width,
+  timeWindowConfig,
+  start,
   showCursor,
   stickyCursor,
   className,
 }: Props) {
-  const {cursorLabelFormat} = timeWindowConfig[timeWindow];
+  const {cursorLabelFormat} = timeWindowConfig;
 
   const makeCursorText = useCallback(
     (percentPosition: number) => {
-      const start = getStartFromTimeWindow(end, timeWindow);
       const timeOffset = (end.getTime() - start.getTime()) * percentPosition;
 
       return moment(start.getTime() + timeOffset).format(cursorLabelFormat);
     },
-    [cursorLabelFormat, end, timeWindow]
+    [cursorLabelFormat, end, start]
   );
 
   const {cursorContainerRef, timelineCursor} = useTimelineCursor<HTMLDivElement>({
@@ -98,9 +105,11 @@ export function GridLineOverlay({
     <Overlay ref={cursorContainerRef} className={className}>
       {timelineCursor}
       <GridLineContainer>
-        {getTimeMarkers(end, timeWindow, width).map(({date, position}) => (
-          <Gridline key={date.getTime()} left={position} />
-        ))}
+        {getTimeMarkersFromConfig(start, end, timeWindowConfig, width).map(
+          ({date, position}) => (
+            <Gridline key={date.getTime()} left={position} />
+          )
+        )}
       </GridLineContainer>
     </Overlay>
   );

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -18,7 +18,7 @@ import {Monitor} from '../../types';
 import {ResolutionSelector} from './resolutionSelector';
 import {TimelineTableRow} from './timelineTableRow';
 import {MonitorBucketData, TimeWindow} from './types';
-import {getStartFromTimeWindow, timeWindowConfig} from './utils';
+import {getConfigFromTimeRange, getStartFromTimeWindow} from './utils';
 
 interface Props {
   monitorList: Monitor[];
@@ -33,9 +33,8 @@ export function OverviewTimeline({monitorList}: Props) {
   const start = getStartFromTimeWindow(nowRef.current, timeWindow);
   const {elementRef, width: timelineWidth} = useDimensions<HTMLDivElement>();
 
-  const rollup = Math.floor(
-    (timeWindowConfig[timeWindow].elapsedMinutes * 60) / timelineWidth
-  );
+  const timeWindowConfig = getConfigFromTimeRange(start, nowRef.current, timelineWidth);
+  const rollup = Math.floor((timeWindowConfig.elapsedMinutes * 60) / timelineWidth);
   const monitorStatsQueryKey = `/organizations/${organization.slug}/monitors-stats/`;
   const {data: monitorStats, isLoading} = useApiQuery<Record<string, MonitorBucketData>>(
     [
@@ -64,7 +63,8 @@ export function OverviewTimeline({monitorList}: Props) {
       </StickyResolutionSelector>
       <StickyGridLineTimeLabels>
         <BorderlessGridLineTimeLabels
-          timeWindow={timeWindow}
+          timeWindowConfig={timeWindowConfig}
+          start={start}
           end={nowRef.current}
           width={timelineWidth}
         />
@@ -72,7 +72,8 @@ export function OverviewTimeline({monitorList}: Props) {
       <GridLineOverlay
         stickyCursor
         showCursor={!isLoading}
-        timeWindow={timeWindow}
+        timeWindowConfig={timeWindowConfig}
+        start={start}
         end={nowRef.current}
         width={timelineWidth}
       />
@@ -81,10 +82,10 @@ export function OverviewTimeline({monitorList}: Props) {
         <TimelineTableRow
           key={monitor.id}
           monitor={monitor}
-          timeWindow={timeWindow}
+          timeWindowConfig={timeWindowConfig}
+          start={start}
           bucketedData={monitorStats?.[monitor.slug]}
           end={nowRef.current}
-          start={start}
           width={timelineWidth}
         />
       ))}

--- a/static/app/views/monitors/components/overviewTimeline/jobTickTooltip.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/jobTickTooltip.tsx
@@ -8,21 +8,19 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {
   JobTickData,
-  TimeWindow,
+  TimeWindowOptions,
 } from 'sentry/views/monitors/components/overviewTimeline/types';
 import {CheckInStatus} from 'sentry/views/monitors/types';
 import {getColorsFromStatus, statusToText} from 'sentry/views/monitors/utils';
 
-import {timeWindowConfig} from './utils';
-
 interface Props extends Omit<TooltipProps, 'title'> {
   jobTick: JobTickData;
-  timeWindow: TimeWindow;
+  timeWindowConfig: TimeWindowOptions;
 }
 
-export function JobTickTooltip({jobTick, timeWindow, children, ...props}: Props) {
+export function JobTickTooltip({jobTick, timeWindowConfig, children, ...props}: Props) {
   const {startTs, endTs, envMapping} = jobTick;
-  const {dateTimeProps} = timeWindowConfig[timeWindow];
+  const {tooltipDateTimeProps} = timeWindowConfig;
   const capturedEnvs = Object.keys(envMapping);
   const representsSingleJob =
     capturedEnvs.length === 1 &&
@@ -32,11 +30,11 @@ export function JobTickTooltip({jobTick, timeWindow, children, ...props}: Props)
   const tooltipTitle = (
     <Fragment>
       <TooltipTimeLabel>
-        <DateTime date={startTs * 1000} {...dateTimeProps} />
+        <DateTime date={startTs * 1000} {...tooltipDateTimeProps} />
         {!representsSingleJob && (
           <Fragment>
             <Text>{'\u2014'}</Text>
-            <DateTime date={endTs * 1000} {...dateTimeProps} />
+            <DateTime date={endTs * 1000} {...tooltipDateTimeProps} />
           </Fragment>
         )}
       </TooltipTimeLabel>

--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -18,11 +18,17 @@ import {MonitorBucket} from './types';
 interface Props extends Omit<CheckInTimelineProps, 'bucketedData' | 'environment'> {
   monitor: Monitor;
   bucketedData?: MonitorBucket[];
+  singleMonitorView?: boolean;
 }
 
 const MAX_SHOWN_ENVIRONMENTS = 4;
 
-export function TimelineTableRow({monitor, bucketedData, ...timelineProps}: Props) {
+export function TimelineTableRow({
+  monitor,
+  bucketedData,
+  singleMonitorView,
+  ...timelineProps
+}: Props) {
   const [isExpanded, setExpanded] = useState(
     monitor.environments.length <= MAX_SHOWN_ENVIRONMENTS
   );
@@ -32,8 +38,8 @@ export function TimelineTableRow({monitor, bucketedData, ...timelineProps}: Prop
     : monitor.environments.slice(0, MAX_SHOWN_ENVIRONMENTS);
 
   return (
-    <TimelineRow key={monitor.id}>
-      <MonitorDetails monitor={monitor} />
+    <TimelineRow key={monitor.id} isZebraStriped={!singleMonitorView}>
+      {!singleMonitorView && <MonitorDetails monitor={monitor} />}
       <MonitorEnvContainer>
         {environments.map(({name, status}) => (
           <EnvWithStatus key={name}>
@@ -87,16 +93,19 @@ function MonitorDetails({monitor}: {monitor: Monitor}) {
   );
 }
 
-const TimelineRow = styled('div')`
+const TimelineRow = styled('div')<{isZebraStriped: boolean}>`
   display: contents;
 
-  &:nth-child(odd) > * {
-    background: ${p => p.theme.backgroundSecondary};
+  ${p =>
+    p.isZebraStriped &&
+    `&:nth-child(odd) > * {
+    background: ${p.theme.backgroundSecondary};
   }
 
   &:hover > * {
-    background: ${p => p.theme.backgroundTertiary};
+    background: ${p.theme.backgroundTertiary};
   }
+  `}
 
   > * {
     transition: background 50ms ease-in-out;

--- a/static/app/views/monitors/components/overviewTimeline/types.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/types.tsx
@@ -19,9 +19,11 @@ export interface TimeWindowOptions {
    * The interval between each grid line and time label in minutes
    */
   timeMarkerInterval: number;
+  /**
+   * Props to pass to <DateTime> when displaying the job tick tooltip
+   */
+  tooltipDateTimeProps: {dateOnly?: boolean; timeOnly?: boolean};
 }
-
-export type TimeWindowData = Record<TimeWindow, TimeWindowOptions>;
 
 // TODO(davidenwang): Remove this type as its a little too specific
 export type MonitorBucketData = MonitorBucket[];

--- a/static/app/views/monitors/components/overviewTimeline/utils.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/utils.tsx
@@ -2,39 +2,54 @@ import moment from 'moment';
 
 import {getFormat} from 'sentry/utils/dates';
 
-import {TimeWindow, TimeWindowData} from './types';
+import {TimeWindow, TimeWindowOptions} from './types';
 
-// Stores options and data which correspond to each selectable time window
-export const timeWindowConfig: TimeWindowData = {
-  '1h': {
-    cursorLabelFormat: getFormat({timeOnly: true, seconds: true}),
-    elapsedMinutes: 60,
-    timeMarkerInterval: 10,
-    dateTimeProps: {timeOnly: true},
-  },
-  '24h': {
-    cursorLabelFormat: getFormat({timeOnly: true}),
-    elapsedMinutes: 60 * 24,
-    timeMarkerInterval: 60 * 4,
-    dateTimeProps: {timeOnly: true},
-  },
-  '7d': {
-    cursorLabelFormat: getFormat(),
-    elapsedMinutes: 60 * 24 * 7,
-    timeMarkerInterval: 60 * 24,
-    dateTimeProps: {},
-  },
-  '30d': {
-    cursorLabelFormat: getFormat({dateOnly: true}),
-    elapsedMinutes: 60 * 24 * 30,
-    timeMarkerInterval: 60 * 24 * 5,
-    dateTimeProps: {dateOnly: true},
-  },
+// Stores the elapsed minutes for each selectable resolution
+export const resolutionElapsedMinutes: Record<TimeWindow, number> = {
+  '1h': 60,
+  '24h': 60 * 24,
+  '7d': 60 * 24 * 7,
+  '30d': 60 * 24 * 30,
 };
 
 export function getStartFromTimeWindow(end: Date, timeWindow: TimeWindow): Date {
-  const {elapsedMinutes} = timeWindowConfig[timeWindow];
-  const start = moment(end).subtract(elapsedMinutes, 'minute');
+  const start = moment(end).subtract(resolutionElapsedMinutes[timeWindow], 'minute');
 
   return start.toDate();
+}
+
+// The space to allocate to each time label based on (MMM DD HH:SS AM/PM)
+const TIMELABEL_WIDTH = 100;
+
+export function getConfigFromTimeRange(
+  start: Date,
+  end: Date,
+  timelineWidth: number
+): TimeWindowOptions {
+  // Acceptable intervals between time labels, in minutes
+  const minuteRanges = [1, 10, 30, 60, 4 * 60, 8 * 60, 12 * 60];
+  const startEndMinutes = (end.getTime() - start.getTime()) / (1000 * 60);
+  const timeLabelMinutes = startEndMinutes * (TIMELABEL_WIDTH / timelineWidth);
+
+  for (const minutes of minuteRanges) {
+    if (minutes > timeLabelMinutes) {
+      return {
+        cursorLabelFormat: getFormat({timeOnly: true}),
+        elapsedMinutes: startEndMinutes,
+        timeMarkerInterval: minutes,
+        dateTimeProps: {timeOnly: true},
+        tooltipDateTimeProps: {timeOnly: true},
+      };
+    }
+  }
+
+  // Calculate days between each time label interval for larger time ranges
+  const timeLabelIntervalDays = Math.ceil(timeLabelMinutes / (60 * 24));
+  return {
+    cursorLabelFormat: getFormat(),
+    elapsedMinutes: startEndMinutes,
+    timeMarkerInterval: timeLabelIntervalDays * 60 * 24,
+    dateTimeProps: {dateOnly: true},
+    tooltipDateTimeProps: {},
+  };
 }

--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -12,6 +12,7 @@ import {space} from 'sentry/styles/space';
 import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {CronDetailsTimeline} from 'sentry/views/monitors/components/cronDetailsTimeline';
 import DetailsSidebar from 'sentry/views/monitors/components/detailsSidebar';
 
 import MonitorCheckIns from './components/monitorCheckIns';
@@ -93,6 +94,7 @@ function MonitorDetails({params, location}: Props) {
               <MonitorOnboarding monitor={monitor} />
             ) : (
               <Fragment>
+                <CronDetailsTimeline organization={organization} monitor={monitor} />
                 <MonitorStats
                   orgSlug={organization.slug}
                   monitor={monitor}

--- a/static/app/views/monitors/utils/getTimeRangeFromEvent.tsx
+++ b/static/app/views/monitors/utils/getTimeRangeFromEvent.tsx
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 import {Event} from 'sentry/types';
 import {TimeWindow} from 'sentry/views/monitors/components/overviewTimeline/types';
-import {timeWindowConfig} from 'sentry/views/monitors/components/overviewTimeline/utils';
+import {resolutionElapsedMinutes} from 'sentry/views/monitors/components/overviewTimeline/utils';
 
 /**
  * Given a cron event, current time, and time window, attempt to return a
@@ -14,7 +14,7 @@ export function getTimeRangeFromEvent(
   now: Date,
   timeWindow: TimeWindow
 ): {end: Date; start: Date} {
-  const elapsedMinutes = timeWindowConfig[timeWindow].elapsedMinutes;
+  const elapsedMinutes = resolutionElapsedMinutes[timeWindow];
   let end = moment(event.dateReceived).add(elapsedMinutes / 2, 'minute');
   if (end > moment(now)) {
     end = moment(now);


### PR DESCRIPTION
Required some decent timeline logic changes to make this work, the biggest change being that now the timeline view can accept an arbitrary `start/end` or `datetime period` and calculate `TimeWindowOptions` based on that, namely the distance between timeline time labels.

<img width="902" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/e49faab5-fdc1-4f48-9b43-37385c59cc83">
