### PR TITLE
fix(issue-details): Hide source map debug alerts

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -11,13 +11,10 @@ import {ExceptionType, Project} from 'sentry/types';
 import {Event, ExceptionValue} from 'sentry/types/event';
 import {StackType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
-import useOrganization from 'sentry/utils/useOrganization';
 
 import {Mechanism} from './mechanism';
 import {RelatedExceptions} from './relatedExceptions';
-import {SourceMapDebug} from './sourceMapDebug';
 import StackTrace from './stackTrace';
-import {debugFramesEnabled, getUniqueFilesFromException} from './useSourceMapDebug';
 
 type StackTraceProps = React.ComponentProps<typeof StackTrace>;
 
@@ -125,7 +122,6 @@ export function Content({
   groupingCurrentLevel,
   hasHierarchicalGrouping,
   platform,
-  projectSlug,
   values,
   type,
   meta,
@@ -137,29 +133,11 @@ export function Content({
   // Organization context may be unavailable for the shared event view, so we
   // avoid using the `useOrganization` hook here and directly useContext
   // instead.
-  const organization = useOrganization({allowNull: true});
   if (!values) {
     return null;
   }
 
-  const shouldDebugFrames = debugFramesEnabled({
-    sdkName: event.sdk?.name,
-    organization,
-    eventId: event.id,
-    projectSlug,
-  });
-  const debugFrames = shouldDebugFrames
-    ? getUniqueFilesFromException(values, {
-        eventId: event.id,
-        projectSlug: projectSlug!,
-        orgSlug: organization!.slug,
-      })
-    : [];
-
   const children = values.map((exc, excIdx) => {
-    const hasSourcemapDebug = debugFrames.some(
-      ({query}) => query.exceptionIdx === excIdx
-    );
     const id = defined(exc.mechanism?.exception_id)
       ? `exception-${exc.mechanism?.exception_id}`
       : undefined;
@@ -196,11 +174,7 @@ export function Content({
           newestFirst={newestFirst}
           onExceptionClick={expandException}
         />
-        <ErrorBoundary mini>
-          {hasSourcemapDebug && (
-            <SourceMapDebug debugFrames={debugFrames} event={event} />
-          )}
-        </ErrorBoundary>
+        <ErrorBoundary mini />
         <StackTrace
           data={
             type === StackType.ORIGINAL
@@ -217,7 +191,6 @@ export function Content({
           hasHierarchicalGrouping={hasHierarchicalGrouping}
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta?.[excIdx]?.stacktrace}
-          debugFrames={hasSourcemapDebug ? debugFrames : undefined}
           threadId={threadId}
         />
       </div>

--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -2,7 +2,6 @@ import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
-import ErrorBoundary from 'sentry/components/errorBoundary';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {Tooltip} from 'sentry/components/tooltip';
 import {tct, tn} from 'sentry/locale';
@@ -174,7 +173,6 @@ export function Content({
           newestFirst={newestFirst}
           onExceptionClick={expandException}
         />
-        <ErrorBoundary mini />
         <StackTrace
           data={
             type === StackType.ORIGINAL

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
@@ -1,5 +1,4 @@
 import EmptyMessage from 'sentry/components/emptyMessage';
-import type {StacktraceFilenameQuery} from 'sentry/components/events/interfaces/crashContent/exception/useSourceMapDebug';
 import Panel from 'sentry/components/panels/panel';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -20,7 +19,6 @@ type Props = {
   hasHierarchicalGrouping: boolean;
   platform: PlatformType;
   stacktrace: ExceptionValue['stacktrace'];
-  debugFrames?: StacktraceFilenameQuery[];
   expandFirstFrame?: boolean;
   groupingCurrentLevel?: Group['metadata']['current_level'];
   meta?: Record<any, any>;
@@ -33,7 +31,6 @@ function StackTrace({
   stackView,
   stacktrace,
   chainedException,
-  debugFrames,
   platform,
   newestFirst,
   groupingCurrentLevel,
@@ -110,7 +107,6 @@ function StackTrace({
         newestFirst={newestFirst}
         event={event}
         meta={meta}
-        debugFrames={debugFrames}
       />
     );
   }
@@ -124,7 +120,6 @@ function StackTrace({
       newestFirst={newestFirst}
       event={event}
       meta={meta}
-      debugFrames={debugFrames}
       threadId={threadId}
     />
   );

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -2,7 +2,6 @@ import {cloneElement, Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
-import {StacktraceFilenameQuery} from 'sentry/components/events/interfaces/crashContent/exception/useSourceMapDebug';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
 import {Frame, Organization, PlatformType} from 'sentry/types';
@@ -33,7 +32,6 @@ type Props = {
   event: Event;
   platform: PlatformType;
   className?: string;
-  debugFrames?: StacktraceFilenameQuery[];
   hideIcon?: boolean;
   isHoverPreviewed?: boolean;
   lockAddress?: string;
@@ -56,7 +54,6 @@ function Content({
   isHoverPreviewed,
   maxDepth,
   meta,
-  debugFrames,
   hideIcon,
   threadId,
   lockAddress,
@@ -242,7 +239,6 @@ function Content({
           isHoverPreviewed,
           frameMeta: meta?.frames?.[frameIndex],
           registersMeta: meta?.registers,
-          debugFrames,
           isANR,
           threadId,
           lockAddress,

--- a/static/app/components/events/interfaces/crashContent/stackTrace/hierarchicalGroupingContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/hierarchicalGroupingContent.tsx
@@ -12,7 +12,6 @@ import {defined} from 'sentry/utils';
 
 import Line from '../../frame/line';
 import {getImageRange, parseAddress, stackTracePlatformIcon} from '../../utils';
-import {StacktraceFilenameQuery} from '../exception/useSourceMapDebug';
 
 import StacktracePlatformIcon from './platformIcon';
 
@@ -21,7 +20,6 @@ type Props = {
   event: Event;
   platform: PlatformType;
   className?: string;
-  debugFrames?: StacktraceFilenameQuery[];
   expandFirstFrame?: boolean;
   groupingCurrentLevel?: Group['metadata']['current_level'];
   hideIcon?: boolean;
@@ -34,7 +32,6 @@ type Props = {
 
 export function HierarchicalGroupingContent({
   data,
-  debugFrames,
   platform,
   event,
   newestFirst,
@@ -204,7 +201,6 @@ export function HierarchicalGroupingContent({
             isUsedForGrouping,
             frameMeta: meta?.frames?.[frameIndex],
             registersMeta: meta?.registers,
-            debugFrames,
           };
 
           nRepeats = 0;

--- a/static/app/components/events/interfaces/frame/deprecatedLine.spec.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.spec.tsx
@@ -172,18 +172,6 @@ describe('Frame - Line', function () {
           components={[]}
           event={event}
           isExpanded
-          debugFrames={[
-            {
-              filename,
-              query: {
-                eventId: 'event-id',
-                exceptionIdx: 0,
-                frameIdx: 0,
-                orgSlug: 'org-slug',
-                projectSlug: 'project-slug',
-              },
-            },
-          ]}
         />,
         {organization: org}
       );

--- a/static/app/components/events/interfaces/frame/deprecatedLine.spec.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.spec.tsx
@@ -154,30 +154,6 @@ describe('Frame - Line', function () {
         expect(utils.getByText(value)).toBeInTheDocument();
       }
     });
-
-    it('should render sourcemap debug', async () => {
-      const org = TestStubs.Organization();
-      const project = TestStubs.Project();
-      const filename = 'something.js';
-      MockApiClient.addMockResponse({
-        url: `/projects/${org.slug}/${project.slug}/events/event-id/source-map-debug/`,
-        body: {
-          errors: [{type: 'no_release_on_event', message: '', data: null}],
-        },
-      });
-      const {container} = render(
-        <DeprecatedLine
-          data={{...data, filename}}
-          registers={{}}
-          components={[]}
-          event={event}
-          isExpanded
-        />,
-        {organization: org}
-      );
-      expect(await screen.findByLabelText('Missing source map')).toBeInTheDocument();
-      expect(container).toSnapshot();
-    });
   });
 
   describe('ANR suspect frame', () => {

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -5,17 +5,12 @@ import scrollToElement from 'scroll-to-element';
 
 import {Button} from 'sentry/components/button';
 import {analyzeFrameForRootCause} from 'sentry/components/events/interfaces/analyzeFrames';
-import {
-  StacktraceFilenameQuery,
-  useSourceMapDebug,
-} from 'sentry/components/events/interfaces/crashContent/exception/useSourceMapDebug';
 import LeadHint from 'sentry/components/events/interfaces/frame/line/leadHint';
 import {getThreadById} from 'sentry/components/events/interfaces/utils';
 import StrictClick from 'sentry/components/strictClick';
 import Tag from 'sentry/components/tag';
-import {Tooltip} from 'sentry/components/tooltip';
 import {SLOW_TOOLTIP_DELAY} from 'sentry/constants';
-import {IconChevron, IconRefresh, IconWarning} from 'sentry/icons';
+import {IconChevron, IconRefresh} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import DebugMetaStore from 'sentry/stores/debugMetaStore';
 import {space} from 'sentry/styles/space';
@@ -47,7 +42,6 @@ export interface DeprecatedLineProps {
   data: Frame;
   event: Event;
   registers: Record<string, string>;
-  debugFrames?: StacktraceFilenameQuery[];
   emptySourceNotation?: boolean;
   frameMeta?: Record<any, any>;
   hiddenFrameCount?: number;
@@ -100,27 +94,6 @@ function makeFilter(
   }
 
   return addr;
-}
-
-function SourceMapWarning({
-  debugFrames,
-  frame,
-}: {
-  frame: Frame;
-  debugFrames?: StacktraceFilenameQuery[];
-}) {
-  const debugFrame = debugFrames?.find(debug => debug.filename === frame.filename);
-  const {data} = useSourceMapDebug(debugFrame?.query, {
-    enabled: !!debugFrame,
-  });
-
-  return data?.errors?.length ? (
-    <IconWrapper>
-      <Tooltip skipWrapper title={t('Missing source map')}>
-        <IconWarning color="red400" size="sm" aria-label={t('Missing source map')} />
-      </Tooltip>
-    </IconWrapper>
-  ) : null;
 }
 
 export class DeprecatedLine extends Component<Props, State> {
@@ -310,7 +283,6 @@ export class DeprecatedLine extends Component<Props, State> {
   renderDefaultLine() {
     const {
       isHoverPreviewed,
-      debugFrames,
       data,
       isANR,
       threadId,
@@ -344,7 +316,6 @@ export class DeprecatedLine extends Component<Props, State> {
             stacktraceChangesEnabled={stacktraceChangesEnabled && !data.inApp}
           >
             <LeftLineTitle>
-              <SourceMapWarning frame={data} debugFrames={debugFrames} />
               <div>
                 {this.renderLeadHint()}
                 <DefaultTitle
@@ -617,12 +588,6 @@ const StyledLi = styled('li')`
       visibility: visible;
     }
   }
-`;
-
-const IconWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  margin-right: ${space(1)};
 `;
 
 const SuspectFrameTag = styled(Tag)`

--- a/static/app/components/events/interfaces/frame/line/default.tsx
+++ b/static/app/components/events/interfaces/frame/line/default.tsx
@@ -1,13 +1,7 @@
 import styled from '@emotion/styled';
 
-import {
-  StacktraceFilenameQuery,
-  useSourceMapDebug,
-} from 'sentry/components/events/interfaces/crashContent/exception/useSourceMapDebug';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconWarning} from 'sentry/icons';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
-import {t, tn} from 'sentry/locale';
+import {tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Frame} from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -22,7 +16,6 @@ type Props = React.ComponentProps<typeof Expander> &
   React.ComponentProps<typeof LeadHint> & {
     frame: Frame;
     isUsedForGrouping: boolean;
-    debugFrames?: StacktraceFilenameQuery[];
     frameMeta?: Record<any, any>;
     onClick?: () => void;
     onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
@@ -31,7 +24,6 @@ type Props = React.ComponentProps<typeof Expander> &
 
 function Default({
   frame,
-  debugFrames,
   nextFrame,
   isHoverPreviewed,
   isExpanded,
@@ -45,11 +37,6 @@ function Default({
   event,
   ...props
 }: Props) {
-  const debugFrame = debugFrames?.find(debug => debug.filename === frame.filename);
-  const {data} = useSourceMapDebug(debugFrame?.query, {
-    enabled: !!debugFrame,
-  });
-
   function renderRepeats() {
     if (defined(timesRepeated) && timesRepeated > 0) {
       return (
@@ -71,15 +58,6 @@ function Default({
     <Wrapper className="title" onMouseDown={onMouseDown} onClick={onClick}>
       <VertCenterWrapper>
         <Title>
-          {data?.errors?.length ? (
-            <Tooltip skipWrapper title={t('Missing source map')}>
-              <StyledIconWarning
-                color="red400"
-                size="sm"
-                aria-label={t('Missing source map')}
-              />
-            </Tooltip>
-          ) : null}
           <LeadHint
             event={event}
             isExpanded={isExpanded}
@@ -107,10 +85,6 @@ function Default({
 }
 
 export default Default;
-
-const StyledIconWarning = styled(IconWarning)`
-  margin-right: ${space(1)};
-`;
 
 const VertCenterWrapper = styled('div')`
   display: flex;

--- a/static/app/components/events/interfaces/frame/line/index.tsx
+++ b/static/app/components/events/interfaces/frame/line/index.tsx
@@ -43,7 +43,6 @@ type Props = Omit<
 
 function Line({
   frame,
-  debugFrames,
   nextFrame,
   prevFrame,
   timesRepeated,
@@ -129,7 +128,6 @@ function Line({
             onToggleContext={toggleContext}
             isUsedForGrouping={isUsedForGrouping}
             frameMeta={frameMeta}
-            debugFrames={debugFrames}
           />
         );
     }


### PR DESCRIPTION
this pr removes the source map debug alerts from the issue details page because there is not complete confidence in the logic that determines if they show up. 