### PR TITLE
fix(bootstrap): Use Mac 13.x for bootstrap cron

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   bootstrap-script:
     name: bootstrap
-    runs-on: macos-11
-    timeout-minutes: 45
+    runs-on: macos-13
+    timeout-minutes: 30
     steps:
       - name: Run bootstrap scripts
         run: |


### PR DESCRIPTION
This cron job was used to determine if bootstrapping new engineers would fail because external tooling on new Macs has changed.

Recently https://github.com/getsentry/bootstrap-sentry/pull/53 was merged and caused this check to fail.

I noticed this by chance. @asottile-sentry could you please Slack me? I have some thoughts on how to be alerted about this.