### PR TITLE
ref: group tests by a slightly smaller scope

### DIFF
--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -383,7 +383,7 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
     total_groups = int(os.environ.get("TOTAL_TEST_GROUPS", 1))
     current_group = int(os.environ.get("TEST_GROUP", 0))
-    grouping_strategy = os.environ.get("TEST_GROUP_STRATEGY", "file")
+    grouping_strategy = os.environ.get("TEST_GROUP_STRATEGY", "scope")
 
     keep, discard = [], []
 
@@ -391,8 +391,8 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         # In the case where we group by round robin (e.g. TEST_GROUP_STRATEGY is not `file`),
         # we want to only include items in `accepted` list
         item_to_group = (
-            int(md5(str(item.location[0]).encode("utf-8")).hexdigest(), 16)
-            if grouping_strategy == "file"
+            int(md5(item.nodeid.rsplit("::", 1)[0].encode()).hexdigest(), 16)
+            if grouping_strategy == "scope"
             else index
         )
 


### PR DESCRIPTION
this should make test distribution more even


for example with the snuba suite this takes the current spread: (16, 15, 6, 25) and evens it out: (15, 12, 13, 19)