### PR TITLE
feat(backup): Support import filtering

### DIFF
--- a/src/sentry/backup/helpers.py
+++ b/src/sentry/backup/helpers.py
@@ -4,6 +4,8 @@ from enum import Enum
 from functools import lru_cache
 from typing import Type
 
+from django.db import models
+
 from sentry.backup.scopes import RelocationScope
 
 # Django apps we take care to never import or export from.
@@ -44,3 +46,18 @@ def get_exportable_sentry_models() -> set[Type]:
 class Side(Enum):
     left = 1
     right = 2
+
+
+class Filter:
+    """Specifies a field-based filter when performing an import or export operation. This is an
+    allowlist based filtration: models of the given type whose specified field matches ANY of the
+    supplied values will be allowed through."""
+
+    model: Type[models.base.Model]
+    field: str
+    values: set[str]
+
+    def __init__(self, model: Type[models.base.Model], field: str, values: set[str] | None = None):
+        self.model = model
+        self.field = field
+        self.values = values if values is not None else set()

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict, namedtuple
-from typing import TYPE_CHECKING, Sequence, Union, overload
+from typing import TYPE_CHECKING, Optional, Sequence, Union, overload
 
 import sentry_sdk
 from django.conf import settings
@@ -143,8 +143,12 @@ class Actor(Model):
         return self.get_actor_tuple().get_actor_identifier()
 
     # TODO(hybrid-cloud): actor refactor. Remove this method when done.
-    def _normalize_before_relocation_import(self, pk_map: PrimaryKeyMap, scope: ImportScope) -> int:
+    def _normalize_before_relocation_import(
+        self, pk_map: PrimaryKeyMap, scope: ImportScope
+    ) -> Optional[int]:
         old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        if old_pk is None:
+            return None
 
         # `Actor` and `Team` have a direct circular dependency between them for the time being due
         # to an ongoing refactor (that is, `Actor` foreign keys directly into `Team`, and `Team`

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import List
+from typing import List, Optional
 
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.models import UserManager as DjangoUserManager
@@ -370,8 +370,13 @@ class User(BaseModel, AbstractBaseUser):
     def clear_lost_passwords(self):
         LostPasswordHash.objects.filter(user=self).delete()
 
-    def _normalize_before_relocation_import(self, pk_map: PrimaryKeyMap, scope: ImportScope) -> int:
+    def _normalize_before_relocation_import(
+        self, pk_map: PrimaryKeyMap, scope: ImportScope
+    ) -> Optional[int]:
         old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        if old_pk is None:
+            return None
+
         if scope != ImportScope.Global:
             self.is_staff = False
             self.is_superuser = False

--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -91,6 +91,9 @@ class UserEmail(Model):
         self, pk_map: PrimaryKeyMap, obj: DeserializedObject, scope: ImportScope
     ) -> Optional[Tuple[int, int]]:
         old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        if old_pk is None:
+            return None
+
         (useremail, _) = self.__class__.objects.get_or_create(
             user=self.user, email=self.email, defaults=model_to_dict(self)
         )

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -22,7 +22,7 @@ def import_(src, silent):
             use_update_instead_of_create=True,
             use_natural_foreign_keys=True,
         ),
-        (lambda *args, **kwargs: None) if silent else click.echo,
+        printer=(lambda *args, **kwargs: None) if silent else click.echo,
     )
 
 

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -20,8 +20,8 @@ from sentry.backup.exports import (
     export_in_user_scope,
 )
 from sentry.backup.findings import ComparatorFindings
-from sentry.backup.imports import OldImportConfig, _import
-from sentry.backup.scopes import ExportScope, ImportScope
+from sentry.backup.imports import import_in_global_scope
+from sentry.backup.scopes import ExportScope
 from sentry.backup.validate import validate
 from sentry.db.models.fields.bounded import BoundedBigAutoField
 from sentry.incidents.models import (
@@ -167,7 +167,7 @@ def import_export_then_validate(method_name: str, *, reset_pks: bool = True) -> 
         # Write the contents of the "expected" JSON file into the now clean database.
         # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
         with unguarded_write(using="default"), open(tmp_expect) as tmp_file:
-            _import(tmp_file, ImportScope.Global, OldImportConfig(), printer=NOOP_PRINTER)
+            import_in_global_scope(tmp_file, printer=NOOP_PRINTER)
 
         # Validate that the "expected" and "actual" JSON matches.
         actual = export_to_file(tmp_actual, ExportScope.Global)
@@ -211,7 +211,7 @@ def import_export_from_fixture_then_validate(
 
     # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
     with unguarded_write(using="default"), open(fixture_file_path) as fixture_file:
-        _import(fixture_file, ImportScope.Global, OldImportConfig(), printer=NOOP_PRINTER)
+        import_in_global_scope(fixture_file, printer=NOOP_PRINTER)
 
     res = validate(
         expect, export_to_file(tmp_path.joinpath("tmp_test_file.json"), ExportScope.Global), map
@@ -228,11 +228,15 @@ class BackupTestCase(TransactionTestCase):
         self,
         username: str,
         *,
+        email: str | None = None,
         is_admin: bool = False,
         is_staff: bool = False,
         is_superuser: bool = False,
     ) -> User:
-        user = self.create_user(username, is_staff=is_staff, is_superuser=is_superuser)
+        email = username if email is None else email
+        user = self.create_user(
+            email, username=username, is_staff=is_staff, is_superuser=is_superuser
+        )
         UserOption.objects.create(user=user, key="timezone", value="Europe/Vienna")
         UserIP.objects.create(
             user=user,
@@ -248,10 +252,15 @@ class BackupTestCase(TransactionTestCase):
 
         return user
 
-    def create_exhaustive_organization(self, slug: str, owner: User, invitee: User) -> Organization:
-        org = self.create_organization(name=f"test_org_for_{slug}", owner=owner)
-        membership = self.create_member(organization=org, user=invitee, role="member")
+    def create_exhaustive_organization(
+        self, slug: str, owner: User, invitee: User, other: list[User] | None = None
+    ) -> Organization:
+        org = self.create_organization(name=slug, owner=owner)
         owner_id: BoundedBigAutoField = owner.id
+        invited = self.create_member(organization=org, user=invitee, role="member")
+        if other:
+            for o in other:
+                self.create_member(organization=org, user=o, role="member")
 
         OrganizationOption.objects.create(
             organization=org, key="sentry:account-rate-limit", value=0
@@ -294,7 +303,7 @@ class BackupTestCase(TransactionTestCase):
         # Team
         team = self.create_team(name=f"test_team_in_{slug}", organization=org)
         self.create_team_membership(user=owner, team=team)
-        OrganizationAccessRequest.objects.create(member=membership, team=team)
+        OrganizationAccessRequest.objects.create(member=invited, team=team)
 
         # Rule*
         rule = self.create_project_rule(project=project)

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -14,12 +14,22 @@ from sentry.backup.imports import (
     import_in_organization_scope,
     import_in_user_scope,
 )
-from sentry.backup.scopes import RelocationScope
+from sentry.backup.scopes import ExportScope, RelocationScope
+from sentry.models.email import Email
+from sentry.models.organization import Organization
+from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.models.user import User
+from sentry.models.useremail import UserEmail
+from sentry.models.userip import UserIP
 from sentry.models.userpermission import UserPermission
 from sentry.models.userrole import UserRole, UserRoleUser
 from sentry.testutils.factories import get_fixture_path
-from sentry.testutils.helpers.backups import NOOP_PRINTER, BackupTestCase, clear_database
+from sentry.testutils.helpers.backups import (
+    NOOP_PRINTER,
+    BackupTestCase,
+    clear_database,
+    export_to_file,
+)
 from sentry.utils import json
 from tests.sentry.backup import run_backup_tests_only_on_single_db
 
@@ -141,21 +151,25 @@ class SanitizationTests(BackupTestCase):
                     import_in_user_scope(tmp_file, printer=NOOP_PRINTER)
 
 
+class ImportTestCase(BackupTestCase):
+    def export_to_tmp_file_and_clear_database(self, tmp_dir) -> Path:
+        tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
+        export_to_file(tmp_path, ExportScope.Global)
+        clear_database()
+        return tmp_path
+
+
 @run_backup_tests_only_on_single_db
-class ScopingTests(BackupTestCase):
+class ScopingTests(ImportTestCase):
     """
     Ensures that only models with the allowed relocation scopes are actually imported.
     """
 
     def test_user_import_scoping(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            self.create_exhaustive_instance(is_superadmin=True)
-            data = self.import_export_then_validate(self._testMethodName, reset_pks=True)
-            tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w+") as tmp_file:
-                json.dump(data, tmp_file)
+        self.create_exhaustive_instance(is_superadmin=True)
 
-            clear_database()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
             with open(tmp_path) as tmp_file:
                 import_in_user_scope(tmp_file, printer=NOOP_PRINTER)
                 exportable = get_exportable_sentry_models()
@@ -164,14 +178,10 @@ class ScopingTests(BackupTestCase):
                         assert model.objects.count() == 0
 
     def test_organization_import_scoping(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            self.create_exhaustive_instance(is_superadmin=True)
-            data = self.import_export_then_validate(self._testMethodName, reset_pks=True)
-            tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w+") as tmp_file:
-                json.dump(data, tmp_file)
+        self.create_exhaustive_instance(is_superadmin=True)
 
-            clear_database()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
             with open(tmp_path) as tmp_file:
                 import_in_organization_scope(tmp_file, printer=NOOP_PRINTER)
                 exportable = get_exportable_sentry_models()
@@ -181,3 +191,164 @@ class ScopingTests(BackupTestCase):
                         RelocationScope.Organization,
                     }:
                         assert model.objects.count() == 0
+
+
+@run_backup_tests_only_on_single_db
+class FilterTests(ImportTestCase):
+    """
+    Ensures that filtering operations include the correct models.
+    """
+
+    def test_import_filter_users(self):
+        self.create_exhaustive_user("user_1")
+        self.create_exhaustive_user("user_2")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path) as tmp_file:
+                import_in_user_scope(tmp_file, user_filter={"user_2"}, printer=NOOP_PRINTER)
+
+        # Count users, but also count a random model naively derived from just `User` alone, like
+        # `UserIP`. Because `Email` and `UserEmail` have some automagic going on that causes them to
+        # be created when a `User` is, we explicitly check to ensure that they are behaving
+        # correctly as well.
+        assert User.objects.count() == 1
+        assert UserIP.objects.count() == 1
+        assert UserEmail.objects.count() == 1
+        assert Email.objects.count() == 1
+
+        assert not User.objects.filter(username="user_1").exists()
+        assert User.objects.filter(username="user_2").exists()
+
+    def test_export_filter_users_shared_email(self):
+        self.create_exhaustive_user("user_1", email="a@example.com")
+        self.create_exhaustive_user("user_2", email="b@example.com")
+        self.create_exhaustive_user("user_3", email="a@example.com")
+        self.create_exhaustive_user("user_4", email="b@example.com")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path) as tmp_file:
+                import_in_user_scope(
+                    tmp_file, user_filter={"user_1", "user_2", "user_3"}, printer=NOOP_PRINTER
+                )
+
+        assert User.objects.count() == 3
+        assert UserIP.objects.count() == 3
+        assert UserEmail.objects.count() == 3
+        assert Email.objects.count() == 2
+
+        assert User.objects.filter(username="user_1").exists()
+        assert User.objects.filter(username="user_2").exists()
+        assert User.objects.filter(username="user_3").exists()
+        assert not User.objects.filter(username="user_4").exists()
+
+    def test_import_filter_users_empty(self):
+        self.create_exhaustive_user("user_1")
+        self.create_exhaustive_user("user_2")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path) as tmp_file:
+                import_in_user_scope(tmp_file, user_filter=set(), printer=NOOP_PRINTER)
+
+        assert User.objects.count() == 0
+        assert UserIP.objects.count() == 0
+        assert UserEmail.objects.count() == 0
+        assert Email.objects.count() == 0
+
+    def test_import_filter_orgs_single(self):
+        a = self.create_exhaustive_user("user_a_only", email="shared@example.com")
+        b = self.create_exhaustive_user("user_b_only", email="shared@example.com")
+        c = self.create_exhaustive_user("user_c_only", email="shared@example.com")
+        a_b = self.create_exhaustive_user("user_a_and_b")
+        b_c = self.create_exhaustive_user("user_b_and_c")
+        a_b_c = self.create_exhaustive_user("user_all", email="shared@example.com")
+        self.create_exhaustive_organization("org-a", a, a_b, [a_b_c])
+        self.create_exhaustive_organization("org-b", b_c, a_b_c, [b, a_b])
+        self.create_exhaustive_organization("org-c", a_b_c, b_c, [c])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path) as tmp_file:
+                import_in_organization_scope(tmp_file, org_filter={"org-b"}, printer=NOOP_PRINTER)
+
+        assert Organization.objects.count() == 1
+        assert OrgAuthToken.objects.count() == 1
+
+        assert not Organization.objects.filter(slug="org-a").exists()
+        assert Organization.objects.filter(slug="org-b").exists()
+        assert not Organization.objects.filter(slug="org-c").exists()
+
+        assert User.objects.count() == 4
+        assert UserIP.objects.count() == 4
+        assert UserEmail.objects.count() == 4
+        assert Email.objects.count() == 3  # Lower due to `shared@example.com`
+
+        assert not User.objects.filter(username="user_a_only").exists()
+        assert User.objects.filter(username="user_b_only").exists()
+        assert not User.objects.filter(username="user_c_only").exists()
+        assert User.objects.filter(username="user_a_and_b").exists()
+        assert User.objects.filter(username="user_b_and_c").exists()
+        assert User.objects.filter(username="user_all").exists()
+
+    def test_import_filter_orgs_multiple(self):
+        a = self.create_exhaustive_user("user_a_only", email="shared@example.com")
+        b = self.create_exhaustive_user("user_b_only", email="shared@example.com")
+        c = self.create_exhaustive_user("user_c_only", email="shared@example.com")
+        a_b = self.create_exhaustive_user("user_a_and_b")
+        b_c = self.create_exhaustive_user("user_b_and_c")
+        a_b_c = self.create_exhaustive_user("user_all", email="shared@example.com")
+        self.create_exhaustive_organization("org-a", a, a_b, [a_b_c])
+        self.create_exhaustive_organization("org-b", b_c, a_b_c, [b, a_b])
+        self.create_exhaustive_organization("org-c", a_b_c, b_c, [c])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path) as tmp_file:
+                import_in_organization_scope(
+                    tmp_file, org_filter={"org-a", "org-c"}, printer=NOOP_PRINTER
+                )
+
+        assert Organization.objects.count() == 2
+        assert OrgAuthToken.objects.count() == 2
+
+        assert Organization.objects.filter(slug="org-a").exists()
+        assert not Organization.objects.filter(slug="org-b").exists()
+        assert Organization.objects.filter(slug="org-c").exists()
+
+        assert User.objects.count() == 5
+        assert UserIP.objects.count() == 5
+        assert UserEmail.objects.count() == 5
+        assert Email.objects.count() == 3  # Lower due to `shared@example.com`
+
+        assert User.objects.filter(username="user_a_only").exists()
+        assert not User.objects.filter(username="user_b_only").exists()
+        assert User.objects.filter(username="user_c_only").exists()
+        assert User.objects.filter(username="user_a_and_b").exists()
+        assert User.objects.filter(username="user_b_and_c").exists()
+        assert User.objects.filter(username="user_all").exists()
+
+    def test_import_filter_orgs_empty(self):
+        a = self.create_exhaustive_user("user_a_only")
+        b = self.create_exhaustive_user("user_b_only")
+        c = self.create_exhaustive_user("user_c_only")
+        a_b = self.create_exhaustive_user("user_a_and_b")
+        b_c = self.create_exhaustive_user("user_b_and_c")
+        a_b_c = self.create_exhaustive_user("user_all")
+        self.create_exhaustive_organization("org-a", a, a_b, [a_b_c])
+        self.create_exhaustive_organization("org-b", b_c, a_b_c, [b, a_b])
+        self.create_exhaustive_organization("org-c", a_b_c, b_c, [c])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path) as tmp_file:
+                import_in_organization_scope(tmp_file, org_filter=set(), printer=NOOP_PRINTER)
+
+        assert Organization.objects.count() == 0
+        assert OrgAuthToken.objects.count() == 0
+
+        assert User.objects.count() == 0
+        assert UserIP.objects.count() == 0
+        assert UserEmail.objects.count() == 0
+        assert Email.objects.count() == 0


### PR DESCRIPTION
This change allows us to filter imports by either user (in the user scope) or organization (in the org scope). This allows, for example, a subset of available users to be imported, or a subset of available organizations from a large JSON dump.

Issue: getsentry/team-ospo#167