### PR TITLE
feat(tracing-w/o-performance): Handling split results form events-trace-light endpoint

### DIFF
--- a/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
+++ b/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
@@ -5,8 +5,10 @@ import {DiscoverQueryProps} from 'sentry/utils/discover/genericDiscoverQuery';
 import {TraceFullQuery} from 'sentry/utils/performance/quickTrace/traceFullQuery';
 import TraceLiteQuery from 'sentry/utils/performance/quickTrace/traceLiteQuery';
 import {
+  EventLite,
   QuickTraceQueryChildrenProps,
   TraceFull,
+  TraceLite,
   TraceSplitResults,
 } from 'sentry/utils/performance/quickTrace/types';
 import {
@@ -108,9 +110,22 @@ export default function QuickTraceQuery({children, event, ...props}: QueryProps)
               traceLiteResults.trace !== null
             ) {
               const {trace} = traceLiteResults;
+              const {transactions: transactionLite, orphanErrors: orphanErrorsLite} =
+                getTraceSplitResults<EventLite>(trace ?? [], organization);
+
+              const orphanError =
+                orphanErrorsLite && orphanErrorsLite.length === 1
+                  ? orphanErrorsLite[0]
+                  : undefined;
+              const traceTransactions = transactionLite ?? (trace as TraceLite);
               return children({
                 ...traceLiteResults,
-                currentEvent: trace.find(e => isCurrentEvent(e, event)) ?? null,
+                trace: traceTransactions,
+                orphanErrors,
+                currentEvent:
+                  orphanError ??
+                  traceTransactions.find(e => isCurrentEvent(e, event)) ??
+                  null,
               });
             }
 

--- a/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
+++ b/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
@@ -121,7 +121,7 @@ export default function QuickTraceQuery({children, event, ...props}: QueryProps)
               return children({
                 ...traceLiteResults,
                 trace: traceTransactions,
-                orphanErrors,
+                orphanErrors: orphanErrorsLite,
                 currentEvent:
                   orphanError ??
                   traceTransactions.find(e => isCurrentEvent(e, event)) ??

--- a/static/app/utils/performance/quickTrace/traceLiteQuery.tsx
+++ b/static/app/utils/performance/quickTrace/traceLiteQuery.tsx
@@ -5,9 +5,11 @@ import GenericDiscoverQuery, {
 } from 'sentry/utils/discover/genericDiscoverQuery';
 import {
   BaseTraceChildrenProps,
+  EventLite,
   PartialQuickTrace,
   TraceLite,
   TraceRequestProps,
+  TraceSplitResults,
 } from 'sentry/utils/performance/quickTrace/types';
 import {
   getTraceRequestPayload,
@@ -20,7 +22,7 @@ type AdditionalQueryProps = {
 
 type TraceLiteQueryChildrenProps = BaseTraceChildrenProps &
   Omit<PartialQuickTrace, 'trace'> & {
-    trace: TraceLite | null;
+    trace: TraceLite | TraceSplitResults<EventLite> | null;
   };
 
 type QueryProps = Omit<TraceRequestProps, 'eventView'> &

--- a/static/app/utils/performance/quickTrace/types.tsx
+++ b/static/app/utils/performance/quickTrace/types.tsx
@@ -83,7 +83,7 @@ export type TraceFullDetailed = Omit<TraceFull, 'children'> & {
   tags?: EventTag[];
 };
 
-export type TraceSplitResults<U extends TraceFull | TraceFullDetailed> = {
+export type TraceSplitResults<U extends TraceFull | TraceFullDetailed | EventLite> = {
   orphan_errors: TraceError[];
   transactions: U[];
 };

--- a/static/app/views/performance/traceDetails/utils.tsx
+++ b/static/app/views/performance/traceDetails/utils.tsx
@@ -3,6 +3,7 @@ import {LocationDescriptor, Query} from 'history';
 import {PAGE_URL_PARAM} from 'sentry/constants/pageFilters';
 import {Organization, OrganizationSummary} from 'sentry/types';
 import {
+  EventLite,
   TraceError,
   TraceFull,
   TraceFullDetailed,
@@ -63,7 +64,7 @@ export function hasTraceData(
   );
 }
 
-export function getTraceSplitResults<U extends TraceFullDetailed | TraceFull>(
+export function getTraceSplitResults<U extends TraceFullDetailed | TraceFull | EventLite>(
   trace: TraceSplitResults<U> | U[],
   organization: Organization
 ) {


### PR DESCRIPTION
This frontend PR aims to handle the split `{"transactions": [...], "orphan_errors": [...]}` response from the `events-trace-light` endpoint under the feature flag `organizations:performance-tracing-without-performance`.

The trace navigator should load with out any errors for orphan errors in issues details and discover details. 
Link to test with yarn dev-ui:[ link](https://sentry.dev.getsentry.net:7999/issues/4389114778/?query=is%3Aunresolved&referrer=issue-stream&stream_index=1)

Context:
We are now adding views for orphan errors in trace views.
Part of [Tracing without performance concept.](https://www.notion.so/sentry/Tracing-without-performance-efab307eb7f64e71a04f09dc72722530)
Performance Views for tracing without performance: [link](https://getsentry.atlassian.net/browse/PERF-2052)
