### PR TITLE
ref(rules): Re-enable a disabled rule on save

### DIFF
--- a/src/sentry/api/bases/rule.py
+++ b/src/sentry/api/bases/rule.py
@@ -5,7 +5,6 @@ from rest_framework.request import Request
 from sentry.api.api_owners import ApiOwner
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.constants import ObjectStatus
 from sentry.models import Rule
 
 
@@ -26,7 +25,6 @@ class RuleEndpoint(ProjectEndpoint):
             kwargs["rule"] = Rule.objects.get(
                 project=project,
                 id=rule_id,
-                status=ObjectStatus.ACTIVE,
             )
         except Rule.DoesNotExist:
             raise ResourceDoesNotExist

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -170,6 +170,10 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                         status=status.HTTP_400_BAD_REQUEST,
                     )
 
+            if rule.status == ObjectStatus.DISABLED:
+                rule.status = ObjectStatus.ACTIVE
+                rule.save()
+
             if data.get("pending_save"):
                 client = RedisRuleStatus()
                 kwargs.update({"uuid": client.uuid, "rule_id": rule.id})

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -423,7 +423,14 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)
-    def create_project_rule(project, action_data=None, condition_data=None):
+    def create_project_rule(
+        project,
+        action_data=None,
+        condition_data=None,
+        name="",
+        action_match="all",
+        filter_match="all",
+    ):
         action_data = action_data or [
             {
                 "id": "sentry.rules.actions.notify_event.NotifyEventAction",
@@ -446,8 +453,15 @@ class Factories:
             },
         ]
         return Rule.objects.create(
+            label=name,
             project=project,
-            data={"conditions": condition_data, "actions": action_data, "action_match": "all"},
+            data={
+                "conditions": condition_data,
+                "actions": action_data,
+                "action_match": action_match,
+                "filter_match": filter_match,
+            },
+            # environment_id=e
         )
 
     @staticmethod

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -461,7 +461,6 @@ class Factories:
                 "action_match": action_match,
                 "filter_match": filter_match,
             },
-            # environment_id=e
         )
 
     @staticmethod


### PR DESCRIPTION
If a user edits a disabled rule and it passes our checks for "bad" rules, we should re-enable it on save. 