### PR TITLE
fix(indexer): add SENTRY_METRICS_INDEXER_REINDEXED_INTS

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2056,6 +2056,8 @@ SENTRY_METRICS_INDEXER_TRANSACTIONS_SAMPLE_RATE = 0.1
 
 SENTRY_METRICS_INDEXER_SPANNER_OPTIONS: dict[str, Any] = {}
 
+SENTRY_METRICS_INDEXER_REINDEXED_INTS: dict[int, str] = {}
+
 # Rate limits during string indexing for our metrics product.
 # Which cluster to use. Example: {"cluster": "default"}
 SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS: dict[str, str] = {}

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -1,5 +1,7 @@
 from typing import Collection, Dict, Mapping, Optional, Set
 
+from django.conf import settings
+
 from sentry.sentry_metrics.indexer.base import (
     FetchType,
     OrgId,
@@ -236,6 +238,13 @@ class StaticStringIndexer(StringIndexer):
     def reverse_resolve(self, use_case_id: UseCaseID, org_id: int, id: int) -> Optional[str]:
         if id in REVERSE_SHARED_STRINGS:
             return REVERSE_SHARED_STRINGS[id]
+
+        # HACK: if a string gets re-indexed we need to have some way to look
+        # up the old id and we do it this way because the table has a unique
+        # constraint on the org_id and the string.
+        reindexed_ints = settings.SENTRY_METRICS_INDEXER_REINDEXED_INTS
+        if id in reindexed_ints:
+            return reindexed_ints[id]
         return self.indexer.reverse_resolve(use_case_id, org_id, id)
 
     def bulk_reverse_resolve(

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -239,13 +239,15 @@ class StaticStringIndexer(StringIndexer):
         if id in REVERSE_SHARED_STRINGS:
             return REVERSE_SHARED_STRINGS[id]
 
-        # HACK: if a string gets re-indexed we need to have some way to look
-        # up the old id and we do it this way because the table has a unique
-        # constraint on the org_id and the string.
-        reindexed_ints = settings.SENTRY_METRICS_INDEXER_REINDEXED_INTS
-        if id in reindexed_ints:
-            return reindexed_ints[id]
-        return self.indexer.reverse_resolve(use_case_id, org_id, id)
+        resolved_id = self.indexer.reverse_resolve(use_case_id, org_id, id)
+        if resolved_id is None:
+            # HACK: if a string gets re-indexed we need to have some way to look
+            # up the old id and we do it this way because the table has a unique
+            # constraint on the org_id and the string.
+            reindexed_ints = settings.SENTRY_METRICS_INDEXER_REINDEXED_INTS
+            if id in reindexed_ints:
+                return reindexed_ints[id]
+        return resolved_id
 
     def bulk_reverse_resolve(
         self, use_case_id: UseCaseID, org_id: int, ids: Collection[int]

--- a/tests/sentry/sentry_metrics/test_strings.py
+++ b/tests/sentry/sentry_metrics/test_strings.py
@@ -1,3 +1,5 @@
+from django.test import override_settings
+
 from sentry.sentry_metrics.indexer.mock import MockIndexer
 from sentry.sentry_metrics.indexer.strings import SHARED_STRINGS, StaticStringIndexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
@@ -57,3 +59,22 @@ def test_reverse_resolve_shared_org_no_entry() -> None:
     # shared string start quite high 2^63 so anything smaller should return None
     actual = indexer.reverse_shared_org_resolve(5)
     assert actual is None
+
+
+REINDEXED_INTS = {12345678: "release"}
+
+
+@override_settings(SENTRY_METRICS_INDEXER_REINDEXED_INTS=REINDEXED_INTS)
+def test_reverse_resolve_reindexed():
+    """
+    If we have deleted a record accidentally and whose id still lives in
+    ClickHouse, then we need to account for the re-indexed id. Since the
+    indexer table has a unique contraint on the org and string, we have a
+    hardcoded setting that let's us patch reverse_resolve so that we don't
+    get MetricIndexNotFound and return a 500.
+    """
+    indexer = StaticStringIndexer(MockIndexer())
+    id = indexer.record(use_case_id, 2, "release")
+
+    assert indexer.reverse_resolve(UseCaseID.SESSIONS, 1, id) == "release"
+    assert indexer.reverse_resolve(UseCaseID.SESSIONS, 1, 12345678) == "release"

--- a/tests/sentry/sentry_metrics/test_strings.py
+++ b/tests/sentry/sentry_metrics/test_strings.py
@@ -75,6 +75,8 @@ def test_reverse_resolve_reindexed():
     """
     indexer = StaticStringIndexer(MockIndexer())
     id = indexer.record(use_case_id, 2, "release")
+    # for mypy
+    assert id
 
     assert indexer.reverse_resolve(UseCaseID.SESSIONS, 1, id) == "release"
     assert indexer.reverse_resolve(UseCaseID.SESSIONS, 1, 12345678) == "release"


### PR DESCRIPTION
**context**:
We have a case where an indexed string got deleted in Postgres, but still lives in ClickHouse. This means we are still attempting to `reverse_resolve` the id but are getting a `MetricIndexNotFound` which blows up the release page for a user. 

The string has been re-indexed, so we can't update the row or add in the old value again (can't have two ids in the db point to the same string for the same org) so I added 
`SENTRY_METRICS_INDEXER_REINDEXED_INTS`. This allows us to have two different ids resolve to the same string.

This may cause the UI to be a little confusing but the main immediate goal is to stop it from 500'ing

*note:* A getsentry PR is needed to update the settings: https://github.com/getsentry/getsentry/pull/11505