### PR TITLE
feat(apis): Add publish status to all endpoints

### DIFF
--- a/src/sentry/api/api_publish_status.py
+++ b/src/sentry/api/api_publish_status.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class ApiPublishStatus(Enum):
+    """
+    Used to track if an API is publicly documented
+    """
+
+    UNKNOWN = "unknown"
+    PUBLIC = "public"
+    PRIVATE = "private"
+    EXPERIMENTAL = "experimental"

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -25,7 +25,7 @@ from sentry_sdk import Scope
 from sentry import analytics, options, tsdb
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.apidocs.hooks import HTTP_METHODS_SET
+from sentry.apidocs.hooks import HTTP_METHOD_NAME, HTTP_METHODS_SET
 from sentry.auth import access
 from sentry.models import Environment
 from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
@@ -156,8 +156,7 @@ class Endpoint(APIView):
 
     public: Optional[HTTP_METHODS_SET] = None
     owner: ApiOwner = ApiOwner.UNOWNED
-    publish_status: {HTTP_METHODS_SET: ApiPublishStatus} = {}
-
+    publish_status: dict[HTTP_METHOD_NAME, ApiPublishStatus] = {}
     rate_limits: RateLimitConfig | dict[
         str, dict[RateLimitCategory, RateLimit]
     ] = DEFAULT_RATE_LIMIT_CONFIG

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -24,6 +24,7 @@ from sentry_sdk import Scope
 
 from sentry import analytics, options, tsdb
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.apidocs.hooks import HTTP_METHODS_SET
 from sentry.auth import access
 from sentry.models import Environment
@@ -155,6 +156,7 @@ class Endpoint(APIView):
 
     public: Optional[HTTP_METHODS_SET] = None
     owner: ApiOwner = ApiOwner.UNOWNED
+    publish_status: [{HTTP_METHODS_SET: ApiPublishStatus}] = []
 
     rate_limits: RateLimitConfig | dict[
         str, dict[RateLimitCategory, RateLimit]

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -156,7 +156,7 @@ class Endpoint(APIView):
 
     public: Optional[HTTP_METHODS_SET] = None
     owner: ApiOwner = ApiOwner.UNOWNED
-    publish_status: [{HTTP_METHODS_SET: ApiPublishStatus}] = []
+    publish_status: {HTTP_METHODS_SET: ApiPublishStatus} = {}
 
     rate_limits: RateLimitConfig | dict[
         str, dict[RateLimitCategory, RateLimit]

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.invite_helper import (
     ApiInviteHelper,
@@ -66,6 +67,10 @@ def get_invite_state(
 
 @control_silo_endpoint
 class AcceptOrganizationInvite(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     # Disable authentication and permission requirements.
     permission_classes = []
 

--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
@@ -24,6 +25,10 @@ class InvalidPayload(Exception):
 
 @region_silo_endpoint
 class AcceptProjectTransferEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 

--- a/src/sentry/api/endpoints/actionable_items.py
+++ b/src/sentry/api/endpoints/actionable_items.py
@@ -7,6 +7,7 @@ from typing_extensions import TypedDict
 
 from sentry import eventstore, features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.actionable_items_helper import (
@@ -37,6 +38,9 @@ class SourceMapProcessingResponse(TypedDict):
 # errors or messages we show to users about problems with their event which we will show the user how to fix.
 @region_silo_endpoint
 class ActionableItemsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ISSUES
 
     def has_feature(self, organization: Organization, request: Request):

--- a/src/sentry/api/endpoints/admin_project_configs.py
+++ b/src/sentry/api/endpoints/admin_project_configs.py
@@ -2,6 +2,7 @@ from django.http import Http404
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.models import Project
@@ -10,6 +11,9 @@ from sentry.relay import projectconfig_cache
 
 @region_silo_endpoint
 class AdminRelayProjectConfigsEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/api_application_details.py
+++ b/src/sentry/api/endpoints/api_application_details.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import ListField
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
@@ -33,6 +34,11 @@ class ApiApplicationSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class ApiApplicationDetailsEndpoint(Endpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 

--- a/src/sentry/api/endpoints/api_application_rotate_secret.py
+++ b/src/sentry/api/endpoints/api_application_rotate_secret.py
@@ -3,6 +3,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
@@ -12,6 +13,9 @@ from sentry.models.apiapplication import generate_token
 
 @control_silo_endpoint
 class ApiApplicationRotateSecretEndpoint(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 

--- a/src/sentry/api/endpoints/api_applications.py
+++ b/src/sentry/api/endpoints/api_applications.py
@@ -3,6 +3,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -11,6 +12,10 @@ from sentry.models import ApiApplication, ApiApplicationStatus
 
 @control_silo_endpoint
 class ApiApplicationsEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 

--- a/src/sentry/api/endpoints/api_authorizations.py
+++ b/src/sentry/api/endpoints/api_authorizations.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -13,6 +14,10 @@ from sentry.models import ApiApplicationStatus, ApiAuthorization, ApiToken
 
 @control_silo_endpoint
 class ApiAuthorizationsEndpoint(Endpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)

--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import SessionNoAuthTokenAuthentication
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.fields import MultipleChoiceField
@@ -22,6 +23,11 @@ class ApiTokenSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class ApiTokensEndpoint(Endpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = (SessionNoAuthTokenAuthentication,)
     permission_classes = (IsAuthenticated,)
 

--- a/src/sentry/api/endpoints/artifact_bundles.py
+++ b/src/sentry/api/endpoints/artifact_bundles.py
@@ -9,6 +9,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist, SentryAPIException
@@ -52,6 +53,10 @@ class ArtifactBundlesMixin:
 
 @region_silo_endpoint
 class ArtifactBundlesEndpoint(ProjectEndpoint, ArtifactBundlesMixin):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def get(self, request: Request, project) -> Response:

--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -8,6 +8,7 @@ from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import SymbolicError
 
 from sentry import ratelimits
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.endpoints.debug_files import has_download_permission
@@ -32,6 +33,9 @@ MAX_RELEASEFILES_QUERY = 10
 
 @region_silo_endpoint
 class ProjectArtifactLookupEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def download_file(self, download_id, project: Project):

--- a/src/sentry/api/endpoints/assistant.py
+++ b/src/sentry/api/endpoints/assistant.py
@@ -9,6 +9,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.assistant import manager
 from sentry.models import AssistantActivity
@@ -55,6 +56,10 @@ class AssistantSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class AssistantEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (IsAuthenticated,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/auth_config.py
+++ b/src/sentry/api/endpoints/auth_config.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 
 from sentry import newsletter
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.constants import WARN_SESSION_EXPIRED
 from sentry.http import get_server_hostname
@@ -22,6 +23,9 @@ from sentry.web.frontend.base import OrganizationMixin
 
 @control_silo_endpoint
 class AuthConfigEndpoint(Endpoint, OrganizationMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     # Disable authentication and permission requirements.
     permission_classes = []

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import QuietBasicAuthentication
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.exceptions import SsoRequired
@@ -40,6 +41,12 @@ DISABLE_SU_FORM_U2F_CHECK_FOR_LOCAL = getattr(
 
 @control_silo_endpoint
 class AuthIndexEndpoint(Endpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     """
     Manage session authentication
 

--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 
 from sentry import ratelimits as ratelimiter
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.user import DetailedSelfUserSerializer
@@ -17,6 +18,9 @@ from sentry.web.frontend.base import OrganizationMixin
 
 @control_silo_endpoint
 class AuthLoginEndpoint(Endpoint, OrganizationMixin):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     # Disable authentication and permission requirements.
     permission_classes = []

--- a/src/sentry/api/endpoints/authenticator_index.py
+++ b/src/sentry/api/endpoints/authenticator_index.py
@@ -5,12 +5,16 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.models import Authenticator
 
 
 @control_silo_endpoint
 class AuthenticatorIndexEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (IsAuthenticated,)
 

--- a/src/sentry/api/endpoints/avatar/doc_integration.py
+++ b/src/sentry/api/endpoints/avatar/doc_integration.py
@@ -1,3 +1,4 @@
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.avatar import AvatarMixin
 from sentry.api.bases.doc_integrations import DocIntegrationBaseEndpoint
@@ -7,6 +8,10 @@ from sentry.models import DocIntegrationAvatar
 
 @control_silo_endpoint
 class DocIntegrationAvatarEndpoint(AvatarMixin, DocIntegrationBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     object_type = "doc_integration"
     model = DocIntegrationAvatar
     serializer_cls = DocIntegrationAvatarSerializer

--- a/src/sentry/api/endpoints/avatar/organization.py
+++ b/src/sentry/api/endpoints/avatar/organization.py
@@ -1,3 +1,4 @@
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.avatar import AvatarMixin
 from sentry.api.bases.organization import OrganizationEndpoint
@@ -6,6 +7,10 @@ from sentry.models import OrganizationAvatar
 
 @region_silo_endpoint
 class OrganizationAvatarEndpoint(AvatarMixin, OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     object_type = "organization"
     model = OrganizationAvatar
 

--- a/src/sentry/api/endpoints/avatar/project.py
+++ b/src/sentry/api/endpoints/avatar/project.py
@@ -1,3 +1,4 @@
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.avatar import AvatarMixin
 from sentry.api.bases.project import ProjectEndpoint
@@ -6,5 +7,9 @@ from sentry.models import ProjectAvatar
 
 @region_silo_endpoint
 class ProjectAvatarEndpoint(AvatarMixin, ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     object_type = "project"
     model = ProjectAvatar

--- a/src/sentry/api/endpoints/avatar/sentry_app.py
+++ b/src/sentry/api/endpoints/avatar/sentry_app.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppBaseEndpoint
 from sentry.api.bases.avatar import AvatarMixin
@@ -10,6 +11,10 @@ from sentry.models import SentryAppAvatar
 
 @control_silo_endpoint
 class SentryAppAvatarEndpoint(AvatarMixin, SentryAppBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     object_type = "sentry_app"
     model = SentryAppAvatar
     serializer_cls = SentryAppAvatarSerializer

--- a/src/sentry/api/endpoints/avatar/team.py
+++ b/src/sentry/api/endpoints/avatar/team.py
@@ -1,3 +1,4 @@
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.avatar import AvatarMixin
 from sentry.api.bases.team import TeamEndpoint
@@ -6,5 +7,9 @@ from sentry.models import TeamAvatar
 
 @region_silo_endpoint
 class TeamAvatarEndpoint(AvatarMixin, TeamEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     object_type = "team"
     model = TeamAvatar

--- a/src/sentry/api/endpoints/avatar/user.py
+++ b/src/sentry/api/endpoints/avatar/user.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import options
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.avatar import AvatarMixin
 from sentry.api.bases.user import UserEndpoint
@@ -13,6 +14,10 @@ from sentry.services.hybrid_cloud.user.service import user_service
 
 @control_silo_endpoint
 class UserAvatarEndpoint(AvatarMixin, UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     object_type = "user"
     model = UserAvatar
 

--- a/src/sentry/api/endpoints/broadcast_details.py
+++ b/src/sentry/api/endpoints/broadcast_details.py
@@ -5,6 +5,7 @@ from django.db.models import Q
 from django.utils import timezone
 from rest_framework.permissions import IsAuthenticated
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import AdminBroadcastSerializer, BroadcastSerializer, serialize
@@ -20,6 +21,10 @@ from rest_framework.response import Response
 
 @control_silo_endpoint
 class BroadcastDetailsEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (IsAuthenticated,)
 
     def _get_broadcast(self, request: Request, broadcast_id):

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -8,6 +8,7 @@ from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from django.utils import timezone
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import DateTimePaginator
@@ -27,6 +28,11 @@ from rest_framework.response import Response
 
 @control_silo_endpoint
 class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationPermission,)
 
     def _get_serializer(self, request: Request):

--- a/src/sentry/api/endpoints/builtin_symbol_sources.py
+++ b/src/sentry/api/endpoints/builtin_symbol_sources.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.serializers import serialize
 
@@ -17,6 +18,9 @@ def normalize_symbol_source(key, source):
 
 @region_silo_endpoint
 class BuiltinSymbolSourcesEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = ()
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/check_am2_compatibility.py
+++ b/src/sentry/api/endpoints/check_am2_compatibility.py
@@ -2,6 +2,7 @@ import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.tasks.check_am2_compatibility import (
@@ -14,6 +15,9 @@ from sentry.tasks.check_am2_compatibility import (
 
 @region_silo_endpoint
 class CheckAM2CompatibilityEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 
 from sentry import options
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
 from sentry.models import FileBlob
@@ -46,6 +47,10 @@ class GzipChunk(BytesIO):
 
 @region_silo_endpoint
 class ChunkUploadEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.OWNERS_NATIVE
     permission_classes = (OrganizationReleasePermission,)
     rate_limits = RateLimitConfig(group="CLI")

--- a/src/sentry/api/endpoints/codeowners/details.py
+++ b/src/sentry/api/endpoints/codeowners/details.py
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -23,6 +24,11 @@ logger = logging.getLogger(__name__)
 
 @region_silo_endpoint
 class ProjectCodeOwnersDetailsEndpoint(ProjectEndpoint, ProjectCodeOwnersMixin):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def convert_args(
         self,
         request: Request,

--- a/src/sentry/api/endpoints/codeowners/external_actor/team_details.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/team_details.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalTeamSerializer
 from sentry.api.bases.team import TeamEndpoint
@@ -16,6 +17,11 @@ logger = logging.getLogger(__name__)
 
 @region_silo_endpoint
 class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def convert_args(
         self,
         request: Request,

--- a/src/sentry/api/endpoints/codeowners/external_actor/team_index.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/team_index.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalTeamSerializer
 from sentry.api.bases.team import TeamEndpoint
@@ -15,6 +16,10 @@ logger = logging.getLogger(__name__)
 
 @region_silo_endpoint
 class ExternalTeamEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def post(self, request: Request, team: Team) -> Response:
         """
         Create an External Team

--- a/src/sentry/api/endpoints/codeowners/external_actor/user_details.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/user_details.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalUserSerializer
 from sentry.api.bases.organization import OrganizationEndpoint
@@ -18,6 +19,11 @@ logger = logging.getLogger(__name__)
 
 @control_silo_endpoint
 class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def convert_args(  # type: ignore[override]
         self,
         request: Request,

--- a/src/sentry/api/endpoints/codeowners/external_actor/user_index.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/user_index.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalUserSerializer
@@ -15,6 +16,10 @@ logger = logging.getLogger(__name__)
 
 @region_silo_endpoint
 class ExternalUserEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def post(self, request: Request, organization: Organization) -> Response:
         """
         Create an External User

--- a/src/sentry/api/endpoints/codeowners/index.py
+++ b/src/sentry/api/endpoints/codeowners/index.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
@@ -17,6 +18,11 @@ from . import ProjectCodeOwnerSerializer, ProjectCodeOwnersMixin
 
 @region_silo_endpoint
 class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectCodeOwnersMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def add_owner_id_to_schema(self, codeowner: ProjectCodeOwners, project: Project) -> None:
         if not hasattr(codeowner, "schema") or (
             codeowner.schema

--- a/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
+++ b/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from sentry_relay.processing import pii_selector_suggestions_from_event
 
 from sentry import nodestore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.eventstore.models import Event
@@ -12,6 +13,10 @@ from sentry.eventstore.models import Event
 
 @region_silo_endpoint
 class DataScrubbingSelectorSuggestionsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         """
         Generate a list of data scrubbing selectors from existing event data.

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -15,6 +15,7 @@ from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import SymbolicError
 
 from sentry import ratelimits, roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -88,6 +89,10 @@ def has_download_permission(request, project):
 
 @region_silo_endpoint
 class ProguardArtifactReleasesEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def post(self, request: Request, project) -> Response:
@@ -165,6 +170,11 @@ class ProguardArtifactReleasesEndpoint(ProjectEndpoint):
 
 @region_silo_endpoint
 class DebugFilesEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def download(self, debug_file_id, project):
@@ -340,6 +350,9 @@ class DebugFilesEndpoint(ProjectEndpoint):
 
 @region_silo_endpoint
 class UnknownDebugFilesEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def get(self, request: Request, project) -> Response:
@@ -350,6 +363,9 @@ class UnknownDebugFilesEndpoint(ProjectEndpoint):
 
 @region_silo_endpoint
 class AssociateDSymFilesEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     # Legacy endpoint, kept for backwards compatibility
@@ -359,6 +375,9 @@ class AssociateDSymFilesEndpoint(ProjectEndpoint):
 
 @region_silo_endpoint
 class DifAssembleEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def post(self, request: Request, project) -> Response:
@@ -477,6 +496,10 @@ class DifAssembleEndpoint(ProjectEndpoint):
 
 @region_silo_endpoint
 class SourceMapsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def get(self, request: Request, project) -> Response:

--- a/src/sentry/api/endpoints/event_ai_suggested_fix.py
+++ b/src/sentry/api/endpoints/event_ai_suggested_fix.py
@@ -7,6 +7,7 @@ from django.dispatch import Signal
 from django.http import HttpResponse, StreamingHttpResponse
 
 from sentry import eventstore, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -274,6 +275,9 @@ def reduce_stream(response):
 
 @region_silo_endpoint
 class EventAiSuggestedFixEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
     # go away
     private = True
     enforce_rate_limit = True

--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -2,6 +2,7 @@ from django.http import HttpResponse, StreamingHttpResponse
 from rest_framework.request import Request
 
 from sentry import eventstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -11,6 +12,10 @@ from sentry.utils.safe import get_path
 
 @region_silo_endpoint
 class EventAppleCrashReportEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, event_id) -> HttpResponse:
         """
         Retrieve an Apple Crash Report from an event

--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore, features, roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.serializers import serialize
@@ -45,6 +46,10 @@ class EventAttachmentDetailsPermission(ProjectPermission):
 
 @region_silo_endpoint
 class EventAttachmentDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (EventAttachmentDetailsPermission,)
 
     def download(self, attachment):

--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -12,6 +13,10 @@ from sentry.search.utils import tokenize_query
 
 @region_silo_endpoint
 class EventAttachmentsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, event_id) -> Response:
         """
         Retrieve attachments for an event

--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.models import Commit, Group, Release
@@ -11,6 +12,10 @@ from sentry.utils.committers import get_serialized_event_file_committers
 
 @region_silo_endpoint
 class EventFileCommittersEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, event_id) -> Response:
         """
         Retrieve Committer information for an event

--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -3,6 +3,7 @@ import logging
 from django.http import HttpRequest, HttpResponse
 
 from sentry import eventstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -16,6 +17,10 @@ logger = logging.getLogger(__name__)
 
 @region_silo_endpoint
 class EventGroupingInfoEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: HttpRequest, project, event_id) -> HttpResponse:
         """
         Returns the grouping information for an event

--- a/src/sentry/api/endpoints/event_owners.py
+++ b/src/sentry/api/endpoints/event_owners.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
@@ -12,6 +13,10 @@ from sentry.models.projectownership import ProjectOwnership
 
 @region_silo_endpoint
 class EventOwnersEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, event_id) -> Response:
         """
         Retrieve suggested owners information for an event

--- a/src/sentry/api/endpoints/event_reprocessable.py
+++ b/src/sentry/api/endpoints/event_reprocessable.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.reprocessing2 import CannotReprocess, pull_event_data
@@ -10,6 +11,10 @@ from sentry.reprocessing2 import CannotReprocess, pull_event_data
 
 @region_silo_endpoint
 class EventReprocessableEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, event_id) -> Response:
         """
         Retrieve information about whether an event can be reprocessed.

--- a/src/sentry/api/endpoints/filechange.py
+++ b/src/sentry/api/endpoints/filechange.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -12,6 +13,10 @@ from sentry.models.commitfilechange import CommitFileChange
 
 @region_silo_endpoint
 class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, version) -> Response:
         """
         Retrieve Files Changed in a Release's Commits

--- a/src/sentry/api/endpoints/group_activities.py
+++ b/src/sentry/api/endpoints/group_activities.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import serialize
@@ -9,6 +10,10 @@ from sentry.models import Activity
 
 @region_silo_endpoint
 class GroupActivitiesEndpoint(GroupEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group) -> Response:
         """
         Retrieve all the Activities for a Group

--- a/src/sentry/api/endpoints/group_attachments.py
+++ b/src/sentry/api/endpoints/group_attachments.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.paginator import DateTimePaginator
@@ -11,6 +12,10 @@ from sentry.models import EventAttachment, event_attachment_screenshot_filter
 
 @region_silo_endpoint
 class GroupAttachmentsEndpoint(GroupEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group) -> Response:
         """
         List Event Attachments

--- a/src/sentry/api/endpoints/group_current_release.py
+++ b/src/sentry/api/endpoints/group_current_release.py
@@ -2,6 +2,7 @@ import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
@@ -12,6 +13,10 @@ from sentry.models import GroupRelease, ReleaseEnvironment, ReleaseProject
 
 @region_silo_endpoint
 class GroupCurrentReleaseEndpoint(GroupEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def _get_current_release(self, group, environments):
         release_projects = ReleaseProject.objects.filter(project_id=group.project_id).values_list(
             "release_id", flat=True

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 
 from sentry import features, tagstore, tsdb
 from sentry.api import client
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
@@ -39,6 +40,11 @@ delete_logger = logging.getLogger("sentry.deletions.api")
 
 @region_silo_endpoint
 class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/group_event_details.py
+++ b/src/sentry/api/endpoints/group_event_details.py
@@ -9,6 +9,7 @@ from snuba_sdk import Condition, Or
 from snuba_sdk.legacy import is_condition, parse_condition
 
 from sentry import eventstore, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.endpoints.project_event_details import wrap_event_response
@@ -94,6 +95,9 @@ def issue_search_query_to_conditions(
 
 @region_silo_endpoint
 class GroupEventDetailsEndpoint(GroupEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 
 from sentry import eventstore
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -37,6 +38,9 @@ class GroupEventsError(Exception):
 
 @region_silo_endpoint
 class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ISSUES
 
     def get(self, request: Request, group: Group) -> Response:

--- a/src/sentry/api/endpoints/group_external_issue_details.py
+++ b/src/sentry/api/endpoints/group_external_issue_details.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import deletions
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.models import PlatformExternalIssue
@@ -9,6 +10,10 @@ from sentry.models import PlatformExternalIssue
 
 @region_silo_endpoint
 class GroupExternalIssueDetailsEndpoint(GroupEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+    }
+
     def delete(self, request: Request, external_issue_id, group) -> Response:
         try:
             external_issue = PlatformExternalIssue.objects.get(

--- a/src/sentry/api/endpoints/group_external_issues.py
+++ b/src/sentry/api/endpoints/group_external_issues.py
@@ -3,6 +3,7 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
@@ -13,6 +14,10 @@ logger = logging.getLogger("sentry.api")
 
 @region_silo_endpoint
 class GroupExternalIssuesEndpoint(GroupEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group) -> Response:
 
         external_issues = PlatformExternalIssue.objects.filter(group_id=group.id)

--- a/src/sentry/api/endpoints/group_first_last_release.py
+++ b/src/sentry/api/endpoints/group_first_last_release.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.api.helpers.group_index import get_first_last_release
@@ -9,6 +10,9 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 @region_silo_endpoint
 class GroupFirstLastReleaseEndpoint(GroupEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/group_hashes.py
+++ b/src/sentry/api/endpoints/group_hashes.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
@@ -16,6 +17,11 @@ from sentry.utils.snuba import raw_query
 
 @region_silo_endpoint
 class GroupHashesEndpoint(GroupEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group) -> Response:
         """
         List an Issue's Hashes

--- a/src/sentry/api/endpoints/group_hashes_split.py
+++ b/src/sentry/api/endpoints/group_hashes_split.py
@@ -11,6 +11,7 @@ from snuba_sdk.orderby import Direction, OrderBy
 from snuba_sdk.query import Column, Entity, Function, Query
 
 from sentry import eventstore, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import EventSerializer, serialize
@@ -21,6 +22,12 @@ from sentry.utils import snuba
 
 @region_silo_endpoint
 class GroupHashesSplitEndpoint(GroupEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group) -> Response:
         """
         Return information on whether the group can be split up, has been split

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import serialize
@@ -48,6 +49,13 @@ class IntegrationIssueConfigSerializer(IntegrationSerializer):
 
 @region_silo_endpoint
 class GroupIntegrationDetailsEndpoint(GroupEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def _has_issue_feature(self, organization, user):
         has_issue_basic = features.has(
             "organizations:integrations-issue-basic", organization, actor=user

--- a/src/sentry/api/endpoints/group_integrations.py
+++ b/src/sentry/api/endpoints/group_integrations.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features, integrations
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import IntegrationSerializer, serialize
@@ -69,6 +70,10 @@ class IntegrationIssueSerializer(IntegrationSerializer):
 
 @region_silo_endpoint
 class GroupIntegrationsEndpoint(GroupEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group) -> Response:
         has_issue_basic = features.has(
             "organizations:integrations-issue-basic", group.organization, actor=request.user

--- a/src/sentry/api/endpoints/group_notes.py
+++ b/src/sentry/api/endpoints/group_notes.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.paginator import DateTimePaginator
@@ -19,6 +20,11 @@ from sentry.types.activity import ActivityType
 
 @region_silo_endpoint
 class GroupNotesEndpoint(GroupEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group) -> Response:
         notes = Activity.objects.filter(group=group, type=ActivityType.NOTE.value)
 

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -3,6 +3,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -15,6 +16,11 @@ from sentry.types.activity import ActivityType
 
 @region_silo_endpoint
 class GroupNotesDetailsEndpoint(GroupEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     # We explicitly don't allow a request with an ApiKey
     # since an ApiKey is bound to the Organization, not
     # an individual. Not sure if we'd want to allow an ApiKey

--- a/src/sentry/api/endpoints/group_participants.py
+++ b/src/sentry/api/endpoints/group_participants.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.models import GroupSubscriptionManager
@@ -11,6 +12,10 @@ from sentry.services.hybrid_cloud.user.service import user_service
 
 @region_silo_endpoint
 class GroupParticipantsEndpoint(GroupEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group, organization_slug: str | None = None) -> Response:
         participants = GroupSubscriptionManager.get_participating_user_ids(group)
 

--- a/src/sentry/api/endpoints/group_reprocessing.py
+++ b/src/sentry/api/endpoints/group_reprocessing.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.tasks.reprocessing2 import reprocess_group
@@ -9,6 +10,10 @@ from sentry.tasks.reprocessing2 import reprocess_group
 
 @region_silo_endpoint
 class GroupReprocessingEndpoint(GroupEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def post(self, request: Request, group) -> Response:
         """
         Reprocess a group

--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import similarity
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
@@ -20,6 +21,10 @@ def _fix_label(label):
 
 @region_silo_endpoint
 class GroupSimilarIssuesEndpoint(GroupEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group) -> Response:
         features = similarity.features
 

--- a/src/sentry/api/endpoints/group_stats.py
+++ b/src/sentry/api/endpoints/group_stats.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tsdb
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, StatsMixin, region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -11,6 +12,10 @@ from sentry.tsdb.base import TSDBModel
 
 @region_silo_endpoint
 class GroupStatsEndpoint(GroupEndpoint, EnvironmentMixin, StatsMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group) -> Response:
         try:
             environment_id = self._get_environment_id_from_request(

--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tagstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -11,6 +12,10 @@ from sentry.models import Environment
 
 @region_silo_endpoint
 class GroupTagKeyDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group, key) -> Response:
         """
         Retrieve Tag Details

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tagstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -12,6 +13,10 @@ from sentry.api.serializers.models.tagvalue import UserTagValueSerializer
 
 @region_silo_endpoint
 class GroupTagKeyValuesEndpoint(GroupEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group, key) -> Response:
         """
         List a Tag's Values

--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tagstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
@@ -19,6 +20,10 @@ if TYPE_CHECKING:
 
 @region_silo_endpoint
 class GroupTagsEndpoint(GroupEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group: Group) -> Response:
 
         # optional queryparam `key` can be used to get results

--- a/src/sentry/api/endpoints/group_tombstone.py
+++ b/src/sentry/api/endpoints/group_tombstone.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -10,6 +11,10 @@ from sentry.models import GroupTombstone
 
 @region_silo_endpoint
 class GroupTombstoneEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         """
         Retrieve a Project's GroupTombstones

--- a/src/sentry/api/endpoints/group_tombstone_details.py
+++ b/src/sentry/api/endpoints/group_tombstone_details.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -9,6 +10,10 @@ from sentry.models import GroupHash, GroupTombstone
 
 @region_silo_endpoint
 class GroupTombstoneDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+    }
+
     def delete(self, request: Request, project, tombstone_id) -> Response:
         """
         Remove a GroupTombstone

--- a/src/sentry/api/endpoints/group_user_reports.py
+++ b/src/sentry/api/endpoints/group_user_reports.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.paginator import DateTimePaginator
@@ -10,6 +11,10 @@ from sentry.models import Environment, UserReport
 
 @region_silo_endpoint
 class GroupUserReportsEndpoint(GroupEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, group) -> Response:
         """
         List User Reports

--- a/src/sentry/api/endpoints/grouping_configs.py
+++ b/src/sentry/api/endpoints/grouping_configs.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
@@ -8,6 +9,9 @@ from sentry.grouping.strategies.configurations import CONFIGURATIONS
 
 @region_silo_endpoint
 class GroupingConfigsEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = ()
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/index.py
+++ b/src/sentry/api/endpoints/index.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.models.user import User
@@ -8,6 +9,9 @@ from sentry.models.user import User
 
 @control_silo_endpoint
 class IndexEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = ()
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/integration_features.py
+++ b/src/sentry/api/endpoints/integration_features.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.bases.integration import PARANOID_GET
 from sentry.api.permissions import SentryPermission
@@ -21,6 +22,9 @@ class IntegrationFeaturesPermissions(SentryPermission):
 
 @control_silo_endpoint
 class IntegrationFeaturesEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (IntegrationFeaturesPermissions,)
 
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:

--- a/src/sentry/api/endpoints/integrations/doc_integrations/details.py
+++ b/src/sentry/api/endpoints/integrations/doc_integrations/details.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.doc_integrations import DocIntegrationBaseEndpoint
 from sentry.api.serializers import serialize
@@ -16,6 +17,12 @@ logger = logging.getLogger(__name__)
 
 @control_silo_endpoint
 class DocIntegrationDetailsEndpoint(DocIntegrationBaseEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, doc_integration: DocIntegration) -> Response:
         return self.respond(serialize(doc_integration, request.user), status=status.HTTP_200_OK)
 

--- a/src/sentry/api/endpoints/integrations/doc_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/doc_integrations/index.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.doc_integrations import DocIntegrationsBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -17,6 +18,11 @@ logger = logging.getLogger(__name__)
 
 @control_silo_endpoint
 class DocIntegrationsEndpoint(DocIntegrationsBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request):
         if is_active_superuser(request):
             queryset = DocIntegration.objects.all()

--- a/src/sentry/api/endpoints/integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/index.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features, integrations
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -10,6 +11,10 @@ from sentry.api.serializers.models.integration import IntegrationProviderSeriali
 
 @region_silo_endpoint
 class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         def is_provider_enabled(provider):
             if not provider.requires_feature_flag:

--- a/src/sentry/api/endpoints/integrations/install_request.py
+++ b/src/sentry/api/endpoints/integrations/install_request.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import integrations
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization_request_change import OrganizationRequestChangeEndpoint
 from sentry.models import SentryApp
@@ -41,6 +42,10 @@ def get_provider_name(provider_type: str, provider_slug: str) -> str | None:
 
 @region_silo_endpoint
 class OrganizationIntegrationRequestEndpoint(OrganizationRequestChangeEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def post(self, request: Request, organization) -> Response:
         """
         Email the organization owners asking them to install an integration.

--- a/src/sentry/api/endpoints/integrations/organization_integrations/details.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/details.py
@@ -11,6 +11,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization_integrations import OrganizationIntegrationBaseEndpoint
 from sentry.api.serializers import serialize
@@ -30,6 +31,12 @@ class IntegrationSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     @set_referrer_policy("strict-origin-when-cross-origin")
     @method_decorator(never_cache)
     def get(

--- a/src/sentry/api/endpoints/integrations/organization_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/index.py
@@ -5,6 +5,7 @@ from typing import Sequence
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
 from sentry.api.serializers import serialize
@@ -49,6 +50,9 @@ def filter_by_features(
 
 @region_silo_endpoint
 class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationIntegrationsPermission,)
 
     def get(self, request: Request, organization: Organization) -> Response:

--- a/src/sentry/api/endpoints/integrations/plugins/configs_index.py
+++ b/src/sentry/api/endpoints/integrations/plugins/configs_index.py
@@ -2,6 +2,7 @@ from django.http.response import Http404
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -13,6 +14,10 @@ from sentry.plugins.base import plugins
 
 @region_silo_endpoint
 class OrganizationPluginsConfigsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
 
         """

--- a/src/sentry/api/endpoints/integrations/plugins/index.py
+++ b/src/sentry/api/endpoints/integrations/plugins/index.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -12,6 +13,10 @@ from sentry.plugins.base import plugins
 
 @region_silo_endpoint
 class OrganizationPluginsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         all_plugins = {p.slug: p for p in plugins.all()}
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/authorizations.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/authorizations.py
@@ -4,6 +4,7 @@ import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppAuthorizationsBaseEndpoint
 from sentry.api.serializers.models.apitoken import ApiTokenSerializer
@@ -15,6 +16,10 @@ logger = logging.getLogger(__name__)
 
 @control_silo_endpoint
 class SentryAppAuthorizationsEndpoint(SentryAppAuthorizationsBaseEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def post(self, request: Request, installation) -> Response:
         with sentry_sdk.configure_scope() as scope:
             scope.set_tag("organization", installation.organization_id)

--- a/src/sentry/api/endpoints/integrations/sentry_apps/components.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/components.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppBaseEndpoint, add_integration_platform_metric_tag
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint
@@ -20,6 +21,10 @@ from sentry.services.hybrid_cloud.organization.model import (
 #  endpoint that can take project_id or sentry_app_id as a query parameter.
 @control_silo_endpoint
 class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, sentry_app) -> Response:
         return self.paginate(
             request=request,
@@ -31,6 +36,10 @@ class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
 
 @control_silo_endpoint
 class OrganizationSentryAppComponentsEndpoint(ControlSiloOrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     @add_integration_platform_metric_tag
     def get(
         self,

--- a/src/sentry/api/endpoints/integrations/sentry_apps/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/details.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, audit_log, deletions, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.sentryapps import SentryAppBaseEndpoint, catch_raised_errors
 from sentry.api.serializers import serialize
@@ -25,6 +26,12 @@ logger = logging.getLogger(__name__)
 
 @control_silo_endpoint
 class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, sentry_app) -> Response:
         return Response(serialize(sentry_app, request.user, access=request.access))
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/features.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/features.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.sentryapps import SentryAppBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -11,6 +12,10 @@ from sentry.models.integrations.integration_feature import IntegrationTypes
 
 @control_silo_endpoint
 class SentryAppFeaturesEndpoint(SentryAppBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, sentry_app) -> Response:
         features = IntegrationFeature.objects.filter(
             target_id=sentry_app.id, target_type=IntegrationTypes.SENTRY_APP.value

--- a/src/sentry/api/endpoints/integrations/sentry_apps/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/index.py
@@ -6,6 +6,7 @@ from rest_framework.serializers import ValidationError
 
 from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppsBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -23,6 +24,10 @@ logger = logging.getLogger(__name__)
 
 @control_silo_endpoint
 class SentryAppsEndpoint(SentryAppsBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ISSUES
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/details.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, audit_log, deletions
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppInstallationBaseEndpoint
 from sentry.api.serializers import serialize
@@ -20,6 +21,12 @@ from sentry.utils.functional import extract_lazy_object
 
 @control_silo_endpoint
 class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, installation) -> Response:
         return Response(serialize(SentryAppInstallation.objects.get(id=installation.id)))
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/external_issue/actions.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/external_issue/actions.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import SentryAppInstallationBaseEndpoint
 from sentry.api.serializers import serialize
@@ -13,6 +14,10 @@ from sentry.utils.functional import extract_lazy_object
 
 @region_silo_endpoint
 class SentryAppInstallationExternalIssueActionsEndpoint(SentryAppInstallationBaseEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def post(self, request: Request, installation) -> Response:
         data = request.data.copy()
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/external_issue/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/external_issue/details.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import deletions
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import (
     SentryAppInstallationExternalIssueBaseEndpoint as ExternalIssueBaseEndpoint,
@@ -11,6 +12,10 @@ from sentry.models import PlatformExternalIssue
 
 @region_silo_endpoint
 class SentryAppInstallationExternalIssueDetailsEndpoint(ExternalIssueBaseEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+    }
+
     def delete(self, request: Request, installation, external_issue_id) -> Response:
         try:
             platform_external_issue = PlatformExternalIssue.objects.get(

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/external_issue/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/external_issue/index.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import (
     SentryAppInstallationExternalIssueBaseEndpoint as ExternalIssueBaseEndpoint,
@@ -20,6 +21,10 @@ class PlatformExternalIssueSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class SentryAppInstallationExternalIssuesEndpoint(ExternalIssueBaseEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def post(self, request: Request, installation) -> Response:
         data = request.data
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/external_requests.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/external_requests.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import SentryAppInstallationBaseEndpoint
 from sentry.mediators import external_requests
@@ -9,6 +10,10 @@ from sentry.models import Project
 
 @region_silo_endpoint
 class SentryAppInstallationExternalRequestsEndpoint(SentryAppInstallationBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, installation) -> Response:
         try:
             project = Project.objects.get(

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppInstallationsBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -32,6 +33,11 @@ class SentryAppInstallationsSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         queryset = SentryAppInstallation.objects.filter(organization_id=organization.id)
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/interaction.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/interaction.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tsdb
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import StatsMixin, region_silo_endpoint
 from sentry.api.bases import RegionSentryAppBaseEndpoint, SentryAppStatsPermission
 from sentry.api.bases.sentryapps import COMPONENT_TYPES
@@ -21,6 +22,10 @@ def get_component_interaction_key(sentry_app, component_type):
 
 @region_silo_endpoint
 class SentryAppInteractionEndpoint(RegionSentryAppBaseEndpoint, StatsMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SentryAppStatsPermission,)
 
     def get(self, request: Request, sentry_app) -> Response:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, deletions
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppBaseEndpoint, SentryInternalAppTokenPermission
 from sentry.models import ApiToken, SentryAppInstallationToken
@@ -12,6 +13,9 @@ from sentry.models import ApiToken, SentryAppInstallationToken
 
 @control_silo_endpoint
 class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SentryInternalAppTokenPermission,)
 
     def convert_args(self, request: Request, sentry_app_slug, api_token, *args, **kwargs):

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/index.py
@@ -2,6 +2,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppBaseEndpoint, SentryInternalAppTokenPermission
 from sentry.api.serializers.models.apitoken import ApiTokenSerializer
@@ -13,6 +14,10 @@ from sentry.sentry_apps import SentryAppInstallationTokenCreator
 
 @control_silo_endpoint
 class SentryInternalAppTokensEndpoint(SentryAppBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SentryInternalAppTokenPermission,)
 
     def get(self, request: Request, sentry_app) -> Response:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/organization_sentry_apps.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/organization_sentry_apps.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint, add_integration_platform_metric_tag
 from sentry.api.paginator import OffsetPaginator
@@ -11,6 +12,10 @@ from sentry.models import SentryApp
 
 @region_silo_endpoint
 class OrganizationSentryAppsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     @add_integration_platform_metric_tag
     def get(self, request: Request, organization) -> Response:
         queryset = SentryApp.objects.filter(owner_id=organization.id, application__isnull=False)

--- a/src/sentry/api/endpoints/integrations/sentry_apps/publish_request.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/publish_request.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import options
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.sentryapps import COMPONENT_TYPES, SentryAppBaseEndpoint
 from sentry.constants import SentryAppStatus
@@ -14,6 +15,10 @@ from sentry.utils import email
 
 @control_silo_endpoint
 class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def has_ui_component(self, sentry_app):
         """Determine if the sentry app supports issue linking or stack trace linking."""
         elements = (sentry_app.schema or {}).get("elements", [])

--- a/src/sentry/api/endpoints/integrations/sentry_apps/requests.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/requests.py
@@ -5,6 +5,7 @@ from typing import Any, Mapping
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import RegionSentryAppBaseEndpoint, SentryAppStatsPermission
 from sentry.api.serializers import serialize
@@ -40,6 +41,9 @@ class BufferedRequest:
 
 @region_silo_endpoint
 class SentryAppRequestsEndpoint(RegionSentryAppBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SentryAppStatsPermission,)
 
     def get(self, request: Request, sentry_app) -> Response:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/stats/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/stats/details.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tsdb
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import StatsMixin, control_silo_endpoint
 from sentry.api.bases import SentryAppBaseEndpoint, SentryAppStatsPermission
 from sentry.models import SentryAppInstallation
@@ -9,6 +10,9 @@ from sentry.models import SentryAppInstallation
 
 @control_silo_endpoint
 class SentryAppStatsEndpoint(SentryAppBaseEndpoint, StatsMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SentryAppStatsPermission,)
 
     def get(self, request: Request, sentry_app) -> Response:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/stats/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/stats/index.py
@@ -2,6 +2,7 @@ from django.db.models import Count
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppsBaseEndpoint
 from sentry.api.permissions import SuperuserPermission
@@ -11,6 +12,9 @@ from sentry.models import SentryApp, SentryAppAvatar
 
 @control_silo_endpoint
 class SentryAppsStatsEndpoint(SentryAppsBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/internal/beacon.py
+++ b/src/sentry/api/endpoints/internal/beacon.py
@@ -4,6 +4,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.tasks.beacon import send_beacon_metric
 
@@ -38,6 +39,9 @@ class MetricsSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class InternalBeaconEndpoint(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = ()
 
     def post(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/internal/environment.py
+++ b/src/sentry/api/endpoints/internal/environment.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.app import env
@@ -11,6 +12,9 @@ from sentry.app import env
 
 @all_silo_endpoint
 class InternalEnvironmentEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/internal/mail.py
+++ b/src/sentry/api/endpoints/internal/mail.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import options
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.utils.email import send_mail
@@ -9,6 +10,10 @@ from sentry.utils.email import send_mail
 
 @all_silo_endpoint
 class InternalMailEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/internal/packages.py
+++ b/src/sentry/api/endpoints/internal/packages.py
@@ -2,6 +2,7 @@ import pkg_resources
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.plugins.base import plugins
@@ -9,6 +10,9 @@ from sentry.plugins.base import plugins
 
 @all_silo_endpoint
 class InternalPackagesEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/internal/queue_tasks.py
+++ b/src/sentry/api/endpoints/internal/queue_tasks.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.celery import app
@@ -8,6 +9,9 @@ from sentry.celery import app
 
 @all_silo_endpoint
 class InternalQueueTasksEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/internal/quotas.py
+++ b/src/sentry/api/endpoints/internal/quotas.py
@@ -3,12 +3,16 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import options
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 
 
 @all_silo_endpoint
 class InternalQuotasEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/internal/stats.py
+++ b/src/sentry/api/endpoints/internal/stats.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tsdb
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, StatsMixin, region_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.tsdb.base import TSDBModel
@@ -9,6 +10,9 @@ from sentry.tsdb.base import TSDBModel
 
 @region_silo_endpoint
 class InternalStatsEndpoint(Endpoint, StatsMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/internal/warnings.py
+++ b/src/sentry/api/endpoints/internal/warnings.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.utils.warnings import DeprecatedSettingWarning, UnsupportedBackend, seen_warnings
@@ -11,6 +12,9 @@ from sentry.utils.warnings import DeprecatedSettingWarning, UnsupportedBackend, 
 
 @all_silo_endpoint
 class InternalWarningsEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.models import Project
@@ -18,6 +19,9 @@ from sentry.utils.samples import load_data
 
 @region_silo_endpoint
 class IssueOccurrenceEndpoint(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def post(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/notification_defaults.py
+++ b/src/sentry/api/endpoints/notification_defaults.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.notifications.defaults import (
     NOTIFICATION_SETTING_DEFAULTS,
@@ -44,6 +45,9 @@ TYPE_DEFAULTS = get_type_defaults()
 
 @control_silo_endpoint
 class NotificationDefaultsEndpoints(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
     owner = ApiOwner.ISSUES
     permission_classes = ()
     private = True

--- a/src/sentry/api/endpoints/notifications/notification_actions_available.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_available.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.constants import ObjectStatus
@@ -11,6 +12,10 @@ from sentry.services.hybrid_cloud.integration import integration_service
 
 @region_silo_endpoint
 class NotificationActionsAvailableEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization: Organization) -> Response:
         """
         Responds with a payload serialized directly from running the 'serialize_available' methods

--- a/src/sentry/api/endpoints/notifications/notification_actions_details.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_details.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.endpoints.notifications.notification_actions_index import (
@@ -23,6 +24,11 @@ logger = logging.getLogger(__name__)
 
 @region_silo_endpoint
 class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     """
     Manages a single NotificationAction via the action_id passed in the path.
     GET: Returns the serialized NotificationAction

--- a/src/sentry/api/endpoints/notifications/notification_actions_index.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_index.py
@@ -8,6 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import OffsetPaginator
@@ -42,6 +43,10 @@ class NotificationActionsPermission(OrganizationPermission):
 
 @region_silo_endpoint
 class NotificationActionsIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     """
     View existing NotificationActions or create a new one.
     GET: Returns paginated, serialized NotificationActions for an organization

--- a/src/sentry/api/endpoints/oauth_userinfo.py
+++ b/src/sentry/api/endpoints/oauth_userinfo.py
@@ -3,6 +3,7 @@ from rest_framework.authentication import get_authorization_header
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.exceptions import ParameterValidationError, ResourceDoesNotExist, SentryAPIException
 from sentry.models import ApiToken, UserEmail
@@ -16,6 +17,9 @@ class InsufficientScopesError(SentryAPIException):
 
 @control_silo_endpoint
 class OAuthUserInfoEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ()
     permission_classes = ()
 

--- a/src/sentry/api/endpoints/org_auth_token_details.py
+++ b/src/sentry/api/endpoints/org_auth_token_details.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from sentry import analytics, audit_log
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrgAuthTokenPermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -17,6 +18,11 @@ from sentry.services.hybrid_cloud.organization.model import (
 
 @control_silo_endpoint
 class OrgAuthTokenDetailsEndpoint(ControlSiloOrganizationEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrgAuthTokenPermission,)
 

--- a/src/sentry/api/endpoints/org_auth_tokens.py
+++ b/src/sentry/api/endpoints/org_auth_tokens.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 
 from sentry import analytics, audit_log, roles
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrgAuthTokenPermission
 from sentry.api.serializers import serialize
@@ -28,6 +29,10 @@ from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 @control_silo_endpoint
 class OrgAuthTokensEndpoint(ControlSiloOrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrgAuthTokenPermission,)
 

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -43,6 +44,10 @@ class AccessRequestSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = [AccessRequestPermission]
 
     # TODO(dcramer): this should go onto AccessRequestPermission

--- a/src/sentry/api/endpoints/organization_activity.py
+++ b/src/sentry/api/endpoints/organization_activity.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.paginator import DateTimePaginator
@@ -12,6 +13,9 @@ from sentry.types.activity import ActivityType
 
 @region_silo_endpoint
 class OrganizationActivityEndpoint(OrganizationMemberEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ISSUES
 
     def get(self, request: Request, organization, member) -> Response:

--- a/src/sentry/api/endpoints/organization_api_key_details.py
+++ b/src/sentry/api/endpoints/organization_api_key_details.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization import (
     ControlSiloOrganizationEndpoint,
@@ -21,6 +22,11 @@ class ApiKeySerializer(serializers.ModelSerializer):
 
 @control_silo_endpoint
 class OrganizationApiKeyDetailsEndpoint(ControlSiloOrganizationEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationAdminPermission,)
 
     def get(self, request: Request, organization_context, organization, api_key_id) -> Response:

--- a/src/sentry/api/endpoints/organization_api_key_index.py
+++ b/src/sentry/api/endpoints/organization_api_key_index.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization import (
     ControlSiloOrganizationEndpoint,
@@ -16,6 +17,10 @@ DEFAULT_SCOPES = ["project:read", "event:read", "team:read", "org:read", "member
 
 @control_silo_endpoint
 class OrganizationApiKeyIndexEndpoint(ControlSiloOrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationAdminPermission,)
 
     def get(self, request: Request, organization_context, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
+++ b/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, options
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -22,6 +23,10 @@ from sentry.utils import json
 
 @region_silo_endpoint
 class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def post(self, request: Request, organization) -> Response:
         """
         Assembles an artifact bundle and stores the debug ids in the database.

--- a/src/sentry/api/endpoints/organization_auditlogs.py
+++ b/src/sentry/api/endpoints/organization_auditlogs.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from sentry import audit_log
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import ControlSiloOrganizationEndpoint
 from sentry.api.bases.organization import OrganizationAuditPermission
@@ -32,6 +33,9 @@ class AuditLogQueryParamSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class OrganizationAuditLogsEndpoint(ControlSiloOrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrganizationAuditPermission,)
 

--- a/src/sentry/api/endpoints/organization_auth_provider_details.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_details.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationAuthProviderPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -13,6 +14,9 @@ from sentry.services.hybrid_cloud.auth.service import auth_service
 
 @region_silo_endpoint
 class OrganizationAuthProviderDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrganizationAuthProviderPermission,)
 

--- a/src/sentry/api/endpoints/organization_auth_provider_send_reminders.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_send_reminders.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationAdminPermission, OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -15,6 +16,9 @@ ERR_NO_SSO = _("The SSO feature is not enabled for this organization.")
 
 @region_silo_endpoint
 class OrganizationAuthProviderSendRemindersEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrganizationAdminPermission,)
 

--- a/src/sentry/api/endpoints/organization_auth_providers.py
+++ b/src/sentry/api/endpoints/organization_auth_providers.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationAuthProviderPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -10,6 +11,9 @@ from sentry.auth import manager
 
 @region_silo_endpoint
 class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrganizationAuthProviderPermission,)
 

--- a/src/sentry/api/endpoints/organization_code_mapping_codeowners.py
+++ b/src/sentry/api/endpoints/organization_code_mapping_codeowners.py
@@ -4,6 +4,7 @@ from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
 from sentry.models import RepositoryProjectPathConfig
@@ -22,6 +23,9 @@ def get_codeowner_contents(config):
 
 @region_silo_endpoint
 class OrganizationCodeMappingCodeOwnersEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationIntegrationsPermission,)
 
     def convert_args(self, request: Request, organization_slug, config_id, *args, **kwargs):

--- a/src/sentry/api/endpoints/organization_code_mapping_details.py
+++ b/src/sentry/api/endpoints/organization_code_mapping_details.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import (
     OrganizationEndpoint,
@@ -21,6 +22,10 @@ from .organization_code_mappings import (
 
 @region_silo_endpoint
 class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationIntegrationMixin):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationIntegrationsLoosePermission,)
 
     def convert_args(self, request: Request, organization_slug, config_id, *args, **kwargs):

--- a/src/sentry/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/api/endpoints/organization_code_mappings.py
@@ -4,6 +4,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import (
     OrganizationEndpoint,
@@ -126,6 +127,10 @@ class OrganizationIntegrationMixin:
 
 @region_silo_endpoint
 class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegrationMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationIntegrationsLoosePermission,)
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_codeowners_associations.py
+++ b/src/sentry/api/endpoints/organization_codeowners_associations.py
@@ -1,6 +1,7 @@
 from rest_framework import status
 from rest_framework.request import Request
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import (
     OrganizationEndpoint,
@@ -14,6 +15,9 @@ from sentry.services.hybrid_cloud.integration import integration_service
 
 @region_silo_endpoint
 class OrganizationCodeOwnersAssociationsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationIntegrationsLoosePermission,)
 
     def get(self, request: Request, organization: Organization):

--- a/src/sentry/api/endpoints/organization_config_repositories.py
+++ b/src/sentry/api/endpoints/organization_config_repositories.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.plugins.base import bindings
@@ -8,6 +9,10 @@ from sentry.plugins.base import bindings
 
 @region_silo_endpoint
 class OrganizationConfigRepositoriesEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         provider_bindings = bindings.get("repository.provider")
         providers = []

--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.endpoints.organization_dashboards import OrganizationDashboardsPermission
@@ -43,6 +44,12 @@ class OrganizationDashboardBase(OrganizationEndpoint):
 
 @region_silo_endpoint
 class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, dashboard) -> Response:
         """
         Retrieve an Organization's Dashboard
@@ -141,6 +148,10 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
 
 @region_silo_endpoint
 class OrganizationDashboardVisitEndpoint(OrganizationDashboardBase):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def post(self, request: Request, organization, dashboard) -> Response:
         """
         Update last_visited and increment visits counter

--- a/src/sentry/api/endpoints/organization_dashboard_widget_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_widget_details.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.endpoints.organization_dashboards import OrganizationDashboardsPermission
@@ -11,6 +12,9 @@ from sentry.api.serializers.rest_framework import DashboardWidgetSerializer
 
 @region_silo_endpoint
 class OrganizationDashboardWidgetDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.DISCOVER_N_DASHBOARDS
     permission_classes = (OrganizationDashboardsPermission,)
 

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import ChainPaginator
@@ -30,6 +31,10 @@ class OrganizationDashboardsPermission(OrganizationPermission):
 
 @region_silo_endpoint
 class OrganizationDashboardsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.DISCOVER_N_DASHBOARDS
     permission_classes = (OrganizationDashboardsPermission,)
 

--- a/src/sentry/api/endpoints/organization_derive_code_mappings.py
+++ b/src/sentry/api/endpoints/organization_derive_code_mappings.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import (
     OrganizationEndpoint,
@@ -25,6 +26,10 @@ from sentry.tasks.derive_code_mappings import get_installation
 
 @region_silo_endpoint
 class OrganizationDeriveCodeMappingsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationIntegrationsLoosePermission,)
 
     def get(self, request: Request, organization: Organization) -> Response:

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -11,6 +11,7 @@ from rest_framework import serializers, status
 
 from bitfield.types import BitHandler
 from sentry import audit_log, roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import ONE_DAY, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.decorators import sudo_required
@@ -476,6 +477,12 @@ from rest_framework.response import Response
 
 @region_silo_endpoint
 class OrganizationDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         """
         Retrieve an Organization

--- a/src/sentry/api/endpoints/organization_environments.py
+++ b/src/sentry/api/endpoints/organization_environments.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.helpers.environments import environment_visibility_filter_options
@@ -10,6 +11,10 @@ from sentry.models import Environment, EnvironmentProject
 
 @region_silo_endpoint
 class OrganizationEnvironmentsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         visibility = request.GET.get("visibility", "visible")
         if visibility not in environment_visibility_filter_options:

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.serializers import serialize
@@ -12,6 +13,10 @@ from sentry.models.project import Project
 
 @region_silo_endpoint
 class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, project_slug, event_id) -> Response:
         """event_id is validated by a regex in the URL"""
         if not self.has_feature(organization, request):

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -13,6 +14,9 @@ from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
 
 @region_silo_endpoint
 class EventIdLookupEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -8,6 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
@@ -122,6 +123,9 @@ def rate_limit_events(request: Request, organization_slug=None, *args, **kwargs)
 @extend_schema(tags=["Discover"])
 @region_silo_endpoint
 class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
     public = {"GET"}
 
     enforce_rate_limit = True

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tagstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
@@ -14,6 +15,10 @@ from sentry.snuba import discover
 
 @region_silo_endpoint
 class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from snuba_sdk import Column, Condition, Function, Op
 
 from sentry import features, tagstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
@@ -33,6 +34,10 @@ DEFAULT_TAG_KEY_LIMIT = 5
 
 
 class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def has_feature(self, organization, request):
         return features.has("organizations:performance-view", organization, actor=request.user)
 
@@ -130,6 +135,10 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsFacetsPerfor
 class OrganizationEventsFacetsPerformanceHistogramEndpoint(
     OrganizationEventsFacetsPerformanceEndpointBase
 ):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         try:
             params, aggregate_column, filter_query = self._setup(request, organization)

--- a/src/sentry/api/endpoints/organization_events_facets_stats_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_stats_performance.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects
 from sentry.api.endpoints.organization_events_facets_performance import (
@@ -24,6 +25,9 @@ SIX_HOURS = int(timedelta(hours=6).total_seconds())
 class OrganizationEventsFacetsStatsPerformanceEndpoint(
     OrganizationEventsFacetsPerformanceEndpointBase
 ):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.TEAM_STARFISH
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -7,6 +7,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.snuba import discover
@@ -48,6 +49,10 @@ class EventsHasMeasurementsQuerySerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationEventsHasMeasurementsEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_events_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_histogram.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.snuba import discover
@@ -42,6 +43,9 @@ class HistogramSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationEventsHistogramEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.PERFORMANCE
 
     def has_feature(self, organization, request):

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import search
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.event_search import parse_search_query
@@ -18,6 +19,10 @@ from sentry.snuba.referrer import Referrer
 
 @region_silo_endpoint
 class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         try:
             params = self.get_snuba_params(request, organization)
@@ -42,6 +47,10 @@ UNESCAPED_QUOTE_RE = re.compile('(?<!\\\\)"')
 
 @region_silo_endpoint
 class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         try:
             # events-meta is still used by events v1 which doesn't require global views
@@ -101,6 +110,10 @@ class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase, En
 
 @region_silo_endpoint
 class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         try:
             params = self.get_snuba_params(request, organization)

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -1,6 +1,7 @@
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.snuba.metrics_performance import query as metrics_query
@@ -8,6 +9,10 @@ from sentry.snuba.metrics_performance import query as metrics_query
 
 @region_silo_endpoint
 class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request, organization):
         if not features.has(
             "organizations:statistical-detectors-root-cause-analysis",

--- a/src/sentry/api/endpoints/organization_events_span_ops.py
+++ b/src/sentry/api/endpoints/organization_events_span_ops.py
@@ -3,6 +3,7 @@ from typing import Any, TypedDict
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
@@ -19,6 +20,10 @@ class SpanOp(TypedDict):
 
 @region_silo_endpoint
 class OrganizationEventsSpanOpsEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization: Organization) -> Response:
 
         try:

--- a/src/sentry/api/endpoints/organization_events_spans_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_spans_histogram.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.endpoints.organization_events_spans_performance import Span
@@ -35,6 +36,10 @@ class SpansHistogramSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationEventsSpansHistogramEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def has_feature(self, organization, request):
         return features.has(
             "organizations:performance-span-histogram-view", organization, actor=request.user

--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -15,6 +15,7 @@ from snuba_sdk.function import Function, Identifier, Lambda
 from snuba_sdk.orderby import Direction, OrderBy
 
 from sentry import eventstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
@@ -146,6 +147,10 @@ class SpansPerformanceSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsSpansEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization: Organization) -> Response:
 
         try:
@@ -221,6 +226,10 @@ class SpanSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationEventsSpansExamplesEndpoint(OrganizationEventsSpansEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization: Organization) -> Response:
 
         try:
@@ -302,6 +311,10 @@ class SpanExamplesPaginator:
 
 @region_silo_endpoint
 class OrganizationEventsSpansStatsEndpoint(OrganizationEventsSpansEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization: Organization) -> Response:
 
         serializer = SpanSerializer(data=request.GET)

--- a/src/sentry/api/endpoints/organization_events_starfish.py
+++ b/src/sentry/api/endpoints/organization_events_starfish.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects
 from sentry.api.bases.organization_events import OrganizationEventsV2EndpointBase
@@ -19,6 +20,9 @@ FEATURE = "organizations:starfish-test-endpoint"
 
 @region_silo_endpoint
 class OrganizationEventsStarfishEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """
     This is a test endpoint that's meant to only be used for starfish testing
     purposes.

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsV2EndpointBase
 from sentry.constants import MAX_TOP_EVENTS
@@ -90,6 +91,10 @@ ALLOWED_EVENTS_STATS_REFERRERS: Set[str] = {
 
 @region_silo_endpoint
 class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get_features(self, organization: Organization, request: Request) -> Mapping[str, bool]:
         feature_names = [
             "organizations:performance-chart-interpolation",

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -25,6 +25,7 @@ from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 from snuba_sdk import Column, Function
 
 from sentry import constants, eventstore, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.serializers.models.event import get_tags_with_meta
@@ -443,6 +444,10 @@ def query_trace_data(
 
 
 class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def has_feature(self, organization: Organization, request: HttpRequest) -> bool:
         return bool(
             features.has("organizations:performance-view", organization, actor=request.user)
@@ -570,6 +575,10 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
 
 @region_silo_endpoint
 class OrganizationEventsTraceLightEndpoint(OrganizationEventsTraceEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     @staticmethod
     def get_current_transaction(
         transactions: Sequence[SnubaTransaction],
@@ -952,6 +961,10 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
 
 @region_silo_endpoint
 class OrganizationEventsTraceMetaEndpoint(OrganizationEventsTraceEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: HttpRequest, organization: Organization, trace_id: str) -> HttpResponse:
         if not self.has_feature(organization, request):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -10,6 +10,7 @@ from snuba_sdk.expressions import Limit, Offset
 from snuba_sdk.function import Function
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.event_search import AggregateFilter
@@ -76,6 +77,9 @@ class TrendQueryBuilder(QueryBuilder):
 
 
 class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     trend_columns = {
         "p50": "percentile_range({column}, 0.5, {condition}, {boundary}) as {query_alias}",
         "p75": "percentile_range({column}, 0.75, {condition}, {boundary}) as {query_alias}",
@@ -512,6 +516,10 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
 
 @region_silo_endpoint
 class OrganizationEventsTrendsStatsEndpoint(OrganizationEventsTrendsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def build_result_handler(
         self,
         request,

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -15,6 +15,7 @@ from snuba_sdk import Column
 from urllib3 import Retry
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
@@ -74,6 +75,9 @@ def get_trends(snuba_io):
 
 @region_silo_endpoint
 class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/organization_events_vitals.py
+++ b/src/sentry/api/endpoints/organization_events_vitals.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.search.events.fields import get_function_alias
@@ -12,6 +13,9 @@ from sentry.snuba import discover
 
 @region_silo_endpoint
 class OrganizationEventsVitalsEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     VITALS = {
         "measurements.lcp": {"thresholds": [0, 2500, 4000]},
         "measurements.fid": {"thresholds": [0, 100, 300]},

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -10,6 +10,7 @@ from sentry_sdk import start_span
 
 from sentry import features, search
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventPermission, OrganizationEventsEndpointBase
 from sentry.api.event_search import SearchFilter
@@ -140,6 +141,11 @@ def inbox_search(
 
 @region_silo_endpoint
 class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ISSUES
     permission_classes = (OrganizationEventPermission,)
     enforce_rate_limit = True

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -2,6 +2,7 @@ from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventPermission, OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_group_index import ERR_INVALID_STATS_PERIOD
@@ -15,6 +16,9 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 @region_silo_endpoint
 class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationEventPermission,)
     enforce_rate_limit = True
 

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from sentry import analytics, audit_log, features, options
 from sentry import ratelimits as ratelimiter
 from sentry import roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.paginator import DateTimePaginator, OffsetPaginator
@@ -51,6 +52,10 @@ class OrganizationPostSerializer(BaseOrganizationSerializer):
 
 @region_silo_endpoint
 class OrganizationIndexEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/organization_integration_issues.py
+++ b/src/sentry/api/endpoints/organization_integration_issues.py
@@ -3,6 +3,7 @@ from typing import Any
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization_integrations import RegionOrganizationIntegrationBaseEndpoint
 from sentry.integrations.mixins import IssueSyncMixin
@@ -11,6 +12,10 @@ from sentry.models import Organization
 
 @region_silo_endpoint
 class OrganizationIntegrationIssuesEndpoint(RegionOrganizationIntegrationBaseEndpoint):
+    publish_status = {
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def put(
         self,
         request: Request,

--- a/src/sentry/api/endpoints/organization_integration_migrate_opsgenie.py
+++ b/src/sentry/api/endpoints/organization_integration_migrate_opsgenie.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization_integrations import RegionOrganizationIntegrationBaseEndpoint
 from sentry.integrations.opsgenie.integration import OpsgenieIntegration
@@ -12,6 +13,9 @@ from sentry.models import Organization
 
 @region_silo_endpoint
 class OrganizationIntegrationMigrateOpsgenieEndpoint(RegionOrganizationIntegrationBaseEndpoint):
+    publish_status = {
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
 
     def put(

--- a/src/sentry/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/api/endpoints/organization_integration_repos.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization_integrations import RegionOrganizationIntegrationBaseEndpoint
 from sentry.auth.exceptions import IdentityNotValid
@@ -22,6 +23,9 @@ class IntegrationRepository(TypedDict):
 
 @region_silo_endpoint
 class OrganizationIntegrationReposEndpoint(RegionOrganizationIntegrationBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ISSUES
 
     def get(

--- a/src/sentry/api/endpoints/organization_integration_serverless_functions.py
+++ b/src/sentry/api/endpoints/organization_integration_serverless_functions.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization_integrations import RegionOrganizationIntegrationBaseEndpoint
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
@@ -21,6 +22,11 @@ class ServerlessActionSerializer(CamelSnakeSerializer):
 
 @region_silo_endpoint
 class OrganizationIntegrationServerlessFunctionsEndpoint(RegionOrganizationIntegrationBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(
         self,
         request: Request,

--- a/src/sentry/api/endpoints/organization_issues_count.py
+++ b/src/sentry/api/endpoints/organization_issues_count.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from sentry_sdk import start_span
 
 from sentry import features, search
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.helpers.group_index import ValidationError, validate_search_filter_permissions
@@ -20,6 +21,9 @@ ISSUES_COUNT_MAX_HITS_LIMIT = 100
 
 @region_silo_endpoint
 class OrganizationIssuesCountEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/organization_issues_resolved_in_release.py
+++ b/src/sentry/api/endpoints/organization_issues_resolved_in_release.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.helpers.releases import get_group_ids_resolved_in_release
@@ -11,6 +12,9 @@ from sentry.models import Group
 
 @region_silo_endpoint
 class OrganizationIssuesResolvedInReleaseEndpoint(OrganizationEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationPermission,)
 
     def get(self, request: Request, organization, version) -> Response:

--- a/src/sentry/api/endpoints/organization_measurements_meta.py
+++ b/src/sentry/api/endpoints/organization_measurements_meta.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import start_span
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.models import Organization
@@ -12,6 +13,10 @@ from sentry.snuba.metrics.datasource import get_custom_measurements
 
 @region_silo_endpoint
 class OrganizationMeasurementsMeta(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization: Organization) -> Response:
         try:
             params = self.get_snuba_params(request, organization)

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
 from sentry import audit_log, features, ratelimits, roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.bases.organization import OrganizationPermission
@@ -68,6 +69,11 @@ class RelaxedMemberPermission(OrganizationPermission):
 @extend_schema(tags=["Organizations"])
 @region_silo_endpoint
 class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.PUBLIC,
+    }
     public = {"GET", "PUT", "DELETE"}
     permission_classes = [RelaxedMemberPermission]
 

--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -8,6 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, features, ratelimits, roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import OffsetPaginator
@@ -121,6 +122,10 @@ class OrganizationMemberSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (MemberPermission,)
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_member/requests/invite/details.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/details.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.bases.organization import OrganizationPermission
@@ -44,6 +45,11 @@ class InviteRequestPermissions(OrganizationPermission):
 
 @region_silo_endpoint
 class OrganizationInviteRequestDetailsEndpoint(OrganizationMemberEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (InviteRequestPermissions,)
 
     def _get_member(

--- a/src/sentry/api/endpoints/organization_member/requests/invite/index.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/index.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.endpoints.organization_member.index import OrganizationMemberSerializer
@@ -26,6 +27,10 @@ class InviteRequestPermissions(OrganizationPermission):
 
 @region_silo_endpoint
 class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (InviteRequestPermissions,)
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_member/requests/join.py
+++ b/src/sentry/api/endpoints/organization_member/requests/join.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import ratelimits as ratelimiter
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.validators import AllowedEmailField
@@ -49,6 +50,9 @@ def create_organization_join_request(organization, email, ip_address=None):
 
 @region_silo_endpoint
 class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     # Disable authentication and permission requirements.
     permission_classes = []
 

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, features, roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.bases.organization import OrganizationPermission
@@ -96,6 +97,12 @@ def _is_org_owner_or_manager(access: Access) -> bool:
 @extend_schema(tags=["Teams"])
 @region_silo_endpoint
 class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PUBLIC,
+    }
     public = {"DELETE", "POST"}
     permission_classes = (OrganizationTeamMemberPermission,)
 

--- a/src/sentry/api/endpoints/organization_member_unreleased_commits.py
+++ b/src/sentry/api/endpoints/organization_member_unreleased_commits.py
@@ -1,5 +1,6 @@
 from django.db import connections
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.serializers import serialize
@@ -41,6 +42,10 @@ from rest_framework.response import Response
 
 @region_silo_endpoint
 class OrganizationMemberUnreleasedCommitsEndpoint(OrganizationMemberEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, member) -> Response:
         email_list = [
             e.email

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -40,6 +41,9 @@ def get_use_case_id(request: Request) -> UseCaseID:
 
 @region_silo_endpoint
 class OrganizationMetricsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """Get metric name, available operations and the metric unit"""
 
     owner = ApiOwner.TELEMETRY_EXPERIENCE
@@ -54,6 +58,9 @@ class OrganizationMetricsEndpoint(OrganizationEndpoint):
 
 @region_silo_endpoint
 class OrganizationMetricDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """Get metric name, available operations, metric unit and available tags"""
 
     owner = ApiOwner.TELEMETRY_EXPERIENCE
@@ -77,6 +84,9 @@ class OrganizationMetricDetailsEndpoint(OrganizationEndpoint):
 
 @region_silo_endpoint
 class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """Get list of tag names for this project
 
     If the ``metric`` query param is provided, only tags for a certain metric
@@ -107,6 +117,9 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
 
 @region_silo_endpoint
 class OrganizationMetricsTagDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """Get all existing tag values for a metric"""
 
     owner = ApiOwner.TELEMETRY_EXPERIENCE
@@ -136,6 +149,9 @@ class OrganizationMetricsTagDetailsEndpoint(OrganizationEndpoint):
 
 @region_silo_endpoint
 class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """Get the time series data for one or more metrics.
 
     The data can be filtered and grouped by tags.

--- a/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
@@ -7,6 +7,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsV2EndpointBase
 from sentry.models import Organization
@@ -27,6 +28,9 @@ MetricVolumeRow = List[Union[int, List[CountResult]]]
 
 @region_silo_endpoint
 class OrganizationMetricsEstimationStatsEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """Gets the estimated volume of an organization's metric events."""
 
     def get(self, request: Request, organization: Organization) -> Response:

--- a/src/sentry/api/endpoints/organization_metrics_meta.py
+++ b/src/sentry/api/endpoints/organization_metrics_meta.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import set_tag
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.search.events.fields import get_function_alias
@@ -14,6 +15,9 @@ COUNT_NULL = "count_null_transactions()"
 
 @region_silo_endpoint
 class OrganizationMetricsCompatibility(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """Metrics data can contain less than great data like null or unparameterized transactions
 
     This endpoint will return projects that have dynamic sampling turned on, and another list of "compatible projects"
@@ -61,6 +65,9 @@ class OrganizationMetricsCompatibility(OrganizationEventsEndpointBase):
 
 @region_silo_endpoint
 class OrganizationMetricsCompatibilitySums(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """Return the total sum of metrics data, the null transactions and unparameterized transactions
 
     This is so the frontend can have an idea given its current selection of projects how good/bad the display would

--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -10,6 +10,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import Serializer, serialize
@@ -30,6 +31,9 @@ class MissingMembersPermission(OrganizationPermission):
 
 @region_silo_endpoint
 class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (MissingMembersPermission,)
 
     def _get_missing_members(self, organization: Organization) -> QuerySet[CommitAuthor]:

--- a/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
+++ b/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 
 from sentry import analytics
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
@@ -41,6 +42,9 @@ def get_request_builder_args(user: User, organization: Organization, platforms: 
 
 @region_silo_endpoint
 class OrganizationOnboardingContinuationEmail(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.GROWTH
     # let anyone in the org use this endpoint
     permission_classes = ()

--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import onboarding_tasks
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models import OnboardingTaskStatus
@@ -14,6 +15,9 @@ class OnboardingTaskPermission(OrganizationPermission):
 
 @region_silo_endpoint
 class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OnboardingTaskPermission,)
 
     def post(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPinnedSearchPermission
 from sentry.api.serializers import serialize
@@ -28,6 +29,10 @@ class OrganizationSearchSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationPinnedSearchPermission,)
 
     def put(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_processingissues.py
+++ b/src/sentry/api/endpoints/organization_processingissues.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.helpers.processing_issues import get_processing_issues
@@ -9,6 +10,10 @@ from sentry.api.serializers import serialize
 
 @region_silo_endpoint
 class OrganizationProcessingIssuesEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         """
         For each Project in an Organization, list its processing issues. Can

--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from urllib3 import Retry
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
@@ -75,6 +76,10 @@ class FunctionTrendsSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def has_feature(self, organization, request):
         return features.has(
             "organizations:profiling-global-suspect-functions", organization, actor=request.user

--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 
 # from sentry.api.bases.organization import OrganizationEndpoint
@@ -37,6 +38,10 @@ class OrganizationProfilingBaseEndpoint(OrganizationEventsV2EndpointBase):
 
 @region_silo_endpoint
 class OrganizationProfilingFiltersEndpoint(OrganizationProfilingBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization: Organization) -> HttpResponse:
         if not features.has("organizations:profiling", organization, actor=request.user):
             return Response(status=404)
@@ -53,6 +58,10 @@ class OrganizationProfilingFiltersEndpoint(OrganizationProfilingBaseEndpoint):
 
 @region_silo_endpoint
 class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization: Organization) -> HttpResponse:
         if not features.has("organizations:profiling", organization, actor=request.user):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -5,6 +5,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -27,6 +28,9 @@ ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '
 @extend_schema(tags=["Organizations"])
 @region_silo_endpoint
 class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
     public = {"GET"}
 
     @extend_schema(
@@ -153,6 +157,10 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
 @region_silo_endpoint
 class OrganizationProjectsCountEndpoint(OrganizationEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         queryset = Project.objects.filter(organization=organization)
 

--- a/src/sentry/api/endpoints/organization_projects_experiment.py
+++ b/src/sentry/api/endpoints/organization_projects_experiment.py
@@ -12,6 +12,7 @@ from rest_framework.serializers import ValidationError
 
 from sentry import audit_log, features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.endpoints.team_projects import ProjectPostSerializer
@@ -51,6 +52,9 @@ class OrgProjectPermission(OrganizationPermission):
 
 @region_silo_endpoint
 class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrgProjectPermission,)
     logger = logging.getLogger("team-project.create")
     owner = ApiOwner.ENTERPRISE

--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -8,6 +9,10 @@ from sentry.api.serializers import serialize
 
 @region_silo_endpoint
 class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         """
         Verify If Any Project Within An Organization Has Received a First Event

--- a/src/sentry/api/endpoints/organization_recent_searches.py
+++ b/src/sentry/api/endpoints/organization_recent_searches.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import serialize
@@ -24,6 +25,10 @@ class OrganizationRecentSearchPermission(OrganizationPermission):
 
 @region_silo_endpoint
 class OrganizationRecentSearchesEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationRecentSearchPermission,)
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_relay_usage.py
+++ b/src/sentry/api/endpoints/organization_relay_usage.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import serialize
@@ -10,6 +11,9 @@ from sentry.models import RelayUsage
 
 @region_silo_endpoint
 class OrganizationRelayUsage(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationPermission,)
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_release_assemble.py
+++ b/src/sentry/api/endpoints/organization_release_assemble.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -18,6 +19,10 @@ from sentry.utils import json
 
 @region_silo_endpoint
 class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def post(self, request: Request, organization, version) -> Response:
         """
         Handle an artifact bundle and merge it into the release

--- a/src/sentry/api/endpoints/organization_release_commits.py
+++ b/src/sentry/api/endpoints/organization_release_commits.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -10,6 +11,10 @@ from sentry.models import Release, ReleaseCommit
 
 @region_silo_endpoint
 class OrganizationReleaseCommitsEndpoint(OrganizationReleasesBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, version) -> Response:
         """
         List an Organization Release's Commits

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import release_health
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import ReleaseAnalyticsMixin, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.endpoints.organization_releases import (
@@ -272,6 +273,12 @@ class OrganizationReleaseDetailsEndpoint(
     ReleaseAnalyticsMixin,
     OrganizationReleaseDetailsPaginationMixin,
 ):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, version) -> Response:
         """
         Retrieve an Organization's Release

--- a/src/sentry/api/endpoints/organization_release_file_details.py
+++ b/src/sentry/api/endpoints/organization_release_file_details.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.endpoints.project_release_file_details import ReleaseFileDetailsMixin
@@ -17,6 +18,12 @@ class ReleaseFileSerializer(serializers.Serializer):
 class OrganizationReleaseFileDetailsEndpoint(
     OrganizationReleasesBaseEndpoint, ReleaseFileDetailsMixin
 ):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, version, file_id) -> Response:
         """
         Retrieve an Organization Release's File

--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -3,6 +3,7 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.endpoints.project_release_files import ReleaseFilesMixin
@@ -12,6 +13,11 @@ from sentry.models import Release
 
 @region_silo_endpoint
 class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseFilesMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, version) -> Response:
         """
         List an Organization Release's Files

--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -13,6 +14,10 @@ from sentry.models.commitfilechange import CommitFileChange
 
 @region_silo_endpoint
 class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, version) -> Response:
         """
         Retrieve an Organization's Release's Associated Meta Data

--- a/src/sentry/api/endpoints/organization_release_previous_commits.py
+++ b/src/sentry/api/endpoints/organization_release_previous_commits.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 
 from sentry import analytics
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -13,6 +14,9 @@ from sentry.ratelimits.config import RateLimitConfig
 
 @region_silo_endpoint
 class OrganizationReleasePreviousCommitsEndpoint(OrganizationReleasesBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ISSUES
     rate_limits = RateLimitConfig(group="CLI")
 

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -10,6 +10,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, release_health
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, ReleaseAnalyticsMixin, region_silo_endpoint
 from sentry.api.bases import NoProjects
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
@@ -215,6 +216,10 @@ def debounce_update_release_health_data(organization, project_ids):
 class OrganizationReleasesEndpoint(
     OrganizationReleasesBaseEndpoint, EnvironmentMixin, ReleaseAnalyticsMixin
 ):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     SESSION_SORTS = frozenset(
         [
             "crash_free_sessions",
@@ -581,6 +586,10 @@ class OrganizationReleasesEndpoint(
 
 @region_silo_endpoint
 class OrganizationReleasesStatsEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         """
         List an Organization's Releases specifically for building timeseries

--- a/src/sentry/api/endpoints/organization_repositories.py
+++ b/src/sentry/api/endpoints/organization_repositories.py
@@ -2,6 +2,7 @@ from django.db.models import Q
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import (
     OrganizationEndpoint,
@@ -21,6 +22,10 @@ UNMIGRATABLE_PROVIDERS = ("bitbucket", "github")
 
 @region_silo_endpoint
 class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationIntegrationsLoosePermission,)
     rate_limits = RateLimitConfig(
         group="CLI", limit_overrides={"POST": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}

--- a/src/sentry/api/endpoints/organization_repository_commits.py
+++ b/src/sentry/api/endpoints/organization_repository_commits.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -11,6 +12,10 @@ from sentry.models import Commit, Repository
 
 @region_silo_endpoint
 class OrganizationRepositoryCommitsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, repo_id) -> Response:
         """
         List a Repository's Commits

--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -31,6 +32,10 @@ class RepositorySerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationIntegrationsPermission,)
 
     def put(self, request: Request, organization, repo_id) -> Response:

--- a/src/sentry/api/endpoints/organization_request_project_creation.py
+++ b/src/sentry/api/endpoints/organization_request_project_creation.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization_request_change import OrganizationRequestChangeEndpoint
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
@@ -11,6 +12,9 @@ from sentry.utils.http import absolute_uri
 
 
 class OrganizationRequestProjectCreationSerializer(CamelSnakeSerializer):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     target_user_email = serializers.EmailField(required=True)
 
 

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -8,6 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.bases.organization import OrganizationEndpoint
@@ -66,6 +67,10 @@ def serialize(data, projects):
 
 @region_silo_endpoint
 class OrganizationSdkUpdatesEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         projects = self.get_projects(request, organization)
 
@@ -101,6 +106,9 @@ class OrganizationSdkUpdatesEndpoint(OrganizationEventsEndpointBase):
 
 @region_silo_endpoint
 class OrganizationSdksEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_search_details.py
+++ b/src/sentry/api/endpoints/organization_search_details.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationSearchPermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -34,6 +35,10 @@ class OrganizationSearchEditPermission(OrganizationSearchPermission):
 
 @region_silo_endpoint
 class OrganizationSearchDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationSearchEditPermission,)
 
     def convert_args(self, request: Request, organization_slug, search_id, *args, **kwargs):

--- a/src/sentry/api/endpoints/organization_searches.py
+++ b/src/sentry/api/endpoints/organization_searches.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from sentry import analytics
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationSearchPermission
 from sentry.api.serializers import serialize
@@ -17,6 +18,10 @@ from sentry.models.search_common import SearchType
 
 @region_silo_endpoint
 class OrganizationSearchesEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ISSUES
     permission_classes = (OrganizationSearchPermission,)
 

--- a/src/sentry/api/endpoints/organization_sentry_function.py
+++ b/src/sentry/api/endpoints/organization_sentry_function.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -37,6 +38,10 @@ class SentryFunctionSerializer(CamelSnakeSerializer):
 
 @region_silo_endpoint
 class OrganizationSentryFunctionEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
 
     # Creating a new sentry function
 

--- a/src/sentry/api/endpoints/organization_sentry_function_details.py
+++ b/src/sentry/api/endpoints/organization_sentry_function_details.py
@@ -4,6 +4,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.endpoints.organization_sentry_function import SentryFunctionSerializer
@@ -14,6 +15,12 @@ from sentry.utils.cloudfunctions import delete_function, update_function
 
 @region_silo_endpoint
 class OrganizationSentryFunctionDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def convert_args(self, request, organization_slug, function_slug, *args, **kwargs):
         args, kwargs = super().convert_args(request, organization_slug, *args, **kwargs)
 

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 
 from sentry import features, release_health
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
@@ -21,6 +22,9 @@ from sentry.utils.cursors import Cursor, CursorResult
 # NOTE: this currently extends `OrganizationEventsEndpointBase` for `handle_query_errors` only, which should ideally be decoupled from the base class.
 @region_silo_endpoint
 class OrganizationSessionsEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_shortid.py
+++ b/src/sentry/api/endpoints/organization_shortid.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -10,6 +11,10 @@ from sentry.models import Group
 
 @region_silo_endpoint
 class ShortIdLookupEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, short_id) -> Response:
         """
         Resolve a Short ID

--- a/src/sentry/api/endpoints/organization_slugs.py
+++ b/src/sentry/api/endpoints/organization_slugs.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import options
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ConflictError
@@ -15,6 +16,10 @@ from sentry.utils.snowflake import MaxSnowflakeRetryError
 
 @region_silo_endpoint
 class SlugsUpdateEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def put(self, request: Request, organization) -> Response:
         """
         Update Project Slugs

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 
 from sentry import tsdb
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, StatsMixin, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -12,6 +13,9 @@ from sentry.tsdb.base import TSDBModel
 
 @region_silo_endpoint
 class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from typing_extensions import TypedDict
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.utils import InvalidParams as InvalidParamsApi
@@ -131,6 +132,9 @@ class StatsApiResponse(TypedDict):
 @extend_schema(tags=["Organizations"])
 @region_silo_endpoint
 class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
     owner = ApiOwner.ENTERPRISE
     enforce_rate_limit = True
     rate_limits = {

--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tagstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import SequencePaginator
@@ -19,6 +20,10 @@ def validate_sort_field(field_name: str) -> str:
 
 @region_silo_endpoint
 class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, key) -> Response:
         if not TAG_KEY_RE.match(key):
             return Response({"detail": f'Invalid tag key format for "{key}"'}, status=400)

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from sentry import features, tagstore
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.serializers import serialize
@@ -13,6 +14,9 @@ from sentry.utils.sdk import set_measurement
 
 @region_silo_endpoint
 class OrganizationTagsEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.PERFORMANCE
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import (
     DEFAULT_SLUG_ERROR_MESSAGE,
     DEFAULT_SLUG_PATTERN,
@@ -67,6 +68,10 @@ class TeamPostSerializer(serializers.Serializer, PreventNumericSlugMixin):
 @extend_schema(tags=["Teams"])
 @region_silo_endpoint
 class OrganizationTeamsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
+    }
     public = {"GET", "POST"}
     permission_classes = (OrganizationTeamsPermission,)
 

--- a/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
+++ b/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from urllib3 import Retry
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.utils import get_date_range_from_params
@@ -97,6 +98,10 @@ def get_time_params(start, end):
 
 @region_silo_endpoint
 class OrganizationTransactionAnomalyDetectionEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def has_feature(self, organization, request):
         return features.has(
             "organizations:performance-anomaly-detection-ui", organization, actor=request.user

--- a/src/sentry/api/endpoints/organization_user_details.py
+++ b/src/sentry/api/endpoints/organization_user_details.py
@@ -2,6 +2,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.endpoints.organization_member.index import MemberPermission
@@ -10,6 +11,9 @@ from sentry.services.hybrid_cloud.user.service import user_service
 
 @region_silo_endpoint
 class OrganizationUserDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (MemberPermission,)
 
     def get(self, request: Request, organization, user_id) -> Response:

--- a/src/sentry/api/endpoints/organization_user_reports.py
+++ b/src/sentry/api/endpoints/organization_user_reports.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationUserReportsPermission
@@ -13,6 +14,9 @@ from sentry.models import UserReport
 
 @region_silo_endpoint
 class OrganizationUserReportsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationUserReportsPermission,)
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_user_teams.py
+++ b/src/sentry/api/endpoints/organization_user_teams.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -11,6 +12,10 @@ from sentry.models import Team, TeamStatus
 
 @region_silo_endpoint
 class OrganizationUserTeamsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         """
         List your Teams In the Current Organization

--- a/src/sentry/api/endpoints/organization_users.py
+++ b/src/sentry/api/endpoints/organization_users.py
@@ -2,6 +2,7 @@ import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -12,6 +13,10 @@ from sentry.models.projectteam import ProjectTeam
 
 @region_silo_endpoint
 class OrganizationUsersEndpoint(OrganizationEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         """
         List an Organization's Users

--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.rules import rules
@@ -8,6 +9,10 @@ from sentry.rules import rules
 
 @region_silo_endpoint
 class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         """
         Retrieve the list of rule conditions

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -1,4 +1,5 @@
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 
 """Sentry API to manage the App Store Connect credentials for a project.
@@ -82,6 +83,9 @@ class AppStoreConnectCredentialsSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class AppStoreConnectAppsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     """Retrieves available applications with provided credentials.
 
     ``POST projects/{org_slug}/{proj_slug}/appstoreconnect/apps/``
@@ -198,6 +202,9 @@ class AppStoreCreateCredentialsSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class AppStoreConnectCreateCredentialsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     """Returns all the App Store Connect symbol source settings ready to be saved.
 
     ``POST projects/{org_slug}/{proj_slug}/appstoreconnect/``
@@ -273,6 +280,9 @@ class AppStoreUpdateCredentialsSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class AppStoreConnectUpdateCredentialsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     """Updates a subset of the existing credentials.
 
     ``POST projects/{org_slug}/{proj_slug}/appstoreconnect/{id}/``
@@ -336,6 +346,9 @@ class AppStoreConnectUpdateCredentialsEndpoint(ProjectEndpoint):
 
 @region_silo_endpoint
 class AppStoreConnectRefreshEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     """Triggers an immediate check for new App Store Connect builds.
 
     ``POST projects/{org_slug}/{proj_slug}/appstoreconnect/{id}/refresh/``
@@ -387,6 +400,9 @@ class AppStoreConnectRefreshEndpoint(ProjectEndpoint):
 
 @region_silo_endpoint
 class AppStoreConnectStatusEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """Returns a summary of the project's App Store Connect configuration
     and builds.
 

--- a/src/sentry/api/endpoints/project_artifact_bundle_file_details.py
+++ b/src/sentry/api/endpoints/project_artifact_bundle_file_details.py
@@ -8,6 +8,7 @@ from django.http.response import FileResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.endpoints.debug_files import has_download_permission
@@ -47,6 +48,9 @@ class ProjectArtifactBundleFileDetailsMixin:
 class ProjectArtifactBundleFileDetailsEndpoint(
     ProjectEndpoint, ProjectArtifactBundleFileDetailsMixin
 ):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def get(self, request: Request, project, bundle_id, file_id) -> Response:

--- a/src/sentry/api/endpoints/project_artifact_bundle_files.py
+++ b/src/sentry/api/endpoints/project_artifact_bundle_files.py
@@ -4,6 +4,7 @@ from django.utils.functional import cached_property
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.paginator import ChainPaginator
@@ -51,6 +52,9 @@ class ArtifactBundleSource:
 
 @region_silo_endpoint
 class ProjectArtifactBundleFilesEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
     rate_limits = RateLimitConfig(
         group="CLI", limit_overrides={"GET": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}

--- a/src/sentry/api/endpoints/project_commits.py
+++ b/src/sentry/api/endpoints/project_commits.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.paginator import OffsetPaginator
@@ -10,6 +11,9 @@ from sentry.models import Commit
 
 @region_silo_endpoint
 class ProjectCommitsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
 
     permission_classes = (ProjectReleasePermission,)
 

--- a/src/sentry/api/endpoints/project_create_sample.py
+++ b/src/sentry/api/endpoints/project_create_sample.py
@@ -3,6 +3,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.serializers import serialize
@@ -12,6 +13,9 @@ from sentry.utils.samples import create_sample_event
 
 @region_silo_endpoint
 class ProjectCreateSampleEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     # Members should be able to create sample events.
     # This is the same scope that allows members to view all issues for a project.
     permission_classes = (ProjectEventPermission,)

--- a/src/sentry/api/endpoints/project_create_sample_transaction.py
+++ b/src/sentry/api/endpoints/project_create_sample_transaction.py
@@ -6,6 +6,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.serializers import serialize
@@ -66,6 +67,9 @@ def fix_event_data(data):
 
 @region_silo_endpoint
 class ProjectCreateSampleTransactionEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     # Members should be able to create sample events.
     # This is the same scope that allows members to view all issues for a project.
     permission_classes = (ProjectEventPermission,)

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -12,6 +12,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import (
     DEFAULT_SLUG_ERROR_MESSAGE,
     DEFAULT_SLUG_PATTERN,
@@ -382,6 +383,11 @@ class RelaxedProjectPermission(ProjectPermission):
 @extend_schema(tags=["Projects"])
 @region_silo_endpoint
 class ProjectDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.PUBLIC,
+    }
     public = {"GET", "PUT", "DELETE"}
     permission_classes = [RelaxedProjectPermission]
 

--- a/src/sentry/api/endpoints/project_docs_platform.py
+++ b/src/sentry/api/endpoints/project_docs_platform.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -38,6 +39,10 @@ def replace_keys(html, project_key):
 
 @region_silo_endpoint
 class ProjectDocsPlatformEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, platform) -> Response:
         data = load_doc(platform)
         if not data:

--- a/src/sentry/api/endpoints/project_dynamic_sampling.py
+++ b/src/sentry/api/endpoints/project_dynamic_sampling.py
@@ -11,6 +11,7 @@ from snuba_sdk.request import Request as SnubaRequest
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.dynamic_sampling.rules.base import get_guarded_blended_sample_rate
@@ -48,6 +49,9 @@ class DynamicSamplingPermission(ProjectPermission):
 
 @region_silo_endpoint
 class ProjectDynamicSamplingRateEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     permission_classes = (DynamicSamplingReadPermission,)
 
@@ -69,6 +73,9 @@ class ProjectDynamicSamplingRateEndpoint(ProjectEndpoint):
 
 @region_silo_endpoint
 class ProjectDynamicSamplingDistributionEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     permission_classes = (DynamicSamplingPermission,)
 

--- a/src/sentry/api/endpoints/project_environment_details.py
+++ b/src/sentry/api/endpoints/project_environment_details.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -15,6 +16,11 @@ class ProjectEnvironmentSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class ProjectEnvironmentDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, environment) -> Response:
         try:
             instance = EnvironmentProject.objects.select_related("environment").get(

--- a/src/sentry/api/endpoints/project_environments.py
+++ b/src/sentry/api/endpoints/project_environments.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.environments import environment_visibility_filter_options
@@ -10,6 +11,10 @@ from sentry.models import EnvironmentProject
 
 @region_silo_endpoint
 class ProjectEnvironmentsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         """
         List a Project's Environments

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import IssueEventSerializer, serialize
@@ -50,6 +51,10 @@ def wrap_event_response(
 
 @region_silo_endpoint
 class ProjectEventDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, event_id) -> Response:
         """
         Retrieve an Event for a Project
@@ -93,6 +98,10 @@ from rest_framework.response import Response
 
 @region_silo_endpoint
 class EventJsonEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, event_id) -> Response:
         event = eventstore.backend.get_event_by_id(project.id, event_id)
 

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
@@ -14,6 +15,9 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 @region_silo_endpoint
 class ProjectEventsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -23,6 +24,9 @@ from sentry.ingest.inbound_filters import FilterStatKeys
 @extend_schema(tags=["Projects"])
 @region_silo_endpoint
 class ProjectFilterDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "PUT": ApiPublishStatus.PUBLIC,
+    }
     public = {"PUT"}
 
     @extend_schema(

--- a/src/sentry/api/endpoints/project_filters.py
+++ b/src/sentry/api/endpoints/project_filters.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.ingest import inbound_filters
@@ -8,6 +9,10 @@ from sentry.ingest import inbound_filters
 
 @region_silo_endpoint
 class ProjectFiltersEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         """
         List a project's filters

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, eventstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.helpers.group_index import (
@@ -27,6 +28,11 @@ ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', a
 
 @region_silo_endpoint
 class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectEventPermission,)
     enforce_rate_limit = True
 

--- a/src/sentry/api/endpoints/project_group_stats.py
+++ b/src/sentry/api/endpoints/project_group_stats.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tsdb
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, StatsMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -12,6 +13,9 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 @region_silo_endpoint
 class ProjectGroupStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/project_grouping_configs.py
+++ b/src/sentry/api/endpoints/project_grouping_configs.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectEndpoint
 from sentry.api.serializers import serialize
@@ -9,6 +10,9 @@ from sentry.grouping.strategies.configurations import CONFIGURATIONS
 
 @region_silo_endpoint
 class ProjectGroupingConfigsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """Retrieve available grouping configs with project-specific information
 
     See GroupingConfigsEndpoint

--- a/src/sentry/api/endpoints/project_index.py
+++ b/src/sentry/api/endpoints/project_index.py
@@ -4,6 +4,7 @@ from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.bases.project import ProjectPermission
 from sentry.api.paginator import DateTimePaginator
@@ -18,6 +19,9 @@ from sentry.search.utils import tokenize_query
 
 @region_silo_endpoint
 class ProjectIndexEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/project_issues_resolved_in_release.py
+++ b/src/sentry/api/endpoints/project_issues_resolved_in_release.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.helpers.releases import get_group_ids_resolved_in_release
@@ -11,6 +12,9 @@ from sentry.models import Group
 
 @region_silo_endpoint
 class ProjectIssuesResolvedInReleaseEndpoint(ProjectEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectPermission,)
 
     def get(self, request: Request, project, version) -> Response:

--- a/src/sentry/api/endpoints/project_key_details.py
+++ b/src/sentry/api/endpoints/project_key_details.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -26,6 +27,11 @@ from sentry.models import ProjectKey, ProjectKeyStatus
 @extend_schema(tags=["Projects"])
 @region_silo_endpoint
 class ProjectKeyDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.PUBLIC,
+    }
     public = {"GET", "PUT", "DELETE"}
 
     @extend_schema(

--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk.api import capture_exception
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import StatsMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -20,6 +21,9 @@ from sentry.utils.outcomes import Outcome
 
 @region_silo_endpoint
 class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/project_keys.py
+++ b/src/sentry/api/endpoints/project_keys.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
@@ -26,6 +27,10 @@ from sentry.models import ProjectKey, ProjectKeyStatus
 @extend_schema(tags=["Projects"])
 @region_silo_endpoint
 class ProjectKeysEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
+    }
     public = {"GET", "POST"}
 
     @extend_schema(

--- a/src/sentry/api/endpoints/project_member_index.py
+++ b/src/sentry/api/endpoints/project_member_index.py
@@ -2,6 +2,7 @@ from django.db.models import Q
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
@@ -10,6 +11,10 @@ from sentry.models import OrganizationMember
 
 @region_silo_endpoint
 class ProjectMemberIndexEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         queryset = OrganizationMember.objects.filter(
             Q(user_is_active=True, user_id__isnull=False) | Q(user_id__isnull=True),

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectOwnershipPermission
 from sentry.api.serializers import serialize
@@ -159,6 +160,10 @@ class ProjectOwnershipSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class ProjectOwnershipEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = [ProjectOwnershipPermission]
 
     def get_ownership(self, project):

--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, features, projectoptions
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.permissions import SuperuserPermission
@@ -167,6 +168,11 @@ def get_disabled_threshold_options(payload, current_settings):
 
 @region_silo_endpoint
 class ProjectPerformanceIssueSettingsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectOwnerOrSuperUserPermissions,)
 
     def has_feature(self, project, request) -> bool:

--- a/src/sentry/api/endpoints/project_platforms.py
+++ b/src/sentry/api/endpoints/project_platforms.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
@@ -9,6 +10,10 @@ from sentry.models import ProjectPlatform
 
 @region_silo_endpoint
 class ProjectPlatformsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         queryset = ProjectPlatform.objects.filter(project_id=project.id)
         return Response(serialize(list(queryset), request.user))

--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -28,6 +29,13 @@ OK_UPDATED = "Successfully updated configuration."
 
 @region_silo_endpoint
 class ProjectPluginDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def _get_plugin(self, plugin_id):
         try:
             return plugins.get(plugin_id)

--- a/src/sentry/api/endpoints/project_plugins.py
+++ b/src/sentry/api/endpoints/project_plugins.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
@@ -10,6 +11,10 @@ from sentry.plugins.base import plugins
 
 @region_silo_endpoint
 class ProjectPluginsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         context = serialize(
             [plugin for plugin in plugins.configurable_for_project(project, version=None)],

--- a/src/sentry/api/endpoints/project_processingissues.py
+++ b/src/sentry/api/endpoints/project_processingissues.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.processing_issues import get_processing_issues
@@ -11,6 +12,10 @@ from sentry.reprocessing import trigger_reprocessing
 
 @region_silo_endpoint
 class ProjectProcessingIssuesDiscardEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+    }
+
     def delete(self, request: Request, project) -> Response:
         """
         This discards all open processing issues
@@ -21,6 +26,11 @@ class ProjectProcessingIssuesDiscardEndpoint(ProjectEndpoint):
 
 @region_silo_endpoint
 class ProjectProcessingIssuesEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         """
         List a project's processing issues.

--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
@@ -69,6 +70,10 @@ class ProjectProfilingPaginatedBaseEndpoint(ProjectProfilingBaseEndpoint, ABC):
 
 @region_silo_endpoint
 class ProjectProfilingTransactionIDProfileIDEndpoint(ProjectProfilingBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project: Project, transaction_id: str) -> HttpResponse:
         if not features.has("organizations:profiling", project.organization, actor=request.user):
             return Response(status=404)
@@ -81,6 +86,10 @@ class ProjectProfilingTransactionIDProfileIDEndpoint(ProjectProfilingBaseEndpoin
 
 @region_silo_endpoint
 class ProjectProfilingProfileEndpoint(ProjectProfilingBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project: Project, profile_id: str) -> HttpResponse:
         if not features.has("organizations:profiling", project.organization, actor=request.user):
             return Response(status=404)
@@ -128,6 +137,10 @@ def get_release(project: Project, version: str) -> Any:
 
 @region_silo_endpoint
 class ProjectProfilingRawProfileEndpoint(ProjectProfilingBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project: Project, profile_id: str) -> HttpResponse:
         if not features.has("organizations:profiling", project.organization, actor=request.user):
             return Response(status=404)
@@ -140,6 +153,10 @@ class ProjectProfilingRawProfileEndpoint(ProjectProfilingBaseEndpoint):
 
 @region_silo_endpoint
 class ProjectProfilingFlamegraphEndpoint(ProjectProfilingBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project: Project) -> HttpResponse:
         if not features.has("organizations:profiling", project.organization, actor=request.user):
             return Response(status=404)
@@ -154,6 +171,9 @@ class ProjectProfilingFlamegraphEndpoint(ProjectProfilingBaseEndpoint):
 
 @region_silo_endpoint
 class ProjectProfilingFunctionsEndpoint(ProjectProfilingPaginatedBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     DEFAULT_PER_PAGE = 5
     MAX_PER_PAGE = 50
 
@@ -208,6 +228,10 @@ class ProjectProfileEventSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class ProjectProfilingEventEndpoint(ProjectProfilingBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def convert_args(self, request: Request, *args, **kwargs):
         # disables the auto conversion of project slug inherited from the
         # project endpoint since this takes the project id instead of the slug

--- a/src/sentry/api/endpoints/project_release_commits.py
+++ b/src/sentry/api/endpoints/project_release_commits.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -10,6 +11,9 @@ from sentry.models import Release, ReleaseCommit, Repository
 
 @region_silo_endpoint
 class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def get(self, request: Request, project, version) -> Response:

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -2,6 +2,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import ReleaseAnalyticsMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.endpoints.organization_releases import get_stats_period_detail
@@ -18,6 +19,11 @@ from sentry.utils.sdk import bind_organization_context, configure_scope
 
 @region_silo_endpoint
 class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def get(self, request: Request, project, version) -> Response:

--- a/src/sentry/api/endpoints/project_release_file_details.py
+++ b/src/sentry/api/endpoints/project_release_file_details.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.endpoints.debug_files import has_download_permission
@@ -201,6 +202,11 @@ class ReleaseFileDetailsMixin:
 
 @region_silo_endpoint
 class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def get(self, request: Request, project, version, file_id) -> Response:

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -8,6 +8,7 @@ from django.utils.functional import cached_property
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -223,6 +224,10 @@ def pseudo_releasefile(url, info, dist):
 
 @region_silo_endpoint
 class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
     rate_limits = RateLimitConfig(
         group="CLI", limit_overrides={"GET": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}

--- a/src/sentry/api/endpoints/project_release_repositories.py
+++ b/src/sentry/api/endpoints/project_release_repositories.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -10,6 +11,9 @@ from sentry.models import Release, ReleaseCommit, Repository
 
 @region_silo_endpoint
 class ProjectReleaseRepositories(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
 
     permission_classes = (ProjectReleasePermission,)
 

--- a/src/sentry/api/endpoints/project_release_setup.py
+++ b/src/sentry/api/endpoints/project_release_setup.py
@@ -2,6 +2,7 @@ from django.core.cache import cache
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.models import Deploy, Group, ReleaseCommit, ReleaseProject, Repository
@@ -10,6 +11,9 @@ from sentry.utils.hashlib import hash_values
 
 @region_silo_endpoint
 class ProjectReleaseSetupCompletionEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def get(self, request: Request, project) -> Response:

--- a/src/sentry/api/endpoints/project_release_stats.py
+++ b/src/sentry/api/endpoints/project_release_stats.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import release_health
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventsError, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -25,6 +26,9 @@ def upsert_missing_release(project, version):
 
 @region_silo_endpoint
 class ProjectReleaseStatsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def get(self, request: Request, project, version) -> Response:

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.paginator import OffsetPaginator
@@ -23,6 +24,10 @@ from sentry.utils.sdk import bind_organization_context, configure_scope
 
 @region_silo_endpoint
 class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
     rate_limits = RateLimitConfig(
         group="CLI", limit_overrides={"GET": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}

--- a/src/sentry/api/endpoints/project_releases_token.py
+++ b/src/sentry/api/endpoints/project_releases_token.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, StrictProjectPermission
 from sentry.models import ProjectOption
@@ -36,6 +37,10 @@ def _get_signature(project_id, plugin_id, token):
 
 @region_silo_endpoint
 class ProjectReleasesTokenEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (StrictProjectPermission,)
 
     def _regenerate_token(self, project):

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import integrations
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
@@ -94,6 +95,9 @@ class PathMappingSerializer(CamelSnakeSerializer):
 
 
 class ProjectRepoPathParsingEndpointLoosePermission(ProjectPermission):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     """
     Similar to the code_mappings endpoint, loosen permissions to all users
     """

--- a/src/sentry/api/endpoints/project_reprocessing.py
+++ b/src/sentry/api/endpoints/project_reprocessing.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.reprocessing import trigger_reprocessing
@@ -8,6 +9,9 @@ from sentry.reprocessing import trigger_reprocessing
 
 @region_silo_endpoint
 class ProjectReprocessingEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectReleasePermission,)
 
     def post(self, request: Request, project) -> Response:

--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers.rest_framework import RuleActionSerializer
@@ -15,6 +16,9 @@ from sentry.web.decorators import transaction_start
 
 @region_silo_endpoint
 class ProjectRuleActionsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ISSUES
 
     permission_classes = (ProjectAlertRulePermission,)

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.rule import RuleEndpoint
 from sentry.api.endpoints.project_rules import find_duplicate_rule
@@ -34,6 +35,12 @@ from sentry.web.decorators import transaction_start
 
 @region_silo_endpoint
 class ProjectRuleDetailsEndpoint(RuleEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     @transaction_start("ProjectRuleDetailsEndpoint")
     def get(self, request: Request, project, rule) -> Response:
         """

--- a/src/sentry/api/endpoints/project_rule_enable.py
+++ b/src/sentry/api/endpoints/project_rule_enable.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from sentry import audit_log
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.endpoints.project_rules import find_duplicate_rule
@@ -14,6 +15,9 @@ from sentry.models import Rule
 
 @region_silo_endpoint
 class ProjectRuleEnableEndpoint(ProjectEndpoint):
+    publish_status = {
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ISSUES
     permission_classes = (ProjectAlertRulePermission,)
 

--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -5,6 +5,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers import GroupSerializer, serialize
@@ -16,6 +17,9 @@ from sentry.web.decorators import transaction_start
 
 @region_silo_endpoint
 class ProjectRulePreviewEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
 
     permission_classes = (ProjectAlertRulePermission,)
 

--- a/src/sentry/api/endpoints/project_rule_task_details.py
+++ b/src/sentry/api/endpoints/project_rule_task_details.py
@@ -2,6 +2,7 @@ from django.http import Http404
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.serializers import serialize
@@ -12,6 +13,9 @@ from sentry.models import Rule
 
 @region_silo_endpoint
 class ProjectRuleTaskDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = [ProjectSettingPermission]
 
     def get(self, request: Request, project, task_uuid) -> Response:

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 
 from sentry import audit_log, features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers import serialize
@@ -55,6 +56,10 @@ def find_duplicate_rule(rule_data, project, rule_id=None):
 
 @region_silo_endpoint
 class ProjectRulesEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ISSUES
     permission_classes = (ProjectAlertRulePermission,)
 

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.constants import MIGRATED_CONDITIONS, SENTRY_APP_ACTIONS, TICKET_ACTIONS
@@ -10,6 +11,10 @@ from sentry.rules import rules
 
 @region_silo_endpoint
 class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         """
         Retrieve the list of configuration options for a given project.

--- a/src/sentry/api/endpoints/project_servicehook_details.py
+++ b/src/sentry/api/endpoints/project_servicehook_details.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -15,6 +16,12 @@ from sentry.models import ServiceHook
 
 @region_silo_endpoint
 class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, hook_id) -> Response:
         """
         Retrieve a Service Hook

--- a/src/sentry/api/endpoints/project_servicehook_stats.py
+++ b/src/sentry/api/endpoints/project_servicehook_stats.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tsdb
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import StatsMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -11,6 +12,10 @@ from sentry.tsdb.base import TSDBModel
 
 @region_silo_endpoint
 class ProjectServiceHookStatsEndpoint(ProjectEndpoint, StatsMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, hook_id) -> Response:
         try:
             hook = ServiceHook.objects.get(project_id=project.id, guid=hook_id)

--- a/src/sentry/api/endpoints/project_servicehooks.py
+++ b/src/sentry/api/endpoints/project_servicehooks.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
@@ -16,6 +17,11 @@ from sentry.services.hybrid_cloud.hook import hook_service
 
 @region_silo_endpoint
 class ProjectServiceHooksEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def has_feature(self, request: Request, project):
         return features.has("projects:servicehooks", project=project, actor=request.user)
 

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -7,6 +7,7 @@ from sentry_sdk import Scope, configure_scope
 
 from sentry import analytics
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
@@ -186,6 +187,9 @@ def get_code_mapping_configs(project: Project) -> List[RepositoryProjectPathConf
 
 @region_silo_endpoint
 class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """
     Returns valid links for source code providers so that
     users can go from the file in the stack trace to the

--- a/src/sentry/api/endpoints/project_stacktrace_links.py
+++ b/src/sentry/api/endpoints/project_stacktrace_links.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.integrations.base import IntegrationInstallation
@@ -28,6 +29,9 @@ class StacktraceLinksSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class ProjectStacktraceLinksEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """
     Returns valid links for source code providers so that
     users can go from files in the stack trace to the

--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tsdb
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, StatsMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -12,6 +13,10 @@ from sentry.tsdb.base import TSDBModel
 
 @region_silo_endpoint
 class ProjectStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         """
         Retrieve Event Counts for a Project

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, tagstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -13,6 +14,10 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 @region_silo_endpoint
 class ProjectTagKeyDetailsEndpoint(ProjectEndpoint, EnvironmentMixin):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     enforce_rate_limit = True
     rate_limits = {
         "DELETE": {

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tagstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -12,6 +13,10 @@ from sentry.models import Environment
 
 @region_silo_endpoint
 class ProjectTagKeyValuesEndpoint(ProjectEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, key) -> Response:
         """
         List a Tag's Values

--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tagstore
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.constants import DS_DENYLIST, PROTECTED_TAG_KEYS
@@ -10,6 +11,10 @@ from sentry.models import Environment
 
 @region_silo_endpoint
 class ProjectTagsEndpoint(ProjectEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         try:
             environment_id = self._get_environment_id_from_request(request, project.organization_id)

--- a/src/sentry/api/endpoints/project_team_details.py
+++ b/src/sentry/api/endpoints/project_team_details.py
@@ -2,6 +2,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -25,6 +26,10 @@ class ProjectTeamsPermission(ProjectPermission):
 @extend_schema(tags=["Projects"])
 @region_silo_endpoint
 class ProjectTeamDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
+    }
     public = {"POST", "DELETE"}
     permission_classes = (ProjectTeamsPermission,)
 

--- a/src/sentry/api/endpoints/project_teams.py
+++ b/src/sentry/api/endpoints/project_teams.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -10,6 +11,10 @@ from sentry.models import Team
 
 @region_silo_endpoint
 class ProjectTeamsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         """
         List a Project's Teams

--- a/src/sentry/api/endpoints/project_transaction_names.py
+++ b/src/sentry/api/endpoints/project_transaction_names.py
@@ -4,6 +4,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.utils import get_date_range_from_stats_period
@@ -15,6 +16,10 @@ from sentry.ingest.transaction_clusterer.tree import TreeClusterer
 
 @region_silo_endpoint
 class ProjectTransactionNamesCluster(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         """Run the transaction name clusterer and return its output.
 

--- a/src/sentry/api/endpoints/project_transaction_threshold.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.serializers import serialize
@@ -41,6 +42,11 @@ class ProjectTransactionThresholdSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectSettingPermission,)
 
     def has_feature(self, project, request):

--- a/src/sentry/api/endpoints/project_transaction_threshold_override.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold_override.py
@@ -4,6 +4,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectTransactionThresholdOverridePermission
 from sentry.api.bases.organization_events import OrganizationEventsV2EndpointBase
@@ -56,6 +57,11 @@ class ProjectTransactionThresholdOverrideSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class ProjectTransactionThresholdOverrideEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectTransactionThresholdOverridePermission,)
 
     def get_project(self, request: Request, organization):

--- a/src/sentry/api/endpoints/project_transfer.py
+++ b/src/sentry/api/endpoints/project_transfer.py
@@ -8,6 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, options, roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.decorators import sudo_required
@@ -25,6 +26,9 @@ class RelaxedProjectPermission(ProjectPermission):
 
 @region_silo_endpoint
 class ProjectTransferEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = [RelaxedProjectPermission]
 
     @sudo_required

--- a/src/sentry/api/endpoints/project_user_details.py
+++ b/src/sentry/api/endpoints/project_user_details.py
@@ -2,6 +2,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
@@ -11,6 +12,11 @@ from sentry.models import EventUser
 
 @region_silo_endpoint
 class ProjectUserDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, user_hash) -> Response:
         euser = EventUser.objects.get(project_id=project.id, hash=user_hash)
         return Response(serialize(euser, request.user))

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
@@ -20,6 +21,10 @@ class UserReportSerializer(serializers.ModelSerializer):
 
 @region_silo_endpoint
 class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ProjectEndpoint.authentication_classes + (DSNAuthentication,)
 
     def get(self, request: Request, project) -> Response:

--- a/src/sentry/api/endpoints/project_user_stats.py
+++ b/src/sentry/api/endpoints/project_user_stats.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tsdb
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -14,6 +15,10 @@ from sentry.tsdb.base import TSDBModel
 
 @region_silo_endpoint
 class ProjectUserStatsEndpoint(EnvironmentMixin, ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         try:
             environment_id = self._get_environment_id_from_request(request, project.organization_id)

--- a/src/sentry/api/endpoints/project_users.py
+++ b/src/sentry/api/endpoints/project_users.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import DateTimePaginator
@@ -10,6 +11,10 @@ from sentry.models import EventUser
 
 @region_silo_endpoint
 class ProjectUsersEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         """
         List a Project's Users

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -9,6 +9,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.models import Organization, Project, PromptsActivity
 from sentry.utils.prompts import prompt_config
@@ -33,6 +34,10 @@ class PromptsActivitySerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class PromptsActivityEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (IsAuthenticated,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/relay/details.py
+++ b/src/sentry/api/endpoints/relay/details.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.permissions import SuperuserPermission
@@ -10,6 +11,9 @@ from sentry.models import Relay
 
 @region_silo_endpoint
 class RelayDetailsEndpoint(Endpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
     owner = ApiOwner.OWNERS_INGEST
 

--- a/src/sentry/api/endpoints/relay/health_check.py
+++ b/src/sentry/api/endpoints/relay/health_check.py
@@ -2,11 +2,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 
 
 @region_silo_endpoint
 class RelayHealthCheck(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """
     Endpoint checked by downstream Relay when a suspected network error is encountered.
     This endpoint doesn't do anything besides returning an Ok, and the downstream Relay

--- a/src/sentry/api/endpoints/relay/index.py
+++ b/src/sentry/api/endpoints/relay/index.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.permissions import SuperuserPermission
@@ -12,6 +13,9 @@ from sentry.models import Relay
 
 @region_silo_endpoint
 class RelayIndexEndpoint(Endpoint):
+    publish_status = [
+        {"GET": ApiPublishStatus.UNKNOWN},
+    ]
     permission_classes = (SuperuserPermission,)
     owner = ApiOwner.OWNERS_INGEST
 

--- a/src/sentry/api/endpoints/relay/index.py
+++ b/src/sentry/api/endpoints/relay/index.py
@@ -13,9 +13,9 @@ from sentry.models import Relay
 
 @region_silo_endpoint
 class RelayIndexEndpoint(Endpoint):
-    publish_status = [
-        {"GET": ApiPublishStatus.UNKNOWN},
-    ]
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
     owner = ApiOwner.OWNERS_INGEST
 

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from sentry_sdk import Hub, set_tag, start_span, start_transaction
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import RelayAuthentication
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.permissions import RelayPermission
@@ -31,6 +32,9 @@ def _sample_apm():
 
 @region_silo_endpoint
 class RelayProjectConfigsEndpoint(Endpoint):
+    publish_status = [
+        {"POST": ApiPublishStatus.UNKNOWN},
+    ]
     owner = ApiOwner.OWNERS_INGEST
     authentication_classes = (RelayAuthentication,)
     permission_classes = (RelayPermission,)

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -32,9 +32,9 @@ def _sample_apm():
 
 @region_silo_endpoint
 class RelayProjectConfigsEndpoint(Endpoint):
-    publish_status = [
-        {"POST": ApiPublishStatus.UNKNOWN},
-    ]
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.OWNERS_INGEST
     authentication_classes = (RelayAuthentication,)
     permission_classes = (RelayPermission,)

--- a/src/sentry/api/endpoints/relay/project_ids.py
+++ b/src/sentry/api/endpoints/relay/project_ids.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import RelayAuthentication
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.permissions import RelayPermission
@@ -10,6 +11,9 @@ from sentry.models import ProjectKey
 
 @region_silo_endpoint
 class RelayProjectIdsEndpoint(Endpoint):
+    publish_status = [
+        {"POST": ApiPublishStatus.UNKNOWN},
+    ]
     authentication_classes = (RelayAuthentication,)
     permission_classes = (RelayPermission,)
     owner = ApiOwner.OWNERS_INGEST

--- a/src/sentry/api/endpoints/relay/project_ids.py
+++ b/src/sentry/api/endpoints/relay/project_ids.py
@@ -11,9 +11,9 @@ from sentry.models import ProjectKey
 
 @region_silo_endpoint
 class RelayProjectIdsEndpoint(Endpoint):
-    publish_status = [
-        {"POST": ApiPublishStatus.UNKNOWN},
-    ]
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = (RelayAuthentication,)
     permission_classes = (RelayPermission,)
     owner = ApiOwner.OWNERS_INGEST

--- a/src/sentry/api/endpoints/relay/public_keys.py
+++ b/src/sentry/api/endpoints/relay/public_keys.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import RelayAuthentication
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.permissions import RelayPermission
@@ -10,6 +11,9 @@ from sentry.models import Relay
 
 @region_silo_endpoint
 class RelayPublicKeysEndpoint(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = (RelayAuthentication,)
     permission_classes = (RelayPermission,)
     enforce_rate_limit = False

--- a/src/sentry/api/endpoints/relay/register_challenge.py
+++ b/src/sentry/api/endpoints/relay/register_challenge.py
@@ -6,6 +6,7 @@ from sentry_relay.auth import create_register_challenge, is_version_supported
 
 from sentry import options
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import is_internal_relay, is_static_relay, relay_from_id
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.relay.constants import RELAY_AUTH_RATE_LIMITS
@@ -22,6 +23,9 @@ class RelayRegisterChallengeSerializer(RelayIdSerializer):
 
 @region_silo_endpoint
 class RelayRegisterChallengeEndpoint(Endpoint):
+    publish_status = [
+        {"POST": ApiPublishStatus.UNKNOWN},
+    ]
     authentication_classes = ()
     permission_classes = ()
     owner = ApiOwner.OWNERS_INGEST

--- a/src/sentry/api/endpoints/relay/register_challenge.py
+++ b/src/sentry/api/endpoints/relay/register_challenge.py
@@ -23,9 +23,9 @@ class RelayRegisterChallengeSerializer(RelayIdSerializer):
 
 @region_silo_endpoint
 class RelayRegisterChallengeEndpoint(Endpoint):
-    publish_status = [
-        {"POST": ApiPublishStatus.UNKNOWN},
-    ]
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ()
     permission_classes = ()
     owner = ApiOwner.OWNERS_INGEST

--- a/src/sentry/api/endpoints/relay/register_response.py
+++ b/src/sentry/api/endpoints/relay/register_response.py
@@ -7,6 +7,7 @@ from sentry_relay.exceptions import UnpackErrorSignatureExpired
 
 from sentry import options
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import is_internal_relay, relay_from_id
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.relay.constants import RELAY_AUTH_RATE_LIMITS
@@ -24,6 +25,9 @@ class RelayRegisterResponseSerializer(RelayIdSerializer):
 
 @region_silo_endpoint
 class RelayRegisterResponseEndpoint(Endpoint):
+    publish_status = [
+        {"POST": ApiPublishStatus.UNKNOWN},
+    ]
     owner = ApiOwner.OWNERS_INGEST
     authentication_classes = ()
     permission_classes = ()

--- a/src/sentry/api/endpoints/relay/register_response.py
+++ b/src/sentry/api/endpoints/relay/register_response.py
@@ -25,9 +25,9 @@ class RelayRegisterResponseSerializer(RelayIdSerializer):
 
 @region_silo_endpoint
 class RelayRegisterResponseEndpoint(Endpoint):
-    publish_status = [
-        {"POST": ApiPublishStatus.UNKNOWN},
-    ]
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.OWNERS_INGEST
     authentication_classes = ()
     permission_classes = ()

--- a/src/sentry/api/endpoints/release_deploys.py
+++ b/src/sentry/api/endpoints/release_deploys.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ParameterValidationError, ResourceDoesNotExist
@@ -32,6 +33,11 @@ class DeploySerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, version) -> Response:
         """
         List a Release's Deploys

--- a/src/sentry/api/endpoints/rpc.py
+++ b/src/sentry/api/endpoints/rpc.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import RpcSignatureAuthentication
 from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.services.hybrid_cloud.auth import AuthenticationContext
@@ -19,6 +20,9 @@ from sentry.utils.env import in_test_environment
 
 @all_silo_endpoint
 class RpcServiceEndpoint(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.HYBRID_CLOUD
     authentication_classes = (RpcSignatureAuthentication,)
     permission_classes = ()

--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers import Serializer, register, serialize
@@ -180,11 +181,19 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint):
 
 @region_silo_endpoint
 class RuleSnoozeEndpoint(BaseRuleSnoozeEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     rule_model = Rule
     rule_field = "rule"
 
 
 @region_silo_endpoint
 class MetricRuleSnoozeEndpoint(BaseRuleSnoozeEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     rule_model = AlertRule
     rule_field = "alert_rule"

--- a/src/sentry/api/endpoints/setup_wizard.py
+++ b/src/sentry/api/endpoints/setup_wizard.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import ratelimits
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.cache import default_cache
@@ -18,6 +19,10 @@ SETUP_WIZARD_CACHE_TIMEOUT = 600
 
 @region_silo_endpoint
 class SetupWizard(Endpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = ()
 
     def delete(self, request: Request, wizard_hash=None) -> Response | None:

--- a/src/sentry/api/endpoints/shared_group_details.py
+++ b/src/sentry/api/endpoints/shared_group_details.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, EnvironmentMixin, region_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import (
@@ -16,6 +17,9 @@ from sentry.models import Group
 
 @region_silo_endpoint
 class SharedGroupDetailsEndpoint(Endpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = ()
 
     def get(

--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from typing_extensions import TypedDict
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.source_map_helper import source_map_debug
@@ -29,6 +30,9 @@ class SourceMapProcessingResponse(TypedDict):
 @region_silo_endpoint
 @extend_schema(tags=["Events"])
 class SourceMapDebugEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
     public = {"GET"}
     owner = ApiOwner.ISSUES
 

--- a/src/sentry/api/endpoints/system_health.py
+++ b/src/sentry/api/endpoints/system_health.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import status_checks
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.auth.superuser import is_active_superuser
 from sentry.ratelimits.config import RateLimitConfig
@@ -14,6 +15,9 @@ from sentry.utils.hashlib import md5_text
 
 @all_silo_endpoint
 class SystemHealthEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (IsAuthenticated,)
     rate_limits = RateLimitConfig(group="INTERNAL")
 

--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 import sentry
 from sentry import options
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.utils.email import is_smtp_enabled
@@ -22,6 +23,10 @@ SYSTEM_OPTIONS_ALLOWLIST = (
 
 @all_silo_endpoint
 class SystemOptionsEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/team_alerts_triggered.py
+++ b/src/sentry/api/endpoints/team_alerts_triggered.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -24,6 +25,10 @@ from sentry.models import Project
 
 @region_silo_endpoint
 class TeamAlertsTriggeredTotalsEndpoint(TeamEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, team) -> Response:
         """
         Return a time-bucketed (by day) count of triggered alerts owned by a given team.
@@ -117,6 +122,10 @@ class TriggeredAlertRuleSerializer(AlertRuleSerializer):
 
 @region_silo_endpoint
 class TeamAlertsTriggeredIndexEndpoint(TeamEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request, team) -> Response:
         """
         Returns alert rules ordered by highest number of alerts fired this week.

--- a/src/sentry/api/endpoints/team_all_unresolved_issues.py
+++ b/src/sentry/api/endpoints/team_all_unresolved_issues.py
@@ -8,6 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.helpers.environments import get_environments
@@ -107,6 +108,10 @@ def calculate_unresolved_counts(team, project_list, start, end, environment_id):
 
 @region_silo_endpoint
 class TeamAllUnresolvedIssuesEndpoint(TeamEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, team: Team) -> Response:
         """
         Returns cumulative counts of unresolved groups per day within the stats period time range.

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, features, roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import (
     DEFAULT_SLUG_ERROR_MESSAGE,
     DEFAULT_SLUG_PATTERN,
@@ -51,6 +52,12 @@ class TeamSerializer(CamelSnakeModelSerializer, PreventNumericSlugMixin):
 
 @region_silo_endpoint
 class TeamDetailsEndpoint(TeamEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, team) -> Response:
         """
         Retrieve a Team

--- a/src/sentry/api/endpoints/team_groups_old.py
+++ b/src/sentry/api/endpoints/team_groups_old.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.helpers.environments import get_environments
@@ -13,6 +14,10 @@ from sentry.models import Group, GroupStatus
 
 @region_silo_endpoint
 class TeamGroupsOldEndpoint(TeamEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, team) -> Response:
         """
         Return the oldest issues owned by a team

--- a/src/sentry/api/endpoints/team_issue_breakdown.py
+++ b/src/sentry/api/endpoints/team_issue_breakdown.py
@@ -8,6 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.helpers.environments import get_environments
@@ -22,6 +23,10 @@ from sentry.models.grouphistory import (
 
 @region_silo_endpoint
 class TeamIssueBreakdownEndpoint(TeamEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, team: Team) -> Response:
         """
         Returns a dict of team projects, and a time-series dict of issue stat breakdowns for each.

--- a/src/sentry/api/endpoints/team_members.py
+++ b/src/sentry/api/endpoints/team_members.py
@@ -2,6 +2,7 @@ from django.db.models import Q, prefetch_related_objects
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -43,6 +44,10 @@ class DetailedOrganizationMemberTeamSerializer(Serializer):
 
 @region_silo_endpoint
 class TeamMembersEndpoint(TeamEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, team) -> Response:
         queryset = OrganizationMemberTeam.objects.filter(
             Q(organizationmember__user_is_active=True, organizationmember__user_id__isnull=False)

--- a/src/sentry/api/endpoints/team_notification_settings_details.py
+++ b/src/sentry/api/endpoints/team_notification_settings_details.py
@@ -2,6 +2,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.serializers import serialize
@@ -12,6 +13,10 @@ from sentry.models import NotificationSetting, Team
 
 @region_silo_endpoint
 class TeamNotificationSettingsDetailsEndpoint(TeamEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     """
     This Notification Settings endpoint is the generic way to interact with the
     NotificationSettings table via the API.

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import (
     DEFAULT_SLUG_ERROR_MESSAGE,
     DEFAULT_SLUG_PATTERN,
@@ -69,6 +70,10 @@ class TeamProjectPermission(TeamPermission):
 @extend_schema(tags=["Teams"])
 @region_silo_endpoint
 class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
+    }
     public = {"GET", "POST"}
     permission_classes = (TeamProjectPermission,)
 

--- a/src/sentry/api/endpoints/team_release_count.py
+++ b/src/sentry/api/endpoints/team_release_count.py
@@ -8,6 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.utils import get_date_range_from_params
@@ -16,6 +17,10 @@ from sentry.models import Project, Release
 
 @region_silo_endpoint
 class TeamReleaseCountEndpoint(TeamEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, team) -> Response:
         """
         Returns a dict of team projects, and a time-series list of release counts for each.

--- a/src/sentry/api/endpoints/team_stats.py
+++ b/src/sentry/api/endpoints/team_stats.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import tsdb
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, StatsMixin, region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -11,6 +12,10 @@ from sentry.tsdb.base import TSDBModel
 
 @region_silo_endpoint
 class TeamStatsEndpoint(TeamEndpoint, EnvironmentMixin, StatsMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, team) -> Response:
         """
         Retrieve Event Counts for a Team

--- a/src/sentry/api/endpoints/team_time_to_resolution.py
+++ b/src/sentry/api/endpoints/team_time_to_resolution.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.helpers.environments import get_environments
@@ -16,6 +17,10 @@ from sentry.models import GroupHistory, GroupHistoryStatus
 
 @region_silo_endpoint
 class TeamTimeToResolutionEndpoint(TeamEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, team) -> Response:
         """
         Return a a time bucketed list of mean group resolution times for a given team.

--- a/src/sentry/api/endpoints/team_unresolved_issue_age.py
+++ b/src/sentry/api/endpoints/team_unresolved_issue_age.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.helpers.environments import get_environments
@@ -26,6 +27,10 @@ OLDEST_LABEL = "> 1 year"
 
 @region_silo_endpoint
 class TeamUnresolvedIssueAgeEndpoint(TeamEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, team: Team) -> Response:
         """
         Return a time bucketed list of how old unresolved issues are.

--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import OrganizationUserPermission, UserEndpoint
 from sentry.api.decorators import sudo_required
@@ -17,6 +18,11 @@ from sentry.security import capture_security_activity
 
 @control_silo_endpoint
 class UserAuthenticatorDetailsEndpoint(UserEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrganizationUserPermission,)
 

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 
 from sentry import ratelimits as ratelimiter
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import email_verification_required, sudo_required
@@ -106,6 +107,10 @@ def get_serializer_field_metadata(serializer, fields=None):
 
 @control_silo_endpoint
 class UserAuthenticatorEnrollEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
 
     @sudo_required

--- a/src/sentry/api/endpoints/user_authenticator_index.py
+++ b/src/sentry/api/endpoints/user_authenticator_index.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.serializers import serialize
@@ -10,6 +11,9 @@ from sentry.models import Authenticator
 
 @control_silo_endpoint
 class UserAuthenticatorIndexEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
 
     def get(self, request: Request, user) -> Response:

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 
 from sentry import roles
 from sentry.api import client
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import sudo_required
@@ -130,6 +131,12 @@ class DeleteUserSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class UserDetailsEndpoint(UserEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, user) -> Response:
         """
         Retrieve User Details

--- a/src/sentry/api/endpoints/user_emails.py
+++ b/src/sentry/api/endpoints/user_emails.py
@@ -4,6 +4,7 @@ from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from rest_framework import serializers
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import sudo_required
@@ -58,6 +59,13 @@ from rest_framework.response import Response
 
 @control_silo_endpoint
 class UserEmailsEndpoint(UserEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, user) -> Response:
         """
         Get list of emails

--- a/src/sentry/api/endpoints/user_emails_confirm.py
+++ b/src/sentry/api/endpoints/user_emails_confirm.py
@@ -4,6 +4,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.validators import AllowedEmailField
@@ -35,6 +36,9 @@ class EmailSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class UserEmailsConfirmEndpoint(UserEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     rate_limits = {
         "POST": {
             RateLimitCategory.USER: RateLimit(10, 60),

--- a/src/sentry/api/endpoints/user_identity.py
+++ b/src/sentry/api/endpoints/user_identity.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -10,6 +11,10 @@ from sentry.models import Identity
 
 @control_silo_endpoint
 class UserIdentityEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, user) -> Response:
         """
         Retrieve all of a users' identities (NOT AuthIdentities)

--- a/src/sentry/api/endpoints/user_identity_config.py
+++ b/src/sentry/api/endpoints/user_identity_config.py
@@ -6,6 +6,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.serializers import serialize
@@ -76,6 +77,10 @@ def get_identities(user: User) -> Iterable[UserIdentityConfig]:
 
 @control_silo_endpoint
 class UserIdentityConfigEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, user) -> Response:
         """
         Retrieve all of a user's SocialIdentity, Identity, and AuthIdentity values
@@ -91,6 +96,11 @@ class UserIdentityConfigEndpoint(UserEndpoint):
 
 @control_silo_endpoint
 class UserIdentityConfigDetailsEndpoint(UserEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     @staticmethod
     def _get_identity(user, category, identity_id) -> Optional[UserIdentityConfig]:
         identity_id = int(identity_id)

--- a/src/sentry/api/endpoints/user_identity_details.py
+++ b/src/sentry/api/endpoints/user_identity_details.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.models import AuthIdentity
@@ -8,6 +9,10 @@ from sentry.models import AuthIdentity
 
 @control_silo_endpoint
 class UserIdentityDetailsEndpoint(UserEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+    }
+
     def delete(self, request: Request, user, identity_id) -> Response:
         AuthIdentity.objects.filter(user=user, id=identity_id).delete()
         return Response(status=204)

--- a/src/sentry/api/endpoints/user_index.py
+++ b/src/sentry/api/endpoints/user_index.py
@@ -2,6 +2,7 @@ from django.db.models import Q
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.permissions import SuperuserPermission
@@ -13,6 +14,9 @@ from sentry.search.utils import tokenize_query
 
 @control_silo_endpoint
 class UserIndexEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/user_ips.py
+++ b/src/sentry/api/endpoints/user_ips.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import sudo_required
@@ -11,6 +12,10 @@ from sentry.models import UserIP
 
 @control_silo_endpoint
 class UserIPsEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     @sudo_required
     def get(self, request: Request, user) -> Response:
         """

--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -4,6 +4,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.fields.empty_integer import EmptyIntegerField
@@ -74,6 +75,11 @@ class UserNotificationDetailsSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class UserNotificationDetailsEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, user) -> Response:
         serialized = serialize(user, request.user, UserNotificationsSerializer())
         return Response(serialized)

--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.serializers import serialize
@@ -28,6 +29,11 @@ INVALID_USER_MSG = (
 
 @control_silo_endpoint
 class UserNotificationFineTuningEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, user, notification_type) -> Response:
         try:
             notification_type = FineTuningAPIKey(notification_type)

--- a/src/sentry/api/endpoints/user_notification_settings_details.py
+++ b/src/sentry/api/endpoints/user_notification_settings_details.py
@@ -2,6 +2,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.serializers import serialize
@@ -12,6 +13,10 @@ from sentry.models import NotificationSetting, User
 
 @control_silo_endpoint
 class UserNotificationSettingsDetailsEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     """
     This Notification Settings endpoint is the generic way to interact with the
     NotificationSettings table via the API.

--- a/src/sentry/api/endpoints/user_notification_settings_options.py
+++ b/src/sentry/api/endpoints/user_notification_settings_options.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.exceptions import ParameterValidationError
@@ -16,6 +17,10 @@ from sentry.notifications.validators import UserNotificationSettingOptionWithVal
 
 @control_silo_endpoint
 class UserNotificationSettingsOptionsEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
+    }
     owner = ApiOwner.ISSUES
     # TODO(Steve): Make not private when we launch new system
     private = True

--- a/src/sentry/api/endpoints/user_notification_settings_options_detail.py
+++ b/src/sentry/api/endpoints/user_notification_settings_options_detail.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.models import User
@@ -11,6 +12,9 @@ from sentry.models.notificationsettingoption import NotificationSettingOption
 
 @control_silo_endpoint
 class UserNotificationSettingsOptionsDetailEndpoint(UserEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.PRIVATE,
+    }
     owner = ApiOwner.ISSUES
     # TODO(Steve): Make not private when we launch new system
     private = True

--- a/src/sentry/api/endpoints/user_notification_settings_providers.py
+++ b/src/sentry/api/endpoints/user_notification_settings_providers.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.exceptions import ParameterValidationError
@@ -21,6 +22,10 @@ from sentry.notifications.validators import (
 
 @control_silo_endpoint
 class UserNotificationSettingsProvidersEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
+    }
     owner = ApiOwner.ISSUES
     # TODO(Steve): Make not private when we launch new system
     private = True

--- a/src/sentry/api/endpoints/user_organizationintegrations.py
+++ b/src/sentry/api/endpoints/user_organizationintegrations.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -12,6 +13,10 @@ from sentry.services.hybrid_cloud.user.service import user_service
 
 @control_silo_endpoint
 class UserOrganizationIntegrationsEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, user) -> Response:
         """
         Retrieve all of a users' organization integrations

--- a/src/sentry/api/endpoints/user_organizations.py
+++ b/src/sentry/api/endpoints/user_organizations.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from typing_extensions import override
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.bases.user import UserPermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -17,6 +18,9 @@ from sentry.services.hybrid_cloud.user.service import user_service
 
 @region_silo_endpoint
 class UserOrganizationsEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (UserPermission,)
 
     @override

--- a/src/sentry/api/endpoints/user_password.py
+++ b/src/sentry/api/endpoints/user_password.py
@@ -3,6 +3,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.auth import password_validation
@@ -44,6 +45,10 @@ class UserPasswordSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class UserPasswordEndpoint(UserEndpoint):
+    publish_status = {
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def put(self, request: Request, user) -> Response:
         # pass some context to serializer otherwise when we create a new serializer instance,
         # user.password gets set to new plaintext password from request and

--- a/src/sentry/api/endpoints/user_permission_details.py
+++ b/src/sentry/api/endpoints/user_permission_details.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import sudo_required
@@ -17,6 +18,11 @@ audit_logger = logging.getLogger("sentry.audit.user")
 
 @control_silo_endpoint
 class UserPermissionDetailsEndpoint(UserEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (SuperuserPermission,)
 

--- a/src/sentry/api/endpoints/user_permissions.py
+++ b/src/sentry/api/endpoints/user_permissions.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.permissions import SuperuserPermission
@@ -10,6 +11,9 @@ from sentry.models import UserPermission
 
 @control_silo_endpoint
 class UserPermissionsEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (SuperuserPermission,)
 

--- a/src/sentry/api/endpoints/user_permissions_config.py
+++ b/src/sentry/api/endpoints/user_permissions_config.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.permissions import SuperuserPermission
@@ -10,6 +11,9 @@ from sentry.api.permissions import SuperuserPermission
 
 @control_silo_endpoint
 class UserPermissionsConfigEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (SuperuserPermission,)
 

--- a/src/sentry/api/endpoints/user_role_details.py
+++ b/src/sentry/api/endpoints/user_role_details.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import sudo_required
@@ -17,6 +18,11 @@ audit_logger = logging.getLogger("sentry.audit.user")
 
 @control_silo_endpoint
 class UserUserRoleDetailsEndpoint(UserEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request, user, role_name) -> Response:

--- a/src/sentry/api/endpoints/user_roles.py
+++ b/src/sentry/api/endpoints/user_roles.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.permissions import SuperuserPermission
@@ -10,6 +11,9 @@ from sentry.models import UserRole
 
 @control_silo_endpoint
 class UserUserRolesEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request, user) -> Response:

--- a/src/sentry/api/endpoints/user_social_identities_index.py
+++ b/src/sentry/api/endpoints/user_social_identities_index.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.serializers import serialize
@@ -9,6 +10,10 @@ from social_auth.models import UserSocialAuth
 
 @control_silo_endpoint
 class UserSocialIdentitiesIndexEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, user) -> Response:
         """
         List Account's Identities

--- a/src/sentry/api/endpoints/user_social_identity_details.py
+++ b/src/sentry/api/endpoints/user_social_identity_details.py
@@ -3,6 +3,7 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from social_auth.backends import get_backend
@@ -13,6 +14,10 @@ logger = logging.getLogger("sentry.accounts")
 
 @control_silo_endpoint
 class UserSocialIdentityDetailsEndpoint(UserEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+    }
+
     def delete(self, request: Request, user, identity_id) -> Response:
         """
         Disconnect a Identity from Account

--- a/src/sentry/api/endpoints/user_subscriptions.py
+++ b/src/sentry/api/endpoints/user_subscriptions.py
@@ -3,6 +3,7 @@ from django.utils import timezone
 from rest_framework import serializers
 
 from sentry import newsletter
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.models import User, UserEmail
@@ -23,6 +24,12 @@ from rest_framework.response import Response
 
 @control_silo_endpoint
 class UserSubscriptionsEndpoint(UserEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, user) -> Response:
         """
         Retrieve Account Subscriptions

--- a/src/sentry/api/endpoints/userroles_details.py
+++ b/src/sentry/api/endpoints/userroles_details.py
@@ -4,6 +4,7 @@ from django.db import IntegrityError, router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.permissions import SuperuserPermission
@@ -16,6 +17,11 @@ audit_logger = logging.getLogger("sentry.audit.user")
 
 @control_silo_endpoint
 class UserRoleDetailsEndpoint(Endpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     @sudo_required

--- a/src/sentry/api/endpoints/userroles_index.py
+++ b/src/sentry/api/endpoints/userroles_index.py
@@ -4,6 +4,7 @@ from django.db import IntegrityError, router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.permissions import SuperuserPermission
@@ -16,6 +17,10 @@ audit_logger = logging.getLogger("sentry.audit.user")
 
 @control_silo_endpoint
 class UserRolesEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -1,4 +1,3 @@
-import inspect
 from typing import Any, Dict, List, Literal, Mapping, Set, Tuple, TypedDict
 
 from sentry.api.api_owners import ApiOwner
@@ -70,65 +69,10 @@ def __get_explicit_endpoints() -> List[Tuple[str, str, str, Any]]:
     ]
 
 
-def codemod_publish_status(endpoints):
-    class_methods = {}
-    for (path, path_regex, method, callback) in endpoints:
-        view_class = callback.view_class
-        if view_class not in class_methods:
-            if view_class.publish_status == {}:
-                class_methods[view_class] = set()
-            else:
-                # print("****Already implemented in :", view_class)
-                continue
-        if method not in class_methods[view_class]:
-            class_methods[view_class].add(method)
-
-    # print("all methods", len(class_methods))
-    # Not doing a full loop to just generate a few examples
-    for key in class_methods:
-        value = class_methods[key]
-        if len(value) > 0:
-            # Read file and find the location you want to add the param to
-            class_name = key.__name__
-            file_path = inspect.getfile(key)
-            # print("file_path", file_path)
-            file_to_read = open(file_path)
-            current_line = file_to_read.readline()
-            previous_lines = [current_line]
-            while f"class {class_name}" not in current_line:
-                current_line = file_to_read.readline()
-                previous_lines.append(current_line)
-
-            next_lines = file_to_read.readlines()
-            file_to_read.close()
-
-            # Prepare what you want to write
-            content = "    publish_status = {\n"
-
-            for method in value:
-                if key.public and method in key.public:
-                    content = content + '        "' + method + '"' + ": ApiPublishStatus.PUBLIC,\n"
-                elif hasattr(key, "private") and key.private:
-                    content = content + '        "' + method + '"' + ": ApiPublishStatus.PRIVATE,\n"
-                else:
-                    content = content + '        "' + method + '"' + ": ApiPublishStatus.UNKNOWN,\n"
-            content = content + "    }\n"
-
-            # Write new content to file
-            file_to_write = open(file_path, "w")
-            file_to_write.writelines("from sentry.api.api_publish_status import ApiPublishStatus\n")
-            file_to_write.writelines(previous_lines)
-            file_to_write.writelines(content)
-            file_to_write.writelines(next_lines)
-
-            file_to_write.truncate()
-            file_to_write.close()
-
-
 def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, rename
     filtered = []
-    codemod_publish_status(endpoints)
     for (path, path_regex, method, callback) in endpoints:
+
         if callback.view_class.owner == ApiOwner.UNOWNED:
             if path not in API_OWNERSHIP_ALLOWLIST_DONT_MODIFY:
                 raise SentryApiBuildError(

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -1,8 +1,6 @@
 import inspect
 from typing import Any, Dict, List, Literal, Mapping, Set, Tuple, TypedDict
 
-from more_itertools import take
-
 from sentry.api.api_owners import ApiOwner
 from sentry.apidocs.api_ownership_allowlist_dont_modify import API_OWNERSHIP_ALLOWLIST_DONT_MODIFY
 from sentry.apidocs.build import OPENAPI_TAGS
@@ -79,13 +77,16 @@ def codemod_publish_status(endpoints):
         if view_class not in class_methods:
             if view_class.publish_status == {}:
                 class_methods[view_class] = set()
-            # else:
-            # print("****Already implemented in :", view_class)
+            else:
+                # print("****Already implemented in :", view_class)
+                continue
         if method not in class_methods[view_class]:
             class_methods[view_class].add(method)
 
+    # print("all methods", len(class_methods))
     # Not doing a full loop to just generate a few examples
-    for (key, value) in take(5, class_methods.items()):
+    for key in class_methods:
+        value = class_methods[key]
         if len(value) > 0:
             # Read file and find the location you want to add the param to
             class_name = key.__name__

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -5,9 +5,10 @@ from sentry.apidocs.api_ownership_allowlist_dont_modify import API_OWNERSHIP_ALL
 from sentry.apidocs.build import OPENAPI_TAGS
 from sentry.apidocs.utils import SentryApiBuildError
 
-HTTP_METHODS_SET = Set[
-    Literal["GET", "POST", "PUT", "OPTIONS", "HEAD", "DELETE", "TRACE", "CONNECT", "PATCH"]
+HTTP_METHOD_NAME = Literal[
+    "GET", "POST", "PUT", "OPTIONS", "HEAD", "DELETE", "TRACE", "CONNECT", "PATCH"
 ]
+HTTP_METHODS_SET = Set[HTTP_METHOD_NAME]
 
 
 class EndpointRegistryType(TypedDict):

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationDataExportPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -112,6 +113,9 @@ class DataExportQuerySerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationDataExportPermission,)
 
     def post(self, request: Request, organization) -> Response:

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import pending_silo_endpoint
 from sentry.api.bases.organization import OrganizationDataExportPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -16,6 +17,9 @@ from ..models import ExportedData
 
 @pending_silo_endpoint
 class DataExportDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationDataExportPermission,)
 
     def get(self, request: Request, organization: Organization, data_export_id: str) -> Response:

--- a/src/sentry/discover/endpoints/discover_homepage_query.py
+++ b/src/sentry/discover/endpoints/discover_homepage_query.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -22,6 +23,11 @@ def get_homepage_query(organization, user):
 
 @region_silo_endpoint
 class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
 
     permission_classes = (
         IsAuthenticated,

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import KeyTransactionBase
 from sentry.api.bases.organization import OrganizationPermission
@@ -32,6 +33,11 @@ class KeyTransactionPermission(OrganizationPermission):
 
 @region_silo_endpoint
 class KeyTransactionEndpoint(KeyTransactionBase):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (KeyTransactionPermission,)
 
     def get(self, request: Request, organization) -> Response:
@@ -139,6 +145,9 @@ class KeyTransactionEndpoint(KeyTransactionBase):
 
 @region_silo_endpoint
 class KeyTransactionListEndpoint(KeyTransactionBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (KeyTransactionPermission,)
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
@@ -18,6 +19,10 @@ from sentry.search.utils import tokenize_query
 
 @region_silo_endpoint
 class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (DiscoverSavedQueryPermission,)
 
     def has_feature(self, organization, request):

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -16,6 +17,11 @@ from sentry.discover.models import DiscoverSavedQuery
 
 @region_silo_endpoint
 class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (DiscoverSavedQueryPermission,)
 
     def has_feature(self, organization, request):
@@ -110,6 +116,9 @@ from rest_framework.response import Response
 
 @region_silo_endpoint
 class DiscoverSavedQueryVisitEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (DiscoverSavedQueryPermission,)
 
     def has_feature(self, organization, request):

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.constants import SentryAppStatus
@@ -72,6 +73,10 @@ def build_action_response(
 
 @region_silo_endpoint
 class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         """
         Fetches actions that an alert rule can perform for an organization

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -3,6 +3,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
@@ -131,6 +132,12 @@ def remove_alert_rule(request: Request, organization, alert_rule):
 
 @region_silo_endpoint
 class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, alert_rule) -> Response:
         """
         Fetch a metric alert rule.

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationAlertRulePermission, OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -120,6 +121,10 @@ class AlertRuleIndexMixin(Endpoint):
 
 @region_silo_endpoint
 class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization) -> Response:
         """
         Fetches (metric) alert rules and legacy (issue alert) rules for an organization
@@ -244,6 +249,10 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
 
 @region_silo_endpoint
 class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationAlertRulePermission,)
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/incidents/endpoints/organization_incident_activity_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_activity_index.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.api.paginator import OffsetPaginator
@@ -10,6 +11,9 @@ from sentry.incidents.logic import get_incident_activity
 
 @region_silo_endpoint
 class OrganizationIncidentActivityIndexEndpoint(IncidentEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (IncidentPermission,)
 
     def get(self, request: Request, organization, incident) -> Response:

--- a/src/sentry/incidents/endpoints/organization_incident_comment_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_comment_details.py
@@ -3,6 +3,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -46,6 +47,10 @@ class CommentDetailsEndpoint(IncidentEndpoint):
 
 @region_silo_endpoint
 class OrganizationIncidentCommentDetailsEndpoint(CommentDetailsEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (IncidentPermission,)
 
     def delete(self, request: Request, organization, incident, activity) -> Response:

--- a/src/sentry/incidents/endpoints/organization_incident_comment_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_comment_index.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.api.fields.actor import ActorField
@@ -22,6 +23,9 @@ class CommentSerializer(serializers.Serializer, MentionsMixin):
 
 @region_silo_endpoint
 class OrganizationIncidentCommentIndexEndpoint(IncidentEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (IncidentPermission,)
 
     def post(self, request: Request, organization, incident) -> Response:

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.api.serializers import serialize
@@ -28,6 +29,10 @@ class IncidentSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (IncidentPermission,)
 
     def get(self, request: Request, organization, incident) -> Response:

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.incident import IncidentPermission
 from sentry.api.bases.organization import OrganizationEndpoint
@@ -27,6 +28,9 @@ from .utils import parse_team_params
 
 @region_silo_endpoint
 class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (IncidentPermission,)
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/incidents/endpoints/organization_incident_seen.py
+++ b/src/sentry/incidents/endpoints/organization_incident_seen.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.incidents.logic import set_incident_seen
@@ -8,6 +9,9 @@ from sentry.incidents.logic import set_incident_seen
 
 @region_silo_endpoint
 class OrganizationIncidentSeenEndpoint(IncidentEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (IncidentPermission,)
 
     def post(self, request: Request, organization, incident) -> Response:

--- a/src/sentry/incidents/endpoints/organization_incident_subscription_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_subscription_index.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.incidents.logic import subscribe_to_incident, unsubscribe_from_incident
@@ -19,6 +20,10 @@ class IncidentSubscriptionPermission(IncidentPermission):
 
 @region_silo_endpoint
 class OrganizationIncidentSubscriptionIndexEndpoint(IncidentEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (IncidentSubscriptionPermission,)
 
     def post(self, request: Request, organization, incident) -> Response:

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.incidents.endpoints.bases import ProjectAlertRuleEndpoint
 from sentry.incidents.endpoints.organization_alert_rule_details import (
@@ -12,6 +13,12 @@ from sentry.incidents.endpoints.organization_alert_rule_details import (
 
 @region_silo_endpoint
 class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, alert_rule) -> Response:
         """
         Fetch a metric alert rule. @deprecated. Use OrganizationAlertRuleDetailsEndpoint instead.

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.paginator import CombinedQuerysetIntermediary, CombinedQuerysetPaginator
@@ -15,6 +16,10 @@ from sentry.snuba.dataset import Dataset
 
 @region_silo_endpoint
 class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project) -> Response:
         """
         Fetches alert rules and legacy rules for a project
@@ -45,6 +50,10 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
 
 @region_silo_endpoint
 class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleIndexMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (ProjectAlertRulePermission,)
 
     def get(self, request: Request, project) -> Response:

--- a/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
@@ -2,6 +2,7 @@ from django.http import Http404
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.serializers import serialize
@@ -11,6 +12,9 @@ from sentry.integrations.slack.utils import RedisRuleStatus
 
 @region_silo_endpoint
 class ProjectAlertRuleTaskDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = [ProjectSettingPermission]
 
     def get(self, request: Request, project, task_uuid) -> Response:

--- a/src/sentry/integrations/bitbucket/descriptor.py
+++ b/src/sentry/integrations/bitbucket/descriptor.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.integrations.bitbucket.integration import scopes
 from sentry.utils.http import absolute_uri
@@ -10,6 +11,9 @@ from .client import BITBUCKET_KEY
 
 @control_silo_endpoint
 class BitbucketDescriptorEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ()
     permission_classes = ()
 

--- a/src/sentry/integrations/bitbucket/installed.py
+++ b/src/sentry/integrations/bitbucket/installed.py
@@ -2,6 +2,7 @@ from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.integrations.pipeline import ensure_integration
 
@@ -10,6 +11,9 @@ from .integration import BitbucketIntegrationProvider
 
 @control_silo_endpoint
 class BitbucketInstalledEndpoint(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ()
     permission_classes = ()
 

--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -3,6 +3,7 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.integrations.bitbucket.integration import BitbucketIntegration
@@ -14,6 +15,10 @@ logger = logging.getLogger("sentry.integrations.bitbucket")
 
 @control_silo_endpoint
 class BitbucketSearchEndpoint(IntegrationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, organization, integration_id, **kwds) -> Response:
         try:
             integration = Integration.objects.get(

--- a/src/sentry/integrations/bitbucket/uninstalled.py
+++ b/src/sentry/integrations/bitbucket/uninstalled.py
@@ -2,6 +2,7 @@ from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.utils import AtlassianConnectValidationError, get_integration_from_jwt
@@ -12,6 +13,9 @@ from sentry.services.hybrid_cloud.integration import integration_service
 
 @control_silo_endpoint
 class BitbucketUninstalledEndpoint(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ()
     permission_classes = ()
 

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -9,6 +9,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.integrations.bitbucket.constants import BITBUCKET_IP_RANGES, BITBUCKET_IPS
 from sentry.models import Commit, CommitAuthor, Organization, Repository
@@ -107,6 +108,9 @@ class PushEventWebhook(Webhook):
 
 @region_silo_endpoint
 class BitbucketWebhookEndpoint(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = ()
     _handlers = {"repo:push": PushEventWebhook}
 

--- a/src/sentry/integrations/discord/webhooks/base.py
+++ b/src/sentry/integrations/discord/webhooks/base.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.integrations.discord.requests.base import DiscordRequest, DiscordRequestError
 from sentry.integrations.discord.webhooks.command import DiscordCommandHandler
@@ -16,6 +17,9 @@ from .types import DiscordResponseTypes
 
 @region_silo_endpoint
 class DiscordInteractionsEndpoint(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     """
     All Discord -> Sentry communication will come through our interactions
     endpoint. We need to figure out what Discord is sending us and direct the

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -3,6 +3,7 @@ from typing import Any
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.integrations.github.integration import build_repository_query
@@ -13,6 +14,9 @@ from sentry.shared_integrations.exceptions import ApiError
 
 @control_silo_endpoint
 class GithubSharedSearchEndpoint(IntegrationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """NOTE: This endpoint is a shared search endpoint for Github and Github Enterprise integrations."""
 
     def get(

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -15,6 +15,7 @@ from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 
 from sentry import analytics, features, options
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.utils.scope import clear_tags_and_context
@@ -552,6 +553,9 @@ class GitHubWebhookBase(Endpoint):
 
 @region_silo_endpoint
 class GitHubIntegrationsWebhookEndpoint(GitHubWebhookBase):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     _handlers = {
         "push": PushEventWebhook,
         "pull_request": PullRequestEventWebhook,

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -10,6 +10,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.integrations.github.webhook import (
     InstallationEventWebhook,
     PullRequestEventWebhook,
@@ -177,6 +178,9 @@ class GitHubEnterpriseWebhookBase(Endpoint):
 
 @region_silo_endpoint
 class GitHubEnterpriseWebhookEndpoint(GitHubEnterpriseWebhookBase):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     _handlers = {
         "push": GitHubEnterprisePushEventWebhook,
         "pull_request": GitHubEnterprisePullRequestEventWebhook,

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -3,6 +3,7 @@ from typing import Any
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.models import Integration
@@ -12,6 +13,10 @@ from sentry.shared_integrations.exceptions import ApiError
 
 @control_silo_endpoint
 class GitlabIssueSearchEndpoint(IntegrationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(
         self, request: Request, organization: RpcOrganization, integration_id: int, **kwds: Any
     ) -> Response:

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -12,6 +12,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.models import Commit, CommitAuthor, Organization, PullRequest, Repository
@@ -232,6 +233,9 @@ class GitlabWebhookMixin:
 
 @region_silo_endpoint
 class GitlabWebhookEndpoint(Endpoint, GitlabWebhookMixin):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ()
     permission_classes = ()
     provider = "gitlab"

--- a/src/sentry/integrations/jira/endpoints/descriptor.py
+++ b/src/sentry/integrations/jira/endpoints/descriptor.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.utils.assets import get_frontend_app_asset_url
 from sentry.utils.http import absolute_uri
@@ -19,6 +20,9 @@ if settings.JIRA_USE_EMAIL_SCOPE:
 
 @control_silo_endpoint
 class JiraDescriptorEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """
     Provides the metadata needed by Jira to setup an instance of the Sentry integration within Jira.
     Only used by on-prem orgs and devs setting up local instances of the integration. (Sentry SAAS

--- a/src/sentry/integrations/jira/endpoints/search.py
+++ b/src/sentry/integrations/jira/endpoints/search.py
@@ -5,6 +5,7 @@ from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.models import Integration
@@ -17,6 +18,9 @@ from ..utils import build_user_choice
 
 @control_silo_endpoint
 class JiraSearchEndpoint(IntegrationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """
     Called by our front end when it needs to make requests to Jira's API for data.
     """

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -3,6 +3,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.integrations.pipeline import ensure_integration
 from sentry.integrations.utils import authenticate_asymmetric_jwt, verify_claims
@@ -15,6 +16,9 @@ from .base import JiraWebhookBase
 
 @control_silo_endpoint
 class JiraSentryInstalledWebhook(JiraWebhookBase):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     """
     Webhook hit by Jira whenever someone installs the Sentry integration in their Jira instance.
     """

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import Scope
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.integrations.utils import get_integration_from_jwt
 from sentry.integrations.utils.scope import bind_org_context_from_integration
@@ -22,6 +23,9 @@ logger = logging.getLogger(__name__)
 
 @region_silo_endpoint
 class JiraIssueUpdatedWebhook(JiraWebhookBase):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     """
     Webhook hit by Jira whenever an issue is updated in Jira's database.
     """

--- a/src/sentry/integrations/jira/webhooks/uninstalled.py
+++ b/src/sentry/integrations/jira/webhooks/uninstalled.py
@@ -2,6 +2,7 @@ import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.utils import get_integration_from_jwt
@@ -13,6 +14,9 @@ from .base import JiraWebhookBase
 
 @control_silo_endpoint
 class JiraSentryUninstalledWebhook(JiraWebhookBase):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     """
     Webhook hit by Jira whenever someone uninstalls the Sentry integration from their Jira instance.
     """

--- a/src/sentry/integrations/jira_server/search.py
+++ b/src/sentry/integrations/jira_server/search.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.models import Integration
@@ -15,6 +16,9 @@ from .utils import build_user_choice
 
 @control_silo_endpoint
 class JiraServerSearchEndpoint(IntegrationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     provider = "jira_server"
 
     def _get_integration(self, organization, integration_id):

--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -5,6 +5,7 @@ from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.integrations.jira_server.utils import handle_assignee_change, handle_status_change
 from sentry.integrations.utils.scope import clear_tags_and_context
@@ -44,6 +45,9 @@ def get_integration_from_token(token):
 
 @control_silo_endpoint
 class JiraServerIssueUpdatedWebhook(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ()
     permission_classes = ()
 

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import AuthenticationFailed, NotAuthenticated
 
 from sentry import analytics, audit_log, eventstore, features, options
 from sentry.api import client
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.models import ApiKey, Group, Rule
 from sentry.models.activity import ActivityIntegration
@@ -160,6 +161,9 @@ class MsTeamsWebhookMixin:
 
 @region_silo_endpoint
 class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ()
     permission_classes = ()
     provider = "msteams"

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 
 from sentry import analytics
 from sentry.api import ApiClient, client
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.helpers.group_index import update_groups
 from sentry.auth.access import from_member
@@ -130,6 +131,9 @@ def _is_message(data: Mapping[str, Any]) -> bool:
 
 @region_silo_endpoint
 class SlackActionEndpoint(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ()
     permission_classes = ()
     slack_request_class = SlackActionRequest

--- a/src/sentry/integrations/slack/webhooks/command.py
+++ b/src/sentry/integrations/slack/webhooks/command.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.integrations.slack.message_builder.disconnected import SlackDisconnectedMessageBuilder
 from sentry.integrations.slack.requests.base import SlackDMRequest, SlackRequestError
@@ -45,6 +46,9 @@ def is_team_linked_to_channel(organization: Organization, slack_request: SlackDM
 
 @region_silo_endpoint
 class SlackCommandsEndpoint(SlackDMEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ()
     permission_classes = ()
     slack_request_class = SlackCommandRequest

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder.help import SlackHelpMessageBuilder
@@ -29,6 +30,9 @@ from .command import LINK_FROM_CHANNEL_MESSAGE
 
 @region_silo_endpoint
 class SlackEventEndpoint(SlackDMEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     """
     XXX(dcramer): a lot of this is copied from sentry-plugins right now, and will need refactoring
     """

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from sentry_sdk import configure_scope
 
 from sentry import VERSION, audit_log, http, options
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.models import (
     Integration,
@@ -127,6 +128,10 @@ def get_payload_and_token(
 
 @control_silo_endpoint
 class VercelWebhookEndpoint(Endpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ()
     permission_classes = ()
     provider = "vercel"

--- a/src/sentry/integrations/vsts/search.py
+++ b/src/sentry/integrations/vsts/search.py
@@ -3,6 +3,7 @@ from typing import Any
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.models import Integration
@@ -12,6 +13,10 @@ from sentry.services.hybrid_cloud.organization import RpcOrganization
 
 @control_silo_endpoint
 class VstsSearchEndpoint(IntegrationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(
         self, request: Request, organization: RpcOrganization, integration_id: int, **kwds: Any
     ) -> Response:

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -8,6 +8,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.integrations.mixins import IssueSyncMixin
 from sentry.integrations.utils import sync_group_assignee_inbound
@@ -32,6 +33,9 @@ class VstsWebhookMixin:
 
 @region_silo_endpoint
 class WorkItemWebhook(Endpoint, VstsWebhookMixin):
+    publish_status = {
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     authentication_classes = ()
     permission_classes = ()
 

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -6,6 +6,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import (
@@ -30,6 +31,9 @@ from .base import MonitorIngestEndpoint
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
 class MonitorIngestCheckInDetailsEndpoint(MonitorIngestEndpoint):
+    publish_status = {
+        "PUT": ApiPublishStatus.PUBLIC,
+    }
     public = {"PUT"}
 
     @extend_schema(

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -10,6 +10,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import ratelimits
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
@@ -43,6 +44,9 @@ CHECKIN_QUOTA_WINDOW = 60
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
 class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.PUBLIC,
+    }
     public = {"POST"}
 
     rate_limits = RateLimitConfig(

--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.exceptions import ParameterValidationError
 from sentry.api.helpers.environments import get_environments
@@ -33,6 +34,11 @@ from .base import MonitorEndpoint
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
 class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.PUBLIC,
+    }
     public = {"GET", "PUT", "DELETE"}
 
     @extend_schema(

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -4,6 +4,7 @@ from django.db.models import Case, DateTimeField, IntegerField, OuterRef, Q, Sub
 from drf_spectacular.utils import extend_schema
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects
 from sentry.api.bases.organization import OrganizationEndpoint
@@ -65,6 +66,10 @@ MONITOR_ENVIRONMENT_ORDERING = Case(
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
 class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
+    }
     public = {"GET", "POST"}
     permission_classes = (OrganizationMonitorPermission,)
 

--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -9,6 +9,7 @@ from django.db.models.functions import Extract
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import StatsMixin, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.helpers.environments import get_environments
@@ -29,6 +30,10 @@ def normalize_to_epoch(timestamp: datetime, seconds: int):
 
 @region_silo_endpoint
 class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     # TODO(epurkhiser): probably convert to snuba
     def get(self, request: Request, organization) -> Response:
         # Do not restirct rollups allowing us to define custom resolutions.

--- a/src/sentry/monitors/endpoints/organization_monitor_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_stats.py
@@ -8,6 +8,7 @@ from django.db.models.functions import Extract
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import StatsMixin, region_silo_endpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.monitors.models import CheckInStatus, MonitorCheckIn
@@ -29,6 +30,10 @@ def normalize_to_epoch(timestamp: datetime, seconds: int):
 
 @region_silo_endpoint
 class OrganizationMonitorStatsEndpoint(MonitorEndpoint, StatsMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     # TODO(dcramer): probably convert to tsdb
     def get(self, request: Request, organization, project, monitor) -> Response:
         args = self._parse_args(request)

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -6,6 +6,7 @@ from django.utils.html import format_html
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers.models.plugin import PluginSerializer
 
@@ -27,6 +28,10 @@ from sentry.utils.safe import safe_execute
 # TODO(dcramer): remove this in favor of GroupEndpoint
 @region_silo_endpoint
 class IssueGroupActionEndpoint(PluginGroupEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     view_method_name = None
     plugin = None
 

--- a/src/sentry/plugins/endpoints.py
+++ b/src/sentry/plugins/endpoints.py
@@ -1,3 +1,4 @@
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 
 __all__ = ["PluginProjectEndpoint", "PluginGroupEndpoint"]
@@ -35,6 +36,10 @@ from rest_framework.response import Response
 
 @region_silo_endpoint
 class PluginGroupEndpoint(GroupEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
+    }
     plugin = None
     view = None
 

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from snuba_sdk import Request
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects
 from sentry.api.bases.organization_events import OrganizationEventsV2EndpointBase
@@ -25,6 +26,9 @@ FILTER_HAS_A_REPLAY = "AND !replayId:''"
 
 @region_silo_endpoint
 class OrganizationReplayCountEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """
     Get all the replay ids associated with a set of issues/transactions in discover,
     then verify that they exist in the replays dataset, and return the count.

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import NoProjects, OrganizationEndpoint
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
@@ -21,6 +22,9 @@ from sentry.replays.validators import ReplayValidator
 @region_silo_endpoint
 @extend_schema(tags=["Replays"])
 class OrganizationReplayDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
     """
     The same data as ProjectReplayDetails, except no project is required.
     This works as we'll query for this replay_id across all projects in the

--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
@@ -13,6 +14,9 @@ from sentry.snuba import discover
 
 @region_silo_endpoint
 class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     """The generic Events endpoints require that the `organizations:global-views` feature
     be enabled before they return across multiple projects.
 

--- a/src/sentry/replays/endpoints/organization_replay_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_index.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import NoProjects, OrganizationEndpoint
 from sentry.api.event_search import parse_search_query
@@ -26,6 +27,9 @@ from sentry.utils.snuba import QueryMemoryLimitExceeded
 @region_silo_endpoint
 @extend_schema(tags=["Replays"])
 class OrganizationReplayIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
     public = {"GET"}
 
     def get_replay_filter_params(self, request, organization):

--- a/src/sentry/replays/endpoints/organization_replay_selector_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_selector_index.py
@@ -23,6 +23,7 @@ from snuba_sdk import Request as SnubaRequest
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import NoProjects, OrganizationEndpoint
 from sentry.api.event_search import SearchConfig
@@ -36,6 +37,9 @@ from sentry.utils.snuba import raw_snql_query
 
 @region_silo_endpoint
 class OrganizationReplaySelectorIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     owner = ApiOwner.REPLAY
 
     def get_replay_filter_params(self, request, organization):

--- a/src/sentry/replays/endpoints/project_replay_clicks_index.py
+++ b/src/sentry/replays/endpoints/project_replay_clicks_index.py
@@ -25,6 +25,7 @@ from snuba_sdk.expressions import Expression
 from snuba_sdk.orderby import Direction
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.event_search import ParenExpression, SearchFilter, parse_search_query
@@ -47,6 +48,10 @@ REFERRER = "replays.query.query_replay_clicks_dataset"
 
 @region_silo_endpoint
 class ProjectReplayClicksIndexEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project: Project, replay_id: str) -> Response:
         if not features.has(
             "organizations:session-replay", project.organization, actor=request.user

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.models.project import Project
@@ -24,6 +25,10 @@ class ReplayDetailsPermission(ProjectPermission):
 
 @region_silo_endpoint
 class ProjectReplayDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
 
     permission_classes = (ReplayDetailsPermission,)
 

--- a/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
@@ -8,6 +8,7 @@ from django.http.response import HttpResponseBase
 from rest_framework.request import Request
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.replays.lib.storage import RecordingSegmentStorageMeta, make_filename
@@ -16,6 +17,10 @@ from sentry.replays.usecases.reader import download_segment, fetch_segment_metad
 
 @region_silo_endpoint
 class ProjectReplayRecordingSegmentDetailsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def get(self, request: Request, project, replay_id, segment_id) -> HttpResponseBase:
         if not features.has(
             "organizations:session-replay", project.organization, actor=request.user

--- a/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
@@ -14,6 +15,10 @@ from sentry.replays.usecases.reader import download_segments, fetch_segments_met
 
 @region_silo_endpoint
 class ProjectReplayRecordingSegmentIndexEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     def __init__(self, **options) -> None:
         storage.initialize_client()
         super().__init__(**options)

--- a/src/sentry/rules/history/endpoints/project_rule_group_history.py
+++ b/src/sentry/rules/history/endpoints/project_rule_group_history.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.rule import RuleEndpoint
 from sentry.api.serializers import Serializer, serialize
@@ -53,6 +54,10 @@ class RuleGroupHistorySerializer(Serializer):
 @extend_schema(tags=["issue_alerts"])
 @region_silo_endpoint
 class ProjectRuleGroupHistoryIndexEndpoint(RuleEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     @extend_schema(
         operation_id="Retrieve a group firing history for an issue alert",
         parameters=[GlobalParams.ORG_SLUG, GlobalParams.PROJECT_SLUG, IssueAlertParams],

--- a/src/sentry/rules/history/endpoints/project_rule_stats.py
+++ b/src/sentry/rules/history/endpoints/project_rule_stats.py
@@ -7,6 +7,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.rule import RuleEndpoint
 from sentry.api.serializers import Serializer, serialize
@@ -37,6 +38,10 @@ class TimeSeriesValueSerializer(Serializer):
 @extend_schema(tags=["issue_alerts"])
 @region_silo_endpoint
 class ProjectRuleStatsIndexEndpoint(RuleEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
     @extend_schema(
         operation_id="Retrieve firing starts for an issue alert rule for a given time range. Results are returned in hourly buckets.",
         parameters=[GlobalParams.ORG_SLUG, GlobalParams.PROJECT_SLUG, IssueAlertParams],

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -15,6 +15,7 @@ from rest_framework.response import Response
 from typing_extensions import TypedDict
 
 from sentry import audit_log, roles
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organizationmember import OrganizationMemberEndpoint
 from sentry.api.endpoints.organization_member.index import OrganizationMemberSerializer
@@ -141,6 +142,12 @@ def resolve_maybe_bool_value(value):
 
 @region_silo_endpoint
 class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.UNKNOWN,
+        "PATCH": ApiPublishStatus.PUBLIC,
+    }
     permission_classes = (OrganizationSCIMMemberPermission,)
     public = {"GET", "DELETE", "PATCH"}
 
@@ -367,6 +374,10 @@ class SCIMListResponseDict(TypedDict):
 
 @region_silo_endpoint
 class OrganizationSCIMMemberIndex(SCIMEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
+    }
     permission_classes = (OrganizationSCIMMemberPermission,)
     public = {"GET", "POST"}
 

--- a/src/sentry/scim/endpoints/schemas.py
+++ b/src/sentry/scim/endpoints/schemas.py
@@ -3,6 +3,7 @@ from typing import Any
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 
 from .constants import SCIM_SCHEMA_GROUP, SCIM_SCHEMA_USER
@@ -188,6 +189,9 @@ SCIM_SCHEMA_LIST = [SCIM_USER_ATTRIBUTES_SCHEMA, SCIM_GROUP_ATTRIBUTES_SCHEMA]
 
 @region_silo_endpoint
 class OrganizationSCIMSchemaIndex(SCIMEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
     permission_classes = (OrganizationSCIMMemberPermission,)
 
     def get(self, request: Request, *args: Any, **kwds: Any) -> Response:

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from typing_extensions import TypedDict
 
 from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.endpoints.organization_teams import CONFLICTING_SLUG_ERROR, TeamPostSerializer
 from sentry.api.endpoints.team_details import TeamDetailsEndpoint, TeamSerializer
@@ -97,6 +98,10 @@ class SCIMListResponseDict(TypedDict):
 @extend_schema(tags=["SCIM"])
 @region_silo_endpoint
 class OrganizationSCIMTeamIndex(SCIMEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
+    }
     permission_classes = (OrganizationSCIMTeamPermission,)
     public = {"GET", "POST"}
 
@@ -228,6 +233,12 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint):
 @extend_schema(tags=["SCIM"])
 @region_silo_endpoint
 class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.UNKNOWN,
+        "PATCH": ApiPublishStatus.PUBLIC,
+    }
     permission_classes = (OrganizationSCIMTeamPermission,)
     public = {"GET", "PATCH", "DELETE"}
 


### PR DESCRIPTION
More info on big picture: https://www.notion.so/Tracking-API-Ownership-And-Publish-State-57e34e8defb4401fb081fdf257d6dbe5

This PR:
1. First commit: I'm writing code to programmatically add publish status to all endpoints but for now just changing 5 of them. Take a look at the code and let me know what you think about the approach. This code will be removed in the 2nd commit and I only leave the code changes in the endpoints.
2. Last commit includes all the endpoints with their publish status

Next PR:
Will add accountability testing to make sure no one adds methods in "unknown" state and all methods exist in publish status.
