### PR TITLE
fix(replay): Prevent dead-click & rage-click tables from showing "add to filter" dropdowns

### DIFF
--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -21,10 +21,12 @@ import {
   ActivityCell,
   BrowserCell,
   DeadClickCountCell,
+  DeadClickCountWithDropdownCell,
   DurationCell,
   ErrorCountCell,
   OSCell,
   RageClickCountCell,
+  RageClickCountWithDropdownCell,
   ReplayCell,
   TransactionCell,
 } from 'sentry/views/replays/replayTable/tableCell';
@@ -156,7 +158,12 @@ function ReplayTable({
                   return <BrowserCell key="browser" replay={replay} />;
 
                 case ReplayColumn.COUNT_DEAD_CLICKS:
-                  return <DeadClickCountCell key="countDeadClicks" replay={replay} />;
+                  return (
+                    <DeadClickCountWithDropdownCell
+                      key="countDeadClicks"
+                      replay={replay}
+                    />
+                  );
 
                 case ReplayColumn.COUNT_DEAD_CLICKS_NO_HEADER:
                   return <DeadClickCountCell key="countDeadClicks" replay={replay} />;
@@ -165,7 +172,12 @@ function ReplayTable({
                   return <ErrorCountCell key="countErrors" replay={replay} />;
 
                 case ReplayColumn.COUNT_RAGE_CLICKS:
-                  return <RageClickCountCell key="countRageClicks" replay={replay} />;
+                  return (
+                    <RageClickCountWithDropdownCell
+                      key="countRageClicks"
+                      replay={replay}
+                    />
+                  );
 
                 case ReplayColumn.COUNT_RAGE_CLICKS_NO_HEADER:
                   return <RageClickCountCell key="countRageClicks" replay={replay} />;

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -506,7 +506,7 @@ export function DurationCell({replay}: Props) {
   );
 }
 
-export function RageClickCountCell({replay}: Props) {
+export function RageClickCountWithDropdownCell({replay}: Props) {
   if (replay.is_archived) {
     return <Item isArchived />;
   }
@@ -527,7 +527,24 @@ export function RageClickCountCell({replay}: Props) {
   );
 }
 
-export function DeadClickCountCell({replay}: Props) {
+export function RageClickCountCell({replay}: Props) {
+  if (replay.is_archived) {
+    return <Item isArchived />;
+  }
+  return (
+    <Item data-test-id="replay-table-count-rage-clicks">
+      <Container>
+        {replay.count_rage_clicks ? (
+          <DeadRageCount>{replay.count_rage_clicks}</DeadRageCount>
+        ) : (
+          <Count>0</Count>
+        )}
+      </Container>
+    </Item>
+  );
+}
+
+export function DeadClickCountWithDropdownCell({replay}: Props) {
   if (replay.is_archived) {
     return <Item isArchived />;
   }
@@ -543,6 +560,23 @@ export function DeadClickCountCell({replay}: Props) {
           type="count_dead_clicks"
           val={replay.count_dead_clicks ?? 0}
         />
+      </Container>
+    </Item>
+  );
+}
+
+export function DeadClickCountCell({replay}: Props) {
+  if (replay.is_archived) {
+    return <Item isArchived />;
+  }
+  return (
+    <Item data-test-id="replay-table-count-dead-clicks">
+      <Container>
+        {replay.count_dead_clicks ? (
+          <DeadRageCount>{replay.count_dead_clicks}</DeadRageCount>
+        ) : (
+          <Count>0</Count>
+        )}
       </Container>
     </Item>
   );


### PR DESCRIPTION
Before you could hover over the Dead & Rage click cards and see the "add to filter" dropdowns.

**Before:**
| On hover | After click |
| --- | --- |
| ![SCR-20230823-iuvy](https://github.com/getsentry/sentry/assets/187460/0f127714-01e8-434b-a109-91ed1f40a363) | ![SCR-20230823-ivbj](https://github.com/getsentry/sentry/assets/187460/4186b6a5-ef40-4c28-b2d7-a0f7e5b9cfb5) |


Those shouldn't be there inside these tables... only inside the main table.

The real problem is that we're re-using the table definition too much. But it won't be a problem much longer, as the next scheduled change is to use data from a different api endpoint. So the tables should not be shared, and have unique columns/cells. 