### PR TITLE
chore(ui): Remove pyright as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "prismjs": "^1.29.0",
     "process": "^0.11.10",
     "prop-types": "^15.8.1",
-    "pyright": "1.1.255",
     "qrcode.react": "^3.1.0",
     "query-string": "7.0.1",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9266,11 +9266,6 @@ pure-rand@^6.0.0:
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.2.tgz#a9c2ddcae9b68d736a8163036f088a2781c8b306"
   integrity sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==
 
-pyright@1.1.255:
-  version "1.1.255"
-  resolved "https://registry.yarnpkg.com/pyright/-/pyright-1.1.255.tgz#a0a5e99c9c84bfc93f3f3ac63a1265c8ed85c47d"
-  integrity sha512-pAec1Mqyq0l0+C6JH7o7Va0oWyZVACEFgP2cWD9DU/C1epoqZAt/PCRbae/7fFfn7ZGew5tiTMdtO/2RZO/cRg==
-
 qrcode.react@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/qrcode.react/-/qrcode.react-3.1.0.tgz#5c91ddc0340f768316fbdb8fff2765134c2aecd8"


### PR DESCRIPTION
We stopped using it in https://github.com/getsentry/sentry/pull/51350 and its actually 13mb
