### PR TITLE
fix(useHotkeys): Ensure OTHER modifiers are not pressed

### DIFF
--- a/static/app/utils/useHotkeys.spec.tsx
+++ b/static/app/utils/useHotkeys.spec.tsx
@@ -50,7 +50,7 @@ describe('useHotkeys', function () {
     const callback = jest.fn();
 
     reactHooks.renderHook(p => useHotkeys(p, []), {
-      initialProps: [{match: ['ctrl+s', 'cmd+m'], callback}],
+      initialProps: [{match: ['ctrl+s', 'command+m'], callback}],
     });
 
     expect(events.keydown).toBeDefined();
@@ -70,7 +70,7 @@ describe('useHotkeys', function () {
     const callback = jest.fn();
 
     reactHooks.renderHook(p => useHotkeys(p, []), {
-      initialProps: [{match: ['cmd+control+option+shift+x'], callback}],
+      initialProps: [{match: ['command+ctrl+alt+shift+x'], callback}],
     });
 
     expect(events.keydown).toBeDefined();
@@ -86,6 +86,28 @@ describe('useHotkeys', function () {
     );
 
     expect(callback).toHaveBeenCalled();
+  });
+
+  it('does not match when extra modifiers are pressed', function () {
+    const callback = jest.fn();
+
+    reactHooks.renderHook(p => useHotkeys(p, []), {
+      initialProps: [{match: ['command+shift+x'], callback}],
+    });
+
+    expect(events.keydown).toBeDefined();
+    expect(callback).not.toHaveBeenCalled();
+
+    events.keydown(
+      makeKeyEvent('x', {
+        altKey: true,
+        metaKey: true,
+        shiftKey: true,
+        ctrlKey: true,
+      })
+    );
+
+    expect(callback).not.toHaveBeenCalled();
   });
 
   it('updates with rerender', function () {
@@ -106,7 +128,7 @@ describe('useHotkeys', function () {
     expect(callback).toHaveBeenCalled();
     callback.mockClear();
 
-    rerender({match: 'cmd+m'});
+    rerender({match: 'command+m'});
 
     events.keydown(makeKeyEvent('s', {ctrlKey: true}));
     expect(callback).not.toHaveBeenCalled();

--- a/static/app/utils/useHotkeys.tsx
+++ b/static/app/utils/useHotkeys.tsx
@@ -20,6 +20,8 @@ const isKeyPressed = (key: string, evt: KeyboardEvent): boolean => {
   }
 };
 
+const modifiers = ['command', 'shift', 'ctrl', 'alt'];
+
 type Hotkey = {
   /**
    * The callback triggered when the matching key is pressed
@@ -56,12 +58,15 @@ export function useHotkeys(hotkeys: Hotkey[], deps: React.DependencyList): void 
     (evt: KeyboardEvent) => {
       for (const hotkey of memoizedHotkeys) {
         const preventDefault = !hotkey.skipPreventDefault;
-        const keysets = toArray(hotkey.match);
+        const keysets = toArray(hotkey.match).map(keys => keys.toLowerCase());
 
         for (const keyset of keysets) {
           const keys = keyset.split('+');
+          const unusedModifiers = modifiers.filter(modifier => !keys.includes(modifier));
 
-          const allKeysPressed = keys.every(key => isKeyPressed(key, evt));
+          const allKeysPressed =
+            keys.every(key => isKeyPressed(key, evt)) &&
+            unusedModifiers.every(modifier => !isKeyPressed(modifier, evt));
 
           const inputHasFocus =
             !hotkey.includeInputs && evt.target instanceof HTMLElement


### PR DESCRIPTION
If I have a hotkey `command+shift+1` it should not be activated when
pressing `command+shift+alt+1`