### PR TITLE
fix(issues): Align context line stacktrace link

### DIFF
--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -54,11 +54,10 @@ function OpenInContextLine({lineNo, filename, components}: Props) {
 export {OpenInContextLine};
 
 const OpenInContainer = styled('div')<{columnQuantity: number}>`
-  position: relative;
-  z-index: 1;
-  display: grid;
-  grid-template-columns: repeat(${p => p.columnQuantity}, max-content);
+  display: flex;
   gap: ${space(1)};
+  align-items: center;
+  z-index: 1;
   color: ${p => p.theme.subText};
   background-color: ${p => p.theme.background};
   font-family: ${p => p.theme.text.family};
@@ -71,9 +70,9 @@ const OpenInContainer = styled('div')<{columnQuantity: number}>`
 `;
 
 const OpenInLink = styled(ExternalLink)`
-  align-items: center;
-  grid-template-columns: max-content auto;
+  display: flex;
   gap: ${space(0.75)};
+  align-items: center;
   color: ${p => p.theme.gray300};
 `;
 

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -368,6 +368,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
 const StacktraceLinkWrapper = styled('div')`
   display: flex;
   gap: ${space(2)};
+  align-items: center;
   color: ${p => p.theme.subText};
   background-color: ${p => p.theme.background};
   font-family: ${p => p.theme.text.family};


### PR DESCRIPTION
I think these are from a sentry app? Don't see them very often. 

Fixes the alignment

before
<img width="641" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/cae48b7e-4eac-4be5-8663-202aeca30669">

after
<img width="600" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/f1a7c497-59fb-43b2-99d8-ab40ca38d607">
