### PR TITLE
fix(api): correct fetch request error catching

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -471,104 +471,112 @@ export class Client {
     // XXX(epurkhiser): We migrated off of jquery, so for now we have a
     // compatibility layer which mimics that of the jquery response objects.
     fetchRequest
-      .then(async response => {
-        // The Response's body can only be resolved/used at most once.
-        // So we clone the response so we can resolve the body content as text content.
-        // Response objects need to be cloned before its body can be used.
-        let responseJSON: any;
-        let responseText: any;
+      .then(
+        async response => {
+          // The Response's body can only be resolved/used at most once.
+          // So we clone the response so we can resolve the body content as text content.
+          // Response objects need to be cloned before its body can be used.
+          let responseJSON: any;
+          let responseText: any;
 
-        const {status, statusText} = response;
-        let {ok} = response;
-        let errorReason = 'Request not OK'; // the default error reason
-        let twoHundredErrorReason;
+          const {status, statusText} = response;
+          let {ok} = response;
+          let errorReason = 'Request not OK'; // the default error reason
+          let twoHundredErrorReason;
 
-        // Try to get text out of the response no matter the status
-        try {
-          responseText = await response.text();
-        } catch (error) {
-          twoHundredErrorReason = 'Failed awaiting response.text()';
-          ok = false;
-          if (error.name === 'AbortError') {
-            errorReason = 'Request was aborted';
-          } else {
-            errorReason = error.toString();
-          }
-        }
-
-        const responseContentType = response.headers.get('content-type');
-        const isResponseJSON = responseContentType?.includes('json');
-
-        const isStatus3XX = status >= 300 && status < 400;
-        if (status !== 204 && !isStatus3XX) {
+          // Try to get text out of the response no matter the status
           try {
-            responseJSON = JSON.parse(responseText);
+            responseText = await response.text();
           } catch (error) {
-            twoHundredErrorReason = 'Failed trying to parse responseText';
+            twoHundredErrorReason = 'Failed awaiting response.text()';
+            ok = false;
             if (error.name === 'AbortError') {
-              ok = false;
               errorReason = 'Request was aborted';
-            } else if (isResponseJSON && error instanceof SyntaxError) {
-              // If the MIME type is `application/json` but decoding failed,
-              // this should be an error.
-              ok = false;
-              errorReason = 'JSON parse error';
+            } else {
+              errorReason = error.toString();
             }
           }
-        }
 
-        const responseMeta: ResponseMeta = {
-          status,
-          statusText,
-          responseJSON,
-          responseText,
-          getResponseHeader: (header: string) => response.headers.get(header),
-        };
+          const responseContentType = response.headers.get('content-type');
+          const isResponseJSON = responseContentType?.includes('json');
 
-        // Respect the response content-type header
-        const responseData = isResponseJSON ? responseJSON : responseText;
-
-        if (ok) {
-          successHandler(responseMeta, statusText, responseData);
-        } else {
-          // There's no reason we should be here with a 200 response, but we get
-          // tons of events from this codepath with a 200 status nonetheless.
-          // Until we know why, let's do what is essentially some very fancy print debugging.
-          if (status === 200 && responseText) {
-            const parameterizedPath = sanitizePath(path);
-            const message = '200 treated as error';
-
-            const scope = new Sentry.Scope();
-            scope.setTags({endpoint: `${method} ${parameterizedPath}`, errorReason});
-            scope.setExtras({
-              twoHundredErrorReason,
-              responseJSON,
-              responseText,
-              responseContentType,
-              errorReason,
-            });
-            // Make sure all of these errors group, so we don't produce a bunch of noise
-            scope.setFingerprint([message]);
-
-            Sentry.captureException(
-              new Error(`${message}: ${method} ${parameterizedPath}`),
-              scope
-            );
+          const isStatus3XX = status >= 300 && status < 400;
+          if (status !== 204 && !isStatus3XX) {
+            try {
+              responseJSON = JSON.parse(responseText);
+            } catch (error) {
+              twoHundredErrorReason = 'Failed trying to parse responseText';
+              if (error.name === 'AbortError') {
+                ok = false;
+                errorReason = 'Request was aborted';
+              } else if (isResponseJSON && error instanceof SyntaxError) {
+                // If the MIME type is `application/json` but decoding failed,
+                // this should be an error.
+                ok = false;
+                errorReason = 'JSON parse error';
+              }
+            }
           }
 
-          const shouldSkipErrorHandler =
-            globalErrorHandlers.map(handler => handler(responseMeta)).filter(Boolean)
-              .length > 0;
+          const responseMeta: ResponseMeta = {
+            status,
+            statusText,
+            responseJSON,
+            responseText,
+            getResponseHeader: (header: string) => response.headers.get(header),
+          };
 
-          if (!shouldSkipErrorHandler) {
-            errorHandler(responseMeta, statusText, errorReason);
+          // Respect the response content-type header
+          const responseData = isResponseJSON ? responseJSON : responseText;
+
+          if (ok) {
+            successHandler(responseMeta, statusText, responseData);
+          } else {
+            // There's no reason we should be here with a 200 response, but we get
+            // tons of events from this codepath with a 200 status nonetheless.
+            // Until we know why, let's do what is essentially some very fancy print debugging.
+            if (status === 200 && responseText) {
+              const parameterizedPath = sanitizePath(path);
+              const message = '200 treated as error';
+
+              const scope = new Sentry.Scope();
+              scope.setTags({endpoint: `${method} ${parameterizedPath}`, errorReason});
+              scope.setExtras({
+                twoHundredErrorReason,
+                responseJSON,
+                responseText,
+                responseContentType,
+                errorReason,
+              });
+              // Make sure all of these errors group, so we don't produce a bunch of noise
+              scope.setFingerprint([message]);
+
+              Sentry.captureException(
+                new Error(`${message}: ${method} ${parameterizedPath}`),
+                scope
+              );
+            }
+
+            const shouldSkipErrorHandler =
+              globalErrorHandlers.map(handler => handler(responseMeta)).filter(Boolean)
+                .length > 0;
+
+            if (!shouldSkipErrorHandler) {
+              errorHandler(responseMeta, statusText, errorReason);
+            }
           }
-        }
 
-        completeHandler(responseMeta, statusText);
-      })
-      .catch(() => {
-        // Ignore all failed requests
+          completeHandler(responseMeta, statusText);
+        },
+        () => {
+          // Ignore failed fetch calls or errors in the fetch request itself (e.g. cancelled requests)
+          // Not related to errors in responses
+        }
+      )
+      .catch(error => {
+        // eslint-disable-next-line no-console
+        console.error(error);
+        Sentry.captureException(error);
       });
 
     const request = new Request(fetchRequest, aborter);


### PR DESCRIPTION
Now:
- ignore failed fetch calls or errors in the fetch request itself (e.g. cancelled requests)
- do not ignore errors in responses

Changes are lines 571-579; everything else was shifted due to formatting