### PR TITLE
feat(github-invite): invite members modal

### DIFF
--- a/fixtures/js-stubs/missingMembers.tsx
+++ b/fixtures/js-stubs/missingMembers.tsx
@@ -5,27 +5,27 @@ export function MissingMembers(params = []): MissingMember[] {
     {
       commitCount: 6,
       email: 'hello@sentry.io',
-      externalId: 'hello',
+      externalId: 'github:hello',
     },
     {
       commitCount: 5,
       email: 'abcd@sentry.io',
-      externalId: 'abcd',
+      externalId: 'github:abcd',
     },
     {
       commitCount: 4,
       email: 'hola@sentry.io',
-      externalId: 'hola',
+      externalId: 'github:hola',
     },
     {
       commitCount: 3,
       email: 'test@sentry.io',
-      externalId: 'test',
+      externalId: 'github:test',
     },
     {
       commitCount: 2,
       email: 'five@sentry.io',
-      externalId: 'five',
+      externalId: 'github:five',
     },
     ...params,
   ];

--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -60,13 +60,6 @@ type InviteMembersModalOptions = {
   source?: string;
 };
 
-type InviteMissingMembersModalOptions = {
-  allowedRoles: OrgRole[];
-  missingMembers: {integration: string; users: MissingMember[]};
-  onClose: () => void;
-  organization: Organization;
-};
-
 export async function openSudo({onClose, ...args}: OpenSudoModalOptions = {}) {
   const mod = await import('sentry/components/modals/sudoModal');
   const {default: Modal} = mod;
@@ -254,6 +247,13 @@ export async function openInviteMembersModal({
 
   openModal(deps => <Modal {...deps} {...args} />, {modalCss, onClose});
 }
+
+type InviteMissingMembersModalOptions = {
+  allowedRoles: OrgRole[];
+  missingMembers: {integration: string; users: MissingMember[]};
+  onClose: () => void;
+  organization: Organization;
+};
 
 export async function openInviteMissingMembersModal({
   onClose,

--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -11,7 +11,9 @@ import type {
   Event,
   Group,
   IssueOwnership,
+  MissingMember,
   Organization,
+  OrgRole,
   Project,
   SentryApp,
   Team,
@@ -56,6 +58,13 @@ type InviteMembersModalOptions = {
   initialData?: Partial<InviteRow>[];
   onClose?: () => void;
   source?: string;
+};
+
+type InviteMissingMembersModalOptions = {
+  allowedRoles?: OrgRole[];
+  missingMembers?: {integration: string; users: MissingMember[]};
+  onClose?: () => void;
+  organization?: Organization;
 };
 
 export async function openSudo({onClose, ...args}: OpenSudoModalOptions = {}) {
@@ -241,6 +250,16 @@ export async function openInviteMembersModal({
   ...args
 }: InviteMembersModalOptions = {}) {
   const mod = await import('sentry/components/modals/inviteMembersModal');
+  const {default: Modal, modalCss} = mod;
+
+  openModal(deps => <Modal {...deps} {...args} />, {modalCss, onClose});
+}
+
+export async function openInviteMissingMembersModal({
+  onClose,
+  ...args
+}: InviteMissingMembersModalOptions = {}) {
+  const mod = await import('sentry/components/modals/inviteMissingMembersModal');
   const {default: Modal, modalCss} = mod;
 
   openModal(deps => <Modal {...deps} {...args} />, {modalCss, onClose});

--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -61,10 +61,10 @@ type InviteMembersModalOptions = {
 };
 
 type InviteMissingMembersModalOptions = {
-  allowedRoles?: OrgRole[];
-  missingMembers?: {integration: string; users: MissingMember[]};
-  onClose?: () => void;
-  organization?: Organization;
+  allowedRoles: OrgRole[];
+  missingMembers: {integration: string; users: MissingMember[]};
+  onClose: () => void;
+  organization: Organization;
 };
 
 export async function openSudo({onClose, ...args}: OpenSudoModalOptions = {}) {
@@ -258,7 +258,7 @@ export async function openInviteMembersModal({
 export async function openInviteMissingMembersModal({
   onClose,
   ...args
-}: InviteMissingMembersModalOptions = {}) {
+}: InviteMissingMembersModalOptions) {
   const mod = await import('sentry/components/modals/inviteMissingMembersModal');
   const {default: Modal, modalCss} = mod;
 

--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -41,13 +41,15 @@ interface State extends AsyncComponentState {
 
 const DEFAULT_ROLE = 'member';
 
-const InviteModalHook = HookOrDefault({
+export const InviteModalHook = HookOrDefault({
   hookName: 'member-invite-modal:customization',
   defaultComponent: ({onSendInvites, children}) =>
     children({sendInvites: onSendInvites, canSend: true}),
 });
 
-type InviteModalRenderFunc = React.ComponentProps<typeof InviteModalHook>['children'];
+export type InviteModalRenderFunc = React.ComponentProps<
+  typeof InviteModalHook
+>['children'];
 
 class InviteMembersModal extends DeprecatedAsyncComponent<
   InviteMembersModalProps,
@@ -508,7 +510,7 @@ const FooterContent = styled('div')`
   flex: 1;
 `;
 
-const StatusMessage = styled('div')<{status?: 'success' | 'error'}>`
+export const StatusMessage = styled('div')<{status?: 'success' | 'error'}>`
   display: flex;
   gap: ${space(1)};
   align-items: center;

--- a/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
@@ -1,0 +1,209 @@
+import selectEvent from 'react-select-event';
+import styled from '@emotion/styled';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {makeCloseButton} from 'sentry/components/globalModal/components';
+import InviteMissingMembersModal, {
+  InviteMissingMembersModalProps,
+} from 'sentry/components/modals/inviteMissingMembersModal';
+import TeamStore from 'sentry/stores/teamStore';
+import {OrgRole} from 'sentry/types';
+
+const roles = [
+  {
+    id: 'admin',
+    name: 'Admin',
+    desc: 'This is the admin role',
+    allowed: true,
+  },
+  {
+    id: 'member',
+    name: 'Member',
+    desc: 'This is the member role',
+    allowed: true,
+  },
+] as OrgRole[];
+
+describe('InviteMissingMembersModal', function () {
+  const team = TestStubs.Team();
+  const org = TestStubs.Organization({access: ['member:write'], teams: [team]});
+  TeamStore.loadInitialData([team]);
+  const missingMembers = TestStubs.MissingMembers();
+
+  const styledWrapper = styled(c => c.children);
+  const modalProps: InviteMissingMembersModalProps = {
+    Body: styledWrapper(),
+    Header: p => <span>{p.children}</span>,
+    Footer: styledWrapper(),
+    closeModal: () => {},
+    CloseButton: makeCloseButton(() => {}),
+    organization: TestStubs.Organization(),
+    missingMembers: [],
+    invitableRoles: [],
+  };
+
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/members/me/`,
+      method: 'GET',
+      body: {roles},
+    });
+  });
+
+  it('renders with empty table when no missing members', function () {
+    render(<InviteMissingMembersModal {...modalProps} />);
+
+    expect(
+      screen.getByRole('heading', {name: 'Invite Your Dev Team'})
+    ).toBeInTheDocument();
+
+    // 1 checkbox column + 4 content columns
+    expect(screen.queryAllByTestId('table-header')).toHaveLength(5);
+  });
+
+  it('does not render without org:write', function () {
+    const organization = TestStubs.Organization({access: []});
+    render(<InviteMissingMembersModal {...modalProps} organization={organization} />);
+
+    expect(
+      screen.queryByRole('heading', {name: 'Invite Your Dev Team'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables invite button if no members selected', function () {
+    render(<InviteMissingMembersModal {...modalProps} missingMembers={missingMembers} />);
+
+    expect(
+      screen.getByRole('heading', {name: 'Invite Your Dev Team'})
+    ).toBeInTheDocument();
+
+    expect(screen.getByLabelText('Send Invites')).toBeDisabled();
+    expect(screen.getByText('Invite missing members')).toBeInTheDocument();
+  });
+
+  it('enables and disables invite button when toggling one checkbox', async function () {
+    render(<InviteMissingMembersModal {...modalProps} missingMembers={missingMembers} />);
+
+    expect(
+      screen.getByRole('heading', {name: 'Invite Your Dev Team'})
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Select hello@sentry.io'));
+
+    expect(screen.getByLabelText('Send Invites')).toBeEnabled();
+    expect(screen.getByText('Invite 1 missing member')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Select hello@sentry.io'));
+
+    expect(screen.getByLabelText('Send Invites')).toBeDisabled();
+    expect(screen.getByText('Invite missing members')).toBeInTheDocument();
+  });
+
+  it('can select and deselect all rows', async function () {
+    render(<InviteMissingMembersModal {...modalProps} missingMembers={missingMembers} />);
+
+    expect(
+      screen.getByRole('heading', {name: 'Invite Your Dev Team'})
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Select All'));
+
+    expect(screen.getByLabelText('Send Invites')).toBeEnabled();
+    expect(screen.getByText('Invite all 5 missing members')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Deselect All'));
+
+    expect(screen.getByLabelText('Send Invites')).toBeDisabled();
+    expect(screen.getByText('Invite missing members')).toBeInTheDocument();
+  });
+
+  it('can invite all members', async function () {
+    render(
+      <InviteMissingMembersModal
+        {...modalProps}
+        organization={TestStubs.Organization({defaultRole: 'member'})}
+        missingMembers={missingMembers}
+        invitableRoles={roles}
+      />
+    );
+
+    const createMemberMock = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/members/`,
+      method: 'POST',
+      body: {},
+    });
+
+    expect(
+      screen.getByRole('heading', {name: 'Invite Your Dev Team'})
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Select All'));
+    await userEvent.click(screen.getByLabelText('Send Invites'));
+
+    // Verify data sent to the backend
+    expect(createMemberMock).toHaveBeenCalledTimes(5);
+
+    missingMembers.forEach((member, i) => {
+      expect(createMemberMock).toHaveBeenNthCalledWith(
+        i + 1,
+        `/organizations/${org.slug}/members/`,
+        expect.objectContaining({
+          data: {email: member.email, role: 'member', teams: []},
+        })
+      );
+    });
+  });
+
+  it('can invite multiple members', async function () {
+    render(
+      <InviteMissingMembersModal
+        {...modalProps}
+        organization={TestStubs.Organization({defaultRole: 'member', teams: [team]})}
+        missingMembers={missingMembers}
+        invitableRoles={roles}
+      />
+    );
+
+    const createMemberMock = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/members/`,
+      method: 'POST',
+      body: {},
+    });
+
+    expect(
+      screen.getByRole('heading', {name: 'Invite Your Dev Team'})
+    ).toBeInTheDocument();
+
+    const roleInputs = screen.getAllByRole('textbox', {name: 'Role'});
+    const teamInputs = screen.getAllByRole('textbox', {name: 'Add to Team'});
+
+    await userEvent.click(screen.getByLabelText('Select hello@sentry.io'));
+    await selectEvent.select(roleInputs[0], 'Admin');
+
+    await userEvent.click(screen.getByLabelText('Select abcd@sentry.io'));
+    await selectEvent.select(teamInputs[1], '#team-slug');
+
+    await userEvent.click(screen.getByLabelText('Send Invites'));
+
+    // Verify data sent to the backend
+    expect(createMemberMock).toHaveBeenCalledTimes(2);
+
+    expect(createMemberMock).toHaveBeenNthCalledWith(
+      1,
+      `/organizations/${org.slug}/members/`,
+      expect.objectContaining({
+        data: {email: 'hello@sentry.io', role: 'admin', teams: []},
+      })
+    );
+
+    expect(createMemberMock).toHaveBeenNthCalledWith(
+      2,
+      `/organizations/${org.slug}/members/`,
+      expect.objectContaining({
+        data: {email: 'abcd@sentry.io', role: 'member', teams: [team.slug]},
+      })
+    );
+  });
+});

--- a/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
@@ -29,7 +29,7 @@ describe('InviteMissingMembersModal', function () {
   const team = TestStubs.Team();
   const org = TestStubs.Organization({access: ['member:write'], teams: [team]});
   TeamStore.loadInitialData([team]);
-  const missingMembers = TestStubs.MissingMembers();
+  const missingMembers = {integration: 'github', users: TestStubs.MissingMembers()};
 
   const styledWrapper = styled(c => c.children);
   const modalProps: InviteMissingMembersModalProps = {
@@ -39,8 +39,8 @@ describe('InviteMissingMembersModal', function () {
     closeModal: () => {},
     CloseButton: makeCloseButton(() => {}),
     organization: TestStubs.Organization(),
-    missingMembers: [],
-    invitableRoles: [],
+    missingMembers: {integration: 'github', users: []},
+    allowedRoles: [],
   };
 
   beforeEach(function () {
@@ -125,7 +125,7 @@ describe('InviteMissingMembersModal', function () {
         {...modalProps}
         organization={TestStubs.Organization({defaultRole: 'member'})}
         missingMembers={missingMembers}
-        invitableRoles={roles}
+        allowedRoles={roles}
       />
     );
 
@@ -145,7 +145,7 @@ describe('InviteMissingMembersModal', function () {
     // Verify data sent to the backend
     expect(createMemberMock).toHaveBeenCalledTimes(5);
 
-    missingMembers.forEach((member, i) => {
+    missingMembers.users.forEach((member, i) => {
       expect(createMemberMock).toHaveBeenNthCalledWith(
         i + 1,
         `/organizations/${org.slug}/members/`,
@@ -162,7 +162,7 @@ describe('InviteMissingMembersModal', function () {
         {...modalProps}
         organization={TestStubs.Organization({defaultRole: 'member', teams: [team]})}
         missingMembers={missingMembers}
-        invitableRoles={roles}
+        allowedRoles={roles}
       />
     );
 

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -48,20 +48,24 @@ export function InviteMissingMembersModal({
     externalId: member.externalId,
     selected: false,
   }));
-  const [members, setMembers] = useState<MissingMemberInvite[]>(initialMemberInvites);
+  const [memberInvites, setMemberInvites] =
+    useState<MissingMemberInvite[]>(initialMemberInvites);
   const [inviteStatus, setInviteStatus] = useState<InviteStatus>({});
   const [sendingInvites, setSendingInvites] = useState(false);
   const [complete, setComplete] = useState(false);
 
   const api = useApi();
 
-  if (!members || (organization.access && !organization.access.includes('org:write'))) {
+  if (
+    !memberInvites ||
+    (organization.access && !organization.access.includes('org:write'))
+  ) {
     return null;
   }
 
   const setRole = (role: string, index: number) => {
-    setMembers(
-      members.map((member, i) => {
+    setMemberInvites(
+      memberInvites.map((member, i) => {
         if (i === index) {
           member.role = role;
         }
@@ -71,8 +75,8 @@ export function InviteMissingMembersModal({
   };
 
   const setTeams = (teams: string[], index: number) => {
-    setMembers(
-      members.map((member, i) => {
+    setMemberInvites(
+      memberInvites.map((member, i) => {
         if (i === index) {
           member.teams = new Set(teams);
         }
@@ -82,17 +86,17 @@ export function InviteMissingMembersModal({
   };
 
   const selectAll = (checked: boolean) => {
-    const selectedMembers = members.map(m => {
+    const selectedMembers = memberInvites.map(m => {
       m.selected = checked;
       return m;
     });
-    setMembers(selectedMembers);
+    setMemberInvites(selectedMembers);
   };
 
   const checkboxToggle = (checked: boolean, index: number) => {
-    const selectedMembers = [...members];
+    const selectedMembers = [...memberInvites];
     selectedMembers[index].selected = checked;
-    setMembers(selectedMembers);
+    setMemberInvites(selectedMembers);
   };
 
   const renderStatusMessage = () => {
@@ -167,7 +171,7 @@ export function InviteMissingMembersModal({
 
   const sendMemberInvites = async () => {
     setSendingInvites(true);
-    await Promise.all(members.filter(i => i.selected).map(sendMemberInvite));
+    await Promise.all(memberInvites.filter(i => i.selected).map(sendMemberInvite));
     setSendingInvites(false);
     setComplete(true);
 
@@ -180,13 +184,13 @@ export function InviteMissingMembersModal({
     );
   };
 
-  const selectedCount = members.filter(i => i.selected).length;
-  const selectedAll = members.length === selectedCount;
+  const selectedCount = memberInvites.filter(i => i.selected).length;
+  const selectedAll = memberInvites.length === selectedCount;
 
   const inviteButtonLabel = () => {
     return tct('Invite [memberCount] missing member[isPlural]', {
       memberCount:
-        members.length === selectedCount
+        memberInvites.length === selectedCount
           ? `all ${selectedCount}`
           : selectedCount === 0
           ? ''
@@ -218,8 +222,8 @@ export function InviteMissingMembersModal({
           t('Team'),
         ]}
       >
-        {members?.map((member, i) => {
-          const checked = members[i].selected;
+        {memberInvites?.map((member, i) => {
+          const checked = memberInvites[i].selected;
           return (
             <Fragment key={i}>
               <div>

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -23,7 +23,6 @@ import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {MissingMember, Organization, OrgRole} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {uniqueId} from 'sentry/utils/guid';
 import useApi from 'sentry/utils/useApi';
 import {
   StyledExternalLink,
@@ -41,7 +40,7 @@ export function InviteMissingMembersModal({
   organization,
   invitableRoles,
 }: InviteMissingMembersModalProps) {
-  const start = missingMembers?.map(member => ({
+  const initialMemberInvites = missingMembers?.map(member => ({
     email: member.email,
     commitCount: member.commitCount,
     role: organization.defaultRole,
@@ -49,13 +48,12 @@ export function InviteMissingMembersModal({
     externalId: member.externalId,
     selected: false,
   }));
-  const [members, setMembers] = useState<MissingMemberInvite[]>(start);
+  const [members, setMembers] = useState<MissingMemberInvite[]>(initialMemberInvites);
   const [inviteStatus, setInviteStatus] = useState<InviteStatus>({});
   const [sendingInvites, setSendingInvites] = useState(false);
   const [complete, setComplete] = useState(false);
 
   const api = useApi();
-  const sessionId = uniqueId();
 
   if (!members || (organization.access && !organization.access.includes('org:write'))) {
     return null;
@@ -173,10 +171,13 @@ export function InviteMissingMembersModal({
     setSendingInvites(false);
     setComplete(true);
 
-    trackAnalytics('missing_members_invite_modal.requests_sent', {
-      organization,
-      modal_session: sessionId,
-    });
+    trackAnalytics(
+      'missing_members_invite_modal.requests_sent',
+      {
+        organization,
+      },
+      {startSession: true}
+    );
   };
 
   const selectedCount = members.filter(i => i.selected).length;

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -1,0 +1,327 @@
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {closeModal, ModalRenderProps} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import Checkbox from 'sentry/components/checkbox';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {
+  InviteModalHook,
+  InviteModalRenderFunc,
+  StatusMessage,
+} from 'sentry/components/modals/inviteMembersModal';
+import {InviteStatus} from 'sentry/components/modals/inviteMembersModal/types';
+import {MissingMemberInvite} from 'sentry/components/modals/inviteMissingMembersModal/types';
+import PanelItem from 'sentry/components/panels/panelItem';
+import PanelTable from 'sentry/components/panels/panelTable';
+import RoleSelectControl from 'sentry/components/roleSelectControl';
+import TeamSelector from 'sentry/components/teamSelector';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconCheckmark, IconCommit, IconGithub, IconInfo} from 'sentry/icons';
+import {t, tct, tn} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {MissingMember, Organization, OrgRole} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {uniqueId} from 'sentry/utils/guid';
+import useApi from 'sentry/utils/useApi';
+import {
+  StyledExternalLink,
+  Subtitle,
+} from 'sentry/views/settings/organizationMembers/inviteBanner';
+
+export interface InviteMissingMembersModalProps extends ModalRenderProps {
+  invitableRoles: OrgRole[];
+  missingMembers: MissingMember[];
+  organization: Organization;
+}
+
+export function InviteMissingMembersModal({
+  missingMembers,
+  organization,
+  invitableRoles,
+}: InviteMissingMembersModalProps) {
+  const start = missingMembers?.map(member => ({
+    email: member.email,
+    commitCount: member.commitCount,
+    role: organization.defaultRole,
+    teams: new Set<string>(),
+    externalId: member.externalId,
+    selected: false,
+  }));
+  const [members, setMembers] = useState<MissingMemberInvite[]>(start);
+  const [inviteStatus, setInviteStatus] = useState<InviteStatus>({});
+  const [sendingInvites, setSendingInvites] = useState(false);
+  const [complete, setComplete] = useState(false);
+
+  const api = useApi();
+  const sessionId = uniqueId();
+
+  if (!members || (organization.access && !organization.access.includes('org:write'))) {
+    return null;
+  }
+
+  const setRole = (role: string, index: number) => {
+    setMembers(
+      members.map((member, i) => {
+        if (i === index) {
+          member.role = role;
+        }
+        return member;
+      })
+    );
+  };
+
+  const setTeams = (teams: string[], index: number) => {
+    setMembers(
+      members.map((member, i) => {
+        if (i === index) {
+          member.teams = new Set(teams);
+        }
+        return member;
+      })
+    );
+  };
+
+  const selectAll = (checked: boolean) => {
+    const selectedMembers = members.map(m => {
+      m.selected = checked;
+      return m;
+    });
+    setMembers(selectedMembers);
+  };
+
+  const checkboxToggle = (checked: boolean, index: number) => {
+    const selectedMembers = [...members];
+    selectedMembers[index].selected = checked;
+    setMembers(selectedMembers);
+  };
+
+  const renderStatusMessage = () => {
+    if (sendingInvites) {
+      return (
+        <StatusMessage>
+          <LoadingIndicator mini relative hideMessage size={16} />
+          {t('Sending organization invitations\u2026')}
+        </StatusMessage>
+      );
+    }
+
+    if (complete) {
+      const statuses = Object.values(inviteStatus);
+      const sentCount = statuses.filter(i => i.sent).length;
+      const errorCount = statuses.filter(i => i.error).length;
+
+      const invites = <strong>{tn('%s invite', '%s invites', sentCount)}</strong>;
+      const tctComponents = {
+        invites,
+        failed: errorCount,
+      };
+
+      return (
+        <StatusMessage status="success">
+          <IconCheckmark size="sm" />
+          {errorCount > 0
+            ? tct('Sent [invites], [failed] failed to send.', tctComponents)
+            : tct('Sent [invites]', tctComponents)}
+        </StatusMessage>
+      );
+    }
+
+    return null;
+  };
+
+  const sendMemberInvite = async (invite: MissingMemberInvite) => {
+    const data = {
+      email: invite.email,
+      teams: [...invite.teams],
+      role: invite.role,
+    };
+
+    try {
+      await api.requestPromise(`/organizations/${organization.slug}/members/`, {
+        method: 'POST',
+        data,
+      });
+    } catch (err) {
+      const errorResponse = err.responseJSON;
+
+      // Use the email error message if available. This inconsistently is
+      // returned as either a list of errors for the field, or a single error.
+      const emailError =
+        !errorResponse || !errorResponse.email
+          ? false
+          : Array.isArray(errorResponse.email)
+          ? errorResponse.email[0]
+          : errorResponse.email;
+
+      const error = emailError || t('Could not invite user');
+
+      setInviteStatus(prevInviteStatus => {
+        return {...prevInviteStatus, [invite.email]: {sent: false, error}};
+      });
+    }
+
+    setInviteStatus(prevInviteStatus => {
+      return {...prevInviteStatus, [invite.email]: {sent: true}};
+    });
+  };
+
+  const sendMemberInvites = async () => {
+    setSendingInvites(true);
+    await Promise.all(members.filter(i => i.selected).map(sendMemberInvite));
+    setSendingInvites(false);
+    setComplete(true);
+
+    trackAnalytics('missing_members_invite_modal.requests_sent', {
+      organization,
+      modal_session: sessionId,
+    });
+  };
+
+  const selectedCount = members.filter(i => i.selected).length;
+  const selectedAll = members.length === selectedCount;
+
+  const inviteButtonLabel = () => {
+    return tct('Invite [memberCount] missing member[isPlural]', {
+      memberCount:
+        members.length === selectedCount
+          ? `all ${selectedCount}`
+          : selectedCount === 0
+          ? ''
+          : selectedCount,
+      isPlural: selectedCount !== 1 ? 's' : '',
+    });
+  };
+
+  const hookRenderer: InviteModalRenderFunc = ({sendInvites, canSend, headerInfo}) => (
+    <Fragment>
+      <h4>{t('Invite Your Dev Team')}</h4>
+      {headerInfo}
+      <StyledPanelTable
+        headers={[
+          <Checkbox
+            key={0}
+            aria-label={selectedAll ? 'Deselect All' : 'Select All'}
+            onChange={() => selectAll(!selectedAll)}
+            checked={selectedAll}
+          />,
+          t('User Information'),
+          <StyledHeader key={1}>
+            {t('Recent Commits')}{' '}
+            <Tooltip title={t('Based on the last 30 days of commit data')}>
+              <IconInfo size="xs" />
+            </Tooltip>
+          </StyledHeader>,
+          t('Role'),
+          t('Team'),
+        ]}
+      >
+        {members?.map((member, i) => {
+          const checked = members[i].selected;
+          return (
+            <Fragment key={i}>
+              <div>
+                <Checkbox
+                  aria-label={t('Select %s', member.email)}
+                  checked={checked}
+                  onChange={() => checkboxToggle(!checked, i)}
+                />
+              </div>
+              <StyledPanelItem>
+                <ContentRow>
+                  <IconGithub size="sm" />
+                  <StyledExternalLink href={`http://github.com/${member.externalId}`}>
+                    {tct('@[userId]', {userId: member.externalId})}
+                  </StyledExternalLink>
+                </ContentRow>
+                <Subtitle>{member.email}</Subtitle>
+              </StyledPanelItem>
+              <ContentRow>
+                <IconCommit size="sm" />
+                {member.commitCount}
+              </ContentRow>
+              <RoleSelectControl
+                aria-label={t('Role')}
+                data-test-id="select-role"
+                disabled={false}
+                roles={invitableRoles}
+                disableUnallowed
+                onChange={value => setRole(value?.value, i)}
+              />
+              <TeamSelector
+                aria-label={t('Add to Team')}
+                data-test-id="select-teams"
+                disabled={false}
+                placeholder={t('Add to teams\u2026')}
+                onChange={opts => setTeams(opts ? opts.map(v => v.value) : [], i)}
+                multiple
+                clearable
+              />
+            </Fragment>
+          );
+        })}
+      </StyledPanelTable>
+      <Footer>
+        <div>{renderStatusMessage()}</div>
+        <ButtonBar gap={1}>
+          <Button size="sm" onClick={() => closeModal()} style={{marginRight: space(1)}}>
+            {t('Cancel')}
+          </Button>
+          <Button
+            size="sm"
+            priority="primary"
+            aria-label={t('Send Invites')}
+            onClick={sendInvites}
+            style={{marginRight: space(1)}}
+            disabled={!canSend || selectedCount === 0}
+          >
+            {inviteButtonLabel()}
+          </Button>
+        </ButtonBar>
+      </Footer>
+    </Fragment>
+  );
+
+  return (
+    <InviteModalHook
+      organization={organization}
+      willInvite
+      onSendInvites={sendMemberInvites}
+    >
+      {hookRenderer}
+    </InviteModalHook>
+  );
+}
+
+export default InviteMissingMembersModal;
+
+const StyledPanelTable = styled(PanelTable)`
+  grid-template-columns: max-content 1fr max-content 1fr 1fr;
+  overflow: visible;
+`;
+
+const StyledHeader = styled('div')`
+  display: flex;
+  & > *:first-child {
+    margin-left: ${space(0.5)};
+  }
+`;
+
+const StyledPanelItem = styled(PanelItem)`
+  flex-direction: column;
+`;
+
+const Footer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const ContentRow = styled('div')`
+  display: flex;
+  align-items: center;
+  font-size: ${p => p.theme.fontSizeMedium};
+  & > *:first-child {
+    margin-right: ${space(0.75)};
+  }
+`;

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -32,9 +32,9 @@ import {
 } from 'sentry/views/settings/organizationMembers/inviteBanner';
 
 export interface InviteMissingMembersModalProps extends ModalRenderProps {
-  allowedRoles?: OrgRole[];
-  missingMembers?: {integration: string; users: MissingMember[]};
-  organization?: Organization;
+  allowedRoles: OrgRole[];
+  missingMembers: {integration: string; users: MissingMember[]};
+  organization: Organization;
 }
 
 export function InviteMissingMembersModal({
@@ -43,10 +43,10 @@ export function InviteMissingMembersModal({
   allowedRoles,
   closeModal,
 }: InviteMissingMembersModalProps) {
-  const initialMemberInvites = (missingMembers?.users || []).map(member => ({
+  const initialMemberInvites = (missingMembers.users || []).map(member => ({
     email: member.email,
     commitCount: member.commitCount,
-    role: organization?.defaultRole ?? 'member',
+    role: organization.defaultRole,
     teamSlugs: new Set<string>(),
     externalId: member.externalId,
     selected: false,
@@ -59,7 +59,7 @@ export function InviteMissingMembersModal({
 
   const api = useApi();
 
-  if (!memberInvites || !organization?.access.includes('org:write')) {
+  if (!memberInvites || !organization.access.includes('org:write')) {
     return null;
   }
 
@@ -215,7 +215,7 @@ export function InviteMissingMembersModal({
           />,
           t('User Information'),
           <StyledHeader key={1}>
-            {t('Recent Commits')}{' '}
+            {t('Recent Commits')}
             <Tooltip title={t('Based on the last 30 days of commit data')}>
               <IconInfo size="xs" />
             </Tooltip>
@@ -252,7 +252,7 @@ export function InviteMissingMembersModal({
                 aria-label={t('Role')}
                 data-test-id="select-role"
                 disabled={false}
-                roles={allowedRoles ?? []}
+                roles={allowedRoles}
                 disableUnallowed
                 onChange={value => setRole(value?.value, i)}
               />
@@ -315,9 +315,7 @@ const StyledPanelTable = styled(PanelTable)`
 
 const StyledHeader = styled('div')`
   display: flex;
-  & > *:first-child {
-    margin-left: ${space(0.5)};
-  }
+  gap: ${space(0.5)};
 `;
 
 const StyledPanelItem = styled(PanelItem)`

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -223,6 +223,7 @@ export function InviteMissingMembersModal({
       >
         {memberInvites?.map((member, i) => {
           const checked = memberInvites[i].selected;
+          const username = member.externalId.split(':').pop();
           return (
             <Fragment key={i}>
               <div>
@@ -235,8 +236,8 @@ export function InviteMissingMembersModal({
               <StyledPanelItem>
                 <ContentRow>
                   <IconGithub size="sm" />
-                  <StyledExternalLink href={`https://github.com/${member.externalId}`}>
-                    @{member.externalId}
+                  <StyledExternalLink href={`https://github.com/${username}`}>
+                    @{username}
                   </StyledExternalLink>
                 </ContentRow>
                 <Subtitle>{member.email}</Subtitle>

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -64,8 +64,8 @@ export function InviteMissingMembersModal({
   }
 
   const setRole = (role: string, index: number) => {
-    setMemberInvites(
-      memberInvites.map((member, i) => {
+    setMemberInvites(currentMemberInvites =>
+      currentMemberInvites.map((member, i) => {
         if (i === index) {
           member.role = role;
         }
@@ -75,8 +75,8 @@ export function InviteMissingMembersModal({
   };
 
   const setTeams = (teamSlugs: string[], index: number) => {
-    setMemberInvites(
-      memberInvites.map((member, i) => {
+    setMemberInvites(currentMemberInvites =>
+      currentMemberInvites.map((member, i) => {
         if (i === index) {
           member.teamSlugs = new Set(teamSlugs);
         }
@@ -86,14 +86,11 @@ export function InviteMissingMembersModal({
   };
 
   const selectAll = (checked: boolean) => {
-    const selectedMembers = memberInvites.map(m => {
-      m.selected = checked;
-      return m;
-    });
+    const selectedMembers = memberInvites.map(m => ({...m, selected: checked}));
     setMemberInvites(selectedMembers);
   };
 
-  const checkboxToggle = (checked: boolean, index: number) => {
+  const toggleCheckbox = (checked: boolean, index: number) => {
     const selectedMembers = [...memberInvites];
     selectedMembers[index].selected = checked;
     setMemberInvites(selectedMembers);
@@ -232,14 +229,14 @@ export function InviteMissingMembersModal({
                 <Checkbox
                   aria-label={t('Select %s', member.email)}
                   checked={checked}
-                  onChange={() => checkboxToggle(!checked, i)}
+                  onChange={() => toggleCheckbox(!checked, i)}
                 />
               </div>
               <StyledPanelItem>
                 <ContentRow>
                   <IconGithub size="sm" />
-                  <StyledExternalLink href={`http://github.com/${member.externalId}`}>
-                    {member.externalId}
+                  <StyledExternalLink href={`https://github.com/${member.externalId}`}>
+                    @{member.externalId}
                   </StyledExternalLink>
                 </ContentRow>
                 <Subtitle>{member.email}</Subtitle>

--- a/static/app/components/modals/inviteMissingMembersModal/types.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/types.tsx
@@ -1,0 +1,8 @@
+export type MissingMemberInvite = {
+  commitCount: number;
+  email: string;
+  externalId: string;
+  role: string;
+  selected: boolean;
+  teams: Set<string>;
+};

--- a/static/app/components/modals/inviteMissingMembersModal/types.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/types.tsx
@@ -4,5 +4,5 @@ export type MissingMemberInvite = {
   externalId: string;
   role: string;
   selected: boolean;
-  teams: Set<string>;
+  teamSlugs: Set<string>;
 };

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -43,6 +43,7 @@ describe('inviteBanner', function () {
         missingMembers={missingMembers}
         onSendInvite={() => undefined}
         organization={org}
+        invitableRoles={[]}
       />
     );
 
@@ -65,6 +66,7 @@ describe('inviteBanner', function () {
         missingMembers={missingMembers}
         onSendInvite={() => undefined}
         organization={org}
+        invitableRoles={[]}
       />
     );
 
@@ -85,6 +87,7 @@ describe('inviteBanner', function () {
         missingMembers={noMissingMembers}
         onSendInvite={() => undefined}
         organization={org}
+        invitableRoles={[]}
       />
     );
 
@@ -106,6 +109,7 @@ describe('inviteBanner', function () {
         missingMembers={noMissingMembers}
         onSendInvite={() => undefined}
         organization={org}
+        invitableRoles={[]}
       />
     );
 
@@ -138,6 +142,7 @@ describe('inviteBanner', function () {
         missingMembers={missingMembers}
         onSendInvite={() => undefined}
         organization={org}
+        invitableRoles={[]}
       />
     );
 
@@ -170,6 +175,7 @@ describe('inviteBanner', function () {
         missingMembers={missingMembers}
         onSendInvite={() => undefined}
         organization={org}
+        invitableRoles={[]}
       />
     );
 

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -41,9 +41,10 @@ describe('inviteBanner', function () {
     render(
       <InviteBanner
         missingMembers={missingMembers}
-        onSendInvite={() => undefined}
+        onSendInvite={() => {}}
         organization={org}
-        invitableRoles={[]}
+        allowedRoles={[]}
+        onModalClose={() => {}}
       />
     );
 
@@ -64,9 +65,10 @@ describe('inviteBanner', function () {
     render(
       <InviteBanner
         missingMembers={missingMembers}
-        onSendInvite={() => undefined}
+        onSendInvite={() => {}}
         organization={org}
-        invitableRoles={[]}
+        allowedRoles={[]}
+        onModalClose={() => {}}
       />
     );
 
@@ -85,9 +87,10 @@ describe('inviteBanner', function () {
     render(
       <InviteBanner
         missingMembers={noMissingMembers}
-        onSendInvite={() => undefined}
+        onSendInvite={() => {}}
         organization={org}
-        invitableRoles={[]}
+        allowedRoles={[]}
+        onModalClose={() => {}}
       />
     );
 
@@ -107,9 +110,10 @@ describe('inviteBanner', function () {
     render(
       <InviteBanner
         missingMembers={noMissingMembers}
-        onSendInvite={() => undefined}
+        onSendInvite={() => {}}
         organization={org}
-        invitableRoles={[]}
+        allowedRoles={[]}
+        onModalClose={() => {}}
       />
     );
 
@@ -140,9 +144,10 @@ describe('inviteBanner', function () {
     render(
       <InviteBanner
         missingMembers={missingMembers}
-        onSendInvite={() => undefined}
+        onSendInvite={() => {}}
         organization={org}
-        invitableRoles={[]}
+        allowedRoles={[]}
+        onModalClose={() => {}}
       />
     );
 
@@ -173,9 +178,10 @@ describe('inviteBanner', function () {
     render(
       <InviteBanner
         missingMembers={missingMembers}
-        onSendInvite={() => undefined}
+        onSendInvite={() => {}}
         organization={org}
-        invitableRoles={[]}
+        allowedRoles={[]}
+        onModalClose={() => {}}
       />
     );
 

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -125,7 +125,12 @@ export function InviteBanner({
   ));
 
   cards.push(
-    <SeeMoreCard key="see-more" missingUsers={users} organization={organization} />
+    <SeeMoreCard
+      key="see-more"
+      missingUsers={users}
+      organization={organization}
+      invitableRoles={invitableRoles}
+    />
   );
 
   return (
@@ -184,11 +189,12 @@ export function InviteBanner({
 export default withOrganization(InviteBanner);
 
 type SeeMoreCardProps = {
+  invitableRoles: OrgRole[];
   missingUsers: MissingMember[];
   organization: Organization;
 };
 
-function SeeMoreCard({missingUsers, organization}: SeeMoreCardProps) {
+function SeeMoreCard({missingUsers, organization, invitableRoles}: SeeMoreCardProps) {
   return (
     <MemberCard data-test-id="see-more-card">
       <MemberCardContent>

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -97,32 +97,38 @@ export function InviteBanner({
 
   const users = missingMembers.users;
 
-  const cards = users.slice(0, 5).map(member => (
-    <MemberCard key={member.externalId} data-test-id={`member-card-${member.externalId}`}>
-      <MemberCardContent>
-        <MemberCardContentRow>
-          <IconGithub size="sm" />
-          {/* TODO(cathy): create mapping from integration to lambda external link function */}
-          <StyledExternalLink href={`https://github.com/${member.externalId}`}>
-            @{member.externalId}
-          </StyledExternalLink>
-        </MemberCardContentRow>
-        <MemberCardContentRow>
-          <IconCommit size="xs" />
-          {tct('[commitCount] Recent Commits', {commitCount: member.commitCount})}
-        </MemberCardContentRow>
-        <Subtitle>{member.email}</Subtitle>
-      </MemberCardContent>
-      <Button
-        size="sm"
-        onClick={() => handleSendInvite(member.email)}
-        data-test-id="invite-missing-member"
-        icon={<IconMail />}
+  const cards = users.slice(0, 5).map(member => {
+    const username = member.externalId.split(':').pop();
+    return (
+      <MemberCard
+        key={member.externalId}
+        data-test-id={`member-card-${member.externalId}`}
       >
-        {t('Invite')}
-      </Button>
-    </MemberCard>
-  ));
+        <MemberCardContent>
+          <MemberCardContentRow>
+            <IconGithub size="sm" />
+            {/* TODO(cathy): create mapping from integration to lambda external link function */}
+            <StyledExternalLink href={`https://github.com/${username}`}>
+              @{username}
+            </StyledExternalLink>
+          </MemberCardContentRow>
+          <MemberCardContentRow>
+            <IconCommit size="xs" />
+            {tct('[commitCount] Recent Commits', {commitCount: member.commitCount})}
+          </MemberCardContentRow>
+          <Subtitle>{member.email}</Subtitle>
+        </MemberCardContent>
+        <Button
+          size="sm"
+          onClick={() => handleSendInvite(member.email)}
+          data-test-id="invite-missing-member"
+          icon={<IconMail />}
+        >
+          {t('Invite')}
+        </Button>
+      </MemberCard>
+    );
+  });
 
   cards.push(
     <SeeMoreCard

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -103,8 +103,8 @@ export function InviteBanner({
         <MemberCardContentRow>
           <IconGithub size="sm" />
           {/* TODO(cathy): create mapping from integration to lambda external link function */}
-          <StyledExternalLink href={`http://github.com/${member.externalId}`}>
-            {tct('@[externalId]', {externalId: member.externalId})}
+          <StyledExternalLink href={`https://github.com/${member.externalId}`}>
+            @{member.externalId}
           </StyledExternalLink>
         </MemberCardContentRow>
         <MemberCardContentRow>
@@ -197,7 +197,7 @@ function SeeMoreCard({
   onModalClose,
   organization,
 }: SeeMoreCardProps) {
-  const users = missingMembers.users;
+  const {users} = missingMembers;
 
   return (
     <MemberCard data-test-id="see-more-card">

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -159,9 +159,7 @@ export function InviteBanner({
               openInviteMissingMembersModal({
                 allowedRoles,
                 missingMembers,
-                onClose: () => {
-                  onModalClose();
-                },
+                onClose: onModalClose,
                 organization,
               })
             }
@@ -225,9 +223,7 @@ function SeeMoreCard({
             allowedRoles,
             missingMembers,
             organization,
-            onClose: () => {
-              onModalClose();
-            },
+            onClose: onModalClose,
           })
         }
       >

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -340,6 +340,7 @@ class OrganizationMembersList extends DeprecatedAsyncView<Props, State> {
         <InviteBanner
           missingMembers={githubMissingMembers}
           onSendInvite={this.handleInviteMissingMember}
+          invitableRoles={currentMember ? currentMember.roles : ORG_ROLES}
         />
         <ClassNames>
           {({css}) =>

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -340,7 +340,8 @@ class OrganizationMembersList extends DeprecatedAsyncView<Props, State> {
         <InviteBanner
           missingMembers={githubMissingMembers}
           onSendInvite={this.handleInviteMissingMember}
-          invitableRoles={currentMember ? currentMember.roles : ORG_ROLES}
+          onModalClose={this.fetchMembersList}
+          allowedRoles={currentMember ? currentMember.roles : ORG_ROLES}
         />
         <ClassNames>
           {({css}) =>


### PR DESCRIPTION
Display all missing organization members found through CommitAuthors in a modal hooked up to the invite banner. Allow users with `org:write` to select multiple or all users, select the role and teams for those users, and invite them to their organization.

https://github.com/getsentry/sentry/assets/70817427/afe33ea7-70dd-4b69-b208-9f11dc33daea

For ER-1739