### PR TITLE
fix(org-token): Better error message when using too-long name

### DIFF
--- a/src/sentry/api/endpoints/org_auth_token_details.py
+++ b/src/sentry/api/endpoints/org_auth_token_details.py
@@ -8,7 +8,7 @@ from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrgAuthTokenPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.models.orgauthtoken import MAX_NAME_LENGTH, OrgAuthToken
 from sentry.services.hybrid_cloud.organization.model import (
     RpcOrganization,
     RpcUserOrganizationContext,
@@ -55,7 +55,7 @@ class OrgAuthTokenDetailsEndpoint(ControlSiloOrganizationEndpoint):
         if not name:
             return Response({"detail": ["The name cannot be blank."]}, status=400)
 
-        if len(name) > 255:
+        if len(name) > MAX_NAME_LENGTH:
             return Response(
                 {"detail": ["The name cannot be longer than 255 characters."]}, status=400
             )

--- a/src/sentry/api/endpoints/org_auth_token_details.py
+++ b/src/sentry/api/endpoints/org_auth_token_details.py
@@ -55,6 +55,11 @@ class OrgAuthTokenDetailsEndpoint(ControlSiloOrganizationEndpoint):
         if not name:
             return Response({"detail": ["The name cannot be blank."]}, status=400)
 
+        if len(name) > 255:
+            return Response(
+                {"detail": ["The name cannot be longer than 255 characters."]}, status=400
+            )
+
         instance.update(name=name)
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/org_auth_tokens.py
+++ b/src/sentry/api/endpoints/org_auth_tokens.py
@@ -16,7 +16,7 @@ from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrgAu
 from sentry.api.serializers import serialize
 from sentry.api.utils import generate_region_url
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
-from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.models.orgauthtoken import MAX_NAME_LENGTH, OrgAuthToken
 from sentry.models.user import User
 from sentry.security.utils import capture_security_activity
 from sentry.services.hybrid_cloud.organization.model import (
@@ -66,7 +66,7 @@ class OrgAuthTokensEndpoint(ControlSiloOrganizationEndpoint):
         if not name:
             return Response({"detail": ["The name cannot be blank."]}, status=400)
 
-        if len(name) > 255:
+        if len(name) > MAX_NAME_LENGTH:
             return Response(
                 {"detail": ["The name cannot be longer than 255 characters."]}, status=400
             )

--- a/src/sentry/api/endpoints/org_auth_tokens.py
+++ b/src/sentry/api/endpoints/org_auth_tokens.py
@@ -66,6 +66,11 @@ class OrgAuthTokensEndpoint(ControlSiloOrganizationEndpoint):
         if not name:
             return Response({"detail": ["The name cannot be blank."]}, status=400)
 
+        if len(name) > 255:
+            return Response(
+                {"detail": ["The name cannot be longer than 255 characters."]}, status=400
+            )
+
         token = OrgAuthToken.objects.create(
             name=name,
             organization_id=organization.id,

--- a/src/sentry/models/orgauthtoken.py
+++ b/src/sentry/models/orgauthtoken.py
@@ -18,6 +18,8 @@ from sentry.db.models import (
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.services.hybrid_cloud.orgauthtoken import orgauthtoken_service
 
+MAX_NAME_LENGTH = 255
+
 
 def validate_scope_list(value):
     for choice in value:
@@ -34,7 +36,7 @@ class OrgAuthToken(Model):
     token_hashed = models.TextField(unique=True, null=False)
     # An optional representation of the last characters of the original token, to be shown to the user
     token_last_characters = models.CharField(max_length=4, null=True)
-    name = models.CharField(max_length=255, null=False, blank=False)
+    name = models.CharField(max_length=MAX_NAME_LENGTH, null=False, blank=False)
     scope_list = ArrayField(
         models.TextField(),
         validators=[validate_scope_list],

--- a/tests/sentry/api/endpoints/test_org_auth_tokens.py
+++ b/tests/sentry/api/endpoints/test_org_auth_tokens.py
@@ -156,6 +156,16 @@ class OrgAuthTokenCreateTest(APITestCase):
         assert response.content
         assert response.data == {"detail": ["The name cannot be blank."]}
 
+    def test_name_too_long(self):
+        payload = {"name": "a" * 300}
+
+        self.login_as(self.user)
+        response = self.get_error_response(
+            self.organization.slug, status_code=status.HTTP_400_BAD_REQUEST, **payload
+        )
+        assert response.content
+        assert response.data == {"detail": ["The name cannot be longer than 255 characters."]}
+
     def test_no_auth(self):
         response = self.get_error_response(self.organization.slug)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
When a name is too long, this is not nicely validated but results in a SQL exception. Instead, let's properly check for that.

Closes https://github.com/getsentry/sentry/issues/55248