### PR TITLE
fix(docs): Remove trailing slash from servers field base url

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1312,7 +1312,7 @@ if os.environ.get("OPENAPIGENERATE", False):
         "CONTACT": {"email": "partners@sentry.io"},
         "LICENSE": {"name": "Apache 2.0", "url": "http://www.apache.org/licenses/LICENSE-2.0.html"},
         "VERSION": "v0",
-        "SERVERS": [{"url": "https://sentry.io/"}],
+        "SERVERS": [{"url": "https://sentry.io"}],
         "PARSER_WHITELIST": ["rest_framework.parsers.JSONParser"],
         "APPEND_PATHS": get_old_json_paths(OLD_OPENAPI_JSON_PATH),
         "APPEND_COMPONENTS": get_old_json_components(OLD_OPENAPI_JSON_PATH),


### PR DESCRIPTION
Originally, we had a trailing slash in the servers field that looked like:
```JSON
  "servers": [
    {
      "url": "https://sentry.io/"
    }
  ],
```
However, we can remove this as seen in the [OpenAPI docs](https://learn.openapis.org/specification/servers.html) because our paths in the OpenAPI JSON that are generated by drf-spectacular already contain a leading `/`
eg: 
```
  "paths": {
    "/api/0/organizations/...
```
I've checked that this change doesn't break the API docs locally.