### PR TITLE
ref: fix accessing a join for object which has not been committed in django 4

### DIFF
--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -667,11 +667,12 @@ class GetEntitySubscriptionFromSnubaQueryTest(TestCase):
         ]
 
         for expected_entity_subscription, query_type, dataset, aggregate in cases:
-            snuba_query = SnubaQuery(
+            snuba_query = SnubaQuery.objects.create(
                 time_window=60,
                 type=query_type.value,
                 dataset=dataset.value,
                 aggregate=aggregate,
+                resolution=5,
             )
             assert isinstance(
                 get_entity_subscription_from_snuba_query(snuba_query, self.organization.id),
@@ -735,12 +736,13 @@ class GetEntityKeyFromSnubaQueryTest(TestCase):
         ]
 
         for expected_entity_key, query_type, dataset, aggregate, query in cases:
-            snuba_query = SnubaQuery(
+            snuba_query = SnubaQuery.objects.create(
                 time_window=60,
                 type=query_type.value,
                 dataset=dataset.value,
                 aggregate=aggregate,
                 query=query,
+                resolution=5,
             )
             assert expected_entity_key == get_entity_key_from_snuba_query(
                 snuba_query, self.organization.id, self.project.id


### PR DESCRIPTION
prior to this django silently allowed the join to fail -- in django 4 it complains since the object does not yet have a primary key to join on