### PR TITLE
chore(hybrid-cloud): Adds outbox type for subscription post-save events

### DIFF
--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -103,6 +103,8 @@ class OutboxCategory(IntEnum):
     DISABLE_AUTH_PROVIDER = 20
     RESET_IDP_FLAGS = 21
     MARK_INVALID_SSO = 22
+    SUBSCRIPTION_ORGANIZATION_ALERT_RULES = 23
+    FLUSH_SUBSCRIPTION_QUOTA_CACHE = 24
 
     @classmethod
     def as_choices(cls):

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -103,8 +103,7 @@ class OutboxCategory(IntEnum):
     DISABLE_AUTH_PROVIDER = 20
     RESET_IDP_FLAGS = 21
     MARK_INVALID_SSO = 22
-    SUBSCRIPTION_ORGANIZATION_ALERT_RULES = 23
-    FLUSH_SUBSCRIPTION_QUOTA_CACHE = 24
+    SUBSCRIPTION_UPDATE = 23
 
     @classmethod
     def as_choices(cls):

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -57,6 +57,7 @@ class OutboxScope(IntEnum):
     APP_SCOPE = 6
     TEAM_SCOPE = 7
     PROVISION_SCOPE = 8
+    SUBSCRIPTION_SCOPE = 9
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
Adds new outbox types for subscription post-save operations that query different databases. Not an ideal solution so I'm open to other ways to handle this situation instead.
