### PR TITLE
feat(starfish): add chart panel and fix projects on sample list

### DIFF
--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -217,7 +217,6 @@ function SpanSummaryPage({params}: Props) {
           )}
 
           <SampleList
-            projectId={span[SpanMetricsField.PROJECT_ID]}
             groupId={span[SpanMetricsField.SPAN_GROUP]}
             transactionName={transaction}
             transactionMethod={transactionMethod}

--- a/static/app/views/starfish/components/chartPanel.tsx
+++ b/static/app/views/starfish/components/chartPanel.tsx
@@ -3,14 +3,16 @@ import styled from '@emotion/styled';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {space} from 'sentry/styles/space';
+import {Subtitle} from 'sentry/views/performance/landing/widgets/widgets/singleFieldAreaWidget';
 
 type Props = {
   children: React.ReactNode;
   button?: JSX.Element;
+  subtitle?: React.ReactNode;
   title?: React.ReactNode;
 };
 
-export default function ChartPanel({title, children, button}: Props) {
+export default function ChartPanel({title, children, button, subtitle}: Props) {
   return (
     <Panel>
       <PanelBody withPadding>
@@ -20,19 +22,27 @@ export default function ChartPanel({title, children, button}: Props) {
             {button}
           </Header>
         )}
+        {subtitle && (
+          <SubtitleContainer>
+            <Subtitle>{subtitle}</Subtitle>
+          </SubtitleContainer>
+        )}
         {children}
       </PanelBody>
     </Panel>
   );
 }
 
-const ChartLabel = styled('p')`
+const SubtitleContainer = styled('div')`
+  padding-top: ${space(0.5)};
+`;
+
+const ChartLabel = styled('div')`
   ${p => p.theme.text.cardTitle}
 `;
 
 const Header = styled('div')`
   padding: 0 ${space(1)} 0 0;
-  min-height: 36px;
   width: 100%;
   display: flex;
   align-items: center;

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -138,7 +138,6 @@ function SpanSummaryPage({params, location}: Props) {
 
                 <SampleList
                   groupId={span[SpanMetricsField.SPAN_GROUP]}
-                  projectId={spanMetrics[SpanMetricsField.PROJECT_ID]}
                   transactionName={transaction}
                   transactionMethod={transactionMethod}
                 />

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -3,14 +3,15 @@ import {useTheme} from '@emotion/react';
 import {t} from 'sentry/locale';
 import {EChartClickHandler, EChartHighlightHandler, Series} from 'sentry/types/echarts';
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {AVG_COLOR} from 'sentry/views/starfish/colours';
 import Chart from 'sentry/views/starfish/components/chart';
+import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {isNearAverage} from 'sentry/views/starfish/components/samplesTable/common';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {SpanSample, useSpanSamples} from 'sentry/views/starfish/queries/useSpanSamples';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 import {
   crossIconPath,
   downwardPlayIconPath,
@@ -41,6 +42,7 @@ function DurationChart({
 }: Props) {
   const theme = useTheme();
   const {setPageError} = usePageError();
+  const pageFilter = usePageFilters();
 
   const getSampleSymbol = (
     duration: number,
@@ -176,27 +178,32 @@ function DurationChart({
     setPageError(t('An error has occured while loading chart data'));
   }
 
+  const subtitle = pageFilter.selection.datetime.period
+    ? t('Last %s', pageFilter.selection.datetime.period)
+    : t('Last period');
+
   return (
-    <div onMouseLeave={handleMouseLeave}>
-      <h5>{DataTitles.avg}</h5>
-      <Chart
-        height={140}
-        onClick={handleChartClick}
-        onHighlight={handleChartHighlight}
-        aggregateOutputFormat="duration"
-        data={[spanMetricsSeriesData?.[`avg(${SPAN_SELF_TIME})`], baselineAvgSeries]}
-        loading={isLoading}
-        scatterPlot={
-          areSpanSamplesLoading || areSpanSamplesRefetching
-            ? undefined
-            : sampledSpanDataSeries
-        }
-        utc={false}
-        chartColors={[AVG_COLOR, 'black']}
-        isLineChart
-        definedAxisTicks={4}
-      />
-    </div>
+    <ChartPanel title={t('Average Duration')} subtitle={subtitle}>
+      <div onMouseLeave={handleMouseLeave}>
+        <Chart
+          height={140}
+          onClick={handleChartClick}
+          onHighlight={handleChartHighlight}
+          aggregateOutputFormat="duration"
+          data={[spanMetricsSeriesData?.[`avg(${SPAN_SELF_TIME})`], baselineAvgSeries]}
+          loading={isLoading}
+          scatterPlot={
+            areSpanSamplesLoading || areSpanSamplesRefetching
+              ? undefined
+              : sampledSpanDataSeries
+          }
+          utc={false}
+          chartColors={[AVG_COLOR, 'black']}
+          isLineChart
+          definedAxisTicks={4}
+        />
+      </div>
+    </ChartPanel>
   );
 }
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -23,17 +23,11 @@ import SampleTable from 'sentry/views/starfish/views/spanSummaryPage/sampleList/
 
 type Props = {
   groupId: string;
-  projectId: number;
   transactionMethod: string;
   transactionName: string;
 };
 
-export function SampleList({
-  groupId,
-  projectId,
-  transactionName,
-  transactionMethod,
-}: Props) {
+export function SampleList({groupId, transactionName, transactionMethod}: Props) {
   const router = useRouter();
   const [highlightedSpanId, setHighlightedSpanId] = useState<string | undefined>(
     undefined
@@ -56,8 +50,8 @@ export function SampleList({
   const {projects} = useProjects();
 
   const project = useMemo(
-    () => projects.find(p => p.id === String(projectId)),
-    [projects, projectId]
+    () => projects.find(p => p.id === String(query.project)),
+    [projects, query.project]
   );
 
   const onOpenDetailPanel = useCallback(() => {
@@ -72,7 +66,7 @@ export function SampleList({
       : transactionName;
 
   const link = `/performance/summary/?${qs.stringify({
-    project: projectId,
+    project: query.project,
     transaction: transactionName,
   })}`;
 


### PR DESCRIPTION
ref https://www.notion.so/sentry/Design-Parity-Review-II-541bf4950d8e4daa916c21b6e0411e8e

There are two changes in this PR, but looped them both in because it's easier to focus on the span sample component this way.

The first change was to add a panel around the duration chart. I also adjusted some of the padding of the chart headers in general to match performance view and figma mocks a little closer.

The second change was to fix the project icon, which stopped rendering. This was done by grabbing the project ID from the query parameters instead of passing it down via props.

![image](https://github.com/getsentry/sentry/assets/18689448/6b3318f3-ca08-4f31-ab8f-0fdb86f6fc7b)
