### PR TITLE
sentry/utils/distutils: fix yarn invocation

### DIFF
--- a/src/sentry/utils/distutils/commands/base.py
+++ b/src/sentry/utils/distutils/commands/base.py
@@ -122,7 +122,7 @@ class BaseBuildCommand(Command):
 
         if node_version[2] is not None:
             log.info(f"using node ({node_version})")
-            self._run_command(["yarn", "install", "--production", "--frozen-lockfile", "--quiet"])
+            self._run_command(["yarn", "install", "--production", "--frozen-lockfile"])
 
     def _run_command(self, cmd, env=None):
         cmd_str = " ".join(cmd)


### PR DESCRIPTION
Yarn doesn't have `--quiet` flag and fails immediately when executed with such flag.
Tested with Yarn 1.22.19.

### Legal Boilerplate

I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
