### PR TITLE
fix(hybridcloud) Add affordances for deleted models to db routing

### DIFF
--- a/tests/sentry/db/test_router.py
+++ b/tests/sentry/db/test_router.py
@@ -103,6 +103,14 @@ class SiloRouterSimulatedTest(TestCase):
         assert router.allow_migrate("default", "sentry", Organization)
         assert router.allow_migrate("control", "sentry", User)
 
+    @pytest.mark.skipif(not use_split_dbs(), reason="requires split db mode")
+    @override_settings(SILO_MODE="REGION")
+    def test_removed_region_model(self):
+        router = SiloRouter()
+        assert router.allow_migrate(
+            "default", "sentry", hints={"tables": ["sentry_pagerdutyservice"]}
+        )
+
 
 class SiloRouterIsolatedTest(TestCase):
     """Isolated mode raises errors for the 'other' silo"""
@@ -126,6 +134,8 @@ class SiloRouterIsolatedTest(TestCase):
             router.db_for_write(Organization)
         with pytest.raises(ValueError):
             router.allow_migrate("default", "sentry", Organization)
+        with pytest.raises(ValueError):
+            router.allow_migrate("default", "sentry", tables=["sentry_pagerdutyservice"])
 
     @override_settings(SILO_MODE="REGION")
     def test_for_region(self):
@@ -139,6 +149,9 @@ class SiloRouterIsolatedTest(TestCase):
         assert not router.allow_migrate(
             "default", "sentry", model=None, tables=["jira_ac_tenant"]
         ), "Removed tables end up excluded from migrations"
+        assert router.allow_migrate(
+            "default", "sentry", hints={"tables": ["sentry_pagerdutyservice"]}
+        ), "Historical silo mapped tables can be migrated"
 
         with pytest.raises(ValueError):
             router.db_for_read(User)
@@ -160,3 +173,6 @@ class SiloRouterIsolatedTest(TestCase):
         assert "default" == router.db_for_write(User)
         assert router.allow_migrate("default", "sentry", Organization)
         assert router.allow_migrate("default", "sentry", User)
+        assert router.allow_migrate(
+            "default", "sentry", hints={"tables": ["sentry_pagerdutyservice"]}
+        ), "Historical silo mapped tables can be migrated"


### PR DESCRIPTION
When we remove models from the application we lose the ability to determine which silo the model belonged to. This will cause migrations to fail when building new environments as we no longer have the model class to read the silo assignment from.

When models are removed they can now have their silo assignments frozen into the router to preserve compatibility with historical migrations. This should avoid needing to patch old migrations like in #54781

