### PR TITLE
ref: fix test pollution caused by leaked responses mock

### DIFF
--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -26,6 +26,10 @@ class SlackTasksTest(TestCase):
     def setUp(self):
         self.integration = install_slack(self.organization)
         self.uuid = uuid4().hex
+
+        self.mck = responses.mock
+        self.mck.__enter__()
+
         responses.add(
             method=responses.POST,
             url="https://slack.com/api/chat.scheduleMessage",
@@ -42,6 +46,9 @@ class SlackTasksTest(TestCase):
             content_type="application/json",
             body=json.dumps({"ok": True}),
         )
+
+    def tearDown(self):
+        self.mck.__exit__(None, None, None)
 
     @cached_property
     def metric_alert_data(self):


### PR DESCRIPTION
previously failing with:

```console
$ pytest tests/sentry/integrations/slack/test_tasks.py::SlackTasksTest::test_task_existing_metric_alert tests/sentry/integrations/slack/test_utils.py::GetChannelIdTest::test_invalid_channel_selected
============= test session starts ============
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: fail-slow-0.3.0, rerunfailures-11.0, sentry-0.1.11, xdist-3.0.2, cov-4.0.0, repeat-0.9.1, django-4.4.0
collected 2 items                                                                                                               

tests/sentry/integrations/slack/test_tasks.py .                                                                           [ 50%]
tests/sentry/integrations/slack/test_utils.py F                                                                           [100%]

======== FAILURES ============
________ GetChannelIdTest.test_invalid_channel_selected _____
tests/sentry/integrations/slack/test_utils.py:115: in test_invalid_channel_selected
    assert get_channel_id(self.organization, self.integration, "#fake-channel")[1] is None
E   AssertionError: assert 'chan-id' is None
========== short test summary info =========
FAILED tests/sentry/integrations/slack/test_utils.py::GetChannelIdTest::test_invalid_channel_selected - AssertionError: assert 'chan-id' is None
```