### PR TITLE
fix(perf): Isolate endpoint table cursor

### DIFF
--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -43,7 +43,7 @@ type Query = {
   endpointMethod: string;
   transaction: string;
   transactionMethod: string;
-  [QueryParameterNames.SORT]: string;
+  [QueryParameterNames.SPANS_SORT]: string;
 };
 
 type Props = {

--- a/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
@@ -54,7 +54,7 @@ export const renderHeadCell = ({column, location, sort}: Options) => {
           ...location,
           query: {
             ...location?.query,
-            [QueryParameterNames.SORT]: newSort,
+            [QueryParameterNames.SPANS_SORT]: newSort,
           },
         };
       }}

--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -54,11 +54,11 @@ export function SpanDescriptionCell({
     endpointMethod,
   };
 
-  const sort: string | undefined = queryString[QueryParameterNames.SORT];
+  const sort: string | undefined = queryString[QueryParameterNames.SPANS_SORT];
 
   // the spans page uses time_spent_percentage(local), so to persist the sort upon navigation we need to replace
   if (sort?.includes(`${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`)) {
-    queryString[QueryParameterNames.SORT] = sort.replace(
+    queryString[QueryParameterNames.SPANS_SORT] = sort.replace(
       `${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`,
       `${StarfishFunctions.TIME_SPENT_PERCENTAGE}(local)`
     );

--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -24,7 +24,8 @@ export type SpanTransactionMetrics = {
 export const useSpanTransactionMetrics = (
   group: string,
   options: {sorts?: Sort[]; transactions?: string[]},
-  referrer = 'api.starfish.span-transaction-metrics'
+  referrer = 'api.starfish.span-transaction-metrics',
+  cursor?: string
 ) => {
   const location = useLocation();
 
@@ -38,6 +39,7 @@ export const useSpanTransactionMetrics = (
     enabled: Boolean(group),
     limit: 25,
     referrer,
+    cursor,
   });
 };
 

--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -24,7 +24,7 @@ export type SpanTransactionMetrics = {
 export const useSpanTransactionMetrics = (
   group: string,
   options: {sorts?: Sort[]; transactions?: string[]},
-  _referrer = 'api.starfish.span-transaction-metrics'
+  referrer = 'api.starfish.span-transaction-metrics'
 ) => {
   const location = useLocation();
 
@@ -37,7 +37,7 @@ export const useSpanTransactionMetrics = (
     initialData: [],
     enabled: Boolean(group),
     limit: 25,
-    referrer: _referrer,
+    referrer,
   });
 };
 

--- a/static/app/views/starfish/views/queryParameters.tsx
+++ b/static/app/views/starfish/views/queryParameters.tsx
@@ -1,5 +1,5 @@
 export enum QueryParameterNames {
   SPANS_CURSOR = 'spansCursor',
+  SPANS_SORT = 'spansSort',
   ENDPOINTS_CURSOR = 'endpointsCursor',
-  SORT = 'spansSort',
 }

--- a/static/app/views/starfish/views/queryParameters.tsx
+++ b/static/app/views/starfish/views/queryParameters.tsx
@@ -1,4 +1,5 @@
 export enum QueryParameterNames {
   SPANS_CURSOR = 'spansCursor',
+  ENDPOINTS_CURSOR = 'endpointsCursor',
   SORT = 'spansSort',
 }

--- a/static/app/views/starfish/views/queryParameters.tsx
+++ b/static/app/views/starfish/views/queryParameters.tsx
@@ -1,4 +1,4 @@
 export enum QueryParameterNames {
-  CURSOR = 'spansCursor',
+  SPANS_CURSOR = 'spansCursor',
   SORT = 'spansSort',
 }

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -36,7 +36,7 @@ type Query = {
   endpointMethod: string;
   transaction: string;
   transactionMethod: string;
-  [QueryParameterNames.SORT]: string;
+  [QueryParameterNames.SPANS_SORT]: string;
 };
 
 type Props = {
@@ -54,7 +54,7 @@ function SpanSummaryPage({params, location}: Props) {
     : {};
 
   const sort =
-    fromSorts(location.query[QueryParameterNames.SORT]).filter(isAValidSort)[0] ??
+    fromSorts(location.query[QueryParameterNames.SPANS_SORT]).filter(isAValidSort)[0] ??
     DEFAULT_SORT; // We only allow one sort on this table in this view
 
   if (endpointMethod && queryFilter) {

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -62,7 +62,7 @@ export default function SpansTable({
   const location = useLocation();
   const organization = useOrganization();
 
-  const spansCursor = decodeScalar(location.query?.[QueryParameterNames.CURSOR]);
+  const spansCursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
 
   const {isLoading, data, meta, pageLinks} = useSpanList(
     moduleName ?? ModuleName.ALL,
@@ -78,7 +78,7 @@ export default function SpansTable({
   const handleCursor: CursorHandler = (cursor, pathname, query) => {
     browserHistory.push({
       pathname,
-      query: {...query, [QueryParameterNames.CURSOR]: cursor},
+      query: {...query, [QueryParameterNames.SPANS_CURSOR]: cursor},
     });
   };
 

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -62,7 +62,7 @@ export default function SpansTable({
   const location = useLocation();
   const organization = useOrganization();
 
-  const spansCursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
+  const cursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
 
   const {isLoading, data, meta, pageLinks} = useSpanList(
     moduleName ?? ModuleName.ALL,
@@ -72,13 +72,13 @@ export default function SpansTable({
     [sort],
     limit,
     'api.starfish.use-span-list',
-    spansCursor
+    cursor
   );
 
-  const handleCursor: CursorHandler = (cursor, pathname, query) => {
+  const handleCursor: CursorHandler = (newCursor, pathname, query) => {
     browserHistory.push({
       pathname,
-      query: {...query, [QueryParameterNames.SPANS_CURSOR]: cursor},
+      query: {...query, [QueryParameterNames.SPANS_CURSOR]: newCursor},
     });
   };
 

--- a/static/app/views/starfish/views/spans/useModuleSort.ts
+++ b/static/app/views/starfish/views/spans/useModuleSort.ts
@@ -5,7 +5,7 @@ import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types'
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 
 type Query = {
-  [QueryParameterNames.SORT]: string;
+  [QueryParameterNames.SPANS_SORT]: string;
 };
 
 const SORTABLE_FIELDS = [
@@ -28,7 +28,7 @@ export function useModuleSort(fallback: Sort = DEFAULT_SORT) {
   const location = useLocation<Query>();
 
   return (
-    fromSorts(location.query[QueryParameterNames.SORT]).filter(isAValidSort)[0] ??
+    fromSorts(location.query[QueryParameterNames.SPANS_SORT]).filter(isAValidSort)[0] ??
     fallback
   );
 }


### PR DESCRIPTION
Paginating the endpoints table breaks _everything_ because all our Discover queries automatically pick up the `cursor=` URL parameter, which the endpoint pagination changes. Since we _only_ want to paginate the table cursor, I'm isolating it. We do the same thing for the spans table! Paginating through the endpoints only changes the `endpointsCursor` parameter, so the `cursor=` parameter is never filled, so all the queries work correctly because they don't specify a cursor.

- Rename spans cursor parameter name
- Rename span sort parameter name
- Fix incorrect argument name
- Clarify cursor variable names
- Allow span transactions hook to accept cursor
- Isolate endpoint list cursor
