### PR TITLE
fix(migrations) Fix incorrect table name in migration hints

### DIFF
--- a/src/sentry/migrations/0535_add_created_date_to_outbox_model.py
+++ b/src/sentry/migrations/0535_add_created_date_to_outbox_model.py
@@ -33,7 +33,7 @@ class Migration(CheckedMigration):
                     reverse_sql="""
                     ALTER TABLE "sentry_controloutbox" DROP COLUMN "date_added"
                     """,
-                    hints={"tables": ["sentry_region_outbox"]},
+                    hints={"tables": ["sentry_controloutbox"]},
                 ),
                 migrations.RunSQL(
                     sql="""


### PR DESCRIPTION
We need the correct table name in order to route this migration correctly in split silo modes.