### PR TITLE
feat(performance-tracing-w/o-performance): UI improvements.

### DIFF
--- a/static/app/components/quickTrace/index.tsx
+++ b/static/app/components/quickTrace/index.tsx
@@ -103,6 +103,23 @@ export default function QuickTrace({
   const {root, ancestors, parent, children, descendants, current} = parsedQuickTrace;
 
   const nodes: React.ReactNode[] = [];
+  const isOrphanErrorNode = traceLength === 1 && isTraceError(current);
+
+  const currentNode = (
+    <EventNodeSelector
+      key="current-node"
+      location={location}
+      organization={organization}
+      text={t('This Event')}
+      events={[current]}
+      currentEvent={event}
+      anchor={anchor}
+      nodeKey="current"
+      errorDest={errorDest}
+      isOrphanErrorNode={isOrphanErrorNode}
+      transactionDest={transactionDest}
+    />
+  );
 
   if (root) {
     nodes.push(
@@ -119,7 +136,27 @@ export default function QuickTrace({
         transactionDest={transactionDest}
       />
     );
-    nodes.push(<TraceConnector key="root-connector" />);
+    nodes.push(<TraceConnector key="root-connector" dashed={isOrphanErrorNode} />);
+  }
+
+  if (isOrphanErrorNode) {
+    nodes.push(
+      <EventNodeSelector
+        key="root-node"
+        location={location}
+        organization={organization}
+        events={[]}
+        currentEvent={event}
+        text={t('Root')}
+        anchor={anchor}
+        nodeKey="root"
+        errorDest={errorDest}
+        transactionDest={transactionDest}
+      />
+    );
+    nodes.push(<TraceConnector key="root-connector" dashed />);
+    nodes.push(currentNode);
+    return <QuickTraceContainer>{nodes}</QuickTraceContainer>;
   }
 
   if (ancestors?.length) {
@@ -157,22 +194,6 @@ export default function QuickTrace({
     );
     nodes.push(<TraceConnector key="parent-connector" />);
   }
-
-  const currentNode = (
-    <EventNodeSelector
-      key="current-node"
-      location={location}
-      organization={organization}
-      text={t('This Event')}
-      events={[current]}
-      currentEvent={event}
-      anchor={anchor}
-      nodeKey="current"
-      errorDest={errorDest}
-      isOrphanErrorNode={traceLength === 1 && isTraceError(current)}
-      transactionDest={transactionDest}
-    />
-  );
 
   if (traceLength === 1) {
     nodes.push(

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -199,7 +199,7 @@ class TraceDetailsContent extends Component<Props, State> {
         <TraceSearchBar
           defaultQuery=""
           query={this.state.searchQuery || ''}
-          placeholder={t('Search for transactions')}
+          placeholder={t('Search for events')}
           onSearch={this.handleTransactionFilter}
         />
       </TraceSearchContainer>
@@ -268,9 +268,6 @@ class TraceDetailsContent extends Component<Props, State> {
 
     let warning: React.ReactNode = null;
 
-    const hasOnlyOrphanErrors =
-      hasTraceData(traces, orphanErrors) && (!traces || traces.length <= 0);
-
     if (roots === 0 && orphans > 0) {
       warning = (
         <Alert type="info" showIcon>
@@ -299,14 +296,14 @@ class TraceDetailsContent extends Component<Props, State> {
           </ExternalLink>
         </Alert>
       );
-    } else if (hasOnlyOrphanErrors) {
+    } else if (orphanErrors && orphanErrors.length > 1) {
       warning = (
         <Alert type="info" showIcon>
           {tct(
-            "The good news is we know these errors are related to each other. The bad news is you haven't enabled tracing to tell you more than that. [tracingLink: Configure Tracing]",
+            "The good news is we know these errors are related to each other. The bad news is that we can't tell you more than that. If you haven't already, [tracingLink: configure tracing for your SDKs] to learn more about service interactions.",
             {
               tracingLink: (
-                <ExternalLink href="https://docs.sentry.io/product/sentry-basics/tracing/distributed-tracing/" />
+                <ExternalLink href="https://docs.sentry.io/product/performance/getting-started/" />
               ),
             }
           )}

--- a/static/app/views/performance/traceDetails/limitExceededMessage.tsx
+++ b/static/app/views/performance/traceDetails/limitExceededMessage.tsx
@@ -19,10 +19,10 @@ function LimitExceededMessage({
   organization,
   meta,
 }: LimitExceededMessageProps) {
-  const count = traceInfo.transactions.size;
-  const totalTransactions = meta?.transactions ?? count;
+  const count = traceInfo.transactions.size + traceInfo.errors.size;
+  const totalEvents = (meta && meta.transactions + meta.errors) ?? count;
 
-  if (totalTransactions === null || count >= totalTransactions) {
+  if (totalEvents === null || count >= totalEvents) {
     return null;
   }
 
@@ -30,21 +30,18 @@ function LimitExceededMessage({
 
   return (
     <MessageRow>
-      {tct(
-        'Limited to a view of [count] transactions. To view the full list, [discover].',
-        {
-          count,
-          discover: (
-            <DiscoverFeature>
-              {({hasFeature}) => (
-                <Link disabled={!hasFeature} to={target}>
-                  {t('Open in Discover')}
-                </Link>
-              )}
-            </DiscoverFeature>
-          ),
-        }
-      )}
+      {tct('Limited to a view of [count] rows. To view the full list, [discover].', {
+        count,
+        discover: (
+          <DiscoverFeature>
+            {({hasFeature}) => (
+              <Link disabled={!hasFeature} to={target}>
+                {t('Open in Discover')}
+              </Link>
+            )}
+          </DiscoverFeature>
+        ),
+      })}
     </MessageRow>
   );
 }

--- a/static/app/views/performance/traceDetails/traceView.tsx
+++ b/static/app/views/performance/traceDetails/traceView.tsx
@@ -147,7 +147,6 @@ export default function TraceView({
     description: 'trace-view-content',
   });
   const hasOrphanErrors = orphanErrors && orphanErrors.length > 0;
-  const traceHasSingleOrphanError = orphanErrors?.length === 1 && traces.length <= 0;
 
   useEffect(() => {
     trackAnalytics('performance_views.trace_view.view', {
@@ -441,7 +440,6 @@ export default function TraceView({
                     hasGuideAnchor={false}
                     renderedChildren={transactionGroups}
                     barColor={pickBarColor('')}
-                    traceHasSingleOrphanError={traceHasSingleOrphanError}
                     numOfOrphanErrors={orphanErrors?.length}
                   />
                   <TraceHiddenMessage

--- a/static/app/views/performance/traceDetails/transactionBar.tsx
+++ b/static/app/views/performance/traceDetails/transactionBar.tsx
@@ -88,7 +88,6 @@ type Props = {
   isOrphanError?: boolean;
   measurements?: Map<number, VerticalMark>;
   numOfOrphanErrors?: number;
-  traceHasSingleOrphanError?: boolean;
 };
 
 type State = {
@@ -478,10 +477,6 @@ class TransactionBar extends Component<Props, State> {
   }
 
   renderRectangle() {
-    if (this.props.traceHasSingleOrphanError) {
-      return null;
-    }
-
     const {transaction, traceInfo, barColor} = this.props;
     const {showDetail} = this.state;
 
@@ -565,11 +560,11 @@ class TransactionBar extends Component<Props, State> {
     dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps;
     scrollbarManagerChildrenProps: ScrollbarManager.ScrollbarManagerChildrenProps;
   }) {
-    const {hasGuideAnchor, index} = this.props;
+    const {hasGuideAnchor, index, transaction, organization} = this.props;
     const {showDetail} = this.state;
     const {dividerPosition} = dividerHandlerChildrenProps;
 
-    return (
+    const rowcellContainer = (
       <RowCellContainer showDetail={showDetail}>
         <RowCell
           data-test-id="transaction-row-title"
@@ -609,6 +604,14 @@ class TransactionBar extends Component<Props, State> {
         </RowCell>
         {!showDetail && this.renderGhostDivider(dividerHandlerChildrenProps)}
       </RowCellContainer>
+    );
+
+    return isTraceError(transaction) ? (
+      <Link to={generateIssueEventTarget(transaction, organization)}>
+        {rowcellContainer}
+      </Link>
+    ) : (
+      rowcellContainer
     );
   }
 

--- a/static/app/views/performance/traceDetails/transactionGroup.tsx
+++ b/static/app/views/performance/traceDetails/transactionGroup.tsx
@@ -33,7 +33,6 @@ type Props = ScrollbarManagerChildrenProps & {
   isOrphanError?: boolean;
   measurements?: Map<number, VerticalMark>;
   numOfOrphanErrors?: number;
-  traceHasSingleOrphanError?: boolean;
 };
 
 type State = {
@@ -76,7 +75,6 @@ class TransactionGroup extends Component<Props, State> {
       generateBounds,
       numOfOrphanErrors,
       isOrphanError,
-      traceHasSingleOrphanError,
     } = this.props;
     const {isExpanded} = this.state;
 
@@ -103,7 +101,6 @@ class TransactionGroup extends Component<Props, State> {
           onWheel={onWheel}
           numOfOrphanErrors={numOfOrphanErrors}
           isOrphanError={isOrphanError}
-          traceHasSingleOrphanError={traceHasSingleOrphanError}
         />
         {isExpanded && renderedChildren}
       </Fragment>

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.spec.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.spec.tsx
@@ -42,9 +42,6 @@ describe('QuickTraceMeta', function () {
 
     expect(screen.getByRole('heading', {name: 'Trace Navigator'})).toBeInTheDocument();
     expect(screen.getByTestId('quick-trace-body')).toBeInTheDocument();
-    expect(screen.getByTestId('quick-trace-footer')).toHaveTextContent(
-      `View Full Trace: ${'a'.repeat(8)} (0 events)`
-    );
   });
 
   it('renders placeholder while loading', function () {
@@ -67,9 +64,6 @@ describe('QuickTraceMeta', function () {
     expect(screen.getByRole('heading', {name: 'Trace Navigator'})).toBeInTheDocument();
     const qtBody = screen.getByTestId('quick-trace-body');
     expect(within(qtBody).getByTestId('loading-placeholder')).toBeInTheDocument();
-    expect(screen.getByTestId('quick-trace-footer')).toHaveTextContent(
-      `View Full Trace: ${'a'.repeat(8)} (0 events)`
-    );
   });
 
   it('renders errors', function () {
@@ -91,8 +85,49 @@ describe('QuickTraceMeta', function () {
 
     expect(screen.getByRole('heading', {name: 'Trace Navigator'})).toBeInTheDocument();
     expect(screen.getByTestId('quick-trace-body')).toHaveTextContent('\u2014');
+  });
+
+  it('renders footer', function () {
+    render(
+      <QuickTraceMeta
+        event={event}
+        project={project}
+        location={location}
+        quickTrace={{
+          ...emptyQuickTrace,
+          type: 'full',
+          trace: [
+            {
+              event_id: '6c2fa0db524a41b784db2de220f9754c',
+              span_id: '9f4d8db340e5b9c2',
+              transaction: '/api/0/internal/health/',
+              'transaction.duration': 15,
+              project_id: 1,
+              project_slug: 'sentry',
+              parent_span_id: '87a45c44efdf60d5',
+              parent_event_id: null,
+              generation: 0,
+              errors: [],
+              performance_issues: [],
+            },
+          ],
+        }}
+        traceMeta={{
+          projects: 0,
+          transactions: 1,
+          errors: 0,
+          performance_issues: 0,
+        }}
+        anchor="left"
+        errorDest="issue"
+        transactionDest="performance"
+      />
+    );
+
+    expect(screen.getByRole('heading', {name: 'Trace Navigator'})).toBeInTheDocument();
+    expect(screen.getByTestId('quick-trace-body')).toBeInTheDocument();
     expect(screen.getByTestId('quick-trace-footer')).toHaveTextContent(
-      `View Full Trace: ${'a'.repeat(8)} (0 events)`
+      `View Full Trace: ${'a'.repeat(8)} (1 event)`
     );
   });
 

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -5,21 +5,18 @@ import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {Hovercard} from 'sentry/components/hovercard';
 import ExternalLink from 'sentry/components/links/externalLink';
-import Link from 'sentry/components/links/link';
 import Placeholder from 'sentry/components/placeholder';
 import QuickTrace from 'sentry/components/quickTrace';
-import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
-import {t, tct, tn} from 'sentry/locale';
-import {AvatarProject, OrganizationSummary} from 'sentry/types';
+import {t} from 'sentry/locale';
+import {AvatarProject} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {getConfigureTracingDocsLink} from 'sentry/utils/docs';
-import {getShortEventId} from 'sentry/utils/events';
 import {
   QuickTraceQueryChildrenProps,
   TraceMeta,
 } from 'sentry/utils/performance/quickTrace/types';
 import useOrganization from 'sentry/utils/useOrganization';
+import {TraceLink} from 'sentry/views/issueDetails/quickTrace/traceLink';
 
 import {MetaData} from './styles';
 
@@ -31,13 +28,6 @@ interface Props
   quickTrace: QuickTraceQueryChildrenProps | null;
   traceMeta: TraceMeta | null;
   project?: AvatarProject;
-}
-
-function handleTraceLink(organization: OrganizationSummary) {
-  trackAnalytics('quick_trace.trace_id.clicked', {
-    organization: organization.id,
-    source: 'events',
-  });
 }
 
 export default function QuickTraceMeta({
@@ -58,8 +48,6 @@ export default function QuickTraceMeta({
   const docsLink = getConfigureTracingDocsLink(project);
 
   const traceId = event.contexts?.trace?.trace_id ?? null;
-  const traceTarget = generateTraceTarget(event, organization);
-
   let body: React.ReactNode;
   let footer: React.ReactNode;
 
@@ -99,14 +87,12 @@ export default function QuickTraceMeta({
     }
 
     footer = (
-      <Link to={traceTarget} onClick={() => handleTraceLink(organization)}>
-        {tct('View Full Trace: [id][events]', {
-          id: getShortEventId(traceId ?? ''),
-          events: traceMeta
-            ? tn(' (%s event)', ' (%s events)', traceMeta.transactions + traceMeta.errors)
-            : '',
-        })}
-      </Link>
+      <TraceLink
+        quickTrace={quickTrace}
+        event={event}
+        traceMeta={traceMeta}
+        source="events"
+      />
     );
   }
 


### PR DESCRIPTION
This PR aims to introduce minor UI improvements for orphan error traceviews and and tracenavigator under the feature flag  `organizations:performance-tracing-without-performance`.

List of notable improvements:
- Trace Link under Trace Navigator lists event count
- Root node instead of ??? parent for orphan error nodes
<img width="416" alt="Screenshot 2023-08-18 at 2 26 09 PM" src="https://github.com/getsentry/sentry/assets/60121741/4c8b99e6-37c5-45da-8f21-7de06dae4771">

- Only error rows in trace view are now clickable.
- Updated banner message and link for orphan errors. Banner is hidden for trace wiht 1 orphan error.
<img width="1276" alt="Screenshot 2023-08-18 at 2 29 29 PM" src="https://github.com/getsentry/sentry/assets/60121741/1b916f6d-866b-45f5-a436-e9a155ca9bbd">

- Exceeds message under traceview appears for only orphan error trace:
<img width="812" alt="Screenshot 2023-08-18 at 2 30 54 PM" src="https://github.com/getsentry/sentry/assets/60121741/34e9be8b-ced0-49ff-a8f5-c35318adc132">

Context:
We are now adding views for orphan errors in trace views.
Part of [Tracing without performance concept.](https://www.notion.so/sentry/Tracing-without-performance-efab307eb7f64e71a04f09dc72722530)
Performance Views for tracing without performance: [link](https://getsentry.atlassian.net/browse/PERF-2052)


