### PR TITLE
fix(ref): rename flamechart to flamegraph and flamegraph to aggregate…

### DIFF
--- a/static/app/components/events/profileEventEvidence.spec.tsx
+++ b/static/app/components/events/profileEventEvidence.spec.tsx
@@ -43,7 +43,7 @@ describe('ProfileEventEvidence', function () {
 
     expect(screen.getByRole('button', {name: 'View Profile'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/profiling/profile/project-slug/profile-id/flamechart/?frameName=some_func&framePackage=something.dll&referrer=issue'
+      '/organizations/org-slug/profiling/profile/project-slug/profile-id/flamegraph/?frameName=some_func&framePackage=something.dll&referrer=issue'
     );
   });
 

--- a/static/app/components/profiling/aggregateFlamegraphPanel.tsx
+++ b/static/app/components/profiling/aggregateFlamegraphPanel.tsx
@@ -28,7 +28,7 @@ export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
   return (
     <Flex column gap={space(1)}>
       <Flex align="center" gap={space(0.5)}>
-        <HeaderTitle>{t('Flamegraph')}</HeaderTitle>
+        <HeaderTitle>{t('Aggregate Flamegraph')}</HeaderTitle>
         <QuestionTooltip
           size="sm"
           position="right"
@@ -38,7 +38,7 @@ export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
               <p>{t('An aggregate of profiles for this transaction.')}</p>
               <p>
                 {t(
-                  'Navigate the flamegraph by scrolling and by double clicking a frame to zoom.'
+                  'Navigate the aggregate flamegraph by scrolling and by double clicking a frame to zoom.'
                 )}
               </p>
             </TooltipContent>
@@ -63,10 +63,10 @@ export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
             <Panel>
               <Flex h={400} column justify="center">
                 {isLoading ? (
-                  <LoadingIndicator>{t('Loading Flamegraph')}</LoadingIndicator>
+                  <LoadingIndicator>{t('Loading Aggregate Flamegraph')}</LoadingIndicator>
                 ) : isEmpty ? (
                   <EmptyStateWarning>
-                    <p>{t(`A flamegraph isn't available for your query`)}</p>
+                    <p>{t(`Aggregate flamegraph isn't available for your query`)}</p>
                   </EmptyStateWarning>
                 ) : (
                   <AggregateFlamegraph

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeContextMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeContextMenu.tsx
@@ -35,7 +35,7 @@ export function FlamegraphTreeContextMenu(props: FlamegraphTreeContextMenuProps)
             {...props.contextMenu.getMenuItemProps()}
             onClick={props.onZoomIntoFrameClick}
           >
-            {t('Show on flamechart')}
+            {t('Show on flamegraph')}
           </ProfilingContextMenuItem>
           <ProfilingContextMenuItem
             {...props.contextMenu.getMenuItemProps()}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2017,8 +2017,13 @@ function buildRoutes() {
         path="profile/:projectId/:eventId/"
         component={make(() => import('sentry/views/profiling/profilesProvider'))}
       >
+        {/* @TODO Remove flamechart route name */}
         <Route
           path="flamechart/"
+          component={make(() => import('sentry/views/profiling/profileFlamechart'))}
+        />
+        <Route
+          path="flamegraph/"
           component={make(() => import('sentry/views/profiling/profileFlamechart'))}
         />
       </Route>

--- a/static/app/utils/profiling/routes.tsx
+++ b/static/app/utils/profiling/routes.tsx
@@ -26,7 +26,7 @@ export function generateProfileFlamechartRoute({
   profileId: Trace['id'];
   projectSlug: Project['slug'];
 }): string {
-  return `/organizations/${orgSlug}/profiling/profile/${projectSlug}/${profileId}/flamechart/`;
+  return `/organizations/${orgSlug}/profiling/profile/${projectSlug}/${profileId}/flamegraph/`;
 }
 
 export function generateProfileDetailsRoute({

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.spec.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.spec.tsx
@@ -184,7 +184,7 @@ describe('SlowestFunctionsWidget', function () {
     expect(transaction1).toBeInTheDocument();
     expect(transaction1).toHaveAttribute(
       'href',
-      '/organizations/org-slug/profiling/profile/proj-slug/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/flamechart/?frameName=bar&framePackage=foo'
+      '/organizations/org-slug/profiling/profile/proj-slug/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/flamegraph/?frameName=bar&framePackage=foo'
     );
     expect(screen.getByText('1k')).toBeInTheDocument();
     expect(screen.getByText('1.00ms')).toBeInTheDocument();
@@ -194,7 +194,7 @@ describe('SlowestFunctionsWidget', function () {
     expect(transaction2).toBeInTheDocument();
     expect(transaction2).toHaveAttribute(
       'href',
-      '/organizations/org-slug/profiling/profile/proj-slug/cccccccccccccccccccccccccccccccc/flamechart/?frameName=bar&framePackage=foo'
+      '/organizations/org-slug/profiling/profile/proj-slug/cccccccccccccccccccccccccccccccc/flamegraph/?frameName=bar&framePackage=foo'
     );
     expect(screen.getByText('2.5k')).toBeInTheDocument();
     expect(screen.getByText('0.50ms')).toBeInTheDocument();
@@ -209,7 +209,7 @@ describe('SlowestFunctionsWidget', function () {
     expect(transaction3).toBeInTheDocument();
     expect(transaction3).toHaveAttribute(
       'href',
-      '/organizations/org-slug/profiling/profile/proj-slug/dddddddddddddddddddddddddddddddd/flamechart/?frameName=qux&framePackage=baz'
+      '/organizations/org-slug/profiling/profile/proj-slug/dddddddddddddddddddddddddddddddd/flamegraph/?frameName=qux&framePackage=baz'
     );
     expect(screen.getByText('2k')).toBeInTheDocument();
     expect(screen.getByText('2.00ms')).toBeInTheDocument();
@@ -219,7 +219,7 @@ describe('SlowestFunctionsWidget', function () {
     expect(transaction4).toBeInTheDocument();
     expect(transaction4).toHaveAttribute(
       'href',
-      '/organizations/org-slug/profiling/profile/proj-slug/ffffffffffffffffffffffffffffffff/flamechart/?frameName=qux&framePackage=baz'
+      '/organizations/org-slug/profiling/profile/proj-slug/ffffffffffffffffffffffffffffffff/flamegraph/?frameName=qux&framePackage=baz'
     );
     expect(screen.getByText('3.5k')).toBeInTheDocument();
     expect(screen.getByText('0.70ms')).toBeInTheDocument();


### PR DESCRIPTION
Rename public references of flamechart to flamegraph and flamegraph is aggregate flamegraph as users were confused.

Preserving the private naming as the team is aware of the differences (open to changing, just didn't want to rename _everything_). I  also renamed the /flamechart route to /flamegraph, but kept the flamechart fallback so we don't break people's existing links and set a reminder in a month from now to remove the /flamechart route.