### PR TITLE
feat(profiling): disable measurement charts from changing Y axis on spans and flamechart

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -829,12 +829,7 @@ function Flamegraph(): ReactElement {
       mat: mat3,
       sourceTransformConfigView: CanvasView<any>
     ) => {
-      if (
-        sourceTransformConfigView === flamegraphView ||
-        sourceTransformConfigView === uiFramesView ||
-        sourceTransformConfigView === cpuChartView ||
-        sourceTransformConfigView === memoryChartView
-      ) {
+      if (sourceTransformConfigView === flamegraphView) {
         flamegraphView.transformConfigView(mat);
         if (spansView) {
           const beforeY = spansView.configView.y;
@@ -860,6 +855,37 @@ function Flamegraph(): ReactElement {
         const beforeY = flamegraphView.configView.y;
         flamegraphView.transformConfigView(mat);
         flamegraphView.setConfigView(flamegraphView.configView.withY(beforeY));
+        if (uiFramesView) {
+          uiFramesView.transformConfigView(mat);
+        }
+        if (batteryChartView) {
+          batteryChartView.transformConfigView(mat);
+        }
+        if (cpuChartView) {
+          cpuChartView.transformConfigView(mat);
+        }
+        if (memoryChartView) {
+          memoryChartView.transformConfigView(mat);
+        }
+      }
+
+      if (
+        sourceTransformConfigView === uiFramesView ||
+        sourceTransformConfigView === cpuChartView ||
+        sourceTransformConfigView === memoryChartView ||
+        sourceTransformConfigView === batteryChartView
+      ) {
+        if (flamegraphView) {
+          const beforeY = flamegraphView.configView.y;
+          flamegraphView.transformConfigView(mat);
+          flamegraphView.setConfigView(flamegraphView.configView.withY(beforeY));
+        }
+
+        if (spansView) {
+          const beforeY = spansView.configView.y;
+          spansView.transformConfigView(mat);
+          spansView.setConfigView(spansView.configView.withY(beforeY));
+        }
         if (uiFramesView) {
           uiFramesView.transformConfigView(mat);
         }


### PR DESCRIPTION
Measurement charts cannot pan vertically, however, the matrix transform still includes the Y transform when the mouse moves (zoom/pan), which can cause the flamechart and spans view to jump positions. 

I could opt to ensure the Y translation on the dispatched matrix is always set to 0, but I prefer handling this in the onTransformConfigView so that we keep our options open in the future when/if we need charts to have this behavior.