### PR TITLE
fix: Delete artifact bundle's assemble status when it is deleted

### DIFF
--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -114,6 +114,15 @@ class ArtifactBundle(Model):
 
 
 def delete_file_for_artifact_bundle(instance, **kwargs):
+    from sentry.tasks.assemble import AssembleTask, delete_assemble_status
+
+    if instance.organization_id is not None and instance.file.checksum is not None:
+        delete_assemble_status(
+            AssembleTask.ARTIFACT_BUNDLE,
+            instance.organization_id,
+            instance.file.checksum,
+        )
+
     instance.file.delete()
 
 

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -192,6 +192,14 @@ def set_assemble_status(task, scope, checksum, state, detail=None):
     default_cache.set(cache_key, (state, detail), 600)
 
 
+def delete_assemble_status(task, scope, checksum):
+    """
+    Deletes the status of an assembling task.
+    """
+    cache_key = _get_cache_key(task, scope, checksum)
+    default_cache.delete(cache_key)
+
+
 @instrumented_task(
     name="sentry.tasks.assemble.assemble_dif",
     queue="assemble",

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -275,6 +275,11 @@ class AssembleArtifactsTest(BaseAssembleTest):
             ReleaseArtifactBundle.objects.all().delete()
             ProjectArtifactBundle.objects.all().delete()
 
+            status, details = get_assemble_status(
+                AssembleTask.ARTIFACT_BUNDLE, self.organization.id, total_checksum
+            )
+            assert status is None
+
     @patch("sentry.tasks.assemble.ArtifactBundlePostAssembler.post_assemble")
     def test_assembled_bundle_is_deleted_if_post_assembler_error_occurs(self, post_assemble):
         post_assemble.side_effect = Exception


### PR DESCRIPTION
Assemble statuses persist in the cache for a while, which can result in the artifact bundle being reported to `sentry-cli` as already existing after deletion.

Should fix https://github.com/getsentry/sentry-cli/issues/1724.