### PR TITLE
ref(starfish): Rename plural enums

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -50,7 +50,7 @@ import {
 } from 'sentry/views/performance/transactionSummary/filter';
 import {PercentChangeCell} from 'sentry/views/starfish/components/tableCells/percentChangeCell';
 import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 
 import {decodeScalar} from '../queryString';
 
@@ -769,7 +769,7 @@ const SPECIAL_FUNCTIONS: SpecialFunctions = {
     return (
       <TimeSpentCell
         percentage={data[fieldName]}
-        total={data[`sum(${SpanMetricsFields.SPAN_SELF_TIME})`]}
+        total={data[`sum(${SpanMetricsField.SPAN_SELF_TIME})`]}
       />
     );
   },

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -11,7 +11,7 @@ import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
-import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {ActionSelector} from 'sentry/views/starfish/views/spans/selectors/actionSelector';
 import {DomainSelector} from 'sentry/views/starfish/views/spans/selectors/domainSelector';
 import SpansTable from 'sentry/views/starfish/views/spans/spansTable';
@@ -64,12 +64,12 @@ function DatabaseLandingPage() {
           <FilterOptionsContainer>
             <ActionSelector
               moduleName={moduleName}
-              value={moduleFilters[SpanMetricsFields.SPAN_ACTION] || ''}
+              value={moduleFilters[SpanMetricsField.SPAN_ACTION] || ''}
             />
 
             <DomainSelector
               moduleName={moduleName}
-              value={moduleFilters[SpanMetricsFields.SPAN_DOMAIN] || ''}
+              value={moduleFilters[SpanMetricsField.SPAN_DOMAIN] || ''}
             />
           </FilterOptionsContainer>
 

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -26,7 +26,7 @@ import {
   useSpanMetrics,
 } from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
-import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {
   getDurationChartTitle,
@@ -69,14 +69,14 @@ function SpanSummaryPage({params}: Props) {
     groupId,
     queryFilter,
     [
-      SpanMetricsFields.SPAN_OP,
-      SpanMetricsFields.SPAN_DESCRIPTION,
-      SpanMetricsFields.SPAN_ACTION,
-      SpanMetricsFields.SPAN_DOMAIN,
+      SpanMetricsField.SPAN_OP,
+      SpanMetricsField.SPAN_DESCRIPTION,
+      SpanMetricsField.SPAN_ACTION,
+      SpanMetricsField.SPAN_DOMAIN,
       'count()',
       `${StarfishFunctions.SPM}()`,
-      `sum(${SpanMetricsFields.SPAN_SELF_TIME})`,
-      `avg(${SpanMetricsFields.SPAN_SELF_TIME})`,
+      `sum(${SpanMetricsField.SPAN_SELF_TIME})`,
+      `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
       `${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`,
       `${StarfishFunctions.HTTP_ERROR_COUNT}()`,
     ],
@@ -85,27 +85,27 @@ function SpanSummaryPage({params}: Props) {
 
   const span = {
     ...spanMetrics,
-    [SpanMetricsFields.SPAN_GROUP]: groupId,
+    [SpanMetricsField.SPAN_GROUP]: groupId,
   } as {
-    [SpanMetricsFields.SPAN_OP]: string;
-    [SpanMetricsFields.SPAN_DESCRIPTION]: string;
-    [SpanMetricsFields.SPAN_ACTION]: string;
-    [SpanMetricsFields.SPAN_DOMAIN]: string;
-    [SpanMetricsFields.SPAN_GROUP]: string;
+    [SpanMetricsField.SPAN_OP]: string;
+    [SpanMetricsField.SPAN_DESCRIPTION]: string;
+    [SpanMetricsField.SPAN_ACTION]: string;
+    [SpanMetricsField.SPAN_DOMAIN]: string;
+    [SpanMetricsField.SPAN_GROUP]: string;
   };
 
   const {isLoading: areSpanMetricsSeriesLoading, data: spanMetricsSeriesData} =
     useSpanMetricsSeries(
       groupId,
       queryFilter,
-      [`avg(${SpanMetricsFields.SPAN_SELF_TIME})`, 'spm()', 'http_error_count()'],
+      [`avg(${SpanMetricsField.SPAN_SELF_TIME})`, 'spm()', 'http_error_count()'],
       'api.starfish.span-summary-page-metrics-chart'
     );
 
   useSynchronizeCharts([!areSpanMetricsSeriesLoading]);
 
   const spanMetricsThroughputSeries = {
-    seriesName: span?.[SpanMetricsFields.SPAN_OP]?.startsWith('db')
+    seriesName: span?.[SpanMetricsField.SPAN_OP]?.startsWith('db')
       ? 'Queries'
       : 'Requests',
     data: spanMetricsSeriesData?.['spm()'].data,
@@ -155,14 +155,14 @@ function SpanSummaryPage({params}: Props) {
             <SpanMetricsRibbon spanMetrics={span} />
           </HeaderContainer>
 
-          {span?.[SpanMetricsFields.SPAN_DESCRIPTION] && (
+          {span?.[SpanMetricsField.SPAN_DESCRIPTION] && (
             <DescriptionContainer>
               <SpanDescription
                 span={{
                   ...span,
-                  [SpanMetricsFields.SPAN_DESCRIPTION]:
+                  [SpanMetricsField.SPAN_DESCRIPTION]:
                     fullSpan?.description ??
-                    spanMetrics?.[SpanMetricsFields.SPAN_DESCRIPTION],
+                    spanMetrics?.[SpanMetricsField.SPAN_DESCRIPTION],
                 }}
               />
             </DescriptionContainer>
@@ -171,7 +171,7 @@ function SpanSummaryPage({params}: Props) {
           <BlockContainer>
             <Block>
               <ChartPanel
-                title={getThroughputChartTitle(span?.[SpanMetricsFields.SPAN_OP])}
+                title={getThroughputChartTitle(span?.[SpanMetricsField.SPAN_OP])}
               >
                 <Chart
                   height={CHART_HEIGHT}
@@ -191,13 +191,11 @@ function SpanSummaryPage({params}: Props) {
             </Block>
 
             <Block>
-              <ChartPanel
-                title={getDurationChartTitle(span?.[SpanMetricsFields.SPAN_OP])}
-              >
+              <ChartPanel title={getDurationChartTitle(span?.[SpanMetricsField.SPAN_OP])}>
                 <Chart
                   height={CHART_HEIGHT}
                   data={[
-                    spanMetricsSeriesData?.[`avg(${SpanMetricsFields.SPAN_SELF_TIME})`],
+                    spanMetricsSeriesData?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`],
                   ]}
                   loading={areSpanMetricsSeriesLoading}
                   utc={false}
@@ -219,8 +217,8 @@ function SpanSummaryPage({params}: Props) {
           )}
 
           <SampleList
-            projectId={span[SpanMetricsFields.PROJECT_ID]}
-            groupId={span[SpanMetricsFields.SPAN_GROUP]}
+            projectId={span[SpanMetricsField.PROJECT_ID]}
+            groupId={span[SpanMetricsField.SPAN_GROUP]}
             transactionName={transaction}
             transactionMethod={transactionMethod}
           />

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -26,7 +26,7 @@ import {
   useSpanMetrics,
 } from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
-import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {
   getDurationChartTitle,
@@ -74,11 +74,11 @@ function SpanSummaryPage({params}: Props) {
       SpanMetricsField.SPAN_ACTION,
       SpanMetricsField.SPAN_DOMAIN,
       'count()',
-      `${StarfishFunctions.SPM}()`,
+      `${SpanFunction.SPM}()`,
       `sum(${SpanMetricsField.SPAN_SELF_TIME})`,
       `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
-      `${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`,
-      `${StarfishFunctions.HTTP_ERROR_COUNT}()`,
+      `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
+      `${SpanFunction.HTTP_ERROR_COUNT}()`,
     ],
     'api.starfish.span-summary-page-metrics'
   );

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -50,15 +50,15 @@ import {
 } from 'sentry/utils/discover/fields';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 
 const STARFISH_CHART_GROUP = 'starfish_chart_group';
 
 export const STARFISH_FIELDS: Record<string, {outputType: AggregationOutputType}> = {
-  [SpanMetricsFields.SPAN_DURATION]: {
+  [SpanMetricsField.SPAN_DURATION]: {
     outputType: 'duration',
   },
-  [SpanMetricsFields.SPAN_SELF_TIME]: {
+  [SpanMetricsField.SPAN_SELF_TIME]: {
     outputType: 'duration',
   },
   // local is only used with `time_spent_percentage` function

--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -1,22 +1,22 @@
 import styled from '@emotion/styled';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
-import {SpanMetricsFields, SpanMetricsFieldTypes} from 'sentry/views/starfish/types';
+import {SpanMetricsField, SpanMetricsFieldTypes} from 'sentry/views/starfish/types';
 import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatter';
 
 type Props = {
   span: Pick<
     SpanMetricsFieldTypes,
-    SpanMetricsFields.SPAN_OP | SpanMetricsFields.SPAN_DESCRIPTION
+    SpanMetricsField.SPAN_OP | SpanMetricsField.SPAN_DESCRIPTION
   >;
 };
 
 export function SpanDescription({span}: Props) {
-  if (span[SpanMetricsFields.SPAN_OP].startsWith('db')) {
+  if (span[SpanMetricsField.SPAN_OP].startsWith('db')) {
     return <DatabaseSpanDescription span={span} />;
   }
 
-  return <WordBreak>{span[SpanMetricsFields.SPAN_DESCRIPTION]}</WordBreak>;
+  return <WordBreak>{span[SpanMetricsField.SPAN_DESCRIPTION]}</WordBreak>;
 }
 
 function DatabaseSpanDescription({span}: Props) {
@@ -24,7 +24,7 @@ function DatabaseSpanDescription({span}: Props) {
 
   return (
     <CodeSnippet language="sql">
-      {formatter.toString(span[SpanMetricsFields.SPAN_DESCRIPTION])}
+      {formatter.toString(span[SpanMetricsField.SPAN_DESCRIPTION])}
     </CodeSnippet>
   );
 }

--- a/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
@@ -8,7 +8,7 @@ import {
   parseFunction,
   Sort,
 } from 'sentry/utils/discover/fields';
-import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 
 type Options = {
@@ -17,7 +17,7 @@ type Options = {
   sort?: Sort;
 };
 
-const {SPAN_SELF_TIME} = SpanMetricsFields;
+const {SPAN_SELF_TIME} = SpanMetricsField;
 const {TIME_SPENT_PERCENTAGE, SPS, SPM, HTTP_ERROR_COUNT} = StarfishFunctions;
 
 export const SORTABLE_FIELDS = new Set([

--- a/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
@@ -8,7 +8,7 @@ import {
   parseFunction,
   Sort,
 } from 'sentry/utils/discover/fields';
-import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 
 type Options = {
@@ -18,7 +18,7 @@ type Options = {
 };
 
 const {SPAN_SELF_TIME} = SpanMetricsField;
-const {TIME_SPENT_PERCENTAGE, SPS, SPM, HTTP_ERROR_COUNT} = StarfishFunctions;
+const {TIME_SPENT_PERCENTAGE, SPS, SPM, HTTP_ERROR_COUNT} = SpanFunction;
 
 export const SORTABLE_FIELDS = new Set([
   `avg(${SPAN_SELF_TIME})`,

--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -13,7 +13,7 @@ import {useHoverOverlay, UseHoverOverlayProps} from 'sentry/utils/useHoverOverla
 import {useLocation} from 'sentry/utils/useLocation';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import {useFullSpanFromTrace} from 'sentry/views/starfish/queries/useFullSpanFromTrace';
-import {ModuleName, StarfishFunctions} from 'sentry/views/starfish/types';
+import {ModuleName, SpanFunction} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {useRoutingContext} from 'sentry/views/starfish/utils/routingContext';
 import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatter';
@@ -57,10 +57,10 @@ export function SpanDescriptionCell({
   const sort: string | undefined = queryString[QueryParameterNames.SPANS_SORT];
 
   // the spans page uses time_spent_percentage(local), so to persist the sort upon navigation we need to replace
-  if (sort?.includes(`${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`)) {
+  if (sort?.includes(`${SpanFunction.TIME_SPENT_PERCENTAGE}()`)) {
     queryString[QueryParameterNames.SPANS_SORT] = sort.replace(
-      `${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`,
-      `${StarfishFunctions.TIME_SPENT_PERCENTAGE}(local)`
+      `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
+      `${SpanFunction.TIME_SPENT_PERCENTAGE}(local)`
     );
   }
 

--- a/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
+++ b/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
@@ -1,6 +1,6 @@
 import {useEventJSON} from 'sentry/views/starfish/queries/useEventJSON';
 import {useIndexedSpans} from 'sentry/views/starfish/queries/useIndexedSpans';
-import {SpanIndexedFields} from 'sentry/views/starfish/types';
+import {SpanIndexedField} from 'sentry/views/starfish/types';
 
 // NOTE: Fetching the top one is a bit naive, but works for now. A better
 // approach might be to fetch several at a time, and let the hook consumer
@@ -9,7 +9,7 @@ export function useFullSpanFromTrace(group?: string, enabled: boolean = true) {
   const filters: {[key: string]: string} = {};
 
   if (group) {
-    filters[SpanIndexedFields.SPAN_GROUP] = group;
+    filters[SpanIndexedField.SPAN_GROUP] = group;
   }
 
   const indexedSpansResponse = useIndexedSpans(filters, 1, enabled);
@@ -17,12 +17,12 @@ export function useFullSpanFromTrace(group?: string, enabled: boolean = true) {
   const firstIndexedSpan = indexedSpansResponse.data?.[0];
 
   const eventJSONResponse = useEventJSON(
-    firstIndexedSpan ? firstIndexedSpan[SpanIndexedFields.TRANSACTION_ID] : undefined,
-    firstIndexedSpan ? firstIndexedSpan[SpanIndexedFields.PROJECT] : undefined
+    firstIndexedSpan ? firstIndexedSpan[SpanIndexedField.TRANSACTION_ID] : undefined,
+    firstIndexedSpan ? firstIndexedSpan[SpanIndexedField.PROJECT] : undefined
   );
 
   const fullSpan = eventJSONResponse?.data?.spans?.find(
-    span => span.span_id === firstIndexedSpan?.[SpanIndexedFields.ID]
+    span => span.span_id === firstIndexedSpan?.[SpanIndexedField.ID]
   );
 
   // N.B. There isn't a great pattern for us to merge the responses together,

--- a/static/app/views/starfish/queries/useIndexedSpans.tsx
+++ b/static/app/views/starfish/queries/useIndexedSpans.tsx
@@ -4,7 +4,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import {SpanIndexedFields, SpanIndexedFieldTypes} from 'sentry/views/starfish/types';
+import {SpanIndexedField, SpanIndexedFieldTypes} from 'sentry/views/starfish/types';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
 const DEFAULT_LIMIT = 10;
@@ -43,7 +43,7 @@ function getEventView(filters: Filters, location: Location) {
     {
       name: '',
       query: search.formatString(),
-      fields: Object.values(SpanIndexedFields),
+      fields: Object.values(SpanIndexedField),
       dataset: DiscoverDatasets.SPANS_INDEXED,
       version: 2,
     },

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -6,12 +6,12 @@ import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
-import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
 const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, SPAN_DOMAIN, PROJECT_ID} =
-  SpanMetricsFields;
+  SpanMetricsField;
 
 export type SpanMetrics = {
   'avg(span.self_time)': number;

--- a/static/app/views/starfish/queries/useSpanMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.tsx
@@ -3,10 +3,10 @@ import {Location} from 'history';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
-const {SPAN_GROUP} = SpanMetricsFields;
+const {SPAN_GROUP} = SpanMetricsField;
 
 export type SpanMetrics = {
   [metric: string]: number | string;

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -7,11 +7,11 @@ import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {SpanSummaryQueryFilters} from 'sentry/views/starfish/queries/useSpanMetrics';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
-const {SPAN_GROUP} = SpanMetricsFields;
+const {SPAN_GROUP} = SpanMetricsField;
 
 export type SpanMetrics = {
   interval: number;

--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -9,11 +9,11 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {computeAxisMax} from 'sentry/views/starfish/components/chart';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
-import {SpanIndexedFields, SpanIndexedFieldTypes} from 'sentry/views/starfish/types';
+import {SpanIndexedField, SpanIndexedFieldTypes} from 'sentry/views/starfish/types';
 import {getDateConditions} from 'sentry/views/starfish/utils/getDateConditions';
 import {DATE_FORMAT} from 'sentry/views/starfish/utils/useSpansQuery';
 
-const {SPAN_SELF_TIME, SPAN_GROUP} = SpanIndexedFields;
+const {SPAN_SELF_TIME, SPAN_GROUP} = SpanIndexedField;
 
 type Options = {
   groupId: string;
@@ -23,11 +23,11 @@ type Options = {
 
 export type SpanSample = Pick<
   SpanIndexedFieldTypes,
-  | SpanIndexedFields.SPAN_SELF_TIME
-  | SpanIndexedFields.TRANSACTION_ID
-  | SpanIndexedFields.PROJECT
-  | SpanIndexedFields.TIMESTAMP
-  | SpanIndexedFields.ID
+  | SpanIndexedField.SPAN_SELF_TIME
+  | SpanIndexedField.TRANSACTION_ID
+  | SpanIndexedField.PROJECT
+  | SpanIndexedField.TIMESTAMP
+  | SpanIndexedField.ID
 >;
 
 export const useSpanSamples = (options: Options) => {

--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -5,10 +5,10 @@ import {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
-const {SPAN_SELF_TIME, SPAN_GROUP} = SpanMetricsFields;
+const {SPAN_SELF_TIME, SPAN_GROUP} = SpanMetricsField;
 
 export type SpanTransactionMetrics = {
   'avg(span.self_time)': number;

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -39,7 +39,7 @@ export type SpanMetricsFieldTypes = {
   [SpanMetricsField.SPAN_DURATION]: number;
 };
 
-export enum SpanIndexedFields {
+export enum SpanIndexedField {
   SPAN_SELF_TIME = 'span.self_time',
   SPAN_GROUP = 'span.group', // Span group computed from the normalized description. Matches the group in the metrics data set
   SPAN_GROUP_RAW = 'span.group_raw', // Span group computed from non-normalized description. Matches the group in the event payload
@@ -57,23 +57,23 @@ export enum SpanIndexedFields {
 }
 
 export type SpanIndexedFieldTypes = {
-  [SpanIndexedFields.SPAN_SELF_TIME]: number;
-  [SpanIndexedFields.SPAN_GROUP]: string;
-  [SpanIndexedFields.SPAN_GROUP_RAW]: string;
-  [SpanIndexedFields.SPAN_MODULE]: string;
-  [SpanIndexedFields.SPAN_DESCRIPTION]: string;
-  [SpanIndexedFields.SPAN_OP]: string;
-  [SpanIndexedFields.ID]: string;
-  [SpanIndexedFields.SPAN_ACTION]: string;
-  [SpanIndexedFields.TRANSACTION_ID]: string;
-  [SpanIndexedFields.TRANSACTION_METHOD]: string;
-  [SpanIndexedFields.TRANSACTION_OP]: string;
-  [SpanIndexedFields.SPAN_DOMAIN]: string;
-  [SpanIndexedFields.TIMESTAMP]: string;
-  [SpanIndexedFields.PROJECT]: string;
+  [SpanIndexedField.SPAN_SELF_TIME]: number;
+  [SpanIndexedField.SPAN_GROUP]: string;
+  [SpanIndexedField.SPAN_GROUP_RAW]: string;
+  [SpanIndexedField.SPAN_MODULE]: string;
+  [SpanIndexedField.SPAN_DESCRIPTION]: string;
+  [SpanIndexedField.SPAN_OP]: string;
+  [SpanIndexedField.ID]: string;
+  [SpanIndexedField.SPAN_ACTION]: string;
+  [SpanIndexedField.TRANSACTION_ID]: string;
+  [SpanIndexedField.TRANSACTION_METHOD]: string;
+  [SpanIndexedField.TRANSACTION_OP]: string;
+  [SpanIndexedField.SPAN_DOMAIN]: string;
+  [SpanIndexedField.TIMESTAMP]: string;
+  [SpanIndexedField.PROJECT]: string;
 };
 
-export type Op = SpanIndexedFieldTypes[SpanIndexedFields.SPAN_OP];
+export type Op = SpanIndexedFieldTypes[SpanIndexedField.SPAN_OP];
 
 export enum StarfishFunctions {
   SPS = 'sps',
@@ -84,8 +84,8 @@ export enum StarfishFunctions {
 }
 
 export const StarfishDatasetFields = {
-  [DiscoverDatasets.SPANS_METRICS]: SpanIndexedFields,
-  [DiscoverDatasets.SPANS_INDEXED]: SpanIndexedFields,
+  [DiscoverDatasets.SPANS_METRICS]: SpanIndexedField,
+  [DiscoverDatasets.SPANS_INDEXED]: SpanIndexedField,
 };
 
 export const STARFISH_AGGREGATION_FIELDS: Record<

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -16,7 +16,7 @@ export enum ModuleName {
   OTHER = 'other',
 }
 
-export enum SpanMetricsFields {
+export enum SpanMetricsField {
   SPAN_OP = 'span.op',
   SPAN_DESCRIPTION = 'span.description',
   SPAN_MODULE = 'span.module',
@@ -29,14 +29,14 @@ export enum SpanMetricsFields {
 }
 
 export type SpanMetricsFieldTypes = {
-  [SpanMetricsFields.SPAN_OP]: string;
-  [SpanMetricsFields.SPAN_DESCRIPTION]: string;
-  [SpanMetricsFields.SPAN_MODULE]: string;
-  [SpanMetricsFields.SPAN_ACTION]: string;
-  [SpanMetricsFields.SPAN_DOMAIN]: string;
-  [SpanMetricsFields.SPAN_GROUP]: string;
-  [SpanMetricsFields.SPAN_SELF_TIME]: number;
-  [SpanMetricsFields.SPAN_DURATION]: number;
+  [SpanMetricsField.SPAN_OP]: string;
+  [SpanMetricsField.SPAN_DESCRIPTION]: string;
+  [SpanMetricsField.SPAN_MODULE]: string;
+  [SpanMetricsField.SPAN_ACTION]: string;
+  [SpanMetricsField.SPAN_DOMAIN]: string;
+  [SpanMetricsField.SPAN_GROUP]: string;
+  [SpanMetricsField.SPAN_SELF_TIME]: number;
+  [SpanMetricsField.SPAN_DURATION]: number;
 };
 
 export enum SpanIndexedFields {

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -75,7 +75,7 @@ export type SpanIndexedFieldTypes = {
 
 export type Op = SpanIndexedFieldTypes[SpanIndexedField.SPAN_OP];
 
-export enum StarfishFunctions {
+export enum SpanFunction {
   SPS = 'sps',
   SPM = 'spm',
   SPS_PERCENENT_CHANGE = 'sps_percent_change',
@@ -89,34 +89,34 @@ export const StarfishDatasetFields = {
 };
 
 export const STARFISH_AGGREGATION_FIELDS: Record<
-  StarfishFunctions,
+  SpanFunction,
   FieldDefinition & {defaultOutputType: AggregationOutputType}
 > = {
-  [StarfishFunctions.SPS]: {
+  [SpanFunction.SPS]: {
     desc: t('Spans per second'),
     kind: FieldKind.FUNCTION,
     defaultOutputType: 'number',
     valueType: FieldValueType.NUMBER,
   },
-  [StarfishFunctions.SPM]: {
+  [SpanFunction.SPM]: {
     desc: t('Spans per minute'),
     kind: FieldKind.FUNCTION,
     defaultOutputType: 'number',
     valueType: FieldValueType.NUMBER,
   },
-  [StarfishFunctions.TIME_SPENT_PERCENTAGE]: {
+  [SpanFunction.TIME_SPENT_PERCENTAGE]: {
     desc: t('Span time spent percentage'),
     defaultOutputType: 'percentage',
     kind: FieldKind.FUNCTION,
     valueType: FieldValueType.NUMBER,
   },
-  [StarfishFunctions.HTTP_ERROR_COUNT]: {
+  [SpanFunction.HTTP_ERROR_COUNT]: {
     desc: t('Count of 5XX http errors'),
     defaultOutputType: 'integer',
     kind: FieldKind.FUNCTION,
     valueType: FieldValueType.NUMBER,
   },
-  [StarfishFunctions.SPS_PERCENENT_CHANGE]: {
+  [SpanFunction.SPS_PERCENENT_CHANGE]: {
     desc: t('Spans per second percentage change'),
     defaultOutputType: 'percentage',
     kind: FieldKind.FUNCTION,

--- a/static/app/views/starfish/utils/buildEventViewQuery.tsx
+++ b/static/app/views/starfish/utils/buildEventViewQuery.tsx
@@ -1,12 +1,12 @@
 import {Location} from 'history';
 
 import {defined} from 'sentry/utils';
-import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 import {NULL_SPAN_CATEGORY} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
 const {SPAN_DESCRIPTION, SPAN_OP, SPAN_DOMAIN, SPAN_ACTION, SPAN_MODULE} =
-  SpanMetricsFields;
+  SpanMetricsField;
 
 const SPAN_FILTER_KEYS = [
   SPAN_OP,

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -19,7 +19,7 @@ import {
   SpanSummaryQueryFilters,
   useSpanMetrics,
 } from 'sentry/views/starfish/queries/useSpanMetrics';
-import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
@@ -65,21 +65,21 @@ function SpanSummaryPage({params, location}: Props) {
     groupId,
     queryFilter,
     [
-      SpanMetricsFields.SPAN_OP,
-      SpanMetricsFields.SPAN_GROUP,
-      SpanMetricsFields.PROJECT_ID,
+      SpanMetricsField.SPAN_OP,
+      SpanMetricsField.SPAN_GROUP,
+      SpanMetricsField.PROJECT_ID,
       `${StarfishFunctions.SPS}()`,
     ],
     'api.starfish.span-summary-page-metrics'
   );
 
   const span = {
-    [SpanMetricsFields.SPAN_OP]: spanMetrics[SpanMetricsFields.SPAN_OP],
-    [SpanMetricsFields.SPAN_GROUP]: groupId,
+    [SpanMetricsField.SPAN_OP]: spanMetrics[SpanMetricsField.SPAN_OP],
+    [SpanMetricsField.SPAN_GROUP]: groupId,
   };
 
   const title = [
-    getSpanOperationDescription(span[SpanMetricsFields.SPAN_OP]),
+    getSpanOperationDescription(span[SpanMetricsField.SPAN_OP]),
     t('Summary'),
   ].join(' ');
 
@@ -137,8 +137,8 @@ function SpanSummaryPage({params, location}: Props) {
                 )}
 
                 <SampleList
-                  groupId={span[SpanMetricsFields.SPAN_GROUP]}
-                  projectId={spanMetrics[SpanMetricsFields.PROJECT_ID]}
+                  groupId={span[SpanMetricsField.SPAN_GROUP]}
+                  projectId={spanMetrics[SpanMetricsField.PROJECT_ID]}
                   transactionName={transaction}
                   transactionMethod={transactionMethod}
                 />

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -19,7 +19,7 @@ import {
   SpanSummaryQueryFilters,
   useSpanMetrics,
 } from 'sentry/views/starfish/queries/useSpanMetrics';
-import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
@@ -68,7 +68,7 @@ function SpanSummaryPage({params, location}: Props) {
       SpanMetricsField.SPAN_OP,
       SpanMetricsField.SPAN_GROUP,
       SpanMetricsField.PROJECT_ID,
-      `${StarfishFunctions.SPS}()`,
+      `${SpanFunction.SPS}()`,
     ],
     'api.starfish.span-summary-page-metrics'
   );

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -9,7 +9,7 @@ import {isNearAverage} from 'sentry/views/starfish/components/samplesTable/commo
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {SpanSample, useSpanSamples} from 'sentry/views/starfish/queries/useSpanSamples';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 import {
   crossIconPath,
@@ -17,7 +17,7 @@ import {
   upwardPlayIconPath,
 } from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart/symbol';
 
-const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsFields;
+const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
 
 type Props = {
   groupId: string;

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -6,11 +6,11 @@ import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 
-const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsFields;
+const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
 
 type Props = {
   groupId: string;

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.spec.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.spec.tsx
@@ -5,7 +5,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {PageFilters} from 'sentry/types';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 
 import SampleTable from './sampleTable';
 
@@ -94,8 +94,8 @@ const initializeMockRequests = () => {
     body: {
       data: [
         {
-          [SpanMetricsFields.SPAN_OP]: 'db',
-          [`avg(${SpanMetricsFields.SPAN_SELF_TIME})`]: 0.52,
+          [SpanMetricsField.SPAN_OP]: 'db',
+          [`avg(${SpanMetricsField.SPAN_SELF_TIME})`]: 0.52,
         },
       ],
     },

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -13,9 +13,9 @@ import {SpanSamplesTable} from 'sentry/views/starfish/components/samplesTable/sp
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {SpanSample, useSpanSamples} from 'sentry/views/starfish/queries/useSpanSamples';
 import {useTransactions} from 'sentry/views/starfish/queries/useTransactions';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 
-const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsFields;
+const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
 
 const SpanSamplesTableContainer = styled('div')`
   padding-bottom: ${space(2)};

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.spec.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.spec.tsx
@@ -1,14 +1,14 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
 import {SpanMetricsRibbon} from 'sentry/views/starfish/views/spanSummaryPage/spanMetricsRibbon';
 
 describe('SpanMetricsRibbon', function () {
   const sampleMetrics = {
-    [SpanMetricsFields.SPAN_OP]: 'db',
+    [SpanMetricsField.SPAN_OP]: 'db',
     [`${StarfishFunctions.SPM}()`]: 17.8,
-    [`avg(${SpanMetricsFields.SPAN_SELF_TIME})`]: 127.1,
-    [`sum(${SpanMetricsFields.SPAN_SELF_TIME})`]: 1172319,
+    [`avg(${SpanMetricsField.SPAN_SELF_TIME})`]: 127.1,
+    [`sum(${SpanMetricsField.SPAN_SELF_TIME})`]: 1172319,
     [`${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`]: 0.002,
   };
 

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.spec.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.spec.tsx
@@ -1,15 +1,15 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {SpanMetricsRibbon} from 'sentry/views/starfish/views/spanSummaryPage/spanMetricsRibbon';
 
 describe('SpanMetricsRibbon', function () {
   const sampleMetrics = {
     [SpanMetricsField.SPAN_OP]: 'db',
-    [`${StarfishFunctions.SPM}()`]: 17.8,
+    [`${SpanFunction.SPM}()`]: 17.8,
     [`avg(${SpanMetricsField.SPAN_SELF_TIME})`]: 127.1,
     [`sum(${SpanMetricsField.SPAN_SELF_TIME})`]: 1172319,
-    [`${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`]: 0.002,
+    [`${SpanFunction.TIME_SPENT_PERCENTAGE}()`]: 0.002,
   };
 
   it('renders basic metrics', function () {

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
@@ -4,22 +4,22 @@ import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
-import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 
 interface Props {
   spanMetrics: {
-    [SpanMetricsFields.SPAN_OP]?: string;
-    [SpanMetricsFields.SPAN_DESCRIPTION]?: string;
-    [SpanMetricsFields.SPAN_ACTION]?: string;
-    [SpanMetricsFields.SPAN_DOMAIN]?: string;
-    [SpanMetricsFields.SPAN_GROUP]?: string;
+    [SpanMetricsField.SPAN_OP]?: string;
+    [SpanMetricsField.SPAN_DESCRIPTION]?: string;
+    [SpanMetricsField.SPAN_ACTION]?: string;
+    [SpanMetricsField.SPAN_DOMAIN]?: string;
+    [SpanMetricsField.SPAN_GROUP]?: string;
   };
 }
 
 export function SpanMetricsRibbon({spanMetrics}: Props) {
-  const op = spanMetrics?.[SpanMetricsFields.SPAN_OP] ?? '';
+  const op = spanMetrics?.[SpanMetricsField.SPAN_OP] ?? '';
 
   return (
     <BlockContainer>
@@ -32,7 +32,7 @@ export function SpanMetricsRibbon({spanMetrics}: Props) {
 
       <Block title={DataTitles.avg}>
         <DurationCell
-          milliseconds={spanMetrics?.[`avg(${SpanMetricsFields.SPAN_SELF_TIME})`]}
+          milliseconds={spanMetrics?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]}
         />
       </Block>
 
@@ -45,7 +45,7 @@ export function SpanMetricsRibbon({spanMetrics}: Props) {
       <Block title={t('Time Spent')}>
         <TimeSpentCell
           percentage={spanMetrics?.[`${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`]}
-          total={spanMetrics?.[`sum(${SpanMetricsFields.SPAN_SELF_TIME})`]}
+          total={spanMetrics?.[`sum(${SpanMetricsField.SPAN_SELF_TIME})`]}
         />
       </Block>
     </BlockContainer>

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
@@ -4,7 +4,7 @@ import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
-import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 
@@ -25,7 +25,7 @@ export function SpanMetricsRibbon({spanMetrics}: Props) {
     <BlockContainer>
       <Block title={getThroughputTitle(op)}>
         <ThroughputCell
-          rate={spanMetrics?.[`${StarfishFunctions.SPM}()`]}
+          rate={spanMetrics?.[`${SpanFunction.SPM}()`]}
           unit={RateUnits.PER_MINUTE}
         />
       </Block>
@@ -38,13 +38,13 @@ export function SpanMetricsRibbon({spanMetrics}: Props) {
 
       {op.startsWith('http') && (
         <Block title={t('5XX Responses')} description={t('5XX responses in this span')}>
-          <CountCell count={spanMetrics?.[`${StarfishFunctions.HTTP_ERROR_COUNT}()`]} />
+          <CountCell count={spanMetrics?.[`${SpanFunction.HTTP_ERROR_COUNT}()`]} />
         </Block>
       )}
 
       <Block title={t('Time Spent')}>
         <TimeSpentCell
-          percentage={spanMetrics?.[`${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`]}
+          percentage={spanMetrics?.[`${SpanFunction.TIME_SPENT_PERCENTAGE}()`]}
           total={spanMetrics?.[`sum(${SpanMetricsField.SPAN_SELF_TIME})`]}
         />
       </Block>

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -16,7 +16,7 @@ import {
   useSpanMetrics,
 } from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
-import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {
   DataTitles,
   getThroughputChartTitle,
@@ -56,11 +56,11 @@ export function SpanSummaryView({groupId}: Props) {
       SpanMetricsField.SPAN_ACTION,
       SpanMetricsField.SPAN_DOMAIN,
       'count()',
-      `${StarfishFunctions.SPM}()`,
+      `${SpanFunction.SPM}()`,
       `sum(${SpanMetricsField.SPAN_SELF_TIME})`,
       `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
-      `${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`,
-      `${StarfishFunctions.HTTP_ERROR_COUNT}()`,
+      `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
+      `${SpanFunction.HTTP_ERROR_COUNT}()`,
     ],
     'api.starfish.span-summary-page-metrics'
   );

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -16,7 +16,7 @@ import {
   useSpanMetrics,
 } from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
-import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
 import {
   DataTitles,
   getThroughputChartTitle,
@@ -51,14 +51,14 @@ export function SpanSummaryView({groupId}: Props) {
     groupId,
     queryFilter,
     [
-      SpanMetricsFields.SPAN_OP,
-      SpanMetricsFields.SPAN_DESCRIPTION,
-      SpanMetricsFields.SPAN_ACTION,
-      SpanMetricsFields.SPAN_DOMAIN,
+      SpanMetricsField.SPAN_OP,
+      SpanMetricsField.SPAN_DESCRIPTION,
+      SpanMetricsField.SPAN_ACTION,
+      SpanMetricsField.SPAN_DOMAIN,
       'count()',
       `${StarfishFunctions.SPM}()`,
-      `sum(${SpanMetricsFields.SPAN_SELF_TIME})`,
-      `avg(${SpanMetricsFields.SPAN_SELF_TIME})`,
+      `sum(${SpanMetricsField.SPAN_SELF_TIME})`,
+      `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
       `${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`,
       `${StarfishFunctions.HTTP_ERROR_COUNT}()`,
     ],
@@ -67,27 +67,27 @@ export function SpanSummaryView({groupId}: Props) {
 
   const span = {
     ...spanMetrics,
-    [SpanMetricsFields.SPAN_GROUP]: groupId,
+    [SpanMetricsField.SPAN_GROUP]: groupId,
   } as {
-    [SpanMetricsFields.SPAN_OP]: string;
-    [SpanMetricsFields.SPAN_DESCRIPTION]: string;
-    [SpanMetricsFields.SPAN_ACTION]: string;
-    [SpanMetricsFields.SPAN_DOMAIN]: string;
-    [SpanMetricsFields.SPAN_GROUP]: string;
+    [SpanMetricsField.SPAN_OP]: string;
+    [SpanMetricsField.SPAN_DESCRIPTION]: string;
+    [SpanMetricsField.SPAN_ACTION]: string;
+    [SpanMetricsField.SPAN_DOMAIN]: string;
+    [SpanMetricsField.SPAN_GROUP]: string;
   };
 
   const {isLoading: areSpanMetricsSeriesLoading, data: spanMetricsSeriesData} =
     useSpanMetricsSeries(
       groupId,
       queryFilter,
-      [`avg(${SpanMetricsFields.SPAN_SELF_TIME})`, 'spm()', 'http_error_count()'],
+      [`avg(${SpanMetricsField.SPAN_SELF_TIME})`, 'spm()', 'http_error_count()'],
       'api.starfish.span-summary-page-metrics-chart'
     );
 
   useSynchronizeCharts([!areSpanMetricsSeriesLoading]);
 
   const spanMetricsThroughputSeries = {
-    seriesName: span?.[SpanMetricsFields.SPAN_OP]?.startsWith('db')
+    seriesName: span?.[SpanMetricsField.SPAN_OP]?.startsWith('db')
       ? 'Queries'
       : 'Requests',
     data: spanMetricsSeriesData?.['spm()'].data,
@@ -103,14 +103,13 @@ export function SpanSummaryView({groupId}: Props) {
         <SpanMetricsRibbon spanMetrics={span} />
       </HeaderContainer>
 
-      {span?.[SpanMetricsFields.SPAN_DESCRIPTION] && (
+      {span?.[SpanMetricsField.SPAN_DESCRIPTION] && (
         <DescriptionContainer>
           <SpanDescription
             span={{
               ...span,
-              [SpanMetricsFields.SPAN_DESCRIPTION]:
-                fullSpan?.description ??
-                spanMetrics?.[SpanMetricsFields.SPAN_DESCRIPTION],
+              [SpanMetricsField.SPAN_DESCRIPTION]:
+                fullSpan?.description ?? spanMetrics?.[SpanMetricsField.SPAN_DESCRIPTION],
             }}
           />
         </DescriptionContainer>
@@ -118,7 +117,7 @@ export function SpanSummaryView({groupId}: Props) {
 
       <BlockContainer>
         <Block>
-          <ChartPanel title={getThroughputChartTitle(span?.[SpanMetricsFields.SPAN_OP])}>
+          <ChartPanel title={getThroughputChartTitle(span?.[SpanMetricsField.SPAN_OP])}>
             <Chart
               height={CHART_HEIGHT}
               data={[spanMetricsThroughputSeries]}
@@ -140,7 +139,7 @@ export function SpanSummaryView({groupId}: Props) {
           <ChartPanel title={DataTitles.avg}>
             <Chart
               height={CHART_HEIGHT}
-              data={[spanMetricsSeriesData?.[`avg(${SpanMetricsFields.SPAN_SELF_TIME})`]]}
+              data={[spanMetricsSeriesData?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]]}
               loading={areSpanMetricsSeriesLoading}
               utc={false}
               chartColors={[AVG_COLOR]}
@@ -150,7 +149,7 @@ export function SpanSummaryView({groupId}: Props) {
           </ChartPanel>
         </Block>
 
-        {span?.[SpanMetricsFields.SPAN_OP]?.startsWith('http') && (
+        {span?.[SpanMetricsField.SPAN_OP]?.startsWith('http') && (
           <Block>
             <ChartPanel title={DataTitles.errorCount}>
               <Chart

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -31,7 +31,7 @@ import {
 import {
   SpanIndexedFields,
   SpanIndexedFieldTypes,
-  SpanMetricsFields,
+  SpanMetricsField,
   SpanMetricsFieldTypes,
 } from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
@@ -52,7 +52,7 @@ type Props = {
   sort: ValidSort;
   span: Pick<
     SpanMetricsFieldTypes,
-    SpanMetricsFields.SPAN_GROUP | SpanMetricsFields.SPAN_OP
+    SpanMetricsField.SPAN_GROUP | SpanMetricsField.SPAN_OP
   >;
   endpoint?: string;
   endpointMethod?: string;
@@ -74,7 +74,7 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
     isLoading,
     pageLinks,
   } = useSpanTransactionMetrics(
-    span[SpanMetricsFields.SPAN_GROUP],
+    span[SpanMetricsField.SPAN_GROUP],
     {
       transactions: endpoint ? [endpoint] : undefined,
       sorts: [sort],
@@ -99,7 +99,7 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
 
       const pathname = `${routingContext.baseURL}/${
         extractRoute(location) ?? 'spans'
-      }/span/${encodeURIComponent(span[SpanMetricsFields.SPAN_GROUP])}`;
+      }/span/${encodeURIComponent(span[SpanMetricsField.SPAN_GROUP])}`;
       const query = {
         ...location.query,
         endpoint,
@@ -196,7 +196,7 @@ const getColumnOrder = (
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: `avg(${SpanMetricsFields.SPAN_SELF_TIME})`,
+    key: `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
     name: DataTitles.avg,
     width: COL_WIDTH_UNDEFINED,
   },

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -29,7 +29,7 @@ import {
   useSpanTransactionMetrics,
 } from 'sentry/views/starfish/queries/useSpanTransactionMetrics';
 import {
-  SpanIndexedFields,
+  SpanIndexedField,
   SpanIndexedFieldTypes,
   SpanMetricsField,
   SpanMetricsFieldTypes,
@@ -182,7 +182,7 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
 const getColumnOrder = (
   span: Pick<
     SpanIndexedFieldTypes,
-    SpanIndexedFields.SPAN_GROUP | SpanIndexedFields.SPAN_OP
+    SpanIndexedField.SPAN_GROUP | SpanIndexedField.SPAN_OP
   >
 ): TableColumnHeader[] => [
   {
@@ -192,7 +192,7 @@ const getColumnOrder = (
   },
   {
     key: 'spm()',
-    name: getThroughputTitle(span[SpanIndexedFields.SPAN_OP]),
+    name: getThroughputTitle(span[SpanIndexedField.SPAN_OP]),
     width: COL_WIDTH_UNDEFINED,
   },
   {

--- a/static/app/views/starfish/views/spans/index.tsx
+++ b/static/app/views/starfish/views/spans/index.tsx
@@ -12,13 +12,13 @@ import {useLocation} from 'sentry/utils/useLocation';
 import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
 import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
 import {StarfishProjectSelector} from 'sentry/views/starfish/components/starfishProjectSelector';
-import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 import {RoutingContextProvider} from 'sentry/views/starfish/utils/routingContext';
 
 import SpansView from './spansView';
 
-const {SPAN_MODULE} = SpanMetricsFields;
+const {SPAN_MODULE} = SpanMetricsField;
 
 type Query = {
   'span.category'?: string;

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -8,7 +8,7 @@ import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
-import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {
@@ -16,7 +16,7 @@ import {
   EmptyContainer,
 } from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
-const {SPAN_ACTION} = SpanMetricsFields;
+const {SPAN_ACTION} = SpanMetricsField;
 
 type Props = {
   moduleName?: ModuleName;

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -9,7 +9,7 @@ import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
-import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {
@@ -17,7 +17,7 @@ import {
   EmptyContainer,
 } from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
-const {SPAN_DOMAIN} = SpanMetricsFields;
+const {SPAN_DOMAIN} = SpanMetricsField;
 
 type Props = {
   moduleName?: ModuleName;

--- a/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
@@ -7,7 +7,7 @@ import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
-import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {
@@ -15,7 +15,7 @@ import {
   EMPTY_OPTION_VALUE,
 } from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
-const {SPAN_OP} = SpanMetricsFields;
+const {SPAN_OP} = SpanMetricsField;
 
 type Props = {
   value: string;

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -12,7 +12,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {AVG_COLOR, ERRORS_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
 import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
-import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {useErrorRateQuery as useErrorCountQuery} from 'sentry/views/starfish/views/spans/queries';
@@ -24,7 +24,7 @@ import {
 import {ModuleFilters} from 'sentry/views/starfish/views/spans/useModuleFilters';
 import {NULL_SPAN_CATEGORY} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
-const {SPAN_SELF_TIME, SPAN_MODULE, SPAN_DESCRIPTION} = SpanMetricsFields;
+const {SPAN_SELF_TIME, SPAN_MODULE, SPAN_DESCRIPTION} = SpanMetricsField;
 
 const CHART_HEIGHT = 140;
 

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -18,7 +18,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import {SpanDescriptionCell} from 'sentry/views/starfish/components/tableCells/spanDescriptionCell';
 import {useSpanList} from 'sentry/views/starfish/queries/useSpanList';
-import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 import type {ValidSort} from 'sentry/views/starfish/views/spans/useModuleSort';
@@ -48,7 +48,7 @@ type Props = {
 };
 
 const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_DOMAIN, SPAN_GROUP, SPAN_OP, PROJECT_ID} =
-  SpanMetricsFields;
+  SpanMetricsField;
 
 export default function SpansTable({
   moduleName,

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
-import {ModuleName, SpanMetricsFields} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {ActionSelector} from 'sentry/views/starfish/views/spans/selectors/actionSelector';
 import {DomainSelector} from 'sentry/views/starfish/views/spans/selectors/domainSelector';
 import {SpanOperationSelector} from 'sentry/views/starfish/views/spans/selectors/spanOperationSelector';
@@ -12,7 +12,7 @@ import {useModuleSort} from 'sentry/views/starfish/views/spans/useModuleSort';
 
 import SpansTable from './spansTable';
 
-const {SPAN_ACTION, SPAN_DOMAIN, SPAN_OP} = SpanMetricsFields;
+const {SPAN_ACTION, SPAN_DOMAIN, SPAN_OP} = SpanMetricsField;
 
 const LIMIT: number = 25;
 

--- a/static/app/views/starfish/views/spans/useModuleFilters.ts
+++ b/static/app/views/starfish/views/spans/useModuleFilters.ts
@@ -1,22 +1,22 @@
 import pick from 'lodash/pick';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 
 export type ModuleFilters = {
-  [SpanMetricsFields.SPAN_ACTION]?: string;
-  [SpanMetricsFields.SPAN_DOMAIN]?: string;
-  [SpanMetricsFields.SPAN_GROUP]?: string;
-  [SpanMetricsFields.SPAN_OP]?: string;
+  [SpanMetricsField.SPAN_ACTION]?: string;
+  [SpanMetricsField.SPAN_DOMAIN]?: string;
+  [SpanMetricsField.SPAN_GROUP]?: string;
+  [SpanMetricsField.SPAN_OP]?: string;
 };
 
 export const useModuleFilters = () => {
   const location = useLocation<ModuleFilters>();
 
   return pick(location.query, [
-    SpanMetricsFields.SPAN_ACTION,
-    SpanMetricsFields.SPAN_DOMAIN,
-    SpanMetricsFields.SPAN_OP,
-    SpanMetricsFields.SPAN_GROUP,
+    SpanMetricsField.SPAN_ACTION,
+    SpanMetricsField.SPAN_DOMAIN,
+    SpanMetricsField.SPAN_OP,
+    SpanMetricsField.SPAN_GROUP,
   ]);
 };

--- a/static/app/views/starfish/views/spans/useModuleSort.ts
+++ b/static/app/views/starfish/views/spans/useModuleSort.ts
@@ -1,7 +1,7 @@
 import {fromSorts} from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
-import {SpanMetricsFields, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 
 type Query = {
@@ -9,7 +9,7 @@ type Query = {
 };
 
 const SORTABLE_FIELDS = [
-  `avg(${SpanMetricsFields.SPAN_SELF_TIME})`,
+  `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
   `${StarfishFunctions.HTTP_ERROR_COUNT}()`,
   `${StarfishFunctions.SPM}()`,
   `${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`,

--- a/static/app/views/starfish/views/spans/useModuleSort.ts
+++ b/static/app/views/starfish/views/spans/useModuleSort.ts
@@ -1,7 +1,7 @@
 import {fromSorts} from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
-import {SpanMetricsField, StarfishFunctions} from 'sentry/views/starfish/types';
+import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 
 type Query = {
@@ -10,10 +10,10 @@ type Query = {
 
 const SORTABLE_FIELDS = [
   `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
-  `${StarfishFunctions.HTTP_ERROR_COUNT}()`,
-  `${StarfishFunctions.SPM}()`,
-  `${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`,
-  `${StarfishFunctions.TIME_SPENT_PERCENTAGE}(local)`,
+  `${SpanFunction.HTTP_ERROR_COUNT}()`,
+  `${SpanFunction.SPM}()`,
+  `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
+  `${SpanFunction.TIME_SPENT_PERCENTAGE}(local)`,
 ] as const;
 
 export type ValidSort = Sort & {
@@ -35,7 +35,7 @@ export function useModuleSort(fallback: Sort = DEFAULT_SORT) {
 
 const DEFAULT_SORT: Sort = {
   kind: 'desc',
-  field: `${StarfishFunctions.TIME_SPENT_PERCENTAGE}()`,
+  field: `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
 };
 
 function isAValidSort(sort: Sort): sort is ValidSort {

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -13,14 +13,14 @@ import {tooltipFormatterUsingAggregateOutputType} from 'sentry/utils/discover/ch
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import useOrganization from 'sentry/utils/useOrganization';
 import Chart from 'sentry/views/starfish/components/chart';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {useRoutingContext} from 'sentry/views/starfish/utils/routingContext';
 import {
   DataDisplayType,
   DataRow,
 } from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
-const {SPAN_MODULE} = SpanMetricsFields;
+const {SPAN_MODULE} = SpanMetricsField;
 
 type Props = {
   colorPalette: string[];

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -16,12 +16,12 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {SpanMetricsFields} from 'sentry/views/starfish/types';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {useEventsStatsQuery} from 'sentry/views/starfish/utils/useEventsStatsQuery';
 import {SpanGroupBreakdown} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdown';
 
-const {SPAN_SELF_TIME} = SpanMetricsFields;
+const {SPAN_SELF_TIME} = SpanMetricsField;
 
 const OTHER_SPAN_GROUP_MODULE = 'Other';
 export const NULL_SPAN_CATEGORY = t('custom');


### PR DESCRIPTION
Annoyed at this while doing other refactoring. Enum name should be singular, and also we don't need to prefix things with "Starfish" anymore as we approach LA.

- `SpanMetricsFields` -> `SpanMetricsField`
- `SpanIndexedFields` -> `SpanIndexedField`
- `StarfishFunctions` -> `SpanFunction`
