### PR TITLE
ref(rules): Pre-save rules w/o condition names

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -18,6 +20,18 @@ from sentry.rules.processor import is_condition_slow
 from sentry.signals import alert_rule_created
 from sentry.tasks.integrations.slack import find_channel_id_for_rule
 from sentry.web.decorators import transaction_start
+
+
+def clean_rule_data(data):
+    for datum in data:
+        if datum.get("name"):
+            del datum["name"]
+
+
+@receiver(pre_save, sender=Rule)
+def pre_save_rule(instance, sender, *args, **kwargs):
+    clean_rule_data(instance.data.get("conditions", []))
+    clean_rule_data(instance.data.get("conditions", []))
 
 
 @region_silo_endpoint

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -31,7 +31,7 @@ def clean_rule_data(data):
 @receiver(pre_save, sender=Rule)
 def pre_save_rule(instance, sender, *args, **kwargs):
     clean_rule_data(instance.data.get("conditions", []))
-    clean_rule_data(instance.data.get("conditions", []))
+    clean_rule_data(instance.data.get("actions", []))
 
 
 @region_silo_endpoint

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -109,7 +109,6 @@ class SlackTasksTest(TestCase):
                 "channel": "#my-channel",
                 "channel_id": "chan-id",
                 "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
-                "name": "Send a notification to the funinthesun Slack workspace to #secrets and show tags [] in notification",
                 "tags": "",
                 "workspace": self.integration.id,
             }
@@ -158,7 +157,6 @@ class SlackTasksTest(TestCase):
                 "channel": "#my-channel",
                 "channel_id": "chan-id",
                 "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
-                "name": "Send a notification to the funinthesun Slack workspace to #secrets and show tags [] in notification",
                 "tags": "",
                 "workspace": self.integration.id,
             }

--- a/tests/sentry/mediators/project_rules/test_creator.py
+++ b/tests/sentry/mediators/project_rules/test_creator.py
@@ -48,7 +48,6 @@ class TestCreator(TestCase):
             "actions": [
                 {
                     "id": "sentry.rules.actions.notify_event.NotifyEventAction",
-                    "name": "Send a notification (for all legacy integrations)",
                 }
             ],
             "conditions": [

--- a/tests/sentry/mediators/project_rules/test_updater.py
+++ b/tests/sentry/mediators/project_rules/test_updater.py
@@ -63,7 +63,6 @@ class TestUpdater(TestCase):
         assert self.rule.data["actions"] == [
             {
                 "id": "sentry.rules.actions.notify_event.NotifyEventAction",
-                "name": "Send a notification (for all legacy integrations)",
             }
         ]
 


### PR DESCRIPTION
Add a `pre_save` signal to `Rule` to hopefully actually prevent any `name` data being save in the conditions part of rule.data. Everything should have been covered in https://github.com/getsentry/sentry/pull/54746/files but looking at production data since that was deployed shows an edge case where sometimes it's still being saved that I can't replicate. 

Closes #55112 