### PR TITLE
feat(starfish): Add tooltips to column headings

### DIFF
--- a/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
@@ -2,6 +2,8 @@ import {Location} from 'history';
 
 import {GridColumnHeader} from 'sentry/components/gridEditable';
 import SortLink, {Alignments} from 'sentry/components/gridEditable/sortLink';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
 import {
   aggregateFunctionOutputType,
   fieldAlignment,
@@ -13,6 +15,7 @@ import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 
 type Options = {
   column: GridColumnHeader<string>;
+  isAggregate?: boolean;
   location?: Location;
   sort?: Sort;
 };
@@ -30,25 +33,35 @@ export const SORTABLE_FIELDS = new Set([
   `${HTTP_ERROR_COUNT}()`,
 ]);
 
-export const renderHeadCell = ({column, location, sort}: Options) => {
+export const renderHeadCell = ({
+  column,
+  location,
+  sort,
+  isAggregate = false,
+}: Options) => {
   const {key, name} = column;
   const alignment = getAlignment(key);
 
-  let newSortDirection: Sort['kind'] = 'desc';
-  if (sort?.field === column.key) {
-    if (sort.kind === 'desc') {
-      newSortDirection = 'asc';
-    }
-  }
+  const newSortDirection: Sort['kind'] =
+    sort?.field === column.key && sort.kind === 'desc' ? 'asc' : 'desc';
 
   const newSort = `${newSortDirection === 'desc' ? '-' : ''}${key}`;
+
+  const tooltipContent = getFieldDescription(key, isAggregate);
+  const title = tooltipContent ? (
+    <Tooltip key={key} isHoverable title={tooltipContent} showUnderline>
+      <div>{name}</div>
+    </Tooltip>
+  ) : (
+    name
+  );
 
   return (
     <SortLink
       align={alignment}
       canSort={Boolean(location && sort && SORTABLE_FIELDS.has(key))}
       direction={sort?.field === column.key ? sort.kind : undefined}
-      title={name}
+      title={title}
       generateSortLink={() => {
         return {
           ...location,
@@ -72,3 +85,24 @@ export const getAlignment = (key: string): Alignments => {
   }
   return 'left';
 };
+
+function getFieldDescription(key: string, isAggregate: boolean): string | undefined {
+  if (isAggregate) {
+    switch (key) {
+      case `${SPM}()`:
+        return t('The number of queries per minute across all endpoints.');
+      case `avg(${SPAN_SELF_TIME})`:
+        return t('The average duration of this query across all endpoints.');
+      default:
+    }
+  }
+
+  switch (key) {
+    case `${SPM}()`:
+      return t('The number of queries per minute in this endpoint.');
+    case `avg(${SPAN_SELF_TIME})`:
+      return t('The average duration of this query in this endpoint.');
+    default:
+      return undefined;
+  }
+}

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -103,7 +103,8 @@ export default function SpansTable({
             },
           ]}
           grid={{
-            renderHeadCell: column => renderHeadCell({column, sort, location}),
+            renderHeadCell: column =>
+              renderHeadCell({column, sort, location, isAggregate: true}),
             renderBodyCell: (column, row) =>
               renderBodyCell(
                 column,


### PR DESCRIPTION
ref https://www.notion.so/sentry/Design-Parity-Review-II-541bf4950d8e4daa916c21b6e0411e8e

This PR adds tooltips to the column headers in the db module and db query summary views. 

<img width="1327" alt="image" src="https://github.com/getsentry/sentry/assets/18689448/a3ad520c-6954-42fe-a925-f5a33d1c9d17">

<img width="1307" alt="image" src="https://github.com/getsentry/sentry/assets/18689448/53e01ea4-f8b6-409a-a538-770de33e7173">

I'd like to refactor this after to put all the sortable fields into their own enum, that way we don't have to duplicate things like `avg(${SPAN_SELF_TIME})` everywhere, but I'll do it in a follow-up PR.