### PR TITLE
feat(hybrid-cloud): Add webhook identifier for getsentry requests

### DIFF
--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -132,6 +132,7 @@ class WebhookProviderIdentifier(IntEnum):
     GITHUB_ENTERPRISE = 8
     BITBUCKET_SERVER = 9
     LEGACY_PLUGIN = 10
+    GETSENTRY = 11
 
 
 def _ensure_not_null(k: str, v: Any) -> Any:


### PR DESCRIPTION
This identifier will act as a catch all for webhooks consumed in the getsentry codebase. This will avoid having to make a sentry change for adding new webhook parsers in getsentry.

The alternative is to instead create identifiers for `salesforce`, `github_marketplace` and `stripe` which do not occur in this codebase.