### PR TITLE
ref: fix test pollution caused by superuser global request

### DIFF
--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -172,20 +172,20 @@ class ProjectSerializerTest(TestCase):
         req = self.make_request()
         req.user = self.user
         req.superuser.set_logged_in(req.user)
-        env.request = req
 
-        result = serialize(self.project, self.user)
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is False
+        with mock.patch.object(env, "request", req):
+            result = serialize(self.project, self.user)
+            assert result["access"] == TEAM_ADMIN["scopes"]
+            assert result["hasAccess"] is True
+            assert result["isMember"] is False
 
-        self.organization.flags.allow_joinleave = False
-        self.organization.save()
-        result = serialize(self.project, self.user)
-        # after changing to allow_joinleave=False
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is False
+            self.organization.flags.allow_joinleave = False
+            self.organization.save()
+            result = serialize(self.project, self.user)
+            # after changing to allow_joinleave=False
+            assert result["access"] == TEAM_ADMIN["scopes"]
+            assert result["hasAccess"] is True
+            assert result["isMember"] is False
 
     def test_member_on_owner_team(self):
         organization = self.create_organization()

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.conf import settings
 
 from sentry.api.serializers import serialize
@@ -235,22 +237,22 @@ class TeamSerializerTest(TestCase):
         req = self.make_request()
         req.user = user
         req.superuser.set_logged_in(req.user)
-        env.request = req
 
-        result = serialize(team, user)
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is False
-        assert result["teamRole"] is None
+        with mock.patch.object(env, "request", req):
+            result = serialize(team, user)
+            assert result["access"] == TEAM_ADMIN["scopes"]
+            assert result["hasAccess"] is True
+            assert result["isMember"] is False
+            assert result["teamRole"] is None
 
-        organization.flags.allow_joinleave = False
-        organization.save()
-        result = serialize(team, user)
-        # after changing to allow_joinleave=False
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is False
-        assert result["teamRole"] is None
+            organization.flags.allow_joinleave = False
+            organization.save()
+            result = serialize(team, user)
+            # after changing to allow_joinleave=False
+            assert result["access"] == TEAM_ADMIN["scopes"]
+            assert result["hasAccess"] is True
+            assert result["isMember"] is False
+            assert result["teamRole"] is None
 
     def test_member_on_owner_team(self):
         user = self.create_user(username="foo")


### PR DESCRIPTION
previously:

```console
$ pytest tests/sentry/api/serializers/test_team.py::TeamSerializerTest::test_superuser tests/sentry/manager/test_project_manager.py::ProjectManagerTest__InRegionMode::test_get_for_user
============================= test session starts ==============================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: fail-slow-0.3.0, rerunfailures-11.0, sentry-0.1.11, xdist-3.0.2, cov-4.0.0, repeat-0.9.1, django-4.4.0
collected 2 items                                                              

tests/sentry/api/serializers/test_team.py .                              [ 50%]
tests/sentry/manager/test_project_manager.py F                           [100%]

=================================== FAILURES ===================================
______________ ProjectManagerTest__InRegionMode.test_get_for_user ______________
tests/sentry/manager/test_project_manager.py:29: in test_get_for_user
    assert result == []
E   AssertionError: assert [<Project at ..., slug='foo'>] == []
E     Left contains 2 more items, first extra item: <Project at 0x1269499d0: id=4552491687542804, team_id=None, name='baz', slug='baz'>
E     Use -v to get more diff
=========================== short test summary info ============================
FAILED tests/sentry/manager/test_project_manager.py::ProjectManagerTest__InRegionMode::test_get_for_user - AssertionError: assert [<Project at ..., slug='foo'>] == []
========================= 1 failed, 1 passed in 4.39s ==========================
```