### PR TITLE
fix(perf-db-http-widget): Update text copy to be specific

### DIFF
--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -89,7 +89,7 @@ export function WidgetEmptyStateWarning() {
   );
 }
 
-export function WidgetAddInstrumentationWarning() {
+export function WidgetAddInstrumentationWarning({type}: {type: 'db' | 'http'}) {
   const pageFilters = usePageFilters();
   const fullProjects = useProjects();
 
@@ -113,8 +113,9 @@ export function WidgetAddInstrumentationWarning() {
       <PrimaryMessage>{t('No results found')}</PrimaryMessage>
       <SecondaryMessage>
         {tct(
-          'No transactions with Database or HTTP spans found, you may need to [added].',
+          'No transactions with [spanCategory] spans found, you may need to [added].',
           {
+            spanCategory: type === 'db' ? t('Database') : t('HTTP'),
             added: <ExternalLink href={url}>{t('add integrations')}</ExternalLink>,
           }
         )}

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -75,7 +75,13 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
     props.chartSetting
   );
   const emptyComponent = canHaveIntegrationEmptyState
-    ? WidgetAddInstrumentationWarning
+    ? () => (
+        <WidgetAddInstrumentationWarning
+          type={
+            props.chartSetting === PerformanceWidgetSetting.SLOW_DB_OPS ? 'db' : 'http'
+          }
+        />
+      )
     : WidgetEmptyStateWarning;
 
   const field = props.fields[0];


### PR DESCRIPTION
The text copy should be specific to HTTP if viewing an HTTP widget, or similarly for DB widgets.

Just added a variable for `tct` because we're treating HTTP and Database as proper nouns here