### PR TITLE
ref(escalating): Add more detail to forecast out of range error

### DIFF
--- a/src/sentry/issues/escalating_group_forecast.py
+++ b/src/sentry/issues/escalating_group_forecast.py
@@ -75,9 +75,12 @@ class EscalatingGroupForecast:
         if not escalating_forecast:
             return None
 
-        forecast_today_index = (date_now - escalating_forecast.date_added.date()).days
+        date_added = escalating_forecast.date_added.date()
+        forecast_today_index = (date_now - date_added).days
         if forecast_today_index >= len(escalating_forecast.forecast):
-            logger.error("Forecast list index is out of range")
+            logger.error(
+                f"Forecast list index is out of range. Index: {forecast_today_index}. Date now: {date_now}. Forecast date added: {date_added}."
+            )
             # Use last available forecast as a fallback
             forecast_today_index = -1
         return escalating_forecast.forecast[forecast_today_index]

--- a/tests/sentry/issues/test_escalating.py
+++ b/tests/sentry/issues/test_escalating.py
@@ -308,4 +308,4 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
                 date_added=datetime.now() - timedelta(15),
             )
             assert is_escalating(archived_group) == (True, 1)
-            logger.error.assert_called_once_with("Forecast list index is out of range")
+            logger.error.assert_called_once()


### PR DESCRIPTION
Add more detail to forecast out of range error.

With the detail provided in this [error](https://sentry.sentry.io/issues/4210955209/?project=1&referrer=issue-stream&statsPeriod=30d&stream_index=0), I cannot figure out why this out of range error would occur.
If no forecast exists in nodestore, we return a new 14 day forecast and the TTL in nodestore is 14 days.
