### PR TITLE
chore(hybridcloud) Be specific about domains for avatars

### DIFF
--- a/static/app/components/avatar/baseAvatar.tsx
+++ b/static/app/components/avatar/baseAvatar.tsx
@@ -101,6 +101,13 @@ type BaseProps = DefaultProps & {
    * Additional props for the tooltip
    */
   tooltipOptions?: Omit<TooltipProps, 'children' | 'title'>;
+  /**
+   * The region domain that organization avatars are on
+   */
+  uploadDomain?: string;
+  /**
+   * The uuid for the uploaded avatar.
+   */
   uploadId?: string | null | undefined;
 };
 
@@ -125,7 +132,7 @@ class BaseAvatar extends Component<Props, State> {
     };
   }
 
-  getRemoteImageSize = () => {
+  getRemoteImageSize() {
     const {remoteImageSize, size} = this.props;
     // Try to make sure remote image size is >= requested size
     // If requested size > allowed size then use the largest allowed size
@@ -135,15 +142,15 @@ class BaseAvatar extends Component<Props, State> {
         ALLOWED_SIZES[ALLOWED_SIZES.length - 1]);
 
     return remoteImageSize || allowed || DEFAULT_GRAVATAR_SIZE;
-  };
+  }
 
-  buildUploadUrl = () => {
-    const {uploadPath, uploadId} = this.props;
+  buildUploadUrl() {
+    const {uploadDomain, uploadPath, uploadId} = this.props;
 
-    return `/${uploadPath || 'avatar'}/${uploadId}/?${qs.stringify({
+    return `${uploadDomain || ''}/${uploadPath || 'avatar'}/${uploadId}/?${qs.stringify({
       s: DEFAULT_REMOTE_SIZE,
     })}`;
-  };
+  }
 
   handleLoad = () => {
     this.setState({showBackupAvatar: false, hasLoaded: true});
@@ -153,7 +160,7 @@ class BaseAvatar extends Component<Props, State> {
     this.setState({showBackupAvatar: true, loadError: true, hasLoaded: true});
   };
 
-  renderImg = () => {
+  renderImg() {
     if (this.state.loadError) {
       return null;
     }
@@ -194,7 +201,7 @@ class BaseAvatar extends Component<Props, State> {
     }
 
     return this.renderLetterAvatar();
-  };
+  }
 
   renderLetterAvatar() {
     const {title, letterId, round, suggested} = this.props;

--- a/static/app/components/avatar/index.spec.tsx
+++ b/static/app/components/avatar/index.spec.tsx
@@ -19,6 +19,10 @@ describe('Avatar', function () {
     avatar,
   };
 
+  window.__initialData = {
+    links: {sentryUrl: 'https://sentry.io'},
+  } as any;
+
   const userNameInitials = user.name
     .split(' ')
     .map(n => n[0])
@@ -55,14 +59,17 @@ describe('Avatar', function () {
 
       expect(screen.getByTestId(`${avatar.avatarType}-avatar`)).toBeInTheDocument();
       const avatarImage = await screen.findByRole('img');
-      expect(avatarImage).toHaveAttribute('src', `/avatar/${avatar.avatarUuid}/?s=120`);
+      expect(avatarImage).toHaveAttribute(
+        'src',
+        `https://sentry.io/avatar/${avatar.avatarUuid}/?s=120`
+      );
     });
 
     it('should show an upload with the correct size (static 120 size)', async function () {
       const avatar1 = render(<AvatarComponent user={user} size={76} />);
       expect(await screen.findByRole('img')).toHaveAttribute(
         'src',
-        `/avatar/${avatar.avatarUuid}/?s=120`
+        `https://sentry.io/avatar/${avatar.avatarUuid}/?s=120`
       );
 
       avatar1.unmount();
@@ -70,7 +77,7 @@ describe('Avatar', function () {
       const avatar2 = render(<AvatarComponent user={user} size={121} />);
       expect(await screen.findByRole('img')).toHaveAttribute(
         'src',
-        `/avatar/${avatar.avatarUuid}/?s=120`
+        `https://sentry.io/avatar/${avatar.avatarUuid}/?s=120`
       );
 
       avatar2.unmount();
@@ -78,7 +85,7 @@ describe('Avatar', function () {
       const avatar3 = render(<AvatarComponent user={user} size={32} />);
       expect(await screen.findByRole('img')).toHaveAttribute(
         'src',
-        `/avatar/${avatar.avatarUuid}/?s=120`
+        `https://sentry.io/avatar/${avatar.avatarUuid}/?s=120`
       );
 
       avatar3.unmount();
@@ -86,7 +93,7 @@ describe('Avatar', function () {
       render(<AvatarComponent user={user} size={1} />);
       expect(await screen.findByRole('img')).toHaveAttribute(
         'src',
-        `/avatar/${avatar.avatarUuid}/?s=120`
+        `https://sentry.io/avatar/${avatar.avatarUuid}/?s=120`
       );
     });
 
@@ -138,6 +145,23 @@ describe('Avatar', function () {
 
       expect(screen.getByTestId(`letter_avatar-avatar`)).toBeInTheDocument();
       expect(screen.getByText('TO')).toBeInTheDocument();
+    });
+
+    it('can display an organization Avatar upload', function () {
+      const organization = TestStubs.Organization({
+        slug: 'test-organization',
+        avatar: {
+          avatarType: 'upload',
+          avatarUuid: 'abc123def',
+        },
+      });
+
+      render(<AvatarComponent organization={organization} />);
+
+      expect(screen.getByRole('img')).toHaveAttribute(
+        'src',
+        'https://us.sentry.io/organization-avatar/abc123def/?s=120'
+      );
     });
 
     it('displays platform list icons for project Avatar', function () {
@@ -193,14 +217,14 @@ describe('Avatar', function () {
       const avatar1 = render(<AvatarComponent sentryApp={sentryApp} isColor />);
       expect(await screen.findByRole('img')).toHaveAttribute(
         'src',
-        `/sentry-app-avatar/${colorAvatar.avatarUuid}/?s=120`
+        `https://sentry.io/sentry-app-avatar/${colorAvatar.avatarUuid}/?s=120`
       );
       avatar1.unmount();
 
       const avatar2 = render(<AvatarComponent sentryApp={sentryApp} isColor={false} />);
       expect(await screen.findByRole('img')).toHaveAttribute(
         'src',
-        `/sentry-app-avatar/${simpleAvatar.avatarUuid}/?s=120`
+        `https://sentry.io/sentry-app-avatar/${simpleAvatar.avatarUuid}/?s=120`
       );
       avatar2.unmount();
 
@@ -222,7 +246,7 @@ describe('Avatar', function () {
       const avatar2 = render(<AvatarComponent sentryApp={sentryApp} />);
       expect(await screen.findByRole('img')).toHaveAttribute(
         'src',
-        `/sentry-app-avatar/${colorAvatar.avatarUuid}/?s=120`
+        `https://sentry.io/sentry-app-avatar/${colorAvatar.avatarUuid}/?s=120`
       );
       avatar2.unmount();
 

--- a/static/app/components/avatar/organizationAvatar.tsx
+++ b/static/app/components/avatar/organizationAvatar.tsx
@@ -19,7 +19,7 @@ function OrganizationAvatar({organization, ...props}: Props) {
       type={(organization.avatar && organization.avatar.avatarType) || 'letter_avatar'}
       uploadPath="organization-avatar"
       uploadId={organization.avatar && organization.avatar.avatarUuid}
-      uploadDomain={organization.links.regionUrl}
+      uploadDomain={organization.links?.regionUrl}
       letterId={slug}
       tooltip={slug}
       title={title}

--- a/static/app/components/avatar/organizationAvatar.tsx
+++ b/static/app/components/avatar/organizationAvatar.tsx
@@ -19,6 +19,7 @@ function OrganizationAvatar({organization, ...props}: Props) {
       type={(organization.avatar && organization.avatar.avatarType) || 'letter_avatar'}
       uploadPath="organization-avatar"
       uploadId={organization.avatar && organization.avatar.avatarUuid}
+      uploadDomain={organization.links.regionUrl}
       letterId={slug}
       tooltip={slug}
       title={title}

--- a/static/app/components/avatar/sentryAppAvatar.tsx
+++ b/static/app/components/avatar/sentryAppAvatar.tsx
@@ -21,12 +21,14 @@ function SentryAppAvatar({isColor = true, sentryApp, isDefault, ...props}: Props
   if (isDefault || !avatarDetails || avatarDetails.avatarType === 'default') {
     return defaultSentryAppAvatar;
   }
+  const {sentryUrl} = window.__initialData.links;
   return (
     <BaseAvatar
       {...props}
       type="upload"
       uploadPath="sentry-app-avatar"
       uploadId={avatarDetails?.avatarUuid}
+      uploadDomain={sentryUrl}
       title={sentryApp?.name}
       backupAvatar={defaultSentryAppAvatar}
     />

--- a/static/app/components/avatar/sentryAppAvatar.tsx
+++ b/static/app/components/avatar/sentryAppAvatar.tsx
@@ -21,7 +21,7 @@ function SentryAppAvatar({isColor = true, sentryApp, isDefault, ...props}: Props
   if (isDefault || !avatarDetails || avatarDetails.avatarType === 'default') {
     return defaultSentryAppAvatar;
   }
-  const {sentryUrl} = window.__initialData.links;
+  const {sentryUrl} = window.__initialData?.links ?? {};
   return (
     <BaseAvatar
       {...props}

--- a/static/app/components/avatar/userAvatar.tsx
+++ b/static/app/components/avatar/userAvatar.tsx
@@ -66,7 +66,7 @@ function UserAvatar({
         letterId: user.email || user.username || user.id || user.ip_address,
         title: user.name || user.email || user.username || '',
       };
-  const {sentryUrl} = window.__initialData.links;
+  const {sentryUrl} = window.__initialData?.links ?? {};
 
   return (
     <BaseAvatar

--- a/static/app/components/avatar/userAvatar.tsx
+++ b/static/app/components/avatar/userAvatar.tsx
@@ -66,6 +66,7 @@ function UserAvatar({
         letterId: user.email || user.username || user.id || user.ip_address,
         title: user.name || user.email || user.username || '',
       };
+  const {sentryUrl} = window.__initialData.links;
 
   return (
     <BaseAvatar
@@ -74,6 +75,7 @@ function UserAvatar({
       type={type}
       uploadPath="avatar"
       uploadId={avatarData.uploadId}
+      uploadDomain={sentryUrl}
       gravatarId={avatarData.gravatarId}
       letterId={avatarData.letterId}
       title={avatarData.title}


### PR DESCRIPTION
Use absolute URLs with domains for avatars. In multi-region sentry organization avatars need to point directly to the region servers as we don't have a proxy API for image rendering.

Furthermore, user and sentryapp avatars always need to come from control silo which will be hosted on sentry.io