### PR TITLE
feat(notifications): new notification settings endpoints part2 cleanup

### DIFF
--- a/src/sentry/api/endpoints/user_notification_settings_options.py
+++ b/src/sentry/api/endpoints/user_notification_settings_options.py
@@ -14,7 +14,7 @@ from sentry.notifications.validators import UserNotificationSettingOptionWithVal
 
 
 @control_silo_endpoint
-class UserNotificationOptionsEndpoint(UserEndpoint):
+class UserNotificationSettingsOptionsEndpoint(UserEndpoint):
     # TODO(Steve): Make not private when we launch new system
     private = True
 

--- a/src/sentry/api/endpoints/user_notification_settings_options_detail.py
+++ b/src/sentry/api/endpoints/user_notification_settings_options_detail.py
@@ -9,7 +9,7 @@ from sentry.models.notificationsettingoption import NotificationSettingOption
 
 
 @control_silo_endpoint
-class UserNotificationOptionsDetailEndpoint(UserEndpoint):
+class UserNotificationSettingsOptionsDetailEndpoint(UserEndpoint):
     # TODO(Steve): Make not private when we launch new system
     private = True
 

--- a/src/sentry/api/endpoints/user_notification_settings_providers.py
+++ b/src/sentry/api/endpoints/user_notification_settings_providers.py
@@ -19,7 +19,7 @@ from sentry.notifications.validators import (
 
 
 @control_silo_endpoint
-class UserNotificationProvidersEndpoint(UserEndpoint):
+class UserNotificationSettingsProvidersEndpoint(UserEndpoint):
     # TODO(Steve): Make not private when we launch new system
     private = True
 

--- a/src/sentry/api/endpoints/user_notification_settings_providers.py
+++ b/src/sentry/api/endpoints/user_notification_settings_providers.py
@@ -63,12 +63,12 @@ class UserNotificationSettingsProvidersEndpoint(UserEndpoint):
             for provider in allowed_providers:
                 value = (
                     NotificationSettingsOptionEnum.ALWAYS.value
-                    if provider in data["provider"]
+                    if provider in data["providers"]
                     else NotificationSettingsOptionEnum.NEVER.value
                 )
                 (
                     notification_setting_provider,
-                    created,
+                    _,
                 ) = NotificationSettingProvider.objects.update_or_create(
                     user_id=user.id,
                     scope_type=data["scope_type"],

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -546,10 +546,14 @@ from .endpoints.user_index import UserIndexEndpoint
 from .endpoints.user_ips import UserIPsEndpoint
 from .endpoints.user_notification_details import UserNotificationDetailsEndpoint
 from .endpoints.user_notification_fine_tuning import UserNotificationFineTuningEndpoint
-from .endpoints.user_notification_options import UserNotificationOptionsEndpoint
-from .endpoints.user_notification_options_detail import UserNotificationOptionsDetailEndpoint
-from .endpoints.user_notification_providers import UserNotificationProvidersEndpoint
 from .endpoints.user_notification_settings_details import UserNotificationSettingsDetailsEndpoint
+from .endpoints.user_notification_settings_options import UserNotificationSettingsOptionsEndpoint
+from .endpoints.user_notification_settings_options_detail import (
+    UserNotificationSettingsOptionsDetailEndpoint,
+)
+from .endpoints.user_notification_settings_providers import (
+    UserNotificationSettingsProvidersEndpoint,
+)
 from .endpoints.user_organizationintegrations import UserOrganizationIntegrationsEndpoint
 from .endpoints.user_organizations import UserOrganizationsEndpoint
 from .endpoints.user_password import UserPasswordEndpoint
@@ -823,17 +827,17 @@ USER_URLS = [
     ),
     re_path(
         r"^(?P<user_id>[^\/]+)/notification-options/$",
-        UserNotificationOptionsEndpoint.as_view(),
+        UserNotificationSettingsOptionsEndpoint.as_view(),
         name="sentry-api-0-user-notification-options",
     ),
     re_path(
         r"^(?P<user_id>[^\/]+)/notification-options/(?P<notification_option_id>[^\/]+)/$",
-        UserNotificationOptionsDetailEndpoint.as_view(),
+        UserNotificationSettingsOptionsDetailEndpoint.as_view(),
         name="sentry-api-0-user-notification-options-details",
     ),
     re_path(
         r"^(?P<user_id>[^\/]+)/notification-providers/$",
-        UserNotificationProvidersEndpoint.as_view(),
+        UserNotificationSettingsProvidersEndpoint.as_view(),
         name="sentry-api-0-user-notification-providers",
     ),
     re_path(

--- a/src/sentry/notifications/validators.py
+++ b/src/sentry/notifications/validators.py
@@ -55,9 +55,9 @@ class UserNotificationSettingOptionWithValueSerializer(
 class UserNotificationSettingsProvidersDetailsSerializer(
     UserNotificationSettingsOptionsDetailsSerializer
 ):
-    provider = serializers.ListField(child=serializers.CharField())
+    providers = serializers.ListField(child=serializers.CharField())
 
-    def validate_provider(self, value):
+    def validate_providers(self, value):
         for provider in value:
             if provider not in allowed_providers:
                 raise serializers.ValidationError("Invalid provider")

--- a/tests/sentry/api/endpoints/test_user_notification_settings_options.py
+++ b/tests/sentry/api/endpoints/test_user_notification_settings_options.py
@@ -1,6 +1,6 @@
 from rest_framework import status
 
-from sentry.models.notificationsettingprovider import NotificationSettingProvider
+from sentry.models.notificationsettingoption import NotificationSettingOption
 from sentry.notifications.types import (
     NotificationScopeEnum,
     NotificationSettingEnum,
@@ -8,71 +8,53 @@ from sentry.notifications.types import (
 )
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.types.integrations import ExternalProviderEnum
 
 
-class UserNotificationProvidersBaseTest(APITestCase):
-    endpoint = "sentry-api-0-user-notification-providers"
+class UserNotificationSettingsOptionsBaseTest(APITestCase):
+    endpoint = "sentry-api-0-user-notification-options"
 
 
 @control_silo_test(stable=True)
-class UserNotificationProvidersGetTest(UserNotificationProvidersBaseTest):
+class UserNotificationSettingsOptionsGetTest(UserNotificationSettingsOptionsBaseTest):
     def setUp(self):
         super().setUp()
         self.login_as(self.user)
 
     def test_simple(self):
         other_user = self.create_user()
-        NotificationSettingProvider.objects.create(
+        NotificationSettingOption.objects.create(
             user_id=self.user.id,
             scope_type=NotificationScopeEnum.ORGANIZATION.value,
             scope_identifier=self.organization.id,
             type=NotificationSettingEnum.ISSUE_ALERTS.value,
-            provider=ExternalProviderEnum.SLACK.value,
             value=NotificationSettingsOptionEnum.ALWAYS.value,
         )
-        NotificationSettingProvider.objects.create(
-            user_id=self.user.id,
-            scope_type=NotificationScopeEnum.ORGANIZATION.value,
-            scope_identifier=self.organization.id,
-            type=NotificationSettingEnum.ISSUE_ALERTS.value,
-            provider=ExternalProviderEnum.EMAIL.value,
-            value=NotificationSettingsOptionEnum.ALWAYS.value,
-        )
-        NotificationSettingProvider.objects.create(
+        NotificationSettingOption.objects.create(
             user_id=self.user.id,
             scope_type=NotificationScopeEnum.ORGANIZATION.value,
             scope_identifier=self.organization.id,
             type=NotificationSettingEnum.WORKFLOW.value,
-            provider=ExternalProviderEnum.EMAIL.value,
             value=NotificationSettingsOptionEnum.ALWAYS.value,
         )
-        NotificationSettingProvider.objects.create(
+        NotificationSettingOption.objects.create(
             user_id=other_user.id,
             scope_type=NotificationScopeEnum.ORGANIZATION.value,
             scope_identifier=self.organization.id,
             type=NotificationSettingEnum.ISSUE_ALERTS.value,
-            provider=ExternalProviderEnum.SLACK.value,
             value=NotificationSettingsOptionEnum.ALWAYS.value,
         )
 
         response = self.get_success_response("me", type="alerts").data
-        assert len(response) == 2
-        slack_item = next(item for item in response if item["provider"] == "slack")
-        email_item = next(item for item in response if item["provider"] == "email")
-
-        assert slack_item["scopeType"] == "organization"
-        assert slack_item["scopeIdentifier"] == str(self.organization.id)
-        assert slack_item["user_id"] == str(self.user.id)
-        assert slack_item["team_id"] is None
-        assert slack_item["value"] == "always"
-        assert slack_item["type"] == "alerts"
-        assert slack_item["provider"] == "slack"
-
-        assert email_item["provider"] == "email"
+        assert len(response) == 1
+        assert response[0]["scopeType"] == "organization"
+        assert response[0]["scopeIdentifier"] == str(self.organization.id)
+        assert response[0]["user_id"] == str(self.user.id)
+        assert response[0]["team_id"] is None
+        assert response[0]["value"] == "always"
+        assert response[0]["type"] == "alerts"
 
         response = self.get_success_response("me").data
-        assert len(response) == 3
+        assert len(response) == 2
 
     def test_invalid_type(self):
         response = self.get_error_response(
@@ -84,7 +66,7 @@ class UserNotificationProvidersGetTest(UserNotificationProvidersBaseTest):
 
 
 @control_silo_test(stable=True)
-class UserNotificationProvidersPutTest(UserNotificationProvidersBaseTest):
+class UserNotificationSettingsOptionsPutTest(UserNotificationSettingsOptionsBaseTest):
     method = "PUT"
 
     def setUp(self):
@@ -100,31 +82,29 @@ class UserNotificationProvidersPutTest(UserNotificationProvidersBaseTest):
             type="alerts",
             status_code=status.HTTP_201_CREATED,
             value="always",
-            provider=["slack"],
         )
-        assert NotificationSettingProvider.objects.filter(
+        row = NotificationSettingOption.objects.filter(
             user_id=self.user.id,
             scope_type=NotificationScopeEnum.ORGANIZATION.value,
             scope_identifier=self.organization.id,
             type=NotificationSettingEnum.ISSUE_ALERTS.value,
             value=NotificationSettingsOptionEnum.ALWAYS.value,
-            provider=ExternalProviderEnum.SLACK.value,
-        ).exists()
-        assert len(response.data) == 3
+        ).first()
+        assert response.data["id"] == str(row.id)
 
     def test_invalid_scope_type(self):
         response = self.get_error_response(
             "me",
             user_id=self.user.id,
-            scope_type="project",
-            scope_identifier=self.project.id,
+            scope_type="invalid",
+            scope_identifier=self.organization.id,
             type="alerts",
             status_code=status.HTTP_400_BAD_REQUEST,
-            provider=["slack"],
+            value="always",
         )
         assert response.data["scopeType"] == ["Invalid scope type"]
 
-    def test_invalid_provider(self):
+    def test_invalid_value(self):
         response = self.get_error_response(
             "me",
             user_id=self.user.id,
@@ -132,6 +112,18 @@ class UserNotificationProvidersPutTest(UserNotificationProvidersBaseTest):
             scope_identifier=self.organization.id,
             type="alerts",
             status_code=status.HTTP_400_BAD_REQUEST,
-            provider=["github"],
+            value="hello",
         )
-        assert response.data["provider"] == ["Invalid provider"]
+        assert response.data["value"] == ["Invalid value"]
+
+    def test_invalid_value_for_option(self):
+        response = self.get_error_response(
+            "me",
+            user_id=self.user.id,
+            scope_type="organization",
+            scope_identifier=self.organization.id,
+            type="alerts",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            value=NotificationSettingsOptionEnum.SUBSCRIBE_ONLY.value,
+        )
+        assert response.data["nonFieldErrors"] == ["Invalid type for value"]

--- a/tests/sentry/api/endpoints/test_user_notification_settings_options_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_settings_options_details.py
@@ -10,12 +10,14 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
-class UserNotificationOptionsDetailsBaseTest(APITestCase):
+class UserNotificationSettingsOptionsDetailsBaseTest(APITestCase):
     endpoint = "sentry-api-0-user-notification-options-details"
 
 
 @control_silo_test(stable=True)
-class UserNotificationOptionsDetailsDeleteTest(UserNotificationOptionsDetailsBaseTest):
+class UserNotificationSettingsOptionsDetailsDeleteTest(
+    UserNotificationSettingsOptionsDetailsBaseTest
+):
     method = "DELETE"
 
     def setUp(self):

--- a/tests/sentry/api/endpoints/test_user_notification_settings_providers.py
+++ b/tests/sentry/api/endpoints/test_user_notification_settings_providers.py
@@ -100,7 +100,7 @@ class UserNotificationSettingsProvidersPutTest(UserNotificationSettingsProviders
             type="alerts",
             status_code=status.HTTP_201_CREATED,
             value="always",
-            provider=["slack"],
+            providers=["slack"],
         )
         assert NotificationSettingProvider.objects.filter(
             user_id=self.user.id,
@@ -120,7 +120,7 @@ class UserNotificationSettingsProvidersPutTest(UserNotificationSettingsProviders
             scope_identifier=self.project.id,
             type="alerts",
             status_code=status.HTTP_400_BAD_REQUEST,
-            provider=["slack"],
+            providers=["slack"],
         )
         assert response.data["scopeType"] == ["Invalid scope type"]
 
@@ -132,6 +132,6 @@ class UserNotificationSettingsProvidersPutTest(UserNotificationSettingsProviders
             scope_identifier=self.organization.id,
             type="alerts",
             status_code=status.HTTP_400_BAD_REQUEST,
-            provider=["github"],
+            providers=["github"],
         )
-        assert response.data["provider"] == ["Invalid provider"]
+        assert response.data["providers"] == ["Invalid provider"]

--- a/tests/sentry/api/endpoints/test_user_notification_settings_providers.py
+++ b/tests/sentry/api/endpoints/test_user_notification_settings_providers.py
@@ -74,6 +74,22 @@ class UserNotificationSettingsProvidersGetTest(UserNotificationSettingsProviders
         response = self.get_success_response("me").data
         assert len(response) == 3
 
+        # check for all the provider options
+        alert_slack_item = next(
+            item for item in response if item["provider"] == "slack" and item["type"] == "alerts"
+        )
+        assert alert_slack_item["value"] == "always"
+
+        workflow_email_item = next(
+            item for item in response if item["provider"] == "email" and item["type"] == "workflow"
+        )
+        assert workflow_email_item["value"] == "always"
+
+        alert_slack_item = next(
+            item for item in response if item["provider"] == "email" and item["type"] == "alerts"
+        )
+        assert alert_slack_item["value"] == "always"
+
     def test_invalid_type(self):
         response = self.get_error_response(
             "me",

--- a/tests/sentry/api/endpoints/test_user_notification_settings_providers.py
+++ b/tests/sentry/api/endpoints/test_user_notification_settings_providers.py
@@ -1,6 +1,6 @@
 from rest_framework import status
 
-from sentry.models.notificationsettingoption import NotificationSettingOption
+from sentry.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.notifications.types import (
     NotificationScopeEnum,
     NotificationSettingEnum,
@@ -8,53 +8,71 @@ from sentry.notifications.types import (
 )
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.types.integrations import ExternalProviderEnum
 
 
-class UserNotificationOptionsBaseTest(APITestCase):
-    endpoint = "sentry-api-0-user-notification-options"
+class UserNotificationSettingsProvidersBaseTest(APITestCase):
+    endpoint = "sentry-api-0-user-notification-providers"
 
 
 @control_silo_test(stable=True)
-class UserNotificationOptionsGetTest(UserNotificationOptionsBaseTest):
+class UserNotificationSettingsProvidersGetTest(UserNotificationSettingsProvidersBaseTest):
     def setUp(self):
         super().setUp()
         self.login_as(self.user)
 
     def test_simple(self):
         other_user = self.create_user()
-        NotificationSettingOption.objects.create(
+        NotificationSettingProvider.objects.create(
             user_id=self.user.id,
             scope_type=NotificationScopeEnum.ORGANIZATION.value,
             scope_identifier=self.organization.id,
             type=NotificationSettingEnum.ISSUE_ALERTS.value,
+            provider=ExternalProviderEnum.SLACK.value,
             value=NotificationSettingsOptionEnum.ALWAYS.value,
         )
-        NotificationSettingOption.objects.create(
+        NotificationSettingProvider.objects.create(
+            user_id=self.user.id,
+            scope_type=NotificationScopeEnum.ORGANIZATION.value,
+            scope_identifier=self.organization.id,
+            type=NotificationSettingEnum.ISSUE_ALERTS.value,
+            provider=ExternalProviderEnum.EMAIL.value,
+            value=NotificationSettingsOptionEnum.ALWAYS.value,
+        )
+        NotificationSettingProvider.objects.create(
             user_id=self.user.id,
             scope_type=NotificationScopeEnum.ORGANIZATION.value,
             scope_identifier=self.organization.id,
             type=NotificationSettingEnum.WORKFLOW.value,
+            provider=ExternalProviderEnum.EMAIL.value,
             value=NotificationSettingsOptionEnum.ALWAYS.value,
         )
-        NotificationSettingOption.objects.create(
+        NotificationSettingProvider.objects.create(
             user_id=other_user.id,
             scope_type=NotificationScopeEnum.ORGANIZATION.value,
             scope_identifier=self.organization.id,
             type=NotificationSettingEnum.ISSUE_ALERTS.value,
+            provider=ExternalProviderEnum.SLACK.value,
             value=NotificationSettingsOptionEnum.ALWAYS.value,
         )
 
         response = self.get_success_response("me", type="alerts").data
-        assert len(response) == 1
-        assert response[0]["scopeType"] == "organization"
-        assert response[0]["scopeIdentifier"] == str(self.organization.id)
-        assert response[0]["user_id"] == str(self.user.id)
-        assert response[0]["team_id"] is None
-        assert response[0]["value"] == "always"
-        assert response[0]["type"] == "alerts"
+        assert len(response) == 2
+        slack_item = next(item for item in response if item["provider"] == "slack")
+        email_item = next(item for item in response if item["provider"] == "email")
+
+        assert slack_item["scopeType"] == "organization"
+        assert slack_item["scopeIdentifier"] == str(self.organization.id)
+        assert slack_item["user_id"] == str(self.user.id)
+        assert slack_item["team_id"] is None
+        assert slack_item["value"] == "always"
+        assert slack_item["type"] == "alerts"
+        assert slack_item["provider"] == "slack"
+
+        assert email_item["provider"] == "email"
 
         response = self.get_success_response("me").data
-        assert len(response) == 2
+        assert len(response) == 3
 
     def test_invalid_type(self):
         response = self.get_error_response(
@@ -66,7 +84,7 @@ class UserNotificationOptionsGetTest(UserNotificationOptionsBaseTest):
 
 
 @control_silo_test(stable=True)
-class UserNotificationOptionsPutTest(UserNotificationOptionsBaseTest):
+class UserNotificationSettingsProvidersPutTest(UserNotificationSettingsProvidersBaseTest):
     method = "PUT"
 
     def setUp(self):
@@ -82,29 +100,31 @@ class UserNotificationOptionsPutTest(UserNotificationOptionsBaseTest):
             type="alerts",
             status_code=status.HTTP_201_CREATED,
             value="always",
+            provider=["slack"],
         )
-        row = NotificationSettingOption.objects.filter(
+        assert NotificationSettingProvider.objects.filter(
             user_id=self.user.id,
             scope_type=NotificationScopeEnum.ORGANIZATION.value,
             scope_identifier=self.organization.id,
             type=NotificationSettingEnum.ISSUE_ALERTS.value,
             value=NotificationSettingsOptionEnum.ALWAYS.value,
-        ).first()
-        assert response.data["id"] == str(row.id)
+            provider=ExternalProviderEnum.SLACK.value,
+        ).exists()
+        assert len(response.data) == 3
 
     def test_invalid_scope_type(self):
         response = self.get_error_response(
             "me",
             user_id=self.user.id,
-            scope_type="invalid",
-            scope_identifier=self.organization.id,
+            scope_type="project",
+            scope_identifier=self.project.id,
             type="alerts",
             status_code=status.HTTP_400_BAD_REQUEST,
-            value="always",
+            provider=["slack"],
         )
         assert response.data["scopeType"] == ["Invalid scope type"]
 
-    def test_invalid_value(self):
+    def test_invalid_provider(self):
         response = self.get_error_response(
             "me",
             user_id=self.user.id,
@@ -112,18 +132,6 @@ class UserNotificationOptionsPutTest(UserNotificationOptionsBaseTest):
             scope_identifier=self.organization.id,
             type="alerts",
             status_code=status.HTTP_400_BAD_REQUEST,
-            value="hello",
+            provider=["github"],
         )
-        assert response.data["value"] == ["Invalid value"]
-
-    def test_invalid_value_for_option(self):
-        response = self.get_error_response(
-            "me",
-            user_id=self.user.id,
-            scope_type="organization",
-            scope_identifier=self.organization.id,
-            type="alerts",
-            status_code=status.HTTP_400_BAD_REQUEST,
-            value=NotificationSettingsOptionEnum.SUBSCRIBE_ONLY.value,
-        )
-        assert response.data["nonFieldErrors"] == ["Invalid type for value"]
+        assert response.data["provider"] == ["Invalid provider"]


### PR DESCRIPTION
This is a follow-up to [this PR](https://github.com/getsentry/sentry/pull/54871) to address comments left there:

1. Changes `provider` to `providers` as it's really a list of providers
2. Fix some naming
3. Deepen tests