### PR TITLE
ref: use class name instead of view func __qualname__ for ratelimit key

### DIFF
--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -57,7 +57,7 @@ def get_rate_limit_key(
     ):
         return None
 
-    view = view_func.__qualname__
+    view = view_func.view_class.__name__
     http_method = request.method
 
     # This avoids touching user session, which means we avoid


### PR DESCRIPTION
in django 4 the view function is wrapped in a closure which gets a useless `<locals>.view` qualname