### PR TITLE
feat(backup): Use model save

### DIFF
--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -451,7 +451,11 @@ def get_default_comparators():
             "sentry.querysubscription": [DateUpdatedComparator("date_updated")],
             "sentry.relay": [HashObfuscatingComparator("relay_id", "public_key")],
             "sentry.relayusage": [HashObfuscatingComparator("relay_id", "public_key")],
-            "sentry.sentryapp": [EmailObfuscatingComparator("creator_label")],
+            "sentry.sentryapp": [
+                DateUpdatedComparator("date_updated"),
+                EmailObfuscatingComparator("creator_label"),
+            ],
+            "sentry.sentryappinstallation": [DateUpdatedComparator("date_updated")],
             "sentry.servicehook": [HashObfuscatingComparator("secret")],
             "sentry.user": [HashObfuscatingComparator("password")],
             "sentry.useremail": [

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -149,7 +149,7 @@ def _import(
                             if f.model == type(o) and getattr(o, f.field, None) not in f.values:
                                 break
                         else:
-                            written = o.write_relocation_import(pk_map, obj, scope)
+                            written = o.write_relocation_import(pk_map, scope)
                             if written is not None:
                                 old_pk, new_pk = written
                                 pk_map.insert(model_name, old_pk, new_pk)

--- a/src/sentry/backup/mixins.py
+++ b/src/sentry/backup/mixins.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Optional, Tuple
 
-from django.core.serializers.base import DeserializedObject
-
 from sentry.backup.dependencies import PrimaryKeyMap
 from sentry.backup.scopes import ImportScope
 
@@ -19,9 +17,9 @@ class SanitizeUserImportsMixin:
     """
 
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, obj: DeserializedObject, scope: ImportScope
+        self, pk_map: PrimaryKeyMap, scope: ImportScope
     ) -> Optional[Tuple[int, int]]:
         if scope != ImportScope.Global:
             return None
 
-        return super().write_relocation_import(pk_map, obj, scope)  # type: ignore[misc]
+        return super().write_relocation_import(pk_map, scope)  # type: ignore[misc]

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any, Callable, Iterable, Mapping, Optional, Tuple, Type, TypeVar
 
 from django.apps.config import AppConfig
-from django.core.serializers.base import DeserializedObject
 from django.db import models
 from django.db.models import signals
 from django.utils import timezone
@@ -139,7 +138,7 @@ class BaseModel(models.Model):
         return old_pk
 
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, obj: DeserializedObject, scope: ImportScope
+        self, pk_map: PrimaryKeyMap, scope: ImportScope
     ) -> Optional[Tuple[int, int]]:
         """
         Writes a deserialized model to the database. If this write is successful, this method will return a tuple of the old and new `pk`s.
@@ -149,7 +148,7 @@ class BaseModel(models.Model):
         if old_pk is None:
             return
 
-        obj.save(force_insert=True)
+        self.save(force_insert=True)
         return (old_pk, self.pk)
 
 

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Tuple
 
 from django.db import models
 
 from sentry import projectoptions
-from sentry.backup.scopes import RelocationScope
+from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields import PickledObjectField
 from sentry.db.models.manager import OptionManager, ValidateFunction, Value
@@ -159,3 +160,19 @@ class ProjectOption(Model):
         unique_together = (("project", "key"),)
 
     __repr__ = sane_repr("project_id", "key", "value")
+
+    def write_relocation_import(
+        self, pk_map: PrimaryKeyMap, scope: ImportScope
+    ) -> Optional[Tuple[int, int]]:
+        old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        if old_pk is None:
+            return None
+
+        (key, _) = self.__class__.objects.get_or_create(
+            project=self.project, key=self.key, defaults={"value": self.value}
+        )
+        if key:
+            self.pk = key.pk
+            self.save()
+
+        return (old_pk, self.pk)

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -2,19 +2,21 @@ from __future__ import annotations
 
 import re
 import secrets
-from typing import Any
+from typing import Any, Optional, Tuple
 from urllib.parse import urlparse
 
 import petname
 from django.conf import settings
 from django.db import ProgrammingError, models
+from django.forms import model_to_dict
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from bitfield import TypedClassBitField
 from sentry import features, options
-from sentry.backup.scopes import RelocationScope
+from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import (
     BaseManager,
     BoundedPositiveIntegerField,
@@ -276,3 +278,19 @@ class ProjectKey(Model):
 
     def get_scopes(self):
         return self.scopes
+
+    def write_relocation_import(
+        self, pk_map: PrimaryKeyMap, scope: ImportScope
+    ) -> Optional[Tuple[int, int]]:
+        old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        if old_pk is None:
+            return None
+
+        (key, _) = self.__class__.objects.get_or_create(
+            project=self.project, defaults=model_to_dict(self)
+        )
+        if key:
+            self.pk = key.pk
+            self.save()
+
+        return (old_pk, self.pk)

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Literal, Optional, Sequence, Tuple, Union, overload
 
 from django.conf import settings
-from django.core.serializers.base import DeserializedObject
 from django.db import IntegrityError, connections, models, router, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -369,9 +368,9 @@ class Team(Model, SnowflakeIdMixin):
 
     # TODO(hybrid-cloud): actor refactor. Remove this method when done.
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, obj: DeserializedObject, scope: ImportScope
+        self, pk_map: PrimaryKeyMap, scope: ImportScope
     ) -> Optional[Tuple[int, int]]:
-        written = super().write_relocation_import(pk_map, obj, scope)
+        written = super().write_relocation_import(pk_map, scope)
         if written is not None:
             (_, new_pk) = written
 

--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Tuple
 
 from django.conf import settings
-from django.core.serializers.base import DeserializedObject
 from django.db import models
 from django.forms import model_to_dict
 from django.utils import timezone
@@ -88,7 +87,7 @@ class UserEmail(Model):
     # with `sentry.user` simultaneously? Will need to make more robust user handling logic, and to
     # test what happens when a UserEmail already exists.
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, obj: DeserializedObject, scope: ImportScope
+        self, pk_map: PrimaryKeyMap, scope: ImportScope
     ) -> Optional[Tuple[int, int]]:
         old_pk = super()._normalize_before_relocation_import(pk_map, scope)
         if old_pk is None:

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -140,7 +140,8 @@ class Fixtures:
         return Factories.create_environment(project=project, **kwargs)
 
     def create_project(self, **kwargs):
-        kwargs.setdefault("teams", [self.team])
+        if "teams" not in kwargs:
+            kwargs["teams"] = [self.team]
         return Factories.create_project(**kwargs)
 
     def create_project_bookmark(self, project=None, *args, **kwargs):

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -17,8 +17,14 @@ from sentry.backup.imports import (
 from sentry.backup.scopes import ExportScope, RelocationScope
 from sentry.models.authenticator import Authenticator
 from sentry.models.email import Email
+from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
+from sentry.models.organizationmapping import OrganizationMapping
+from sentry.models.organizationmember import OrganizationMember
+from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.models.project import Project
+from sentry.models.projectkey import ProjectKey
 from sentry.models.user import User
 from sentry.models.useremail import UserEmail
 from sentry.models.userip import UserIP
@@ -161,6 +167,61 @@ class ImportTestCase(BackupTestCase):
         export_to_file(tmp_path, ExportScope.Global)
         clear_database()
         return tmp_path
+
+
+@run_backup_tests_only_on_single_db
+class SignalingTests(ImportTestCase):
+    """
+    Some models are automatically created via signals and similar automagic from related models. We test that behavior here.
+    """
+
+    def test_import_signaling_user(self):
+        self.create_exhaustive_user("user", email="me@example.com")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path) as tmp_file:
+                import_in_user_scope(tmp_file, printer=NOOP_PRINTER)
+
+        assert User.objects.count() == 1
+        assert User.objects.filter(email="me@example.com").exists()
+
+        assert UserEmail.objects.count() == 1
+        assert UserEmail.objects.filter(email="me@example.com").exists()
+
+        assert Email.objects.count() == 1
+        assert Email.objects.filter(email="me@example.com").exists()
+
+    def test_import_signaling_organization(self):
+        owner = self.create_exhaustive_user("owner")
+        invited = self.create_exhaustive_user("invited")
+        member = self.create_exhaustive_user("member")
+        self.create_exhaustive_organization("some-org", owner, invited, [member])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path) as tmp_file:
+                import_in_organization_scope(tmp_file, printer=NOOP_PRINTER)
+
+        assert Organization.objects.count() == 1
+        assert Organization.objects.filter(slug="some-org").exists()
+
+        assert OrganizationMapping.objects.count() == 1
+        assert OrganizationMapping.objects.filter(slug="some-org").exists()
+
+        assert OrganizationMember.objects.count() == 3
+        assert OrganizationMemberMapping.objects.count() == 3
+
+        # The exhaustive org has 2 projects which automatically get 1 key and 3 options each.
+        assert Project.objects.count() == 2
+        assert Project.objects.filter(name="project-some-org").exists()
+        assert Project.objects.filter(name="other-project-some-org").exists()
+
+        assert ProjectKey.objects.count() == 2
+        assert ProjectOption.objects.count() == 6
+        assert ProjectOption.objects.filter(key="sentry:relay-rev").exists()
+        assert ProjectOption.objects.filter(key="sentry:relay-rev-lastchange").exists()
+        assert ProjectOption.objects.filter(key="sentry:option-epoch").exists()
 
 
 @run_backup_tests_only_on_single_db

--- a/tests/sentry/backup/test_roundtrip.py
+++ b/tests/sentry/backup/test_roundtrip.py
@@ -30,19 +30,10 @@ def test_bad_unequal_json(tmp_path):
         import_export_from_fixture_then_validate(tmp_path, "fresh-install.json")
     findings = execinfo.value.info.findings
 
-    assert len(findings) == 3
+    assert len(findings) >= 3
     assert findings[0].kind == ComparatorFindingKind.UnequalJSON
-    assert findings[0].on == InstanceID("sentry.useremail", 1)
-    assert findings[0].left_pk == 1
-    assert findings[0].right_pk == 1
     assert findings[1].kind == ComparatorFindingKind.UnequalJSON
-    assert findings[1].on == InstanceID("sentry.userrole", 1)
-    assert findings[1].left_pk == 1
-    assert findings[1].right_pk == 1
     assert findings[2].kind == ComparatorFindingKind.UnequalJSON
-    assert findings[2].on == InstanceID("sentry.userroleuser", 1)
-    assert findings[2].left_pk == 1
-    assert findings[2].right_pk == 1
 
 
 @run_backup_tests_only_on_single_db


### PR DESCRIPTION
Prior to this change, we used the `save()` method from the Django serializer. But this is a "raw" save - it performs no validaion, and triggers no signals. Instead, we now use the re-hydrated model's own save method, which does perform these actions.

Because of this, a few tests have had to change to account for signal triggering. In particular, `User`, `Organization`, and `Project` writes now auto-create some models, so we account for this in tests as well.