### PR TITLE
fix(perf): Prevent SQL parser from finding keywords inside other words

### DIFF
--- a/static/app/views/starfish/utils/sqlish/SQLishParser.spec.tsx
+++ b/static/app/views/starfish/utils/sqlish/SQLishParser.spec.tsx
@@ -35,6 +35,39 @@ describe('SQLishParser', function () {
 
   describe('SQLishParser.parse', () => {
     const parser = new SQLishParser();
+
+    it('Distinguishes between real keywords and interpolated words', () => {
+      expect(parser.parse('SELECT country')).toEqual([
+        {
+          type: 'Keyword',
+          content: 'SELECT',
+        },
+        {
+          type: 'Whitespace',
+          content: ' ',
+        },
+        {
+          type: 'GenericToken',
+          content: 'country',
+        },
+      ]);
+
+      expect(parser.parse('SELECT discount')).toEqual([
+        {
+          type: 'Keyword',
+          content: 'SELECT',
+        },
+        {
+          type: 'Whitespace',
+          content: ' ',
+        },
+        {
+          type: 'GenericToken',
+          content: 'discount',
+        },
+      ]);
+    });
+
     it('Detects collapsed columns', () => {
       expect(parser.parse('select ..')).toEqual([
         {

--- a/static/app/views/starfish/utils/sqlish/sqlish.pegjs
+++ b/static/app/views/starfish/utils/sqlish/sqlish.pegjs
@@ -11,7 +11,7 @@ RightParenthesis
   = ")" { return { type: 'RightParenthesis', content: ')' } }
 
 Keyword
-  = Keyword:("ADD"i / "ALL"i / "ALTER"i / "AND"i / "ANY"i / "AS"i / "ASC"i / "BACKUP"i / "BETWEEN"i / "BY"i / "CASE"i / "CHECK"i / "COLUMN"i / "CONSTRAINT"i / "COUNT"i / "CREATE"i / "DATABASE"i / "DEFAULT"i / "DELETE"i / "DESC"i / "DISTINCT"i / "DROP"i / "EXEC"i / "EXISTS"i / "FOREIGN"i / "FROM"i / "FROM"i / "FULL"i / "GROUP"i / "HAVING"i / "INNER"i / "INSERT"i / "JOIN"i / "KEY"i / "LEFT"i / "LIMIT"i / "OFFSET"i / "ON"i / "ORDER"i / "OUTER"i / "RETURNING"i / "RIGHT"i / "SELECT"i / "SELECT"i / "TABLE"i / "UPDATE"i / "VALUES"i / "WHERE"i / JoinKeyword) {
+  = Keyword:("ADD"i / "ALL"i / "ALTER"i / "AND"i / "ANY"i / "AS"i / "ASC"i / "BACKUP"i / "BETWEEN"i / "BY"i / "CASE"i / "CHECK"i / "COLUMN"i / "CONSTRAINT"i / "COUNT"i / "CREATE"i / "DATABASE"i / "DEFAULT"i / "DELETE"i / "DESC"i / "DISTINCT"i / "DROP"i / "EXEC"i / "EXISTS"i / "FOREIGN"i / "FROM"i / "FROM"i / "FULL"i / "GROUP"i / "HAVING"i / "INNER"i / "INSERT"i / "JOIN"i / "KEY"i / "LEFT"i / "LIMIT"i / "OFFSET"i / "ON"i / "ORDER"i / "OUTER"i / "RETURNING"i / "RIGHT"i / "SELECT"i / "SELECT"i / "TABLE"i / "UPDATE"i / "VALUES"i / "WHERE"i / JoinKeyword) & (Whitespace / LeftParenthesis / RightParenthesis) {
   return { type: 'Keyword', content: Keyword.toUpperCase() }
 }
 

--- a/static/app/views/starfish/utils/sqlish/sqlish.pegjs
+++ b/static/app/views/starfish/utils/sqlish/sqlish.pegjs
@@ -11,7 +11,7 @@ RightParenthesis
   = ")" { return { type: 'RightParenthesis', content: ')' } }
 
 Keyword
-  = Keyword:("ADD"i / "ALL"i / "ALTER"i / "AND"i / "ANY"i / "AS"i / "ASC"i / "BACKUP"i / "BETWEEN"i / "BY"i / "CASE"i / "CHECK"i / "COLUMN"i / "CONSTRAINT"i / "COUNT"i / "CREATE"i / "DATABASE"i / "DEFAULT"i / "DELETE"i / "DESC"i / "DISTINCT"i / "DROP"i / "EXEC"i / "EXISTS"i / "FOREIGN"i / "FROM"i / "FROM"i / "FULL"i / "GROUP"i / "HAVING"i / "INNER"i / "INSERT"i / "JOIN"i / "KEY"i / "LEFT"i / "LIMIT"i / "OFFSET"i / "ON"i / "ORDER"i / "OUTER"i / "RETURNING"i / "RIGHT"i / "SELECT"i / "SELECT"i / "TABLE"i / "UPDATE"i / "VALUES"i / "WHERE"i / JoinKeyword) & (Whitespace / LeftParenthesis / RightParenthesis) {
+  = Keyword:("ADD"i / "ALL"i / "ALTER"i / "AND"i / "ANY"i / "AS"i / "ASC"i / "BACKUP"i / "BETWEEN"i / "BY"i / "CASE"i / "CHECK"i / "COLUMN"i / "CONSTRAINT"i / "COUNT"i / "CREATE"i / "DATABASE"i / "DEFAULT"i / "DELETE"i / "DESC"i / "DISTINCT"i / "DROP"i / "EXEC"i / "EXISTS"i / "FOREIGN"i / "FROM"i / "FROM"i / "FULL"i / "GROUP"i / "HAVING"i / "INNER"i / "INSERT"i / "JOIN"i / "KEY"i / "LEFT"i / "LIMIT"i / "OFFSET"i / "ON"i / "ORDER"i / "OUTER"i / "RETURNING"i / "RIGHT"i / "SELECT"i / "SELECT"i / "SET"i / "TABLE"i / "UPDATE"i / "VALUES"i / "WHERE"i / JoinKeyword) & (Whitespace / LeftParenthesis / RightParenthesis) {
   return { type: 'Keyword', content: Keyword.toUpperCase() }
 }
 


### PR DESCRIPTION
**Before:**

- `SET` should be capital, but is not
- `COUNTry` should not be capital, but is

<img width="847" alt="Screenshot 2023-08-29 at 1 46 09 PM" src="https://github.com/getsentry/sentry/assets/989898/2cbe154b-7f51-43a7-9952-07a9ffbee6ac">

**After:**
<img width="696" alt="Screenshot 2023-08-29 at 1 47 22 PM" src="https://github.com/getsentry/sentry/assets/989898/b4cef6d8-e53f-4fa3-982e-6d566a7e5332">


- Add spec for parsing keywords
- Keywords must be followed by whitespace or paren
- Add "SET" keyword
