### PR TITLE
feat(settings): Improve readability of ownership rule audit entries

### DIFF
--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -212,6 +212,20 @@ function AuditNote({
     );
   }
 
+  if (entry.event === 'project.ownership-rule.edit') {
+    return (
+      <Note>
+        {tct('Modified ownership rules in project [projectSettingsLink]', {
+          projectSettingsLink: (
+            <Link to={`/settings/${orgSlug}/projects/${project.slug}/`}>
+              {entry.data.slug}
+            </Link>
+          ),
+        })}
+      </Note>
+    );
+  }
+
   return <Note>{entry.note}</Note>;
 }
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Changed ownership rule audit entry note so that it is a little more human-readable :)))

# From this...
<img width="806" alt="Screenshot 2023-08-29 at 5 08 27 PM" src="https://github.com/getsentry/sentry/assets/45607721/fea59012-cdb4-450c-b8fa-549a7c9115c7">


# ... To this!
<img width="900" alt="Screenshot 2023-08-29 at 4 49 08 PM" src="https://github.com/getsentry/sentry/assets/45607721/23f4aa69-2eb0-4426-a002-185b55f3aff1">

