### PR TITLE
fix(starfish): Improve span summary metrics ribbon

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/block.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/block.tsx
@@ -5,15 +5,16 @@ import {space} from 'sentry/styles/space';
 
 interface Props {
   children: React.ReactNode;
+  alignment?: 'left' | 'right';
   description?: React.ReactNode;
   title?: React.ReactNode;
 }
 
-export function Block({title, description, children}: Props) {
+export function Block({title, description, alignment = 'right', children}: Props) {
   return (
     <BlockWrapper>
       {title && (
-        <BlockTitle>
+        <BlockTitle alignment={alignment}>
           {title}
           {description && (
             <BlockTooltipContainer>
@@ -22,7 +23,7 @@ export function Block({title, description, children}: Props) {
           )}
         </BlockTitle>
       )}
-      <BlockContent>{children}</BlockContent>
+      <BlockContent alignment={alignment}>{children}</BlockContent>
     </BlockWrapper>
   );
 }
@@ -40,18 +41,19 @@ const BlockWrapper = styled('div')`
   padding-bottom: ${space(2)};
 `;
 
-const BlockTitle = styled('h3')`
+const BlockTitle = styled('h3')<{alignment: 'left' | 'right'}>`
   color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeMedium};
   margin: 0;
   white-space: nowrap;
-  display: flex;
   height: ${space(3)};
+  text-align: ${p => p.alignment};
 `;
 
-const BlockContent = styled('h4')`
+const BlockContent = styled('h4')<{alignment: 'left' | 'right'}>`
   margin: 0;
   font-weight: normal;
+  text-align: ${p => p.alignment};
 `;
 
 const BlockTooltipContainer = styled('span')`

--- a/static/app/views/starfish/views/spanSummaryPage/block.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/block.tsx
@@ -44,7 +44,6 @@ const BlockTitle = styled('h3')`
   color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeMedium};
   margin: 0;
-  margin-bottom: ${space(1)};
   white-space: nowrap;
   display: flex;
   height: ${space(3)};

--- a/static/app/views/starfish/views/spanSummaryPage/block.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/block.tsx
@@ -30,7 +30,7 @@ export function Block({title, description, children}: Props) {
 export const BlockContainer = styled('div')`
   display: flex;
   flex-wrap: wrap;
-  gap: ${space(2)};
+  gap: ${space(4)};
 `;
 
 const BlockWrapper = styled('div')`

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -1,4 +1,5 @@
 import {CSSProperties} from 'react';
+import styled from '@emotion/styled';
 
 import {RateUnits} from 'sentry/utils/discover/fields';
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
@@ -43,22 +44,28 @@ function SampleInfo(props: Props) {
   }
 
   return (
-    <BlockContainer>
-      <Block title={getThroughputTitle(spanMetrics?.[SPAN_OP])}>
-        <ThroughputCell
-          containerProps={{style}}
-          rate={spanMetrics?.['spm()']}
-          unit={RateUnits.PER_MINUTE}
-        />
-      </Block>
-      <Block title={DataTitles.avg}>
-        <DurationCell
-          containerProps={{style}}
-          milliseconds={spanMetrics?.[`avg(${SPAN_SELF_TIME})`]}
-        />
-      </Block>
-    </BlockContainer>
+    <SampleInfoContainer>
+      <BlockContainer>
+        <Block title={getThroughputTitle(spanMetrics?.[SPAN_OP])} alignment="left">
+          <ThroughputCell
+            containerProps={{style}}
+            rate={spanMetrics?.['spm()']}
+            unit={RateUnits.PER_MINUTE}
+          />
+        </Block>
+        <Block title={DataTitles.avg} alignment="left">
+          <DurationCell
+            containerProps={{style}}
+            milliseconds={spanMetrics?.[`avg(${SPAN_SELF_TIME})`]}
+          />
+        </Block>
+      </BlockContainer>
+    </SampleInfoContainer>
   );
 }
+
+const SampleInfoContainer = styled('div')`
+  display: flex;
+`;
 
 export default SampleInfo;

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.spec.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.spec.tsx
@@ -1,0 +1,23 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanMetricsRibbon} from 'sentry/views/starfish/views/spanSummaryPage/spanMetricsRibbon';
+
+describe('SpanMetricsRibbon', function () {
+  const sampleMetrics = {
+    [SpanMetricsFields.SPAN_OP]: 'db',
+    [`${StarfishFunctions.SPM}()`]: 17.8,
+    [`avg(${SpanMetricsFields.SPAN_SELF_TIME})`]: 127.1,
+    [`sum(${SpanMetricsFields.SPAN_SELF_TIME})`]: 1172319,
+    [`${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`]: 0.002,
+  };
+
+  it('renders basic metrics', function () {
+    render(<SpanMetricsRibbon spanMetrics={sampleMetrics} />);
+
+    expect(screen.getByText('17.8/min')).toBeInTheDocument();
+    expect(screen.getByText('127.10ms')).toBeInTheDocument();
+    expect(screen.getByText('19.54min')).toBeInTheDocument();
+    expect(screen.getByText(/0.2%/)).toBeInTheDocument();
+  });
+});

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
@@ -25,10 +25,6 @@ export function SpanMetricsRibbon({spanMetrics}: Props) {
 
   return (
     <BlockContainer>
-      {op.startsWith('db') && op !== 'db.redis' && (
-        <Block title={t('Table')}>{spanMetrics?.[SpanMetricsFields.SPAN_DOMAIN]}</Block>
-      )}
-
       <Block
         title={getThroughputTitle(op)}
         description={tct('Throughput of this [opDescription] span per minute', {

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
@@ -1,4 +1,4 @@
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {RateUnits} from 'sentry/utils/discover/fields';
 import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
@@ -7,7 +7,6 @@ import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpe
 import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
-import {getSpanOperationDescription} from 'sentry/views/starfish/views/spanSummaryPage/getSpanOperationDescription';
 
 interface Props {
   spanMetrics: {
@@ -21,31 +20,17 @@ interface Props {
 
 export function SpanMetricsRibbon({spanMetrics}: Props) {
   const op = spanMetrics?.[SpanMetricsFields.SPAN_OP] ?? '';
-  const opDescription = getSpanOperationDescription(op);
 
   return (
     <BlockContainer>
-      <Block
-        title={getThroughputTitle(op)}
-        description={tct('Throughput of this [opDescription] span per minute', {
-          opDescription,
-        })}
-      >
+      <Block title={getThroughputTitle(op)}>
         <ThroughputCell
           rate={spanMetrics?.[`${StarfishFunctions.SPM}()`]}
           unit={RateUnits.PER_MINUTE}
         />
       </Block>
 
-      <Block
-        title={DataTitles.avg}
-        description={tct(
-          'The average duration of [opDescription] spans in the selected period',
-          {
-            opDescription,
-          }
-        )}
-      >
+      <Block title={DataTitles.avg}>
         <DurationCell
           milliseconds={spanMetrics?.[`avg(${SpanMetricsFields.SPAN_SELF_TIME})`]}
         />
@@ -57,12 +42,7 @@ export function SpanMetricsRibbon({spanMetrics}: Props) {
         </Block>
       )}
 
-      <Block
-        title={t('Time Spent')}
-        description={t(
-          'Time spent in this span as a proportion of total application time'
-        )}
-      >
+      <Block title={t('Time Spent')}>
         <TimeSpentCell
           percentage={spanMetrics?.[`${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`]}
           total={spanMetrics?.[`sum(${SpanMetricsFields.SPAN_SELF_TIME})`]}


### PR DESCRIPTION
- Remove "Table" "metric"
- Add spec
- Reduce space under block titles
- Increase gap between elements
- Remove tooltips
- Allow `Block` to accept an alignment
- Align sample ribbon left

**e.g.,**
<img width="486" alt="Screenshot 2023-08-28 at 1 55 50 PM" src="https://github.com/getsentry/sentry/assets/989898/6826527a-1705-436a-8560-da4ba10b33ba">

