### PR TITLE
feat(discord): Add banner about channel ID to Discord issue alert action form

### DIFF
--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -412,6 +412,28 @@ function RuleNode({
     }
 
     if (
+      data.id === 'sentry.integrations.discord.notify_action.DiscordNotifyServiceAction'
+    ) {
+      return (
+        <MarginlessAlert
+          type="info"
+          showIcon
+          trailingItems={
+            <Button
+              href="https://docs.sentry.io/product/accounts/early-adopter-features/discord/#issue-alerts"
+              external
+              size="xs"
+            >
+              {t('Learn More')}
+            </Button>
+          }
+        >
+          {t('Note that you must enter a Discord channel ID, not a channel name.')}
+        </MarginlessAlert>
+      );
+    }
+
+    if (
       data.id === NOTIFY_EMAIL_ACTION &&
       data.targetType === MailActionTargetType.ISSUE_OWNERS &&
       !organization.features.includes('issue-alert-fallback-targeting')


### PR DESCRIPTION
Banner gives a link to where we discuss how to get the channel ID in our docs.

![image (3)](https://github.com/getsentry/sentry/assets/62224025/fa4d2d5a-86c4-4a14-88d2-c8efe1021405)
