### PR TITLE
ref(backup): Move relocation logic into models

### DIFF
--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -7,9 +7,8 @@ import click
 from django.apps import apps
 from django.core import management, serializers
 from django.db import IntegrityError, connection, transaction
-from django.forms import model_to_dict
 
-from sentry.backup.dependencies import PrimaryKeyMap, dependencies, normalize_model_name
+from sentry.backup.dependencies import PrimaryKeyMap, normalize_model_name
 from sentry.backup.helpers import EXCLUDED_APPS
 
 
@@ -31,76 +30,26 @@ class OldImportConfig(NamedTuple):
 def imports(src, old_config: OldImportConfig, printer=click.echo):
     """Imports core data for the Sentry installation."""
 
-    # TODO(hybrid-cloud): actor refactor. Remove this import when done.
-    from sentry.models.actor import Actor
-
     try:
         # Import / export only works in monolith mode with a consolidated db.
         with transaction.atomic("default"):
             pk_map = PrimaryKeyMap()
-            deps = dependencies()
-
             for obj in serializers.deserialize(
                 "json", src, stream=True, use_natural_keys=old_config.use_natural_foreign_keys
             ):
-                if obj.object._meta.app_label not in EXCLUDED_APPS:
+                o = obj.object
+                if o._meta.app_label not in EXCLUDED_APPS or o:
                     # TODO(getsentry/team-ospo#183): This conditional should be removed once we want
                     # to roll out the new API to self-hosted.
                     if old_config.use_update_instead_of_create:
                         obj.save()
                     else:
                         o = obj.object
-                        label = o._meta.label_lower
-                        model_name = normalize_model_name(o)
-                        for field, model_relation in deps[model_name].foreign_keys.items():
-                            field_id = field if field.endswith("_id") else f"{field}_id"
-                            fk = getattr(o, field_id, None)
-                            if fk is not None:
-                                new_pk = pk_map.get(normalize_model_name(model_relation.model), fk)
-                                # TODO(getsentry/team-ospo#167): Will allow missing items when we
-                                # implement org-based filtering.
-                                setattr(o, field_id, new_pk)
-
-                        old_pk = o.pk
-                        o.pk = None
-                        o.id = None
-
-                        # TODO(hybrid-cloud): actor refactor. Remove this conditional when done.
-                        #
-                        # `Actor` and `Team` have a direct circular dependency between them for the
-                        # time being due to an ongoing refactor (that is, `Actor` foreign keys
-                        # directly into `Team`, and `Team` foreign keys directly into `Actor`). If
-                        # we use `INSERT` database calls naively, they will always fail, because one
-                        # half of the cycle will always be missing.
-                        #
-                        # Because `Actor` ends up first in the dependency sorting (see:
-                        # fixtures/backup/model_dependencies/sorted.json), a viable solution here is
-                        # to always null out the `team_id` field of the `Actor` when we write it,
-                        # and then make sure to circle back and update the relevant actor after we
-                        # create the `Team` models later on (see snippet at the end of this scope).
-                        if label == "sentry.actor":
-                            o.team_id = None
-
-                        # TODO(getsentry/team-ospo#181): what's up with email/useremail here? Seems
-                        # like both gets added with `sentry.user` simultaneously? Will need to make
-                        # more robust user handling logic, and to test what happens when a UserEmail
-                        # already exists.
-                        if label == "sentry.useremail":
-                            (o, _) = o.__class__.objects.get_or_create(
-                                user=o.user, email=o.email, defaults=model_to_dict(o)
-                            )
-                            pk_map.insert(model_name, old_pk, o.pk)
-                            continue
-
-                        obj.save(force_insert=True)
-                        pk_map.insert(model_name, old_pk, o.pk)
-
-                        # TODO(hybrid-cloud): actor refactor. Remove this conditional when done.
-                        if label == "sentry.team":
-                            if o.actor_id is not None:
-                                actor = Actor.objects.get(pk=o.actor_id)
-                                actor.team_id = o.pk
-                                actor.save()
+                        written = o.write_relocation_import(pk_map, obj)
+                        if written is not None:
+                            old_pk, new_pk = written
+                            model_name = normalize_model_name(o)
+                            pk_map.insert(model_name, old_pk, new_pk)
 
     # For all database integrity errors, let's warn users to follow our
     # recommended backup/restore workflow before reraising exception. Most of

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable, Mapping, Tuple, Type, TypeVar
+from typing import Any, Callable, Iterable, Mapping, Optional, Tuple, Type, TypeVar
 
 from django.apps.config import AppConfig
+from django.core.serializers.base import DeserializedObject
 from django.db import models
 from django.db.models import signals
 from django.utils import timezone
 
+from sentry.backup.dependencies import PrimaryKeyMap, dependencies, normalize_model_name
+from sentry.backup.scopes import RelocationScope
 from sentry.silo import SiloLimit, SiloMode
 
 from .fields.bounded import BoundedBigAutoField
@@ -42,6 +45,8 @@ def sane_repr(*attrs: str) -> Callable[[object], str]:
 class BaseModel(models.Model):
     class Meta:
         abstract = True
+
+    __relocation_scope__: RelocationScope
 
     objects = BaseManager[M]()  # type: ignore
 
@@ -95,6 +100,51 @@ class BaseModel(models.Model):
         # Ask if a relational field has a cached value.
         name = self._meta.get_field(field_name).get_cache_name()
         return name in self._state.fields_cache
+
+    def get_relocation_scope(self) -> RelocationScope:
+        """
+        Retrieves the `RelocationScope` for a `Model` subclass. It generally just forwards `__relocation_scope__`, but some models have instance-specific logic for deducing the scope.
+        """
+
+        return self.__relocation_scope__
+
+    def _normalize_before_relocation_import(self, pk_map: PrimaryKeyMap) -> int:
+        """
+        A helper function that normalizes a deserialized model. Note that this modifies the model in place, so it should generally be done inside of the companion `write_relocation_import` method, to avoid data skew or corrupted local state.
+
+        The only reason this function is left as a standalone, rather than being folded into `write_relocation_import`, is that it is often useful to adjust just the normalization logic by itself. Overrides of this method should take care not to mutate the `pk_map`.
+
+        The default normalization logic merely replaces foreign keys with their new values from the provided `pk_map`.
+
+        The method returns the old `pk` that was replaced.
+        """
+
+        deps = dependencies()
+        model_name = normalize_model_name(self)
+        for field, model_relation in deps[model_name].foreign_keys.items():
+            field_id = field if field.endswith("_id") else f"{field}_id"
+            fk = getattr(self, field_id, None)
+            if fk is not None:
+                new_fk = pk_map.get(normalize_model_name(model_relation.model), fk)
+                # TODO(getsentry/team-ospo#167): Will allow missing items when we
+                # implement org-based filtering.
+                setattr(self, field_id, new_fk)
+
+        old_pk = self.pk
+        self.pk = None
+
+        return old_pk
+
+    def write_relocation_import(
+        self, pk_map: PrimaryKeyMap, obj: DeserializedObject
+    ) -> Optional[Tuple[int, int]]:
+        """
+        Writes a deserialized model to the database. If this write is successful, this method will return a tuple of the old and new `pk`s.
+        """
+
+        old_pk = self._normalize_before_relocation_import(pk_map)
+        obj.save(force_insert=True)
+        return (old_pk, self.pk)
 
 
 class Model(BaseModel):

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -9,6 +9,7 @@ from django.db import IntegrityError, models, router, transaction
 from django.db.models.signals import post_save
 from rest_framework import serializers
 
+from sentry.backup.dependencies import PrimaryKeyMap
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, region_silo_only_model
 from sentry.db.models.fields.foreignkey import FlexibleForeignKey
@@ -140,6 +141,24 @@ class Actor(Model):
         # Returns a string like "team:1"
         # essentially forwards request to ActorTuple.get_actor_identifier
         return self.get_actor_tuple().get_actor_identifier()
+
+    # TODO(hybrid-cloud): actor refactor. Remove this method when done.
+    def _normalize_before_relocation_import(self, pk_map: PrimaryKeyMap) -> int:
+        old_pk = super()._normalize_before_relocation_import(pk_map)
+
+        # `Actor` and `Team` have a direct circular dependency between them for the time being due
+        # to an ongoing refactor (that is, `Actor` foreign keys directly into `Team`, and `Team`
+        # foreign keys directly into `Actor`). If we use `INSERT` database calls naively, they will
+        # always fail, because one half of the cycle will always be missing.
+        #
+        # Because `Actor` ends up first in the dependency sorting (see:
+        # fixtures/backup/model_dependencies/sorted.json), a viable solution here is to always null
+        # out the `team_id` field of the `Actor` when we import it, and then make sure to circle
+        # back and update the relevant `Actor` after we create the `Team` models later on (see the
+        # `write_relocation_import` method override on that class for details).
+        self.team_id = None
+
+        return old_pk
 
 
 def get_actor_id_for_user(user: Union[User, RpcUser]) -> int:

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -5,11 +5,13 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Literal, Optional, Sequence, Tuple, Union, overload
 
 from django.conf import settings
+from django.core.serializers.base import DeserializedObject
 from django.db import IntegrityError, connections, models, router, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from sentry.app import env
+from sentry.backup.dependencies import PrimaryKeyMap
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
@@ -367,3 +369,28 @@ class Team(Model, SnowflakeIdMixin):
         ).values_list("id", flat=True)
 
         return owner_ids
+
+    # TODO(hybrid-cloud): actor refactor. Remove this method when done.
+    def write_relocation_import(
+        self, pk_map: PrimaryKeyMap, obj: DeserializedObject
+    ) -> Optional[Tuple[int, int]]:
+        written = super().write_relocation_import(pk_map, obj)
+        if written is not None:
+            (_, new_pk) = written
+
+            # `Actor` and `Team` have a direct circular dependency between them for the time being
+            # due to an ongoing refactor (that is, `Actor` foreign keys directly into `Team`, and
+            # `Team` foreign keys directly into `Actor`). If we use `INSERT` database calls naively,
+            # they will always fail, because one half of the cycle will always be missing.
+            #
+            # Because `Actor` ends up first in the dependency sorting (see:
+            # fixtures/backup/model_dependencies/sorted.json), a viable solution here is to always
+            # null out the `team_id` field of the `Actor` when we import it, and then make sure to
+            # circle back and update the relevant `Actor` after we create the `Team` models, which
+            # is exactly what this method override does.
+            if self.actor_id is not None:
+                actor = Actor.objects.get(pk=self.actor_id)
+                actor.team_id = new_pk
+                actor.save()
+
+        return written

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -18,6 +18,7 @@ from sentry.backup.exports import OldExportConfig, exports
 from sentry.backup.findings import ComparatorFindings
 from sentry.backup.imports import OldImportConfig, imports
 from sentry.backup.validate import validate
+from sentry.db.models.fields.bounded import BoundedBigAutoField
 from sentry.incidents.models import (
     IncidentActivity,
     IncidentSnapshot,
@@ -234,6 +235,7 @@ class BackupTestCase(TransactionTestCase):
     def create_exhaustive_organization(self, slug: str, owner: User, invitee: User) -> Organization:
         org = self.create_organization(name=f"test_org_for_{slug}", owner=owner)
         membership = self.create_member(organization=org, user=invitee, role="member")
+        owner_id: BoundedBigAutoField = owner.id
 
         OrganizationOption.objects.create(
             organization=org, key="sentry:account-rate-limit", value=0
@@ -281,7 +283,7 @@ class BackupTestCase(TransactionTestCase):
         # Rule*
         rule = self.create_project_rule(project=project)
         RuleActivity.objects.create(rule=rule, type=RuleActivityType.CREATED.value)
-        self.snooze_rule(user_id=owner.id, owner_id=owner.id, rule=rule)
+        self.snooze_rule(user_id=owner_id, owner_id=owner_id, rule=rule)
 
         # Environment*
         env = self.create_environment()
@@ -330,7 +332,7 @@ class BackupTestCase(TransactionTestCase):
             unique_users=1,
             total_events=1,
         )
-        IncidentSubscription.objects.create(incident=incident, user_id=owner.id)
+        IncidentSubscription.objects.create(incident=incident, user_id=owner_id)
         IncidentTrigger.objects.create(
             incident=incident,
             alert_rule_trigger=trigger,
@@ -344,7 +346,7 @@ class BackupTestCase(TransactionTestCase):
 
         # Dashboard
         dashboard = Dashboard.objects.create(
-            title=f"Dashboard 1 for {slug}", created_by_id=owner.id, organization=org
+            title=f"Dashboard 1 for {slug}", created_by_id=owner_id, organization=org
         )
         widget = DashboardWidget.objects.create(
             dashboard=dashboard,
@@ -359,7 +361,7 @@ class BackupTestCase(TransactionTestCase):
         # *Search
         RecentSearch.objects.create(
             organization=org,
-            user_id=owner.id,
+            user_id=owner_id,
             type=SearchType.ISSUE.value,
             query=f"some query for {slug}",
         )


### PR DESCRIPTION
We've accumulated a decent number of special cases for how we do relocation, what with Actors and Teams having circular dependencies, Users auto-creating their UserEmails, the need to sanitize out dangerous models like UserPermissions, etc, etc, etc.

This is a simple refactoring change that uses a roughly "typeclass"-ish pattern: we define two new methods on `BaseModel`, `_normalize_before_relocation_import` to transform the data (no transform by default) and `write_relocation_import` to actually save it to the database. Downstream models that need special logic at either of these stages are then free overwrite one or both of these steps as they please.

The main benefit of this approach is that this logic lives closer to the models it affects, rather than in some farflung section of the codebase. When we make changes to them in the future, relocation logic will be right there, encouraging folks to remember to change how that works (if necessary) as well.