### PR TITLE
fix(hc): Add missing control_silo_test annotation

### DIFF
--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -6,6 +6,7 @@ import pytest
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.sentry_app_installations.installation_notifier import InstallationNotifier
 from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
 
@@ -20,6 +21,7 @@ MockResponse = namedtuple(
 MockResponseInstance = MockResponse({}, {}, True, 200, raiseStatusFalse)
 
 
+@control_silo_test(stable=True)
 class TestInstallationNotifier(TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
This resolves test failures in `TestInstallationNotifier` in `tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py` when running in split-db mode.