### PR TITLE
fix(replays): add tag replayId to event linking

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -844,6 +844,18 @@ def process_snoozes(job: PostProcessJob) -> None:
 
 
 def process_replay_link(job: PostProcessJob) -> None:
+    def _get_replay_id(event):
+        # replay ids can either come as a context, or a tag.
+        # right now they come as a context on non-js events,
+        # and javascript transaction (through DSC context)
+        # It comes as a tag on js errors.
+        # TODO: normalize this upstream in relay and javascript SDK. and eventually remove the tag
+        # logic.
+        context_replay_id = event.data.get("contexts", {}).get("replay", {}).get("replay_id")
+        tag_replay_id = event.get_tag("replayId")
+
+        return context_replay_id or tag_replay_id
+
     if job["is_reprocessed"]:
         return
 
@@ -856,7 +868,8 @@ def process_replay_link(job: PostProcessJob) -> None:
     metrics.incr("post_process.process_replay_link.id_sampled")
 
     group_event = job["event"]
-    if not group_event.data.get("contexts", {}).get("replay", {}).get("replay_id"):
+    replay_id = _get_replay_id(group_event)
+    if not replay_id:
         return
 
     metrics.incr("post_process.process_replay_link.id_exists")

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -852,9 +852,8 @@ def process_replay_link(job: PostProcessJob) -> None:
         # TODO: normalize this upstream in relay and javascript SDK. and eventually remove the tag
         # logic.
         context_replay_id = event.data.get("contexts", {}).get("replay", {}).get("replay_id")
-        tag_replay_id = event.get_tag("replayId")
 
-        return context_replay_id or tag_replay_id
+        return context_replay_id or event.get_tag("replayId")
 
     if job["is_reprocessed"]:
         return

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1663,6 +1663,23 @@ class ReplayLinkageTestMixin(BasePostProgressGroupMixin):
             incr.assert_any_call("post_process.process_replay_link.id_sampled")
             incr.assert_any_call("post_process.process_replay_link.id_exists")
 
+    def test_replay_linkage_with_tag(self, incr):
+        replay_id = uuid.uuid4().hex
+        event = self.create_event(
+            data={"message": "testing", "tags": {"replayId": replay_id}},
+            project_id=self.project.id,
+        )
+
+        with self.feature({"organizations:session-replay-event-linking": True}):
+            self.call_post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                event=event,
+            )
+            incr.assert_any_call("post_process.process_replay_link.id_sampled")
+            incr.assert_any_call("post_process.process_replay_link.id_exists")
+
     def test_no_replay(self, incr):
         event = self.create_event(
             data={"message": "testing"},


### PR DESCRIPTION
Frontend JS SDK does not send DSC on errors, therefore the replay comes in as a tag. We will eventually align this in the JS SDK / upstream in relay. For now, look for both to get the replay_id in post_process