### PR TITLE
fix(hc): Add missing import

### DIFF
--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.ratelimits.concurrent import ConcurrentRateLimiter
 from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
+from sentry.services.hybrid_cloud.auth import AuthenticatedToken
 from sentry.types.ratelimit import RateLimit, RateLimitCategory, RateLimitMeta, RateLimitType
 from sentry.utils.hashlib import md5_text
 
@@ -19,7 +20,6 @@ from . import backend as ratelimiter
 if TYPE_CHECKING:
     from sentry.models import Organization, User
     from sentry.models.apitoken import ApiToken
-    from sentry.services.hybrid_cloud.auth import AuthenticatedToken
 
 # TODO(mgaeta): It's not currently possible to type a Callable's args with kwargs.
 EndpointFunction = Callable[..., Response]

--- a/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
+++ b/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
@@ -5,7 +5,7 @@ from rest_framework.permissions import AllowAny
 from sentry.api.base import Endpoint
 from sentry.api.endpoints.organization_group_index import OrganizationGroupIndexEndpoint
 from sentry.auth.system import SystemToken
-from sentry.models import User
+from sentry.models import ApiToken, User
 from sentry.ratelimits import get_rate_limit_config, get_rate_limit_key
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.testutils.cases import TestCase
@@ -85,6 +85,17 @@ class GetRateLimitKeyTest(TestCase):
                 self.view, self.request, self.rate_limit_group, self.rate_limit_config
             )
             == f"org:default:OrganizationGroupIndexEndpoint:GET:{install.organization_id}"
+        )
+
+    def test_api_token(self):
+        token = ApiToken.objects.create(user=self.user, scope_list=["event:read", "org:read"])
+        self.request.auth = token
+        self.request.user = self.user
+        assert (
+            get_rate_limit_key(
+                self.view, self.request, self.rate_limit_group, self.rate_limit_config
+            )
+            == f"user:default:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
         )
 
 

--- a/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
+++ b/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
@@ -8,6 +8,7 @@ from sentry.auth.system import SystemToken
 from sentry.models import ApiToken, User
 from sentry.ratelimits import get_rate_limit_config, get_rate_limit_key
 from sentry.ratelimits.config import RateLimitConfig
+from sentry.services.hybrid_cloud.auth import AuthenticatedToken
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -90,6 +91,20 @@ class GetRateLimitKeyTest(TestCase):
     def test_api_token(self):
         token = ApiToken.objects.create(user=self.user, scope_list=["event:read", "org:read"])
         self.request.auth = token
+        self.request.user = self.user
+        assert (
+            get_rate_limit_key(
+                self.view, self.request, self.rate_limit_group, self.rate_limit_config
+            )
+            == f"user:default:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
+        )
+
+    def test_authenticated_token(self):
+        # Ensure AuthenticatedToken kinds are registered
+        import sentry.services.hybrid_cloud.auth.impl  # noqa: F401
+
+        token = ApiToken.objects.create(user=self.user, scope_list=["event:read", "org:read"])
+        self.request.auth = AuthenticatedToken.from_token(token)
         self.request.user = self.user
         assert (
             get_rate_limit_key(


### PR DESCRIPTION
AuthenticatedToken was previously only imported when type checking but it is used in get_rate_limit_key.

Fixes HC-TEST-CONTROL-6F
Fixes HC-TEST-REGION-7C