### PR TITLE
chore(integrations): Do not report some integration issues

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -78,7 +78,7 @@ class Webhook:
                     "external_id": str(external_id),
                 },
             )
-            logger.exception("Integration does not exist.")
+            metrics.incr("github.webhook.integration_does_not_exist")
             return
 
         if "repository" in event:

--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -10,7 +10,7 @@ from sentry.integrations.jira_server.utils import handle_assignee_change, handle
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.models import Integration
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.utils import jwt
+from sentry.utils import jwt, metrics
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +59,8 @@ class JiraServerIssueUpdatedWebhook(Endpoint):
             extra["integration_id"] = integration.id
         except ValueError as err:
             extra.update({"token": token, "error": str(err)})
-            logger.info("token-validation-error", extra=extra)
-            logger.exception("Invalid token.")
+            logger.warning("token-validation-error", extra=extra)
+            metrics.incr("jira_server.webhook.invalid_token")
             return self.respond(status=400)
 
         data = request.data


### PR DESCRIPTION
Both issues are similar, we receive payloads from them but there's no Sentry integration associated anymore.

Do not report the issue to Sentry but track it as a metric instead (at least we can gauge volume if we were to wish to).

Fixes [SENTRY-14WB](https://sentry.sentry.io/issues/4389114778/) Fixes [SENTRY-XXC](https://sentry.sentry.io/issues/3899249419/)