### PR TITLE
feat(issues): Add environment to regression activity

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1979,9 +1979,11 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
             )
 
     if is_regression:
+        environment_name = event.get_tag("environment")
         activity_data: dict[str, str | bool] = {
             "event_id": event.event_id,
             "version": release.version if release else "",
+            "environment": environment_name if environment_name else "",
         }
         if resolved_in_activity and release:
             activity_data.update(


### PR DESCRIPTION
We're storing the release version and if the project is using semver. This stores the regression environment. It can be helpful to know which of your environments caused a regression.

Our alerts say `issue x regressed in release y in environment z`. We should have something similar in the activity feed