### PR TITLE
fix(replay): Allow virtual grid headers to be labelled with react nodes

### DIFF
--- a/static/app/components/replays/virtualizedGrid/headerCell.tsx
+++ b/static/app/components/replays/virtualizedGrid/headerCell.tsx
@@ -27,7 +27,7 @@ interface SortSpanFrame {
 type Props = {
   field: string;
   handleSort: (fieldName: string) => void;
-  label: string;
+  label: ReactNode;
   sortConfig: SortCrumbs | SortBreadcrumbFrame | SortSpanFrame;
   style: CSSProperties;
   tooltipTitle: undefined | ReactNode;


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry/issues/55293
