### PR TITLE
ref: use sentry settings to get symblicator port

### DIFF
--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -72,10 +72,10 @@ def _requires_relay() -> None:
 
 @pytest.fixture(scope="session")
 def _requires_symbolicator() -> None:
-    from sentry import options
+    symbolicator_conf = settings.SENTRY_DEVSERVICES["symbolicator"](settings, {})
+    (port,) = symbolicator_conf["ports"].values()
 
-    parsed = urlparse(options.get("symbolicator.options", True)["url"])
-    if not _service_available(parsed.hostname, parsed.port):
+    if not _service_available("127.0.0.1", port):
         pytest.skip("requires symbolicator server running")
 
 


### PR DESCRIPTION
turns out we still can't access this as early as we want -- `options` is only available when the django db is available and that's only available at the function level scope -- so instead we grab the symbolicator port out of sentry devservices config

cherry picked from my branch where I'm trying to make options not fail silently under test