### PR TITLE
feat: Add note about retired roles in organization role select

### DIFF
--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -62,6 +62,12 @@ class OrganizationRoleSelect extends Component<Props> {
                     {name}
                     <TextBlock noMargin>
                       <div className="help-block">{desc}</div>
+                      {isRetired && (
+                        <div className="help-block">
+                          (This role is retired. Consider picking a different role, or
+                          using team roles instead.)
+                        </div>
+                      )}
                     </TextBlock>
                   </div>
                 </Label>


### PR DESCRIPTION
If a role is disabled because it is retired it is super confusing to users. There is no indication that the role is disabled because it is deprecated.

This PR adds a note about this.

Ref https://sentry.zendesk.com/agent/tickets/101294