### PR TITLE
feat(metrics): Implement metrics backend for minisentry

### DIFF
--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -1,0 +1,35 @@
+from typing import Optional, Union
+
+from sentry.metrics.base import MetricsBackend, Tags
+
+
+class CompositeExperimentalMetricsBackend(MetricsBackend):
+    def incr(
+        self,
+        key: str,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        amount: Union[float, int] = 1,
+        sample_rate: float = 1,
+    ) -> None:
+        pass
+
+    def timing(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+    ) -> None:
+        pass
+
+    def gauge(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+    ) -> None:
+        pass

--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional, Type, Union
 
 from sentry.metrics.base import MetricsBackend, Tags
 from sentry.metrics.dummy import DummyMetricsBackend
+from sentry.metrics.minimetrics import MiniMetricsMetricsBackend
 from sentry.utils.imports import import_string
 
 
@@ -13,12 +14,13 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         )
 
     def _initialize_backends(self, primary_backend: Optional[str], backend_args: Dict[str, Any]):
-        # If we don't have a primary metrics backend
+        # If we don't have a primary metrics backend we default to the dummy, which won't do anything.
         if primary_backend is None:
             self._primary_backend = DummyMetricsBackend()
 
         cls: Type[MetricsBackend] = import_string(primary_backend)
         self._primary_backend = cls(**backend_args)
+        self._minimetrics = MiniMetricsMetricsBackend()
 
     def incr(
         self,

--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -35,7 +35,7 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
             # We want to control the sample rate of minimetrics independently of the primary backend's sample rate.
             return options.get("delightful_metrics.minimetrics_sample_rate")
         except UnknownOption:
-            return 0.5
+            return 0.0
 
     def incr(
         self,

--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -16,11 +16,12 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
     def _initialize_backends(self, primary_backend: Optional[str], backend_args: Dict[str, Any]):
         # If we don't have a primary metrics backend we default to the dummy, which won't do anything.
         if primary_backend is None:
-            self._primary_backend = DummyMetricsBackend()
+            self._primary_backend: MetricsBackend = DummyMetricsBackend()
+        else:
+            cls: Type[MetricsBackend] = import_string(primary_backend)
+            self._primary_backend = cls(**backend_args)
 
-        cls: Type[MetricsBackend] = import_string(primary_backend)
-        self._primary_backend = cls(**backend_args)
-        self._minimetrics = MiniMetricsMetricsBackend()
+        self._minimetrics: MetricsBackend = MiniMetricsMetricsBackend()
 
     def incr(
         self,

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -1,3 +1,4 @@
+import random
 import threading
 import time
 import zlib
@@ -292,6 +293,10 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         super().__init__(prefix=prefix)
         self._client = Client()
 
+    @staticmethod
+    def _keep_metric(sample_rate: float) -> bool:
+        return random.random() < sample_rate
+
     def incr(
         self,
         key: str,
@@ -300,7 +305,8 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
     ) -> None:
-        self._client.incr(key=self._get_key(key), value=amount, tags=tags)
+        if self._keep_metric(sample_rate):
+            self._client.incr(key=self._get_key(key), value=amount, tags=tags)
 
     def timing(
         self,
@@ -310,7 +316,8 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
     ) -> None:
-        self._client.timing(key=self._get_key(key), value=value, tags=tags)
+        if self._keep_metric(sample_rate):
+            self._client.timing(key=self._get_key(key), value=value, tags=tags)
 
     def gauge(
         self,
@@ -320,4 +327,5 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
     ) -> None:
-        self._client.gauge(key=self._get_key(key), value=value, tags=tags)
+        if self._keep_metric(sample_rate):
+            self._client.gauge(key=self._get_key(key), value=value, tags=tags)

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -191,9 +191,9 @@ class Aggregator:
             time.sleep(2.0)
 
     def _emit(self, extracted_metrics: Any) -> Any:
-        # In order to avoid an infinite recursion for metrics, we want to use a thread local variable that will signal
-        # the downstream calls to only propagate the metric to DataDog, otherwise if propagated to minimetrics, it will
-        # cause unbounded recursion.
+        # In order to avoid an infinite recursion for metrics, we want to use a thread local variable that will
+        # signal the downstream calls to only propagate the metric to the primary backend, otherwise if propagated to
+        # minimetrics, it will cause unbounded recursion.
         thread_local.in_minimetrics = True
         # We want to emit a metric on how many metrics we would technically emit if we were to use minimetrics.
         metrics.incr("minimetrics.emit", amount=len(extracted_metrics))

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -2,16 +2,28 @@ import threading
 import time
 import zlib
 from threading import Lock, Thread
-from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Set, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
 
-from sentry.metrics.base import MetricsBackend
+from sentry.metrics.base import MetricsBackend, Tags
 from sentry.utils import metrics
 
 # The thread local instance must be initialized globally in order to correctly use the state.
 thread_local = threading.local()
 
 
-Tags = Dict[str, str]
 T = TypeVar("T")
 
 
@@ -200,12 +212,12 @@ class Aggregator:
         if timestamp is None:
             timestamp = time.time()
 
-        bucket_key = (
+        bucket_key: ComposedKey = (
             int((timestamp // self.ROLLUP_IN_SECONDS) * self.ROLLUP_IN_SECONDS),
             ty,
             key,
             unit,
-            tuple(sorted(tuple((tags or {}).items()))),
+            cast(Tuple[Tuple[str, str], ...], tuple(sorted(tuple((tags or {}).items())))),
         )
 
         with self._lock:

--- a/src/sentry/metrics/minisentry.py
+++ b/src/sentry/metrics/minisentry.py
@@ -1,0 +1,295 @@
+import time
+import zlib
+from threading import Lock, Thread
+from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Set, Tuple, TypeVar, Union
+
+from sentry.metrics.base import MetricsBackend
+from sentry.utils import json
+
+Tags = Dict[str, str]
+T = TypeVar("T")
+
+
+MetricUnit = Literal[
+    None,
+    "nanosecond",
+    "microsecond",
+    "millisecond",
+    "second",
+    "minute",
+    "hour",
+    "day",
+    "week",
+    "bit",
+    "byte",
+    "kilobyte",
+    "kibibyte",
+    "mebibyte",
+    "gigabyte",
+    "terabyte",
+    "tebibyte",
+    "petabyte",
+    "pebibyte",
+    "exabyte",
+    "exbibyte",
+    "ratio",
+    "percent",
+]
+
+
+class Metric(Generic[T]):
+    def add(self, value: T) -> None:
+        raise NotImplementedError()
+
+    def serialize_value(self) -> Any:
+        raise NotImplementedError()
+
+
+class CounterMetric(Metric[float]):
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def add(self, value: float) -> None:
+        self.value += value
+
+    def serialize_value(self) -> Any:
+        return self.value
+
+
+class GaugeMetric(Metric[float]):
+    __slots__ = ("min", "max", "sum", "count", "last")
+
+    def __init__(self) -> None:
+        self.min = float("inf")
+        self.max = float("-inf")
+        self.sum = 0.0
+        self.count = 0.0
+        self.last = float("nan")
+
+    def add(self, value: float) -> None:
+        self.min = min(self.min, value)
+        self.max = max(self.max, value)
+        self.last = value
+        self.count += 1
+        self.sum += value
+
+    def serialize_value(self) -> Any:
+        return {
+            "min": self.min,
+            "max": self.max,
+            "last": self.last,
+            "sum": self.sum,
+            "count": self.count,
+        }
+
+
+class DistributionMetric(Metric[float]):
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value: List[float] = []
+
+    def add(self, value: float) -> None:
+        self.value.append(value)
+
+    def serialize_value(self) -> Any:
+        return self.value
+
+
+class SetMetric(Metric[Union[str, int]]):
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value: Set[Union[str, int]] = set()
+
+    def add(self, value: Union[str, int]) -> None:
+        self.value.add(value)
+
+    def serialize_value(self) -> Any:
+        def _hash(x: Any) -> int:
+            if isinstance(x, str):
+                return zlib.crc32(x.encode("utf-8")) & 0xFFFFFFFF
+            return int(x)
+
+        return [_hash(x) for x in self.value]
+
+
+METRIC_TYPES: Dict[str, Callable[[], Metric[Any]]] = {
+    "c": CounterMetric,
+    "g": GaugeMetric,
+    "d": DistributionMetric,
+    "s": SetMetric,
+}
+
+ComposedKey = Tuple[int, str, str, MetricUnit, Tuple[Tuple[str, str], ...]]
+
+
+class Aggregator:
+    ROLLUP_IN_SECONDS = 10.0
+
+    def __init__(self) -> None:
+        self.buckets: Dict[ComposedKey, Metric[Any]] = {}
+        self._lock = Lock()
+        self._running = True
+        self._flusher = Thread(target=self._flush)
+        self._flusher.daemon = True
+        self._flusher.start()
+
+    def _flush(self) -> None:
+        while self._running:
+            cutoff = time.time() - self.ROLLUP_IN_SECONDS
+            cleanup = set()
+            metrics = []
+            buckets = self.buckets
+
+            with self._lock:
+                for bucket_key, metric in buckets.items():
+                    ts, ty, name, unit, tags = bucket_key
+                    if ts > cutoff:
+                        continue
+
+                    m = {
+                        "timestamp": ts,
+                        "width": int(self.ROLLUP_IN_SECONDS),
+                        "name": name,
+                        "type": ty,
+                        "value": metric.serialize_value(),
+                    }
+                    if unit:
+                        m["unit"] = unit
+                    if tags:
+                        m["tags"] = dict(tags)
+
+                    metrics.append(m)
+                    cleanup.add(bucket_key)
+
+                for key in cleanup:
+                    buckets.pop(key)
+
+            if metrics:
+                self._emit(metrics)
+            time.sleep(2.0)
+
+    def _emit(self, metrics: Any) -> Any:
+        return json.dumps(metrics, indent=2)
+
+    def add(
+        self,
+        ty: str,
+        key: str,
+        value: Any,
+        unit: MetricUnit,
+        tags: Optional[Tags],
+        timestamp: Optional[float],
+    ) -> None:
+        if timestamp is None:
+            timestamp = time.time()
+
+        bucket_key = (
+            int((timestamp // self.ROLLUP_IN_SECONDS) * self.ROLLUP_IN_SECONDS),
+            ty,
+            key,
+            unit,
+            tuple(sorted(tuple((tags or {}).items()))),
+        )
+
+        with self._lock:
+            metric = self.buckets.get(bucket_key)
+            if metric is None:
+                metric = METRIC_TYPES[ty]()
+                self.buckets[bucket_key] = metric
+            metric.add(value)
+
+    def stop(self):
+        self._running = False
+        self._flusher.join()
+
+
+class Client:
+    def __init__(self) -> None:
+        self.aggregator = Aggregator()
+
+    def incr(
+        self,
+        key: str,
+        value: float,
+        unit: MetricUnit = "nanosecond",
+        tags: Optional[Tags] = None,
+        timestamp: Optional[float] = None,
+    ) -> None:
+        self.aggregator.add("c", key, value, unit, tags, timestamp)
+
+    def timing(
+        self,
+        key: str,
+        value: float,
+        unit: MetricUnit = "second",
+        tags: Optional[Tags] = None,
+        timestamp: Optional[float] = None,
+    ) -> None:
+        self.aggregator.add("d", key, value, unit, tags, timestamp)
+
+    def set(
+        self,
+        key: str,
+        value: Union[str, int],
+        tags: Optional[Tags] = None,
+        timestamp: Optional[float] = None,
+    ) -> None:
+        self.aggregator.add("s", key, value, None, tags, timestamp)
+
+    def gauge(
+        self,
+        key: str,
+        value: float,
+        unit: MetricUnit = "second",
+        tags: Optional[Tags] = None,
+        timestamp: Optional[float] = None,
+    ) -> None:
+        self.aggregator.add("g", key, value, unit, tags, timestamp)
+
+
+# TODO:
+#   * Check how to use units
+#   * Check usage of instance
+#
+class MiniSentryMetricsBackend(MetricsBackend):
+    def __init__(self):
+        super().__init__()
+        self._client = Client()
+
+    def incr(
+        self,
+        key: str,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        amount: Union[float, int] = 1,
+        sample_rate: float = 1,
+    ) -> None:
+        self._client.incr(key=key, value=amount, tags=tags)
+
+    def timing(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+    ) -> None:
+        self._client.timing(key=key, value=value, tags=tags)
+
+    def gauge(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+    ) -> None:
+        self._client.gauge(key=key, value=value, tags=tags)
+
+    def __del__(self):
+        # We want to make sure to stop the aggregator once the backend is destructed.
+        self._client.aggregator.stop()

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1500,3 +1500,9 @@ register(
     default=100,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "delightful_metrics.minimetrics_sample_rate",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -1,0 +1,21 @@
+import time
+from unittest.mock import patch
+
+from sentry.metrics.minimetrics import MiniMetricsMetricsBackend
+from sentry.testutils.cases import TestCase
+
+
+class DatadogMetricsBackendTest(TestCase):
+    def setUp(self):
+        self.backend = MiniMetricsMetricsBackend(prefix="sentrytest.")
+
+    @patch("sentry.metrics.minimetrics.Aggregator.ROLLUP_IN_SECONDS", 1.0)
+    @patch("sentry.metrics.minimetrics.metrics.incr")
+    def test_incr(self, metrics_incr):
+        self.backend.incr("foo", instance="bar")
+        # We wait for the metric to be flushed.
+        time.sleep(2.0)
+        # We stop the flusher.
+        self.backend._client.aggregator._running = False
+        self.backend._client.aggregator._flusher.join()
+        metrics_incr.assert_called_once()


### PR DESCRIPTION
This PR implements the two new metrics backends with the goal of measuring the amount of metrics that we would extract at Sentry. The two backends are:
* `MiniMetricsMetricsBackend` -> sends metrics to the minimetrics aggregator that will measure how many metrics it would actually emit.
* `CompositeExperimentalMetricsBackend` -> supports a primary backend to which data will be sent and also forwards the metrics to the `MiniMetricsMetricsBackend`.

Closes https://github.com/getsentry/sentry/issues/55439