### PR TITLE
ref(rules): Fix dupe check on edit

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -142,7 +142,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 "actions": data["actions"],
                 "frequency": data.get("frequency"),
             }
-            duplicate_rule = find_duplicate_rule(kwargs, project)
+            duplicate_rule = find_duplicate_rule(kwargs, project, rule.id)
             if duplicate_rule:
                 return Response(
                     {

--- a/src/sentry/api/endpoints/project_rule_enable.py
+++ b/src/sentry/api/endpoints/project_rule_enable.py
@@ -39,7 +39,7 @@ class ProjectRuleEnableEndpoint(ProjectEndpoint):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        duplicate_rule = find_duplicate_rule(rule.data, project)
+        duplicate_rule = find_duplicate_rule(rule.data, project, rule_id)
         if duplicate_rule:
             return Response(
                 {

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -34,9 +34,11 @@ def pre_save_rule(instance, sender, *args, **kwargs):
     clean_rule_data(instance.data.get("actions", []))
 
 
-def find_duplicate_rule(rule_data, project):
+def find_duplicate_rule(rule_data, project, rule_id=None):
     matchers = [key for key in list(rule_data.keys()) if key not in ("name", "user_id")]
-    existing_rules = Rule.objects.filter(project=project, status=ObjectStatus.ACTIVE)
+    existing_rules = Rule.objects.exclude(id=rule_id).filter(
+        project=project, status=ObjectStatus.ACTIVE
+    )
     for existing_rule in existing_rules:
         keys = 0
         matches = 0

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -454,6 +454,43 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             == f"This rule is an exact duplicate of '{rule.label}' in this project and may not be created."
         )
 
+    def test_edit_rule(self):
+        """Test that you can edit an alert rule w/o it comparing it to itself as a dupe"""
+        conditions = [
+            {
+                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+            }
+        ]
+        actions = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+            }
+        ]
+        self.create_project_rule(
+            project=self.project, action_match=actions, condition_match=conditions
+        )
+        conditions.append(
+            {
+                "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
+                "interval": "1h",
+                "value": "100",
+                "comparisonType": "count",
+            }
+        )
+        payload = {
+            "name": "hello world",
+            "environment": self.environment.name,
+            "actionMatch": "all",
+            "actions": actions,
+            "conditions": conditions,
+        }
+        self.get_success_response(
+            self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
+        )
+
     def test_with_environment(self):
         payload = {
             "name": "hello world",


### PR DESCRIPTION
In some cases when you edit an alert rule (maybe not immediately after creating it?) it's comparing the rule to itself for the duplicate check, so let's explicitly exclude that id from the comparison. 