### PR TITLE
fix(getting-started-docs): Hide package manager copy if not js platform

### DIFF
--- a/static/app/components/onboarding/productSelection.spec.tsx
+++ b/static/app/components/onboarding/productSelection.spec.tsx
@@ -232,4 +232,40 @@ describe('Onboarding Product Selection', function () {
       })
     );
   });
+
+  it('renders npm & yarn info text', function () {
+    const {routerContext} = initializeOrg({
+      router: {
+        location: {
+          query: {product: [ProductSolution.PERFORMANCE_MONITORING]},
+        },
+        params: {},
+      },
+    });
+
+    render(<ProductSelection platform="javascript-react" />, {
+      context: routerContext,
+    });
+
+    expect(screen.queryByText('npm')).toBeInTheDocument();
+    expect(screen.queryByText('yarn')).toBeInTheDocument();
+  });
+
+  it('does not render npm & yarn info text', function () {
+    const {routerContext} = initializeOrg({
+      router: {
+        location: {
+          query: {product: [ProductSolution.PERFORMANCE_MONITORING]},
+        },
+        params: {},
+      },
+    });
+
+    render(<ProductSelection platform="python-django" />, {
+      context: routerContext,
+    });
+
+    expect(screen.queryByText('npm')).not.toBeInTheDocument();
+    expect(screen.queryByText('yarn')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -243,18 +243,25 @@ export function ProductSelection({
     return null;
   }
 
+  // TODO(aknaus): clean up
+  // The package manager info is only shown for javascript platforms
+  // until we improve multi snippet suppport
+  const showPackageManagerInfo = platform?.indexOf('javascript') === 0;
+
   return (
     <Fragment>
-      <TextBlock>
-        {lazyLoader
-          ? tct('In this quick guide you’ll use our [loaderScript] to set up:', {
-              loaderScript: <strong>Loader Script</strong>,
-            })
-          : tct('In this quick guide you’ll use [npm] or [yarn] to set up:', {
-              npm: <strong>npm</strong>,
-              yarn: <strong>yarn</strong>,
-            })}
-      </TextBlock>
+      {showPackageManagerInfo && (
+        <TextBlock>
+          {lazyLoader
+            ? tct('In this quick guide you’ll use our [loaderScript] to set up:', {
+                loaderScript: <strong>Loader Script</strong>,
+              })
+            : tct('In this quick guide you’ll use [npm] or [yarn] to set up:', {
+                npm: <strong>npm</strong>,
+                yarn: <strong>yarn</strong>,
+              })}
+        </TextBlock>
+      )}
       <Products>
         <Product
           label={t('Error Monitoring')}
@@ -316,7 +323,7 @@ export function ProductSelection({
           />
         )}
       </Products>
-      {lazyLoader && (
+      {showPackageManagerInfo && lazyLoader && (
         <AlternativeInstallationAlert type="info" showIcon>
           {tct('Prefer to set up Sentry using [npm:npm] or [yarn:yarn]? [goHere].', {
             npm: <strong />,


### PR DESCRIPTION
The current information is hardcoded to npm and yarn  / the loader script.
We do not wan't to show this when displaying the docs for non-js platforms.

![Screenshot 2023-08-28 at 11 16 57](https://github.com/getsentry/sentry/assets/7033940/709a7370-2d8f-4496-9b3d-6a367bf3f877)
![Screenshot 2023-08-28 at 11 15 52](https://github.com/getsentry/sentry/assets/7033940/f289b82c-10dc-461c-ae1d-27845206a433)

Closes https://github.com/getsentry/sentry/issues/55246
Relates to https://github.com/getsentry/sentry/issues/53859 (we will consider improvements to this in there)
