### PR TITLE
ref(metrics layer): Add http_error_count/http_error_rate functions for spans

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -54,7 +54,9 @@ from sentry.snuba.metrics.fields.snql import (
     failure_count_transaction,
     foreground_anr_users,
     histogram_snql_factory,
+    http_error_count_span_snql,
     http_error_count_transaction,
+    http_error_rate_span_snql,
     max_timestamp,
     min_timestamp,
     miserable_users,
@@ -1713,6 +1715,22 @@ DERIVED_OPS: Mapping[MetricOperationType, DerivedOp] = {
             snql_func=max_timestamp,
             meta_type="datetime",
             default_null_value=None,
+        ),
+        DerivedOp(
+            op="http_error_count",
+            can_groupby=False,
+            can_orderby=True,
+            can_filter=False,
+            snql_func=http_error_count_span_snql,
+            default_null_value=0,
+        ),
+        DerivedOp(
+            op="http_error_rate",
+            can_groupby=False,
+            can_orderby=True,
+            can_filter=False,
+            snql_func=http_error_rate_span_snql,
+            default_null_value=0,
         ),
     ]
 }

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -95,6 +95,8 @@ MetricOperationType = Literal[
     "uniq_if_column",
     "min_timestamp",
     "max_timestamp",
+    "http_error_count",
+    "http_error_rate",
 ]
 MetricUnit = Literal[
     "nanosecond",
@@ -282,6 +284,8 @@ DERIVED_OPERATIONS = (
     "uniq_if_column",
     "min_timestamp",
     "max_timestamp",
+    "http_error_count",
+    "http_error_rate",
 )
 OPERATIONS = (
     (

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2477,7 +2477,6 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     def test_time_spent(self):
         super().test_time_spent()
 
-    @pytest.mark.xfail(reason="Not supported")
     def test_http_error_rate(self):
         super().test_http_error_rate()
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -548,10 +548,6 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     def test_time_spent_percentage_local(self):
         super().test_time_spent_percentage_local()
 
-    @pytest.mark.xfail(reason="Not implemented")
-    def test_http_error_rate_and_count(self):
-        super().test_http_error_rate_and_count()
-
     @pytest.mark.xfail(reason="Cannot group by transform")
     def test_span_module(self):
         super().test_span_module()


### PR DESCRIPTION
Add the spans versions of http_error_count and http_error_rate to the spans
metrics layer. This was done using a DerivedOp, to allow for the different
versions of self time.