### PR TITLE
feat(statistical-detectors): Change the name of the group class and a slug

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -18,7 +18,7 @@ from sentry import features
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.issues.grouptype import PerformanceP95TransactionDurationRegressionGroupType
+from sentry.issues.grouptype import PerformanceDurationRegressionGroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.producer import produce_occurrence_to_kafka
 from sentry.net.http import connection_from_url
@@ -401,8 +401,8 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                     project_id=project_id,
                     event_id=uuid.uuid4().hex,
                     fingerprint=[fingerprint_regression(qualifying_trend)],
-                    type=PerformanceP95TransactionDurationRegressionGroupType,
-                    issue_title=PerformanceP95TransactionDurationRegressionGroupType.description,
+                    type=PerformanceDurationRegressionGroupType,
+                    issue_title=PerformanceDurationRegressionGroupType.description,
                     subtitle=f"Increased from {displayed_old_baseline}ms to {displayed_new_baseline}ms (P95)",
                     culprit=qualifying_trend["transaction"],
                     evidence_data=qualifying_trend,

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -319,9 +319,9 @@ class PerformanceHTTPOverheadGroupType(PerformanceGroupTypeDefaults, GroupType):
 
 
 @dataclass(frozen=True)
-class PerformanceP95TransactionDurationRegressionGroupType(PerformanceGroupTypeDefaults, GroupType):
+class PerformanceDurationRegressionGroupType(PerformanceGroupTypeDefaults, GroupType):
     type_id = 1017
-    slug = "performance_p95_transaction_duration_regression"
+    slug = "performance_duration_regression"
     description = "Duration Regression"
     noise_config = NoiseConfig(ignore_limit=0)
     category = GroupCategory.PERFORMANCE.value

--- a/tests/sentry/api/endpoints/test_organization_events_trends_v2.py
+++ b/tests/sentry/api/endpoints/test_organization_events_trends_v2.py
@@ -6,7 +6,7 @@ import pytest
 from django.urls import reverse
 from freezegun import freeze_time
 
-from sentry.issues.grouptype import PerformanceP95TransactionDurationRegressionGroupType
+from sentry.issues.grouptype import PerformanceDurationRegressionGroupType
 from sentry.snuba.metrics.naming_layer import TransactionMRI
 from sentry.testutils.cases import MetricsAPIBaseTestCase
 from sentry.testutils.helpers.datetime import iso_format
@@ -535,7 +535,7 @@ class OrganizationEventsTrendsStatsV2EndpointTest(MetricsAPIBaseTestCase):
                     },
                     {"name": "Transaction", "value": "foo", "important": True},
                 ],
-                "type": PerformanceP95TransactionDurationRegressionGroupType.type_id,
+                "type": PerformanceDurationRegressionGroupType.type_id,
                 "level": "info",
                 "culprit": "foo",
             },


### PR DESCRIPTION
this shortens the group slug to better reflect the group description and also to make sure feature flag name isn't too long