### PR TITLE
fix(getting-started): Switch Vue 2 and Vue 3 configuration headings

### DIFF
--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -68,7 +68,7 @@ npm install --save @sentry/vue
     ),
     configurations: [
       {
-        description: <h5>V2</h5>,
+        description: <h5>Vue 3</h5>,
         language: 'javascript',
         code: `
         import { createApp } from "vue";
@@ -92,7 +92,7 @@ npm install --save @sentry/vue
         `,
       },
       {
-        description: <h5>V3</h5>,
+        description: <h5>Vue 2</h5>,
         language: 'javascript',
         code: `
         import Vue from "vue";


### PR DESCRIPTION
As reported in #55155, the the Vue getting started page installation instructions for Vue 2 showed the Vue 3 code snippet and - vice versa - the Vue 3 heading showed the Vue 2 snippet. This might have happened when migrating over the docs or it was mixed up even before that. 

This fixes this mixup by swapping out headings for Vue 2 and 3. We want to show Vue 3 first and Vue 2 further below. Given that Vue 2 is EOL, we might wanna consider removing it from the getting started page in the future but for now this will do.

Closes #55155 