### PR TITLE
ref: Extract toPixels and narrow the allowed val types

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
@@ -365,7 +365,7 @@ function ProfileIdsSubMenu(props: {
         }}
       >
         <Flex w="100%" justify="space-between" align="center">
-          <Flex.Item>{t('Appears in %s profiles', props.profileIds.length)} </Flex.Item>
+          <Flex.Item>{t('Appears in %s profiles', props.profileIds.length)}</Flex.Item>
           <IconChevron direction="right" size="xs" />
         </Flex>
       </ProfilingContextMenuItemButton>

--- a/static/app/components/profiling/flex.tsx
+++ b/static/app/components/profiling/flex.tsx
@@ -1,32 +1,32 @@
 import {CSSProperties} from 'react';
 import styled from '@emotion/styled';
 
-const px = (val: string | number | undefined) =>
-  typeof val === 'string' ? val : typeof val === 'number' ? val + 'px' : undefined;
+import type {CssSize} from 'sentry/utils/number/toPixels';
+import toPixels from 'sentry/utils/number/toPixels';
 
 interface FlexProps {
   align?: CSSProperties['alignItems'];
   column?: boolean;
-  gap?: number | string;
-  h?: number | string;
+  gap?: number | CssSize;
+  h?: number | CssSize;
   justify?: CSSProperties['justifyContent'];
-  m?: number | string;
-  maxH?: number | string;
-  mb?: number | string;
-  minH?: number | string;
-  ml?: number | string;
-  mr?: number | string;
-  mt?: number | string;
-  mx?: number | string;
-  my?: number | string;
-  p?: number | string;
-  pb?: number | string;
-  pl?: number | string;
-  pr?: number | string;
-  pt?: number | string;
-  px?: number | string;
-  py?: number | string;
-  w?: number | string;
+  m?: number | CssSize;
+  maxH?: number | CssSize;
+  mb?: number | CssSize;
+  minH?: number | CssSize;
+  ml?: number | CssSize;
+  mr?: number | CssSize;
+  mt?: number | CssSize;
+  mx?: number | CssSize;
+  my?: number | CssSize;
+  p?: number | CssSize;
+  pb?: number | CssSize;
+  pl?: number | CssSize;
+  pr?: number | CssSize;
+  pt?: number | CssSize;
+  px?: number | CssSize;
+  py?: number | CssSize;
+  w?: number | CssSize;
   wrap?: CSSProperties['flexWrap'];
 }
 
@@ -34,27 +34,27 @@ interface FlexProps {
 const FlexContainer = styled('div')<FlexProps>`
   /* these can all come from a better base primitive */
   display: flex;
-  height: ${p => px(p.h)};
-  width: ${p => px(p.w)};
-  min-height: ${p => px(p.minH)};
-  max-height: ${p => px(p.maxH)};
+  height: ${p => toPixels(p.h)};
+  width: ${p => toPixels(p.w)};
+  min-height: ${p => toPixels(p.minH)};
+  max-height: ${p => toPixels(p.maxH)};
   /* padding */
-  padding: ${p => px(p.p)};
-  padding-left: ${p => px(p.pl || p.px)};
-  padding-right: ${p => px(p.pr || p.px)};
-  padding-top: ${p => px(p.pt || p.py)};
-  padding-bottom: ${p => px(p.pb || p.py)};
+  padding: ${p => toPixels(p.p)};
+  padding-left: ${p => toPixels(p.pl || p.px)};
+  padding-right: ${p => toPixels(p.pr || p.px)};
+  padding-top: ${p => toPixels(p.pt || p.py)};
+  padding-bottom: ${p => toPixels(p.pb || p.py)};
   /* margin */
-  margin: ${p => px(p.m)};
-  margin-left: ${p => px(p.ml || p.mx)};
-  margin-right: ${p => px(p.mr || p.mx)};
-  margin-top: ${p => px(p.mt || p.my)};
-  margin-bottom: ${p => px(p.mb || p.my)};
+  margin: ${p => toPixels(p.m)};
+  margin-left: ${p => toPixels(p.ml || p.mx)};
+  margin-right: ${p => toPixels(p.mr || p.mx)};
+  margin-top: ${p => toPixels(p.mt || p.my)};
+  margin-bottom: ${p => toPixels(p.mb || p.my)};
   /* flex specific */
   flex-direction: ${p => (p.column ? 'column' : 'row')};
   justify-content: ${p => p.justify};
   align-items: ${p => p.align};
-  gap: ${p => px(p.gap)};
+  gap: ${p => toPixels(p.gap)};
   flex-wrap: ${p => p.wrap};
 `;
 

--- a/static/app/components/profiling/flex.tsx
+++ b/static/app/components/profiling/flex.tsx
@@ -65,10 +65,9 @@ interface FlexItemProps {
 }
 
 const FlexItem = styled('div')<FlexItemProps>`
-  /* // TODO: determine sane defaults for these */
-  flex-grow: ${p => p.grow};
-  flex-shrink: ${p => p.shrink};
-  flex-basis: ${p => p.basis};
+  flex-grow: ${p => p.grow ?? 0};
+  flex-shrink: ${p => p.shrink ?? 1};
+  flex-basis: ${p => p.basis ?? 'auto'};
   overflow: hidden;
 `;
 

--- a/static/app/utils/number/toPixels.spec.tsx
+++ b/static/app/utils/number/toPixels.spec.tsx
@@ -1,0 +1,17 @@
+import toPixels from 'sentry/utils/number/toPixels';
+
+describe('toPixels', () => {
+  it('should convert a number to a string suffixed with px', () => {
+    expect(toPixels(12)).toEqual('12px');
+  });
+
+  it('should leave a string alone and return it', () => {
+    expect(toPixels('12px')).toEqual('12px');
+    expect(toPixels('100%')).toEqual('100%');
+    expect(toPixels('1em')).toEqual('1em');
+  });
+
+  it('should return undefined if that was passed in', () => {
+    expect(toPixels(undefined)).toBeUndefined();
+  });
+});

--- a/static/app/utils/number/toPixels.tsx
+++ b/static/app/utils/number/toPixels.tsx
@@ -1,0 +1,9 @@
+export type CssSize = number | `${number}px` | `1em` | '100%';
+
+/**
+ * Convert a number into a `${number}px` value
+ * Or, if the input is a string (as returned from `space(number)`), return it directly.
+ */
+export default function toPixels(val: CssSize | undefined) {
+  return typeof val === 'string' ? val : typeof val === 'number' ? val + 'px' : undefined;
+}


### PR DESCRIPTION
Instead of allowing all strings, lets be specific. Using `space()` will 'just work' because it returns something in the form `${number}px` and typescript knows it. People can still pass in random values like `toPixels('13px')` but thats harder to manage.


Related to the Flex change, there are two spots to check in the app:
- FlamegraphContextMenu
- ProfilingSlowestTransactionsPanel
I'm actually not sure where these components appear in the app.