### PR TITLE
ref: defer calculating service-related skips to after import time

### DIFF
--- a/src/sentry/testutils/pytest/__init__.py
+++ b/src/sentry/testutils/pytest/__init__.py
@@ -1,4 +1,5 @@
 pytest_plugins = [
+    "sentry.testutils.skips",
     "sentry.testutils.pytest.sentry",
     "sentry.testutils.pytest.selenium",
     "sentry.testutils.pytest.fixtures",


### PR DESCRIPTION
loading options at import time causes django to error on the database lookup.  I'd like to make that error loud so I need to defer the lookup of options until we're in a test context.  this also was making network requests at import time which is also not great!

this pushes back the lookup to fixture evaluation time when django's database is available

I also got rid of some global variables and coordinated the logic