### PR TITLE
feat(replay): Setup the feature flag changes for the new Replay Performance tab

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -73,17 +73,32 @@ describe('useActiveReplayTab', () => {
     });
   });
 
-  it('should allow ERRORS', () => {
+  it('should disallow PERF by default', () => {
     mockOrganization({
-      features: ['session-replay-errors-tab'],
+      features: [],
+    });
+
+    const {result} = reactHooks.renderHook(useActiveReplayTab);
+    expect(result.current.getActiveTab()).toBe(TabKey.CONSOLE);
+
+    result.current.setActiveTab(TabKey.PERF);
+    expect(mockPush).toHaveBeenLastCalledWith({
+      pathname: '',
+      query: {t_main: TabKey.CONSOLE},
+    });
+  });
+
+  it('should allow PERF when the feature is enabled', () => {
+    mockOrganization({
+      features: ['session-replay-trace-table'],
     });
     const {result} = reactHooks.renderHook(useActiveReplayTab);
     expect(result.current.getActiveTab()).toBe(TabKey.CONSOLE);
 
-    result.current.setActiveTab(TabKey.ERRORS);
+    result.current.setActiveTab(TabKey.PERF);
     expect(mockPush).toHaveBeenLastCalledWith({
       pathname: '',
-      query: {t_main: TabKey.ERRORS},
+      query: {t_main: TabKey.PERF},
     });
   });
 });

--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -14,9 +14,15 @@ export enum TabKey {
   MEMORY = 'memory',
   NETWORK = 'network',
   TRACE = 'trace',
+  PERF = 'perf',
 }
 
-function isReplayTab(tab: string, _organization: Organization): tab is TabKey {
+function isReplayTab(tab: string, organization: Organization): tab is TabKey {
+  const hasPerfTab = true || organization.features.includes('session-replay-trace-table');
+
+  if (tab === TabKey.PERF) {
+    return hasPerfTab;
+  }
   return Object.values<string>(TabKey).includes(tab);
 }
 
@@ -34,7 +40,7 @@ function useDefaultTab() {
     return TabKey.DOM;
   }
 
-  return TabKey.CONSOLE;
+  return TabKey.NETWORK;
 }
 
 function useActiveReplayTab() {

--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -13,8 +13,8 @@ export enum TabKey {
   ERRORS = 'errors',
   MEMORY = 'memory',
   NETWORK = 'network',
-  TRACE = 'trace',
   PERF = 'perf',
+  TRACE = 'trace',
 }
 
 function isReplayTab(tab: string, organization: Organization): tab is TabKey {
@@ -40,7 +40,7 @@ function useDefaultTab() {
     return TabKey.DOM;
   }
 
-  return TabKey.NETWORK;
+  return TabKey.CONSOLE;
 }
 
 function useActiveReplayTab() {

--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -18,7 +18,7 @@ export enum TabKey {
 }
 
 function isReplayTab(tab: string, organization: Organization): tab is TabKey {
-  const hasPerfTab = true || organization.features.includes('session-replay-trace-table');
+  const hasPerfTab = organization.features.includes('session-replay-trace-table');
 
   if (tab === TabKey.PERF) {
     return hasPerfTab;

--- a/static/app/views/replays/detail/layout/focusArea.tsx
+++ b/static/app/views/replays/detail/layout/focusArea.tsx
@@ -6,6 +6,7 @@ import DomMutations from 'sentry/views/replays/detail/domMutations';
 import ErrorList from 'sentry/views/replays/detail/errorList/index';
 import MemoryChart from 'sentry/views/replays/detail/memoryChart';
 import NetworkList from 'sentry/views/replays/detail/network';
+import PerfTable from 'sentry/views/replays/detail/perfTable/index';
 import Trace from 'sentry/views/replays/detail/trace/index';
 
 type Props = {};
@@ -28,6 +29,8 @@ function FocusArea({}: Props) {
       );
     case TabKey.TRACE:
       return <Trace organization={organization} replayRecord={replay?.getReplay()} />;
+    case TabKey.PERF:
+      return <PerfTable />;
     case TabKey.ERRORS:
       return (
         <ErrorList

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -15,8 +15,8 @@ function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
   const hasPerfTab = organization.features.includes('session-replay-trace-table');
 
   return {
-    [TabKey.CONSOLE]: t('Console'),
     [TabKey.NETWORK]: t('Network'),
+    [TabKey.CONSOLE]: t('Console'),
     [TabKey.ERRORS]: (
       <Fragment>
         {t('Errors')} <FeatureBadge type="new" />

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -5,23 +5,31 @@ import FeatureBadge from 'sentry/components/featureBadge';
 import ListLink from 'sentry/components/links/listLink';
 import ScrollableTabs from 'sentry/components/replays/scrollableTabs';
 import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
-function getReplayTabs(): Record<TabKey, ReactNode> {
+function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
+  const hasPerfTab = organization.features.includes('session-replay-trace-table');
+
   return {
     [TabKey.CONSOLE]: t('Console'),
     [TabKey.NETWORK]: t('Network'),
-    [TabKey.DOM]: t('DOM Events'),
     [TabKey.ERRORS]: (
       <Fragment>
         {t('Errors')} <FeatureBadge type="new" />
       </Fragment>
     ),
-    [TabKey.MEMORY]: t('Memory'),
     [TabKey.TRACE]: t('Trace'),
+    [TabKey.PERF]: hasPerfTab ? (
+      <Fragment>
+        {t('Perf')} <FeatureBadge type="alpha" />
+      </Fragment>
+    ) : null,
+    [TabKey.DOM]: t('DOM Events'),
+    [TabKey.MEMORY]: t('Memory'),
   };
 }
 
@@ -37,7 +45,7 @@ function FocusTabs({className}: Props) {
 
   return (
     <ScrollableTabs className={className} underlined>
-      {Object.entries(getReplayTabs()).map(([tab, label]) =>
+      {Object.entries(getReplayTabs(organization)).map(([tab, label]) =>
         label ? (
           <ListLink
             data-test-id={`replay-details-${tab}-btn`}

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -15,8 +15,8 @@ function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
   const hasPerfTab = organization.features.includes('session-replay-trace-table');
 
   return {
-    [TabKey.NETWORK]: t('Network'),
     [TabKey.CONSOLE]: t('Console'),
+    [TabKey.NETWORK]: t('Network'),
     [TabKey.ERRORS]: (
       <Fragment>
         {t('Errors')} <FeatureBadge type="new" />

--- a/static/app/views/replays/detail/perfTable/index.tsx
+++ b/static/app/views/replays/detail/perfTable/index.tsx
@@ -1,0 +1,15 @@
+// import {useReplayContext} from 'sentry/components/replays/replayContext';
+// import PerfTable from 'sentry/views/replays/detail/perfTable/perfTable';
+// import useReplayPerfData from 'sentry/views/replays/detail/perfTable/useReplayPerfData';
+
+type Props = {};
+
+function Perf({}: Props) {
+  // const {replay} = useReplayContext();
+  // const perfData = useReplayPerfData({replay});
+
+  // return <PerfTable perfData={perfData} />;
+  return <div />;
+}
+
+export default Perf;


### PR DESCRIPTION
There is nothing inside the tab yet, which is intentional. This is just about setting up the feature checks (only sentry org is enabled right now) and also about setting the tab order (which applies to everyone).

The tab changes are:
- DOM and memory are near right now.

| label | pic |
| --- | --- |
| Old tab order | ![SCR-20230817-kugg](https://github.com/getsentry/sentry/assets/187460/c77ef7bf-7b06-4912-8d14-282c99f98463) |
| New Tab order | ![SCR-20230817-ktmn](https://github.com/getsentry/sentry/assets/187460/17ea55e5-1776-4dbe-932f-28047964ba6e) |
| With Perf tab | ![SCR-20230817-ktqb](https://github.com/getsentry/sentry/assets/187460/005eb97d-1314-4453-90ca-8dd40af1aa32) |

