### PR TITLE
Only delete old `FileBlob`s

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -23,7 +23,8 @@ from sentry.api.serializers import serialize
 from sentry.auth.superuser import is_active_superuser
 from sentry.auth.system import is_system_auth
 from sentry.constants import DEBUG_FILES_ROLE_DEFAULT, KNOWN_DIF_FORMATS
-from sentry.debug_files.upload import find_missing_chunks, maybe_renew_debug_files
+from sentry.debug_files.debug_files import maybe_renew_debug_files
+from sentry.debug_files.upload import find_missing_chunks
 from sentry.models import (
     File,
     OrganizationMember,

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -23,10 +23,9 @@ from sentry.api.serializers import serialize
 from sentry.auth.superuser import is_active_superuser
 from sentry.auth.system import is_system_auth
 from sentry.constants import DEBUG_FILES_ROLE_DEFAULT, KNOWN_DIF_FORMATS
-from sentry.debug_files.debug_files import maybe_renew_debug_files
+from sentry.debug_files.upload import find_missing_chunks, maybe_renew_debug_files
 from sentry.models import (
     File,
-    FileBlobOwner,
     OrganizationMember,
     ProjectDebugFile,
     Release,
@@ -357,16 +356,6 @@ class AssociateDSymFilesEndpoint(ProjectEndpoint):
         return Response({"associatedDsymFiles": []})
 
 
-def find_missing_chunks(organization, chunks):
-    """Returns a list of chunks which are missing for an org."""
-    owned = set(
-        FileBlobOwner.objects.filter(
-            blob__checksum__in=chunks, organization_id=organization.id
-        ).values_list("blob__checksum", flat=True)
-    )
-    return list(set(chunks) - owned)
-
-
 @region_silo_endpoint
 class DifAssembleEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
@@ -456,7 +445,7 @@ class DifAssembleEndpoint(ProjectEndpoint):
                 continue
 
             # Check if all requested chunks have been uploaded.
-            missing_chunks = find_missing_chunks(project.organization, chunks)
+            missing_chunks = find_missing_chunks(project.organization.id, chunks)
             if missing_chunks:
                 file_response[checksum] = {
                     "state": ChunkFileState.NOT_FOUND,

--- a/src/sentry/api/endpoints/project_release_file_details.py
+++ b/src/sentry/api/endpoints/project_release_file_details.py
@@ -191,7 +191,7 @@ class ReleaseFileDetailsMixin:
 
         file = releasefile.file
 
-        # TODO(dcramer): this doesnt handle a failure from file.deletefile() to
+        # TODO(dcramer): this doesnt handle a failure from file.delete() to
         # the actual deletion of the db row
         releasefile.delete()
         file.delete()

--- a/src/sentry/debug_files/upload.py
+++ b/src/sentry/debug_files/upload.py
@@ -1,0 +1,13 @@
+from typing import Sequence
+
+from sentry.models.files.fileblobowner import FileBlobOwner
+
+
+def find_missing_chunks(organization_id: int, chunks: Sequence[str]):
+    """Returns a list of chunks which are missing for an org."""
+    owned = set(
+        FileBlobOwner.objects.filter(
+            blob__checksum__in=chunks, organization_id=organization_id
+        ).values_list("blob__checksum", flat=True)
+    )
+    return list(set(chunks) - owned)

--- a/src/sentry/models/files/abstractfileblob.py
+++ b/src/sentry/models/files/abstractfileblob.py
@@ -143,6 +143,7 @@ class AbstractFileBlob(Model):
                     lock = locked_blob(cls, checksum, logger=logger)
                     existing = lock.__enter__()
                     if existing is not None:
+                        existing.update(timestamp=timezone.now())
                         lock.__exit__(None, None, None)
                         blobs_created.append(existing)
                         _ensure_blob_owned(existing)
@@ -184,6 +185,7 @@ class AbstractFileBlob(Model):
         # and duplicate files are uploaded then we need to prune one
         with locked_blob(cls, checksum, logger=logger) as existing:
             if existing is not None:
+                existing.update(timestamp=timezone.now())
                 return existing
 
             blob = cls(size=size, checksum=checksum)
@@ -206,7 +208,13 @@ class AbstractFileBlob(Model):
 
     def delete(self, *args, **kwargs):
         if self.path:
-            self.deletefile(commit=False)
+            # Defer this by 1 minute just to make sure
+            # we avoid any transaction isolation where the
+            # FileBlob row might still be visible by the
+            # task before transaction is committed.
+            self.DELETE_FILE_TASK.apply_async(
+                kwargs={"path": self.path, "checksum": self.checksum}, countdown=60
+            )
         lock = locks.get(
             f"fileblob:upload:{self.checksum}",
             duration=UPLOAD_RETRY_TIME,
@@ -216,22 +224,6 @@ class AbstractFileBlob(Model):
             lock.acquire
         ):
             super().delete(*args, **kwargs)
-
-    def deletefile(self, commit=False):
-        assert self.path
-
-        # Defer this by 1 minute just to make sure
-        # we avoid any transaction isolation where the
-        # FileBlob row might still be visible by the
-        # task before transaction is committed.
-        self.DELETE_FILE_TASK.apply_async(
-            kwargs={"path": self.path, "checksum": self.checksum}, countdown=60
-        )
-
-        self.path = None
-
-        if commit:
-            self.save()
 
     def getfile(self):
         """


### PR DESCRIPTION
The existing code has a race condition between uploading a file, and assembling it. In particular, a `FileBlob` can disappear between upload and assembly. This changes the code so that `FileBlob` upload will bump its timestamp, and the deletion code will only consider old `FileBlob` for deletion.

This does *not* change any fundamental logic of how `File/Blob/Owner` and `FileBlobIndex` work. No changes to deduplication and assembly are made. However purely going by the timestamp, this should reduce the number of errors we see where files fail assembly due to vanishing `FileBlob`s.