### PR TITLE
fix(on-demand): Fix wrong query function

### DIFF
--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -756,7 +756,7 @@ def on_demand_failure_rate_snql_factory(aggregate_filter, org_id, use_case_id, a
         "divide",
         [
             Function(
-                "countIf",
+                "sumIf",
                 [
                     Column("value"),
                     Function(
@@ -774,7 +774,7 @@ def on_demand_failure_rate_snql_factory(aggregate_filter, org_id, use_case_id, a
                     ),
                 ],
             ),
-            Function("countIf", [Column("value"), aggregate_filter]),
+            Function("sumIf", [Column("value"), aggregate_filter]),
         ],
         alias=alias,
     )
@@ -784,7 +784,7 @@ def on_demand_apdex_snql_factory(aggregate_filter, org_id, use_case_id, alias=No
     # For more information about the formula, check https://docs.sentry.io/product/performance/metrics/#apdex.
 
     satisfactory = Function(
-        "countIf",
+        "sumIf",
         [
             Column("value"),
             Function(
@@ -806,7 +806,7 @@ def on_demand_apdex_snql_factory(aggregate_filter, org_id, use_case_id, alias=No
         "divide",
         [
             Function(
-                "countIf",
+                "sumIf",
                 [
                     Column("value"),
                     Function(
@@ -827,7 +827,7 @@ def on_demand_apdex_snql_factory(aggregate_filter, org_id, use_case_id, alias=No
             2,
         ],
     )
-    total = Function("countIf", [Column("value"), aggregate_filter])
+    total = Function("sumIf", [Column("value"), aggregate_filter])
 
     return Function(
         "divide",

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -2174,14 +2174,15 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
                 timestamp=self.start + datetime.timedelta(hours=hour),
             )
 
-            self.store_transaction_metric(
-                value=1,
-                metric=TransactionMetricKey.COUNT_ON_DEMAND.value,
-                internal_metric=TransactionMRI.COUNT_ON_DEMAND.value,
-                entity="metrics_counters",
-                tags={"query_hash": spec.query_hash, "satisfaction": "tolerable"},
-                timestamp=self.start + datetime.timedelta(hours=hour),
-            )
+            for j in range(0, 4):
+                self.store_transaction_metric(
+                    value=1,
+                    metric=TransactionMetricKey.COUNT_ON_DEMAND.value,
+                    internal_metric=TransactionMRI.COUNT_ON_DEMAND.value,
+                    entity="metrics_counters",
+                    tags={"query_hash": spec.query_hash, "satisfaction": "tolerable"},
+                    timestamp=self.start + datetime.timedelta(hours=hour),
+                )
 
         query = TimeseriesMetricQueryBuilder(
             self.params,
@@ -2197,23 +2198,23 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         assert result["data"][:5] == [
             {
                 "time": self.start.isoformat(),
-                "apdex_10": 0.75,
+                "apdex_10": 0.6,
             },
             {
                 "time": (self.start + datetime.timedelta(hours=1)).isoformat(),
-                "apdex_10": 0.75,
+                "apdex_10": 0.6,
             },
             {
                 "time": (self.start + datetime.timedelta(hours=2)).isoformat(),
-                "apdex_10": 0.75,
+                "apdex_10": 0.6,
             },
             {
                 "time": (self.start + datetime.timedelta(hours=3)).isoformat(),
-                "apdex_10": 0.75,
+                "apdex_10": 0.6,
             },
             {
                 "time": (self.start + datetime.timedelta(hours=4)).isoformat(),
-                "apdex_10": 0.75,
+                "apdex_10": 0.6,
             },
         ]
         self.assertCountEqual(


### PR DESCRIPTION
This PR fixes a problem with the queries for `failure_rate()` and `apdex()` which were using `countIf` instead of `sumIf`.