### PR TITLE
chore(integrations): change key TTL from 30 days to 8 days

### DIFF
--- a/src/sentry/integrations/request_buffer.py
+++ b/src/sentry/integrations/request_buffer.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from sentry.utils import redis
 
 BUFFER_SIZE = 30  # 30 days
-KEY_EXPIRY = 60 * 60 * 24 * 30  # 30 days
+KEY_EXPIRY = 60 * 60 * 24 * 8  # 8 days
 
 BROKEN_RANGE_DAYS = 7  # 7 days
 


### PR DESCRIPTION
Since we only use a 7 day window we can lower the key expiry from 30 days

