### PR TITLE
fix(metrics): Set Metrics Interface backend to Kafka in self-hosted

### DIFF
--- a/self-hosted/sentry.conf.py
+++ b/self-hosted/sentry.conf.py
@@ -262,3 +262,9 @@ if "SENTRY_RUNNING_UWSGI" not in os.environ and len(secret_key) < 32:
     print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 
 SENTRY_OPTIONS["system.secret-key"] = secret_key
+
+##################
+# Sentry Metrics #
+##################
+
+SENTRY_METRICS_INTERFACE_BACKEND = "sentry.sentry_metrics.client.kafka.KafkaMetricsBackend"


### PR DESCRIPTION
The default behavior is for this backend to be pointing at the Snuba backend, which is incorrect. We want to be using the backend which directly produces the metrics onto the indexer (in the generic metrics platform), which is the Kafka-based backend.