### PR TITLE
fix(repos): hide disabled repos in settings/repos

### DIFF
--- a/static/app/views/settings/organizationRepositories/index.tsx
+++ b/static/app/views/settings/organizationRepositories/index.tsx
@@ -21,9 +21,7 @@ type State = DeprecatedAsyncView['state'] & {
 class OrganizationRepositoriesContainer extends DeprecatedAsyncView<Props, State> {
   getEndpoints(): ReturnType<DeprecatedAsyncView['getEndpoints']> {
     const {organization} = this.props;
-    return [
-      ['itemList', `/organizations/${organization.slug}/repos/`, {query: {status: ''}}],
-    ];
+    return [['itemList', `/organizations/${organization.slug}/repos/`]];
   }
 
   // Callback used by child component to signal state change


### PR DESCRIPTION
We now set a repo to have `ObjectStatus.DISABLED` when a user "deletes" a repository. The current `/settings/repos/` page sends an API request with query param `status=` (empty string) which returns all repos regardless of status. Removing the query param will only return active repos. There is no way to delete a disabled repo on this page, which can be confusing for the user when they've already "deleted" it once before.