### PR TITLE
ref(starfish): Remove manual `db.redis` omission from queries

### DIFF
--- a/static/app/views/starfish/utils/buildEventViewQuery.tsx
+++ b/static/app/views/starfish/utils/buildEventViewQuery.tsx
@@ -59,10 +59,6 @@ export function buildEventViewQuery({
     result.push(`${SPAN_MODULE}:${moduleName}`);
   }
 
-  if (moduleName === ModuleName.DB) {
-    result.push(`!${SPAN_OP}:db.redis`);
-  }
-
   if (defined(spanCategory)) {
     if (spanCategory === NULL_SPAN_CATEGORY) {
       result.push(`!has:span.category`);

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -24,7 +24,7 @@ import {
 import {ModuleFilters} from 'sentry/views/starfish/views/spans/useModuleFilters';
 import {NULL_SPAN_CATEGORY} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
-const {SPAN_SELF_TIME, SPAN_OP, SPAN_MODULE, SPAN_DESCRIPTION} = SpanMetricsFields;
+const {SPAN_SELF_TIME, SPAN_MODULE, SPAN_DESCRIPTION} = SpanMetricsFields;
 
 const CHART_HEIGHT = 140;
 
@@ -267,10 +267,6 @@ const buildDiscoverQueryConditions = (
 
   if (moduleName !== ModuleName.ALL) {
     result.push(`${SPAN_MODULE}:${moduleName}`);
-  }
-
-  if (moduleName === ModuleName.DB) {
-    result.push(`!${SPAN_OP}:db.redis`);
   }
 
   if (spanCategory) {


### PR DESCRIPTION
The `"db"` module tag now omits `"db.redis"` so there's no need to do this on the frontend. The `category` tag still includes `"db.redis"` as far as I know, so I didn't touch those conditions.
