### PR TITLE
chore(logging): Fix `_handle_regression` log messages

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1846,7 +1846,7 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
     if not group.is_resolved():
         if should_log_extra_info:
             logger.info(
-                "_handle_regression: group.is_resolved returned true", extra={**logging_details}
+                "_handle_regression: group.is_resolved() returned False", extra={**logging_details}
             )
         return None
 
@@ -1855,21 +1855,24 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
     elif GroupResolution.has_resolution(group, release):
         if should_log_extra_info:
             logger.info(
-                "_handle_regression: group.is_resolved returned true", extra={**logging_details}
+                "_handle_regression: GroupResolution.has_resolution() returned True",
+                extra={**logging_details},
             )
         return None
 
     elif has_pending_commit_resolution(group):
         if should_log_extra_info:
             logger.info(
-                "_handle_regression: group.is_resolved returned true", extra={**logging_details}
+                "_handle_regression: has_pending_commit_resolution() returned True",
+                extra={**logging_details},
             )
         return None
 
     if not plugin_is_regression(group, event):
         if should_log_extra_info:
             logger.info(
-                "_handle_regression: group.is_resolved returned true", extra={**logging_details}
+                "_handle_regression: plugin_is_regression() returned False",
+                extra={**logging_details},
             )
         return None
 


### PR DESCRIPTION
This updates some log messages in `_handle_regression` to better reflect the conditions in which they're found. (All four were the same as the first one (which was making my linter mad), so I assume this was just a copying error.)