### PR TITLE
feat(settings): Add Ownership Rule Edit Audit Log Entry Event

### DIFF
--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -24,7 +24,6 @@ class ProjectOwnershipSerializer(serializers.Serializer):
     fallthrough = serializers.BooleanField()
     autoAssignment = serializers.CharField(allow_blank=False)
     codeownersAutoSync = serializers.BooleanField(default=True)
-    updateType = serializers.CharField(allow_blank=True)
 
     @staticmethod
     def _validate_no_codeowners(rules):

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -111,12 +111,6 @@ class ProjectOwnershipSerializer(serializers.Serializer):
                 ownership.codeowners_auto_sync = codeowners_auto_sync
                 changed = True
 
-        if "updateType" in self.validated_data:
-            update_type = self.validated_data["updateType"]
-            if ownership.update_type != update_type:
-                ownership.update_type = update_type
-                changed = True
-
         changed = self.__modify_auto_assignment(ownership) or changed
 
         if changed:

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -24,6 +24,7 @@ class ProjectOwnershipSerializer(serializers.Serializer):
     fallthrough = serializers.BooleanField()
     autoAssignment = serializers.CharField(allow_blank=False)
     codeownersAutoSync = serializers.BooleanField(default=True)
+    updateType = serializers.CharField(allow_blank=True)
 
     @staticmethod
     def _validate_no_codeowners(rules):
@@ -108,6 +109,12 @@ class ProjectOwnershipSerializer(serializers.Serializer):
             codeowners_auto_sync = self.validated_data["codeownersAutoSync"]
             if ownership.codeowners_auto_sync != codeowners_auto_sync:
                 ownership.codeowners_auto_sync = codeowners_auto_sync
+                changed = True
+
+        if "updateType" in self.validated_data:
+            update_type = self.validated_data["updateType"]
+            if ownership.update_type != update_type:
+                ownership.update_type = update_type
                 changed = True
 
         changed = self.__modify_auto_assignment(ownership) or changed
@@ -262,7 +269,7 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
                 actor=request.user,
                 organization=project.organization,
                 target_object=project.id,
-                event=audit_log.get_event_id("PROJECT_EDIT"),
+                event=audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT"),
                 data={**change_data, **project.get_audit_log_data()},
             )
             ownership_rule_created.send_robust(project=project, sender=self.__class__)

--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -175,16 +175,7 @@ class ProjectOwnershipRuleEditAuditLogEvent(AuditLogEvent):
         )
 
     def render(self, audit_log_entry: AuditLogEntry):
-        try:
-            update_type = audit_log_entry.data["updateType"]
-        except Exception:
-            update_type = None
-        if update_type == "addition":
-            return "added ownership rules"
-        elif update_type == "deletion":
-            return "deleted ownership rules"
-        else:
-            return "modified ownership rules"
+        return "modified ownership rules"
 
 
 class SSOEditAuditLogEvent(AuditLogEvent):

--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -168,6 +168,22 @@ class ProjectDisableAuditLogEvent(AuditLogEvent):
         return render_project_action(audit_log_entry, "disable")
 
 
+class ProjectOwnershipRuleEditAuditLogEvent(AuditLogEvent):
+    def __init__(self):
+        super().__init__(
+            event_id=179, name="PROJECT_OWNERSHIPRULE_EDIT", api_name="project.ownership-rule.edit"
+        )
+
+    def render(self, audit_log_entry: AuditLogEntry):
+        update_type = audit_log_entry.data["updateType"]
+        if update_type == "addition":
+            return "added ownership rules"
+        elif update_type == "deletion":
+            return "deleted ownership rules"
+        else:
+            return "modified ownership rules"
+
+
 class SSOEditAuditLogEvent(AuditLogEvent):
     def __init__(self):
         super().__init__(event_id=62, name="SSO_EDIT", api_name="sso.edit")

--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -175,7 +175,10 @@ class ProjectOwnershipRuleEditAuditLogEvent(AuditLogEvent):
         )
 
     def render(self, audit_log_entry: AuditLogEntry):
-        update_type = audit_log_entry.data["updateType"]
+        try:
+            update_type = audit_log_entry.data["updateType"]
+        except Exception:
+            update_type = None
         if update_type == "addition":
             return "added ownership rules"
         elif update_type == "deletion":

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -393,3 +393,4 @@ default_manager.add(
         template="removed org auth token {name}",
     )
 )
+default_manager.add(events.ProjectOwnershipRuleEditAuditLogEvent())

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -172,9 +172,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
 
     def test_audit_log_ownership_change(self):
         with outbox_runner():
-            resp = self.client.put(
-                self.path, {"raw": "*.js admin@localhost #tiger-team", "updateType": "addition"}
-            )
+            resp = self.client.put(self.path, {"raw": "*.js admin@localhost #tiger-team"})
         assert resp.status_code == 200
 
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -185,7 +183,6 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
             )
         assert len(auditlog) == 1
         assert "modified" in auditlog[0].data["ownership_rules"]
-        assert "addition" in auditlog[0].data["updateType"]
 
     @with_feature("organizations:streamline-targeting-context")
     def test_update_with_streamline_targeting(self):

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -164,7 +164,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             auditlog = AuditLogEntry.objects.filter(
                 organization_id=self.project.organization.id,
-                event=audit_log.get_event_id("PROJECT_EDIT"),
+                event=audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT"),
                 target_object=self.project.id,
             )
         assert len(auditlog) == 1
@@ -172,17 +172,20 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
 
     def test_audit_log_ownership_change(self):
         with outbox_runner():
-            resp = self.client.put(self.path, {"raw": "*.js admin@localhost #tiger-team"})
+            resp = self.client.put(
+                self.path, {"raw": "*.js admin@localhost #tiger-team", "updateType": "addition"}
+            )
         assert resp.status_code == 200
 
         with assume_test_silo_mode(SiloMode.CONTROL):
             auditlog = AuditLogEntry.objects.filter(
                 organization_id=self.project.organization.id,
-                event=audit_log.get_event_id("PROJECT_EDIT"),
+                event=audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT"),
                 target_object=self.project.id,
             )
         assert len(auditlog) == 1
         assert "modified" in auditlog[0].data["ownership_rules"]
+        assert "addition" in auditlog[0].data["updateType"]
 
     @with_feature("organizations:streamline-targeting-context")
     def test_update_with_streamline_targeting(self):

--- a/tests/sentry/audit_log/test_register.py
+++ b/tests/sentry/audit_log/test_register.py
@@ -31,6 +31,7 @@ class AuditLogEventRegisterTest(TestCase):
             "project.accept-transfer",
             "project.enable",
             "project.disable",
+            "project.ownership-rule.edit",
             "tagkey.remove",
             "projectkey.create",
             "projectkey.edit",

--- a/tests/sentry/utils/test_audit.py
+++ b/tests/sentry/utils/test_audit.py
@@ -301,52 +301,7 @@ class CreateAuditEntryTest(TestCase):
             == "edited project performance issue detector settings to enable detection of File IO on Main Thread issue"
         )
 
-    def test_audit_entry_project_ownership_rule_edit_addition(self):
-        entry = create_audit_entry(
-            request=self.req,
-            organization=self.org,
-            target_object=self.project.id,
-            event=audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT"),
-            data={"updateType": "addition"},
-        )
-        audit_log_event = audit_log.get(entry.event)
-
-        assert entry.actor == self.user
-        assert entry.target_object == self.project.id
-        assert entry.event == audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT")
-        assert audit_log_event.render(entry) == "added ownership rules"
-
-    def test_audit_entry_project_ownership_rule_edit_deletion(self):
-        entry = create_audit_entry(
-            request=self.req,
-            organization=self.org,
-            target_object=self.project.id,
-            event=audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT"),
-            data={"updateType": "deletion"},
-        )
-        audit_log_event = audit_log.get(entry.event)
-
-        assert entry.actor == self.user
-        assert entry.target_object == self.project.id
-        assert entry.event == audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT")
-        assert audit_log_event.render(entry) == "deleted ownership rules"
-
-    def test_audit_entry_project_ownership_rule_edit_modification(self):
-        entry = create_audit_entry(
-            request=self.req,
-            organization=self.org,
-            target_object=self.project.id,
-            event=audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT"),
-            data={"updateType": "modification"},
-        )
-        audit_log_event = audit_log.get(entry.event)
-
-        assert entry.actor == self.user
-        assert entry.target_object == self.project.id
-        assert entry.event == audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT")
-        assert audit_log_event.render(entry) == "modified ownership rules"
-
-    def test_audit_entry_project_ownership_rule_edit_no_update_type(self):
+    def test_audit_entry_project_ownership_rule_edit(self):
         entry = create_audit_entry(
             request=self.req,
             organization=self.org,

--- a/tests/sentry/utils/test_audit.py
+++ b/tests/sentry/utils/test_audit.py
@@ -301,6 +301,65 @@ class CreateAuditEntryTest(TestCase):
             == "edited project performance issue detector settings to enable detection of File IO on Main Thread issue"
         )
 
+    def test_audit_entry_project_ownership_rule_edit_addition(self):
+        entry = create_audit_entry(
+            request=self.req,
+            organization=self.org,
+            target_object=self.project.id,
+            event=audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT"),
+            data={"updateType": "addition"},
+        )
+        audit_log_event = audit_log.get(entry.event)
+
+        assert entry.actor == self.user
+        assert entry.target_object == self.project.id
+        assert entry.event == audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT")
+        assert audit_log_event.render(entry) == "added ownership rules"
+
+    def test_audit_entry_project_ownership_rule_edit_deletion(self):
+        entry = create_audit_entry(
+            request=self.req,
+            organization=self.org,
+            target_object=self.project.id,
+            event=audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT"),
+            data={"updateType": "deletion"},
+        )
+        audit_log_event = audit_log.get(entry.event)
+
+        assert entry.actor == self.user
+        assert entry.target_object == self.project.id
+        assert entry.event == audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT")
+        assert audit_log_event.render(entry) == "deleted ownership rules"
+
+    def test_audit_entry_project_ownership_rule_edit_modification(self):
+        entry = create_audit_entry(
+            request=self.req,
+            organization=self.org,
+            target_object=self.project.id,
+            event=audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT"),
+            data={"updateType": "modification"},
+        )
+        audit_log_event = audit_log.get(entry.event)
+
+        assert entry.actor == self.user
+        assert entry.target_object == self.project.id
+        assert entry.event == audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT")
+        assert audit_log_event.render(entry) == "modified ownership rules"
+
+    def test_audit_entry_project_ownership_rule_edit_no_update_type(self):
+        entry = create_audit_entry(
+            request=self.req,
+            organization=self.org,
+            target_object=self.project.id,
+            event=audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT"),
+        )
+        audit_log_event = audit_log.get(entry.event)
+
+        assert entry.actor == self.user
+        assert entry.target_object == self.project.id
+        assert entry.event == audit_log.get_event_id("PROJECT_OWNERSHIPRULE_EDIT")
+        assert audit_log_event.render(entry) == "modified ownership rules"
+
     def test_audit_entry_integration_log(self):
         project = self.create_project()
         self.login_as(user=self.user)


### PR DESCRIPTION
<!-- Describe your PR here. -->

At the moment, ownership rule changes are tracked as "project.edit" events. This PR adds the "project.ownership-rule.edit" event key, allowing us to format ownership rule changes in the audit log in a way a bit more specific to ownership rule changes (as opposed to being treated the same as other project edits).

Next steps:
- Reflecting these changes in the UI so our audit entries are a bit more human-readable (see below for an example of the audit log showing me adding, modifying, and deleting ownership rules respectively in the current UI 😄)

![image](https://github.com/getsentry/sentry/assets/45607721/145c1629-6946-42ca-91ae-4874057a48fb)