### PR TITLE
feat(gitlab): creating feature flag for disabling gitlab integrations

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1365,8 +1365,6 @@ SENTRY_FEATURES = {
     "organizations:create": True,
     # Enable usage of customer domains on the frontend
     "organizations:customer-domains": False,
-    # Allow disabling github integrations when broken is detected
-    "organizations:github-disable-on-broken": False,
     # Enable the 'discover' interface.
     "organizations:discover": False,
     # Enables events endpoint rate limit
@@ -1419,6 +1417,10 @@ SENTRY_FEATURES = {
     "organizations:profiling-memory-chart": False,
     # Enable profiling battery usage chart
     "organizations:profiling-battery-usage-chart": False,
+    # Enable disabling github integrations when broken is detected
+    "organizations:github-disable-on-broken": False,
+    # Enable disabling gitlab integrations when broken is detected
+    "organizations:gitlab-disable-on-broken": False,
     # Enable multi project selection
     "organizations:global-views": False,
     # Enable experimental new version of Merged Issues where sub-hashes are shown

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -266,6 +266,7 @@ default_manager.add("organizations:ds-sliding-window", OrganizationFeature, Feat
 default_manager.add("organizations:ds-sliding-window-org", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:ds-org-recalibration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:github-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:gitlab-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sourcemaps-bundle-flat-file-indexing", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sourcemaps-upload-release-as-artifact-bundle", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:recap-server", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -499,9 +499,16 @@ class BaseApiClient(TrackResponseMixin):
             extra=extra,
         )
 
-        if (rpc_integration.provider == "slack" and buffer.is_integration_fatal_broken()) or (
-            features.has("organizations:github-disable-on-broken", org)
-            and rpc_integration.provider == "github"
+        if (
+            (rpc_integration.provider == "slack" and buffer.is_integration_fatal_broken())
+            or (
+                features.has("organizations:github-disable-on-broken", org)
+                and rpc_integration.provider == "github"
+            )
+            or (
+                features.has("organizations:gitlab-disable-on-broken", org)
+                and rpc_integration.provider == "gitlab"
+            )
         ):
 
             integration_service.update_integration(


### PR DESCRIPTION
Created new flag: `"organizations:gitlab-disable-on-broken"` that will disable gitlab integrations that have consistently responded with errors for 7 consecutive days.
Also moved the github flag so it is sorted correctly in `SENTRY_FEATURES`
Milestone 3 of [Notify on Disabled Integration project](https://www.notion.so/sentry/Tech-Spec-Notify-on-Disabled-Integration-Spec-e7ea0f86ccd6419cb3e564067cf4a2ef?pvs=4)