### PR TITLE
fix(stat-detector): Update issue type value and fix date

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
+++ b/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
@@ -39,7 +39,7 @@ function EventStatisticalDetectorMessage({event}: EventStatisticalDetectorMessag
               <Link to={normalizeUrl(transactionSummaryLink)}>{transactionName}</Link>
             ),
             amount: formatPercentage(
-              event?.occurrence?.evidenceData?.trendPercentage / 100
+              event?.occurrence?.evidenceData?.trendPercentage - 1
             ),
             date: detectionTime.toLocaleDateString(undefined, {
               month: 'short',

--- a/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
+++ b/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
@@ -25,8 +25,7 @@ function EventStatisticalDetectorMessage({event}: EventStatisticalDetectorMessag
     projectID: event.projectID,
     display: DisplayModes.TREND,
   });
-  const detectionTime = new Date(0);
-  detectionTime.setUTCSeconds(event?.occurrence?.evidenceData?.breakpoint);
+  const detectionTime = new Date(event?.occurrence?.evidenceData?.breakpoint * 1000);
 
   // TODO: This messaging should respect selected locale in user settings
   return (

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -72,7 +72,7 @@ export enum IssueType {
   PERFORMANCE_UNCOMPRESSED_ASSET = 'performance_uncompressed_assets',
   PERFORMANCE_LARGE_HTTP_PAYLOAD = 'performance_large_http_payload',
   PERFORMANCE_HTTP_OVERHEAD = 'performance_http_overhead',
-  PERFORMANCE_P95_TRANSACTION_DURATION_REGRESSION = 'performance_p95_transaction_duration_regression',
+  PERFORMANCE_DURATION_REGRESSION = 'performance_duration_regression',
 
   // Profile
   PROFILE_FILE_IO_MAIN_THREAD = 'profile_file_io_main_thread',

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -85,11 +85,16 @@ function GroupEventDetailsContent({
 
   const eventEntryProps = {group, event, project};
 
-  if (group.issueType === IssueType.PERFORMANCE_P95_TRANSACTION_DURATION_REGRESSION) {
+  if (group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION) {
     return (
-      // TODO: Swap this feature flag with the statistical detector flag
-      <Feature features={['performance-trends-issues']}>
-        <RegressionMessage event={event} />
+      <Feature
+        features={['performance-duration-regression']}
+        organization={organization}
+        renderDisabled
+      >
+        <Fragment>
+          <RegressionMessage event={event} />
+        </Fragment>
       </Feature>
     );
   }


### PR DESCRIPTION
The issue type has changed to be a shorter string, and I realized the way I was setting Date was incorrect. I can just pass the breakpoint time. I had to multiply by 1000 because the timestamp recorded in the issue occurrence is a Unix timestamp, meaning it's in seconds. The Date module expects a timestamp in ms.