### PR TITLE
ref(query-builder): Move discover logic out of querybuilder

### DIFF
--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -328,7 +328,9 @@ class OrganizationEventsSpansStatsEndpoint(OrganizationEventsSpansEndpointBase):
                     rollup,
                     query=query,
                     selected_columns=query_columns,
-                    functions_acl=["array_join", "percentileArray", "sumArray"],
+                    config=QueryBuilderConfig(
+                        functions_acl=["array_join", "percentileArray", "sumArray"],
+                    ),
                 )
 
                 span_op_column = builder.resolve_function("array_join(spans_op)")

--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -21,7 +21,7 @@ from sentry.api.paginator import GenericOffsetPaginator
 from sentry.discover.arithmetic import is_equation, strip_equation
 from sentry.models import Organization
 from sentry.search.events.builder import QueryBuilder, TimeseriesQueryBuilder
-from sentry.search.events.types import ParamsType
+from sentry.search.events.types import ParamsType, QueryBuilderConfig
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
 from sentry.utils.cursors import Cursor, CursorResult
@@ -508,11 +508,13 @@ def query_suspect_span_groups(
         equations=equations,
         query=query,
         orderby=[direction + column for column in suspect_span_columns.suspect_op_group_sort],
-        auto_aggregations=True,
-        use_aggregate_conditions=True,
         limit=limit,
         offset=offset,
-        functions_acl=["array_join", "sumArray", "percentileArray", "maxArray"],
+        config=QueryBuilderConfig(
+            auto_aggregations=True,
+            use_aggregate_conditions=True,
+            functions_acl=["array_join", "sumArray", "percentileArray", "maxArray"],
+        ),
     )
 
     extra_conditions = []

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -32,7 +32,7 @@ from sentry.eventstore.models import Event
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models import Group, Organization
 from sentry.search.events.builder import QueryBuilder
-from sentry.search.events.types import ParamsType
+from sentry.search.events.types import ParamsType, QueryBuilderConfig
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
 from sentry.utils.dates import to_timestamp_from_iso_format
@@ -387,7 +387,9 @@ def query_trace_data(
         query=f"trace:{trace_id}",
         selected_columns=["event_id"],
         groupby_columns=["event_id"],
-        functions_acl=["groupArray"],
+        config=QueryBuilderConfig(
+            functions_acl=["groupArray"],
+        ),
     )
     occurrence_query.columns.append(
         Function("groupArray", parameters=[Column("group_id")], alias="issue.ids")
@@ -411,8 +413,10 @@ def query_trace_data(
         ],
         # Don't add timestamp to this orderby as snuba will have to split the time range up and make multiple queries
         orderby=["id"],
-        auto_fields=False,
         limit=MAX_TRACE_SIZE,
+        config=QueryBuilderConfig(
+            auto_fields=False,
+        ),
     )
     results = bulk_snql_query(
         [

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -17,7 +17,7 @@ from sentry.api.paginator import GenericOffsetPaginator
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.fields import DateArg, parse_function
-from sentry.search.events.types import Alias, SelectType, WhereType
+from sentry.search.events.types import Alias, QueryBuilderConfig, SelectType, WhereType
 from sentry.search.utils import InvalidQuery, parse_datetime_string
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
@@ -463,9 +463,11 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
                 dataset=Dataset.Discover,
                 params=params,
                 selected_columns=selected_columns,
-                auto_fields=False,
-                auto_aggregations=True,
-                use_aggregate_conditions=True,
+                config=QueryBuilderConfig(
+                    auto_fields=False,
+                    auto_aggregations=True,
+                    use_aggregate_conditions=True,
+                ),
             )
             snql_trend_columns = self.resolve_trend_columns(trend_query, function, column, middle)
             trend_query.columns.extend(snql_trend_columns.values())
@@ -476,7 +478,7 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
             # Both orderby and conditions need to be resolved after the columns because of aliasing
             trend_query.orderby = trend_query.resolve_orderby(orderby)
             trend_query.groupby = trend_query.resolve_groupby()
-            where, having = trend_query.resolve_conditions(query, use_aggregate_conditions=True)
+            where, having = trend_query.resolve_conditions(query)
             trend_query.where += where
             trend_query.having += having
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -24,6 +24,7 @@ from sentry.search.events.constants import (
     TEAM_KEY_TRANSACTION_ALIAS,
 )
 from sentry.search.events.fields import FIELD_ALIASES, FUNCTIONS
+from sentry.search.events.types import QueryBuilderConfig
 from sentry.search.utils import (
     InvalidQuery,
     parse_datetime_range,
@@ -501,7 +502,9 @@ class SearchVisitor(NodeVisitor):
 
             # TODO: read dataset from config
             self.builder = UnresolvedQuery(
-                dataset=Dataset.Discover, params=self.params, functions_acl=FUNCTIONS.keys()
+                dataset=Dataset.Discover,
+                params=self.params,
+                config=QueryBuilderConfig(functions_acl=FUNCTIONS.keys()),
             )
         else:
             self.builder = builder

--- a/src/sentry/search/events/builder/__init__.py
+++ b/src/sentry/search/events/builder/__init__.py
@@ -1,4 +1,5 @@
 from .discover import (  # NOQA
+    BaseQueryBuilder,
     HistogramQueryBuilder,
     QueryBuilder,
     TimeseriesQueryBuilder,
@@ -35,6 +36,7 @@ from .spans_metrics import (  # NOQA
 )
 
 __all__ = [
+    "BaseQueryBuilder",
     "HistogramQueryBuilder",
     "QueryBuilder",
     "TimeseriesQueryBuilder",

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -98,6 +98,8 @@ from sentry.utils.validators import INVALID_ID_DETAILS, INVALID_SPAN_ID, WILDCAR
 class BaseQueryBuilder:
     requires_organization_condition: bool = False
     organization_column: str = "organization.id"
+    function_alias_prefix: str | None = None
+    spans_metrics_builder = False
 
     def get_middle(self):
         """Get the middle for comparison functions"""
@@ -124,13 +126,6 @@ class BaseQueryBuilder:
                 Function("toDateTime", [self.get_middle()]),
             ],
         )
-
-
-class QueryBuilder(BaseQueryBuilder):
-    """Builds a discover query"""
-
-    function_alias_prefix: str | None = None
-    spans_metrics_builder = False
 
     def _dataclass_params(
         self, snuba_params: Optional[SnubaParams], params: ParamsType
@@ -286,12 +281,6 @@ class QueryBuilder(BaseQueryBuilder):
             equations=equations,
             orderby=orderby,
         )
-
-    def are_columns_resolved(self) -> bool:
-        return self.columns and isinstance(self.columns[0], Function)
-
-    def get_default_converter(self) -> Callable[[event_search.SearchFilter], Optional[WhereType]]:
-        return self._default_filter_converter
 
     def resolve_time_conditions(self) -> None:
         if self.builder_config.skip_time_conditions:
@@ -668,7 +657,6 @@ class QueryBuilder(BaseQueryBuilder):
             if resolved_column not in self.columns:
                 resolved_columns.append(resolved_column)
 
-        # Happens after resolving columns to check if there any aggregates
         if self.builder_config.auto_fields:
             # Ensure fields we require to build a functioning interface
             # are present.
@@ -686,15 +674,6 @@ class QueryBuilder(BaseQueryBuilder):
         """
         tag_match = constants.TAG_KEY_RE.search(raw_field)
         field = tag_match.group("tag") if tag_match else raw_field
-
-        if field == "group_id":
-            # We don't expose group_id publicly, so if a user requests it
-            # we expect it is a custom tag. Convert it to tags[group_id]
-            # and ensure it queries tag data
-            # These maps are updated so the response can be mapped back to group_id
-            self.tag_to_prefixed_map["group_id"] = "tags[group_id]"
-            self.prefixed_to_tag_map["tags[group_id]"] = "group_id"
-            raw_field = "tags[group_id]"
 
         if constants.VALID_FIELD_PATTERN.match(field):
             return self.aliased_column(raw_field) if alias else self.column(raw_field)
@@ -796,13 +775,6 @@ class QueryBuilder(BaseQueryBuilder):
 
         params to this function should match that of resolve_function
         """
-        if function in constants.TREND_FUNCTION_TYPE_MAP:
-            # HACK: Don't invalid query here if we don't recognize the function
-            # this is cause non-snql tests still need to run and will check here
-            # TODO: once non-snql is removed and trends has its own builder this
-            # can be removed
-            return constants.TREND_FUNCTION_TYPE_MAP.get(function)
-
         resolved_function = self.resolve_function(function, resolve_only=True)
 
         if not isinstance(resolved_function, Function) or resolved_function.alias is None:
@@ -1038,13 +1010,7 @@ class QueryBuilder(BaseQueryBuilder):
     def get_field_type(self, field: str) -> Optional[str]:
         if field in self.meta_resolver_map:
             return self.meta_resolver_map[field]
-        if (
-            field == "transaction.duration"
-            or is_duration_measurement(field)
-            or is_span_op_breakdown(field)
-        ):
-            return "duration"
-        elif is_percentage_measurement(field):
+        if is_percentage_measurement(field):
             return "percentage"
         elif is_numeric_measurement(field):
             return "number"
@@ -1185,21 +1151,7 @@ class QueryBuilder(BaseQueryBuilder):
         return parsed_terms
 
     def format_search_filter(self, term: event_search.SearchFilter) -> Optional[WhereType]:
-        """For now this function seems a bit redundant inside QueryFilter but
-        most of the logic from the existing format_search_filter hasn't been
-        converted over yet
-        """
-        name = term.key.name
-
-        converted_filter = self.convert_search_filter_to_condition(
-            event_search.SearchFilter(
-                # We want to use group_id elsewhere so shouldn't be removed from the dataset
-                # but if a user has a tag with the same name we want to make sure that works
-                event_search.SearchKey("tags[group_id]" if name == "group_id" else name),
-                term.operator,
-                term.value,
-            )
-        )
+        converted_filter = self.convert_search_filter_to_condition(term)
         return converted_filter if converted_filter else None
 
     def _combine_conditions(
@@ -1265,10 +1217,10 @@ class QueryBuilder(BaseQueryBuilder):
         if name in constants.NO_CONVERSION_FIELDS:
             return None
 
-        converter = self.search_filter_converter.get(name, self._default_filter_converter)
+        converter = self.search_filter_converter.get(name, self.default_filter_converter)
         return converter(search_filter)
 
-    def _default_filter_converter(
+    def default_filter_converter(
         self, search_filter: event_search.SearchFilter
     ) -> Optional[WhereType]:
         name = search_filter.key.name
@@ -1312,36 +1264,6 @@ class QueryBuilder(BaseQueryBuilder):
         # last_seen needs an integer
         if isinstance(value, datetime) and name not in constants.TIMESTAMP_FIELDS:
             value = int(to_timestamp(value)) * 1000
-
-        if name in {"trace.span", "trace.parent_span"}:
-            if search_filter.value.is_wildcard():
-                raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(name))
-            if not search_filter.value.is_span_id():
-                raise InvalidSearchQuery(INVALID_SPAN_ID.format(name))
-
-        # Validate event ids, trace ids, and profile ids are uuids
-        if name in {"id", "trace", "profile.id"}:
-            if search_filter.value.is_wildcard():
-                raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(name))
-            elif not search_filter.value.is_event_id():
-                if name == "trace":
-                    label = "Filter Trace ID"
-                elif name == "profile.id":
-                    label = "Filter Profile ID"
-                else:
-                    label = "Filter ID"
-                raise InvalidSearchQuery(INVALID_ID_DETAILS.format(label))
-
-        if name in constants.TIMESTAMP_FIELDS:
-            if (
-                operator in ["<", "<="]
-                and value < self.start
-                or operator in [">", ">="]
-                and value > self.end
-            ):
-                raise InvalidSearchQuery(
-                    "Filter on timestamp is outside of the selected date range."
-                )
 
         # Tags are never null, but promoted tags are columns and so can be null.
         # To handle both cases, use `ifNull` to convert to an empty string and
@@ -1581,6 +1503,109 @@ class QueryBuilder(BaseQueryBuilder):
                     "tips": {},
                 },
             }
+
+
+class QueryBuilder(BaseQueryBuilder):
+    """Builds a discover query"""
+
+    def resolve_field(self, raw_field: str, alias: bool = False) -> Column:
+        tag_match = constants.TAG_KEY_RE.search(raw_field)
+        field = tag_match.group("tag") if tag_match else raw_field
+
+        if field == "group_id":
+            # We don't expose group_id publicly, so if a user requests it
+            # we expect it is a custom tag. Convert it to tags[group_id]
+            # and ensure it queries tag data
+            # These maps are updated so the response can be mapped back to group_id
+            self.tag_to_prefixed_map["group_id"] = "tags[group_id]"
+            self.prefixed_to_tag_map["tags[group_id]"] = "group_id"
+            raw_field = "tags[group_id]"
+
+        return super().resolve_field(raw_field, alias)
+
+    def get_function_result_type(
+        self,
+        function: str,
+    ) -> Optional[str]:
+        if function in constants.TREND_FUNCTION_TYPE_MAP:
+            # HACK: Don't invalid query here if we don't recognize the function
+            # this is cause non-snql tests still need to run and will check here
+            # TODO: once non-snql is removed and trends has its own builder this
+            # can be removed
+            return constants.TREND_FUNCTION_TYPE_MAP.get(function)
+
+        return super().get_function_result_type(function)
+
+    def get_field_type(self, field: str) -> Optional[str]:
+        if (
+            field == "transaction.duration"
+            or is_duration_measurement(field)
+            or is_span_op_breakdown(field)
+        ):
+            return "duration"
+
+        return super().get_field_type(field)
+
+    def format_search_filter(self, term: event_search.SearchFilter) -> Optional[WhereType]:
+        """For now this function seems a bit redundant inside QueryFilter but
+        most of the logic from the existing format_search_filter hasn't been
+        converted over yet
+        """
+        name = term.key.name
+
+        converted_filter = self.convert_search_filter_to_condition(
+            event_search.SearchFilter(
+                # We want to use group_id elsewhere so shouldn't be removed from the dataset
+                # but if a user has a tag with the same name we want to make sure that works
+                event_search.SearchKey("tags[group_id]" if name == "group_id" else name),
+                term.operator,
+                term.value,
+            )
+        )
+        return converted_filter if converted_filter else None
+
+    def default_filter_converter(
+        self, search_filter: event_search.SearchFilter
+    ) -> Optional[WhereType]:
+        name = search_filter.key.name
+        operator = search_filter.operator
+        value = search_filter.value.value
+
+        # Some fields aren't valid queries
+        if name in constants.SKIP_FILTER_RESOLUTION:
+            name = f"tags[{name}]"
+
+        if name in {"trace.span", "trace.parent_span"}:
+            if search_filter.value.is_wildcard():
+                raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(name))
+            if not search_filter.value.is_span_id():
+                raise InvalidSearchQuery(INVALID_SPAN_ID.format(name))
+
+        # Validate event ids, trace ids, and profile ids are uuids
+        if name in {"id", "trace", "profile.id"}:
+            if search_filter.value.is_wildcard():
+                raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(name))
+            elif not search_filter.value.is_event_id():
+                if name == "trace":
+                    label = "Filter Trace ID"
+                elif name == "profile.id":
+                    label = "Filter Profile ID"
+                else:
+                    label = "Filter ID"
+                raise InvalidSearchQuery(INVALID_ID_DETAILS.format(label))
+
+        if name in constants.TIMESTAMP_FIELDS:
+            if (
+                operator in ["<", "<="]
+                and value < self.start
+                or operator in [">", ">="]
+                and value > self.end
+            ):
+                raise InvalidSearchQuery(
+                    "Filter on timestamp is outside of the selected date range."
+                )
+
+        return super().default_filter_converter(search_filter)
 
 
 class UnresolvedQuery(QueryBuilder):

--- a/src/sentry/search/events/builder/issue_platform.py
+++ b/src/sentry/search/events/builder/issue_platform.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from sentry.issues.query import manual_group_on_time_aggregation
 from sentry.search.events.builder import TimeseriesQueryBuilder
-from sentry.search.events.types import ParamsType, SelectType
+from sentry.search.events.types import ParamsType, QueryBuilderConfig, SelectType
 from sentry.snuba.dataset import Dataset
 
 
@@ -17,10 +17,8 @@ class IssuePlatformTimeseriesQueryBuilder(TimeseriesQueryBuilder):
         query: Optional[str] = None,
         selected_columns: Optional[List[str]] = None,
         equations: Optional[List[str]] = None,
-        functions_acl: Optional[List[str]] = None,
         limit: Optional[int] = 10000,
-        has_metrics: bool = False,
-        skip_tag_resolution: bool = False,
+        config: Optional[QueryBuilderConfig] = None,
     ):
         super().__init__(
             dataset,
@@ -29,9 +27,7 @@ class IssuePlatformTimeseriesQueryBuilder(TimeseriesQueryBuilder):
             query=query,
             selected_columns=selected_columns,
             equations=equations,
-            functions_acl=functions_acl,
-            has_metrics=has_metrics,
-            skip_tag_resolution=skip_tag_resolution,
+            config=config,
         )
         self.groupby = [self.time_column]
 

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -509,7 +509,7 @@ class MetricsQueryBuilder(QueryBuilder):
             return value
         return self.resolve_metric_index(value)
 
-    def _default_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
+    def default_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
         name = search_filter.key.name
         operator = search_filter.operator
         value = search_filter.value.value

--- a/src/sentry/search/events/builder/sessions.py
+++ b/src/sentry/search/events/builder/sessions.py
@@ -42,10 +42,10 @@ class SessionsV2QueryBuilder(QueryBuilder):
             return []
         return list({self.resolve_column(column) for column in groupby_columns})
 
-    def _default_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
+    def default_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
         name = search_filter.key.name
         if name in self.filter_allowlist_fields or name in self._extra_filter_allowlist_fields:
-            return super()._default_filter_converter(search_filter)
+            return super().default_filter_converter(search_filter)
         raise InvalidSearchQuery(f"Invalid search filter: {name}")
 
 

--- a/src/sentry/search/events/builder/spans_metrics.py
+++ b/src/sentry/search/events/builder/spans_metrics.py
@@ -5,7 +5,7 @@ from snuba_sdk import AliasedExpression, And, Condition, CurriedFunction, Granul
 
 from sentry.search.events import constants
 from sentry.search.events.builder import MetricsQueryBuilder, TimeseriesMetricQueryBuilder
-from sentry.search.events.types import ParamsType, SelectType, WhereType
+from sentry.search.events.types import ParamsType, QueryBuilderConfig, SelectType, WhereType
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import create_result_key
 from sentry.utils.snuba import bulk_snql_query
@@ -21,9 +21,13 @@ class SpansMetricsQueryBuilder(MetricsQueryBuilder):
         *args: Any,
         **kwargs: Any,
     ):
-        parser_config_overrides = kwargs.pop("parser_config_overrides", {})
+        config = kwargs.pop("config", QueryBuilderConfig())
+        parser_config_overrides = (
+            config.parser_config_overrides if config.parser_config_overrides else {}
+        )
         parser_config_overrides["free_text_key"] = "span.description"
-        kwargs["parser_config_overrides"] = parser_config_overrides
+        config.parser_config_overrides = parser_config_overrides
+        kwargs["config"] = config
         super().__init__(*args, **kwargs)
 
     def get_field_type(self, field: str) -> Optional[str]:

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1672,7 +1672,7 @@ class DiscoverDatasetConfig(DatasetConfig):
                 1,
             )
         else:
-            return self.builder.get_default_converter()(search_filter)
+            return self.builder.default_filter_converter(search_filter)
 
     def _transaction_status_filter_converter(
         self, search_filter: SearchFilter

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1597,7 +1597,7 @@ class DiscoverDatasetConfig(DatasetConfig):
         return filter_aliases.semver_build_filter_converter(self.builder, search_filter)
 
     def _issue_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
-        if self.builder.skip_issue_validation:
+        if self.builder.builder_config.skip_issue_validation:
             return None
 
         operator = search_filter.operator

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -66,7 +66,7 @@ def release_filter_converter(
             )
         )
 
-    return builder._default_filter_converter(SearchFilter(search_filter.key, operator, value))
+    return builder.default_filter_converter(SearchFilter(search_filter.key, operator, value))
 
 
 def project_slug_converter(

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -94,3 +94,26 @@ class SnubaParams:
         if self.start and self.end:
             return (self.end - self.start).total_seconds()
         return None
+
+
+@dataclass
+class QueryBuilderConfig:
+    auto_fields: bool = False
+    auto_aggregations: bool = False
+    use_aggregate_conditions: bool = False
+    functions_acl: Optional[List[str]] = None
+    equation_config: Optional[Dict[str, bool]] = None
+    # This allows queries to be resolved without adding time constraints. Currently this is just
+    # used to allow metric alerts to be built and validated before creation in snuba.
+    skip_time_conditions: bool = False
+    parser_config_overrides: Optional[Mapping[str, Any]] = None
+    has_metrics: bool = False
+    transform_alias_to_input_format: bool = False
+    use_metrics_layer: bool = False
+    # This skips converting tags back to their non-prefixed versions when processing the results
+    # Currently this is only used for avoiding conflicting values when doing the first query
+    # of a top events request
+    skip_tag_resolution: bool = False
+    on_demand_metrics_enabled: bool = False
+    skip_issue_validation: bool = False
+    allow_metric_aggregates: Optional[bool] = False

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -27,7 +27,7 @@ from sentry.search.events.fields import (
     get_json_meta_type,
     is_function,
 )
-from sentry.search.events.types import HistogramParams, ParamsType
+from sentry.search.events.types import HistogramParams, ParamsType, QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT
 from sentry.utils.dates import to_timestamp
@@ -229,17 +229,19 @@ def query(
         selected_columns=selected_columns,
         equations=equations,
         orderby=orderby,
-        auto_fields=auto_fields,
-        auto_aggregations=auto_aggregations,
-        use_aggregate_conditions=use_aggregate_conditions,
-        functions_acl=functions_acl,
         limit=limit,
         offset=offset,
-        equation_config={"auto_add": include_equation_fields},
         sample_rate=sample,
-        has_metrics=has_metrics,
-        transform_alias_to_input_format=transform_alias_to_input_format,
-        skip_tag_resolution=skip_tag_resolution,
+        config=QueryBuilderConfig(
+            auto_fields=auto_fields,
+            auto_aggregations=auto_aggregations,
+            use_aggregate_conditions=use_aggregate_conditions,
+            functions_acl=functions_acl,
+            equation_config={"auto_add": include_equation_fields},
+            has_metrics=has_metrics,
+            transform_alias_to_input_format=transform_alias_to_input_format,
+            skip_tag_resolution=skip_tag_resolution,
+        ),
     )
     if conditions is not None:
         builder.add_conditions(conditions)
@@ -297,8 +299,10 @@ def timeseries_query(
             query=query,
             selected_columns=columns,
             equations=equations,
-            functions_acl=functions_acl,
-            has_metrics=has_metrics,
+            config=QueryBuilderConfig(
+                functions_acl=functions_acl,
+                has_metrics=has_metrics,
+            ),
         )
         query_list = [base_builder]
         if comparison_delta:
@@ -456,8 +460,10 @@ def top_events_timeseries(
         selected_columns=selected_columns,
         timeseries_columns=timeseries_columns,
         equations=equations,
-        functions_acl=functions_acl,
-        skip_tag_resolution=True,
+        config=QueryBuilderConfig(
+            functions_acl=functions_acl,
+            skip_tag_resolution=True,
+        ),
     )
     if len(top_events["data"]) == limit and include_other:
         other_events_builder = TopEventsQueryBuilder(

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -24,6 +24,7 @@ from sentry import features
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, CRASH_RATE_ALERT_SESSION_COUNT_ALIAS
 from sentry.exceptions import InvalidQuerySubscription, UnsupportedQuerySubscription
 from sentry.models import Environment, Organization
+from sentry.search.events.types import QueryBuilderConfig
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.sentry_metrics.utils import (
     MetricIndexNotFound,
@@ -193,9 +194,11 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
             params=params,
             offset=None,
             limit=None,
-            skip_time_conditions=True,
-            parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
-            skip_issue_validation=skip_issue_validation,
+            config=QueryBuilderConfig(
+                skip_time_conditions=True,
+                parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
+                skip_issue_validation=skip_issue_validation,
+            ),
         )
 
     def get_entity_extra_params(self) -> Mapping[str, Any]:
@@ -287,10 +290,12 @@ class SessionsEntitySubscription(BaseEntitySubscription):
             params=params,
             offset=None,
             limit=None,
-            functions_acl=["identity"],
-            skip_time_conditions=True,
-            parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
-            skip_issue_validation=skip_issue_validation,
+            config=QueryBuilderConfig(
+                functions_acl=["identity"],
+                skip_time_conditions=True,
+                parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
+                skip_issue_validation=skip_issue_validation,
+            ),
         )
 
 
@@ -385,11 +390,13 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
             selected_columns=self.get_snql_aggregations(),
             params=params,
             offset=None,
-            skip_time_conditions=True,
             granularity=self.get_granularity(),
-            use_metrics_layer=self.use_metrics_layer,
-            on_demand_metrics_enabled=self.on_demand_metrics_enabled,
-            skip_issue_validation=skip_issue_validation,
+            config=QueryBuilderConfig(
+                skip_time_conditions=True,
+                use_metrics_layer=self.use_metrics_layer,
+                on_demand_metrics_enabled=self.on_demand_metrics_enabled,
+                skip_issue_validation=skip_issue_validation,
+            ),
         )
         extra_conditions = self.get_snql_extra_conditions()
 

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -11,7 +11,7 @@ from sentry.search.events.builder import (
     ProfileTopFunctionsTimeseriesQueryBuilder,
 )
 from sentry.search.events.fields import get_json_meta_type
-from sentry.search.events.types import ParamsType, SnubaParams
+from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import transform_tips, zerofill
 from sentry.utils.snuba import SnubaTSResult
@@ -49,13 +49,15 @@ def query(
         snuba_params=snuba_params,
         selected_columns=selected_columns,
         orderby=orderby,
-        auto_fields=False,
-        auto_aggregations=auto_aggregations,
-        use_aggregate_conditions=use_aggregate_conditions,
-        transform_alias_to_input_format=transform_alias_to_input_format,
-        functions_acl=functions_acl,
         limit=limit,
         offset=offset,
+        config=QueryBuilderConfig(
+            auto_fields=False,
+            auto_aggregations=auto_aggregations,
+            use_aggregate_conditions=use_aggregate_conditions,
+            transform_alias_to_input_format=transform_alias_to_input_format,
+            functions_acl=functions_acl,
+        ),
     )
     result = builder.process_results(builder.run_query(referrer))
     result["meta"]["tips"] = transform_tips(builder.tips)
@@ -82,7 +84,9 @@ def timeseries_query(
         query=query,
         interval=rollup,
         selected_columns=selected_columns,
-        functions_acl=functions_acl,
+        config=QueryBuilderConfig(
+            functions_acl=functions_acl,
+        ),
     )
     results = builder.run_query(referrer)
 
@@ -143,8 +147,10 @@ def top_events_timeseries(
         selected_columns=selected_columns,
         timeseries_columns=timeseries_columns,
         equations=equations,
-        functions_acl=functions_acl,
-        skip_tag_resolution=True,
+        config=QueryBuilderConfig(
+            functions_acl=functions_acl,
+            skip_tag_resolution=True,
+        ),
     )
 
     if len(top_events["data"]) == limit and include_other:

--- a/src/sentry/snuba/issue_platform.py
+++ b/src/sentry/snuba/issue_platform.py
@@ -8,6 +8,7 @@ from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events.builder import IssuePlatformTimeseriesQueryBuilder, QueryBuilder
 from sentry.search.events.fields import get_json_meta_type
+from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import EventsResponse, transform_tips, zerofill
 from sentry.utils.snuba import SnubaTSResult, bulk_snql_query
@@ -79,17 +80,19 @@ def query(
         selected_columns=selected_columns,
         equations=equations,
         orderby=orderby,
-        auto_fields=auto_fields,
-        auto_aggregations=auto_aggregations,
-        use_aggregate_conditions=use_aggregate_conditions,
-        functions_acl=functions_acl,
         limit=limit,
         offset=offset,
-        equation_config={"auto_add": include_equation_fields},
         sample_rate=sample,
-        has_metrics=has_metrics,
-        transform_alias_to_input_format=transform_alias_to_input_format,
-        skip_tag_resolution=skip_tag_resolution,
+        config=QueryBuilderConfig(
+            auto_fields=auto_fields,
+            auto_aggregations=auto_aggregations,
+            use_aggregate_conditions=use_aggregate_conditions,
+            functions_acl=functions_acl,
+            equation_config={"auto_add": include_equation_fields},
+            has_metrics=has_metrics,
+            transform_alias_to_input_format=transform_alias_to_input_format,
+            skip_tag_resolution=skip_tag_resolution,
+        ),
     )
     if conditions is not None:
         builder.add_conditions(conditions)
@@ -144,8 +147,10 @@ def timeseries_query(
             query=query,
             selected_columns=columns,
             equations=equations,
-            functions_acl=functions_acl,
-            has_metrics=has_metrics,
+            config=QueryBuilderConfig(
+                functions_acl=functions_acl,
+                has_metrics=has_metrics,
+            ),
         )
         query_list = [base_builder]
         if comparison_delta:

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -11,6 +11,7 @@ from sentry.search.events.builder import (
     TimeseriesMetricQueryBuilder,
 )
 from sentry.search.events.fields import get_function_alias
+from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
 from sentry.utils.snuba import SnubaTSResult, bulk_snql_query
@@ -43,24 +44,26 @@ def query(
     with sentry_sdk.start_span(op="mep", description="MetricQueryBuilder"):
         metrics_query = MetricsQueryBuilder(
             params,
+            dataset=Dataset.PerformanceMetrics,
             snuba_params=snuba_params,
             query=query,
             selected_columns=selected_columns,
             equations=[],
             orderby=orderby,
-            # Auto fields will add things like id back in if enabled
-            auto_fields=False,
-            auto_aggregations=auto_aggregations,
-            use_aggregate_conditions=use_aggregate_conditions,
-            allow_metric_aggregates=allow_metric_aggregates,
-            functions_acl=functions_acl,
             limit=limit,
             offset=offset,
-            dataset=Dataset.PerformanceMetrics,
-            transform_alias_to_input_format=transform_alias_to_input_format,
-            use_metrics_layer=use_metrics_layer,
             granularity=granularity,
-            on_demand_metrics_enabled=on_demand_metrics_enabled,
+            config=QueryBuilderConfig(
+                auto_aggregations=auto_aggregations,
+                use_aggregate_conditions=use_aggregate_conditions,
+                allow_metric_aggregates=allow_metric_aggregates,
+                functions_acl=functions_acl,
+                # Auto fields will add things like id back in if enabled
+                auto_fields=False,
+                transform_alias_to_input_format=transform_alias_to_input_format,
+                use_metrics_layer=use_metrics_layer,
+                on_demand_metrics_enabled=on_demand_metrics_enabled,
+            ),
         )
         metrics_referrer = referrer + ".metrics-enhanced"
         results = metrics_query.run_query(metrics_referrer)
@@ -107,10 +110,12 @@ def bulk_timeseries_query(
                     dataset=Dataset.PerformanceMetrics,
                     query=query,
                     selected_columns=columns,
-                    functions_acl=functions_acl,
-                    allow_metric_aggregates=allow_metric_aggregates,
-                    use_metrics_layer=use_metrics_layer,
-                    groupby=groupby,
+                    config=QueryBuilderConfig(
+                        functions_acl=functions_acl,
+                        allow_metric_aggregates=allow_metric_aggregates,
+                        use_metrics_layer=use_metrics_layer,
+                        groupby=groupby,
+                    ),
                 )
                 snql_query = metrics_query.get_snql_query()
                 metrics_queries.append(snql_query[0])
@@ -202,11 +207,13 @@ def timeseries_query(
                 dataset=Dataset.PerformanceMetrics,
                 query=query,
                 selected_columns=columns,
-                functions_acl=functions_acl,
-                allow_metric_aggregates=allow_metric_aggregates,
-                use_metrics_layer=use_metrics_layer,
                 groupby=groupby,
-                on_demand_metrics_enabled=on_demand_metrics_enabled,
+                config=QueryBuilderConfig(
+                    functions_acl=functions_acl,
+                    allow_metric_aggregates=allow_metric_aggregates,
+                    use_metrics_layer=use_metrics_layer,
+                    on_demand_metrics_enabled=on_demand_metrics_enabled,
+                ),
             )
             metrics_referrer = referrer + ".metrics-enhanced"
             result = metrics_query.run_query(metrics_referrer)
@@ -321,7 +328,9 @@ def histogram_query(
         selected_columns=[f"histogram({field})" for field in fields],
         orderby=order_by,
         limitby=limit_by,
-        use_metrics_layer=use_metrics_layer,
+        config=QueryBuilderConfig(
+            use_metrics_layer=use_metrics_layer,
+        ),
     )
     if extra_conditions is not None:
         builder.add_conditions(extra_conditions)

--- a/src/sentry/snuba/profiles.py
+++ b/src/sentry/snuba/profiles.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events.builder import ProfilesQueryBuilder, ProfilesTimeseriesQueryBuilder
 from sentry.search.events.fields import get_json_meta_type
-from sentry.search.events.types import ParamsType, SnubaParams
+from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import transform_tips, zerofill
 from sentry.utils.snuba import SnubaTSResult
@@ -40,13 +40,15 @@ def query(
         snuba_params=snuba_params,
         selected_columns=selected_columns,
         orderby=orderby,
-        auto_fields=auto_fields,
-        auto_aggregations=auto_aggregations,
-        use_aggregate_conditions=use_aggregate_conditions,
-        transform_alias_to_input_format=transform_alias_to_input_format,
-        functions_acl=functions_acl,
         limit=limit,
         offset=offset,
+        config=QueryBuilderConfig(
+            auto_fields=auto_fields,
+            auto_aggregations=auto_aggregations,
+            use_aggregate_conditions=use_aggregate_conditions,
+            transform_alias_to_input_format=transform_alias_to_input_format,
+            functions_acl=functions_acl,
+        ),
     )
     result = builder.process_results(builder.run_query(referrer))
     result["meta"]["tips"] = transform_tips(builder.tips)
@@ -73,7 +75,9 @@ def timeseries_query(
         query=query,
         interval=rollup,
         selected_columns=selected_columns,
-        functions_acl=functions_acl,
+        config=QueryBuilderConfig(
+            functions_acl=functions_acl,
+        ),
     )
     results = builder.run_query(referrer)
 

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -9,6 +9,7 @@ from snuba_sdk import Column, Condition, Function, Limit, Op
 from sentry.api.utils import get_date_range_from_params
 from sentry.release_health.base import AllowedResolution, SessionsQueryConfig
 from sentry.search.events.builder import SessionsV2QueryBuilder, TimeseriesSessionsV2QueryBuilder
+from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.utils.dates import parse_stats_period, to_datetime, to_timestamp
 
@@ -325,8 +326,8 @@ class QueryDefinition:
             "query": self.query,
             "orderby": orderby,
             "limit": max_groups,
-            "auto_aggregations": True,
             "granularity": self.rollup,
+            "config": QueryBuilderConfig(auto_aggregations=True),
         }
         if self._query_config.allow_session_status_query:
             query_builder_dict.update({"extra_filter_allowlist_fields": ["session.status"]})

--- a/src/sentry/snuba/spans_indexed.py
+++ b/src/sentry/snuba/spans_indexed.py
@@ -10,6 +10,7 @@ from sentry.search.events.builder import (
     TimeseriesSpanIndexedQueryBuilder,
     TopEventsSpanIndexedQueryBuilder,
 )
+from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
 from sentry.utils.snuba import SnubaTSResult, bulk_snql_query
@@ -50,17 +51,19 @@ def query(
         selected_columns=selected_columns,
         equations=equations,
         orderby=orderby,
-        auto_fields=auto_fields,
-        auto_aggregations=auto_aggregations,
-        use_aggregate_conditions=use_aggregate_conditions,
-        functions_acl=functions_acl,
         limit=limit,
         offset=offset,
-        equation_config={"auto_add": include_equation_fields},
         sample_rate=sample,
-        has_metrics=has_metrics,
-        transform_alias_to_input_format=transform_alias_to_input_format,
-        skip_tag_resolution=skip_tag_resolution,
+        config=QueryBuilderConfig(
+            has_metrics=has_metrics,
+            transform_alias_to_input_format=transform_alias_to_input_format,
+            skip_tag_resolution=skip_tag_resolution,
+            equation_config={"auto_add": include_equation_fields},
+            auto_fields=auto_fields,
+            auto_aggregations=auto_aggregations,
+            use_aggregate_conditions=use_aggregate_conditions,
+            functions_acl=functions_acl,
+        ),
     )
 
     result = builder.process_results(builder.run_query(referrer))
@@ -94,7 +97,9 @@ def timeseries_query(
             rollup,
             query=query,
             selected_columns=columns,
-            functions_acl=functions_acl,
+            config=QueryBuilderConfig(
+                functions_acl=functions_acl,
+            ),
         )
         result = query.run_query(referrer)
     with sentry_sdk.start_span(op="spans_indexed", description="query.transform_results"):

--- a/src/sentry/snuba/spans_metrics.py
+++ b/src/sentry/snuba/spans_metrics.py
@@ -9,6 +9,7 @@ from sentry.search.events.builder import (
     TimeseriesSpansMetricsQueryBuilder,
 )
 from sentry.search.events.builder.spans_metrics import TopSpansMetricsQueryBuilder
+from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
 from sentry.utils.snuba import SnubaTSResult
@@ -49,18 +50,20 @@ def query(
         selected_columns=selected_columns,
         equations=equations,
         orderby=orderby,
-        auto_fields=auto_fields,
-        auto_aggregations=auto_aggregations,
-        use_aggregate_conditions=use_aggregate_conditions,
-        functions_acl=functions_acl,
         limit=limit,
         offset=offset,
-        equation_config={"auto_add": include_equation_fields},
         sample_rate=sample,
-        has_metrics=has_metrics,
-        use_metrics_layer=use_metrics_layer,
-        transform_alias_to_input_format=transform_alias_to_input_format,
-        skip_tag_resolution=skip_tag_resolution,
+        config=QueryBuilderConfig(
+            auto_fields=auto_fields,
+            auto_aggregations=auto_aggregations,
+            use_aggregate_conditions=use_aggregate_conditions,
+            functions_acl=functions_acl,
+            equation_config={"auto_add": include_equation_fields},
+            has_metrics=has_metrics,
+            use_metrics_layer=use_metrics_layer,
+            transform_alias_to_input_format=transform_alias_to_input_format,
+            skip_tag_resolution=skip_tag_resolution,
+        ),
     )
 
     result = builder.process_results(builder.run_query(referrer))
@@ -92,10 +95,12 @@ def timeseries_query(
         dataset=Dataset.PerformanceMetrics,
         query=query,
         selected_columns=selected_columns,
-        functions_acl=functions_acl,
-        allow_metric_aggregates=allow_metric_aggregates,
-        use_metrics_layer=use_metrics_layer,
         groupby=groupby,
+        config=QueryBuilderConfig(
+            functions_acl=functions_acl,
+            allow_metric_aggregates=allow_metric_aggregates,
+            use_metrics_layer=use_metrics_layer,
+        ),
     )
     result = metrics_query.run_query(referrer)
 
@@ -189,8 +194,10 @@ def top_events_timeseries(
         query=user_query,
         selected_columns=selected_columns,
         timeseries_columns=timeseries_columns,
-        functions_acl=functions_acl,
-        skip_tag_resolution=True,
+        config=QueryBuilderConfig(
+            functions_acl=functions_acl,
+            skip_tag_resolution=True,
+        ),
     )
     if len(top_events["data"]) == limit and include_other:
         other_events_builder = TopSpansMetricsQueryBuilder(


### PR DESCRIPTION
- This moves most of the logic out of the QueryBuilder so that not everything has to inherit a bunch of Discover logic that doesn't apply to it