### PR TITLE
feat: Never show source maps wizard widget in issues

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.spec.tsx
@@ -180,34 +180,4 @@ describe('SourceMapDebug', () => {
       'https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/legacy-uploading-methods/#verify-artifact-names-match-stack-trace-frames'
     );
   });
-
-  it('should show source maps wizard alert for DEBUG_ID_NO_SOURCEMAPS', async () => {
-    const error: SourceMapDebugError = {
-      type: SourceMapProcessingIssueType.DEBUG_ID_NO_SOURCEMAPS,
-      message: '',
-    };
-
-    MockApiClient.addMockResponse({
-      url,
-      body: {errors: [error]},
-    });
-
-    render(<SourceMapDebug debugFrames={debugFrames} event={event} />, {
-      organization,
-    });
-
-    expect(
-      await screen.findByText("You're not a computer, so why parse minified code?")
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(
-          'Upload source maps with the Sentry Wizard to unlock readable stack traces and better error grouping. Learn more'
-        )
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher('npx @sentry/wizard@latest -i sourcemaps'))
-    ).toBeInTheDocument();
-  });
 });

--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
@@ -4,7 +4,6 @@ import uniqBy from 'lodash/uniqBy';
 
 import Alert from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
-import SourceMapsWizard from 'sentry/components/events/interfaces/crashContent/exception/sourcemapsWizard';
 import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
@@ -278,14 +277,6 @@ export function SourceMapDebug({debugFrames, event}: SourcemapDebugProps) {
       type,
     });
   };
-
-  if (
-    errorMessages.filter(
-      error => error.type === SourceMapProcessingIssueType.DEBUG_ID_NO_SOURCEMAPS
-    ).length > 0
-  ) {
-    return <SourceMapsWizard analyticsParams={analyticsParams} />;
-  }
 
   return (
     <Alert


### PR DESCRIPTION
The logic to determine whether to show this widget or not is not fleshed out enough. Right now we're showing it too often which is arguably worse than not showing it at all. For this reason we're removing it for now until we have robust logic to show it in the right moments.