### PR TITLE
fix(hybridcloud) Remove cross silo queries in authprovider details

### DIFF
--- a/src/sentry/api/endpoints/organization_auth_provider_details.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_details.py
@@ -6,7 +6,9 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationAuthProviderPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import AuthProvider
+from sentry.api.serializers.models.auth_provider import AuthProviderSerializer
+from sentry.models.organization import Organization
+from sentry.services.hybrid_cloud.auth.service import auth_service
 
 
 @region_silo_endpoint
@@ -14,7 +16,7 @@ class OrganizationAuthProviderDetailsEndpoint(OrganizationEndpoint):
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrganizationAuthProviderPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Retrieve details about Organization's SSO settings and
         currently installed auth_provider
@@ -23,11 +25,18 @@ class OrganizationAuthProviderDetailsEndpoint(OrganizationEndpoint):
         :pparam string organization_slug: the organization short name
         :auth: required
         """
-        try:
-            auth_provider = AuthProvider.objects.get(organization_id=organization.id)
-        except AuthProvider.DoesNotExist:
+        auth_providers = auth_service.get_auth_providers(organization_id=organization.id)
+        if not auth_providers:
             # This is a valid state where org does not have an auth provider
             # configured, make sure we respond with a 20x
             return Response(status=status.HTTP_204_NO_CONTENT)
 
-        return Response(serialize(auth_provider, request.user))
+        auth_provider = auth_providers[0]
+        return Response(
+            serialize(
+                auth_provider,
+                request.user,
+                organization=organization,
+                serializer=AuthProviderSerializer(),
+            )
+        )

--- a/src/sentry/api/serializers/models/auth_provider.py
+++ b/src/sentry/api/serializers/models/auth_provider.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from django.db.models import F
 
 from sentry import features
 from sentry.api.serializers import Serializer, register
 from sentry.models import AuthProvider, Organization, OrganizationMember
-from sentry.services.hybrid_cloud.organization import RpcOrganization, organization_service
+from sentry.services.hybrid_cloud.auth import RpcAuthProvider
+from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 from sentry.types.organization import OrganizationAbsoluteUrlMixin
-
-if TYPE_CHECKING:
-    from sentry.services.hybrid_cloud.auth import RpcAuthProvider
 
 
 @register(AuthProvider)
@@ -21,14 +17,8 @@ class AuthProviderSerializer(Serializer):
         obj: AuthProvider | RpcAuthProvider,
         attrs,
         user,
-        organization: Organization | RpcOrganization | None = None,
+        organization: Organization | RpcOrganization,
     ):
-        if not organization:
-            org_context = organization_service.get_organization_by_id(id=obj.organization_id)
-            if org_context:
-                organization = org_context.organization
-        assert organization, "Could not find organization for serialization"
-
         pending_links_count = OrganizationMember.objects.filter(
             organization_id=organization.id,
             flags=F("flags").bitand(~OrganizationMember.flags["sso:linked"]),

--- a/tests/sentry/api/endpoints/test_organization_auth_provider_details.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_provider_details.py
@@ -4,7 +4,7 @@ from sentry.testutils.cases import APITestCase, PermissionTestCase, SCIMTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class OrganizationAuthProviderPermissionTest(PermissionTestCase):
     def setUp(self):
         super().setUp()
@@ -17,7 +17,7 @@ class OrganizationAuthProviderPermissionTest(PermissionTestCase):
             self.assert_member_can_access(self.path)
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class OrganizationAuthProviderTest(SCIMTestCase, APITestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
We previously had this endpoint marked as a region endpoint but it was doing queries to AuthProvider (control silo). We have existing RPC methods to get an organizations auth providers. I chose to use this method and keep OrganizationAuthProviderDetails in region vs building more RPC methods and having this be a control endpoint.