### PR TITLE
feat(perf): Reflow long lines when formatting SQL

### DIFF
--- a/static/app/views/starfish/utils/sqlish/SQLishFormatter.spec.tsx
+++ b/static/app/views/starfish/utils/sqlish/SQLishFormatter.spec.tsx
@@ -74,6 +74,37 @@ describe('SQLishFormatter', function () {
         LIMIT 1"
       `);
     });
+
+    it('Reflows long lines to a max length', () => {
+      expect(
+        formatter.toString(
+          'SELECT "sentry_organization"."id", "sentry_organization"."name", "sentry_organization"."slug", "sentry_organization"."status", "sentry_organization"."date_added", "sentry_organization"."default_role", "sentry_organization"."is_test", "sentry_organization"."flags" FROM "sentry_organization" WHERE "sentry_organization"."id" = %s LIMIT 21'
+        )
+      ).toMatchInlineSnapshot(`
+        "SELECT "sentry_organization"."id", "sentry_organization"."name", "sentry_organization"."slug",
+          "sentry_organization"."status", "sentry_organization"."date_added",
+          "sentry_organization"."default_role", "sentry_organization"."is_test", "sentry_organization"."flags"
+        FROM "sentry_organization"
+        WHERE "sentry_organization"."id" = %s
+        LIMIT 21"
+      `);
+    });
+
+    it('Reflows avoid unnecessary newlines', () => {
+      expect(
+        formatter.toString(
+          'SELECT "sentry_team"."org_role" FROM "sentry_team" INNER JOIN "sentry_organizationmember_teams" ON ("sentry_team"."id" = "sentry_organizationmember_teams"."team_id" WHERE ( "sentry_organizationmember_teams"."organizationmember_id" = %s AND NOT ("sentry_team"."org_role" IS NULL)'
+        )
+      ).toMatchInlineSnapshot(`
+        "SELECT "sentry_team"."org_role"
+        FROM "sentry_team"
+        INNER JOIN "sentry_organizationmember_teams" ON ("sentry_team"."id" =
+          "sentry_organizationmember_teams"."team_id"
+        WHERE (
+           "sentry_organizationmember_teams"."organizationmember_id" = %s AND NOT ("sentry_team"."org_role" IS
+            NULL)"
+      `);
+    });
   });
 
   describe('SQLishFormatter.toSimpleMarkup()', () => {

--- a/static/app/views/starfish/utils/sqlish/formatters/string.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/string.ts
@@ -5,7 +5,6 @@ export function string(tokens: Token[]): string {
   const accumulator = new StringAccumulator();
 
   let precedingNonWhitespaceToken: Token | undefined = undefined;
-  let indentation: number = 0; // Tracks the current indent level
   let parenthesisLevel: number = 0; // Tracks the current parenthesis nesting level
   const indentationLevels: number[] = []; // Tracks the parenthesis nesting levels at which we've incremented the indentation
 
@@ -27,7 +26,7 @@ export function string(tokens: Token[]): string {
       ) {
         accumulator.break();
 
-        indentation += 1;
+        accumulator.indent();
         indentationLevels.push(parenthesisLevel);
       }
     }
@@ -37,8 +36,7 @@ export function string(tokens: Token[]): string {
       // we incremented the indentation, decrement the indentation
       if (indentationLevels.at(-1) === parenthesisLevel) {
         accumulator.break();
-        indentation -= 1;
-        accumulator.indentTo(indentation);
+        accumulator.unindent();
         indentationLevels.pop();
       }
 
@@ -52,7 +50,6 @@ export function string(tokens: Token[]): string {
           accumulator.break();
         }
 
-        accumulator.indentTo(indentation);
         accumulator.add(token.content);
       } else if (token.type === 'Whitespace') {
         // Convert all whitespace to single spaces
@@ -60,7 +57,6 @@ export function string(tokens: Token[]): string {
       } else if (['LeftParenthesis', 'RightParenthesis'].includes(token.type)) {
         // Parenthesis contents are appended above, so we can skip them here
       } else {
-        accumulator.indentTo(indentation);
         accumulator.add(token.content);
       }
     }

--- a/static/app/views/starfish/utils/sqlish/formatters/string.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/string.ts
@@ -60,9 +60,7 @@ export function string(tokens: Token[]): string {
       } else if (['LeftParenthesis', 'RightParenthesis'].includes(token.type)) {
         // Parenthesis contents are appended above, so we can skip them here
       } else {
-        if (accumulator.endsWith(NEWLINE)) {
-          accumulator.indentTo(indentation);
-        }
+        accumulator.indentTo(indentation);
         accumulator.add(token.content);
       }
     }
@@ -98,5 +96,3 @@ const NEWLINE_KEYWORDS = new Set([
 
 // Keywords that may or may not trigger a newline, but they always trigger a newlines if followed by a parenthesis
 const PARENTHESIS_NEWLINE_KEYWORDS = new Set([...NEWLINE_KEYWORDS, ...['IN']]);
-
-const NEWLINE = '\n';

--- a/static/app/views/starfish/utils/sqlish/formatters/string.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/string.ts
@@ -38,7 +38,7 @@ export function string(tokens: Token[]): string {
       if (indentationLevels.at(-1) === parenthesisLevel) {
         accumulator.break();
         indentation -= 1;
-        accumulator.add(INDENTATION.repeat(indentation));
+        accumulator.indentTo(indentation);
         indentationLevels.pop();
       }
 
@@ -48,11 +48,11 @@ export function string(tokens: Token[]): string {
 
     if (typeof token.content === 'string') {
       if (token.type === 'Keyword' && NEWLINE_KEYWORDS.has(token.content)) {
-        if (!accumulator.endsWith(NEWLINE)) {
+        if (!accumulator.lastLine.isEmpty) {
           accumulator.break();
         }
 
-        accumulator.indent(indentation);
+        accumulator.indentTo(indentation);
         accumulator.add(token.content);
       } else if (token.type === 'Whitespace') {
         // Convert all whitespace to single spaces
@@ -61,7 +61,7 @@ export function string(tokens: Token[]): string {
         // Parenthesis contents are appended above, so we can skip them here
       } else {
         if (accumulator.endsWith(NEWLINE)) {
-          accumulator.add(INDENTATION.repeat(indentation));
+          accumulator.indentTo(indentation);
         }
         accumulator.add(token.content);
       }
@@ -99,5 +99,4 @@ const NEWLINE_KEYWORDS = new Set([
 // Keywords that may or may not trigger a newline, but they always trigger a newlines if followed by a parenthesis
 const PARENTHESIS_NEWLINE_KEYWORDS = new Set([...NEWLINE_KEYWORDS, ...['IN']]);
 
-const INDENTATION = '  ';
 const NEWLINE = '\n';

--- a/static/app/views/starfish/utils/sqlish/formatters/string.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/string.ts
@@ -1,3 +1,4 @@
+import {StringAccumulator} from 'sentry/views/starfish/utils/sqlish/formatters/stringAccumulator';
 import type {Token} from 'sentry/views/starfish/utils/sqlish/types';
 
 export function string(tokens: Token[]): string {
@@ -98,51 +99,5 @@ const NEWLINE_KEYWORDS = new Set([
 // Keywords that may or may not trigger a newline, but they always trigger a newlines if followed by a parenthesis
 const PARENTHESIS_NEWLINE_KEYWORDS = new Set([...NEWLINE_KEYWORDS, ...['IN']]);
 
-class StringAccumulator {
-  tokens: string[];
-
-  constructor() {
-    this.tokens = [];
-  }
-
-  add(token: string) {
-    if (!token) {
-      return;
-    }
-
-    this.tokens.push(token);
-  }
-
-  space() {
-    this.rtrim();
-    this.tokens.push(SPACE);
-  }
-
-  break() {
-    this.rtrim();
-
-    this.tokens.push(NEWLINE);
-  }
-
-  indent(count: number = 1) {
-    this.tokens.push(INDENTATION.repeat(count));
-  }
-
-  rtrim() {
-    while (this.tokens.at(-1)?.trim() === '') {
-      this.tokens.pop();
-    }
-  }
-
-  endsWith(token: string) {
-    return this.tokens.at(-1) === token;
-  }
-
-  toString() {
-    return this.tokens.join('').trim();
-  }
-}
-
-const SPACE = ' ';
 const INDENTATION = '  ';
 const NEWLINE = '\n';

--- a/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
@@ -26,10 +26,6 @@ export class StringAccumulator {
   }
 
   break() {
-    if (this.lastLine.isEmpty) {
-      this.lines.pop();
-    }
-
     this.lines.push(new Line());
   }
 

--- a/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
@@ -18,11 +18,11 @@ export class StringAccumulator {
       return;
     }
 
-    this.lastLine.push(token);
+    this.lastLine.add(token);
   }
 
   space() {
-    this.lastLine.push(SPACE);
+    this.lastLine.add(SPACE);
   }
 
   break() {
@@ -69,7 +69,7 @@ class Line {
     return this.toString().trim() === '';
   }
 
-  push(token: string) {
+  add(token: string) {
     this.tokens.push(token);
   }
 

--- a/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
@@ -1,0 +1,47 @@
+export class StringAccumulator {
+  tokens: string[];
+
+  constructor() {
+    this.tokens = [];
+  }
+
+  add(token: string) {
+    if (!token) {
+      return;
+    }
+
+    this.tokens.push(token);
+  }
+
+  space() {
+    this.rtrim();
+    this.tokens.push(SPACE);
+  }
+
+  break() {
+    this.rtrim();
+
+    this.tokens.push(NEWLINE);
+  }
+
+  indent(count: number = 1) {
+    this.tokens.push(INDENTATION.repeat(count));
+  }
+
+  rtrim() {
+    while (this.tokens.at(-1)?.trim() === '') {
+      this.tokens.pop();
+    }
+  }
+
+  endsWith(token: string) {
+    return this.tokens.at(-1) === token;
+  }
+
+  toString() {
+    return this.tokens.join('').trim();
+  }
+}
+const SPACE = ' ';
+const INDENTATION = '  ';
+const NEWLINE = '\n';

--- a/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
@@ -77,12 +77,12 @@ class Line {
     this.indentation += 1;
   }
 
-  indentTo(level: number) {
-    this.indentation = level;
-  }
-
   unindent() {
     this.indentation -= 1;
+  }
+
+  indentTo(level: number) {
+    this.indentation = level;
   }
 
   toString() {

--- a/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
@@ -41,24 +41,59 @@ export class StringAccumulator {
   }
 
   toString() {
-    return this.lines
-      .map(line => line.toString())
-      .join(NEWLINE)
-      .trim();
+    let output: Line[] = [];
+
+    this.lines.forEach(line => {
+      if (line.textLength <= LINE_LENGTH) {
+        output.push(line);
+        return;
+      }
+
+      const splitLines: Line[] = [new Line([], line.indentation)];
+      let tokenIndex = 0;
+
+      while (tokenIndex < line.tokens.length) {
+        const incomingToken = line.tokens.at(tokenIndex) as string;
+
+        const totalLength = (splitLines.at(-1) as Line).textLength + incomingToken.length;
+
+        if (totalLength <= LINE_LENGTH) {
+          splitLines.at(-1)?.add(incomingToken);
+        } else {
+          splitLines.push(new Line([incomingToken], line.indentation + 1));
+        }
+
+        tokenIndex += 1;
+      }
+
+      output = [...output, ...splitLines.filter(splitLine => !splitLine.isEmpty)];
+    });
+
+    return output.join(NEWLINE).trim();
   }
 }
+
+const LINE_LENGTH = 100;
 
 class Line {
   tokens: string[];
   indentation: number;
 
-  constructor() {
-    this.tokens = [];
-    this.indentation = 0;
+  constructor(tokens: string[] = [], indentation: number = 0) {
+    this.tokens = tokens;
+    this.indentation = indentation;
   }
 
   get isEmpty() {
     return this.toString().trim() === '';
+  }
+
+  get length() {
+    return this.toString().length;
+  }
+
+  get textLength() {
+    return this.toString().trim().length;
   }
 
   add(token: string) {

--- a/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
@@ -26,7 +26,18 @@ export class StringAccumulator {
   }
 
   break() {
-    this.lines.push(new Line());
+    const newLine = new Line();
+    newLine.indentTo(this.lastLine.indentation);
+
+    this.lines.push(newLine);
+  }
+
+  indent() {
+    this.lastLine.indent();
+  }
+
+  unindent() {
+    this.lastLine.unindent();
   }
 
   indentTo(level: number = 1) {

--- a/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
@@ -29,7 +29,7 @@ export class StringAccumulator {
     this.lines.push(new Line());
   }
 
-  indent(level: number = 1) {
+  indentTo(level: number = 1) {
     this.lastLine.indentTo(level);
   }
 

--- a/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
@@ -9,10 +9,6 @@ export class StringAccumulator {
     return this.lines.at(-1) as Line;
   }
 
-  get lastToken(): string | undefined {
-    return this.lastLine.lastToken;
-  }
-
   add(token: string) {
     if (!token) {
       return;
@@ -59,10 +55,6 @@ class Line {
   constructor() {
     this.tokens = [];
     this.indentation = 0;
-  }
-
-  get lastToken() {
-    return this.tokens.at(-1);
   }
 
   get isEmpty() {

--- a/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
@@ -1,8 +1,16 @@
 export class StringAccumulator {
-  tokens: string[];
+  lines: Line[];
 
   constructor() {
-    this.tokens = [];
+    this.lines = [new Line()];
+  }
+
+  get lastLine(): Line {
+    return this.lines.at(-1) as Line;
+  }
+
+  get lastToken(): string | undefined {
+    return this.lastLine.lastToken;
   }
 
   add(token: string) {
@@ -10,38 +18,79 @@ export class StringAccumulator {
       return;
     }
 
-    this.tokens.push(token);
+    this.lastLine.push(token);
   }
 
   space() {
-    this.rtrim();
-    this.tokens.push(SPACE);
+    this.lastLine.push(SPACE);
   }
 
   break() {
-    this.rtrim();
-
-    this.tokens.push(NEWLINE);
-  }
-
-  indent(count: number = 1) {
-    this.tokens.push(INDENTATION.repeat(count));
-  }
-
-  rtrim() {
-    while (this.tokens.at(-1)?.trim() === '') {
-      this.tokens.pop();
+    if (this.lastLine.isEmpty) {
+      this.lines.pop();
     }
+
+    this.lines.push(new Line());
+  }
+
+  indent(level: number = 1) {
+    this.lastLine.indentTo(level);
   }
 
   endsWith(token: string) {
-    return this.tokens.at(-1) === token;
+    if (token === NEWLINE) {
+      return this.lastLine.isEmpty;
+    }
+
+    return this.lastLine.lastToken === token;
   }
 
   toString() {
-    return this.tokens.join('').trim();
+    return this.lines
+      .map(line => line.toString())
+      .join(NEWLINE)
+      .trim();
   }
 }
+
+class Line {
+  tokens: string[];
+  indentation: number;
+
+  constructor() {
+    this.tokens = [];
+    this.indentation = 0;
+  }
+
+  get lastToken() {
+    return this.tokens.at(-1);
+  }
+
+  get isEmpty() {
+    return this.toString().trim() === '';
+  }
+
+  push(token: string) {
+    this.tokens.push(token);
+  }
+
+  indent() {
+    this.indentation += 1;
+  }
+
+  indentTo(level: number) {
+    this.indentation = level;
+  }
+
+  unindent() {
+    this.indentation -= 1;
+  }
+
+  toString() {
+    return `${INDENTATION.repeat(this.indentation)}${this.tokens.join('').trimEnd()}`;
+  }
+}
+
 const SPACE = ' ';
 const INDENTATION = '  ';
 const NEWLINE = '\n';

--- a/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
+++ b/static/app/views/starfish/utils/sqlish/formatters/stringAccumulator.ts
@@ -33,14 +33,6 @@ export class StringAccumulator {
     this.lastLine.indentTo(level);
   }
 
-  endsWith(token: string) {
-    if (token === NEWLINE) {
-      return this.lastLine.isEmpty;
-    }
-
-    return this.lastLine.lastToken === token;
-  }
-
   toString() {
     return this.lines
       .map(line => line.toString())


### PR DESCRIPTION
Changes the string formatter to use a line-wise storage method. This makes indentation much simpler and moves some gross logic into the accumulator, making the code nicer overall. Being line-aware also makes it much easier to reflow lines, which is this PR's main purpose. Allowed me to remove a bunch of API surface, too.

**Before:**
<img width="2288" alt="Screenshot 2023-08-28 at 3 34 50 PM" src="https://github.com/getsentry/sentry/assets/989898/c1f63025-54a0-4004-aeb6-a525d0f48c18">

**After:**
<img width="828" alt="Screenshot 2023-08-28 at 3 35 12 PM" src="https://github.com/getsentry/sentry/assets/989898/ab1a0e73-e2bb-40df-8175-3aa889d465e4">

- Move `StringAccumulator` into own file
- Use a line-wise abstraction instead
- Use cleaner indentation idiom
- Remove manuals end checks
- Use cleaner indentation idiom
- Reflow long lines
