### PR TITLE
ref(rules): Add status to Rule response

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from django.db.models import Q
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -26,9 +25,7 @@ from sentry.models.integrations.sentry_app_installation import (
     SentryAppInstallation,
     prepare_ui_component,
 )
-from sentry.models.rulesnooze import RuleSnooze
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
-from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.signals import alert_rule_edited
 from sentry.tasks.integrations.slack import find_channel_id_for_rule
 from sentry.web.decorators import transaction_start
@@ -89,22 +86,6 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
 
         if len(errors):
             serialized_rule["errors"] = errors
-
-        rule_snooze = RuleSnooze.objects.filter(
-            Q(user_id=request.user.id) | Q(user_id=None), rule=rule
-        )
-        if rule_snooze.exists():
-            serialized_rule["snooze"] = True
-            snooze = rule_snooze[0]
-            if request.user.id == snooze.owner_id:
-                created_by = "You"
-            else:
-                creator_name = user_service.get_user(snooze.owner_id).get_display_name()
-                created_by = creator_name
-            serialized_rule["snoozeCreatedBy"] = created_by
-            serialized_rule["snoozeForEveryone"] = snooze.user_id is None
-        else:
-            serialized_rule["snooze"] = False
 
         return Response(serialized_rule)
 

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -174,6 +174,7 @@ class RuleSerializer(Serializer):
             "createdBy": attrs.get("created_by", None),
             "environment": environment.name if environment is not None else None,
             "projects": [obj.project.slug],
+            "status": obj.status,
         }
         if "last_triggered" in attrs:
             d["lastTriggered"] = attrs["last_triggered"]

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -116,6 +116,7 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
         )
         assert response.data["id"] == str(self.rule.id)
         assert response.data["environment"] == self.environment.name
+        assert response.data["status"] == 0
 
     def test_with_filters(self):
         conditions: list[dict[str, Any]] = [

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -116,7 +116,7 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
         )
         assert response.data["id"] == str(self.rule.id)
         assert response.data["environment"] == self.environment.name
-        assert response.data["status"] == 0
+        assert response.data["status"] == ObjectStatus.ACTIVE
 
     def test_with_filters(self):
         conditions: list[dict[str, Any]] = [

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -3,6 +3,7 @@ from sentry.api.serializers.models.alert_rule import (
     CombinedRuleSerializer,
     DetailedAlertRuleSerializer,
 )
+from sentry.constants import ObjectStatus
 from sentry.incidents.logic import create_alert_rule_trigger
 from sentry.incidents.models import AlertRule, AlertRuleThresholdType
 from sentry.models import Rule
@@ -220,4 +221,6 @@ class CombinedRuleSerializerTest(BaseAlertRuleSerializerTest, APITestCase, TestC
 
         self.assert_alert_rule_serialized(alert_rule, result[0])
         assert result[1]["id"] == str(issue_rule.id)
+        assert result[1]["status"] == ObjectStatus.ACTIVE
+        assert not result[1]["snooze"]
         self.assert_alert_rule_serialized(other_alert_rule, result[2])


### PR DESCRIPTION
Add the `status` to the Rule response for both individual issue alert rules and issue alert rules returned in the combined rule endpoint.

Closes #55098 