### PR TITLE
fix(hybrid-cloud): Fixes issue with international org names causing slug creation failures

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization_actions/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_actions/impl.py
@@ -1,5 +1,6 @@
 import hashlib
 from typing import Optional
+from uuid import uuid4
 
 from django.db import router, transaction
 from django.db.models.expressions import CombinedExpression
@@ -127,7 +128,9 @@ def generate_deterministic_organization_slug(
     # Start by slugifying the original name using django utils
     slugified_base_str = slugify(desired_slug_base)
 
-    assert len(slugified_base_str) > 0, "Slugs must be valid strings that can be ASCII encoded"
+    # If the slug cannot be encoded as ASCII, we need to select a random fallback
+    if len(slugified_base_str) == 0:
+        slugified_base_str = uuid4().hex[0:10]
 
     hashed_org_data = hashlib.md5(
         "/".join([slugified_base_str, desired_org_name, str(owning_user_id)]).encode("utf8")

--- a/tests/sentry/services/test_organization_actions.py
+++ b/tests/sentry/services/test_organization_actions.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from sentry.models import (
@@ -280,12 +282,14 @@ class TestGenerateDeterministicOrganizationSlug(TestCase):
     def test_slug_with_0_length(self):
         unicoded_str = "😅"
 
-        with pytest.raises(AssertionError):
-            generate_deterministic_organization_slug(
-                desired_slug_base=unicoded_str, desired_org_name=unicoded_str, owning_user_id=42
-            )
+        slug = generate_deterministic_organization_slug(
+            desired_slug_base=unicoded_str, desired_org_name=unicoded_str, owning_user_id=42
+        )
 
-        with pytest.raises(AssertionError):
-            generate_deterministic_organization_slug(
-                desired_slug_base="", desired_org_name=unicoded_str, owning_user_id=42
-            )
+        random_slug_regex = re.compile(r"^[a-f0-9]{10}-[a-f0-9]{9}")
+        assert random_slug_regex.match(slug)
+
+        slug = generate_deterministic_organization_slug(
+            desired_slug_base="", desired_org_name=unicoded_str, owning_user_id=42
+        )
+        assert random_slug_regex.match(slug)


### PR DESCRIPTION
Unicode encoded slugs that can't cleanly be converted to ASCII are currently failing to provision orgs. While this is intended in some cases, it is not meant to bar international customers from provisioning orgs. This makes the `deterministic slug` generating method take a best effort approach, with a random fallback if the conversion fails.

