### PR TITLE
chore(hybrid-cloud): Cleans up error handling for RPC org provisioning

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization_actions/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_actions/impl.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from django.db import router, transaction
 from django.db.models.expressions import CombinedExpression
+from django.utils.text import slugify
 from typing_extensions import TypedDict
 
 from sentry import roles
@@ -122,8 +123,12 @@ def generate_deterministic_organization_slug(
     :param owning_user_id:
     :return:
     """
+
+    # Start by slugifying the original name using django utils
+    slugified_base_str = slugify(desired_slug_base)
+
     hashed_org_data = hashlib.md5(
-        "/".join([desired_slug_base, desired_org_name, str(owning_user_id)]).encode("utf8")
+        "/".join([slugified_base_str, desired_org_name, str(owning_user_id)]).encode("utf8")
     ).hexdigest()
 
-    return f"{desired_slug_base[:20]}-{hashed_org_data[:9]}"
+    return f"{slugified_base_str[:20]}-{hashed_org_data[:9]}"

--- a/src/sentry/services/hybrid_cloud/organization_actions/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_actions/impl.py
@@ -127,6 +127,8 @@ def generate_deterministic_organization_slug(
     # Start by slugifying the original name using django utils
     slugified_base_str = slugify(desired_slug_base)
 
+    assert len(slugified_base_str) > 0, "Slugs must be valid strings that can be ASCII encoded"
+
     hashed_org_data = hashlib.md5(
         "/".join([slugified_base_str, desired_org_name, str(owning_user_id)]).encode("utf8")
     ).hexdigest()

--- a/src/sentry/services/hybrid_cloud/organization_actions/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_actions/impl.py
@@ -34,8 +34,8 @@ def create_organization_with_outbox_message(
 
 
 def create_organization_and_member_for_monolith(
-    organization_name,
-    user_id,
+    organization_name: str,
+    user_id: int,
     slug: str,
 ) -> OrganizationAndMemberCreationResult:
     org = create_organization_with_outbox_message(

--- a/tests/sentry/services/test_organization_actions.py
+++ b/tests/sentry/services/test_organization_actions.py
@@ -276,3 +276,16 @@ class TestGenerateDeterministicOrganizationSlug(TestCase):
         )
 
         assert slug == "si-sentry-3471b1b85"
+
+    def test_slug_with_0_length(self):
+        unicoded_str = "😅"
+
+        with pytest.raises(AssertionError):
+            generate_deterministic_organization_slug(
+                desired_slug_base=unicoded_str, desired_org_name=unicoded_str, owning_user_id=42
+            )
+
+        with pytest.raises(AssertionError):
+            generate_deterministic_organization_slug(
+                desired_slug_base="", desired_org_name=unicoded_str, owning_user_id=42
+            )

--- a/tests/sentry/services/test_organization_actions.py
+++ b/tests/sentry/services/test_organization_actions.py
@@ -260,3 +260,19 @@ class TestGenerateDeterministicOrganizationSlug(TestCase):
         )
         assert len(slug) == 30
         assert slug == "areallylongsentryorg-945bda148"
+
+    def test_slug_with_mixed_casing(self):
+        slug = generate_deterministic_organization_slug(
+            desired_slug_base="A mixed CASING str",
+            desired_org_name="santry",
+            owning_user_id=42,
+        )
+        assert slug == "a-mixed-casing-str-9e9173167"
+
+    def test_slug_with_unicode_chars(self):
+        unicoded_str = "Sí Señtry 😅"
+        slug = generate_deterministic_organization_slug(
+            desired_slug_base=unicoded_str, desired_org_name=unicoded_str, owning_user_id=42
+        )
+
+        assert slug == "si-sentry-3471b1b85"


### PR DESCRIPTION
<!-- Describe your PR here. -->
- chore(hybrid-cloud): Cleans up error handling for RPC org provisioning to be more explicit
- Fixes issue with deterministic slugify code not handling casing, whitespace, or unicode






