### PR TITLE
feat(commit-context): Do not create if older than 1 year old

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import timezone
 from typing import Any, Mapping, Sequence
 from urllib.parse import urlparse
 
 from django import forms
 from django.http import HttpResponse
 from django.utils.translation import gettext_lazy as _
+from isodate import parse_datetime
 from rest_framework.request import Request
 
 from sentry.identity.gitlab import get_oauth_data, get_user_info
@@ -166,13 +167,10 @@ class GitlabIntegration(
         except ApiError as e:
             raise e
 
-        date_format_expected = "%Y-%m-%dT%H:%M:%S.%f%z"
         try:
             commit = max(
                 blame_range,
-                key=lambda blame: datetime.strptime(
-                    blame.get("commit", {}).get("committed_date"), date_format_expected
-                ),
+                key=lambda blame: parse_datetime(blame.get("commit", {}).get("committed_date")),
             )
         except (ValueError, IndexError):
             return None
@@ -182,9 +180,9 @@ class GitlabIntegration(
             return None
         else:
             # TODO(nisanthan): Use dateutil.parser.isoparse once on python 3.11
-            committed_date = datetime.strptime(
-                commitInfo.get("committed_date"), date_format_expected
-            ).astimezone(timezone.utc)
+            committed_date = parse_datetime(commitInfo.get("committed_date")).astimezone(
+                timezone.utc
+            )
 
             return {
                 "commitId": commitInfo.get("id"),

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -181,11 +181,10 @@ class GitlabIntegration(
         if not commitInfo:
             return None
         else:
-            committed_date = "{}Z".format(
-                datetime.strptime(commitInfo.get("committed_date"), date_format_expected)
-                .astimezone(timezone.utc)
-                .strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
-            )
+            committed_date = datetime.strptime(
+                commitInfo.get("committed_date"), date_format_expected
+            ).astimezone(timezone.utc)
+
             return {
                 "commitId": commitInfo.get("id"),
                 "committedDate": committed_date,

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -181,6 +181,7 @@ class GitlabIntegration(
         if not commitInfo:
             return None
         else:
+            # TODO(nisanthan): Use dateutil.parser.isoparse once on python 3.11
             committed_date = datetime.strptime(
                 commitInfo.get("committed_date"), date_format_expected
             ).astimezone(timezone.utc)

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Any, List, Mapping, Sequence, Tuple
 
 import sentry_sdk
@@ -108,7 +109,10 @@ def find_commit_context_for_event(
                 },
             )
 
-        if commit_context:
+        # Only return suspect commits that are less than a year old
+        if commit_context and datetime.strptime(
+            commit_context["committedDate"], "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=timezone.utc) > datetime.now(tz=timezone.utc) - timedelta(days=365):
             result.append((commit_context, code_mapping))
 
     return result, installation

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -110,9 +110,13 @@ def find_commit_context_for_event(
             )
 
         # Only return suspect commits that are less than a year old
-        if commit_context and datetime.strptime(
-            commit_context["committedDate"], "%Y-%m-%dT%H:%M:%SZ"
-        ).replace(tzinfo=timezone.utc) > datetime.now(tz=timezone.utc) - timedelta(days=365):
+        if commit_context and is_date_less_than_year(commit_context["committedDate"]):
             result.append((commit_context, code_mapping))
 
     return result, installation
+
+
+def is_date_less_than_year(date):
+    return datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    ) > datetime.now(tz=timezone.utc) - timedelta(days=365)

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -116,7 +116,5 @@ def find_commit_context_for_event(
     return result, installation
 
 
-def is_date_less_than_year(date):
-    return datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ").replace(
-        tzinfo=timezone.utc
-    ) > datetime.now(tz=timezone.utc) - timedelta(days=365)
+def is_date_less_than_year(date: datetime):
+    return date > datetime.now(tz=timezone.utc) - timedelta(days=365)

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qs, quote, urlencode, urlparse
 import responses
 from django.core.cache import cache
 from django.test import override_settings
+from isodate import parse_datetime
 
 from fixtures.gitlab import GET_COMMIT_RESPONSE, GitLabTestCase
 from sentry.integrations.gitlab import GitlabIntegrationProvider
@@ -427,7 +428,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
 
         commit_context_expected = {
             "commitId": "d42409d56517157c48bf3bd97d3f75974dde19fb",
-            "committedDate": "2015-12-18T08:12:22.000Z",
+            "committedDate": parse_datetime("2015-12-18T08:12:22.000Z"),
             "commitMessage": "Add installation instructions",
             "commitAuthorName": "Nisanthan Nanthakumar",
             "commitAuthorEmail": "nisanthan.nanthakumar@sentry.io",

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -84,9 +84,7 @@ class TestCommitContext(TestCommitContextMixin):
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "asdfwreqr",
-            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            ),
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "admin@localhost",
@@ -149,9 +147,7 @@ class TestCommitContext(TestCommitContextMixin):
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "asdfasdf",
-            "committedDate": (
-                datetime.now(tz=datetime_timezone.utc) - timedelta(days=370)
-            ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=370)),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "admin@localhost",
@@ -186,9 +182,7 @@ class TestCommitContext(TestCommitContextMixin):
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "asdfasdf",
-            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            ),
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "admin@localhost",
@@ -213,9 +207,7 @@ class TestCommitContext(TestCommitContextMixin):
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "asdfwreqr",
-            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            ),
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "admin@localhost",
@@ -300,9 +292,7 @@ class TestCommitContext(TestCommitContextMixin):
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "somekey",
-            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            ),
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "randomuser@sentry.io",
@@ -343,9 +333,7 @@ class TestCommitContext(TestCommitContextMixin):
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "somekey",
-            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            ),
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "randomuser@sentry.io",
@@ -386,9 +374,7 @@ class TestCommitContext(TestCommitContextMixin):
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "somekey",
-            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            ),
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "randomuser@sentry.io",
@@ -474,9 +460,7 @@ class TestCommitContext(TestCommitContextMixin):
     Mock(
         return_value={
             "commitId": "asdfwreqr",
-            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            ),
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "admin@localhost",

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
+from datetime import timezone as datetime_timezone
 from unittest.mock import Mock, patch
 
 import pytest
@@ -83,7 +84,9 @@ class TestCommitContext(TestCommitContextMixin):
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "asdfwreqr",
-            "committedDate": "2023-02-14T11:11Z",
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "admin@localhost",
@@ -141,11 +144,51 @@ class TestCommitContext(TestCommitContextMixin):
             error_message="integration_failed",
         )
 
+    @patch("sentry.tasks.commit_context.logger")
     @patch(
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "asdfasdf",
-            "committedDate": "2023-02-14T11:11Z",
+            "committedDate": (
+                datetime.now(tz=datetime_timezone.utc) - timedelta(days=370)
+            ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "commitMessage": "placeholder commit message",
+            "commitAuthorName": "",
+            "commitAuthorEmail": "admin@localhost",
+        },
+    )
+    def test_found_commit_is_too_old(self, mock_get_commit_context, mock_logger):
+        with self.tasks():
+            assert not GroupOwner.objects.filter(group=self.event.group).exists()
+            event_frames = get_frame_paths(self.event)
+            process_commit_context(
+                event_id=self.event.event_id,
+                event_platform=self.event.platform,
+                event_frames=event_frames,
+                group_id=self.event.group_id,
+                project_id=self.event.project_id,
+            )
+
+        assert mock_logger.info.call_count == 1
+        mock_logger.info.assert_called_with(
+            "process_commit_context.find_commit_context",
+            extra={
+                "event": self.event.event_id,
+                "group": self.event.group_id,
+                "organization": self.event.group.project.organization_id,
+                "reason": "could_not_fetch_commit_context",
+                "code_mappings_count": 1,
+                "fallback": True,
+            },
+        )
+
+    @patch(
+        "sentry.integrations.github.GitHubIntegration.get_commit_context",
+        return_value={
+            "commitId": "asdfasdf",
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "admin@localhost",
@@ -170,7 +213,9 @@ class TestCommitContext(TestCommitContextMixin):
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "asdfwreqr",
-            "committedDate": "2023-02-14T11:11Z",
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "admin@localhost",
@@ -255,7 +300,9 @@ class TestCommitContext(TestCommitContextMixin):
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "somekey",
-            "committedDate": "2023-02-14T11:11Z",
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "randomuser@sentry.io",
@@ -296,7 +343,9 @@ class TestCommitContext(TestCommitContextMixin):
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "somekey",
-            "committedDate": "2023-02-14T11:11Z",
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "randomuser@sentry.io",
@@ -337,7 +386,9 @@ class TestCommitContext(TestCommitContextMixin):
         "sentry.integrations.github.GitHubIntegration.get_commit_context",
         return_value={
             "commitId": "somekey",
-            "committedDate": "2023-02-14T11:11Z",
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "randomuser@sentry.io",
@@ -423,7 +474,9 @@ class TestCommitContext(TestCommitContextMixin):
     Mock(
         return_value={
             "commitId": "asdfwreqr",
-            "committedDate": "2023-02-14T11:11Z",
+            "committedDate": (datetime.now(tz=datetime_timezone.utc) - timedelta(days=7)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
             "commitMessage": "placeholder commit message",
             "commitAuthorName": "",
             "commitAuthorEmail": "admin@localhost",

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1296,7 +1296,9 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
 class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
     github_blame_return_value = {
         "commitId": "asdfwreqr",
-        "committedDate": "",
+        "committedDate": (datetime.now(timezone.utc) - timedelta(days=2)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        ),
         "commitMessage": "placeholder commit message",
         "commitAuthorName": "",
         "commitAuthorEmail": "admin@localhost",

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1296,9 +1296,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
 class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
     github_blame_return_value = {
         "commitId": "asdfwreqr",
-        "committedDate": (datetime.now(timezone.utc) - timedelta(days=2)).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        ),
+        "committedDate": (datetime.now(timezone.utc) - timedelta(days=2)),
         "commitMessage": "placeholder commit message",
         "commitAuthorName": "",
         "commitAuthorEmail": "admin@localhost",


### PR DESCRIPTION
## Objective

Update on the reverted PR: #54624 

The original PR had errors from GitLab date strings not being  parsed correctly bc they are formatted differently from GitHub. So this PR returns the datetime object for internal usage and will make date comparisons easier without needing to know which integration it came from.