### PR TITLE
feat(backup): Support export scopes

### DIFF
--- a/src/sentry/backup/exports.py
+++ b/src/sentry/backup/exports.py
@@ -8,9 +8,17 @@ from django.core.serializers import serialize
 from django.core.serializers.json import DjangoJSONEncoder
 
 from sentry.backup.dependencies import sorted_dependencies
-from sentry.backup.scopes import RelocationScope
+from sentry.backup.scopes import ExportScope
 
 UTC_0 = timezone(timedelta(hours=0))
+
+__all__ = (
+    "DatetimeSafeDjangoJSONEncoder",
+    "OldExportConfig",
+    "export_in_user_scope",
+    "export_in_organization_scope",
+    "export_in_global_scope",
+)
 
 
 class DatetimeSafeDjangoJSONEncoder(DjangoJSONEncoder):
@@ -41,8 +49,14 @@ class OldExportConfig(NamedTuple):
     use_natural_foreign_keys: bool = False
 
 
-def exports(dest, old_config: OldExportConfig, indent: int, printer=click.echo):
-    """Exports core data for the Sentry installation."""
+def _export(dest, scope: ExportScope, old_config: OldExportConfig, indent: int, printer=click.echo):
+    """
+    Exports core data for the Sentry installation.
+
+    It is generally preferable to avoid calling this function directly, as there are certain combinations of input parameters that should not be used together. Instead, use one of the other wrapper functions in this file, named `export_in_XXX_scope()`.
+    """
+
+    allowed_relocation_scopes = scope.value
 
     def yield_objects():
         # Collate the objects to be serialized.
@@ -56,9 +70,11 @@ def exports(dest, old_config: OldExportConfig, indent: int, printer=click.echo):
             # print(f"Deduced rel scope for {model.__name__}: {inferred_relocation_scope.name}\n")
             includable = old_config.include_non_sentry_models
             if hasattr(model, "__relocation_scope__"):
-                # TODO(getsentry/team-ospo#166): Make this check more precise once we pipe the
-                # `scope` argument through.
-                if getattr(model, "__relocation_scope__") != RelocationScope.Excluded:
+                # TODO(getsentry/team-ospo#186): This won't be sufficient once we're trying to get
+                # relocation scopes that may vary on a per-instance, rather than
+                # per-model-definition, basis. We'll probably need to make use of something like
+                # Django annotations to efficiently filter down models.
+                if getattr(model, "__relocation_scope__") in allowed_relocation_scopes:
                     includable = True
 
             if (
@@ -81,3 +97,25 @@ def exports(dest, old_config: OldExportConfig, indent: int, printer=click.echo):
         use_natural_foreign_keys=old_config.use_natural_foreign_keys,
         cls=DatetimeSafeDjangoJSONEncoder,
     )
+
+
+def export_in_user_scope(src, printer=click.echo):
+    """
+    Perform an export in the `User` scope, meaning that only models with `RelocationScope.User` will be exported from the provided `src` file.
+    """
+    return _export(src, ExportScope.User, OldExportConfig(), 2, printer)
+
+
+def export_in_organization_scope(src, printer=click.echo):
+    """
+    Perform an export in the `Organization` scope, meaning that only models with `RelocationScope.User` or `RelocationScope.Organization` will be exported from the provided `src` file.
+    """
+    return _export(src, ExportScope.Organization, OldExportConfig(), 2, printer)
+
+
+def export_in_global_scope(src, printer=click.echo):
+    """
+    Perform an export in the `Global` scope, meaning that all models will be exported from the
+    provided source file.
+    """
+    return _export(src, ExportScope.Global, OldExportConfig(), 2, printer)

--- a/src/sentry/backup/scopes.py
+++ b/src/sentry/backup/scopes.py
@@ -23,10 +23,23 @@ class RelocationScope(Enum):
 
 
 @unique
+class ExportScope(Enum):
+    """
+    When executing the `sentry export` command, these scopes specify which of the above
+    `RelocationScope`s should be included in the final export. The basic idea is that each of these
+    scopes is inclusive of its predecessor in terms of which `RelocationScope`s it accepts.
+    """
+
+    User = {RelocationScope.User}
+    Organization = {RelocationScope.User, RelocationScope.Organization}
+    Global = {RelocationScope.User, RelocationScope.Organization, RelocationScope.Global}
+
+
+@unique
 class ImportScope(Enum):
     """
     When executing the `sentry import` command, these scopes specify which of the above
-    `RelocationScope`s should be included in the final import. The basic idea is that each of these
+    `RelocationScope`s should be included in the final upload. The basic idea is that each of these
     scopes is inclusive of its predecessor in terms of which `RelocationScope`s it accepts.
     """
 

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import click
 
-from sentry.backup.exports import OldExportConfig, exports
+from sentry.backup.exports import OldExportConfig, _export
 from sentry.backup.imports import OldImportConfig, _import
-from sentry.backup.scopes import ImportScope
+from sentry.backup.scopes import ExportScope, ImportScope
 from sentry.runner.decorators import configuration
 
 
@@ -42,8 +42,9 @@ def export(dest, silent, indent, exclude):
     else:
         exclude = exclude.lower().split(",")
 
-    exports(
+    _export(
         dest,
+        ExportScope.Global,
         OldExportConfig(
             include_non_sentry_models=True,
             excluded_models=set(exclude),

--- a/tests/sentry/backup/test_exports.py
+++ b/tests/sentry/backup/test_exports.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from sentry.backup.helpers import get_exportable_final_derivations_of
+from sentry.backup.scopes import ExportScope
+from sentry.db.models.base import BaseModel
+from sentry.testutils.helpers.backups import BackupTestCase, export_to_file
+from tests.sentry.backup import run_backup_tests_only_on_single_db
+
+
+@run_backup_tests_only_on_single_db
+class ScopingTests(BackupTestCase):
+    """
+    Ensures that only models with the allowed relocation scopes are actually exported.
+    """
+
+    @staticmethod
+    def get_models_for_scope(scope: ExportScope) -> set[str]:
+        matching_models = set()
+        for model in get_exportable_final_derivations_of(BaseModel):
+            if model.__relocation_scope__ in scope.value:
+                obj_name = model._meta.object_name
+                if obj_name is not None:
+                    matching_models.add("sentry." + obj_name.lower())
+        return matching_models
+
+    def test_user_export_scoping(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            matching_models = self.get_models_for_scope(ExportScope.User)
+            self.create_exhaustive_instance(is_superadmin=True)
+            tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
+            data = export_to_file(tmp_path, ExportScope.User)
+
+            for entry in data:
+                model_name = entry["model"]
+                if model_name not in matching_models:
+                    raise AssertionError(
+                        f"Model `${model_name}` was included in export despite not being `Relocation.User`"
+                    )
+
+    def test_organization_export_scoping(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            matching_models = self.get_models_for_scope(ExportScope.Organization)
+            self.create_exhaustive_instance(is_superadmin=True)
+            tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
+            data = export_to_file(tmp_path, ExportScope.Organization)
+
+            for entry in data:
+                model_name = entry["model"]
+                if model_name not in matching_models:
+                    raise AssertionError(
+                        f"Model `${model_name}` was included in export despite not being `Relocation.User` or `Relocation.Organization`"
+                    )


### PR DESCRIPTION
We introduce some wrapper functions that make calling exports correctly a bit easier. Now, instead of calling `exports(...)` directly, the main logic is inside of a private `_export(...)` function, which is wrapped in per-scope `export_in_XXX_scope(...)` functions to match the import API.

Closes getsentry/team-ospo#166