### PR TITLE
Show truncated annotation on issues page for strings, arrays, and objects.

### DIFF
--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -332,7 +332,7 @@ class SingleException(Interface):
         )
 
         stacktrace_meta = (
-            self.stacktrace.get_api_meta(meta, is_public=is_public, platform=platform)
+            self.stacktrace.get_api_meta(meta["stacktrace"], is_public=is_public, platform=platform)
             if self.stacktrace and meta.get("stacktrace")
             else None
         )

--- a/static/app/components/contextData/index.spec.tsx
+++ b/static/app/components/contextData/index.spec.tsx
@@ -1,16 +1,169 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ContextData from 'sentry/components/contextData';
+import {castAsMetaContainer} from 'sentry/components/events/meta/metaContainer';
+
+const NO_ELLIPSIS_CASES = [
+  // Cases to make sure we are defensively handling various shapes of meta.
+  {description: 'missing (no meta prop)', props: {}},
+  {description: 'missing (empty meta container)', props: {meta: castAsMetaContainer({})}},
+  {
+    description: 'missing (empty meta)',
+    props: {meta: castAsMetaContainer({'': {}})},
+  },
+  {
+    description: 'missing (null meta)',
+    props: {meta: castAsMetaContainer({'': null})},
+  },
+  {description: 'missing (no len)', props: {meta: castAsMetaContainer({'': {}})}},
+] as const;
+
+const ELLIPSIS = '...';
 
 describe('ContextData', function () {
   describe('render()', function () {
     describe('strings', function () {
+      const ELLIPSIZED_TEXT = 'ABCDEFGHIJ';
+      const TOTAL_LENGTH = ELLIPSIZED_TEXT.length + 1; // 1 unknown character
+
       it('should render urls w/ an additional <a> link', function () {
         const URL = 'https://example.org/foo/bar/';
         render(<ContextData data={URL} />);
 
         expect(screen.getByText(URL)).toBeInTheDocument();
         expect(screen.getByRole('link')).toHaveAttribute('href', URL);
+      });
+
+      it('should render an ellipsis if string has been truncated (remark = x)', async () => {
+        const {container} = render(
+          <ContextData
+            withAnnotatedText
+            data={`${ELLIPSIZED_TEXT}${ELLIPSIS}`}
+            meta={castAsMetaContainer({
+              '': {
+                rem: [
+                  [
+                    '!limit',
+                    'x',
+                    ELLIPSIZED_TEXT.length,
+                    ELLIPSIZED_TEXT.length + ELLIPSIS.length,
+                  ],
+                ],
+                len: TOTAL_LENGTH,
+                chunks: [
+                  {
+                    type: 'text',
+                    text: ELLIPSIZED_TEXT,
+                  },
+                  {
+                    type: 'redaction',
+                    text: ELLIPSIS,
+                    rule_id: '!limit',
+                    remark: 'x',
+                  },
+                ],
+              },
+            })}
+          />
+        );
+
+        expect(screen.getByText(ELLIPSIZED_TEXT)).toBeInTheDocument();
+        await userEvent.hover(screen.getByText(`${ELLIPSIS}`));
+        expect(
+          await screen.findByText(
+            `Removed because of size limits. Serialized object has ${TOTAL_LENGTH} characters total.`
+          )
+        ).toBeInTheDocument();
+        expect(container).toSnapshot();
+      });
+    });
+
+    describe('arrays', function () {
+      const ELLIPSIZED_ARRAY = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+      const TOTAL_LENGTH = ELLIPSIZED_ARRAY.length + 1; // 1 unknown element
+
+      it('should render an ellipsis if array is longer than meta length', async () => {
+        const {container} = render(
+          <ContextData
+            data={ELLIPSIZED_ARRAY}
+            withAnnotatedText
+            meta={castAsMetaContainer({'': {len: TOTAL_LENGTH}})}
+          />
+        );
+        for (const value of ELLIPSIZED_ARRAY) {
+          expect(screen.getByText(String(value))).toBeInTheDocument();
+        }
+        await userEvent.hover(screen.getByText(`${ELLIPSIS}`));
+        expect(
+          await screen.findByText(
+            `Removed because of size limits. Collection has ${TOTAL_LENGTH} items total.`
+          )
+        ).toBeInTheDocument();
+        expect(container).toSnapshot();
+      });
+
+      [
+        ...NO_ELLIPSIS_CASES,
+        {
+          description: 'equal to string length',
+          props: {meta: castAsMetaContainer({'': {len: ELLIPSIZED_ARRAY.length}})},
+        },
+      ].forEach(({description, props}) => {
+        it(`shouldn't render an ellipsis if meta length is ${description}`, function () {
+          render(<ContextData data={ELLIPSIZED_ARRAY} withAnnotatedText {...props} />);
+          for (const value of ELLIPSIZED_ARRAY) {
+            expect(screen.getByText(String(value))).toBeInTheDocument();
+          }
+          expect(screen.queryByText(ELLIPSIS)).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('objects', function () {
+      const ELLIPSIZED_OBJECT = {aaa: '111', bbb: '222', ccc: '333'};
+      const TOTAL_LENGTH = Object.keys(ELLIPSIZED_OBJECT).length + 1;
+
+      it('should render an ellipsis if object has more items than meta length', async () => {
+        const {container} = render(
+          <ContextData
+            data={ELLIPSIZED_OBJECT}
+            withAnnotatedText
+            meta={castAsMetaContainer({'': {len: TOTAL_LENGTH}})}
+          />
+        );
+        for (const [key, value] of Object.entries(ELLIPSIZED_OBJECT)) {
+          for (const text of [key, value]) {
+            expect(screen.getByText(text)).toBeInTheDocument();
+          }
+        }
+        expect(screen.getByText(ELLIPSIS)).toBeInTheDocument();
+        await userEvent.hover(screen.getByText(`${ELLIPSIS}`));
+        expect(
+          await screen.findByText(
+            `Removed because of size limits. Mapping has ${TOTAL_LENGTH} items total.`
+          )
+        ).toBeInTheDocument();
+        expect(container).toSnapshot();
+      });
+
+      [
+        ...NO_ELLIPSIS_CASES,
+        {
+          description: 'equal to object length',
+          props: {
+            meta: castAsMetaContainer({'': {len: Object.keys(ELLIPSIZED_OBJECT).length}}),
+          },
+        },
+      ].forEach(({description, props}) => {
+        it(`shouldn't render an ellipsis if meta length is ${description}`, function () {
+          render(<ContextData data={ELLIPSIZED_OBJECT} withAnnotatedText {...props} />);
+          for (const [key, value] of Object.entries(ELLIPSIZED_OBJECT)) {
+            for (const text of [key, value]) {
+              expect(screen.getByText(text)).toBeInTheDocument();
+            }
+          }
+          expect(screen.queryByText(ELLIPSIS)).not.toBeInTheDocument();
+        });
       });
     });
   });

--- a/static/app/components/contextData/index.tsx
+++ b/static/app/components/contextData/index.tsx
@@ -5,6 +5,12 @@ import isNumber from 'lodash/isNumber';
 import isString from 'lodash/isString';
 
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
+import {AnnotatedEllipsis} from 'sentry/components/events/meta/annotatedText/annotatedEllipsis';
+import {
+  getChildMetaContainer,
+  getMeta,
+  MetaContainer,
+} from 'sentry/components/events/meta/metaContainer';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -17,7 +23,7 @@ type Props = React.HTMLAttributes<HTMLPreElement> & {
   data?: React.ReactNode;
   jsonConsts?: boolean;
   maxDefaultDepth?: number;
-  meta?: Record<any, any>;
+  meta?: MetaContainer;
   preserveQuotes?: boolean;
   withAnnotatedText?: boolean;
 };
@@ -44,7 +50,7 @@ function walk({
   if (value === null) {
     return (
       <span className="val-null">
-        <AnnotatedText value={jsonConsts ? 'null' : 'None'} meta={meta?.[''] ?? meta} />
+        <AnnotatedText value={jsonConsts ? 'null' : 'None'} meta={getMeta(meta)} />
       </span>
     );
   }
@@ -54,7 +60,7 @@ function walk({
       <span className="val-bool">
         <AnnotatedText
           value={jsonConsts ? (value ? 'true' : 'false') : value ? 'True' : 'False'}
-          meta={meta?.[''] ?? meta}
+          meta={getMeta(meta)}
         />
       </span>
     );
@@ -64,10 +70,17 @@ function walk({
     const valueInfo = analyzeStringForRepr(value);
 
     const valueToBeReturned = withAnnotatedText ? (
-      <AnnotatedText value={valueInfo.repr} meta={meta?.[''] ?? meta} />
+      <AnnotatedText value={valueInfo.repr} meta={getMeta(meta)} />
     ) : (
       valueInfo.repr
     );
+
+    const valueNodes = [<span key="value">{valueToBeReturned}</span>];
+
+    if (preserveQuotes) {
+      valueNodes.unshift(<span key="open-quote">"</span>);
+      valueNodes.push(<span key="close-quote">"</span>);
+    }
 
     const out = [
       <span
@@ -78,7 +91,7 @@ function walk({
           (valueInfo.isMultiLine ? ' val-string-multiline' : '')
         }
       >
-        {preserveQuotes ? `"${valueToBeReturned}"` : valueToBeReturned}
+        {valueNodes}
       </span>,
     ];
 
@@ -96,7 +109,7 @@ function walk({
   if (isNumber(value)) {
     const valueToBeReturned =
       withAnnotatedText && meta ? (
-        <AnnotatedText value={value} meta={meta?.[''] ?? meta} />
+        <AnnotatedText value={value} meta={getMeta(meta)} />
       ) : (
         value
       );
@@ -104,6 +117,7 @@ function walk({
   }
 
   if (isArray(value)) {
+    const metaLength = getMeta(meta)?.len ?? value.length;
     for (i = 0; i < value.length; i++) {
       children.push(
         <span className="val-array-item" key={i}>
@@ -113,12 +127,25 @@ function walk({
             preserveQuotes,
             withAnnotatedText,
             jsonConsts,
-            meta: meta?.[i]?.[''] ?? meta?.[i] ?? meta?.[''] ?? meta,
+            meta: getChildMetaContainer(meta, i),
           })}
           {i < value.length - 1 ? <span className="val-array-sep">{', '}</span> : null}
         </span>
       );
     }
+
+    if (metaLength > value.length) {
+      children.push(
+        <span className="val-array-item" key="ellipsis">
+          <AnnotatedEllipsis
+            container="array"
+            metaLength={metaLength}
+            withAnnotatedText={withAnnotatedText}
+          />
+        </span>
+      );
+    }
+
     return (
       <span className="val-array">
         <span className="val-array-marker">{'['}</span>
@@ -135,6 +162,7 @@ function walk({
   }
 
   const keys = Object.keys(value);
+  const metaLength = getMeta(meta)?.len ?? keys.length;
 
   keys.sort(naturalCaseInsensitiveSort);
 
@@ -154,10 +182,21 @@ function walk({
             preserveQuotes,
             withAnnotatedText,
             jsonConsts,
-            meta: meta?.[key]?.[''] ?? meta?.[key] ?? meta?.[''] ?? meta,
+            meta: getChildMetaContainer(meta, key),
           })}
-          {i < keys.length - 1 ? <span className="val-dict-sep">{', '}</span> : null}
+          {i < metaLength - 1 ? <span className="val-dict-sep">{', '}</span> : null}
         </span>
+      </span>
+    );
+  }
+  if (metaLength > keys.length) {
+    children.push(
+      <span className="val-dict-pair" key="ellipsis">
+        <AnnotatedEllipsis
+          container="object"
+          metaLength={metaLength}
+          withAnnotatedText={withAnnotatedText}
+        />
       </span>
     );
   }

--- a/static/app/components/events/contextSummary/contextSummaryDevice.tsx
+++ b/static/app/components/events/contextSummary/contextSummaryDevice.tsx
@@ -2,6 +2,10 @@ import styled from '@emotion/styled';
 
 import {DeviceName} from 'sentry/components/deviceName';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
+import {
+  getChildMetaContainer,
+  getMeta,
+} from 'sentry/components/events/meta/metaContainer';
 import TextOverflow from 'sentry/components/textOverflow';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -22,10 +26,10 @@ type Data = {
 type SubTitle = {
   subject: string;
   value: string;
-  meta?: Meta;
+  meta?: Partial<Meta>;
 };
 
-type Props = ContextItemProps<Data, 'device'>;
+type Props = ContextItemProps<Data>;
 
 export function ContextSummaryDevice({data, meta}: Props) {
   if (Object.keys(data).length === 0) {
@@ -37,14 +41,12 @@ export function ContextSummaryDevice({data, meta}: Props) {
       return t('Unknown Device');
     }
 
+    const nameMeta = getMeta(getChildMetaContainer(meta, 'name'));
     return (
       <DeviceName value={data.model}>
         {deviceName => {
           return (
-            <AnnotatedText
-              value={meta.name?.[''] ? data.name : deviceName}
-              meta={meta.name?.['']}
-            />
+            <AnnotatedText value={nameMeta ? data.name : deviceName} meta={nameMeta} />
           );
         }}
       </DeviceName>
@@ -56,7 +58,7 @@ export function ContextSummaryDevice({data, meta}: Props) {
       return {
         subject: t('Arch:'),
         value: data.arch,
-        meta: meta.arch?.[''],
+        meta: getMeta(getChildMetaContainer(meta, 'arch')),
       };
     }
 
@@ -64,7 +66,7 @@ export function ContextSummaryDevice({data, meta}: Props) {
       return {
         subject: t('Model:'),
         value: data.model,
-        meta: meta.model?.[''],
+        meta: getMeta(getChildMetaContainer(meta, 'model')),
       };
     }
 

--- a/static/app/components/events/contextSummary/contextSummaryGPU.tsx
+++ b/static/app/components/events/contextSummary/contextSummaryGPU.tsx
@@ -1,6 +1,10 @@
 import styled from '@emotion/styled';
 
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
+import {
+  getChildMetaContainer,
+  getMeta,
+} from 'sentry/components/events/meta/metaContainer';
 import TextOverflow from 'sentry/components/textOverflow';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -20,10 +24,10 @@ type Data = {
 type VersionElement = {
   subject: string;
   value: string;
-  meta?: Meta;
+  meta?: Partial<Meta>;
 };
 
-type Props = ContextItemProps<Data, 'gpu'>;
+type Props = ContextItemProps<Data>;
 
 export function ContextSummaryGPU({data, meta}: Props) {
   if (Object.keys(data).length === 0) {
@@ -35,7 +39,7 @@ export function ContextSummaryGPU({data, meta}: Props) {
       return {
         subject: t('Vendor:'),
         value: data.vendor_name,
-        meta: meta.vendor_name?.[''],
+        meta: getMeta(getChildMetaContainer(meta, 'vendor_name')),
       };
     }
 
@@ -50,7 +54,10 @@ export function ContextSummaryGPU({data, meta}: Props) {
   return (
     <Item icon={generateIconName(data.vendor_name ? data.vendor_name : data.name)}>
       <h3>
-        <AnnotatedText value={data.name} meta={meta.name?.['']} />
+        <AnnotatedText
+          value={data.name}
+          meta={getMeta(getChildMetaContainer(meta, 'name'))}
+        />
       </h3>
       <TextOverflow isParagraph>
         <Subject>{versionElement.subject}</Subject>

--- a/static/app/components/events/contextSummary/contextSummaryGeneric.tsx
+++ b/static/app/components/events/contextSummary/contextSummaryGeneric.tsx
@@ -1,6 +1,10 @@
 import styled from '@emotion/styled';
 
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
+import {
+  getChildMetaContainer,
+  getMeta,
+} from 'sentry/components/events/meta/metaContainer';
 import TextOverflow from 'sentry/components/textOverflow';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -16,7 +20,7 @@ type Data = {
   version?: string;
 };
 
-type Props = ContextItemProps<Data, any>;
+type Props = ContextItemProps<Data>;
 
 export function ContextSummaryGeneric({
   data,
@@ -31,7 +35,10 @@ export function ContextSummaryGeneric({
   return (
     <Item icon={generateIconName(data.name, data.version)}>
       <h3>
-        <AnnotatedText value={data.name} meta={meta.name?.['']} />
+        <AnnotatedText
+          value={data.name}
+          meta={getMeta(getChildMetaContainer(meta, 'name'))}
+        />
       </h3>
       {(data.version || !omitUnknownVersion) && (
         <TextOverflow isParagraph>
@@ -39,7 +46,10 @@ export function ContextSummaryGeneric({
           {!defined(data.version) ? (
             t('Unknown')
           ) : (
-            <AnnotatedText value={data.version} meta={meta.version?.['']} />
+            <AnnotatedText
+              value={data.version}
+              meta={getMeta(getChildMetaContainer(meta, 'version'))}
+            />
           )}
         </TextOverflow>
       )}

--- a/static/app/components/events/contextSummary/contextSummaryOS.tsx
+++ b/static/app/components/events/contextSummary/contextSummaryOS.tsx
@@ -1,6 +1,10 @@
 import styled from '@emotion/styled';
 
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
+import {
+  getChildMetaContainer,
+  getMeta,
+} from 'sentry/components/events/meta/metaContainer';
 import TextOverflow from 'sentry/components/textOverflow';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -21,10 +25,10 @@ type Data = {
 type VersionElement = {
   subject: string;
   value: string;
-  meta?: Meta;
+  meta?: Partial<Meta>;
 };
 
-type Props = ContextItemProps<Data, 'os' | 'client_os'>;
+type Props = ContextItemProps<Data>;
 
 export function ContextSummaryOS({data, meta}: Props) {
   if (Object.keys(data).length === 0) {
@@ -36,7 +40,7 @@ export function ContextSummaryOS({data, meta}: Props) {
       return {
         subject: t('Version:'),
         value: data.version,
-        meta: meta.version?.[''],
+        meta: getMeta(getChildMetaContainer(meta, 'version')),
       };
     }
 
@@ -44,7 +48,7 @@ export function ContextSummaryOS({data, meta}: Props) {
       return {
         subject: t('Kernel:'),
         value: data.kernel_version,
-        meta: meta.kernel_version?.[''],
+        meta: getMeta(getChildMetaContainer(meta, 'kernel_version')),
       };
     }
 
@@ -59,7 +63,10 @@ export function ContextSummaryOS({data, meta}: Props) {
   return (
     <Item icon={generateIconName(data.name)}>
       <h3>
-        <AnnotatedText value={data.name} meta={meta.name?.['']} />
+        <AnnotatedText
+          value={data.name}
+          meta={getMeta(getChildMetaContainer(meta, 'name'))}
+        />
       </h3>
       <TextOverflow isParagraph data-test-id="context-sub-title">
         <Subject>{versionElement.subject}</Subject>

--- a/static/app/components/events/contextSummary/contextSummaryUser.tsx
+++ b/static/app/components/events/contextSummary/contextSummaryUser.tsx
@@ -3,6 +3,10 @@ import styled from '@emotion/styled';
 import UserAvatar from 'sentry/components/avatar/userAvatar';
 import {removeFilterMaskedEntries} from 'sentry/components/events/interfaces/utils';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
+import {
+  getChildMetaContainer,
+  getMeta,
+} from 'sentry/components/events/meta/metaContainer';
 import TextOverflow from 'sentry/components/textOverflow';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -16,16 +20,16 @@ import {ContextItemProps} from './types';
 
 type UserTitle = {
   value: string;
-  meta?: Meta;
+  meta?: Partial<Meta>;
 };
 
 type UserDetails = {
   subject: string;
-  meta?: Meta;
+  meta?: Partial<Meta>;
   value?: string;
 };
 
-type Props = ContextItemProps<EventUser, 'user'>;
+type Props = ContextItemProps<EventUser>;
 
 export function ContextSummaryUser({data, meta}: Props) {
   const user = removeFilterMaskedEntries(data);
@@ -38,13 +42,13 @@ export function ContextSummaryUser({data, meta}: Props) {
     const userDetails: UserDetails = {
       subject: t('Username:'),
       value: user.username ?? '',
-      meta: meta.username?.[''],
+      meta: getMeta(getChildMetaContainer(meta, 'username')),
     };
 
     if (key === 'id') {
       userDetails.subject = t('ID:');
       userDetails.value = user.id;
-      userDetails.meta = meta.id?.[''];
+      userDetails.meta = getMeta(getChildMetaContainer(meta, 'id'));
     }
 
     return (
@@ -59,28 +63,28 @@ export function ContextSummaryUser({data, meta}: Props) {
     if (defined(user.email)) {
       return {
         value: user.email,
-        meta: meta.email?.[''],
+        meta: getMeta(getChildMetaContainer(meta, 'email')),
       };
     }
 
     if (defined(user.ip_address)) {
       return {
         value: user.ip_address,
-        meta: meta.ip_address?.[''],
+        meta: getMeta(getChildMetaContainer(meta, 'ip_address')),
       };
     }
 
     if (defined(user.id)) {
       return {
         value: user.id,
-        meta: meta.id?.[''],
+        meta: getMeta(getChildMetaContainer(meta, 'id')),
       };
     }
 
     if (defined(user.username)) {
       return {
         value: user.username,
-        meta: meta.username?.[''],
+        meta: getMeta(getChildMetaContainer(meta, 'username')),
       };
     }
 

--- a/static/app/components/events/contextSummary/index.spec.tsx
+++ b/static/app/components/events/contextSummary/index.spec.tsx
@@ -5,6 +5,7 @@ import ContextSummary from 'sentry/components/events/contextSummary';
 import {ContextSummaryGPU} from 'sentry/components/events/contextSummary/contextSummaryGPU';
 import {ContextSummaryOS} from 'sentry/components/events/contextSummary/contextSummaryOS';
 import {ContextSummaryUser} from 'sentry/components/events/contextSummary/contextSummaryUser';
+import {castAsMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {FILTER_MASK} from 'sentry/constants';
 
 const CONTEXT_USER = {
@@ -195,7 +196,7 @@ describe('OsSummary', function () {
             version: '10.13.4',
             name: 'Mac OS X',
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(container).toSnapshot();
@@ -208,7 +209,7 @@ describe('OsSummary', function () {
             kernel_version: '17.5.0',
             name: 'Mac OS X',
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(container).toSnapshot();
@@ -220,7 +221,7 @@ describe('OsSummary', function () {
           data={{
             name: 'Mac OS X',
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(container).toSnapshot();
@@ -233,14 +234,14 @@ describe('OsSummary', function () {
             name: '',
             version: '10',
           }}
-          meta={{
+          meta={castAsMetaContainer({
             name: {
               '': {
                 rem: [['project:0', 's', 0, 0]],
                 len: 19,
               },
             },
-          }}
+          })}
         />
       );
       await userEvent.hover(screen.getByText(/redacted/));
@@ -260,14 +261,14 @@ describe('OsSummary', function () {
             name: false,
             version: false,
           }}
-          meta={{
+          meta={castAsMetaContainer({
             name: {
               '': {
                 rem: [['project:0', 's', 0, 0]],
                 len: 19,
               },
             },
-          }}
+          })}
         />
       );
       await userEvent.hover(screen.getByText(/redacted/));
@@ -291,7 +292,7 @@ describe('GpuSummary', function () {
             name: 'Mali-T880',
             vendor_name: 'ARM',
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(container).toSnapshot();
@@ -303,7 +304,7 @@ describe('GpuSummary', function () {
           data={{
             name: 'Apple A8 GPU',
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(container).toSnapshot();
@@ -315,14 +316,14 @@ describe('GpuSummary', function () {
           data={{
             name: '',
           }}
-          meta={{
+          meta={castAsMetaContainer({
             name: {
               '': {
                 rem: [['project:0', 's', 0, 0]],
                 len: 19,
               },
             },
-          }}
+          })}
         />
       );
       await userEvent.hover(screen.getByText(/redacted/));
@@ -348,7 +349,9 @@ describe('UserSummary', function () {
         name: 'Maisey Dog',
       };
 
-      const {rerender} = render(<ContextSummaryUser data={user1} meta={{}} />);
+      const {rerender} = render(
+        <ContextSummaryUser data={user1} meta={castAsMetaContainer({})} />
+      );
       expect(screen.getByText(user1.email)).toBeInTheDocument();
 
       const user2 = {
@@ -358,7 +361,7 @@ describe('UserSummary', function () {
         name: 'Maisey Dog',
       };
 
-      rerender(<ContextSummaryUser data={user2} meta={{}} />);
+      rerender(<ContextSummaryUser data={user2} meta={castAsMetaContainer({})} />);
       expect(screen.getByTestId('user-title')?.textContent).toEqual(user2.ip_address);
 
       const user3 = {
@@ -374,7 +377,7 @@ describe('UserSummary', function () {
             username: 'maiseythedog',
             name: 'Maisey Dog',
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(screen.getByTestId('user-title')?.textContent).toEqual(user3.id);
@@ -384,7 +387,7 @@ describe('UserSummary', function () {
         name: 'Maisey Dog',
       };
 
-      rerender(<ContextSummaryUser data={user4} meta={{}} />);
+      rerender(<ContextSummaryUser data={user4} meta={castAsMetaContainer({})} />);
       expect(screen.getByTestId('user-title')).toHaveTextContent(user4.username);
     });
 
@@ -394,7 +397,7 @@ describe('UserSummary', function () {
           data={{
             name: 'Maisey Dog',
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(screen.queryByTestId('user-title')).not.toBeInTheDocument();
@@ -407,7 +410,7 @@ describe('UserSummary', function () {
           data={{
             email: FILTER_MASK,
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(screen.queryByTestId('user-title')).not.toBeInTheDocument();
@@ -423,7 +426,7 @@ describe('UserSummary', function () {
           data={{
             id: FILTER_MASK,
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(screen.queryByTestId('user-title')).not.toBeInTheDocument();
@@ -434,7 +437,7 @@ describe('UserSummary', function () {
           data={{
             username: FILTER_MASK,
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(screen.queryByTestId('user-title')).not.toBeInTheDocument();
@@ -452,7 +455,7 @@ describe('UserSummary', function () {
             id: '26',
             name: FILTER_MASK,
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(screen.getByText('?')).toBeInTheDocument();
@@ -463,7 +466,7 @@ describe('UserSummary', function () {
             id: '26',
             email: FILTER_MASK,
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(screen.getByText('?')).toBeInTheDocument();
@@ -474,7 +477,7 @@ describe('UserSummary', function () {
             id: '26',
             username: FILTER_MASK,
           }}
-          meta={{}}
+          meta={castAsMetaContainer({})}
         />
       );
       expect(screen.getByText('?')).toBeInTheDocument();
@@ -487,14 +490,14 @@ describe('UserSummary', function () {
             name: 'Maisey Dog',
             email: '',
           }}
-          meta={{
+          meta={castAsMetaContainer({
             email: {
               '': {
                 rem: [['project:0', 's', 0, 0]],
                 len: 19,
               },
             },
-          }}
+          })}
         />
       );
       await userEvent.hover(screen.getByText(/redacted/));

--- a/static/app/components/events/contextSummary/types.tsx
+++ b/static/app/components/events/contextSummary/types.tsx
@@ -1,13 +1,11 @@
-import {Event} from 'sentry/types';
-
-type Meta = NonNullable<Event['_meta']>;
+import {MetaContainer} from 'sentry/components/events/meta/metaContainer';
 
 /**
  * The props passed to each context item
  */
-export type ContextItemProps<D, M extends keyof Meta> = {
+export type ContextItemProps<D> = {
   data: D;
-  meta: Meta[M];
+  meta: MetaContainer;
   omitUnknownVersion?: boolean;
   unknownTitle?: string;
 };
@@ -16,7 +14,7 @@ export type ContextItemProps<D, M extends keyof Meta> = {
  * Defines a context type
  */
 export type Context = {
-  Component: React.ComponentType<ContextItemProps<any, any>>;
+  Component: React.ComponentType<ContextItemProps<any>>;
   keys: string[];
   omitUnknownVersion?: boolean;
   unknownTitle?: string;

--- a/static/app/components/events/contexts/app/index.tsx
+++ b/static/app/components/events/contexts/app/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {Event} from 'sentry/types/event';
 
 import {getKnownData, getUnknownData} from '../utils';
@@ -26,7 +27,7 @@ export const appKnownDataValues = [
 const appIgnoredDataValues = [];
 
 export function AppEventContext({data, event}: Props) {
-  const meta = event._meta?.contexts?.app ?? {};
+  const meta = getChildMetaContainer(event._meta, 'contexts', 'app');
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/browser/index.tsx
+++ b/static/app/components/events/contexts/browser/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {Event} from 'sentry/types';
 
 import {getKnownData, getUnknownData} from '../utils';
@@ -19,7 +20,7 @@ export const browserKnownDataValues = [
 ];
 
 export function BrowserEventContext({data, event}: Props) {
-  const meta = event._meta?.contexts?.browser ?? {};
+  const meta = getChildMetaContainer(event._meta, 'contexts', 'browser');
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/device/index.tsx
+++ b/static/app/components/events/contexts/device/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {DeviceContext, Event} from 'sentry/types/event';
 
 import {getKnownData, getUnknownData} from '../utils';
@@ -20,7 +21,7 @@ const deviceIgnoredDataValues = [];
 
 export function DeviceEventContext({data, event}: Props) {
   const inferredData = getInferredData(data);
-  const meta = event._meta?.contexts?.device ?? {};
+  const meta = getChildMetaContainer(event._meta, 'contexts', 'device');
 
   return (
     <Fragment>

--- a/static/app/components/events/contexts/gpu/index.tsx
+++ b/static/app/components/events/contexts/gpu/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {Event} from 'sentry/types/event';
 
 import {getKnownData, getUnknownData} from '../utils';
@@ -26,7 +27,7 @@ export const gpuKnownDataValues = [
 const gpuIgnoredDataValues = [];
 
 export function GPUEventContext({event, data}: Props) {
-  const meta = event._meta?.contexts?.gpu ?? {};
+  const meta = getChildMetaContainer(event._meta, 'contexts', 'gpu');
 
   const gpuValues = [...gpuKnownDataValues];
 

--- a/static/app/components/events/contexts/memoryInfo/index.tsx
+++ b/static/app/components/events/contexts/memoryInfo/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {Event, MemoryInfoContext} from 'sentry/types/event';
 
 import {getKnownData, getUnknownData} from '../utils';
@@ -21,7 +22,8 @@ export function MemoryInfoEventContext({data, event}: Props) {
   }
 
   const meta =
-    event._meta?.contexts?.['Memory Info'] ?? event._meta?.contexts?.memory_info ?? {};
+    getChildMetaContainer(event._meta, 'contexts', 'Memory Info') ??
+    getChildMetaContainer(event._meta, 'contexts', 'memory_info');
 
   return (
     <Fragment>

--- a/static/app/components/events/contexts/operatingSystem/index.tsx
+++ b/static/app/components/events/contexts/operatingSystem/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {Event} from 'sentry/types';
 
 import {getKnownData, getUnknownData} from '../utils';
@@ -27,7 +28,7 @@ export const operatingSystemKnownDataValues = [
 const operatingSystemIgnoredDataValues = [OperatingSystemIgnoredDataType.BUILD];
 
 export function OperatingSystemEventContext({data, event}: Props) {
-  const meta = event._meta?.contexts?.os ?? {};
+  const meta = getChildMetaContainer(event._meta, 'contexts', 'os');
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -2,6 +2,7 @@ import Feature from 'sentry/components/acl/feature';
 import {Button} from 'sentry/components/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import {Event, ProfileContext, ProfileContextKey} from 'sentry/types/event';
@@ -23,7 +24,7 @@ export function ProfileEventContext({event, data}: ProfileContextProps) {
   const organization = useOrganization();
   const {projects} = useProjects();
   const project = projects.find(p => p.id === event.projectID);
-  const meta = event._meta?.contexts?.profile ?? {};
+  const meta = getChildMetaContainer(event._meta, 'contexts', 'profile');
 
   return (
     <Feature organization={organization} features={['profiling']}>

--- a/static/app/components/events/contexts/runtime/index.tsx
+++ b/static/app/components/events/contexts/runtime/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {Event} from 'sentry/types/event';
 
 import {getKnownData, getUnknownData} from '../utils';
@@ -21,7 +22,7 @@ export const runtimeKnownDataValues = [
 const runtimeIgnoredDataValues = [RuntimeIgnoredDataType.BUILD];
 
 export function RuntimeEventContext({data, event}: Props) {
-  const meta = event._meta?.contexts?.runtime ?? {};
+  const meta = getChildMetaContainer(event._meta, 'contexts', 'runtime');
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/state/index.tsx
+++ b/static/app/components/events/contexts/state/index.tsx
@@ -2,6 +2,7 @@ import upperFirst from 'lodash/upperFirst';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {t} from 'sentry/locale';
 import {Event} from 'sentry/types';
 
@@ -21,7 +22,7 @@ type Props = {
 };
 
 export function StateEventContext({data, event}: Props) {
-  const meta = event._meta?.contexts?.state ?? {};
+  const meta = getChildMetaContainer(event._meta, 'contexts', 'state');
 
   function getStateTitle(name: string, type?: string) {
     return `${name}${type ? ` (${upperFirst(type)})` : ''}`;
@@ -37,7 +38,7 @@ export function StateEventContext({data, event}: Props) {
         key: 'state',
         subject: getStateTitle(t('State'), data.state.type),
         value: data.state.value,
-        meta: meta.state?.value?.[''],
+        meta: getChildMetaContainer(meta, 'state', 'value'),
       },
     ];
   }
@@ -49,7 +50,7 @@ export function StateEventContext({data, event}: Props) {
         key: name,
         value: state.value,
         subject: getStateTitle(name, state.type),
-        meta: meta[name]?.value?.[''],
+        meta: getChildMetaContainer(meta, name, 'value'),
       }));
   }
 

--- a/static/app/components/events/contexts/threadPoolInfo/index.tsx
+++ b/static/app/components/events/contexts/threadPoolInfo/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {Event, ThreadPoolInfoContext} from 'sentry/types/event';
 
 import {getKnownData, getUnknownData} from '../utils';
@@ -21,9 +22,8 @@ export function ThreadPoolInfoEventContext({data, event}: Props) {
   }
 
   const meta =
-    event._meta?.contexts?.['ThreadPool Info'] ??
-    event._meta?.contexts?.threadpool_info ??
-    {};
+    getChildMetaContainer(event._meta, 'contexts', 'ThreadPool Info') ??
+    getChildMetaContainer(event._meta, 'contexts', 'threadpool_info');
 
   return (
     <Fragment>

--- a/static/app/components/events/contexts/trace/index.tsx
+++ b/static/app/components/events/contexts/trace/index.tsx
@@ -1,5 +1,6 @@
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {Event} from 'sentry/types/event';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -26,7 +27,7 @@ type Props = {
 
 export function TraceEventContext({event, data}: Props) {
   const organization = useOrganization();
-  const meta = event._meta?.contexts?.trace ?? {};
+  const meta = getChildMetaContainer(event._meta, 'contexts', 'trace');
 
   return (
     <ErrorBoundary mini>

--- a/static/app/components/events/contexts/unity/index.tsx
+++ b/static/app/components/events/contexts/unity/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {Event, UnityContext} from 'sentry/types';
 
 import {getKnownData, getUnknownData} from '../utils';
@@ -17,7 +18,7 @@ export function UnityEventContext({data, event}: Props) {
     return null;
   }
 
-  const meta = event._meta?.contexts?.unity ?? {};
+  const meta = getChildMetaContainer(event._meta, 'contexts', 'unity');
 
   return (
     <Fragment>

--- a/static/app/components/events/contexts/user/index.tsx
+++ b/static/app/components/events/contexts/user/index.tsx
@@ -3,6 +3,7 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import {removeFilterMaskedEntries} from 'sentry/components/events/interfaces/utils';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {AvatarUser} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
@@ -43,7 +44,7 @@ export const userKnownDataValues = [
 const userIgnoredDataValues = [UserIgnoredDataType.DATA];
 
 export function UserEventContext({data, event}: Props) {
-  const meta = event._meta?.user ?? event._meta?.contexts?.user ?? {};
+  const meta = getChildMetaContainer(event._meta, 'contexts', 'user');
 
   return (
     <div className="user-widget">

--- a/static/app/components/events/contexts/user/index.tsx
+++ b/static/app/components/events/contexts/user/index.tsx
@@ -76,7 +76,7 @@ export function UserEventContext({data, event}: Props) {
               key,
               value,
               subject: key,
-              meta: meta[key]?.[''],
+              meta: getChildMetaContainer(meta, key),
             }))}
             isContextData
           />

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -4,10 +4,14 @@ import startCase from 'lodash/startCase';
 import moment from 'moment-timezone';
 
 import ContextData from 'sentry/components/contextData';
+import {
+  getChildMetaContainer,
+  MetaContainer,
+} from 'sentry/components/events/meta/metaContainer';
 import {t} from 'sentry/locale';
 import plugins from 'sentry/plugins';
 import {space} from 'sentry/styles/space';
-import {Event, KeyValueListData} from 'sentry/types';
+import {KeyValueListData} from 'sentry/types';
 import {defined} from 'sentry/utils';
 
 import {AppEventContext} from './app';
@@ -163,7 +167,7 @@ export function getUnknownData({
 }: {
   allData: Record<string, any>;
   knownKeys: string[];
-  meta?: NonNullable<Event['_meta']>[keyof Event['_meta']];
+  meta?: MetaContainer;
 }): KeyValueListData {
   return Object.entries(allData)
     .filter(
@@ -171,13 +175,15 @@ export function getUnknownData({
         key !== 'type' &&
         key !== 'title' &&
         !knownKeys.includes(key) &&
-        (typeof allData[key] !== 'number' && !allData[key] ? !!meta?.[key]?.[''] : true)
+        (typeof allData[key] !== 'number' && !allData[key]
+          ? !!getChildMetaContainer(meta, key)
+          : true)
     )
     .map(([key, value]) => ({
       key,
       value,
       subject: startCase(key),
-      meta: meta?.[key]?.[''],
+      meta: getChildMetaContainer(meta, key),
     }));
 }
 

--- a/static/app/components/events/errorItem.spec.tsx
+++ b/static/app/components/events/errorItem.spec.tsx
@@ -2,6 +2,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ErrorItem} from 'sentry/components/events/errorItem';
+import {castAsMetaContainer} from 'sentry/components/events/meta/metaContainer';
 
 describe('Issue error item', function () {
   it('expand subitems', async function () {
@@ -38,9 +39,9 @@ describe('Issue error item', function () {
           message: 'A required debug information file was missing.',
           type: 'native_missing_dsym',
         }}
-        meta={{
+        meta={castAsMetaContainer({
           image_path: {'': {rem: [['project:2', 's', 0, 0]], len: 117}},
-        }}
+        })}
       />
     );
 

--- a/static/app/components/events/errorItem.tsx
+++ b/static/app/components/events/errorItem.tsx
@@ -6,6 +6,11 @@ import moment from 'moment';
 import {Button} from 'sentry/components/button';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
+import {
+  getChildMetaContainer,
+  getMeta,
+  MetaContainer,
+} from 'sentry/components/events/meta/metaContainer';
 import ExternalLink from 'sentry/components/links/externalLink';
 import ListItem from 'sentry/components/list/listItem';
 import {JavascriptProcessingErrors} from 'sentry/constants/eventErrors';
@@ -34,7 +39,7 @@ const keyMapping = {
 
 export type ErrorItemProps = {
   error: EventErrorData;
-  meta?: Record<any, any>;
+  meta?: MetaContainer;
 };
 
 export function ErrorItem({error, meta}: ErrorItemProps) {
@@ -74,7 +79,10 @@ export function ErrorItem({error, meta}: ErrorItemProps) {
         key,
         value,
         subject: keyMapping[key] || startCase(key),
-        meta: key === 'image_name' ? meta?.image_path?.[''] : meta?.[key]?.[''],
+        meta:
+          key === 'image_name'
+            ? getChildMetaContainer(meta, 'image_path')
+            : getChildMetaContainer(meta, key),
       }))
       .filter(d => {
         if (!d.value && !!d.meta) {
@@ -84,20 +92,22 @@ export function ErrorItem({error, meta}: ErrorItemProps) {
       });
   }, [error.data, meta]);
 
+  const nameMeta = getMeta(getChildMetaContainer(meta, 'data', 'name'));
+  const messageMeta = getMeta(getChildMetaContainer(meta, 'message'));
   return (
     <StyledListItem data-test-id="event-error-item">
       <OverallInfo>
         <div>
-          {meta?.data?.name?.[''] ? (
-            <AnnotatedText value={error.message} meta={meta?.data?.name?.['']} />
+          {nameMeta ? (
+            <AnnotatedText value={error.message} meta={nameMeta} />
           ) : !error.data?.name || typeof error.data?.name !== 'string' ? null : (
             <Fragment>
               <strong>{error.data?.name}</strong>
               {': '}
             </Fragment>
           )}
-          {meta?.message?.[''] ? (
-            <AnnotatedText value={error.message} meta={meta?.message?.['']} />
+          {messageMeta ? (
+            <AnnotatedText value={error.message} meta={messageMeta} />
           ) : (
             error.message
           )}

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 import {CommitRow} from 'sentry/components/commitRow';
 import {EventEvidence} from 'sentry/components/events/eventEvidence';
 import EventReplay from 'sentry/components/events/eventReplay';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {
@@ -117,7 +118,7 @@ function EventEntries({
       <EventDevice event={event} />
       {!isShare && <EventViewHierarchy event={event} project={project} />}
       {!isShare && <EventAttachments event={event} projectSlug={projectSlug} />}
-      <EventSdk sdk={event.sdk} meta={event._meta?.sdk} />
+      <EventSdk sdk={event.sdk} meta={getChildMetaContainer(event._meta, 'sdk')} />
       {!isShare && event.groupID && (
         <EventGroupingInfo
           projectSlug={projectSlug}

--- a/static/app/components/events/eventExtraData/index.tsx
+++ b/static/app/components/events/eventExtraData/index.tsx
@@ -2,6 +2,7 @@ import {memo, useState} from 'react';
 
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {t} from 'sentry/locale';
 import {Event} from 'sentry/types/event';
@@ -47,7 +48,7 @@ export const EventExtraData = memo(
             data={getKnownData<TEventExtraData, EventExtraDataType>({
               data: event.context,
               knownDataTypes: Object.keys(event.context),
-              meta: event._meta?.context,
+              meta: getChildMetaContainer(event._meta, 'context'),
               raw,
               onGetKnownDataDetails: v => getEventExtraDataKnownDataDetails(v),
             })}

--- a/static/app/components/events/interfaces/csp/index.tsx
+++ b/static/app/components/events/interfaces/csp/index.tsx
@@ -2,6 +2,10 @@ import {useState} from 'react';
 
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
+import {
+  getChildMetaContainer,
+  MetaContainer,
+} from 'sentry/components/events/meta/metaContainer';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {t} from 'sentry/locale';
 import {EntryType, Event} from 'sentry/types/event';
@@ -10,7 +14,7 @@ import Help, {HelpProps} from './help';
 
 type View = 'report' | 'raw' | 'help';
 
-function getView(view: View, data: Record<any, any>, meta: Record<any, any>) {
+function getView(view: View, data: Record<any, any>, meta: MetaContainer) {
   switch (view) {
     case 'report':
       return (
@@ -20,7 +24,7 @@ function getView(view: View, data: Record<any, any>, meta: Record<any, any>) {
               key,
               subject: key,
               value,
-              meta: meta?.[key]?.[''],
+              meta: getChildMetaContainer(meta, key),
             };
           })}
           isContextData

--- a/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
+++ b/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
@@ -3,6 +3,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {FrameVariables} from 'sentry/components/events/interfaces/frame/frameVariables';
+import {castAsMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
 describe('Frame Variables', function () {
@@ -32,7 +33,7 @@ describe('Frame Variables', function () {
             "'tags'": null,
           },
         }}
-        meta={{
+        meta={castAsMetaContainer({
           "'client'": {
             '': {
               rem: [['project:0', 's', 0, 0]],
@@ -61,7 +62,7 @@ describe('Frame Variables', function () {
               ],
             },
           },
-        }}
+        })}
       />,
       {organization, router, context: routerContext}
     );

--- a/static/app/components/events/interfaces/frame/frameVariables.tsx
+++ b/static/app/components/events/interfaces/frame/frameVariables.tsx
@@ -1,11 +1,11 @@
 import {KeyValueListData} from 'sentry/types';
 
-import {AnnotatedText} from '../../meta/annotatedText';
+import {getChildMetaContainer, MetaContainer} from '../../meta/metaContainer';
 import KeyValueList from '../keyValueList';
 
 type Props = {
   data: Record<string, string | null | Record<string, string | null>>;
-  meta?: Record<any, any>;
+  meta?: MetaContainer;
 };
 
 export function FrameVariables({data, meta}: Props) {
@@ -23,15 +23,8 @@ export function FrameVariables({data, meta}: Props) {
     transformedData.push({
       key,
       subject: key,
-      value: Array.isArray(data[key])
-        ? (data[key] as unknown as any[]).map((v, i) => {
-            if (!v && meta?.[key]?.[i]?.['']) {
-              return <AnnotatedText key={key} value={v} meta={meta?.[key]?.[i]?.['']} />;
-            }
-            return v;
-          })
-        : data[key],
-      meta: meta?.[key]?.[''],
+      value: data[key],
+      meta: getChildMetaContainer(meta, key),
     });
   }
 

--- a/static/app/components/events/interfaces/frame/functionName.tsx
+++ b/static/app/components/events/interfaces/frame/functionName.tsx
@@ -1,7 +1,6 @@
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
-import {getMeta} from 'sentry/components/events/meta/metaProxy';
 import {t} from 'sentry/locale';
-import {Frame} from 'sentry/types';
+import {Frame, Meta} from 'sentry/types';
 
 type Props = {
   frame: Frame;
@@ -20,7 +19,7 @@ export function FunctionName({
   ...props
 }: Props) {
   const getValueOutput = ():
-    | {meta: ReturnType<typeof getMeta>; value: Frame['function']}
+    | {meta: Meta | undefined; value: Frame['function']}
     | undefined => {
     if (hasHiddenDetails && showCompleteFunctionName && frame.rawFunction) {
       return {

--- a/static/app/components/events/interfaces/keyValueList/value.tsx
+++ b/static/app/components/events/interfaces/keyValueList/value.tsx
@@ -2,6 +2,7 @@ import {Fragment, isValidElement} from 'react';
 
 import ContextData from 'sentry/components/contextData';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
+import {getMeta} from 'sentry/components/events/meta/metaContainer';
 import {KeyValueListData} from 'sentry/types';
 
 export interface ValueProps
@@ -34,7 +35,7 @@ export function Value({subjectIcon, meta, raw, isContextData, value = null}: Val
 
   return (
     <pre className="val-string">
-      <AnnotatedText value={dataValue} meta={meta} />
+      <AnnotatedText value={dataValue} meta={getMeta(meta)} />
       {subjectIcon}
     </pre>
   );

--- a/static/app/components/events/interfaces/request/richHttpContentClippedBoxBodySection.tsx
+++ b/static/app/components/events/interfaces/request/richHttpContentClippedBoxBodySection.tsx
@@ -2,6 +2,7 @@ import ClippedBox from 'sentry/components/clippedBox';
 import ContextData from 'sentry/components/contextData';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
+import type {MetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {t} from 'sentry/locale';
 import {EntryRequest} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
@@ -11,7 +12,7 @@ import getTransformedData from './getTransformedData';
 type Props = {
   data: EntryRequest['data']['data'];
   inferredContentType: EntryRequest['data']['inferredContentType'];
-  meta?: Record<any, any>;
+  meta?: MetaContainer;
 };
 
 export function RichHttpContentClippedBoxBodySection({
@@ -30,6 +31,8 @@ export function RichHttpContentClippedBoxBodySection({
           <ContextData
             data-test-id="rich-http-content-body-context-data"
             data={data}
+            meta={meta}
+            withAnnotatedText
             preserveQuotes
           />
         );

--- a/static/app/components/events/interfaces/request/richHttpContentClippedBoxBodySection.tsx
+++ b/static/app/components/events/interfaces/request/richHttpContentClippedBoxBodySection.tsx
@@ -61,12 +61,21 @@ export function RichHttpContentClippedBoxBodySection({
         );
       }
 
-      default:
+      default: {
+        // FIXME: Is the test case in static/app/components/events/interfaces/request/index.spec.tsx accurate?
+        // `EntryRequest['data']['data']` suggests that data may be [key: string, value: any][], **not** Record<string, any>[].
+        // If this is a real scenario, what is the rule for looking up the relevant data in meta? As a hack, I assume that if
+        // we encounter data as an array, that the same meta structure can be used by all items... which allows the test case
+        // to pass.
+        const wrappedMeta = Array.isArray(data)
+          ? Object.fromEntries(data.map((_: any, i: number) => [i, meta]))
+          : meta;
         return (
           <pre data-test-id="rich-http-content-body-section-pre">
-            <ContextData data={data} meta={meta} withAnnotatedText />
+            <ContextData data={data} meta={wrappedMeta} withAnnotatedText />
           </pre>
         );
+      }
     }
   }
 

--- a/static/app/components/events/interfaces/request/richHttpContentClippedBoxKeyValueList.tsx
+++ b/static/app/components/events/interfaces/request/richHttpContentClippedBoxKeyValueList.tsx
@@ -1,7 +1,7 @@
 import ClippedBox from 'sentry/components/clippedBox';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
-import {Meta} from 'sentry/types';
+import {MetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {EntryRequest} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 
@@ -14,7 +14,7 @@ type Props = {
   title: string;
   defaultCollapsed?: boolean;
   isContextData?: boolean;
-  meta?: Meta;
+  meta?: MetaContainer;
 };
 
 export function RichHttpContentClippedBoxKeyValueList({

--- a/static/app/components/events/meta/annotatedText/annotatedEllipsis.tsx
+++ b/static/app/components/events/meta/annotatedText/annotatedEllipsis.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import {Redaction} from 'sentry/components/events/meta/annotatedText/redaction';
+import {
+  getRemovedForSizeLimitTooltipText,
+  REMOVED_SIZE_LIMIT_CONTAINER_INFO,
+} from 'sentry/components/events/meta/annotatedText/utils';
+import {Tooltip} from 'sentry/components/tooltip';
+
+type Props = {
+  container: keyof typeof REMOVED_SIZE_LIMIT_CONTAINER_INFO;
+  metaLength: number;
+  withAnnotatedText?: boolean;
+};
+
+export function AnnotatedEllipsis({
+  metaLength,
+  container,
+  withAnnotatedText = false,
+}: Props) {
+  if (!withAnnotatedText) {
+    return <React.Fragment>...</React.Fragment>;
+  }
+  return (
+    <Tooltip title={getRemovedForSizeLimitTooltipText(container, metaLength)} isHoverable>
+      <Redaction>...</Redaction>
+    </Tooltip>
+  );
+}

--- a/static/app/components/events/meta/annotatedText/annotatedTextErrors.tsx
+++ b/static/app/components/events/meta/annotatedText/annotatedTextErrors.tsx
@@ -39,7 +39,7 @@ function ErrorMessage({error}: {error?: MetaError}) {
   return <Fragment>{formatErrorKind(error)}</Fragment>;
 }
 
-export function AnnotatedTextErrors({errors = []}: {errors: Array<MetaError>}) {
+export function AnnotatedTextErrors({errors = []}: {errors?: Array<MetaError>}) {
   if (!errors.length) {
     return null;
   }

--- a/static/app/components/events/meta/annotatedText/annotatedTextValue.tsx
+++ b/static/app/components/events/meta/annotatedText/annotatedTextValue.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Tooltip} from 'sentry/components/tooltip';
-import {Organization, Project} from 'sentry/types';
+import {Meta, Organization, Project} from 'sentry/types';
 
 import {Redaction} from './redaction';
 import {getTooltipText} from './utils';
@@ -9,7 +9,7 @@ import {ValueElement} from './valueElement';
 
 type Props = {
   value: React.ReactNode;
-  meta?: Record<any, any>;
+  meta?: Partial<Meta>;
   organization?: Organization;
   project?: Project;
 };
@@ -23,7 +23,11 @@ export function AnnotatedTextValue({value, meta, organization, project}: Props) 
             return (
               <Tooltip
                 skipWrapper
-                title={getTooltipText({rule_id: chunk.rule_id, remark: chunk.remark})}
+                title={getTooltipText({
+                  rule_id: chunk.rule_id,
+                  remark: chunk.remark,
+                  meta,
+                })}
                 key={index}
               >
                 <Redaction>{chunk.text}</Redaction>
@@ -45,6 +49,7 @@ export function AnnotatedTextValue({value, meta, organization, project}: Props) 
           remark: meta.rem[0][1],
           organization,
           project,
+          meta,
         })}
         isHoverable
       >

--- a/static/app/components/events/meta/annotatedText/index.tsx
+++ b/static/app/components/events/meta/annotatedText/index.tsx
@@ -1,3 +1,4 @@
+import {Meta} from 'sentry/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -8,7 +9,7 @@ import {AnnotatedTextValue} from './annotatedTextValue';
 type Props = {
   value: React.ReactNode;
   className?: string;
-  meta?: Record<any, any>;
+  meta?: Partial<Meta>;
 };
 
 export function AnnotatedText({value, meta, className, ...props}: Props) {

--- a/static/app/components/events/meta/annotatedText/utils.tsx
+++ b/static/app/components/events/meta/annotatedText/utils.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import Link from 'sentry/components/links/link';
 import {tct} from 'sentry/locale';
-import {ChunkType, Organization, Project} from 'sentry/types';
+import {ChunkType, Meta, Organization, Project} from 'sentry/types';
 import {convertRelayPiiConfig} from 'sentry/views/settings/components/dataScrubbing/convertRelayPiiConfig';
 import {getRuleDescription} from 'sentry/views/settings/components/dataScrubbing/utils';
 
@@ -21,18 +21,63 @@ const NON_DATA_SCRUBBING_RULES = {
   '!config': 'SDK configuration',
 };
 
+export const REMOVED_SIZE_LIMIT_CONTAINER_INFO = {
+  array: {
+    container: 'Collection',
+    items: 'items',
+  },
+  string: {
+    container: 'Serialized object',
+    items: 'characters',
+  },
+  object: {
+    container: 'Mapping',
+    items: 'items',
+  },
+} satisfies {[containerType: string]: {container: string; items: string}};
+
+const REMOVED_SIZE_LIMIT_INDICATOR = {rule_id: '!limit', remark: 'x'} satisfies {
+  remark: keyof typeof REMARKS;
+  rule_id: keyof typeof NON_DATA_SCRUBBING_RULES;
+};
+
+export function getRemovedForSizeLimitTooltipText(
+  container: keyof typeof REMOVED_SIZE_LIMIT_CONTAINER_INFO,
+  length: number
+) {
+  return tct(
+    '[method] because of [ruleDescription]. [container] has [length] [items] total.',
+    {
+      method: REMARKS[REMOVED_SIZE_LIMIT_INDICATOR.remark],
+      container: REMOVED_SIZE_LIMIT_CONTAINER_INFO[container].container,
+      items: REMOVED_SIZE_LIMIT_CONTAINER_INFO[container].items,
+      ruleDescription: NON_DATA_SCRUBBING_RULES[REMOVED_SIZE_LIMIT_INDICATOR.rule_id],
+      length,
+    }
+  );
+}
+
 export function getTooltipText({
   remark = '',
   rule_id = '',
+  meta,
   organization,
   project,
 }: Pick<ChunkType, 'remark' | 'rule_id'> & {
+  meta?: Partial<Meta>;
   organization?: Organization;
   project?: Project;
 }) {
   const method = REMARKS[remark];
 
   if (NON_DATA_SCRUBBING_RULES[rule_id]) {
+    if (
+      rule_id === REMOVED_SIZE_LIMIT_INDICATOR.rule_id &&
+      remark === REMOVED_SIZE_LIMIT_INDICATOR.remark &&
+      meta?.len
+    ) {
+      return getRemovedForSizeLimitTooltipText('string', meta.len);
+    }
     return tct('[method] because of [ruleDescription]', {
       method,
       ruleDescription: NON_DATA_SCRUBBING_RULES[rule_id],

--- a/static/app/components/events/meta/metaContainer.ts
+++ b/static/app/components/events/meta/metaContainer.ts
@@ -1,0 +1,54 @@
+import {Meta} from 'sentry/types';
+
+declare const __brand: unique symbol;
+
+/**
+ * Nested object found within an event's "_meta" field.
+ *
+ * It should match the following pseudo type (currently impossible to express in TS [^1]):
+ *
+ *    ```ts
+ *    type MetaContainer = {''?: Partial<Meta>, [key: string ~ '']: MetaContainer} | undefined}
+ *    ```
+ *
+ * Instead of providing inaccurate types, we make the type opaque, leveraging "branding" [^2]
+ * and helper methods for accessing the relevant parts of the object in a typesafe way.
+ *
+ * - Use {@link getMeta} to access the Meta of the current object.
+ * - Use {@link getChildMetaContainer} to query for a nested Meta (for arrays / objects).
+ * - Use {@link castAsMetaContainer} to cast an object as MetaContainer.
+ *
+ * [^1]: https://github.com/microsoft/TypeScript/issues/4196#issuecomment-260014226
+ * [^2]: https://egghead.io/blog/using-branded-types-in-typescript
+ */
+export type MetaContainer =
+  | {[key: string]: unknown; readonly [__brand]: 'MetaContainer'}
+  | undefined;
+
+export function castAsMetaContainer(metaContainer: any): MetaContainer {
+  return metaContainer;
+}
+
+/**
+ * @param path - should not contain `''` - use `getMeta` instead.
+ */
+export function getChildMetaContainer(
+  metaContainer: MetaContainer,
+  ...path: Array<string | number>
+): MetaContainer {
+  let current: MetaContainer = metaContainer;
+  for (const key of path) {
+    if (!current) {
+      return undefined;
+    }
+    if (key === '') {
+      return undefined;
+    }
+    current = current[key] as MetaContainer;
+  }
+  return current;
+}
+
+export function getMeta(metaContainer: MetaContainer): Partial<Meta> | undefined {
+  return metaContainer?.[''] as Partial<Meta> | undefined;
+}

--- a/static/app/components/events/meta/metaProxy.tsx
+++ b/static/app/components/events/meta/metaProxy.tsx
@@ -2,8 +2,6 @@ import isEmpty from 'lodash/isEmpty';
 import isNull from 'lodash/isNull';
 import memoize from 'lodash/memoize';
 
-import {Meta} from 'sentry/types';
-
 const GET_META = Symbol('GET_META');
 const IS_PROXY = Symbol('IS_PROXY');
 
@@ -82,14 +80,3 @@ export const withMeta = memoize(function withMeta<T>(event: T): T {
   // https://github.com/microsoft/TypeScript/issues/20846
   return new Proxy(event, new MetaProxy((event as any)._meta)) as T;
 });
-
-export function getMeta<T extends {}>(
-  obj: T | undefined,
-  prop: Extract<keyof T, string>
-): Meta | undefined {
-  if (!obj || typeof obj[GET_META] !== 'function') {
-    return undefined;
-  }
-
-  return obj[GET_META](prop);
-}

--- a/static/app/components/events/packageData.tsx
+++ b/static/app/components/events/packageData.tsx
@@ -2,6 +2,7 @@ import ClippedBox from 'sentry/components/clippedBox';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {t} from 'sentry/locale';
 import {Event} from 'sentry/types/event';
 import {objectIsEmpty} from 'sentry/utils';
@@ -13,11 +14,12 @@ type Props = {
 export function EventPackageData({event}: Props) {
   let longKeys: boolean, title: string;
 
+  const meta = getChildMetaContainer(event._meta, 'packages');
   const packages = Object.entries(event.packages || {}).map(([key, value]) => ({
     key,
     value,
     subject: key,
-    meta: event._meta?.packages?.[key]?.[''],
+    meta: getChildMetaContainer(meta, key),
   }));
 
   switch (event.platform) {

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -3,6 +3,7 @@ import type {
   TraceContextType,
 } from 'sentry/components/events/interfaces/spans/types';
 import type {SymbolicatorStatus} from 'sentry/components/events/interfaces/types';
+import {MetaContainer} from 'sentry/components/events/meta/metaContainer';
 import type {PlatformKey} from 'sentry/data/platformCategories';
 import type {IssueType} from 'sentry/types';
 
@@ -750,7 +751,7 @@ interface EventBase {
     | EventOrGroupType.EXPECTSTAPLE
     | EventOrGroupType.HPKP;
   user: EventUser | null;
-  _meta?: Record<string, any>;
+  _meta?: MetaContainer;
   context?: Record<string, any>;
   dateCreated?: string;
   device?: Record<string, any>;

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -2,6 +2,8 @@ import type {SearchGroup} from 'sentry/components/smartSearchBar/types';
 import type {PlatformKey} from 'sentry/data/platformCategories';
 import type {FieldKind} from 'sentry/utils/fields';
 
+import type {MetaContainer} from '../components/events/meta/metaContainer';
+
 import type {Actor, TimeseriesValue} from './core';
 import type {Event, EventMetadata, EventOrGroupType, Level} from './event';
 import type {Commit, PullRequest, Repository} from './integrations';
@@ -719,7 +721,7 @@ export type KeyValueListDataItem = {
   actionButton?: React.ReactNode;
   isContextData?: boolean;
   isMultiValue?: boolean;
-  meta?: Meta;
+  meta?: MetaContainer;
   subjectDataTestId?: string;
   subjectIcon?: React.ReactNode;
   value?: React.ReactNode;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -19,6 +19,7 @@ import {EventGroupingInfo} from 'sentry/components/events/groupingInfo';
 import {CronTimelineSection} from 'sentry/components/events/interfaces/crons/cronTimelineSection';
 import {AnrRootCause} from 'sentry/components/events/interfaces/performance/anrRootCause';
 import {SpanEvidenceSection} from 'sentry/components/events/interfaces/performance/spanEvidence';
+import {getChildMetaContainer} from 'sentry/components/events/meta/metaContainer';
 import {EventPackageData} from 'sentry/components/events/packageData';
 import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
 import {EventUserFeedback} from 'sentry/components/events/userFeedback';
@@ -145,7 +146,7 @@ function GroupEventDetailsContent({
       <EventDevice event={event} />
       <EventViewHierarchy event={event} project={project} />
       <EventAttachments event={event} projectSlug={project.slug} />
-      <EventSdk sdk={event.sdk} meta={event._meta?.sdk} />
+      <EventSdk sdk={event.sdk} meta={getChildMetaContainer(event._meta, 'sdk')} />
       {event.groupID && (
         <EventGroupingInfo
           projectSlug={project.slug}


### PR DESCRIPTION
<img width="844" alt="image" src="https://github.com/getsentry/sentry/assets/549473/4d46c004-c9e7-4ecf-8b96-0546b525b7fd">

Background
----------
On the issue page, Sentry intended to show "..." at the end of string values with an annotation indicating it was truncated by the SDK, though with no display of the original length. Due to a series of bugs, this has not been surfacing in the UI
in many cases.

For lists and objects, these are similarly truncated at the SDK layer with relevant length information captured in the `_meta` field of an event, _but_ there has never been an indicator in the UI that they are being truncated. This results in a misleading developer experience: for example, with sentry-python, lists are truncated after 10 items, so a developer unfamiliar with this quirk may actually think they are seeing perf issues with 10 items when in fact the actual number of items is orders of magnitude larger. See #26977.

Desired Behavior
----------------
Ensure that a `...` is shown when a captured value (in request body or frame variable) has been truncated due to size limits with a hover annotation that shows the original length.

Changes
-------
1. Fix backend bug where the stacktrace meta was not being properly keyed into, which had resulted in no annotations being shown on the front-end for variable values captured in an exceptions stacktrace (sentry/interfaces/exception.py)

2. Fix frontend bug where HTTP request section did not have `meta` or `withAnnotatedText` specified, so annotations were not being shown (richHttpContentClippedBoxBodySection.tsx).

3. Fix existing ContextData / FrameVariables components to not haphazardly thread `meta['']` / null coalesce to fallbacks. As I understand it, `meta['']` access metadata about the current object, while meta[key] will access a nested object if the value is an array / object. Therefore, `['']` should intentionally be used in contexts where we know we are working with a non-nested object - and otherwise, let the relevant component deduce how to recurse into the `meta` data structure via type introspection. To add some type-safety, I introduce a "metaContainer.ts" module that provides some helpers for interacting with a new "MetaContainer" type. I removed the existing `getMeta` from metaProxy that had previously been phased out to avoid naming confusion.

   This fixes a bug where a truncated string nested inside of an array / object was not annotated, and is a prerequisite for (4).

   NOTE: RichHttpContentClippedBoxBodySection, FrameVariables, ContextData have `meta: MetaContainer`, instead of the traditional `meta: Proxy<Meta>`. Is it worth renaming it, or is the type clear enough to differentiate?

4. Enhance ContextData component to render a `...` if the meta indicates that there are actually more items in a list / object than is being displayed. I used the same redaction / tooltip styling that already exists for truncated strings, abstracted via the new `annotatedEllipsis.tsx`.

5. Enhance `annotatedText/utils.tsx` to surface the original length of the truncated object in the tooltip, leveraged by the existing truncated string and the newly added truncated array / object UI. I tried to used generic terms to describe arrays, objects, and strings to be a bit more language agnostic, i.e. "collection", "mapping", and "serialized object" respectively.

_Meta_ observations
-------------------
1. Most of the bugs fixed in this PR could have been avoided if there were more accurate types and less optional props.
2. The current shape of `meta` isn't really possible to type... namespacing user-defined keys would make the problem simpler, e.g.:

    ```ts
    type MetaContainer = {data: Partial<Meta>, keys: {[userKey: string]: MetaContainer}}
    ```

    ...but seems tricky to make the transition to something like that.

Test Plan
---------
- [x] Unit tests: `yarn test --verbose --no-watch static/app/components/contextData/index.spec.tsx`
- [x] Manual test:
  - Created a debug Flask app with sentry-python integrated:
    ```py
    import sentry_sdk
    from flask import Flask, request
    sentry_sdk.init(dsn="http://826b3e2b25fd355872f754f365b1d941@127.0.0.1:8000/3")
    app = Flask(__name__)
    @app.route('/debug-sentry', methods=["POST"])
    def trigger_error():
        payload = request.json
        division_by_zero = payload / 0
    ```
  - Triggered an error with truncation on arrays, objects, and strings:
    ```bash
    curl -X POST localhost:8080/debug-sentry -H 'Content-Type: application/json' -d '
    {
       "my array": [0,1,2,3,4,5,6,7,8,9,10,11,12],
       "my dict": {
            "0": "A",
            "1": "B",
            "2": "C",
            "3": "D",
            "4": "E",
            "5": "F",
            "6": "G",
            "7": "H",
            "8": "I",
            "9": "J",
            "10": "K",
            "11": "L",
            "12": "M"
       },
       "my string": "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
    }'
    ```

  - Confirmed that `...` with a tooltip rendered for the array, dict, and string in both the frame variables and in the request body sections on the issue page:  
    ![sentry-truncate](https://github.com/getsentry/sentry/assets/549473/2ed910f8-9f09-4cac-94c9-38e0665f24a8)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
