### PR TITLE
ref(commits): Actually continue if repo not found

### DIFF
--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -94,17 +94,16 @@ def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **k
             pass
 
     for ref in refs:
-        try:
-            repo = (
-                Repository.objects.filter(
-                    organization_id=release.organization_id,
-                    name=ref["repository"],
-                    status=ObjectStatus.ACTIVE,
-                )
-                .order_by("-pk")
-                .first()
+        repo = (
+            Repository.objects.filter(
+                organization_id=release.organization_id,
+                name=ref["repository"],
+                status=ObjectStatus.ACTIVE,
             )
-        except Repository.DoesNotExist:
+            .order_by("-pk")
+            .first()
+        )
+        if not repo:
             logger.info(
                 "repository.missing",
                 extra={


### PR DESCRIPTION
`.first()` returns None if nothing is found, not a `DoesNotExist`: https://docs.djangoproject.com/en/4.2/ref/models/querysets/#first

Fixes SENTRY-14YP