### PR TITLE
feat(rules): Create endpoint to enable a disabled rule

### DIFF
--- a/src/sentry/api/endpoints/project_rule_enable.py
+++ b/src/sentry/api/endpoints/project_rule_enable.py
@@ -19,7 +19,7 @@ class ProjectRuleEnableEndpoint(ProjectEndpoint):
 
     def put(self, request: Request, project, rule_id) -> Response:
         try:
-            rule = Rule.objects.get(id=rule_id)
+            rule = Rule.objects.get(id=rule_id, project=project)
         except Rule.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/project_rule_enable.py
+++ b/src/sentry/api/endpoints/project_rule_enable.py
@@ -39,8 +39,7 @@ class ProjectRuleEnableEndpoint(ProjectEndpoint):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        kwargs = {**rule.data}
-        duplicate_rule = find_duplicate_rule(kwargs, project)
+        duplicate_rule = find_duplicate_rule(rule.data, project)
         if duplicate_rule:
             return Response(
                 {

--- a/src/sentry/api/endpoints/project_rule_enable.py
+++ b/src/sentry/api/endpoints/project_rule_enable.py
@@ -1,0 +1,51 @@
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import audit_log
+from sentry.api.api_owners import ApiOwner
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.constants import ObjectStatus
+from sentry.models import Rule
+
+# from sentry.api.endpoints.project_rules import find_duplicate_rule
+
+
+@region_silo_endpoint
+class ProjectRuleEnableEndpoint(ProjectEndpoint):
+    owner = ApiOwner.ISSUES
+    permission_classes = (ProjectAlertRulePermission,)
+
+    def put(self, request: Request, project, rule_id) -> Response:
+        try:
+            rule = Rule.objects.get(id=rule_id, status=ObjectStatus.DISABLED)
+        except Rule.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        if not rule.data.get("actions", []):
+            return Response(
+                {
+                    "Cannot enable a rule with no action.",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        # duplicate_rule = find_duplicate_rule(kwargs, project)
+        # if duplicate_rule:
+        # 	return Response(
+        # 		{
+        # 			f"This rule is an exact duplicate of '{duplicate_rule.label}' in this project and may not be enabled unless it's edited.",
+        # 		},
+        # 		status=status.HTTP_400_BAD_REQUEST,
+        # 	)
+        rule.status = ObjectStatus.ACTIVE
+        rule.save()
+        self.create_audit_entry(
+            request=request,
+            organization=project.organization,
+            target_object=rule.id,
+            event=audit_log.get_event_id("RULE_EDIT"),
+            data=rule.get_audit_log_data(),
+        )
+        return Response(status=202)

--- a/src/sentry/api/endpoints/project_rule_enable.py
+++ b/src/sentry/api/endpoints/project_rule_enable.py
@@ -6,11 +6,10 @@ from sentry import audit_log
 from sentry.api.api_owners import ApiOwner
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
+from sentry.api.endpoints.project_rules import find_duplicate_rule
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.constants import ObjectStatus
 from sentry.models import Rule
-
-# from sentry.api.endpoints.project_rules import find_duplicate_rule
 
 
 @region_silo_endpoint
@@ -20,25 +19,36 @@ class ProjectRuleEnableEndpoint(ProjectEndpoint):
 
     def put(self, request: Request, project, rule_id) -> Response:
         try:
-            rule = Rule.objects.get(id=rule_id, status=ObjectStatus.DISABLED)
+            rule = Rule.objects.get(id=rule_id)
         except Rule.DoesNotExist:
             raise ResourceDoesNotExist
+
+        if rule.status != ObjectStatus.DISABLED:
+            return Response(
+                {
+                    "detail": "Rule is not disabled.",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         if not rule.data.get("actions", []):
             return Response(
                 {
-                    "Cannot enable a rule with no action.",
+                    "detail": "Cannot enable a rule with no action.",
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        # duplicate_rule = find_duplicate_rule(kwargs, project)
-        # if duplicate_rule:
-        # 	return Response(
-        # 		{
-        # 			f"This rule is an exact duplicate of '{duplicate_rule.label}' in this project and may not be enabled unless it's edited.",
-        # 		},
-        # 		status=status.HTTP_400_BAD_REQUEST,
-        # 	)
+
+        kwargs = {**rule.data}
+        duplicate_rule = find_duplicate_rule(kwargs, project)
+        if duplicate_rule:
+            return Response(
+                {
+                    "detail": f"This rule is an exact duplicate of '{duplicate_rule.label}' in this project and may not be enabled unless it's edited."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         rule.status = ObjectStatus.ACTIVE
         rule.save()
         self.create_audit_entry(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -477,6 +477,7 @@ from .endpoints.project_repo_path_parsing import ProjectRepoPathParsingEndpoint
 from .endpoints.project_reprocessing import ProjectReprocessingEndpoint
 from .endpoints.project_rule_actions import ProjectRuleActionsEndpoint
 from .endpoints.project_rule_details import ProjectRuleDetailsEndpoint
+from .endpoints.project_rule_enable import ProjectRuleEnableEndpoint
 from .endpoints.project_rule_preview import ProjectRulePreviewEndpoint
 from .endpoints.project_rule_task_details import ProjectRuleTaskDetailsEndpoint
 from .endpoints.project_rules import ProjectRulesEndpoint
@@ -2190,6 +2191,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>\d+)/$",
         ProjectRuleDetailsEndpoint.as_view(),
         name="sentry-api-0-project-rule-details",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>[^\/]+)/enable/$",
+        ProjectRuleEnableEndpoint.as_view(),
+        name="sentry-api-0-project-rule-enable",
     ),
     re_path(
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>[^\/]+)/snooze/$",

--- a/tests/sentry/api/endpoints/test_project_rule_enable.py
+++ b/tests/sentry/api/endpoints/test_project_rule_enable.py
@@ -1,9 +1,12 @@
 from rest_framework import status
 
+from sentry import audit_log
 from sentry.constants import ObjectStatus
-from sentry.models import Rule
+from sentry.models import AuditLogEntry, Rule
+from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
 @region_silo_test(stable=True)
@@ -18,20 +21,85 @@ class ProjectRuleEnableTestCase(APITestCase):
     def test_simple(self):
         self.rule.status = ObjectStatus.DISABLED
         self.rule.save()
-        self.get_success_response(
+        with outbox_runner():
+            self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.rule.id,
+                status_code=status.HTTP_202_ACCEPTED,
+            )
+        assert Rule.objects.filter(id=self.rule.id, status=ObjectStatus.ACTIVE).exists()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert AuditLogEntry.objects.filter(
+                organization_id=self.organization.id,
+                target_object=self.rule.id,
+                event=audit_log.get_event_id("RULE_EDIT"),
+            ).exists()
+
+    def test_rule_enabled(self):
+        """Test that we do not accept an enabled rule"""
+        response = self.get_error_response(
             self.organization.slug,
             self.project.slug,
             self.rule.id,
-            status_code=status.HTTP_202_ACCEPTED,
+            status_code=status.HTTP_400_BAD_REQUEST,
         )
-        assert Rule.objects.filter(id=self.rule.id, status=ObjectStatus.ACTIVE).exists()
-
-    def test_rule_not_found(self):
-        # maybe it's not disabled
-        pass
+        assert response.data["detail"] == "Rule is not disabled."
 
     def test_duplicate_rule(self):
-        pass
+        """Test that we do not allow enabling a rule that is an exact duplicate of another rule in the same project"""
+        conditions = [
+            {
+                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+            }
+        ]
+        actions = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+            }
+        ]
+        rule = self.create_project_rule(
+            project=self.project, action_match=actions, condition_match=conditions
+        )
+
+        rule2 = self.create_project_rule(
+            project=self.project, action_match=actions, condition_match=conditions
+        )
+        rule2.status = ObjectStatus.DISABLED
+        rule2.save()
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            rule2.id,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+        assert (
+            response.data["detail"]
+            == f"This rule is an exact duplicate of '{rule.label}' in this project and may not be enabled unless it's edited."
+        )
 
     def test_no_action_rule(self):
-        pass
+        """Test that we do not allow enabling a rule that has no action(s)"""
+        conditions = [
+            {
+                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+            }
+        ]
+        rule = Rule.objects.create(
+            project=self.project,
+            data={"conditions": conditions, "action_match": "all"},
+        )
+        rule.status = ObjectStatus.DISABLED
+        rule.save()
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            rule.id,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+        assert response.data["detail"] == "Cannot enable a rule with no action."

--- a/tests/sentry/api/endpoints/test_project_rule_enable.py
+++ b/tests/sentry/api/endpoints/test_project_rule_enable.py
@@ -1,0 +1,37 @@
+from rest_framework import status
+
+from sentry.constants import ObjectStatus
+from sentry.models import Rule
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test(stable=True)
+class ProjectRuleEnableTestCase(APITestCase):
+    endpoint = "sentry-api-0-project-rule-enable"
+    method = "PUT"
+
+    def setUp(self):
+        self.rule = self.create_project_rule(project=self.project)
+        self.login_as(user=self.user)
+
+    def test_simple(self):
+        self.rule.status = ObjectStatus.DISABLED
+        self.rule.save()
+        self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.rule.id,
+            status_code=status.HTTP_202_ACCEPTED,
+        )
+        assert Rule.objects.filter(id=self.rule.id, status=ObjectStatus.ACTIVE).exists()
+
+    def test_rule_not_found(self):
+        # maybe it's not disabled
+        pass
+
+    def test_duplicate_rule(self):
+        pass
+
+    def test_no_action_rule(self):
+        pass


### PR DESCRIPTION
Create an endpoint to enable a disabled rule, but do not allow a "bad" rule to be enabled. A "bad" rule is one without any actions (can't ever fire) or one that's an exact duplicate of another rule in the same project.

Closes #55101 