### PR TITLE
fix(weekly_report): Skip projects that no longer belong to an org

### DIFF
--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -277,6 +277,9 @@ def project_event_counts_for_organization(ctx):
 
     for dat in data:
         project_id = dat["project_id"]
+        # Project no longer in organization, but events still exist
+        if project_id not in ctx.projects:
+            continue
         project_ctx = ctx.projects[project_id]
         total = dat["total"]
         timestamp = int(to_timestamp(parse_snuba_datetime(dat["time"])))


### PR DESCRIPTION
We aren't filtering snuba by projects and we seem to get some that we do not expect.

fixes SENTRY-11Q5