### PR TITLE
ref: correct sending post data for django 4

### DIFF
--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -189,13 +189,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
         # having issues with reading json data
         # request.POST looks like {"lambdaB": "True"}
         # string instead of boolean
-        resp = self.client.post(
-            self.setup_path,
-            data={"lambdaB": "true", "lambdaA": "false"},
-            format="json",
-            HTTP_ACCEPT="application/json",
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
-        )
+        resp = self.client.post(self.setup_path, {"lambdaB": "true", "lambdaA": "false"})
 
         assert resp.status_code == 200
 
@@ -253,13 +247,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             sentry_project_dsn = ProjectKey.get_default(project=self.projectA).get_dsn(public=True)
 
-        resp = self.client.post(
-            self.setup_path,
-            data={"lambdaA": "true"},
-            format="json",
-            HTTP_ACCEPT="application/json",
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
-        )
+        resp = self.client.post(self.setup_path, {"lambdaA": "true"})
 
         assert resp.status_code == 200
 
@@ -328,13 +316,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
             "project_id": self.projectA.id,
         }
 
-        resp = self.client.post(
-            self.setup_path,
-            {"lambdaB": "true"},
-            format="json",
-            HTTP_ACCEPT="application/json",
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
-        )
+        resp = self.client.post(self.setup_path, {"lambdaB": "true"})
 
         assert resp.status_code == 200
         assert not Integration.objects.filter(provider=self.provider.key).exists()
@@ -385,13 +367,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
             "project_id": self.projectA.id,
         }
 
-        resp = self.client.post(
-            self.setup_path,
-            {"lambdaB": "true"},
-            format="json",
-            HTTP_ACCEPT="application/json",
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
-        )
+        resp = self.client.post(self.setup_path, {"lambdaB": "true"})
 
         assert resp.status_code == 200
         assert not Integration.objects.filter(provider=self.provider.key).exists()
@@ -443,13 +419,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
             "project_id": self.projectA.id,
         }
 
-        resp = self.client.post(
-            self.setup_path,
-            {"lambdaB": "true"},
-            format="json",
-            HTTP_ACCEPT="application/json",
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
-        )
+        resp = self.client.post(self.setup_path, {"lambdaB": "true"})
 
         assert resp.status_code == 200
         assert not Integration.objects.filter(provider=self.provider.key).exists()
@@ -506,13 +476,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
             "project_id": self.projectA.id,
         }
 
-        resp = self.client.post(
-            self.setup_path,
-            {"lambdaB": "true"},
-            format="json",
-            HTTP_ACCEPT="application/json",
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
-        )
+        resp = self.client.post(self.setup_path, {"lambdaB": "true"})
 
         assert resp.status_code == 200
         assert not Integration.objects.filter(provider=self.provider.key).exists()


### PR DESCRIPTION
the intention here appears to be to send as json -- but the endpoint itself does not read json data

in django<4 it ignores all the content-type / etc. things in `client.post` -- to send json it needs to be `json.dumps(...)`'d already

the endpoint itself doesn't take json and reads data directly from `request.POST`