### PR TITLE
feat(tracing-w/o-performance): Updated banner message.

### DIFF
--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -300,7 +300,7 @@ class TraceDetailsContent extends Component<Props, State> {
       warning = (
         <Alert type="info" showIcon>
           {tct(
-            "The good news is we know these errors are related to each other. The bad news is that we can't tell you more than that. If you haven't already, [tracingLink: configure tracing for your SDKs] to learn more about service interactions.",
+            "The good news is we know these errors are related to each other. The bad news is that we can't tell you more than that. If you haven't already, [tracingLink: configure performance monitoring for your SDKs] to learn more about service interactions.",
             {
               tracingLink: (
                 <ExternalLink href="https://docs.sentry.io/product/performance/getting-started/" />


### PR DESCRIPTION
Updated orphan error trace view banner message as a request from the SDK team. The errors appearing in the trace view tells us that tracing is enabled. Plus, the link is for setting up performance monitoring. 