### PR TITLE
Add dynamic org slug and set widget layout

### DIFF
--- a/static/app/views/dashboards/exportDashboard.tsx
+++ b/static/app/views/dashboards/exportDashboard.tsx
@@ -17,10 +17,11 @@ async function exportDashboard() {
     const structure = {
       base_url: null,
       dashboard_id: null,
+      org_slug: null,
     };
 
     const params = getAPIParams(structure);
-    const apiUrl = `https://${params.base_url}/api/0/organizations/testorg-az/dashboards/${params.dashboard_id}/`;
+    const apiUrl = `https://${params.base_url}/api/0/organizations/${params.org_slug}/dashboards/${params.dashboard_id}/`;
     const response = await fetch(apiUrl);
     const jsonData = await response.json();
     const normalized = normalizeData(jsonData);
@@ -39,6 +40,7 @@ function getAPIParams(structure) {
   const regex = {
     base_url: /(\/\/)(.*?)(\/)/,
     dashboard_id: /(dashboard\/)(.*?)(\/)/,
+    org_slug: /(\/\/)(.+?)(?=\.)/,
   };
 
   for (const attr in regex) {
@@ -122,6 +124,7 @@ function getPropertyStructure(property) {
         queries: [],
         displayType: '',
         widgetType: '',
+        layout: [],
       };
       break;
     case 'queries':


### PR DESCRIPTION
Related to #52415 

org name was hard-coded to `testorg-az`, setting that value dynamically based on the requester org slug

also adding the layout attribute to the exported JSON
