### PR TITLE
fix(hc): Fix split-silo tests

### DIFF
--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -1,38 +1,31 @@
 from unittest import mock
 
 from sentry.integrations.example.integration import AliasedIntegrationProvider, ExampleIntegration
-from sentry.models import (
-    ExternalIssue,
-    Group,
-    GroupLink,
-    GroupStatus,
-    Integration,
-    OrganizationIntegration,
-)
+from sentry.models import ExternalIssue, Group, GroupLink, GroupStatus, Integration
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class IssueSyncIntegration(TestCase):
     def test_status_sync_inbound_resolve(self):
         group = self.group
         assert group.status == GroupStatus.UNRESOLVED
 
-        integration = Integration.objects.create(provider="example", external_id="123456")
-        integration.add_organization(group.organization, self.user)
-
-        OrganizationIntegration.objects.filter(
-            integration_id=integration.id, organization_id=group.organization.id
-        ).update(
-            config={
-                "sync_comments": True,
-                "sync_status_outbound": True,
-                "sync_status_inbound": True,
-                "sync_assignee_outbound": True,
-                "sync_assignee_inbound": True,
-            }
+        integration = self.create_integration(
+            organization=group.organization,
+            external_id="123456",
+            oi_params={
+                "config": {
+                    "sync_comments": True,
+                    "sync_status_outbound": True,
+                    "sync_status_inbound": True,
+                    "sync_assignee_outbound": True,
+                    "sync_assignee_inbound": True,
+                }
+            },
+            provider="example",
         )
 
         external_issue = ExternalIssue.objects.create(
@@ -64,19 +57,19 @@ class IssueSyncIntegration(TestCase):
         group.save()
         assert group.status == GroupStatus.RESOLVED
 
-        integration = Integration.objects.create(provider="example", external_id="123456")
-        integration.add_organization(group.organization, self.user)
-
-        OrganizationIntegration.objects.filter(
-            integration_id=integration.id, organization_id=group.organization.id
-        ).update(
-            config={
-                "sync_comments": True,
-                "sync_status_outbound": True,
-                "sync_status_inbound": True,
-                "sync_assignee_outbound": True,
-                "sync_assignee_inbound": True,
-            }
+        integration = self.create_integration(
+            organization=group.organization,
+            external_id="123456",
+            oi_params={
+                "config": {
+                    "sync_comments": True,
+                    "sync_status_outbound": True,
+                    "sync_status_inbound": True,
+                    "sync_assignee_outbound": True,
+                    "sync_assignee_inbound": True,
+                }
+            },
+            provider="example",
         )
 
         external_issue = ExternalIssue.objects.create(

--- a/tests/sentry/manager/test_organization_manager.py
+++ b/tests/sentry/manager/test_organization_manager.py
@@ -1,0 +1,15 @@
+from sentry.models import Organization
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test(stable=True)
+class OrganizationManagerTest(TestCase):
+    def test_get_for_user_ids(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        team = self.create_team(organization=org)
+        self.create_team_membership(team, user=user)
+
+        orgs = Organization.objects.get_for_user_ids({user.id})
+        assert list(orgs) == [org]

--- a/tests/sentry/manager/test_project_manager.py
+++ b/tests/sentry/manager/test_project_manager.py
@@ -5,6 +5,16 @@ from sentry.testutils.silo import region_silo_test
 
 @region_silo_test(stable=True)
 class ProjectManagerTest(TestCase):
+    def test_get_for_user_ids(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        team = self.create_team(organization=org)
+        self.create_team_membership(team, user=user)
+        project = self.create_project(teams=[team], name="name")
+
+        projects = Project.objects.get_for_user_ids({user.id})
+        assert list(projects) == [project]
+
     def test_get_for_user(self):
         user = self.create_user("foo@example.com")
         org = self.create_organization()

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -8,7 +8,7 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test
-class UserTest(TestCase, HybridCloudTestMixin):
+class UserTest(TestCase):
     def test_hybrid_cloud_deletion(self):
         user = self.create_user()
         user_id = user.id
@@ -27,13 +27,13 @@ class UserTest(TestCase, HybridCloudTestMixin):
         # Ensure they are all now gone.
         assert not SavedSearch.objects.filter(owner_id=user_id).exists()
 
+
+@control_silo_test(stable=True)
+class UserDetailsTest(TestCase):
     def test_get_full_name(self):
         user = self.create_user(name="foo bar")
         assert user.name == user.get_full_name() == "foo bar"
 
-
-@control_silo_test(stable=True)
-class UserDetailsTest(TestCase):
     def test_salutation(self):
         user = self.create_user(email="a@example.com", username="a@example.com")
         assert user.get_salutation_name() == "A"

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -1,13 +1,4 @@
-from sentry.models import (
-    Authenticator,
-    Organization,
-    OrganizationMember,
-    OrganizationMemberTeam,
-    Project,
-    SavedSearch,
-    User,
-    UserEmail,
-)
+from sentry.models import Authenticator, OrganizationMember, SavedSearch, User, UserEmail
 from sentry.silo import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import TestCase
@@ -18,16 +9,6 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 @control_silo_test
 class UserTest(TestCase, HybridCloudTestMixin):
-    def test_get_orgs(self):
-        user = self.create_user()
-        org = self.create_organization(owner=user)
-        team = self.create_team(organization=org)
-        member = OrganizationMember.objects.get(user_id=user.id, organization=org)
-        OrganizationMemberTeam.objects.create(organizationmember=member, team=team)
-
-        organizations = Organization.objects.get_for_user_ids({user.id})
-        assert {_.id for _ in organizations} == {org.id}
-
     def test_hybrid_cloud_deletion(self):
         user = self.create_user()
         user_id = user.id
@@ -45,17 +26,6 @@ class UserTest(TestCase, HybridCloudTestMixin):
 
         # Ensure they are all now gone.
         assert not SavedSearch.objects.filter(owner_id=user_id).exists()
-
-    def test_get_projects(self):
-        user = self.create_user()
-        org = self.create_organization(owner=user)
-        team = self.create_team(organization=org)
-        member = OrganizationMember.objects.get(user_id=user.id, organization=org)
-        OrganizationMemberTeam.objects.create(organizationmember=member, team=team)
-        project = self.create_project(teams=[team], name="name")
-
-        projects = Project.objects.get_for_user_ids({user.id})
-        assert {_.id for _ in projects} == {project.id}
 
     def test_get_full_name(self):
         user = self.create_user(name="foo bar")


### PR DESCRIPTION
These were all just primarily missing `assume_test_silo_mode`s during test setup.

This also moves manager test cases which were previously in test_user.py into manager-specific test files.