### PR TITLE
chore(hybridcloud) Remove system.region option usage

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from typing import Any, List, Literal, Mapping, Tuple, overload
 from urllib.parse import urlparse
 
+from django.conf import settings
 from django.http import HttpResponseNotAllowed
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
@@ -263,7 +264,7 @@ def generate_organization_url(org_slug: str) -> str:
 def generate_region_url(region_name: str | None = None) -> str:
     region_url_template: str | None = options.get("system.region-api-url-template")
     if region_name is None:
-        region_name = options.get("system.region") or None
+        region_name = settings.SENTRY_REGION
     if not region_url_template or not region_name:
         return options.get("system.url-prefix")
     return region_url_template.replace("{region}", region_name)

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -162,7 +162,6 @@ def pytest_configure(config):
             "system.organization-base-hostname": "{slug}.testserver",
             "system.organization-url-template": "http://{hostname}",
             "system.region-api-url-template": "http://{region}.testserver",
-            "system.region": "us",
             "system.secret-key": "a" * 52,
             "slack.client-id": "slack-client-id",
             "slack.client-secret": "slack-client-secret",
@@ -190,11 +189,12 @@ def pytest_configure(config):
         }
     )
     settings.SENTRY_OPTIONS_COMPLAIN_ON_ERRORS = True
-
     settings.VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON = False
+    settings.SENTRY_REGION = "us"
+
+    # ID controls
     settings.SENTRY_USE_BIG_INTS = True
     settings.SENTRY_USE_SNOWFLAKE = True
-
     settings.SENTRY_SNOWFLAKE_EPOCH_START = datetime(1999, 12, 31, 0, 0).timestamp()
 
     # Plugin-related settings

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -43,7 +43,7 @@ from sentry.utils.snowflake import SnowflakeIdMixin
 TestMethod = Callable[..., None]
 
 _DEFAULT_TEST_REGIONS = (
-    Region("na", 1, "http://na.testserver", RegionCategory.MULTI_TENANT),
+    Region("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT),
     Region("eu", 2, "http://eu.testserver", RegionCategory.MULTI_TENANT),
     Region("acme-single-tenant", 3, "acme.my.sentry.io", RegionCategory.SINGLE_TENANT),
 )

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -437,9 +437,9 @@ class CustomerDomainTest(APITestCase):
 
         region_config = [
             {
-                "name": "na",
+                "name": "us",
                 "snowflake_id": 1,
-                "address": "http://na.testserver",
+                "address": "http://us.testserver",
                 "category": RegionCategory.MULTI_TENANT.name,
             },
             {
@@ -450,7 +450,7 @@ class CustomerDomainTest(APITestCase):
             },
         ]
         with override_region_config(region_config):
-            assert request_with_subdomain("na") == "na"
+            assert request_with_subdomain("us") == "us"
             assert request_with_subdomain("eu") == "eu"
             assert request_with_subdomain("sentry") is None
 

--- a/tests/sentry/hybrid_cloud/test_organization_provisioning.py
+++ b/tests/sentry/hybrid_cloud/test_organization_provisioning.py
@@ -84,7 +84,7 @@ class TestOrganizationProvisioningService(TestCase):
 
         with outbox_context(flush=False):
             results: RpcOrganization = organization_provisioning_service.provision_organization(
-                region_name="na", org_provision_args=org_args
+                region_name="us", org_provision_args=org_args
             )
 
         assert_post_install_outbox_created(org=results, provisioning_options=org_args)
@@ -102,7 +102,7 @@ class TestOrganizationProvisioningService(TestCase):
         self.create_organization(slug="santry", name="santry", owner=self.create_user())
 
         results: RpcOrganization = organization_provisioning_service.provision_organization(
-            region_name="na", org_provision_args=org_args
+            region_name="us", org_provision_args=org_args
         )
 
         assert results
@@ -123,7 +123,7 @@ class TestIdempotentProvisionOrganization(TestCase):
             results: Optional[
                 RpcOrganization
             ] = organization_provisioning_service.idempotent_provision_organization(
-                region_name="na", org_provision_args=org_args
+                region_name="us", org_provision_args=org_args
             )
 
         assert results
@@ -153,7 +153,7 @@ class TestIdempotentProvisionOrganization(TestCase):
         results: Optional[
             RpcOrganization
         ] = organization_provisioning_service.idempotent_provision_organization(
-            region_name="na", org_provision_args=org_args
+            region_name="us", org_provision_args=org_args
         )
 
         with assume_test_silo_mode(SiloMode.REGION):
@@ -176,7 +176,7 @@ class TestIdempotentProvisionOrganization(TestCase):
             results: Optional[
                 RpcOrganization
             ] = organization_provisioning_service.idempotent_provision_organization(
-                region_name="na", org_provision_args=org_args
+                region_name="us", org_provision_args=org_args
             )
 
         assert results
@@ -207,7 +207,7 @@ class TestIdempotentProvisionOrganization(TestCase):
             results: Optional[
                 RpcOrganization
             ] = organization_provisioning_service.idempotent_provision_organization(
-                region_name="na", org_provision_args=org_args
+                region_name="us", org_provision_args=org_args
             )
 
         assert results is None

--- a/tests/sentry/integrations/slack/webhooks/commands/test_help.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_help.py
@@ -27,7 +27,7 @@ def assert_unknown_command_text(data: SlackBody, unknown_command: Optional[str] 
 @control_silo_test(
     stable=True,
     regions=[
-        Region("na", 1, "http://na.testserver", RegionCategory.MULTI_TENANT),
+        Region("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT),
     ],
 )
 class SlackCommandsHelpTest(SlackCommandsTest):
@@ -36,7 +36,7 @@ class SlackCommandsHelpTest(SlackCommandsTest):
         if SiloMode.get_current_mode() == SiloMode.CONTROL:
             responses.add(
                 method=responses.POST,
-                url="http://na.testserver/extensions/slack/commands/",
+                url="http://us.testserver/extensions/slack/commands/",
                 json=MISSING_COMMAND,
             )
         data = self.send_slack_message("")
@@ -47,7 +47,7 @@ class SlackCommandsHelpTest(SlackCommandsTest):
         if SiloMode.get_current_mode() == SiloMode.CONTROL:
             responses.add(
                 method=responses.POST,
-                url="http://na.testserver/extensions/slack/commands/",
+                url="http://us.testserver/extensions/slack/commands/",
                 json=INVALID_COMMAND,
             )
         data = self.send_slack_message("invalid command")
@@ -58,7 +58,7 @@ class SlackCommandsHelpTest(SlackCommandsTest):
         if SiloMode.get_current_mode() == SiloMode.CONTROL:
             responses.add(
                 method=responses.POST,
-                url="http://na.testserver/extensions/slack/commands/",
+                url="http://us.testserver/extensions/slack/commands/",
                 json=HELP_COMMAND,
             )
         data = self.send_slack_message("help")

--- a/tests/sentry/middleware/integrations/parsers/test_base.py
+++ b/tests/sentry/middleware/integrations/parsers/test_base.py
@@ -28,7 +28,7 @@ def error_regions(region: Region, invalid_region_names: Iterable[str]):
 class BaseRequestParserTest(TestCase):
     response_handler = MagicMock()
     region_config = (
-        Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT),
+        Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT),
         Region("eu", 2, "https://eu.testserver", RegionCategory.MULTI_TENANT),
     )
     factory = RequestFactory()
@@ -76,13 +76,13 @@ class BaseRequestParserTest(TestCase):
 
         response_map = self.parser.get_responses_from_region_silos(regions=self.region_config)
         assert mock__get_response.call_count == len(self.region_config)
-        assert response_map["na"].response == "na"
+        assert response_map["us"].response == "us"
         assert type(response_map["eu"].error) is SiloLimit.AvailabilityError
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @patch.object(BaseRequestParser, "get_response_from_region_silo")
     def test_get_responses_from_region_silos_with_complete_failure(self, mock__get_response):
-        mock__get_response.side_effect = lambda region: error_regions(region, ["na", "eu"])
+        mock__get_response.side_effect = lambda region: error_regions(region, ["us", "eu"])
 
         self.response_handler.reset_mock()
         response_map = self.parser.get_responses_from_region_silos(regions=self.region_config)
@@ -106,7 +106,7 @@ class BaseRequestParserTest(TestCase):
         new_outboxes = ControlOutbox.objects.all()
         assert len(new_outboxes) == 2
         for outbox in new_outboxes:
-            assert outbox.region_name in ["na", "eu"]
+            assert outbox.region_name in ["us", "eu"]
             assert outbox.category == OutboxCategory.WEBHOOK_PROXY
             assert outbox.shard_scope == OutboxScope.WEBHOOK_SCOPE
             assert outbox.shard_identifier == WebhookProviderIdentifier.SLACK.value

--- a/tests/sentry/middleware/integrations/parsers/test_bitbucket.py
+++ b/tests/sentry/middleware/integrations/parsers/test_bitbucket.py
@@ -20,7 +20,7 @@ from sentry.types.region import Region, RegionCategory
 class BitbucketRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     factory = RequestFactory()
-    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
     region_config = (region,)
 
     def setUp(self):
@@ -76,7 +76,7 @@ class BitbucketRequestParserTest(TestCase):
 
         # Valid region
         organization_mapping_service.update(
-            organization_id=self.organization.id, update={"region_name": "na"}
+            organization_id=self.organization.id, update={"region_name": "us"}
         )
         with override_regions(self.region_config):
             parser.get_response()

--- a/tests/sentry/middleware/integrations/parsers/test_bitbucket_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_bitbucket_server.py
@@ -20,7 +20,7 @@ from sentry.types.region import Region, RegionCategory
 class BitbucketServerRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     factory = RequestFactory()
-    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
     region_config = (region,)
 
     def setUp(self):
@@ -55,7 +55,7 @@ class BitbucketServerRequestParserTest(TestCase):
 
         # Valid region
         organization_mapping_service.update(
-            organization_id=self.organization.id, update={"region_name": "na"}
+            organization_id=self.organization.id, update={"region_name": "us"}
         )
         with override_regions(self.region_config):
             parser.get_response()

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -19,7 +19,7 @@ class GithubRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     factory = RequestFactory()
     path = reverse("sentry-integration-github-webhook")
-    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
 
     def setUp(self):
         super().setUp()

--- a/tests/sentry/middleware/integrations/parsers/test_github_enterprise.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github_enterprise.py
@@ -19,7 +19,7 @@ class GithubEnterpriseRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     factory = RequestFactory()
     path = reverse("sentry-integration-github-enterprise-webhook")
-    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
     external_host = "12.345.678.901"
     external_identifier = "github_enterprise:1"
     external_id = f"{external_host}:{external_identifier}"

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -21,7 +21,7 @@ class GitlabRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     factory = RequestFactory()
     path = f"{IntegrationClassification.integration_prefix}gitlab/webhook/"
-    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
 
     def setUp(self):
         super().setUp()

--- a/tests/sentry/middleware/integrations/parsers/test_jira.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira.py
@@ -17,7 +17,7 @@ class JiraRequestParserTest(TestCase):
     get_response = MagicMock()
     factory = RequestFactory()
     path_base = f"{IntegrationClassification.integration_prefix}jira"
-    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
 
     def setUp(self):
         super().setUp()
@@ -105,7 +105,7 @@ class JiraRequestParserTest(TestCase):
             parser,
             "get_regions_from_organizations",
             return_value=[
-                Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT),
+                Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT),
                 Region("eu", 2, "https://eu.testserver", RegionCategory.MULTI_TENANT),
             ],
         ) as mock_get_regions:

--- a/tests/sentry/middleware/integrations/parsers/test_jira_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira_server.py
@@ -21,7 +21,7 @@ from sentry.types.region import Region, RegionCategory
 class JiraServerRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     factory = RequestFactory()
-    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
     region_config = (region,)
 
     def setUp(self):
@@ -57,7 +57,7 @@ class JiraServerRequestParserTest(TestCase):
         parser = JiraServerRequestParser(request=request, response_handler=self.get_response)
 
         organization_mapping_service.update(
-            organization_id=self.organization.id, update={"region_name": "na"}
+            organization_id=self.organization.id, update={"region_name": "us"}
         )
         with mock.patch(
             "sentry.middleware.integrations.parsers.jira_server.get_integration_from_token"

--- a/tests/sentry/middleware/integrations/parsers/test_msteams.py
+++ b/tests/sentry/middleware/integrations/parsers/test_msteams.py
@@ -31,7 +31,7 @@ class MsTeamsRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     factory = RequestFactory()
     path = f"{IntegrationClassification.integration_prefix}msteams/webhook/"
-    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
 
     def setUp(self):
         super().setUp()

--- a/tests/sentry/middleware/integrations/parsers/test_plugin.py
+++ b/tests/sentry/middleware/integrations/parsers/test_plugin.py
@@ -19,7 +19,7 @@ from sentry.types.region import Region, RegionCategory
 class PluginRequestParserTest(TestCase):
     get_response = MagicMock()
     factory = RequestFactory()
-    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
 
     @override_regions(regions=(region,))
     @override_settings(SILO_MODE=SiloMode.CONTROL)
@@ -49,7 +49,7 @@ class PluginRequestParserTest(TestCase):
             reverse("sentry-plugins-bitbucket-webhook", args=[self.organization.id]),
         ]
         organization_mapping_service.update(
-            organization_id=self.organization.id, update={"region_name": "na"}
+            organization_id=self.organization.id, update={"region_name": "us"}
         )
         for route in routes:
             request = self.factory.post(route)

--- a/tests/sentry/middleware/integrations/parsers/test_slack.py
+++ b/tests/sentry/middleware/integrations/parsers/test_slack.py
@@ -19,7 +19,7 @@ from sentry.utils.signing import sign
 class SlackRequestParserTest(TestCase):
     get_response = MagicMock()
     factory = RequestFactory()
-    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
 
     @pytest.fixture(autouse=True)
     def patch_get_region(self):

--- a/tests/sentry/middleware/integrations/parsers/test_vsts.py
+++ b/tests/sentry/middleware/integrations/parsers/test_vsts.py
@@ -23,7 +23,7 @@ class VstsRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     factory = RequestFactory()
     path = f"{IntegrationClassification.integration_prefix}vsts/issue-updated/"
-    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
 
     def setUp(self):
         super().setUp()

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -130,9 +130,9 @@ class CustomerDomainMiddlewareTest(TestCase):
         clear_global_regions()
         region_configs: list[dict[str, Any]] = [
             {
-                "name": "na",
+                "name": "us",
                 "snowflake_id": 1,
-                "address": "http://na.testserver",
+                "address": "http://us.testserver",
                 "category": RegionCategory.MULTI_TENANT.name,
             },
             {

--- a/tests/sentry/types/test_region.py
+++ b/tests/sentry/types/test_region.py
@@ -29,7 +29,7 @@ class RegionMappingTest(TestCase):
 
     def test_region_mapping(self):
         regions = [
-            Region("na", 1, "http://na.testserver", RegionCategory.MULTI_TENANT),
+            Region("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT),
             Region("eu", 2, "http://eu.testserver", RegionCategory.MULTI_TENANT),
             Region("acme-single-tenant", 3, "acme.my.sentry.io", RegionCategory.SINGLE_TENANT),
         ]
@@ -41,12 +41,12 @@ class RegionMappingTest(TestCase):
 
     def test_get_local_region(self):
         regions = [
-            Region("na", 1, "http://na.testserver", RegionCategory.MULTI_TENANT),
+            Region("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT),
             Region("eu", 2, "http://eu.testserver", RegionCategory.MULTI_TENANT),
         ]
 
         with override_regions(regions):
-            with override_settings(SILO_MODE=SiloMode.REGION, SENTRY_REGION="na"):
+            with override_settings(SILO_MODE=SiloMode.REGION, SENTRY_REGION="us"):
                 assert get_local_region() == regions[0]
 
         with override_regions(()):
@@ -61,7 +61,7 @@ class RegionMappingTest(TestCase):
 
     def test_get_region_for_organization(self):
         regions = [
-            Region("na", 1, "http://na.testserver", RegionCategory.MULTI_TENANT),
+            Region("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT),
             Region("eu", 2, "http://eu.testserver", RegionCategory.MULTI_TENANT),
         ]
         mapping = OrganizationMapping.objects.get(slug=self.organization.slug)
@@ -87,28 +87,28 @@ class RegionMappingTest(TestCase):
                 get_region_for_organization(self.organization.slug)
 
     def test_validate_region(self):
-        with override_settings(SILO_MODE=SiloMode.REGION, SENTRY_REGION="na"):
-            valid_region = Region("na", 1, "http://na.testserver", RegionCategory.MULTI_TENANT)
+        with override_settings(SILO_MODE=SiloMode.REGION, SENTRY_REGION="us"):
+            valid_region = Region("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT)
             valid_region.validate()
 
     def test_region_to_url(self):
-        region = Region("na", 1, "http://192.168.1.99", RegionCategory.MULTI_TENANT)
-        assert region.to_url("/avatar/abcdef/") == "http://na.testserver/avatar/abcdef/"
+        region = Region("us", 1, "http://192.168.1.99", RegionCategory.MULTI_TENANT)
+        assert region.to_url("/avatar/abcdef/") == "http://us.testserver/avatar/abcdef/"
 
     def test_json_config_injection(self):
         region_config = [
             {
-                "name": "na",
+                "name": "us",
                 "snowflake_id": 1,
-                "address": "http://na.testserver",
+                "address": "http://us.testserver",
                 "category": RegionCategory.MULTI_TENANT.name,
             }
         ]
         with override_settings(
             SENTRY_REGION_CONFIG=json.dumps(region_config),
-            SENTRY_MONOLITH_REGION="na",
+            SENTRY_MONOLITH_REGION="us",
         ):
-            region = get_region_by_name("na")
+            region = get_region_by_name("us")
         assert region.snowflake_id == 1
 
     @patch("sentry.types.region.sentry_sdk")
@@ -118,7 +118,7 @@ class RegionMappingTest(TestCase):
         with override_settings(SENTRY_REGION_CONFIG=json.dumps(region_config)), pytest.raises(
             RegionConfigurationError
         ):
-            get_region_by_name("na")
+            get_region_by_name("us")
         assert sentry_sdk_mock.capture_exception.call_count == 1
 
     def test_default_historic_region_setting(self):
@@ -134,9 +134,9 @@ class RegionMappingTest(TestCase):
     def test_invalid_historic_region_setting(self):
         region_config = [
             {
-                "name": "na",
+                "name": "us",
                 "snowflake_id": 1,
-                "address": "http://na.testserver",
+                "address": "http://us.testserver",
                 "category": RegionCategory.MULTI_TENANT.name,
             }
         ]
@@ -145,21 +145,21 @@ class RegionMappingTest(TestCase):
             SENTRY_MONOLITH_REGION="nonexistent",
         ):
             with pytest.raises(RegionConfigurationError):
-                get_region_by_name("na")
+                get_region_by_name("us")
 
     def test_find_regions_for_user(self):
         from sentry.types.region import find_regions_for_user
 
         region_config = [
             {
-                "name": "na",
+                "name": "us",
                 "snowflake_id": 1,
-                "address": "http://na.testserver",
+                "address": "http://us.testserver",
                 "category": RegionCategory.MULTI_TENANT.name,
             }
         ]
         with override_settings(SILO_MODE=SiloMode.CONTROL), override_region_config(region_config):
-            organization = self.create_organization(name="test name", region="na")
+            organization = self.create_organization(name="test name", region="us")
 
             user = self.create_user()
             organization_service.add_organization_member(
@@ -168,7 +168,7 @@ class RegionMappingTest(TestCase):
                 user_id=user.id,
             )
             actual_regions = find_regions_for_user(user_id=user.id)
-            assert actual_regions == {"na"}
+            assert actual_regions == {"us"}
 
         with override_settings(SILO_MODE=SiloMode.REGION):
             with pytest.raises(SiloLimit.AvailabilityError):

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -2,6 +2,7 @@ from functools import cached_property
 from unittest import mock
 
 from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 
 from sentry.auth import superuser
@@ -294,7 +295,7 @@ class ClientConfigViewTest(TestCase):
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json"
 
-        with self.options({"system.region": "eu"}):
+        with override_settings(SENTRY_REGION="eu"):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"


### PR DESCRIPTION
Remove usage of the system.region option and prefer settings.SENTRY_REGION which is defined by config mangement.

Having both a setting and an option is redundant and has resulted in configuration drift in our test-silo environment.

I've not removed the option just yet, but will in a follow up pull request.