### PR TITLE
feat(backup): Support export filtering

### DIFF
--- a/src/sentry/backup/exports.py
+++ b/src/sentry/backup/exports.py
@@ -6,7 +6,13 @@ import click
 from django.core.serializers import serialize
 from django.core.serializers.json import DjangoJSONEncoder
 
-from sentry.backup.dependencies import sorted_dependencies
+from sentry.backup.dependencies import (
+    PrimaryKeyMap,
+    dependencies,
+    normalize_model_name,
+    sorted_dependencies,
+)
+from sentry.backup.helpers import Filter
 from sentry.backup.scopes import ExportScope
 
 UTC_0 = timezone(timedelta(hours=0))
@@ -59,14 +65,82 @@ class OldExportConfig:
         self.use_natural_foreign_keys = use_natural_foreign_keys
 
 
-def _export(dest, scope: ExportScope, old_config: OldExportConfig, indent: int, printer=click.echo):
+def _export(
+    dest,
+    scope: ExportScope,
+    old_config: OldExportConfig,
+    *,
+    indent: int = 2,
+    filter_by: Filter | None = None,
+    printer=click.echo,
+):
     """
     Exports core data for the Sentry installation.
 
     It is generally preferable to avoid calling this function directly, as there are certain combinations of input parameters that should not be used together. Instead, use one of the other wrapper functions in this file, named `export_in_XXX_scope()`.
     """
 
+    # Import here to prevent circular module resolutions.
+    from sentry.models.email import Email
+    from sentry.models.organization import Organization
+    from sentry.models.organizationmember import OrganizationMember
+    from sentry.models.user import User
+    from sentry.models.useremail import UserEmail
+
     allowed_relocation_scopes = scope.value
+    pk_map = PrimaryKeyMap()
+    deps = dependencies()
+
+    filters = []
+    if filter_by is not None:
+        filters.append(filter_by)
+
+        if filter_by.model == Organization:
+            org_pks = [o.pk for o in Organization.objects.filter(slug__in=filter_by.values)]
+            user_pks = [
+                o.user_id
+                for o in OrganizationMember.objects.filter(organization_id__in=set(org_pks))
+            ]
+            filters.append(Filter(User, "pk", set(user_pks)))
+        elif filter_by.model == User:
+            user_pks = [u.pk for u in User.objects.filter(username__in=filter_by.values)]
+        else:
+            raise TypeError("Filter arguments must only apply to `Organization` or `User` models")
+
+        # `sentry.Email` models don't have any explicit dependencies on `User`, so we need to find
+        # them manually via `UserEmail`.
+        emails = [ue.email for ue in UserEmail.objects.filter(user__in=user_pks)]
+        filters.append(Filter(Email, "email", set(emails)))
+
+    def filter_objects(queryset_iterator):
+        # Intercept each value from the queryset iterator and ensure that all of its dependencies
+        # have already been exported. If they have, store it in the `pk_map`, and then yield it
+        # again. If they have not, we know that some upstream model was filtered out, so we ignore
+        # this one as well.
+        for item in queryset_iterator:
+            model = type(item)
+            model_name = normalize_model_name(model)
+
+            # Make sure this model is not explicitly being filtered.
+            for f in filters:
+                if f.model == model and getattr(item, f.field, None) not in f.values:
+                    break
+            else:
+                # Now make sure its not transitively filtered either.
+                for field, foreign_field in deps[model_name].foreign_keys.items():
+                    dependency_model_name = normalize_model_name(foreign_field.model)
+                    field_id = field if field.endswith("_id") else f"{field}_id"
+                    fk = getattr(item, field_id, None)
+                    if fk is None:
+                        # Null deps are allowed.
+                        continue
+                    if pk_map.get(dependency_model_name, fk) is None:
+                        # The foreign key value exists, but not found! An upstream model must have
+                        # been filtered out, so we can filter this one out as well.
+                        break
+                else:
+                    pk_map.insert(model_name, item.pk, item.pk)
+                    yield item
 
     def yield_objects():
         # Collate the objects to be serialized.
@@ -96,7 +170,7 @@ def _export(dest, scope: ExportScope, old_config: OldExportConfig, indent: int, 
                 continue
 
             queryset = model._base_manager.order_by(model._meta.pk.name)
-            yield from queryset.iterator()
+            yield from filter_objects(queryset.iterator())
 
     printer(">> Beginning export", err=True)
     serialize(
@@ -109,23 +183,43 @@ def _export(dest, scope: ExportScope, old_config: OldExportConfig, indent: int, 
     )
 
 
-def export_in_user_scope(src, printer=click.echo):
+def export_in_user_scope(src, *, user_filter: set[str] | None = None, printer=click.echo):
     """
     Perform an export in the `User` scope, meaning that only models with `RelocationScope.User` will be exported from the provided `src` file.
     """
-    return _export(src, ExportScope.User, OldExportConfig(), 2, printer)
+
+    # Import here to prevent circular module resolutions.
+    from sentry.models.user import User
+
+    return _export(
+        src,
+        ExportScope.User,
+        OldExportConfig(),
+        filter_by=Filter(User, "username", user_filter) if user_filter is not None else None,
+        printer=printer,
+    )
 
 
-def export_in_organization_scope(src, printer=click.echo):
+def export_in_organization_scope(src, *, org_filter: set[str] | None = None, printer=click.echo):
     """
     Perform an export in the `Organization` scope, meaning that only models with `RelocationScope.User` or `RelocationScope.Organization` will be exported from the provided `src` file.
     """
-    return _export(src, ExportScope.Organization, OldExportConfig(), 2, printer)
+
+    # Import here to prevent circular module resolutions.
+    from sentry.models.organization import Organization
+
+    return _export(
+        src,
+        ExportScope.Organization,
+        OldExportConfig(),
+        filter_by=Filter(Organization, "slug", org_filter) if org_filter is not None else None,
+        printer=printer,
+    )
 
 
-def export_in_global_scope(src, printer=click.echo):
+def export_in_global_scope(src, *, printer=click.echo):
     """
     Perform an export in the `Global` scope, meaning that all models will be exported from the
     provided source file.
     """
-    return _export(src, ExportScope.Global, OldExportConfig(), 2, printer)
+    return _export(src, ExportScope.Global, OldExportConfig(), printer=printer)

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -50,6 +50,6 @@ def export(dest, silent, indent, exclude):
             excluded_models=set(exclude),
             use_natural_foreign_keys=True,
         ),
-        indent,
-        (lambda *args, **kwargs: None) if silent else click.echo,
+        indent=indent,
+        printer=(lambda *args, **kwargs: None) if silent else click.echo,
     )

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -97,7 +97,7 @@ class ValidationError(Exception):
         self.info = info
 
 
-def export_to_file(path: Path, scope: ExportScope) -> JSONData:
+def export_to_file(path: Path, scope: ExportScope, filter_by: set[str] | None = None) -> JSONData:
     """Helper function that exports the current state of the database to the specified file."""
 
     json_file_path = str(path)
@@ -107,9 +107,9 @@ def export_to_file(path: Path, scope: ExportScope) -> JSONData:
         if scope == ExportScope.Global:
             export_in_global_scope(tmp_file, printer=NOOP_PRINTER)
         elif scope == ExportScope.Organization:
-            export_in_organization_scope(tmp_file, printer=NOOP_PRINTER)
+            export_in_organization_scope(tmp_file, org_filter=filter_by, printer=NOOP_PRINTER)
         elif scope == ExportScope.User:
-            export_in_user_scope(tmp_file, printer=NOOP_PRINTER)
+            export_in_user_scope(tmp_file, user_filter=filter_by, printer=NOOP_PRINTER)
         else:
             raise AssertionError(f"Unknown `ExportScope`: `{scope.name}`")
 

--- a/tests/sentry/backup/test_exports.py
+++ b/tests/sentry/backup/test_exports.py
@@ -2,15 +2,31 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from typing import Any, Type
 
+from sentry.backup.dependencies import normalize_model_name
 from sentry.backup.helpers import get_exportable_sentry_models
 from sentry.backup.scopes import ExportScope
+from sentry.db import models
+from sentry.models.email import Email
+from sentry.models.organization import Organization
+from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.models.user import User
+from sentry.models.useremail import UserEmail
+from sentry.models.userip import UserIP
 from sentry.testutils.helpers.backups import BackupTestCase, export_to_file
+from sentry.utils.json import JSONData
 from tests.sentry.backup import run_backup_tests_only_on_single_db
 
 
+class ExportTestCase(BackupTestCase):
+    def export(self, tmp_dir, **kwargs) -> JSONData:
+        tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
+        return export_to_file(tmp_path, **kwargs)
+
+
 @run_backup_tests_only_on_single_db
-class ScopingTests(BackupTestCase):
+class ScopingTests(ExportTestCase):
     """
     Ensures that only models with the allowed relocation scopes are actually exported.
     """
@@ -26,12 +42,10 @@ class ScopingTests(BackupTestCase):
         return matching_models
 
     def test_user_export_scoping(self):
+        matching_models = self.get_models_for_scope(ExportScope.User)
+        self.create_exhaustive_instance(is_superadmin=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
-            matching_models = self.get_models_for_scope(ExportScope.User)
-            self.create_exhaustive_instance(is_superadmin=True)
-            tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            data = export_to_file(tmp_path, ExportScope.User)
-
+            data = self.export(tmp_dir, scope=ExportScope.User)
             for entry in data:
                 model_name = entry["model"]
                 if model_name not in matching_models:
@@ -40,15 +54,190 @@ class ScopingTests(BackupTestCase):
                     )
 
     def test_organization_export_scoping(self):
+        matching_models = self.get_models_for_scope(ExportScope.Organization)
+        self.create_exhaustive_instance(is_superadmin=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
-            matching_models = self.get_models_for_scope(ExportScope.Organization)
-            self.create_exhaustive_instance(is_superadmin=True)
-            tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            data = export_to_file(tmp_path, ExportScope.Organization)
-
+            data = self.export(tmp_dir, scope=ExportScope.Organization)
             for entry in data:
                 model_name = entry["model"]
                 if model_name not in matching_models:
                     raise AssertionError(
                         f"Model `${model_name}` was included in export despite not being `Relocation.User` or `Relocation.Organization`"
                     )
+
+
+@run_backup_tests_only_on_single_db
+class FilteringTests(ExportTestCase):
+    """
+    Ensures that filtering operations include the correct models.
+    """
+
+    @staticmethod
+    def count(data: JSONData, model: Type[models.base.BaseModel]) -> int:
+        return len(list(filter(lambda d: d["model"] == normalize_model_name(model).lower(), data)))
+
+    @staticmethod
+    def exists(
+        data: JSONData, model: Type[models.base.BaseModel], key: str, value: Any | None = None
+    ) -> bool:
+        for d in data:
+            if d["model"] == normalize_model_name(model).lower():
+                field = d["fields"].get(key)
+                if field is None:
+                    continue
+                if value is None:
+                    return True
+                if field == value:
+                    return True
+        return False
+
+    def test_export_filter_users(self):
+        self.create_exhaustive_user("user_1")
+        self.create_exhaustive_user("user_2")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data = self.export(tmp_dir, scope=ExportScope.User, filter_by={"user_2"})
+
+            # Count users, but also count a random model naively derived from just `User` alone,
+            # like `UserIP`. Because `Email` and `UserEmail` have some automagic going on that
+            # causes them to be created when a `User` is, we explicitly check to ensure that they
+            # are behaving correctly as well.
+            assert self.count(data, User) == 1
+            assert self.count(data, UserIP) == 1
+            assert self.count(data, UserEmail) == 1
+            assert self.count(data, Email) == 1
+
+            assert not self.exists(data, User, "username", "user_1")
+            assert self.exists(data, User, "username", "user_2")
+
+    def test_export_filter_users_shared_email(self):
+        self.create_exhaustive_user("user_1", email="a@example.com")
+        self.create_exhaustive_user("user_2", email="b@example.com")
+        self.create_exhaustive_user("user_3", email="a@example.com")
+        self.create_exhaustive_user("user_4", email="b@example.com")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data = self.export(
+                tmp_dir,
+                scope=ExportScope.User,
+                filter_by={"user_1", "user_2", "user_3"},
+            )
+
+            assert self.count(data, User) == 3
+            assert self.count(data, UserIP) == 3
+            assert self.count(data, UserEmail) == 3
+            assert self.count(data, Email) == 2
+
+            assert self.exists(data, User, "username", "user_1")
+            assert self.exists(data, User, "username", "user_2")
+            assert self.exists(data, User, "username", "user_3")
+            assert not self.exists(data, User, "username", "user_4")
+
+    def test_export_filter_users_empty(self):
+        self.create_exhaustive_user("user_1")
+        self.create_exhaustive_user("user_2")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data = self.export(tmp_dir, scope=ExportScope.User, filter_by={})
+
+            assert len(data) == 0
+
+    def test_export_filter_orgs_single(self):
+        a = self.create_exhaustive_user("user_a_only", email="shared@example.com")
+        b = self.create_exhaustive_user("user_b_only", email="shared@example.com")
+        c = self.create_exhaustive_user("user_c_only", email="shared@example.com")
+        a_b = self.create_exhaustive_user("user_a_and_b")
+        b_c = self.create_exhaustive_user("user_b_and_c")
+        a_b_c = self.create_exhaustive_user("user_all", email="shared@example.com")
+        self.create_exhaustive_organization("org-a", a, a_b, [a_b_c])
+        self.create_exhaustive_organization("org-b", b_c, a_b_c, [b, a_b])
+        self.create_exhaustive_organization("org-c", a_b_c, b_c, [c])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data = self.export(
+                tmp_dir,
+                scope=ExportScope.Organization,
+                filter_by={"org-b"},
+            )
+
+            assert self.count(data, Organization) == 1
+            assert self.count(data, OrgAuthToken) == 1
+
+            assert not self.exists(data, Organization, "slug", "org-a")
+            assert self.exists(data, Organization, "slug", "org-b")
+            assert not self.exists(data, Organization, "slug", "org-c")
+
+            assert self.count(data, User) == 4
+            assert self.count(data, UserIP) == 4
+            assert self.count(data, UserEmail) == 4
+            assert self.count(data, Email) == 3  # Lower due to `shared@example.com`
+
+            assert not self.exists(data, User, "username", "user_a_only")
+            assert self.exists(data, User, "username", "user_b_only")
+            assert not self.exists(data, User, "username", "user_c_only")
+            assert self.exists(data, User, "username", "user_a_and_b")
+            assert self.exists(data, User, "username", "user_b_and_c")
+            assert self.exists(data, User, "username", "user_all")
+
+    def test_export_filter_orgs_multiple(self):
+        a = self.create_exhaustive_user("user_a_only", email="shared@example.com")
+        b = self.create_exhaustive_user("user_b_only", email="shared@example.com")
+        c = self.create_exhaustive_user("user_c_only", email="shared@example.com")
+        a_b = self.create_exhaustive_user("user_a_and_b")
+        b_c = self.create_exhaustive_user("user_b_and_c")
+        a_b_c = self.create_exhaustive_user("user_all", email="shared@example.com")
+        self.create_exhaustive_organization("org-a", a, a_b, [a_b_c])
+        self.create_exhaustive_organization("org-b", b_c, a_b_c, [b, a_b])
+        self.create_exhaustive_organization("org-c", a_b_c, b_c, [c])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data = self.export(
+                tmp_dir,
+                scope=ExportScope.Organization,
+                filter_by={"org-a", "org-c"},
+            )
+
+            assert self.count(data, Organization) == 2
+            assert self.count(data, OrgAuthToken) == 2
+
+            assert self.exists(data, Organization, "slug", "org-a")
+            assert not self.exists(data, Organization, "slug", "org-b")
+            assert self.exists(data, Organization, "slug", "org-c")
+
+            assert self.count(data, User) == 5
+            assert self.count(data, UserIP) == 5
+            assert self.count(data, UserEmail) == 5
+            assert self.count(data, Email) == 3  # Lower due to `shared@example.com`
+
+            assert self.exists(data, User, "username", "user_a_only")
+            assert not self.exists(data, User, "username", "user_b_only")
+            assert self.exists(data, User, "username", "user_c_only")
+            assert self.exists(data, User, "username", "user_a_and_b")
+            assert self.exists(data, User, "username", "user_b_and_c")
+            assert self.exists(data, User, "username", "user_all")
+
+    def test_export_filter_orgs_empty(self):
+        a = self.create_exhaustive_user("user_a_only")
+        b = self.create_exhaustive_user("user_b_only")
+        c = self.create_exhaustive_user("user_c_only")
+        a_b = self.create_exhaustive_user("user_a_and_b")
+        b_c = self.create_exhaustive_user("user_b_and_c")
+        a_b_c = self.create_exhaustive_user("user_all")
+        self.create_exhaustive_organization("org-a", a, a_b, [a_b_c])
+        self.create_exhaustive_organization("org-b", b_c, a_b_c, [b, a_b])
+        self.create_exhaustive_organization("org-c", a_b_c, b_c, [c])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data = self.export(
+                tmp_dir,
+                scope=ExportScope.Organization,
+                filter_by={},
+            )
+
+            assert self.count(data, Organization) == 0
+            assert self.count(data, OrgAuthToken) == 0
+
+            assert self.count(data, User) == 0
+            assert self.count(data, UserIP) == 0
+            assert self.count(data, UserEmail) == 0
+            assert self.count(data, Email) == 0


### PR DESCRIPTION
This feature allows user to control what subset of their database they export, filtered by either user (when exporting in user scope) or organisation (when exporting in org scope). The available filters are a mirror of those offered for import scopes.

Closes getsentry/team-ospo#167