### PR TITLE
ref(inbound-filters): Port chart to stats_v2

### DIFF
--- a/static/app/views/settings/project/projectFilters/index.spec.tsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.tsx
@@ -35,7 +35,7 @@ describe('ProjectFilters', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: `${PROJECT_URL}stats/`,
+      url: `/organizations/${organization.slug}/stats_v2/`,
       body: [],
     });
 

--- a/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
@@ -13,6 +13,7 @@ import {Organization, Project} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import theme from 'sentry/utils/theme';
 import withApi from 'sentry/utils/withApi';
+import {UsageSeries} from 'sentry/views/organizationStats/types';
 
 type Props = {
   api: Client;
@@ -27,8 +28,6 @@ type State = {
   loading: boolean;
   statsError: boolean;
 };
-
-type RawStats = Record<string, [timestamp: number, value: number][]>;
 
 const STAT_OPS = {
   'browser-extensions': {title: t('Browser Extension'), color: theme.gray200},
@@ -63,57 +62,54 @@ class ProjectFiltersChart extends Component<Props, State> {
     }
   }
 
-  formatData(rawData: RawStats) {
-    const seriesWithData: Set<string> = new Set();
-    const transformed = Object.keys(STAT_OPS).map(stat => ({
-      data: rawData[stat].map(([timestamp, value]) => {
-        if (value > 0) {
-          seriesWithData.add(STAT_OPS[stat].title);
-          this.setState({blankStats: false});
-        }
-        return {name: timestamp * 1000, value};
-      }),
-      seriesName: STAT_OPS[stat].title,
-      color: STAT_OPS[stat].color,
-    }));
+  formatData(rawData: UsageSeries) {
+    const formattedData = rawData.groups
+      .filter(group => STAT_OPS[group.by.reason])
+      .map(group => {
+        const {title, color} = STAT_OPS[group.by.reason];
+        return {
+          seriesName: title,
+          color,
+          data: rawData.intervals
+            .map((interval, index) => ({
+              name: interval,
+              value: group.series['sum(quantity)'][index],
+            }))
+            .filter(dataPoint => !!dataPoint.value),
+        };
+      });
 
-    return transformed.filter((series: Series) => seriesWithData.has(series.seriesName));
+    if (formattedData.length > 0) {
+      this.setState({blankStats: false});
+    }
+
+    return formattedData;
   }
 
-  getFilterStats() {
-    const statOptions = Object.keys(STAT_OPS);
-    const {organization, project} = this.props;
-
-    const until = Math.floor(new Date().getTime() / 1000);
-    const since = until - 3600 * 24 * 30;
-
-    const statEndpoint = `/projects/${organization.slug}/${project.slug}/stats/`;
+  async getFilterStats() {
+    const {organization, project, api} = this.props;
+    const statsEndpoint = `/organizations/${organization.slug}/stats_v2/`;
     const query = {
-      since,
-      until,
-      resolution: '1d',
+      project: project.id,
+      category: ['transaction', 'default', 'security', 'error'],
+      outcome: 'filtered',
+      field: 'sum(quantity)',
+      groupBy: 'reason',
+      interval: '1d',
+      statsPeriod: '30d',
     };
-    const requests = statOptions.map(stat =>
-      this.props.api.requestPromise(statEndpoint, {
-        query: Object.assign({stat}, query),
-      })
-    );
-    Promise.all(requests)
-      .then(results => {
-        const rawStatsData: RawStats = {};
-        for (let i = 0; i < statOptions.length; i++) {
-          rawStatsData[statOptions[i]] = results[i];
-        }
 
-        this.setState({
-          formattedData: this.formatData(rawStatsData),
-          error: false,
-          loading: false,
-        });
-      })
-      .catch(() => {
-        this.setState({error: true, loading: false});
+    try {
+      const response = await api.requestPromise(statsEndpoint, {query});
+
+      this.setState({
+        formattedData: this.formatData(response),
+        error: false,
+        loading: false,
       });
+    } catch {
+      this.setState({error: true, loading: false});
+    }
   }
 
   fetchData = () => {


### PR DESCRIPTION
This PR ports the inbound filter chart to use the new stats_v2 endpoint.
The old endpoint was missing, among other inconsistencies, some of the reasons for the `filtered` outcome (e.g. healthchecks, webcrawlers).

![image](https://github.com/getsentry/sentry/assets/9060071/8bfba1ef-8465-46c4-9c4a-3d4425444981)


Fixes https://github.com/getsentry/sentry/issues/54450