### PR TITLE
fix(settings): Add redirect for legacy route

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -416,6 +416,7 @@ function buildRoutes() {
         name={t('General')}
         component={make(() => import('sentry/views/settings/projectGeneralSettings'))}
       />
+      <Redirect from="install/" to="/projects/:projectId/getting-started/" />
       <Route
         path="teams/"
         name={t('Teams')}


### PR DESCRIPTION
We've recently improved our settings by removing a redundant page( See [PR](https://github.com/getsentry/sentry/pull/48776/)). Since we already offer a comparable option within the project creation flow, we've taken this step to enhance user experience. 

This PR adds a redirect from the old page to the new one, to ensure that users trying to access the old page go to the new one.

