### PR TITLE
fix(on-demand): Use normal has instead of batch_has

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, TypedDict, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, TypedDict, Union
 
 from sentry import features, options
 from sentry.api.endpoints.project_transaction_threshold import DEFAULT_THRESHOLD
@@ -84,12 +84,12 @@ def _on_demand_metrics_feature_flags(organization: Organization) -> Set[str]:
         "organizations:enable-on-demand-metrics-prefill",
     ]
 
-    feature_values = features.batch_has(feature_names, organization=organization)
-    if feature_values is None:
-        return set()
+    enabled_features = set()
+    for feature in feature_names:
+        if features.has(feature, organization=organization):
+            enabled_features.add(feature)
 
-    all_features = feature_values.get(f"organization:{organization.id}", {})
-    return cast(Set[str], {name for name, value in all_features.items() if value})
+    return enabled_features
 
 
 def _get_alert_metric_specs(


### PR DESCRIPTION
This PR uses `has` instead of `batch_has`.