### PR TITLE
remove unused properties of inbound-filter definition

### DIFF
--- a/src/sentry/api/endpoints/project_filters.py
+++ b/src/sentry/api/endpoints/project_filters.py
@@ -25,9 +25,6 @@ class ProjectFiltersEndpoint(ProjectEndpoint):
                     # 'active' will be either a boolean or list for the legacy browser filters
                     # all other filters will be boolean
                     "active": inbound_filters.get_filter_state(flt.id, project),
-                    "description": flt.description,
-                    "name": flt.name,
-                    "hello": flt.id + " - " + flt.name,
                 }
             )
         results.sort(key=lambda x: x["name"])

--- a/src/sentry/api/endpoints/project_filters.py
+++ b/src/sentry/api/endpoints/project_filters.py
@@ -27,5 +27,5 @@ class ProjectFiltersEndpoint(ProjectEndpoint):
                     "active": inbound_filters.get_filter_state(flt.id, project),
                 }
             )
-        results.sort(key=lambda x: x["name"])
+        results.sort(key=lambda x: x["id"])
         return Response(results)

--- a/tests/sentry/api/endpoints/snapshots/ProjectFiltersTest/test_get.pysnap
+++ b/tests/sentry/api/endpoints/snapshots/ProjectFiltersTest/test_get.pysnap
@@ -1,34 +1,13 @@
 ---
-created: '2023-07-04T12:49:12.065585Z'
-creator: sentry
 source: tests/sentry/api/endpoints/test_project_filters.py
 ---
 - active: false
-  description: Certain browser extensions will inject inline scripts and are known
-    to cause errors.
-  hello: browser-extensions - Filter out errors known to be caused by browser extensions
   id: browser-extensions
-  name: Filter out errors known to be caused by browser extensions
-- active: false
-  description: This applies to both IPv4 (``127.0.0.1``) and IPv6 (``::1``) addresses.
-  hello: localhost - Filter out events coming from localhost
-  id: localhost
-  name: Filter out events coming from localhost
 - active: true
-  description: Filter transactions that match most common naming patterns for health
-    checks.
-  hello: filtered-transaction - Filter out health check transactions
   id: filtered-transaction
-  name: Filter out health check transactions
 - active: false
-  description: Older browsers often give less accurate information, and while they
-    may report valid issues, the context to understand them is incorrect or missing.
-  hello: legacy-browsers - Filter out known errors from legacy browsers
   id: legacy-browsers
-  name: Filter out known errors from legacy browsers
 - active: false
-  description: Some crawlers may execute pages in incompatible ways which then cause
-    errors that are unlikely to be seen by a normal user.
-  hello: web-crawlers - Filter out known web crawlers
+  id: localhost
+- active: false
   id: web-crawlers
-  name: Filter out known web crawlers

--- a/tests/sentry/event_manager/interfaces/snapshots/test_http/test_full.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_http/test_full.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2023-06-27T15:08:54.308629Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_http.py
 ---
 errors: null


### PR DESCRIPTION
This PR removes unused fields from the response of the inbound-filter API

Resolves: #54922 