### PR TITLE
ref: Extract useVirtualListDimentionChange from useVirtualizedInspector

### DIFF
--- a/static/app/views/replays/detail/console/consoleLogRow.tsx
+++ b/static/app/views/replays/detail/console/consoleLogRow.tsx
@@ -11,7 +11,7 @@ import type useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import type {BreadcrumbFrame, ConsoleFrame} from 'sentry/utils/replays/types';
 import MessageFormatter from 'sentry/views/replays/detail/console/messageFormatter';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
-import {OnDimensionChange} from 'sentry/views/replays/detail/useVirtualizedInspector';
+import type {OnDimensionChange} from 'sentry/views/replays/detail/useVirtualListDimentionChange';
 
 interface Props extends ReturnType<typeof useCrumbHandlers> {
   currentHoverTime: number | undefined;

--- a/static/app/views/replays/detail/useVirtualListDimentionChange.tsx
+++ b/static/app/views/replays/detail/useVirtualListDimentionChange.tsx
@@ -1,0 +1,29 @@
+import {MouseEvent, RefObject, useCallback} from 'react';
+import {CellMeasurerCache, List} from 'react-virtualized';
+
+import {OnExpandCallback} from 'sentry/components/objectInspector';
+
+type Opts = {
+  cache: CellMeasurerCache;
+  listRef: RefObject<List>;
+};
+
+export type OnDimensionChange = OnExpandCallback extends (...a: infer U) => infer R
+  ? (index: number, ...a: U) => R
+  : never;
+
+export default function useVirtualListDimentionChange({cache, listRef}: Opts) {
+  const handleDimensionChange = useCallback(
+    (index: number, event: MouseEvent<HTMLDivElement>) => {
+      cache.clear(index, 0);
+      listRef.current?.recomputeGridSize({rowIndex: index});
+      listRef.current?.forceUpdateGrid();
+      event.stopPropagation();
+    },
+    [cache, listRef]
+  );
+
+  return {
+    handleDimensionChange,
+  };
+}

--- a/static/app/views/replays/detail/useVirtualizedInspector.tsx
+++ b/static/app/views/replays/detail/useVirtualizedInspector.tsx
@@ -1,44 +1,37 @@
 import {MouseEvent, RefObject, useCallback} from 'react';
 import {CellMeasurerCache, List} from 'react-virtualized';
 
-import {OnExpandCallback} from 'sentry/components/objectInspector';
+import useVirtualListDimentionChange from 'sentry/views/replays/detail/useVirtualListDimentionChange';
 
 type Opts = {
   cache: CellMeasurerCache;
   expandPathsRef: RefObject<Map<number, Set<string>>>;
   listRef: RefObject<List>;
 };
-function useVirtualizedInspector({cache, listRef, expandPathsRef}: Opts) {
-  const handleDimensionChange = useCallback(
-    (
-      index: number,
-      path: string,
-      expandedState: Record<string, boolean>,
-      event: MouseEvent<HTMLDivElement>
-    ) => {
-      const rowState = expandPathsRef.current?.get(index) || new Set();
-      if (expandedState[path]) {
-        rowState.add(path);
-      } else {
-        // Collapsed, i.e. its default state, so no need to store state
-        rowState.delete(path);
-      }
-      expandPathsRef.current?.set(index, rowState);
-      cache.clear(index, 0);
-      listRef.current?.recomputeGridSize({rowIndex: index});
-      listRef.current?.forceUpdateGrid();
-      event.stopPropagation();
-    },
-    [cache, expandPathsRef, listRef]
-  );
+
+export default function useVirtualizedInspector({cache, listRef, expandPathsRef}: Opts) {
+  const {handleDimensionChange} = useVirtualListDimentionChange({cache, listRef});
 
   return {
     expandPaths: expandPathsRef.current,
-    handleDimensionChange,
+    handleDimensionChange: useCallback(
+      (
+        index: number,
+        path: string,
+        expandedState: Record<string, boolean>,
+        event: MouseEvent<HTMLDivElement>
+      ) => {
+        const rowState = expandPathsRef.current?.get(index) || new Set();
+        if (expandedState[path]) {
+          rowState.add(path);
+        } else {
+          // Collapsed, i.e. its default state, so no need to store state
+          rowState.delete(path);
+        }
+        expandPathsRef.current?.set(index, rowState);
+        handleDimensionChange(index, event);
+      },
+      [expandPathsRef, handleDimensionChange]
+    ),
   };
 }
-
-export type OnDimensionChange = OnExpandCallback extends (...a: infer U) => infer R
-  ? (index: number, ...a: U) => R
-  : never;
-export default useVirtualizedInspector;


### PR DESCRIPTION
Quick extraction of the dimension logic so we can re-use it in upcoming replay-trace-view changes.