### PR TITLE
feat(settings): Make Ownership Rule Changes More Readable in Audit Log

### DIFF
--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -197,6 +197,7 @@ export type Frame = {
   mapUrl?: string | null;
   minGroupingLevel?: number;
   origAbsPath?: string | null;
+  sourceLink?: string;
   symbolicatorStatus?: SymbolicatorStatus;
 };
 

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -212,6 +212,28 @@ function AuditNote({
     );
   }
 
+  if (entry.event === 'project.ownership-rule.edit') {
+    let keyword = 'Modified';
+    if (entry.data.updateType === 'addition') {
+      keyword = 'Added';
+    } else if (entry.data.updateType === 'deletion') {
+      keyword = 'Deleted';
+    }
+
+    return (
+      <Note>
+        {tct('[keyword] ownership rules in project [projectSettingsLink]', {
+          keyword,
+          projectSettingsLink: (
+            <Link to={`/settings/${orgSlug}/projects/${project.slug}/`}>
+              {entry.data.slug}
+            </Link>
+          ),
+        })}
+      </Note>
+    );
+  }
+
   return <Note>{entry.note}</Note>;
 }
 

--- a/static/app/views/settings/project/projectOwnership/ownerInput.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownerInput.tsx
@@ -73,13 +73,23 @@ class OwnerInput extends Component<Props, State> {
     const {organization, project, onSave, page, initialText} = this.props;
     const {text} = this.state;
     this.setState({error: null});
+    let updateType = 'modification';
+
+    const originalRules = initialText.split('\n');
+    const newRules = text?.split('\n') || [];
+
+    if (originalRules.length > newRules.length) {
+      updateType = 'deletion';
+    } else if (originalRules.length < newRules.length) {
+      updateType = 'addition';
+    }
 
     const api = new Client();
     const request = api.requestPromise(
       `/projects/${organization.slug}/${project.slug}/ownership/`,
       {
         method: 'PUT',
-        data: {raw: text || ''},
+        data: {raw: text || '', updateType},
       }
     );
 


### PR DESCRIPTION

<!-- Describe your PR here. -->
This PR makes project ownership rule changes just a bit easier to understand in the audit log based on changes made to the ownership rule change event in the backend [here](https://github.com/getsentry/sentry/pull/55373).

(im gonna remake this pr later pls ignore)

# From this...
![image](https://github.com/getsentry/sentry/assets/45607721/6604dbf1-0810-4fa1-8e14-6ed14e1c4dab)


# To this!
![Screenshot 2023-08-29 at 11 56 10 AM](https://github.com/getsentry/sentry/assets/45607721/82f711fc-34fa-4cb3-adcf-ad689f2c7e10)
