### PR TITLE
fix(replay): Fix Replay DOM Tab loading status and new indicator

### DIFF
--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -15,6 +15,7 @@ import type ReplayReader from 'sentry/utils/replays/replayReader';
 import DomFilters from 'sentry/views/replays/detail/domMutations/domFilters';
 import DomMutationRow from 'sentry/views/replays/detail/domMutations/domMutationRow';
 import useDomFilters from 'sentry/views/replays/detail/domMutations/useDomFilters';
+import FilterLoadingIndicator from 'sentry/views/replays/detail/filterLoadingIndicator';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
 import TabItemContainer from 'sentry/views/replays/detail/tabItemContainer';
@@ -41,7 +42,7 @@ function useExtractedDomNodes({replay}: {replay: null | ReplayReader}) {
 }
 
 function DomMutations({replay, startTimestampMs}: Props) {
-  const {data: actions, isLoading} = useExtractedDomNodes({replay});
+  const {data: actions, isFetching} = useExtractedDomNodes({replay});
   const {currentTime, currentHoverTime} = useReplayContext();
   const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
 
@@ -85,9 +86,11 @@ function DomMutations({replay, startTimestampMs}: Props) {
 
   return (
     <FluidHeight>
-      <DomFilters actions={actions} {...filterProps} />
+      <FilterLoadingIndicator isLoading={isFetching}>
+        <DomFilters actions={actions} {...filterProps} />
+      </FilterLoadingIndicator>
       <TabItemContainer data-test-id="replay-details-dom-events-tab">
-        {isLoading || !actions ? (
+        {isFetching || !actions ? (
           <Placeholder height="100%" />
         ) : (
           <AutoSizer onResize={updateList}>

--- a/static/app/views/replays/detail/filterLoadingIndicator.tsx
+++ b/static/app/views/replays/detail/filterLoadingIndicator.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export default function FilterLoadingIndicator({children, isLoading}: Props) {
   return (
-    <Wrapper style={{}}>
+    <Wrapper>
       {children}
       {isLoading ? (
         <Tooltip title={t('Data is still loading')}>

--- a/static/app/views/replays/detail/filterLoadingIndicator.tsx
+++ b/static/app/views/replays/detail/filterLoadingIndicator.tsx
@@ -1,0 +1,31 @@
+import {ReactNode} from 'react';
+import styled from '@emotion/styled';
+
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+interface Props {
+  children: ReactNode;
+  isLoading: boolean;
+}
+
+export default function FilterLoadingIndicator({children, isLoading}: Props) {
+  return (
+    <Wrapper style={{}}>
+      {children}
+      {isLoading ? (
+        <Tooltip title={t('Data is still loading')}>
+          <LoadingIndicator mini />
+        </Tooltip>
+      ) : null}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  gap: ${space(1)};
+`;

--- a/static/app/views/replays/detail/filtersGrid.tsx
+++ b/static/app/views/replays/detail/filtersGrid.tsx
@@ -5,6 +5,7 @@ import {space} from 'sentry/styles/space';
 
 const FiltersGrid = styled('div')`
   display: grid;
+  flex-grow: 1;
   gap: ${space(1)};
   grid-template-columns:
     repeat(${p => Children.toArray(p.children).length - 1}, max-content)


### PR DESCRIPTION
<img width="605" alt="SCR-20230820-mvol" src="https://github.com/getsentry/sentry/assets/187460/167b3d43-91a4-451f-8179-8c7cf31a7fa0">
<img width="610" alt="SCR-20230820-mvqc" src="https://github.com/getsentry/sentry/assets/187460/bd3f6807-7502-48d2-a43e-3831c5221ed9">
