### PR TITLE
feat(severity): Add first event severity to new groups

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3482,6 +3482,11 @@ if int(PG_VERSION.split(".", maxsplit=1)[0]) < 12:
 ANOMALY_DETECTION_URL = "127.0.0.1:9091"
 ANOMALY_DETECTION_TIMEOUT = 30
 
+# TODO: Once this moves to its own service, this URL will need to be updated
+SEVERITY_DETECTION_URL = ANOMALY_DETECTION_URL
+SEVERITY_DETECTION_TIMEOUT = 0.3  # 300 milliseconds
+SEVERITY_DETECTION_RETRIES = 1
+
 # This is the URL to the profiling service
 SENTRY_VROOM = os.getenv("VROOM", "http://127.0.0.1:8085")
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1828,10 +1828,19 @@ def _create_group(project: Project, event: Event, **kwargs: Any) -> Group:
         else None
     )
 
+    # get severity score for use in alerting
+    group_data = kwargs.pop("data", {})
+    if features.has("projects:first-event-severity-calculation", event.project):
+        severity = _get_severity_score(event)
+        if severity:
+            group_data.setdefault("metadata", {})
+            group_data["metadata"]["severity"] = severity
+
     return Group.objects.create(
         project=project,
         short_id=short_id,
         first_release_id=first_release_id,
+        data=group_data,
         **kwargs,
     )
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -12,6 +12,8 @@ from django.test.utils import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework.status import HTTP_404_NOT_FOUND
+from urllib3 import HTTPResponse
+from urllib3.exceptions import MaxRetryError
 
 from fixtures.github import (
     COMPARE_COMMITS_EXAMPLE_WITH_INTERMEDIATE,
@@ -34,10 +36,12 @@ from sentry.event_manager import (
     EventManager,
     HashDiscarded,
     _get_event_instance,
+    _get_severity_score,
     _save_grouphash_and_group,
     get_event_type,
     has_pending_commit_resolution,
     materialize_metadata,
+    severity_connection_pool,
 )
 from sentry.eventstore.models import Event
 from sentry.grouping.utils import hash_from_values
@@ -2493,6 +2497,121 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
             metrics_logged = [call.args[0] for call in mock_metrics_incr.mock_calls]
             assert "grouping.in_app_frame_mix" not in metrics_logged
+
+    @patch(
+        "sentry.event_manager.severity_connection_pool.urlopen",
+        return_value=HTTPResponse(body=json.dumps({"severity": 0.1231})),
+    )
+    def test_get_severity_score_simple(self, mock_urlopen: MagicMock) -> None:
+        manager = EventManager(
+            make_event(exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]})
+        )
+        event = manager.save(self.project.id)
+
+        severity = _get_severity_score(event)
+
+        mock_urlopen.assert_called_with(
+            "POST",
+            "/issues/severity-score",
+            body='{"message":"NopeError: Nopey McNopeface"}',
+            headers={"content-type": "application/json;charset=utf-8"},
+        )
+        assert severity == 0.1231
+
+    @patch(
+        "sentry.event_manager.severity_connection_pool.urlopen",
+        return_value=HTTPResponse(body=json.dumps({"severity": 0.1231})),
+    )
+    def test_get_severity_score_no_message(self, mock_urlopen: MagicMock) -> None:
+        manager = EventManager(make_event())
+        event = manager.save(self.project.id)
+
+        severity = _get_severity_score(event)
+
+        mock_urlopen.assert_not_called()
+        assert severity is None
+
+    @patch(
+        "sentry.event_manager.severity_connection_pool.urlopen",
+        side_effect=MaxRetryError(
+            severity_connection_pool, "/issues/severity-score", Exception("It broke")
+        ),
+    )
+    @patch("sentry.event_manager.logger.warning")
+    def test_get_severity_score_max_retry_exception(
+        self,
+        mock_logger_warning: MagicMock,
+        _mock_urlopen: MagicMock,
+    ) -> None:
+        manager = EventManager(
+            make_event(exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]})
+        )
+        event = manager.save(self.project.id)
+
+        severity = _get_severity_score(event)
+
+        warning_call_args = mock_logger_warning.call_args.args
+        warning_call_kwargs = mock_logger_warning.call_args.kwargs
+
+        assert warning_call_args == (
+            "Unable to get severity score from microservice after 1 retry. Got MaxRetryError caused by: Exception('It broke').",
+        )
+        assert warning_call_kwargs["extra"]["event_id"] == event.event_id
+        assert repr(warning_call_kwargs["extra"]["reason"]) == repr(Exception("It broke"))
+        assert severity is None
+
+    @patch(
+        "sentry.event_manager.severity_connection_pool.urlopen",
+        side_effect=Exception("It broke"),
+    )
+    @patch("sentry.event_manager.logger.warning")
+    def test_get_severity_score_other_exception(
+        self,
+        mock_logger_warning: MagicMock,
+        _mock_urlopen: MagicMock,
+    ) -> None:
+        manager = EventManager(
+            make_event(exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]})
+        )
+        event = manager.save(self.project.id)
+
+        severity = _get_severity_score(event)
+
+        warning_call_args = mock_logger_warning.call_args.args
+        warning_call_kwargs = mock_logger_warning.call_args.kwargs
+
+        assert warning_call_args == (
+            "Unable to get severity score from microservice. Got: Exception('It broke').",
+        )
+        assert warning_call_kwargs["extra"]["event_id"] == event.event_id
+        assert repr(warning_call_kwargs["extra"]["reason"]) == repr(Exception("It broke"))
+        assert severity is None
+
+    @patch("sentry.event_manager._get_severity_score", return_value=0.1121)
+    def test_severity_score_flag_on(self, mock_get_severity_score: MagicMock):
+        with self.feature({"projects:first-event-severity-calculation": True}):
+            manager = EventManager(
+                make_event(
+                    exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]}
+                )
+            )
+            event = manager.save(self.project.id)
+
+            mock_get_severity_score.assert_called()
+            assert event.group and event.group.get_event_metadata()["severity"] == 0.1121
+
+    @patch("sentry.event_manager._get_severity_score", return_value=0.1121)
+    def test_severity_score_flag_off(self, mock_get_severity_score: MagicMock):
+        with self.feature({"projects:first-event-severity-calculation": False}):
+            manager = EventManager(
+                make_event(
+                    exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]}
+                )
+            )
+            event = manager.save(self.project.id)
+
+            mock_get_severity_score.assert_not_called()
+            assert event.group and event.group.get_event_metadata().get("severity") is None
 
 
 class AutoAssociateCommitTest(TestCase, EventManagerTestMixin):


### PR DESCRIPTION
This adds first-event severity calculation to group creation, using a helper function to call the new [severity microservice](https://github.com/getsentry/sentry/issues/54248). The code for computing the event's message is based on [the code which calculates an event's title](https://github.com/getsentry/sentry/blob/cec2d362b6d23859114d7c71173c57e98fb3cc73/src/sentry/eventtypes/error.py#L104-L109) (minus the truncation). Calling the API is gated by the `projects:first-event-severity-calculation` flag added in https://github.com/getsentry/getsentry/pull/11506, which itself depends on both the project id (for now, just the `sentry` project in our Sentry instance) and the new `processing.calculate-severity-on-group-creation` option.

Ref: https://github.com/getsentry/sentry/issues/54249
Ref: https://github.com/getsentry/sentry/issues/54250