### PR TITLE
feat(hybridcloud) Add silo limiters for views

### DIFF
--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import abc
 import inspect
 import logging
-from typing import Any, Mapping, Protocol
+from typing import Any, Callable, Iterable, Mapping, Protocol, Type
 
+from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.http import (
     HttpRequest,
@@ -19,6 +20,7 @@ from django.template.context_processors import csrf
 from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
+from rest_framework.request import Request
 
 from sentry import options
 from sentry.api.utils import generate_organization_url, is_member_disabled_from_limit
@@ -37,6 +39,7 @@ from sentry.services.hybrid_cloud.organization import (
 )
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.silo import SiloLimit
+from sentry.silo.base import SiloMode
 from sentry.utils import auth
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.auth import construct_link_with_query, is_valid_redirect
@@ -47,6 +50,70 @@ from sudo.views import redirect_to_sudo
 
 logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger("sentry.audit.ui")
+
+
+class ViewSiloLimit(SiloLimit):
+    def modify_endpoint_class(self, decorated_class: Type[View]) -> type:
+        dispatch_override = self.create_override(decorated_class.dispatch)
+        new_class = type(
+            decorated_class.__name__,
+            (decorated_class,),
+            {
+                "dispatch": dispatch_override,
+                "silo_limit": self,
+            },
+        )
+        new_class.__module__ = decorated_class.__module__
+        return new_class
+
+    def modify_endpoint_method(self, decorated_method: Callable[..., Any]) -> Callable[..., Any]:
+        return self.create_override(decorated_method)
+
+    def handle_when_unavailable(
+        self,
+        original_method: Callable[..., Any],
+        current_mode: SiloMode,
+        available_modes: Iterable[SiloMode],
+    ) -> Callable[..., Any]:
+        def handle(obj: Any, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+            mode_str = ", ".join(str(m) for m in available_modes)
+            message = (
+                f"Received {request.method} request at {request.path!r} to server in "
+                f"{current_mode} mode. This endpoint is available only in: {mode_str}"
+            )
+            if settings.FAIL_ON_UNAVAILABLE_API_CALL:
+                raise self.AvailabilityError(message)
+            else:
+                logger.warning(message)
+                return HttpResponseNotFound()
+
+        return handle
+
+    def __call__(self, decorated_obj: Any) -> Any:
+        if isinstance(decorated_obj, type):
+            if not issubclass(decorated_obj, View):
+                raise ValueError("`@ViewSiloLimit` can decorate only View subclasses")
+            return self.modify_endpoint_class(decorated_obj)
+
+        if callable(decorated_obj):
+            return self.modify_endpoint_method(decorated_obj)
+
+        raise TypeError("`@ViewSiloLimit` must decorate a class or method")
+
+
+control_silo_view = ViewSiloLimit(SiloMode.CONTROL)
+"""
+Apply to frontend views that exist in CONTROL Silo
+If a request is received and the application is not in CONTROL/MONOLITH
+mode a 404 will be returned.
+"""
+
+region_silo_view = ViewSiloLimit(SiloMode.REGION)
+"""
+Apply to frontend views that exist in REGION Silo
+If a request is received and the application is not in REGION/MONOLITH
+mode a 404 will be returned.
+"""
 
 
 class _HasRespond(Protocol):

--- a/src/sentry/web/frontend/organization_avatar.py
+++ b/src/sentry/web/frontend/organization_avatar.py
@@ -1,6 +1,7 @@
 from sentry.models import OrganizationAvatar
-from sentry.web.frontend.base import AvatarPhotoView
+from sentry.web.frontend.base import AvatarPhotoView, region_silo_view
 
 
+@region_silo_view
 class OrganizationAvatarPhotoView(AvatarPhotoView):
     model = OrganizationAvatar

--- a/src/sentry/web/frontend/sentryapp_avatar.py
+++ b/src/sentry/web/frontend/sentryapp_avatar.py
@@ -1,6 +1,7 @@
 from sentry.models import SentryAppAvatar
-from sentry.web.frontend.base import AvatarPhotoView
+from sentry.web.frontend.base import AvatarPhotoView, control_silo_view
 
 
+@control_silo_view
 class SentryAppAvatarPhotoView(AvatarPhotoView):
     model = SentryAppAvatar

--- a/src/sentry/web/frontend/team_avatar.py
+++ b/src/sentry/web/frontend/team_avatar.py
@@ -1,6 +1,7 @@
 from sentry.models import TeamAvatar
-from sentry.web.frontend.base import AvatarPhotoView
+from sentry.web.frontend.base import AvatarPhotoView, region_silo_view
 
 
+@region_silo_view
 class TeamAvatarPhotoView(AvatarPhotoView):
     model = TeamAvatar

--- a/src/sentry/web/frontend/user_avatar.py
+++ b/src/sentry/web/frontend/user_avatar.py
@@ -1,6 +1,7 @@
 from sentry.models import UserAvatar
-from sentry.web.frontend.base import AvatarPhotoView
+from sentry.web.frontend.base import AvatarPhotoView, control_silo_view
 
 
+@control_silo_view
 class UserAvatarPhotoView(AvatarPhotoView):
     model = UserAvatar

--- a/tests/sentry/web/frontend/test_sentryapp_avatar.py
+++ b/tests/sentry/web/frontend/test_sentryapp_avatar.py
@@ -3,19 +3,40 @@ from io import BytesIO
 from django.urls import reverse
 
 from sentry.models import File, SentryAppAvatar
+from sentry.models.files.control_file import ControlFile
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.web.frontend.generic import FOREVER_CACHE
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class SentryAppAvatarTest(APITestCase):
     def test_headers(self):
+        # We cannot read File from Control silo
+        if SiloMode.get_current_mode() == SiloMode.CONTROL:
+            return
+
         sentry_app = self.create_sentry_app(name="Meow", organization=self.organization)
-        photo = File.objects.create(name="test.png", type="avatar.file")
-        photo.putfile(BytesIO(b"test"))
+        with assume_test_silo_mode(SiloMode.REGION):
+            photo = File.objects.create(name="test.png", type="avatar.file")
+            photo.putfile(BytesIO(b"test"))
         avatar = SentryAppAvatar.objects.create(
             sentry_app=sentry_app, avatar_type=1, color=True, file_id=photo.id
+        )
+        url = reverse("sentry-app-avatar-url", kwargs={"avatar_id": avatar.ident})
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response["Cache-Control"] == FOREVER_CACHE
+        assert response.get("Vary") == "Accept-Language, Cookie"
+        assert response.get("Set-Cookie") is None
+
+    def test_headers_control_file(self):
+        sentry_app = self.create_sentry_app(name="Meow", organization=self.organization)
+        photo = ControlFile.objects.create(name="test.png", type="avatar.file")
+        photo.putfile(BytesIO(b"test"))
+        avatar = SentryAppAvatar.objects.create(
+            sentry_app=sentry_app, avatar_type=1, color=True, control_file_id=photo.id
         )
         url = reverse("sentry-app-avatar-url", kwargs={"avatar_id": avatar.ident})
         response = self.client.get(url)

--- a/tests/sentry/web/frontend/test_user_avatar.py
+++ b/tests/sentry/web/frontend/test_user_avatar.py
@@ -10,9 +10,13 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.web.frontend.generic import FOREVER_CACHE
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserAvatarTest(TestCase):
     def test_headers(self):
+        # We cannot read File from Control silo
+        if SiloMode.get_current_mode() == SiloMode.CONTROL:
+            return
+
         user = self.create_user(email="a@example.com")
         with assume_test_silo_mode(SiloMode.REGION):
             photo = File.objects.create(name="test.png", type="avatar.file")


### PR DESCRIPTION
Add silo limiting decorators for frontend views. Having these will resolve a few 500s in the test environment and create 404s instead.

We'll still need to change the host we request avatars from in order to get them fully working.