### PR TITLE
fix(spans): Add missing event_id and make sure op and status are part of the tags

### DIFF
--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -49,6 +49,7 @@ def _build_snuba_span(relay_span: Mapping[str, Any]) -> MutableMapping[str, Any]
 
     snuba_span: MutableMapping[str, Any] = {}
     snuba_span["description"] = relay_span.get("description")
+    snuba_span["event_id"] = relay_span["event_id"]
     snuba_span["exclusive_time_ms"] = int(relay_span.get("exclusive_time", 0))
     snuba_span["group_raw"] = "0"
     snuba_span["is_segment"] = relay_span.get("is_segment", False)
@@ -82,9 +83,9 @@ def _build_snuba_span(relay_span: Mapping[str, Any]) -> MutableMapping[str, Any]
 
 def _format_event_id(payload: Mapping[str, Any]) -> str:
     event_id = payload.get("event_id")
-    if not event_id:
-        return ""
-    return uuid.UUID(event_id).hex
+    if event_id:
+        return uuid.UUID(event_id).hex
+    return ""
 
 
 def _process_message(message: Message[KafkaPayload]) -> KafkaPayload:

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -79,10 +79,10 @@ def _build_snuba_span(relay_span: Mapping[str, Any]) -> MutableMapping[str, Any]
                 sentry_tags[snuba_tag] = tags.get(relay_tag)
 
     if "op" not in sentry_tags:
-        sentry_tags["op"] = relay_span["op"]
+        sentry_tags["op"] = relay_span.get("op", "")
 
     if "status" not in sentry_tags:
-        sentry_tags["status"] = relay_span["status"]
+        sentry_tags["status"] = relay_span.get("status", "")
 
     snuba_span["sentry_tags"] = sentry_tags
 

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -72,10 +72,18 @@ def _build_snuba_span(relay_span: Mapping[str, Any]) -> MutableMapping[str, Any]
     )
 
     sentry_tags: MutableMapping[str, Any] = {}
+
     if tags := relay_span.get("data"):
         for relay_tag, snuba_tag in TAG_MAPPING.items():
             if relay_tag in tags:
                 sentry_tags[snuba_tag] = tags.get(relay_tag)
+
+    if "op" not in sentry_tags:
+        sentry_tags["op"] = relay_span["op"]
+
+    if "status" not in sentry_tags:
+        sentry_tags["status"] = relay_span["status"]
+
     snuba_span["sentry_tags"] = sentry_tags
 
     return snuba_span


### PR DESCRIPTION
It's unclear if op and status are part of the tags all the time or not so, if they're not present, I'm using the promoted fields to set them in the tags.

It'd be better to rely on those fields directly or tags only and not include them as promoted tags but it's unclear to me which way it is right now. What is it suppose to be @jjbayer?