### PR TITLE
add referrer to analytics record

### DIFF
--- a/src/sentry/analytics/events/join_request_created.py
+++ b/src/sentry/analytics/events/join_request_created.py
@@ -4,7 +4,11 @@ from sentry import analytics
 class JoinRequestCreatedEvent(analytics.Event):
     type = "join_request.created"
 
-    attributes = (analytics.Attribute("member_id"), analytics.Attribute("organization_id"))
+    attributes = (
+        analytics.Attribute("member_id"),
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("referrer", required=False),
+    )
 
 
 analytics.register(JoinRequestCreatedEvent)

--- a/src/sentry/receivers/experiments.py
+++ b/src/sentry/receivers/experiments.py
@@ -5,7 +5,10 @@ from sentry.signals import join_request_created, join_request_link_viewed, user_
 @join_request_created.connect(weak=False)
 def record_join_request_created(member, **kwargs):
     analytics.record(
-        "join_request.created", member_id=member.id, organization_id=member.organization_id
+        "join_request.created",
+        member_id=member.id,
+        organization_id=member.organization_id,
+        referrer=kwargs.get("referrer"),
     )
 
 

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -137,7 +137,10 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
         assert not join_request.invite_approved
 
         mock_record.assert_called_with(
-            "join_request.created", member_id=join_request.id, organization_id=self.organization.id
+            "join_request.created",
+            member_id=join_request.id,
+            organization_id=self.organization.id,
+            referrer=None,
         )
 
         self.assert_org_member_mapping(org_member=join_request)


### PR DESCRIPTION
Realized we aren't passing referrer into the join request event