### PR TITLE
feat(backup): Adjust which models are backed up

### DIFF
--- a/fixtures/backup/model_dependencies/detailed.json
+++ b/fixtures/backup/model_dependencies/detailed.json
@@ -201,7 +201,7 @@
       }
     },
     "model": "sentry.ApiGrant",
-    "relocation_scope": "Excluded",
+    "relocation_scope": "Global",
     "silos": [
       "Control"
     ]
@@ -350,7 +350,7 @@
       }
     },
     "model": "sentry.AuthIdentity",
-    "relocation_scope": "Organization",
+    "relocation_scope": "Global",
     "silos": [
       "Control"
     ]
@@ -363,7 +363,7 @@
       }
     },
     "model": "sentry.AuthProvider",
-    "relocation_scope": "Organization",
+    "relocation_scope": "Global",
     "silos": [
       "Control"
     ]
@@ -1600,7 +1600,7 @@
   "sentry.Integration": {
     "foreign_keys": {},
     "model": "sentry.Integration",
-    "relocation_scope": "Excluded",
+    "relocation_scope": "Global",
     "silos": [
       "Control"
     ]
@@ -1743,7 +1743,7 @@
       }
     },
     "model": "sentry.MonitorEnvironment",
-    "relocation_scope": "Organization",
+    "relocation_scope": "Excluded",
     "silos": [
       "Region"
     ]
@@ -1751,7 +1751,7 @@
   "sentry.MonitorLocation": {
     "foreign_keys": {},
     "model": "sentry.MonitorLocation",
-    "relocation_scope": "Organization",
+    "relocation_scope": "Excluded",
     "silos": [
       "Region"
     ]
@@ -1936,7 +1936,7 @@
       }
     },
     "model": "sentry.OrganizationIntegration",
-    "relocation_scope": "Excluded",
+    "relocation_scope": "Global",
     "silos": [
       "Control"
     ]
@@ -2242,7 +2242,7 @@
       }
     },
     "model": "sentry.ProjectIntegration",
-    "relocation_scope": "Excluded",
+    "relocation_scope": "Global",
     "silos": [
       "Region"
     ]
@@ -2752,7 +2752,7 @@
       }
     },
     "model": "sentry.Repository",
-    "relocation_scope": "Organization",
+    "relocation_scope": "Global",
     "silos": [
       "Region"
     ]

--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -441,9 +441,11 @@ def get_default_comparators():
             "sentry.authidentity": [HashObfuscatingComparator("ident", "token")],
             "sentry.alertrule": [DateUpdatedComparator("date_modified")],
             "sentry.incidenttrigger": [DateUpdatedComparator("date_modified")],
+            "sentry.integration": [DateUpdatedComparator("date_updated")],
             "sentry.orgauthtoken": [
                 HashObfuscatingComparator("token_hashed", "token_last_characters")
             ],
+            "sentry.organizationintegration": [DateUpdatedComparator("date_updated")],
             "sentry.organizationmember": [HashObfuscatingComparator("token")],
             "sentry.projectkey": [HashObfuscatingComparator("public_key", "secret_key")],
             "sentry.querysubscription": [DateUpdatedComparator("date_updated")],

--- a/src/sentry/backup/mixins.py
+++ b/src/sentry/backup/mixins.py
@@ -14,8 +14,8 @@ class SanitizeUserImportsMixin:
     backup to a clean install. In this case, one may want to import so-called "superusers": users
     with powerful various instance-wide permissions generally reserved for admins and instance
     maintainers. Thus, for security reasons, running this import in any `ImportScope` other than
-    `Global` will sanitize user imports by ignoring imports of the `UserPermission`, `UserRole`, and
-    `UserRoleUser` models.
+    `Global` will sanitize user imports by ignoring imports of the `Authenticator`,
+    `UserPermission`, `UserRole`, and `UserRoleUser` models.
     """
 
     def write_relocation_import(

--- a/src/sentry/models/apigrant.py
+++ b/src/sentry/models/apigrant.py
@@ -28,7 +28,7 @@ class ApiGrant(Model):
     of the OAuth 2 spec.
     """
 
-    __relocation_scope__ = RelocationScope.Excluded
+    __relocation_scope__ = RelocationScope.Global
 
     user = FlexibleForeignKey("sentry.User")
     application = FlexibleForeignKey("sentry.ApiApplication")

--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -17,6 +17,7 @@ from sentry.auth.authenticators import (
     available_authenticators,
 )
 from sentry.auth.authenticators.base import EnrollmentStatus
+from sentry.backup.mixins import SanitizeUserImportsMixin
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BaseManager,
@@ -139,7 +140,7 @@ class AuthenticatorConfig(PickledObjectField):
 
 
 @control_silo_only_model
-class Authenticator(BaseModel):
+class Authenticator(SanitizeUserImportsMixin, BaseModel):
     __relocation_scope__ = RelocationScope.User
 
     id = BoundedAutoField(primary_key=True)

--- a/src/sentry/models/authidentity.py
+++ b/src/sentry/models/authidentity.py
@@ -11,7 +11,7 @@ from sentry.db.models.fields.jsonfield import JSONField
 
 @control_silo_only_model
 class AuthIdentity(Model):
-    __relocation_scope__ = RelocationScope.Organization
+    __relocation_scope__ = RelocationScope.Global
 
     # NOTE: not a fk to sentry user
     user = FlexibleForeignKey(settings.AUTH_USER_MODEL)

--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -45,7 +45,7 @@ class AuthProviderDefaultTeams(Model):
 
 @control_silo_only_model
 class AuthProvider(Model):
-    __relocation_scope__ = RelocationScope.Organization
+    __relocation_scope__ = RelocationScope.Global
 
     organization_id = HybridCloudForeignKey("sentry.Organization", on_delete="cascade", unique=True)
     provider = models.CharField(max_length=128)

--- a/src/sentry/models/integrations/integration.py
+++ b/src/sentry/models/integrations/integration.py
@@ -46,7 +46,7 @@ class Integration(DefaultFieldsModel):
     workspace, a single GH org, etc.), which can be shared by multiple Sentry orgs.
     """
 
-    __relocation_scope__ = RelocationScope.Excluded
+    __relocation_scope__ = RelocationScope.Global
 
     provider = models.CharField(max_length=64)
     external_id = models.CharField(max_length=64)

--- a/src/sentry/models/integrations/organization_integration.py
+++ b/src/sentry/models/integrations/organization_integration.py
@@ -20,7 +20,7 @@ from sentry.types.region import find_regions_for_orgs
 
 @control_silo_only_model
 class OrganizationIntegration(DefaultFieldsModel):
-    __relocation_scope__ = RelocationScope.Excluded
+    __relocation_scope__ = RelocationScope.Global
 
     organization_id = HybridCloudForeignKey("sentry.Organization", on_delete="cascade")
     integration = FlexibleForeignKey("sentry.Integration")

--- a/src/sentry/models/integrations/project_integration.py
+++ b/src/sentry/models/integrations/project_integration.py
@@ -11,7 +11,7 @@ class ProjectIntegration(Model):
      Project Integrations.
     """
 
-    __relocation_scope__ = RelocationScope.Excluded
+    __relocation_scope__ = RelocationScope.Global
 
     project = FlexibleForeignKey("sentry.Project")
     integration_id = HybridCloudForeignKey("sentry.Integration", on_delete="CASCADE")

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -21,7 +21,7 @@ from sentry.signals import pending_delete
 
 @region_silo_only_model
 class Repository(Model, PendingDeletionMixin):
-    __relocation_scope__ = RelocationScope.Organization
+    __relocation_scope__ = RelocationScope.Global
 
     organization_id = BoundedBigIntegerField(db_index=True)
     name = models.CharField(max_length=200)

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -467,7 +467,7 @@ class MonitorCheckIn(Model):
 
 @region_silo_only_model
 class MonitorLocation(Model):
-    __relocation_scope__ = RelocationScope.Organization
+    __relocation_scope__ = RelocationScope.Excluded
 
     guid = UUIDField(unique=True, auto_add=True)
     name = models.CharField(max_length=128)
@@ -505,7 +505,7 @@ class MonitorEnvironmentManager(BaseManager):
 
 @region_silo_only_model
 class MonitorEnvironment(Model):
-    __relocation_scope__ = RelocationScope.Organization
+    __relocation_scope__ = RelocationScope.Excluded
 
     monitor = FlexibleForeignKey("sentry.Monitor")
     environment = FlexibleForeignKey("sentry.Environment")

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -33,6 +33,7 @@ from sentry.incidents.models import (
     TimeSeriesSnapshot,
 )
 from sentry.models.apiauthorization import ApiAuthorization
+from sentry.models.apigrant import ApiGrant
 from sentry.models.apikey import ApiKey
 from sentry.models.apitoken import ApiToken
 from sentry.models.authenticator import Authenticator
@@ -46,6 +47,9 @@ from sentry.models.dashboard_widget import (
     DashboardWidgetTypes,
 )
 from sentry.models.environment import EnvironmentProject
+from sentry.models.integrations.integration import Integration
+from sentry.models.integrations.organization_integration import OrganizationIntegration
+from sentry.models.integrations.project_integration import ProjectIntegration
 from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.options.option import ControlOption, Option
 from sentry.models.options.organization_option import OrganizationOption
@@ -58,22 +62,13 @@ from sentry.models.projectownership import ProjectOwnership
 from sentry.models.projectredirect import ProjectRedirect
 from sentry.models.recentsearch import RecentSearch
 from sentry.models.relay import Relay, RelayUsage
-from sentry.models.repository import Repository
 from sentry.models.rule import RuleActivity, RuleActivityType
 from sentry.models.savedsearch import SavedSearch, Visibility
 from sentry.models.search_common import SearchType
 from sentry.models.user import User
 from sentry.models.userip import UserIP
 from sentry.models.userrole import UserRole, UserRoleUser
-from sentry.monitors.models import (
-    CheckInStatus,
-    Monitor,
-    MonitorCheckIn,
-    MonitorEnvironment,
-    MonitorLocation,
-    MonitorType,
-    ScheduleType,
-)
+from sentry.monitors.models import Monitor, MonitorType, ScheduleType
 from sentry.sentry_apps.apps import SentryAppUpdater
 from sentry.silo import unguarded_write
 from sentry.testutils.cases import TransactionTestCase
@@ -244,6 +239,7 @@ class BackupTestCase(TransactionTestCase):
             first_seen=datetime(2012, 4, 5, 3, 29, 45, tzinfo=timezone.utc),
             last_seen=datetime(2012, 4, 5, 3, 29, 45, tzinfo=timezone.utc),
         )
+        Authenticator.objects.create(user=user, type=1)
 
         if is_admin:
             self.add_user_permission(user, "users.admin")
@@ -277,7 +273,6 @@ class BackupTestCase(TransactionTestCase):
         )
         ApiKey.objects.create(key=uuid4().hex, organization_id=org.id)
         auth_provider = AuthProvider.objects.create(organization_id=org.id, provider="sentry")
-        Authenticator.objects.create(user=owner, type=1)
         AuthIdentity.objects.create(
             user=owner,
             auth_provider=auth_provider,
@@ -305,6 +300,18 @@ class BackupTestCase(TransactionTestCase):
         self.create_team_membership(user=owner, team=team)
         OrganizationAccessRequest.objects.create(member=invited, team=team)
 
+        # Integration*
+        integration = Integration.objects.create(
+            provider="slack", name=f"Slack for {slug}", external_id=f"slack:{slug}"
+        )
+        OrganizationIntegration.objects.create(
+            organization_id=org.id, integration=integration, config='{"hello":"hello"}'
+        )
+        # Note: this model is deprecated, and can safely be removed from this test when it is finally removed. Until then, it is included for completeness.
+        ProjectIntegration.objects.create(
+            project=project, integration_id=integration.id, config='{"hello":"hello"}'
+        )
+
         # Rule*
         rule = self.create_project_rule(project=project)
         RuleActivity.objects.create(rule=rule, type=RuleActivityType.CREATED.value)
@@ -314,24 +321,12 @@ class BackupTestCase(TransactionTestCase):
         env = self.create_environment()
         EnvironmentProject.objects.create(project=project, environment=env, is_hidden=False)
 
-        # Monitor*
-        monitor = Monitor.objects.create(
+        # Monitor
+        Monitor.objects.create(
             organization_id=project.organization.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
             config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
-        )
-        mon_env = MonitorEnvironment.objects.create(
-            monitor=monitor,
-            environment=env,
-        )
-        location = MonitorLocation.objects.create(guid=uuid4(), name=f"test_location_in_{slug}")
-        MonitorCheckIn.objects.create(
-            monitor=monitor,
-            monitor_environment=mon_env,
-            location=location,
-            project_id=monitor.project_id,
-            status=CheckInStatus.IN_PROGRESS,
         )
 
         # AlertRule*
@@ -399,11 +394,12 @@ class BackupTestCase(TransactionTestCase):
 
         # misc
         Counter.increment(project, 1)
-        Repository.objects.create(
-            name=f"test_repo_for_{slug}",
-            organization_id=org.id,
-            # TODO(getsentry/issue#187): Re-activate once we add `Integration` model to exports.
-            # integration_id=self.integration.id,
+        self.create_repo(
+            project=self.project,
+            name="getsentry/getsentry",
+            provider="integrations:github",
+            integration_id=integration.id,
+            url="https://github.com/getsentry/getsentry",
         )
 
         return org
@@ -420,6 +416,13 @@ class BackupTestCase(TransactionTestCase):
         ApiAuthorization.objects.create(application=app.application, user=owner)
         ApiToken.objects.create(
             application=app.application, user=owner, token=uuid4().hex, expires_at=None
+        )
+        ApiGrant.objects.create(
+            user=owner,
+            application=app.application,
+            expires_at="2022-01-01 11:11",
+            redirect_uri="https://example.com",
+            scope_list=["openid", "profile", "email"],
         )
 
         # ServiceHook

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -15,6 +15,7 @@ from sentry.backup.imports import (
     import_in_user_scope,
 )
 from sentry.backup.scopes import ExportScope, RelocationScope
+from sentry.models.authenticator import Authenticator
 from sentry.models.email import Email
 from sentry.models.organization import Organization
 from sentry.models.orgauthtoken import OrgAuthToken
@@ -99,6 +100,7 @@ class SanitizationTests(BackupTestCase):
 
         assert User.objects.filter(is_staff=True).count() == 0
         assert User.objects.filter(is_superuser=True).count() == 0
+        assert Authenticator.objects.count() == 0
         assert UserPermission.objects.count() == 0
         assert UserRole.objects.count() == 0
         assert UserRoleUser.objects.count() == 0
@@ -115,6 +117,7 @@ class SanitizationTests(BackupTestCase):
 
         assert User.objects.filter(is_staff=True).count() == 0
         assert User.objects.filter(is_superuser=True).count() == 0
+        assert Authenticator.objects.count() == 0
         assert UserPermission.objects.count() == 0
         assert UserRole.objects.count() == 0
         assert UserRoleUser.objects.count() == 0
@@ -130,6 +133,7 @@ class SanitizationTests(BackupTestCase):
         assert User.objects.filter(is_staff=True).count() == 2
         assert User.objects.filter(is_superuser=True).count() == 2
         assert User.objects.filter(is_staff=False, is_superuser=False).count() == 2
+        assert Authenticator.objects.count() == 4
 
         # 1 from `max_user`, 1 from `permission_user`.
         assert UserPermission.objects.count() == 2
@@ -236,7 +240,7 @@ class FilterTests(ImportTestCase):
         assert User.objects.count() == 3
         assert UserIP.objects.count() == 3
         assert UserEmail.objects.count() == 3
-        assert Email.objects.count() == 2
+        assert Email.objects.count() == 2  # Lower due to shared emails
 
         assert User.objects.filter(username="user_1").exists()
         assert User.objects.filter(username="user_2").exists()

--- a/tests/sentry/backup/test_invariants.py
+++ b/tests/sentry/backup/test_invariants.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from django.db.models.fields.related import ManyToManyField
 
+from sentry.backup.dependencies import dependencies, normalize_model_name
 from sentry.backup.helpers import get_exportable_sentry_models, get_final_derivations_of
+from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BaseModel
 
 
@@ -36,3 +38,30 @@ def test_all_many_to_many_fields_explicitly_set_through_attribute():
                     visited += 1
 
     assert visited > 0
+
+
+def validate_dependency_scopes(allowed: set[RelocationScope]):
+    deps = dependencies()
+    models = [mr.model for mr in filter((lambda mr: mr.relocation_scope in allowed), deps.values())]
+    for model in models:
+        model_name = normalize_model_name(model)
+        own_scope = deps[model_name].relocation_scope
+        for ff in deps[model_name].foreign_keys.values():
+            dependency_name = normalize_model_name(ff.model)
+            dependency_scope = deps[dependency_name].relocation_scope
+            if dependency_scope not in allowed:
+                AssertionError(
+                    f"Model `{model_name}`, which has a relocation scope of `{own_scope.name}`, has a dependency on model `{dependency_name}`, which has the disallowed relocation scope of `{dependency_scope.name}`"
+                )
+
+
+def test_user_relocation_scope_validity():
+    # Models with a `User` relocation scope are only allowed to transitively depend on other
+    # similarly-scoped models.
+    validate_dependency_scopes({RelocationScope.User})
+
+
+def test_organization_relocation_scope_validity():
+    # Models with an `Organization` or `User` relocation scope are only allowed to transitively
+    # depend on other similarly-scoped models.
+    validate_dependency_scopes({RelocationScope.Organization, RelocationScope.User})

--- a/tests/sentry/backup/test_models.py
+++ b/tests/sentry/backup/test_models.py
@@ -26,6 +26,7 @@ from sentry.incidents.models import (
 from sentry.models.actor import Actor
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.apiauthorization import ApiAuthorization
+from sentry.models.apigrant import ApiGrant
 from sentry.models.apikey import ApiKey
 from sentry.models.apitoken import ApiToken
 from sentry.models.authenticator import Authenticator
@@ -40,6 +41,9 @@ from sentry.models.dashboard_widget import (
 )
 from sentry.models.email import Email
 from sentry.models.environment import Environment, EnvironmentProject
+from sentry.models.integrations.integration import Integration
+from sentry.models.integrations.organization_integration import OrganizationIntegration
+from sentry.models.integrations.project_integration import ProjectIntegration
 from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.integrations.sentry_app_component import SentryAppComponent
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
@@ -73,15 +77,7 @@ from sentry.models.useremail import UserEmail
 from sentry.models.userip import UserIP
 from sentry.models.userpermission import UserPermission
 from sentry.models.userrole import UserRole, UserRoleUser
-from sentry.monitors.models import (
-    CheckInStatus,
-    Monitor,
-    MonitorCheckIn,
-    MonitorEnvironment,
-    MonitorLocation,
-    MonitorType,
-    ScheduleType,
-)
+from sentry.monitors.models import Monitor, MonitorType, ScheduleType
 from sentry.sentry_apps.apps import SentryAppUpdater
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.testutils.cases import TransactionTestCase
@@ -136,19 +132,6 @@ class ModelBackupTests(TransactionTestCase):
         dashboard.projects.add(project)
         return dashboard
 
-    def create_monitor(self):
-        """Re-usable monitor object for test cases."""
-
-        user = self.create_user()
-        org = self.create_organization(owner=user)
-        project = self.create_project(organization=org)
-        return Monitor.objects.create(
-            organization_id=project.organization.id,
-            project_id=project.id,
-            type=MonitorType.CRON_JOB,
-            config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
-        )
-
     @targets(mark(Actor))
     def test_actor(self):
         self.create_user(email="test@example.com")
@@ -176,12 +159,19 @@ class ModelBackupTests(TransactionTestCase):
         self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
         return self.import_export_then_validate()
 
-    @targets(mark(ApiAuthorization, ApiApplication))
-    def test_api_authorization_application(self):
+    @targets(mark(ApiAuthorization, ApiApplication, ApiGrant))
+    def test_api_application(self):
         user = self.create_user()
         app = ApiApplication.objects.create(name="test", owner=user)
         ApiAuthorization.objects.create(
             application=app, user=self.create_user("example@example.com")
+        )
+        ApiGrant.objects.create(
+            user=self.user,
+            application=app,
+            expires_at="2022-01-01 11:11",
+            redirect_uri="https://example.com",
+            scope_list=["openid", "profile", "email"],
         )
         return self.import_export_then_validate()
 
@@ -324,26 +314,39 @@ class ModelBackupTests(TransactionTestCase):
         )
         return self.import_export_then_validate()
 
-    @targets(mark(Monitor))
-    def test_monitor(self):
-        self.create_monitor()
+    @targets(mark(Integration, OrganizationIntegration, ProjectIntegration, Repository))
+    def test_integration(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        project = self.create_project()
+        integration = self.create_integration(
+            org, provider="slack", name="Slack 1", external_id="slack:1"
+        )
+
+        # Note: this model is deprecated, and can safely be removed from this test when it is finally removed. Until then, it is included for completeness.
+        ProjectIntegration.objects.create(
+            project=project, integration_id=integration.id, config='{"hello":"hello"}'
+        )
+
+        self.create_repo(
+            project=self.project,
+            name="getsentry/getsentry",
+            provider="integrations:github",
+            integration_id=self.integration.id,
+            url="https://github.com/getsentry/getsentry",
+        )
         return self.import_export_then_validate()
 
-    @targets(mark(MonitorEnvironment, MonitorLocation))
-    def test_monitor_environment(self):
-        monitor = self.create_monitor()
-        env = Environment.objects.create(organization_id=monitor.organization_id, name="test_env")
-        mon_env = MonitorEnvironment.objects.create(
-            monitor=monitor,
-            environment=env,
-        )
-        location = MonitorLocation.objects.create(guid=uuid4(), name="test_location")
-        MonitorCheckIn.objects.create(
-            monitor=monitor,
-            monitor_environment=mon_env,
-            location=location,
-            project_id=monitor.project_id,
-            status=CheckInStatus.IN_PROGRESS,
+    @targets(mark(Monitor))
+    def test_monitor(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        project = self.create_project(organization=org)
+        Monitor.objects.create(
+            organization_id=project.organization.id,
+            project_id=project.id,
+            type=MonitorType.CRON_JOB,
+            config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
         )
         return self.import_export_then_validate()
 
@@ -434,16 +437,6 @@ class ModelBackupTests(TransactionTestCase):
         relay_id = str(uuid4())
         Relay.objects.create(relay_id=relay_id, public_key=str(public_key), is_internal=True)
         RelayUsage.objects.create(relay_id=relay_id, version="0.0.1", public_key=public_key)
-        return self.import_export_then_validate()
-
-    @targets(mark(Repository))
-    def test_repository(self):
-        Repository.objects.create(
-            name="test_repo",
-            organization_id=self.organization.id,
-            # TODO(getsentry/issue#187): Re-activate once we add `Integration` model to exports.
-            # integration_id=self.integration.id,
-        )
         return self.import_export_then_validate()
 
     @targets(mark(Rule, RuleActivity, RuleSnooze))


### PR DESCRIPTION
Basically, we went from this (https://tinyurl.com/5c5cd5sf, note the
dangling grey boxes), to this (https://tinyurl.com/4wnb9huu).
Specifically, the following changes are included in this PR:

- We now include `Integration`, `OrganizationIntegration`, and
  `ProjectIntegration` as `Global` scoped exports. This is because a
  number of other models we already include, like `NotificationAction`
  and its derivatives, depend on `Integration`s. This is no longer a
  dangling dependency.
- Similarly, `SentryAppInstallation` depends on `ApiGrant`, so that is
  included in the `Global` scope as well.
- `MonitorEnvironment` and `MonitorLocation` are removed, since the only
  model that references them, `NonitorCheckIn`, is not included in the
  export already.
- `Repository` depends on `Integration`-derived models, and is therefore
  switched into the `Global` scope.
- `Authenticator` only makes sense to import for self-hosted restores,
  and is therefore sanitized out of non `Global` imports.
- `AuthIdentity` and `AuthProvider` similarly aren't portable between
  self-hosted and SaaS, so are moved into the `Global` scope as well.

Closes https://github.com/getsentry/team-ospo/issues/172