### PR TITLE
ref: fix test pollution caused by test_parallel_indexer

### DIFF
--- a/tests/sentry/sentry_metrics/test_parallel_indexer.py
+++ b/tests/sentry/sentry_metrics/test_parallel_indexer.py
@@ -4,6 +4,7 @@ import pytest
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
 
+from sentry.metrics.middleware import global_tags
 from sentry.sentry_metrics.consumers.indexer.parallel import MetricsConsumerStrategyFactory
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.utils import json
@@ -21,6 +22,14 @@ counter_payload = {
     "org_id": 1,
     "project_id": 3,
 }
+
+
+@pytest.fixture(autouse=True)
+def reset_global_metrics_state():
+    # running a MetricsConsumerStrategyFactory has a side-effect of mutating
+    # global metrics tags
+    with global_tags(_all_threads=True):
+        yield
 
 
 @pytest.mark.parametrize("force_disable_multiprocessing", [True, False])


### PR DESCRIPTION
originally failing with:

```console
$ pytest tests/sentry/sentry_metrics/test_parallel_indexer.py tests/sentry/metrics/test_middleware.py 
============================= test session starts ==============================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: fail-slow-0.3.0, rerunfailures-11.0, sentry-0.1.11, xdist-3.0.2, cov-4.0.0, repeat-0.9.1, django-4.4.0
collected 5 items                                                              

tests/sentry/sentry_metrics/test_parallel_indexer.py ..                  [ 40%]
tests/sentry/metrics/test_middleware.py ..F                              [100%]

=================================== FAILURES ===================================
_________________________________ test_global __________________________________
tests/sentry/metrics/test_middleware.py:32: in test_global
    assert get_current_global_tags() == {}
E   AssertionError: assert {'pipeline': 'release-health'} == {}
E     Left contains 1 more item:
E     {'pipeline': 'release-health'}
E     Use -v to get more diff
```