### PR TITLE
feat(org-tokens): Remove `organizations:org-auth-tokens` feature

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1697,8 +1697,6 @@ SENTRY_FEATURES = {
     "organizations:org-roles-for-teams": False,
     # Enable new JS SDK Dynamic Loader
     "organizations:js-sdk-dynamic-loader": False,
-    # If true, allow to create/use org auth tokens
-    "organizations:org-auth-tokens": False,
     # Enable detecting SDK crashes during event processing
     "organizations:sdk-crash-detection": False,
     # Enable functionality for recap server polling.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -113,7 +113,6 @@ default_manager.add("organizations:on-demand-metrics-extraction-experimental", O
 default_manager.add("organizations:minute-resolution-sessions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:mobile-vitals", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:mobile-cpu-memory-in-transactions", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:org-auth-tokens", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:view-hierarchies-options-dev", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:anr-improvements", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:anr-analyze-frames", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.db.models import F
 from django.http import HttpRequest, HttpResponse
 
-from sentry import features, roles
+from sentry import roles
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY, SETUP_WIZARD_CACHE_TIMEOUT
 from sentry.api.serializers import serialize
 from sentry.api.utils import generate_region_url
@@ -96,9 +96,7 @@ class SetupWizardView(BaseView):
         token = None
         serialized_token = None
 
-        can_use_org_tokens = len(orgs) == 1 and features.has(
-            "organizations:org-auth-tokens", orgs[0], actor=request.user
-        )
+        can_use_org_tokens = len(orgs) == 1
 
         if can_use_org_tokens:
             org = orgs[0]

--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -100,7 +100,6 @@ const organizationNavigation: NavigationSection[] = [
         title: t('Auth Tokens'),
         description: t('Manage organization auth tokens'),
         id: 'auth-tokens',
-        show: ({features}) => features!.has('org-auth-tokens'),
       },
       {
         path: `${pathPrefix}/developer-settings/`,

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -68,8 +68,6 @@ function SettingsIndex({organization, ...props}: SettingsIndexProps) {
     organizationSettingsUrl,
   };
 
-  const hasOrgAuthTokens = organization?.features.includes('org-auth-tokens');
-
   const myAccount = (
     <GridPanel>
       <HomePanelHeader>
@@ -219,13 +217,11 @@ function SettingsIndex({organization, ...props}: SettingsIndexProps) {
       <HomePanelBody>
         <h3>{t('Quick links')}:</h3>
         <ul>
-          {hasOrgAuthTokens && (
-            <li>
-              <HomeLink to={`${organizationSettingsUrl}auth-tokens/`}>
-                {t('Organization Auth Tokens')}
-              </HomeLink>
-            </li>
-          )}
+          <li>
+            <HomeLink to={`${organizationSettingsUrl}auth-tokens/`}>
+              {t('Organization Auth Tokens')}
+            </HomeLink>
+          </li>
           <li>
             <HomeLink to={LINKS.API}>{t('User Auth Tokens')}</HomeLink>
           </li>

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -87,14 +87,16 @@ class SetupWizard(PermissionTestCase):
 
         assert len(cached.get("projects")[0].get("keys")) == 2
 
-    def test_return_user_auth_token_if_org_token_flag_not_set(self):
+    def test_return_user_auth_token_if_multiple_orgs(self):
         user_api_token = ApiToken.objects.create_or_update(
             user=self.user,
             scope_list=["project:releases"],
             refresh_token=None,
             expires_at=None,
         )[0]
-        self.org = self.create_organization(owner=self.user)
+
+        self.org = self.create_organization(name="org1", owner=self.user)
+        self.org2 = self.create_organization(name="org2", owner=self.user)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
 
@@ -114,63 +116,28 @@ class SetupWizard(PermissionTestCase):
 
         assert cached.get("apiKeys") == serialize(user_api_token)
 
-    def test_return_user_auth_token_if_flag_set_but_multiple_orgs(self):
-        user_api_token = ApiToken.objects.create_or_update(
-            user=self.user,
-            scope_list=["project:releases"],
-            refresh_token=None,
-            expires_at=None,
-        )[0]
+    def test_return_org_auth_token_if_one_org(self):
+        self.org = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.org, name="Mariachi Band")
+        self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
 
-        with self.feature("organizations:org-auth-tokens"):
-            self.org = self.create_organization(name="org1", owner=self.user)
-            self.org2 = self.create_organization(name="org2", owner=self.user)
-            self.team = self.create_team(organization=self.org, name="Mariachi Band")
-            self.project = self.create_project(
-                organization=self.org, teams=[self.team], name="Bengal"
-            )
+        self.project.key_set.add(ProjectKey.objects.create(project=self.project, label="abc"))
 
-            self.project.key_set.add(ProjectKey.objects.create(project=self.project, label="abc"))
+        self.login_as(self.user)
 
-            self.login_as(self.user)
+        key = f"{SETUP_WIZARD_CACHE_KEY}abc"
+        default_cache.set(key, "test", 600)
 
-            key = f"{SETUP_WIZARD_CACHE_KEY}abc"
-            default_cache.set(key, "test", 600)
+        url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "abc"})
+        resp = self.client.get(url)
 
-            url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "abc"})
-            resp = self.client.get(url)
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/setup-wizard.html")
+        cached = default_cache.get(key)
 
-            assert resp.status_code == 200
-            self.assertTemplateUsed(resp, "sentry/setup-wizard.html")
-            cached = default_cache.get(key)
+        token = cached.get("apiKeys")["token"]
 
-            assert cached.get("apiKeys") == serialize(user_api_token)
-
-    def test_return_org_auth_token_if_flag_set_and_one_org(self):
-        with self.feature("organizations:org-auth-tokens"):
-            self.org = self.create_organization(owner=self.user)
-            self.team = self.create_team(organization=self.org, name="Mariachi Band")
-            self.project = self.create_project(
-                organization=self.org, teams=[self.team], name="Bengal"
-            )
-
-            self.project.key_set.add(ProjectKey.objects.create(project=self.project, label="abc"))
-
-            self.login_as(self.user)
-
-            key = f"{SETUP_WIZARD_CACHE_KEY}abc"
-            default_cache.set(key, "test", 600)
-
-            url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "abc"})
-            resp = self.client.get(url)
-
-            assert resp.status_code == 200
-            self.assertTemplateUsed(resp, "sentry/setup-wizard.html")
-            cached = default_cache.get(key)
-
-            token = cached.get("apiKeys")["token"]
-
-            assert token.startswith("sntrys_")
+        assert token.startswith("sntrys_")
 
     @override_settings(SENTRY_SIGNUP_URL="https://sentry.io/signup/")
     def test_redirect_to_signup(self):

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -61,7 +61,7 @@ class SetupWizard(PermissionTestCase):
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/setup-wizard.html")
         cached = default_cache.get(key)
-        assert cached.get("apiKeys").get("scopes")[0] == "project:releases"
+        assert cached.get("apiKeys").get("scopes")[0] == "org:ci"
         assert cached.get("projects")[0].get("status") == "active"
         assert cached.get("projects")[0].get("keys")[0].get("isActive")
         assert cached.get("projects")[0].get("organization").get("status").get("id") == "active"


### PR DESCRIPTION
Remove the feature flag, as this is enabled for everyone and we do not need to guard it anymore. Simplifies things a bit and allows to clean up behind us!