### PR TITLE
fix(ui): Make toast indicator undo text more readable

### DIFF
--- a/static/app/components/alerts/toastIndicator.tsx
+++ b/static/app/components/alerts/toastIndicator.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import {motion} from 'framer-motion';
 
 import {Indicator} from 'sentry/actionCreators/indicator';
+import {Button} from 'sentry/components/button';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconCheckmark, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -50,7 +51,11 @@ function ToastIndicator({indicator, onDismiss, className, ...props}: Props) {
         <Icon type={type}>{icon}</Icon>
       )}
       <Message>{message}</Message>
-      {showUndo && <Undo onClick={undo}>{t('Undo')}</Undo>}
+      {showUndo && (
+        <Undo priority="link" onClick={undo}>
+          {t('Undo')}
+        </Undo>
+      )}
     </Toast>
   );
 }
@@ -103,15 +108,12 @@ const Message = styled('div')`
   ${p => p.theme.overflowEllipsis}
 `;
 
-const Undo = styled('div')`
-  display: inline-block;
-  color: ${p => p.theme.linkColor};
-  padding-left: ${space(1)};
-  margin-left: ${space(1)};
-  cursor: pointer;
+const Undo = styled(Button)`
+  color: ${p => p.theme.inverted.linkColor};
+  margin-left: ${space(2)};
 
   &:hover {
-    color: ${p => p.theme.linkHoverColor};
+    color: ${p => p.theme.inverted.linkHoverColor};
   }
 `;
 


### PR DESCRIPTION
It also used to be a div . It's now a button as it should have been.

Before: 

![image](https://github.com/getsentry/sentry/assets/10888943/d84d018b-c3d4-41fd-8637-b51bbf1d68c1)

After:

![CleanShot 2023-08-29 at 11 05 07](https://github.com/getsentry/sentry/assets/10888943/ec3332aa-bfde-4d07-807b-ff346b9e3270)

