### PR TITLE
fix: sentry-cli version detection for chunk uploads

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -63,12 +63,11 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         # User-Agent: sentry-cli/1.70.1
         user_agent = request.headers.get("User-Agent", "")
         sentrycli_version = SENTRYCLI_SEMVER_RE.search(user_agent)
-        supports_relative_url = (
-            (sentrycli_version is not None)
-            and (int(sentrycli_version.group("major")) >= 1)
-            and (int(sentrycli_version.group("minor")) >= 70)
-            and (int(sentrycli_version.group("patch")) >= 1)
-        )
+        supports_relative_url = (sentrycli_version is not None) and (
+            int(sentrycli_version.group("major")),
+            int(sentrycli_version.group("minor")),
+            int(sentrycli_version.group("patch")),
+        ) >= (1, 70, 1)
 
         # If user do not overwritten upload url prefix
         if len(endpoint) == 0:

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -95,6 +95,14 @@ class ChunkUploadTest(APITestCase):
         )
         assert response.data["url"] == self.url.lstrip(API_PREFIX)
 
+        response = self.client.get(
+            self.url,
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_USER_AGENT="sentry-cli/2.20.5",
+            format="json",
+        )
+        assert response.data["url"] == self.url.lstrip(API_PREFIX)
+
         # < 1.70.1
         response = self.client.get(
             self.url,


### PR DESCRIPTION
The code was checking that _all_ components of the version number are greater than those of 1.70.1, instead of comparing the versions lexicographically. Since we're not up to version 2.70.1 yet, this always returned the absolute URL for any user of `sentry-cli` 2.x.y.