### PR TITLE
fix(auto-repo-linking): update reactivated repo url

### DIFF
--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -88,6 +88,7 @@ class IntegrationRepositoryProvider:
         integration_id = result.get("integration_id")
         external_id = result.get("external_id")
         name = result.get("name")
+        url = result.get("url")
 
         # first check if there is an existing hidden repository for the organization and external id
         repositories = repository_service.get_repositories(
@@ -100,6 +101,7 @@ class IntegrationRepositoryProvider:
             existing_repo.status = ObjectStatus.ACTIVE
             existing_repo.name = name
             existing_repo.integration_id = integration_id
+            existing_repo.url = url
             repository_service.update_repository(
                 organization_id=organization.id, update=existing_repo
             )

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -28,6 +28,7 @@ class IntegrationRepositoryTestCase(TestCase):
             "identifier": self.repo_name,
             "external_id": "654321",
             "integration_id": self.integration.id,
+            "url": "https://github.com/getsentry/sentry",
         }
 
         responses.add(
@@ -88,7 +89,10 @@ class IntegrationRepositoryTestCase(TestCase):
             integration_id=integration.id,
         )
 
-        self.provider.create_repository(self.config, self.organization)
+        _, repo = self.provider.create_repository(self.config, self.organization)
+
+        assert repo.name == self.config["identifier"]
+        assert repo.url == self.config["url"]
 
     def test_create_repository__repo_exists_update_name(self, get_jwt):
         repo = self._create_repo(external_id=self.config["external_id"], name="getsentry/santry")


### PR DESCRIPTION
When a repo is set from `ObjectStatus.DISABLED` to `ObjectStatus.ACTIVE`, we should update all the relevant fields (`name`, `integration_id`, `url`) to allow for repo transfer within an organization. The URL was previously not being updated but it should be for the case where orgs move their repos to a new Github organization.