### PR TITLE
fix(actionable-items): Remove dismissing from endpoint

### DIFF
--- a/src/sentry/api/endpoints/actionable_items.py
+++ b/src/sentry/api/endpoints/actionable_items.py
@@ -1,6 +1,5 @@
 from typing import List, Union
 
-from django.utils import timezone
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -14,7 +13,6 @@ from sentry.api.helpers.actionable_items_helper import (
     deprecated_event_errors,
     errors_to_hide,
     find_debug_frames,
-    find_prompts_activity,
     priority_ranking,
     sourcemap_sdks,
 )
@@ -81,23 +79,6 @@ class ActionableItemsEndpoint(ProjectEndpoint):
             response = EventError(event_error).get_api_context()
 
             actions.append(response)
-
-        # Use prompts activity to check if prompt has been dismissed
-        features = [x["type"] for x in actions]
-        prompts_activity = find_prompts_activity(
-            organization.id, project.id, request.user.id, features
-        )
-        prompts_activity = {prompt.feature: prompt.data for prompt in prompts_activity}
-
-        prompt_features = prompts_activity.keys()
-
-        for action in actions:
-            action["dismissed"] = False
-            if action["type"] in prompt_features:
-                dismissed = prompts_activity[action["type"]]["dismissed_ts"]
-                # Check if dismissed within the last week
-                if dismissed and timezone.now().timestamp() < int(dismissed) + 60 * 60 * 24 * 7:
-                    action["dismissed"] = True
 
         priority_get = lambda x: priority_ranking.get(x["type"], ActionPriority.UNKNOWN)
         sorted_errors = sorted(actions, key=priority_get)

--- a/src/sentry/api/helpers/actionable_items_helper.py
+++ b/src/sentry/api/helpers/actionable_items_helper.py
@@ -1,4 +1,4 @@
-from sentry.models import EventError, PromptsActivity, SourceMapProcessingIssue
+from sentry.models import EventError, SourceMapProcessingIssue
 
 
 class ActionPriority:
@@ -126,12 +126,3 @@ def is_frame_filename_valid(frame):
     elif filename and not get_file_extension(filename):
         return False
     return True
-
-
-def find_prompts_activity(organization_id, project_id, user_id, features):
-    return PromptsActivity.objects.filter(
-        organization_id=organization_id,
-        feature__in=features,
-        user_id=user_id,
-        project_id=project_id,
-    )

--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -1,4 +1,3 @@
-from sentry.api.helpers.actionable_items_helper import priority_ranking
 from sentry.models import PromptsActivity
 from sentry.utils.request_cache import request_cache
 
@@ -15,11 +14,6 @@ DEFAULT_PROMPTS = {
     "code_owners": {"required_fields": ["organization_id", "project_id"]},
     "vitals_alert": {"required_fields": ["organization_id"]},
     "github_missing_members": {"required_fields": ["organization_id"]},
-}
-
-ACTIONABLE_ITEMS_PROMPTS = {
-    action: {"reqiured_fields": ["organization_id", "project_id"]}
-    for action in priority_ranking.keys()
 }
 
 
@@ -53,7 +47,7 @@ class PromptsConfig:
         return self.prompts[name]["required_fields"]
 
 
-prompt_config = PromptsConfig({**DEFAULT_PROMPTS, **ACTIONABLE_ITEMS_PROMPTS})
+prompt_config = PromptsConfig(DEFAULT_PROMPTS)
 
 
 # TODO: remove get_prompt_activities and use get_prompt_activities_for_user instead


### PR DESCRIPTION
this pr removes the checks for dismissing these alerts because we have decided that we will not allow them to be dismissed 
