### PR TITLE
feat(notifications): new notification settings home for V2 settings

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -291,7 +291,9 @@ function buildRoutes() {
         <IndexRoute
           component={make(
             () =>
-              import('sentry/views/settings/account/notifications/notificationSettings')
+              import(
+                'sentry/views/settings/account/notifications/notificationSettingsController'
+              )
           )}
         />
         <Route

--- a/static/app/views/settings/account/accountNotificationFineTuningV2.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuningV2.tsx
@@ -46,6 +46,7 @@ const accountNotifications = [
   'approval',
   'quota',
   'spikeProtection',
+  'reports',
 ];
 
 type ANBPProps = {
@@ -141,7 +142,7 @@ type State = DeprecatedAsyncView['state'] & {
   projects: Project[] | null;
 };
 
-class AccountNotificationFineTuning extends DeprecatedAsyncView<Props, State> {
+class AccountNotificationFineTuningV2 extends DeprecatedAsyncView<Props, State> {
   getEndpoints(): ReturnType<DeprecatedAsyncView['getEndpoints']> {
     const {fineTuneType: pathnameType} = this.props.params;
     const fineTuneType = getNotificationTypeFromPathname(pathnameType);
@@ -274,7 +275,7 @@ class AccountNotificationFineTuning extends DeprecatedAsyncView<Props, State> {
             <Form
               saveOnBlur
               apiMethod="PUT"
-              apiEndpoint={`/users/me/notifications-v2/${fineTuneType}/`}
+              apiEndpoint={`/users/me/notifications/${fineTuneType}/`}
               initialData={fineTuneData}
             >
               {isProject && hasProjects && (
@@ -312,4 +313,4 @@ const StyledPanelHeader = styled(PanelHeader)`
   }
 `;
 
-export default withOrganizations(AccountNotificationFineTuning);
+export default withOrganizations(AccountNotificationFineTuningV2);

--- a/static/app/views/settings/account/notifications/notificationSettingsByTypeV2.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByTypeV2.tsx
@@ -1,9 +1,11 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 
 import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import {Field} from 'sentry/components/forms/types';
+import Panel from 'sentry/components/panels/panel';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -311,7 +313,7 @@ class NotificationSettingsByTypeV2 extends DeprecatedAsyncComponent<Props, State
           initialData={this.getInitialTopOptionData()}
           onSubmitSuccess={() => this.trackTuningUpdated('general')}
         >
-          <JsonForm
+          <TopJsonForm
             title={
               isGroupedByProject(notificationType)
                 ? t('All Projects')
@@ -326,7 +328,7 @@ class NotificationSettingsByTypeV2 extends DeprecatedAsyncComponent<Props, State
           apiEndpoint="/users/me/notification-providers/"
           initialData={this.getProviderInitialData()}
         >
-          <JsonForm fields={this.getProviderFields()} />
+          <BottomJsonForm fields={this.getProviderFields()} />
         </Form>
         <NotificationSettingsByEntity
           notificationType={notificationType}
@@ -342,3 +344,19 @@ class NotificationSettingsByTypeV2 extends DeprecatedAsyncComponent<Props, State
 }
 
 export default withOrganizations(NotificationSettingsByTypeV2);
+
+export const TopJsonForm = styled(JsonForm)`
+  ${Panel} {
+    border-bottom: 0;
+    margin-bottom: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+`;
+
+export const BottomJsonForm = styled(JsonForm)`
+  ${Panel} {
+    border-top-right-radius: 0;
+    border-top-left-radius: 0;
+  }
+`;

--- a/static/app/views/settings/account/notifications/notificationSettingsController.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsController.tsx
@@ -1,0 +1,25 @@
+import {RouteComponentProps} from 'react-router';
+
+import {Organization} from 'sentry/types';
+import withOrganizations from 'sentry/utils/withOrganizations';
+
+import NotificationSettings from './notificationSettings';
+import NotificationSettingsV2 from './notificationSettingsV2';
+
+type Props = RouteComponentProps<{fineTuneType: string}, {}> & {
+  organizations: Organization[];
+};
+
+export function NotificationSettingsController({organizations, ...props}: Props) {
+  // check if feature is enabled for any organization
+  const hasFeature = organizations.some(org =>
+    org.features.includes('notification-settings-v2')
+  );
+  return hasFeature ? (
+    <NotificationSettingsV2 {...props} />
+  ) : (
+    <NotificationSettings {...props} />
+  );
+}
+
+export default withOrganizations(NotificationSettingsController);

--- a/static/app/views/settings/account/notifications/notificationSettingsV2.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsV2.spec.tsx
@@ -1,0 +1,78 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {SELF_NOTIFICATION_SETTINGS_TYPES} from 'sentry/views/settings/account/notifications/constants';
+import {NOTIFICATION_SETTING_FIELDS} from 'sentry/views/settings/account/notifications/fields2';
+import NotificationSettings from 'sentry/views/settings/account/notifications/notificationSettingsV2';
+
+function renderMockRequests({}: {}) {
+  MockApiClient.addMockResponse({
+    url: '/users/me/notifications/',
+    method: 'GET',
+    body: {
+      personalActivityNotifications: true,
+      selfAssignOnResolve: true,
+      weeklyReports: true,
+    },
+  });
+}
+
+describe('NotificationSettings', function () {
+  it('should render', async function () {
+    const {routerContext, organization} = initializeOrg();
+
+    renderMockRequests({});
+
+    render(<NotificationSettings organizations={[organization]} />, {
+      context: routerContext,
+    });
+
+    // There are 8 notification setting Selects/Toggles.
+    for (const field of [
+      'alerts',
+      'workflow',
+      'deploy',
+      'approval',
+      'reports',
+      'email',
+      ...SELF_NOTIFICATION_SETTINGS_TYPES,
+    ]) {
+      expect(
+        await screen.findByText(String(NOTIFICATION_SETTING_FIELDS[field].label))
+      ).toBeInTheDocument();
+    }
+    expect(screen.getByText('Issue Alerts')).toBeInTheDocument();
+  });
+
+  it('renders quota section with feature flag', async function () {
+    const {routerContext, organization} = initializeOrg({
+      organization: {
+        features: ['slack-overage-notifications'],
+      },
+    });
+
+    renderMockRequests({});
+
+    render(<NotificationSettings organizations={[organization]} />, {
+      context: routerContext,
+    });
+
+    // There are 9 notification setting Selects/Toggles.
+
+    for (const field of [
+      'alerts',
+      'workflow',
+      'deploy',
+      'approval',
+      'reports',
+      'email',
+      'quota',
+      ...SELF_NOTIFICATION_SETTINGS_TYPES,
+    ]) {
+      expect(
+        await screen.findByText(String(NOTIFICATION_SETTING_FIELDS[field].label))
+      ).toBeInTheDocument();
+    }
+    expect(screen.getByText('Issue Alerts')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/settings/account/notifications/notificationSettingsV2.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsV2.tsx
@@ -1,0 +1,128 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import AlertLink from 'sentry/components/alertLink';
+import {LinkButton} from 'sentry/components/button';
+import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
+import Form from 'sentry/components/forms/form';
+import JsonForm from 'sentry/components/forms/jsonForm';
+import {FieldObject} from 'sentry/components/forms/types';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import PanelHeader from 'sentry/components/panels/panelHeader';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {IconMail, IconSettings} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {Organization} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import withOrganizations from 'sentry/utils/withOrganizations';
+import {
+  NOTIFICATION_FEATURE_MAP,
+  NOTIFICATION_SETTINGS_PATHNAMES,
+  NOTIFICATION_SETTINGS_TYPES,
+  SELF_NOTIFICATION_SETTINGS_TYPES,
+} from 'sentry/views/settings/account/notifications/constants';
+import {NOTIFICATION_SETTING_FIELDS} from 'sentry/views/settings/account/notifications/fields2';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+import TextBlock from 'sentry/views/settings/components/text/textBlock';
+
+type Props = DeprecatedAsyncComponent['props'] & {
+  organizations: Organization[];
+};
+
+function NotificationSettings({organizations}: Props) {
+  const checkFeatureFlag = (flag: string) => {
+    return organizations.some(org => org.features?.includes(flag));
+  };
+  const notificationFields = NOTIFICATION_SETTINGS_TYPES.filter(type => {
+    const notificationFlag = NOTIFICATION_FEATURE_MAP[type];
+    if (notificationFlag) {
+      return checkFeatureFlag(notificationFlag);
+    }
+    return true;
+  });
+
+  const renderOneSetting = (type: string) => {
+    const field = NOTIFICATION_SETTING_FIELDS[type];
+    return (
+      <FieldWrapper>
+        <div>
+          <FieldLabel>{field.label}</FieldLabel>
+          <FieldHelp>{field.help}</FieldHelp>
+        </div>
+        <IconWrapper>
+          <LinkButton
+            icon={<IconSettings size="sm" />}
+            size="sm"
+            borderless
+            aria-label={t('Notification Settings')}
+            to={`/settings/account/notifications/${NOTIFICATION_SETTINGS_PATHNAMES[type]}/`}
+          />
+        </IconWrapper>
+      </FieldWrapper>
+    );
+  };
+
+  const legacyFields = SELF_NOTIFICATION_SETTINGS_TYPES.map(
+    type => NOTIFICATION_SETTING_FIELDS[type] as FieldObject
+  );
+
+  const {data: initialLegacyData, isLoading} = useApiQuery<{[key: string]: string}>(
+    ['/users/me/notifications/'],
+    {
+      staleTime: 0,
+    }
+  );
+
+  return (
+    <Fragment>
+      <SentryDocumentTitle title={t('Notifications')} />
+      <SettingsPageHeader title={t('Notifications')} />
+      <TextBlock>
+        {t('Personal notifications sent by email or an integration.')}
+      </TextBlock>
+      <Panel>
+        <PanelHeader>{t('Notification')}</PanelHeader>
+        <Container>{notificationFields.map(renderOneSetting)}</Container>
+      </Panel>
+      {!isLoading && (
+        <Form
+          saveOnBlur
+          apiMethod="PUT"
+          apiEndpoint="/users/me/notifications/"
+          initialData={initialLegacyData}
+        >
+          <JsonForm title={t('Other')} fields={legacyFields} />
+        </Form>
+      )}
+      <AlertLink to="/settings/account/emails" icon={<IconMail />}>
+        {t('Looking to add or remove an email address? Use the emails panel.')}
+      </AlertLink>
+    </Fragment>
+  );
+}
+export default withOrganizations(NotificationSettings);
+
+const FieldLabel = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const FieldHelp = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.gray300};
+`;
+
+const FieldWrapper = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr min-content;
+  padding: ${p => p.theme.grid * 2}px;
+  border-bottom: 1px solid ${p => p.theme.border};
+`;
+
+const Container = styled(PanelBody)``;
+
+const IconWrapper = styled('div')`
+  display: flex;
+  margin: auto;
+  cursor: pointer;
+`;

--- a/static/app/views/settings/account/notifications/notificationSettingsV2.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsV2.tsx
@@ -73,7 +73,7 @@ function NotificationSettings({organizations}: Props) {
     data: initialLegacyData,
     isLoading,
     isError,
-  } = useApiQuery<{[key: string]: string}>(['/users/me/notificationsddd/'], {
+  } = useApiQuery<{[key: string]: string}>(['/users/me/notifications/'], {
     staleTime: 0,
   });
 

--- a/static/app/views/settings/account/notifications/notificationSettingsV2.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsV2.tsx
@@ -45,7 +45,7 @@ function NotificationSettings({organizations}: Props) {
   const renderOneSetting = (type: string) => {
     const field = NOTIFICATION_SETTING_FIELDS[type];
     return (
-      <FieldWrapper>
+      <FieldWrapper key={type}>
         <div>
           <FieldLabel>{field.label}</FieldLabel>
           <FieldHelp>{field.help}</FieldHelp>
@@ -67,6 +67,7 @@ function NotificationSettings({organizations}: Props) {
     type => NOTIFICATION_SETTING_FIELDS[type] as FieldObject
   );
 
+  // use 0 as stale time because we change the values elsewhere
   const {data: initialLegacyData, isLoading} = useApiQuery<{[key: string]: string}>(
     ['/users/me/notifications/'],
     {

--- a/static/app/views/settings/account/notifications/notificationSettingsV2.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsV2.tsx
@@ -82,10 +82,10 @@ function NotificationSettings({organizations}: Props) {
       <TextBlock>
         {t('Personal notifications sent by email or an integration.')}
       </TextBlock>
-      <Panel>
+      <PanelNoBottomMargin>
         <PanelHeader>{t('Notification')}</PanelHeader>
         <Container>{notificationFields.map(renderOneSetting)}</Container>
-      </Panel>
+      </PanelNoBottomMargin>
       {!isLoading && (
         <Form
           saveOnBlur
@@ -93,7 +93,7 @@ function NotificationSettings({organizations}: Props) {
           apiEndpoint="/users/me/notifications/"
           initialData={initialLegacyData}
         >
-          <JsonForm title={t('Other')} fields={legacyFields} />
+          <BottomForm fields={legacyFields} />
         </Form>
       )}
       <AlertLink to="/settings/account/emails" icon={<IconMail />}>
@@ -126,4 +126,19 @@ const IconWrapper = styled('div')`
   display: flex;
   margin: auto;
   cursor: pointer;
+`;
+
+const BottomForm = styled(JsonForm)`
+  & > ${Panel} {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border-top: 0;
+  }
+`;
+
+const PanelNoBottomMargin = styled(Panel)`
+  margin-bottom: 0;
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 `;

--- a/static/app/views/settings/account/notifications/notificationSettingsV2.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsV2.tsx
@@ -7,6 +7,7 @@ import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import {FieldObject} from 'sentry/components/forms/types';
+import LoadingError from 'sentry/components/loadingError';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
@@ -68,12 +69,17 @@ function NotificationSettings({organizations}: Props) {
   );
 
   // use 0 as stale time because we change the values elsewhere
-  const {data: initialLegacyData, isLoading} = useApiQuery<{[key: string]: string}>(
-    ['/users/me/notifications/'],
-    {
-      staleTime: 0,
-    }
-  );
+  const {
+    data: initialLegacyData,
+    isLoading,
+    isError,
+  } = useApiQuery<{[key: string]: string}>(['/users/me/notificationsddd/'], {
+    staleTime: 0,
+  });
+
+  if (isError) {
+    return <LoadingError />;
+  }
 
   return (
     <Fragment>


### PR DESCRIPTION
This PR updates the notification settings home page for the V2 of notification settings using the new models

<img width="877" alt="Screen Shot 2023-08-25 at 11 48 23 AM" src="https://github.com/getsentry/sentry/assets/8533851/9c17094e-c179-4cb0-b1df-ff1b987dcd6e">
