### PR TITLE
fix(js): Use yarnpkg registry for caniuse-lite

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4311,9 +4311,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001283, caniuse-lite@^1.0.30001449:
-  version "1.0.30001523"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001523.tgz"
-  integrity sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==
+  version "1.0.30001524"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz#1e14bce4f43c41a7deaeb5ebfe86664fe8dadb80"
+  integrity sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==
 
 cbor-web@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
Accidentally made it use npm registry in https://github.com/getsentry/sentry/pull/55221, so fixing that here.

Also bumping it to recently released `1.0.30001524` from `1.0.30001523`, but as per `npx browserslist` there is no difference in supported browsers between them.