### PR TITLE
fix(github-growth): allow repo transfer within org

### DIFF
--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -89,10 +89,9 @@ class IntegrationRepositoryProvider:
         external_id = result.get("external_id")
         name = result.get("name")
 
-        # first check if there is an existing hidden repository with an integration that matches
+        # first check if there is an existing hidden repository for the organization and external id
         repositories = repository_service.get_repositories(
             organization_id=organization.id,
-            integration_id=integration_id,
             external_id=external_id,
             status=ObjectStatus.HIDDEN,
         )
@@ -100,6 +99,7 @@ class IntegrationRepositoryProvider:
         if existing_repo:
             existing_repo.status = ObjectStatus.ACTIVE
             existing_repo.name = name
+            existing_repo.integration_id = integration_id
             repository_service.update_repository(
                 organization_id=organization.id, update=existing_repo
             )

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -45,15 +45,20 @@ class IntegrationRepositoryTestCase(TestCase):
     def provider(self):
         return GitHubRepositoryProvider("integrations:github")
 
-    def _create_repo(self, external_id=None, name=None):
+    def _create_repo(
+        self, external_id=None, name=None, status=ObjectStatus.ACTIVE, integration_id=None
+    ):
+        if not name:
+            name = self.repo_name
         return Repository.objects.create(
-            name=name if name else self.repo_name,
+            name=name,
             provider="integrations:github",
             organization_id=self.organization.id,
-            integration_id=self.integration.id,
-            url="https://github.com/" + self.repo_name,
-            config={"name": self.repo_name},
+            integration_id=integration_id if integration_id else self.integration.id,
+            url="https://github.com/" + name,
+            config={"name": name},
             external_id=external_id if external_id else "123456",
+            status=status,
         )
 
     def test_create_repository(self, get_jwt):
@@ -70,6 +75,20 @@ class IntegrationRepositoryTestCase(TestCase):
 
         with pytest.raises(RepoExistsError):
             self.provider.create_repository(self.config, self.organization)
+
+    def test_create_repository__transfer_repo_in_org(self, get_jwt):
+        # can transfer a disabled repo from one integration to another in a single org
+        integration = self.create_integration(
+            organization=self.organization, provider="github", external_id="123456"
+        )
+        self._create_repo(
+            external_id=self.config["external_id"],
+            name="getsentry/santry",
+            status=ObjectStatus.DISABLED,
+            integration_id=integration.id,
+        )
+
+        self.provider.create_repository(self.config, self.organization)
 
     def test_create_repository__repo_exists_update_name(self, get_jwt):
         repo = self._create_repo(external_id=self.config["external_id"], name="getsentry/santry")


### PR DESCRIPTION
Now that there can be repos with status `ObjectStatus.DISABLED` within an organization, we should allow for transferring repos between integrations if an existing matching repo with the same `external_id` has been disabled.