### PR TITLE
fix(ui): Mini-ify hovercard loading indicator

### DIFF
--- a/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
@@ -18,7 +18,8 @@ export function NoContext({isLoading}: NoContextProps) {
       <LoadingIndicator
         data-test-id="quick-context-loading-indicator"
         hideMessage
-        size={32}
+        mini
+        style={{width: '24px'}}
       />
     </NoContextWrapper>
   ) : (


### PR DESCRIPTION
Before: 
![image](https://github.com/getsentry/sentry/assets/9372512/296f2561-a250-4ed5-a31c-c08cd2fca306)


After: <img width="932" alt="Screenshot 2023-08-29 at 11 04 24 AM" src="https://github.com/getsentry/sentry/assets/9372512/76c0605a-58e6-4c34-bdd9-677e67b4779c">
