### PR TITLE
fix(spans): Use a bigger producer queue length to allow more throughput

### DIFF
--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -154,6 +154,7 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             producer=self.__producer,
             topic=self.__output_topic,
             next_step=CommitOffsets(commit),
+            max_buffer_size=100000,
         )
         return RunTaskWithMultiprocessing(
             num_processes=self.__num_processes,


### PR DESCRIPTION
The spans ingestion pipeline seems to be be spending considerable amount of time being paused. A consumer can get paused if the queue in the producer is full. In those circumstances it raises a MesssageRejected exception and causes the whole pipeline to stall. The default message queue limit is 10000. Let's try out with a message queue size of 100000 to see if it helps the consumer.