### PR TITLE
feat(severity): Add first event severity flags

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1736,6 +1736,10 @@ SENTRY_FEATURES = {
     "projects:discard-groups": False,
     # Extract spans from transactions in Relay, and forward them via Kafka.
     "projects:extract-standalone-spans": False,
+    # Enable considering group severity when creating and evaluating alert rules
+    "projects:first-event-severity-alerting": False,
+    # Enable calculating a severity score for events which create a new group
+    "projects:first-event-severity-calculation": False,
     # Enable functionality for attaching  minidumps to events and displaying
     # then in the group UI.
     "projects:minidump": True,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -281,6 +281,8 @@ default_manager.add("projects:alert-filters", ProjectFeature, FeatureHandlerStra
 default_manager.add("projects:custom-inbound-filters", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:data-forwarding", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:discard-groups", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("projects:first-event-severity-alerting", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("projects:first-event-severity-calculation", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:minidump", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:race-free-group-creation", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:rate-limits", ProjectFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -702,6 +702,13 @@ register(
     "processing.view-hierarchies-dart-deobfuscation", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 
+# Enable calling the severity modeling API on group creation
+register(
+    "processing.calculate-severity-on-group-creation",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # ## sentry.killswitches
 #


### PR DESCRIPTION
This adds two flags and an option, to control various aspects of the first event severity experiment.

`projects:first-event-severity-calculation` - flag which controls (well, will control) whether we hit the severity calculation API whenever a new group is created in the given project
`projects:first-event-severity-alerting` - flag which controls whether severity is available as a filter in alert rules, both in terms of creating the rules and in terms of checking them during ingest
`processing.calculate-severity-on-group-creation` - option which also controls whether or not we hit the API, added in order to serve as a killswitch (available without redeployment), should things somehow go very sideways