### PR TITLE
fix(on-demand): Fix query builder alias

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -141,9 +141,14 @@ class MetricsQueryBuilder(QueryBuilder):
         if self.params.organization is None:
             raise InvalidSearchQuery("An on demand metrics query requires an organization")
 
+        if len(self.selected_columns) == 0:
+            raise InvalidSearchQuery(
+                "An on demand metrics query requires at least one selected column"
+            )
+
         if isinstance(self, TimeseriesMetricQueryBuilder):
             limit = Limit(1)
-            alias = "count"
+            alias = self.resolve_column(self.selected_columns[0]).alias or "count"
             include_series = True
             interval = self.interval
         else:

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -34,6 +34,7 @@ from sentry.search.events.builder.utils import (
     remove_hours,
     remove_minutes,
 )
+from sentry.search.events.fields import get_function_alias
 from sentry.search.events.filter import ParsedTerms
 from sentry.search.events.types import (
     HistogramParams,
@@ -148,7 +149,7 @@ class MetricsQueryBuilder(QueryBuilder):
 
         if isinstance(self, TimeseriesMetricQueryBuilder):
             limit = Limit(1)
-            alias = self.resolve_column(self.selected_columns[0]).alias or "count"
+            alias = get_function_alias(self.selected_columns[0]) or "count"
             include_series = True
             interval = self.interval
         else:

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -2036,30 +2036,30 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         assert result["data"][:5] == [
             {
                 "time": self.start.isoformat(),
-                "count": 0.0,
+                "p75_measurements_fp": 0.0,
             },
             {
                 "time": (self.start + datetime.timedelta(hours=1)).isoformat(),
-                "count": 100.0,
+                "p75_measurements_fp": 100.0,
             },
             {
                 "time": (self.start + datetime.timedelta(hours=2)).isoformat(),
-                "count": 200.0,
+                "p75_measurements_fp": 200.0,
             },
             {
                 "time": (self.start + datetime.timedelta(hours=3)).isoformat(),
-                "count": 300.0,
+                "p75_measurements_fp": 300.0,
             },
             {
                 "time": (self.start + datetime.timedelta(hours=4)).isoformat(),
-                "count": 400.0,
+                "p75_measurements_fp": 400.0,
             },
         ]
         self.assertCountEqual(
             result["meta"],
             [
                 {"name": "time", "type": "DateTime('Universal')"},
-                {"name": "count", "type": "Float64"},
+                {"name": "p75_measurements_fp", "type": "Float64"},
             ],
         )
 
@@ -2099,30 +2099,30 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         assert result["data"][:5] == [
             {
                 "time": self.start.isoformat(),
-                "count": 0.75,
+                "apdex_10": 0.75,
             },
             {
                 "time": (self.start + datetime.timedelta(hours=1)).isoformat(),
-                "count": 0.75,
+                "apdex_10": 0.75,
             },
             {
                 "time": (self.start + datetime.timedelta(hours=2)).isoformat(),
-                "count": 0.75,
+                "apdex_10": 0.75,
             },
             {
                 "time": (self.start + datetime.timedelta(hours=3)).isoformat(),
-                "count": 0.75,
+                "apdex_10": 0.75,
             },
             {
                 "time": (self.start + datetime.timedelta(hours=4)).isoformat(),
-                "count": 0.75,
+                "apdex_10": 0.75,
             },
         ]
         self.assertCountEqual(
             result["meta"],
             [
                 {"name": "time", "type": "DateTime('Universal')"},
-                {"name": "count", "type": "Float64"},
+                {"name": "apdex_10", "type": "Float64"},
             ],
         )
 


### PR DESCRIPTION
This PR fixes a problem in the `alias` computation for the on demand spec in the query builder.

Closes https://github.com/getsentry/team-ingest/issues/205