### PR TITLE
fix(deletion) Fix template variables in org deletion email

### DIFF
--- a/src/sentry/templates/sentry/emails/org_delete_confirm.html
+++ b/src/sentry/templates/sentry/emails/org_delete_confirm.html
@@ -5,9 +5,9 @@
 {% block main %}
     <h3>Organization Queued for Deletion</h3>
     <p>The <strong>{{ organization.name }}</strong> organization has been scheduled for deletion by:</p>
-    <p><pre>User: {{ audit_log_entry.get_actor_name }}
-IP: {{ audit_log_entry.ip_address }}
-Date: {{ audit_log_entry.datetime }}</pre></p>
+    <p><pre>User: {{ username }}
+IP: {{ user_ip_address }}
+Date: {{ deletion_datetime }}</pre></p>
     <p>This irreversible deletion will take place at <strong>{{ eta }}</strong> and will permanently remove all associated data including events, projects, and team members.</p>
     <p><strong>If this was unintentional and you would like to cancel the deletion:</strong></p>
     <p><a href="{{ url }}" class="btn">Restore Organization</a></p>


### PR DESCRIPTION
Align template variables with text version (which was correct). See https://github.com/getsentry/sentry/blob/9593038ba2d19b3d7c1e82fdf92b9aace2d5c4a4/src/sentry/api/endpoints/organization_details.py#L708-L723 for the template context

Fixes #55132