### PR TITLE
ref: add log level option to arroyo consumers

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import signal
 import sys
@@ -698,6 +699,11 @@ def profiles_consumer(**options):
     "--healthcheck-file-path",
     help="A file to touch roughly every second to indicate that the consumer is still alive. See https://getsentry.github.io/arroyo/strategies/healthcheck.html for more information.",
 )
+@click.option(
+    "--log-level",
+    type=click.Choice(["debug", "info", "warning", "error", "critical"], case_sensitive=False),
+    help="log level to pass to the arroyo consumer",
+)
 @strict_offset_reset_option()
 @configuration
 def basic_consumer(consumer_name, consumer_args, topic, **options):
@@ -722,6 +728,12 @@ def basic_consumer(consumer_name, consumer_args, topic, **options):
     from sentry.consumers import get_stream_processor
     from sentry.metrics.middleware import add_global_tags
     from sentry.utils.arroyo import initialize_arroyo_main
+
+    log_level = options.pop("log_level", None)
+    if log_level is not None:
+        import arroyo
+
+        logging.getLogger(arroyo.__name__).setLevel(log_level.upper())
 
     add_global_tags(kafka_topic=topic, consumer_group=options["group_id"])
     initialize_arroyo_main()

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -731,9 +731,7 @@ def basic_consumer(consumer_name, consumer_args, topic, **options):
 
     log_level = options.pop("log_level", None)
     if log_level is not None:
-        import arroyo
-
-        logging.getLogger(arroyo.__name__).setLevel(log_level.upper())
+        logging.getLogger("arroyo").setLevel(log_level.upper())
 
     add_global_tags(kafka_topic=topic, consumer_group=options["group_id"])
     initialize_arroyo_main()


### PR DESCRIPTION
Allows passing in a log level to the arroyo consumers. This is useful in debugging.
