### PR TITLE
feat(profiling): add battery usage chart

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -157,6 +157,7 @@ function findLongestMatchingFrame(
 const LOADING_OR_FALLBACK_FLAMEGRAPH = FlamegraphModel.Empty();
 const LOADING_OR_FALLBACK_SPAN_TREE = SpanTree.Empty;
 const LOADING_OR_FALLBACK_UIFRAMES = UIFrames.Empty;
+const LOADING_OR_FALLBACK_BATTERY_CHART = FlamegraphChartModel.Empty;
 const LOADING_OR_FALLBACK_CPU_CHART = FlamegraphChartModel.Empty;
 const LOADING_OR_FALLBACK_MEMORY_CHART = FlamegraphChartModel.Empty;
 
@@ -215,7 +216,7 @@ function Flamegraph(): ReactElement {
   const hasBatteryChart = useMemo(() => {
     const platform = profileGroup.metadata.platform;
     return (
-      (platform === 'cocoa' || platform === 'android' || platform === 'node') &&
+      platform === 'cocoa' &&
       organization.features.includes('profiling-battery-usage-chart')
     );
   }, [profileGroup.metadata.platform, organization.features]);
@@ -322,7 +323,7 @@ function Flamegraph(): ReactElement {
 
   const batteryChart = useMemo(() => {
     if (!hasCPUChart) {
-      return LOADING_OR_FALLBACK_CPU_CHART;
+      return LOADING_OR_FALLBACK_BATTERY_CHART;
     }
 
     const measures: ProfileSeriesMeasurement[] = [];

--- a/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
@@ -23,6 +23,7 @@ const TIMELINE_LABEL_HEIGHT = 20;
 const EMPTY_TIMELINE_HEIGHT = 80;
 
 interface FlamegraphLayoutProps {
+  batteryChart: React.ReactElement | null;
   cpuChart: React.ReactElement | null;
   flamegraph: React.ReactElement;
   flamegraphDrawer: React.ReactElement;
@@ -152,6 +153,20 @@ export function FlamegraphLayout(props: FlamegraphLayoutProps) {
     });
   }, [dispatch]);
 
+  const onOpenBatteryChart = useCallback(() => {
+    dispatch({
+      type: 'toggle timeline',
+      payload: {timeline: 'battery_chart', value: true},
+    });
+  }, [dispatch]);
+
+  const onCloseBatteryChart = useCallback(() => {
+    dispatch({
+      type: 'toggle timeline',
+      payload: {timeline: 'battery_chart', value: false},
+    });
+  }, [dispatch]);
+
   const spansTreeDepth = props.spansTreeDepth ?? 0;
   const spansTimelineHeight =
     Math.min(
@@ -196,6 +211,24 @@ export function FlamegraphLayout(props: FlamegraphLayoutProps) {
               {props.uiFrames}
             </CollapsibleTimeline>
           </UIFramesContainer>
+        ) : null}
+        {props.batteryChart ? (
+          <BatteryChartContainer
+            containerHeight={
+              timelines.battery_chart
+                ? flamegraphTheme.SIZES.BATTERY_CHART_HEIGHT
+                : TIMELINE_LABEL_HEIGHT
+            }
+          >
+            <CollapsibleTimeline
+              title={t('Battery')}
+              open={timelines.battery_chart}
+              onOpen={onOpenBatteryChart}
+              onClose={onCloseBatteryChart}
+            >
+              {props.batteryChart}
+            </CollapsibleTimeline>
+          </BatteryChartContainer>
         ) : null}
         {props.memoryChart ? (
           <MemoryChartContainer
@@ -298,10 +331,10 @@ const FlamegraphGrid = styled('div')<{
   width: 100%;
   grid-template-rows: ${({layout}) =>
     layout === 'table bottom'
-      ? 'auto auto auto auto auto 1fr'
+      ? 'auto auto auto auto auto auto 1fr'
       : layout === 'table right'
-      ? 'min-content min-content min-content min-content min-content 1fr'
-      : 'min-content min-content min-content min-content min-content 1fr'};
+      ? 'min-content min-content min-content min-content min-content min-content 1fr'
+      : 'min-content min-content min-content min-content min-content min-content 1fr'};
   grid-template-columns: ${({layout}) =>
     layout === 'table bottom'
       ? '100%'
@@ -315,8 +348,9 @@ const FlamegraphGrid = styled('div')<{
     layout === 'table bottom'
       ? `
         'minimap'
-        'ui-frames'
         'spans'
+        'ui-frames'
+        'battery-chart'
         'memory-chart'
         'cpu-chart'
         'flamegraph'
@@ -324,18 +358,20 @@ const FlamegraphGrid = styled('div')<{
         `
       : layout === 'table right'
       ? `
-        'minimap      frame-stack'
-        'ui-frames    frame-stack'
-        'spans        frame-stack'
-        'memory-chart frame-stack'
-        'cpu-chart    frame-stack'
-        'flamegraph   frame-stack'
+        'minimap        frame-stack'
+        'spans          frame-stack'
+        'ui-frames      frame-stack'
+        'battery-chart  frame-stack'
+        'memory-chart   frame-stack'
+        'cpu-chart      frame-stack'
+        'flamegraph     frame-stack'
       `
       : layout === 'table left'
       ? `
         'frame-stack minimap'
-        'frame-stack ui-frames'
         'frame-stack spans'
+        'frame-stack ui-frames'
+        'frame-stack battery-chart'
         'frame-stack memory-chart'
         'frame-stack cpu-chart'
         'frame-stack flamegraph'
@@ -383,6 +419,14 @@ const MemoryChartContainer = styled('div')<{
   position: relative;
   height: ${p => p.containerHeight}px;
   grid-area: memory-chart;
+`;
+
+const BatteryChartContainer = styled('div')<{
+  containerHeight: FlamegraphTheme['SIZES']['BATTERY_CHART_HEIGHT'];
+}>`
+  position: relative;
+  height: ${p => p.containerHeight}px;
+  grid-area: battery-chart;
 `;
 
 const UIFramesContainer = styled('div')<{

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContext.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContext.tsx
@@ -19,6 +19,7 @@ export const DEFAULT_FLAMEGRAPH_STATE: FlamegraphState = {
   },
   preferences: {
     timelines: {
+      battery_chart: true,
       ui_frames: true,
       minimap: true,
       transaction_spans: true,

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphPreferences.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphPreferences.tsx
@@ -18,6 +18,7 @@ export interface FlamegraphPreferences {
   layout: 'table right' | 'table bottom' | 'table left';
   sorting: FlamegraphSorting;
   timelines: {
+    battery_chart: boolean;
     cpu_chart: boolean;
     memory_chart: boolean;
     minimap: boolean;

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -46,6 +46,7 @@ export interface FlamegraphTheme {
   // They should instead be defined as arrays of numbers so we can use them with glsl and avoid unnecessary parsing
   COLORS: {
     BAR_LABEL_FONT_COLOR: string;
+    BATTERY_CHART_COLORS: ColorChannels[];
     CHART_CURSOR_INDICATOR: string;
     CHART_LABEL_COLOR: string;
     COLOR_BUCKET: (t: number) => ColorChannels;
@@ -96,6 +97,7 @@ export interface FlamegraphTheme {
     BAR_FONT_SIZE: number;
     BAR_HEIGHT: number;
     BAR_PADDING: number;
+    BATTERY_CHART_HEIGHT: number;
     CHART_PX_PADDING: number;
     CPU_CHART_HEIGHT: number;
     FLAMEGRAPH_DEPTH_OFFSET: number;
@@ -154,6 +156,7 @@ const SIZES: FlamegraphTheme['SIZES'] = {
   BAR_FONT_SIZE: 11,
   BAR_HEIGHT: 20,
   BAR_PADDING: 4,
+  BATTERY_CHART_HEIGHT: 80,
   FLAMEGRAPH_DEPTH_OFFSET: 12,
   HOVERED_FRAME_BORDER_WIDTH: 2,
   HIGHLIGHTED_FRAME_BORDER_WIDTH: 3,
@@ -186,6 +189,7 @@ export const LightFlamegraphTheme: FlamegraphTheme = {
   SIZES,
   COLORS: {
     BAR_LABEL_FONT_COLOR: '#000',
+    BATTERY_CHART_COLORS: [[0.4, 0.56, 0.9, 0.65]],
     COLOR_BUCKET: makeColorBucketTheme(LCH_LIGHT),
     SPAN_COLOR_BUCKET: makeColorBucketTheme(SPAN_LCH_LIGHT, 140, 220),
     COLOR_MAPS: {
@@ -239,6 +243,7 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
   SIZES,
   COLORS: {
     BAR_LABEL_FONT_COLOR: 'rgb(255 255 255 / 80%)',
+    BATTERY_CHART_COLORS: [hexToColorChannels(CHART_PALETTE[4][4], 0.8)],
     COLOR_BUCKET: makeColorBucketTheme(LCH_DARK),
     SPAN_COLOR_BUCKET: makeColorBucketTheme(SPANS_LCH_DARK, 140, 220),
     COLOR_MAPS: {

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -243,7 +243,7 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
   SIZES,
   COLORS: {
     BAR_LABEL_FONT_COLOR: 'rgb(255 255 255 / 80%)',
-    BATTERY_CHART_COLORS: [hexToColorChannels(CHART_PALETTE[4][4], 0.8)],
+    BATTERY_CHART_COLORS: [[0.4, 0.56, 0.9, 0.5]],
     COLOR_BUCKET: makeColorBucketTheme(LCH_DARK),
     SPAN_COLOR_BUCKET: makeColorBucketTheme(SPANS_LCH_DARK, 140, 220),
     COLOR_MAPS: {
@@ -257,8 +257,8 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
     },
     CPU_CHART_COLORS: CHART_PALETTE[12].map(c => hexToColorChannels(c, 0.8)),
     MEMORY_CHART_COLORS: [
-      hexToColorChannels(CHART_PALETTE[4][2], 0.8),
-      hexToColorChannels(CHART_PALETTE[4][3], 0.8),
+      hexToColorChannels(CHART_PALETTE[4][2], 0.5),
+      hexToColorChannels(CHART_PALETTE[4][3], 0.5),
     ],
     CHART_CURSOR_INDICATOR: 'rgba(255, 255, 255, 0.5)',
     CHART_LABEL_COLOR: 'rgba(255, 255, 255, 0.5)',
@@ -267,8 +267,8 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
     DIFFERENTIAL_INCREASE: [0.98, 0.2058, 0.4381],
     FOCUSED_FRAME_BORDER_COLOR: darkTheme.focus,
     FRAME_GRAYSCALE_COLOR: [0.5, 0.5, 0.5, 0.4],
-    FRAME_APPLICATION_COLOR: [0.1, 0.1, 0.8, 0.4],
-    FRAME_SYSTEM_COLOR: [0.7, 0.1, 0.1, 0.5],
+    FRAME_APPLICATION_COLOR: [0.1, 0.1, 0.5, 0.4],
+    FRAME_SYSTEM_COLOR: [0.6, 0.15, 0.25, 0.3],
     SPAN_FALLBACK_COLOR: [1, 1, 1, 0.3],
     GRID_FRAME_BACKGROUND_COLOR: 'rgb(26, 20, 31,1)',
     GRID_LINE_COLOR: '#222227',


### PR DESCRIPTION
Adds a new battery usage chart to profiling. 

It seems like cocoa might report byte units for cpu_usage which seems odd? I'll verify and we can adjust it later

<img width="1074" alt="CleanShot 2023-08-29 at 19 30 06@2x" src="https://github.com/getsentry/sentry/assets/9317857/d75ca085-14c0-48ea-b3e2-27cb16c3d1bc">
