### PR TITLE
feat(stat-detectors): Add regression message

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
+++ b/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
@@ -1,0 +1,61 @@
+import {DataSection} from 'sentry/components/events/styles';
+import Link from 'sentry/components/links/link';
+import {t, tct} from 'sentry/locale';
+import {Event} from 'sentry/types';
+import {formatPercentage} from 'sentry/utils/formatters';
+import useOrganization from 'sentry/utils/useOrganization';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {
+  DisplayModes,
+  transactionSummaryRouteWithQuery,
+} from 'sentry/views/performance/transactionSummary/utils';
+
+type EventStatisticalDetectorMessageProps = {
+  event: Event;
+};
+
+function EventStatisticalDetectorMessage({event}: EventStatisticalDetectorMessageProps) {
+  const organization = useOrganization();
+
+  const transactionName = event?.occurrence?.evidenceData?.transaction;
+  const transactionSummaryLink = transactionSummaryRouteWithQuery({
+    orgSlug: organization.slug,
+    transaction: transactionName,
+    query: {},
+    projectID: event.projectID,
+    display: DisplayModes.TREND,
+  });
+  const detectionTime = new Date(0);
+  detectionTime.setUTCSeconds(event?.occurrence?.evidenceData?.breakpoint);
+
+  // TODO: This messaging should respect selected locale in user settings
+  return (
+    <DataSection>
+      <div style={{display: 'inline'}}>
+        {tct(
+          '[detected] Based on the transaction [transactionName], there was a [amount] increase in duration (P95) around [date] at [time] UTC. Overall operation percentage changes indicate what may have changed in the regression.',
+          {
+            detected: <strong>{t('Detected:')}</strong>,
+            transactionName: (
+              <Link to={normalizeUrl(transactionSummaryLink)}>{transactionName}</Link>
+            ),
+            amount: formatPercentage(
+              event?.occurrence?.evidenceData?.trendPercentage / 100
+            ),
+            date: detectionTime.toLocaleDateString(undefined, {
+              month: 'short',
+              day: 'numeric',
+            }),
+            time: detectionTime.toLocaleTimeString(undefined, {
+              hour12: true,
+              hour: 'numeric',
+              minute: 'numeric',
+            }),
+          }
+        )}
+      </div>
+    </DataSection>
+  );
+}
+
+export default EventStatisticalDetectorMessage;

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -72,6 +72,7 @@ export enum IssueType {
   PERFORMANCE_UNCOMPRESSED_ASSET = 'performance_uncompressed_assets',
   PERFORMANCE_LARGE_HTTP_PAYLOAD = 'performance_large_http_payload',
   PERFORMANCE_HTTP_OVERHEAD = 'performance_http_overhead',
+  PERFORMANCE_P95_TRANSACTION_DURATION_REGRESSION = 'performance_p95_transaction_duration_regression',
 
   // Profile
   PROFILE_FILE_IO_MAIN_THREAD = 'profile_file_io_main_thread',

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import Feature from 'sentry/components/acl/feature';
 import {CommitRow} from 'sentry/components/commitRow';
 import {EventContexts} from 'sentry/components/events/contexts';
 import {EventDevice} from 'sentry/components/events/device';
@@ -13,6 +14,7 @@ import {EventEvidence} from 'sentry/components/events/eventEvidence';
 import {EventExtraData} from 'sentry/components/events/eventExtraData';
 import EventReplay from 'sentry/components/events/eventReplay';
 import {EventSdk} from 'sentry/components/events/eventSdk';
+import RegressionMessage from 'sentry/components/events/eventStatisticalDetector/regressionMessage';
 import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScreenshot';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
 import {EventGroupingInfo} from 'sentry/components/events/groupingInfo';
@@ -24,7 +26,7 @@ import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
 import {EventUserFeedback} from 'sentry/components/events/userFeedback';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Event, Group, IssueCategory, Project} from 'sentry/types';
+import {Event, Group, IssueCategory, IssueType, Project} from 'sentry/types';
 import {EntryType, EventTransaction} from 'sentry/types/event';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -82,6 +84,15 @@ function GroupEventDetailsContent({
   }
 
   const eventEntryProps = {group, event, project};
+
+  if (group.issueType === IssueType.PERFORMANCE_P95_TRANSACTION_DURATION_REGRESSION) {
+    return (
+      // TODO: Swap this feature flag with the statistical detector flag
+      <Feature features={['performance-trends-issues']}>
+        <RegressionMessage event={event} />
+      </Feature>
+    );
+  }
 
   return (
     <Fragment>


### PR DESCRIPTION
Adds a regression message to indicate to the user what transaction has regressed, by how much, when, and link out to the transaction summary.

Currently only supports UTC messaging. I'll follow up in the future with a PR to support locales better.

![Screenshot 2023-08-28 at 10 04 35 AM](https://github.com/getsentry/sentry/assets/22846452/7ac7cbe0-737d-4c31-9e89-ec7053b77ac8)
