### PR TITLE
ref(js): Update Browserslist DB to caniuse@1.0.30001523

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4311,9 +4311,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001283, caniuse-lite@^1.0.30001449:
-  version "1.0.30001473"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz#3859898b3cab65fc8905bb923df36ad35058153c"
-  integrity sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==
+  version "1.0.30001523"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001523.tgz"
+  integrity sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==
 
 cbor-web@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
Running a hackweek experiment (https://github.com/getsentry/sentry/pull/55143) I tried comparing our browserslist usage to actual production data (what browsers are our users using). This led me to learn that the caniuse is pretty outdated.

![image](https://github.com/getsentry/sentry/assets/18689448/30a09421-3e21-474d-b1b0-9eefc57bb73b)

Ran `npx update-browserslist-db@latest` to update it! Also we might want to automate this.