### PR TITLE
fix(ui) Use organization scoped URLs for issues

### DIFF
--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -390,17 +390,19 @@ export type GroupTagsResponse = GroupTagResponseItem[];
 type FetchIssueTagsParameters = {
   environment: string[];
   limit: number;
+  organizationSlug: string;
   readable: boolean;
   groupId?: string;
 };
 
 export const makeFetchIssueTagsQueryKey = ({
   groupId,
+  organizationSlug,
   environment,
   readable,
   limit,
 }: FetchIssueTagsParameters): ApiQueryKey => [
-  `/issues/${groupId}/tags/`,
+  `/organizations/${organizationSlug}/issues/${groupId}/tags/`,
   {query: {environment, readable, limit}},
 ];
 

--- a/static/app/components/group/externalIssuesList.spec.tsx
+++ b/static/app/components/group/externalIssuesList.spec.tsx
@@ -23,11 +23,11 @@ describe('ExternalIssuesList', () => {
 
   it('renders setup CTA', async () => {
     MockApiClient.addMockResponse({
-      url: `/groups/${group.id}/integrations/`,
+      url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/groups/1/external-issues/',
+      url: `/organizations/${organization.slug}/issues/1/external-issues/`,
       body: [],
     });
     render(
@@ -44,11 +44,11 @@ describe('ExternalIssuesList', () => {
 
   it('renders sentry app issues', async () => {
     MockApiClient.addMockResponse({
-      url: `/groups/${group.id}/integrations/`,
+      url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/groups/${group.id}/external-issues/`,
+      url: `/organizations/${organization.slug}/issues/${group.id}/external-issues/`,
       body: [],
     });
     const component = TestStubs.SentryAppComponent();
@@ -72,7 +72,7 @@ describe('ExternalIssuesList', () => {
 
   it('renders integrations with issues first', async () => {
     MockApiClient.addMockResponse({
-      url: `/groups/${group.id}/integrations/`,
+      url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,
       body: [
         TestStubs.JiraIntegration({status: 'active', externalIssues: []}),
         TestStubs.GitHubIntegration({
@@ -91,7 +91,7 @@ describe('ExternalIssuesList', () => {
       ],
     });
     MockApiClient.addMockResponse({
-      url: `/groups/${group.id}/external-issues/`,
+      url: `/organizations/${organization.slug}/issues/${group.id}/external-issues/`,
       body: [],
     });
     const component = TestStubs.SentryAppComponent();

--- a/static/app/components/group/externalIssuesList.tsx
+++ b/static/app/components/group/externalIssuesList.tsx
@@ -15,6 +15,7 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {
   Group,
   GroupIntegration,
+  OrganizationSummary,
   PlatformExternalIssue,
   Project,
   SentryAppComponent,
@@ -42,12 +43,21 @@ type ExternalIssueComponent = {
   hasLinkedIssue?: boolean;
 };
 
-function makeIntegrationsQueryKey(group: Group): ApiQueryKey {
-  return [`/groups/${group.id}/integrations/`];
+function makeIntegrationsQueryKey(
+  group: Group,
+  organization: OrganizationSummary
+): ApiQueryKey {
+  return [`/organizations/${organization.slug}/issues/${group.id}/integrations/`];
 }
 
-function useFetchIntegrations({group}: {group: Group}) {
-  return useApiQuery<GroupIntegration[]>(makeIntegrationsQueryKey(group), {
+function useFetchIntegrations({
+  group,
+  organization,
+}: {
+  group: Group;
+  organization: OrganizationSummary;
+}) {
+  return useApiQuery<GroupIntegration[]>(makeIntegrationsQueryKey(group, organization), {
     staleTime: Infinity,
   });
 }
@@ -59,9 +69,15 @@ function useFetchIntegrations({group}: {group: Group}) {
 // we need to be more conservative about error cases since we don't have
 // control over those services.
 //
-function useFetchSentryAppData({group}: {group: Group}) {
+function useFetchSentryAppData({
+  group,
+  organization,
+}: {
+  group: Group;
+  organization: OrganizationSummary;
+}) {
   const {data} = useApiQuery<PlatformExternalIssue[]>(
-    [`/groups/${group.id}/external-issues/`],
+    [`/organizations/${organization.slug}/issues/${group.id}/external-issues/`],
     {staleTime: 30_000}
   );
 
@@ -98,8 +114,8 @@ function ExternalIssueList({components, group, event, project}: Props) {
     data: integrations,
     isLoading,
     refetch: refetchIntegrations,
-  } = useFetchIntegrations({group});
-  useFetchSentryAppData({group});
+  } = useFetchIntegrations({group, organization});
+  useFetchSentryAppData({group, organization});
   const issueTrackingFilter = useIssueTrackingFilter();
 
   const externalIssues = useLegacyStore(ExternalIssueStore);

--- a/static/app/components/group/releaseStats.spec.tsx
+++ b/static/app/components/group/releaseStats.spec.tsx
@@ -9,7 +9,7 @@ describe('GroupReleaseStats', function () {
 
   beforeEach(() => {
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/first-last-release/`,
+      url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
       body: {firstRelease: group.firstRelease, lastRelease: group.lastRelease},
     });
   });

--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -48,7 +48,11 @@ function GroupReleaseStats({
       : undefined;
 
   const {data: groupReleaseData} = useApiQuery<GroupRelease>(
-    [defined(group) ? `/issues/${group.id}/first-last-release/` : ''],
+    [
+      defined(group)
+        ? `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`
+        : '',
+    ],
     {
       staleTime: 30000,
       cacheTime: 30000,

--- a/static/app/components/group/tagFacets/index.spec.tsx
+++ b/static/app/components/group/tagFacets/index.spec.tsx
@@ -16,6 +16,7 @@ const {router, organization, routerContext} = initializeOrg({
     },
   },
 });
+
 describe('Tag Facets', function () {
   const project = TestStubs.Project();
   project.platform = 'android';
@@ -23,7 +24,7 @@ describe('Tag Facets', function () {
 
   beforeEach(function () {
     MockApiClient.addMockResponse({
-      url: '/issues/1/tags/',
+      url: `/organizations/${organization.slug}/issues/1/tags/`,
       body: {
         release: {
           key: 'release',
@@ -99,7 +100,7 @@ describe('Tag Facets', function () {
   describe('Tag Distributions', function () {
     it('does not display anything if no tag values recieved', async function () {
       MockApiClient.addMockResponse({
-        url: '/issues/1/tags/',
+        url: `/organizations/${organization.slug}/issues/1/tags/`,
         body: {},
       });
       render(

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -93,6 +93,7 @@ export default function TagFacets({
 
   const {isLoading, isError, data, refetch} = useFetchIssueTagsForDetailsPage({
     groupId,
+    organizationSlug: organization.slug,
     environment: environments,
   });
 

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -97,11 +97,11 @@ describe('groupDetails', () => {
     act(() => ProjectsStore.loadInitialData(defaultInit.organization.projects));
 
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/`,
       body: {...group},
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/events/latest/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/events/latest/`,
       statusCode: 200,
       body: {
         ...event,
@@ -119,7 +119,7 @@ describe('groupDetails', () => {
       body: [project],
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/first-last-release/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/first-last-release/`,
       method: 'GET',
     });
     MockApiClient.addMockResponse({
@@ -138,7 +138,7 @@ describe('groupDetails', () => {
       body: TestStubs.Environments(),
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/tags/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/tags/`,
       body: [],
     });
   });
@@ -166,11 +166,11 @@ describe('groupDetails', () => {
 
   it('renders error when issue is not found', async function () {
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/`,
       statusCode: 404,
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/events/latest/`,
+      url: `/organization/${defaultInit.organization.slug}/issues/${group.id}/events/latest/`,
       statusCode: 404,
     });
 
@@ -187,11 +187,11 @@ describe('groupDetails', () => {
 
   it('renders MissingProjectMembership when trying to access issue in project the user does not belong to', async function () {
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/`,
       statusCode: 403,
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/events/latest/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/events/latest/`,
       statusCode: 403,
     });
 
@@ -229,7 +229,7 @@ describe('groupDetails', () => {
 
   it('renders issue event error', async function () {
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/events/latest/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/events/latest/`,
       statusCode: 404,
     });
     createWrapper();
@@ -238,7 +238,7 @@ describe('groupDetails', () => {
 
   it('renders for review reason', async function () {
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/`,
       body: {
         ...group,
         inbox: {
@@ -254,7 +254,7 @@ describe('groupDetails', () => {
 
   it('renders substatus badge', async function () {
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/`,
       body: {
         ...group,
         inbox: null,
@@ -273,7 +273,7 @@ describe('groupDetails', () => {
     const sampleGroup = TestStubs.Group({issueCategory: IssueCategory.ERROR});
     sampleGroup.tags.push({key: 'sample_event'});
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/tags/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/tags/`,
       body: [{key: 'sample_event'}],
     });
 
@@ -288,7 +288,7 @@ describe('groupDetails', () => {
       method: 'PUT',
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/`,
       body: {...group, project: {slug: 'other-project-slug'}},
     });
 
@@ -301,7 +301,7 @@ describe('groupDetails', () => {
 
   it('uses /helpful endpoint when feature flag is on and no event is provided', async function () {
     const helpfulMock = MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/events/helpful/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/events/helpful/`,
       statusCode: 200,
       body: event,
     });
@@ -320,7 +320,7 @@ describe('groupDetails', () => {
   it('uses /latest endpoint when default is set to latest', async function () {
     ConfigStore.loadInitialData(TestStubs.Config({user: latestUser}));
     const latestMock = MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/events/latest/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/events/latest/`,
       statusCode: 200,
       body: event,
     });
@@ -339,7 +339,7 @@ describe('groupDetails', () => {
   it('uses /oldest endpoint when default is set to oldest', async function () {
     ConfigStore.loadInitialData(TestStubs.Config({user: oldestUser}));
     const oldestMock = MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/events/oldest/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/events/oldest/`,
       statusCode: 200,
       body: event,
     });
@@ -358,7 +358,7 @@ describe('groupDetails', () => {
   it('uses /helpful endpoint when default is set to recommended', async function () {
     ConfigStore.loadInitialData(TestStubs.Config({user: recommendedUser}));
     const recommendedMock = MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/events/helpful/`,
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/events/helpful/`,
       statusCode: 200,
       body: event,
     });

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -260,7 +260,7 @@ function useEventApiQuery({
 
   const endpointEventId = eventIdUrl === 'recommended' ? 'helpful' : eventIdUrl;
   const queryKey: ApiQueryKey = [
-    `/issues/${groupId}/events/${endpointEventId}/`,
+    `/organizations/${organization.slug}/issues/${groupId}/events/${endpointEventId}/`,
     {
       query: getGroupEventDetailsQueryData({
         environments,
@@ -324,13 +324,18 @@ function useEventApiQuery({
 type FetchGroupQueryParameters = {
   environments: string[];
   groupId: string;
+  organizationSlug: string;
 };
 
 function makeFetchGroupQueryKey({
   groupId,
+  organizationSlug,
   environments,
 }: FetchGroupQueryParameters): ApiQueryKey {
-  return [`/issues/${groupId}/`, {query: getGroupDetailsQueryData({environments})}];
+  return [
+    `/organizations/${organizationSlug}/issues/${groupId}/`,
+    {query: getGroupDetailsQueryData({environments})},
+  ];
 }
 
 /**
@@ -341,6 +346,7 @@ function makeFetchGroupQueryKey({
  */
 function useSyncGroupStore(incomingEnvs: string[]) {
   const queryClient = useQueryClient();
+  const organization = useOrganization();
 
   const environmentsRef = useRef<string[]>(incomingEnvs);
   environmentsRef.current = incomingEnvs;
@@ -353,7 +359,11 @@ function useSyncGroupStore(incomingEnvs: string[]) {
       if (defined(storeGroup)) {
         setApiQueryData(
           queryClient,
-          makeFetchGroupQueryKey({groupId: storeGroup.id, environments}),
+          makeFetchGroupQueryKey({
+            groupId: storeGroup.id,
+            organizationSlug: organization.slug,
+            environments,
+          }),
           storeGroup
         );
       }
@@ -397,11 +407,14 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
     isError: isGroupError,
     error: groupError,
     refetch: refetchGroupCall,
-  } = useApiQuery<Group>(makeFetchGroupQueryKey({groupId, environments}), {
-    staleTime: 30000,
-    cacheTime: 30000,
-    retry: false,
-  });
+  } = useApiQuery<Group>(
+    makeFetchGroupQueryKey({organizationSlug: organization.slug, groupId, environments}),
+    {
+      staleTime: 30000,
+      cacheTime: 30000,
+      retry: false,
+    }
+  );
 
   const group = groupData ?? null;
 
@@ -801,6 +814,7 @@ function GroupDetails(props: GroupDetailsProps) {
   const {data} = useFetchIssueTagsForDetailsPage(
     {
       groupId: router.params.groupId,
+      organizationSlug: organization.slug,
       environment: environments,
     },
     // Don't want this query to take precedence over the main requests

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -157,7 +157,7 @@ const mockGroupApis = (
   trace?: QuickTraceEvent
 ) => {
   MockApiClient.addMockResponse({
-    url: `/issues/${group.id}/`,
+    url: `/organizations/${organization.slug}/issues/${group.id}/`,
     body: group,
   });
 
@@ -177,7 +177,7 @@ const mockGroupApis = (
   });
 
   MockApiClient.addMockResponse({
-    url: `/issues/${group.id}/tags/`,
+    url: `/organizations/${organization.slug}/issues/${group.id}/tags/`,
     body: [],
   });
 
@@ -192,16 +192,16 @@ const mockGroupApis = (
   });
 
   MockApiClient.addMockResponse({
-    url: `/groups/${group.id}/integrations/`,
+    url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,
     body: [],
   });
 
   MockApiClient.addMockResponse({
-    url: `/groups/${group.id}/external-issues/`,
+    url: `/organizations/${organization.slug}/issues/${group.id}/external-issues/`,
   });
 
   MockApiClient.addMockResponse({
-    url: `/issues/${group.id}/current-release/`,
+    url: `/organizations/${organization.slug}/issues/${group.id}/current-release/`,
     body: {currentRelease: null},
   });
 
@@ -269,7 +269,7 @@ const mockGroupApis = (
   });
 
   MockApiClient.addMockResponse({
-    url: `/issues/${group.id}/first-last-release/`,
+    url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
     method: 'GET',
   });
 };

--- a/static/app/views/issueDetails/groupSidebar.spec.tsx
+++ b/static/app/views/issueDetails/groupSidebar.spec.tsx
@@ -27,22 +27,22 @@ describe('GroupSidebar', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: '/groups/1/integrations/',
+      url: `/organizations/${organization.slug}/issues/1/integrations/`,
       body: [],
     });
 
     MockApiClient.addMockResponse({
-      url: '/issues/1/',
+      url: `/organizations/${organization.slug}/issues/1/`,
       body: group,
     });
 
     MockApiClient.addMockResponse({
-      url: '/issues/1/current-release/',
+      url: `/organizations/${organization.slug}/issues/1/current-release/`,
       body: {},
     });
 
     MockApiClient.addMockResponse({
-      url: '/groups/1/external-issues/',
+      url: `/organizations/${organization.slug}/issues/1/external-issues/`,
       body: [],
     });
 
@@ -60,7 +60,7 @@ describe('GroupSidebar', function () {
       body: [],
     });
     tagsMock = MockApiClient.addMockResponse({
-      url: '/issues/1/tags/',
+      url: `/organizations/${organization.slug}/issues/1/tags/`,
       body: TestStubs.Tags(),
     });
     MockApiClient.addMockResponse({
@@ -68,7 +68,7 @@ describe('GroupSidebar', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/first-last-release/`,
+      url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
       method: 'GET',
     });
   });
@@ -139,7 +139,7 @@ describe('GroupSidebar', function () {
       expect(await screen.findByText('browser')).toBeInTheDocument();
       expect(tagsMock).toHaveBeenCalledTimes(2);
       expect(tagsMock).toHaveBeenCalledWith(
-        '/issues/1/tags/',
+        '/organizations/org-slug/issues/1/tags/',
         expect.objectContaining({
           query: expect.objectContaining({
             environment: ['staging'],
@@ -154,11 +154,11 @@ describe('GroupSidebar', function () {
       group = TestStubs.Group();
 
       MockApiClient.addMockResponse({
-        url: '/issues/1/',
+        url: '/organization/org-slug/issues/1/',
         body: group,
       });
       MockApiClient.addMockResponse({
-        url: '/issues/1/tags/',
+        url: '/organizations/org-slug/issues/1/tags/',
         body: [],
       });
     });

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -22,7 +22,14 @@ import {backend, frontend} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
-import {AvatarUser, CurrentRelease, Group, Organization, Project} from 'sentry/types';
+import {
+  AvatarUser,
+  CurrentRelease,
+  Group,
+  Organization,
+  OrganizationSummary,
+  Project,
+} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcDateString} from 'sentry/utils/dates';
@@ -41,9 +48,12 @@ type Props = {
   event?: Event;
 };
 
-function useFetchAllEnvsGroupData(group: Group) {
+function useFetchAllEnvsGroupData(organization: OrganizationSummary, group: Group) {
   return useApiQuery<Group>(
-    [`/issues/${group.id}/`, {query: getGroupDetailsQueryData()}],
+    [
+      `/organizations/${organization.slug}/issues/${group.id}/`,
+      {query: getGroupDetailsQueryData()},
+    ],
     {
       staleTime: 30000,
       cacheTime: 30000,
@@ -51,11 +61,14 @@ function useFetchAllEnvsGroupData(group: Group) {
   );
 }
 
-function useFetchCurrentRelease(group: Group) {
-  return useApiQuery<CurrentRelease>([`/issues/${group.id}/current-release/`], {
-    staleTime: 30000,
-    cacheTime: 30000,
-  });
+function useFetchCurrentRelease(organization: OrganizationSummary, group: Group) {
+  return useApiQuery<CurrentRelease>(
+    [`/organizations/${organization.slug}/issues/${group.id}/current-release/`],
+    {
+      staleTime: 30000,
+      cacheTime: 30000,
+    }
+  );
 }
 
 export default function GroupSidebar({
@@ -65,8 +78,8 @@ export default function GroupSidebar({
   organization,
   environments,
 }: Props) {
-  const {data: allEnvironmentsGroupData} = useFetchAllEnvsGroupData(group);
-  const {data: currentRelease} = useFetchCurrentRelease(group);
+  const {data: allEnvironmentsGroupData} = useFetchAllEnvsGroupData(organization, group);
+  const {data: currentRelease} = useFetchCurrentRelease(organization, group);
   const location = useLocation();
 
   const trackAssign: OnAssignCallback = (type, _assignee, suggestedAssignee) => {

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -148,9 +148,11 @@ export function getGroupReprocessingStatus(
 export const useFetchIssueTagsForDetailsPage = (
   {
     groupId,
+    organizationSlug,
     environment = [],
   }: {
     environment: string[];
+    organizationSlug: string;
     groupId?: string;
   },
   {enabled = true}: {enabled?: boolean} = {}
@@ -158,6 +160,7 @@ export const useFetchIssueTagsForDetailsPage = (
   return useFetchIssueTags(
     {
       groupId,
+      organizationSlug,
       environment,
       readable: true,
       limit: 4,


### PR DESCRIPTION
We need an organization slug in the URL in order to successfully route requests through the API gateway in a siloed environment. In the near future API requests will not go to customer subdomains and we'll need a slug in the path.
