### PR TITLE
feat(alerts): Display disabled or muted state on alert list

### DIFF
--- a/fixtures/js-stubs/projectAlertRule.ts
+++ b/fixtures/js-stubs/projectAlertRule.ts
@@ -23,7 +23,7 @@ export function ProjectAlertRule(params: Partial<IssueAlertRule> = {}): IssueAle
     projects: [],
     snooze: false,
     frequency: 1,
-    status: 0,
+    status: 'active',
     ...params,
   };
 }

--- a/fixtures/js-stubs/projectAlertRule.ts
+++ b/fixtures/js-stubs/projectAlertRule.ts
@@ -23,6 +23,7 @@ export function ProjectAlertRule(params: Partial<IssueAlertRule> = {}): IssueAle
     projects: [],
     snooze: false,
     frequency: 1,
+    status: 0,
     ...params,
   };
 }

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -82,6 +82,7 @@ export interface IssueAlertRule extends UnsavedIssueAlertRule {
   id: string;
   projects: string[];
   snooze: boolean;
+  status: 0 | 1;
   errors?: {detail: string}[];
   lastTriggered?: string;
   snoozeCreatedBy?: string;

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -75,6 +75,14 @@ export interface UnsavedIssueAlertRule {
   owner?: string | null;
 }
 
+/**
+ * Coming from ObjectStatus enum in the backend
+ */
+export const enum IssueAlertStatus {
+  ACTIVE = 0,
+  DISABLED = 1,
+}
+
 // Issue-based alert rule
 export interface IssueAlertRule extends UnsavedIssueAlertRule {
   createdBy: {email: string; id: number; name: string} | null;
@@ -82,7 +90,7 @@ export interface IssueAlertRule extends UnsavedIssueAlertRule {
   id: string;
   projects: string[];
   snooze: boolean;
-  status: 0 | 1;
+  status: IssueAlertStatus;
   errors?: {detail: string}[];
   lastTriggered?: string;
   snoozeCreatedBy?: string;

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -75,14 +75,6 @@ export interface UnsavedIssueAlertRule {
   owner?: string | null;
 }
 
-/**
- * Coming from ObjectStatus enum in the backend
- */
-export const enum IssueAlertStatus {
-  ACTIVE = 0,
-  DISABLED = 1,
-}
-
 // Issue-based alert rule
 export interface IssueAlertRule extends UnsavedIssueAlertRule {
   createdBy: {email: string; id: number; name: string} | null;
@@ -90,7 +82,7 @@ export interface IssueAlertRule extends UnsavedIssueAlertRule {
   id: string;
   projects: string[];
   snooze: boolean;
-  status: IssueAlertStatus;
+  status: 'active' | 'disabled';
   errors?: {detail: string}[];
   lastTriggered?: string;
   snoozeCreatedBy?: string;

--- a/static/app/views/alerts/list/rules/index.spec.tsx
+++ b/static/app/views/alerts/list/rules/index.spec.tsx
@@ -7,7 +7,6 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {Organization} from 'sentry/types';
-import {IssueAlertStatus} from 'sentry/types/alerts';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import AlertRulesList from 'sentry/views/alerts/list/rules';
 import {IncidentStatus} from 'sentry/views/alerts/types';
@@ -319,7 +318,7 @@ describe('AlertRulesList', () => {
         TestStubs.ProjectAlertRule({
           name: 'First Issue Alert',
           projects: ['earth'],
-          status: IssueAlertStatus.DISABLED,
+          status: 'disabled',
         }),
       ],
     });
@@ -337,7 +336,7 @@ describe('AlertRulesList', () => {
           name: 'First Issue Alert',
           projects: ['earth'],
           // both disabled and muted
-          status: IssueAlertStatus.DISABLED,
+          status: 'disabled',
           snooze: true,
         }),
       ],

--- a/static/app/views/alerts/list/rules/index.spec.tsx
+++ b/static/app/views/alerts/list/rules/index.spec.tsx
@@ -298,7 +298,7 @@ describe('AlertRulesList', () => {
     );
   });
 
-  it('displays alert status', async () => {
+  it('displays metric alert status', async () => {
     createWrapper();
     const rules = await screen.findAllByText('My Incident Rule');
 
@@ -308,6 +308,60 @@ describe('AlertRulesList', () => {
     expect(screen.getByText('Above 70')).toBeInTheDocument();
     expect(screen.getByText('Below 36')).toBeInTheDocument();
     expect(screen.getAllByTestId('alert-badge')[0]).toBeInTheDocument();
+  });
+
+  it('displays issue alert disabled', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/combined-rules/',
+      headers: {Link: pageLinks},
+      body: [
+        TestStubs.ProjectAlertRule({
+          name: 'First Issue Alert',
+          projects: ['earth'],
+          status: 1,
+        }),
+      ],
+    });
+    createWrapper();
+    expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
+
+  it('displays issue alert disabled instead of muted', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/combined-rules/',
+      headers: {Link: pageLinks},
+      body: [
+        TestStubs.ProjectAlertRule({
+          name: 'First Issue Alert',
+          projects: ['earth'],
+          // both disabled and muted
+          status: 1,
+          snooze: true,
+        }),
+      ],
+    });
+    createWrapper();
+    expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+    expect(screen.queryByText('Muted')).not.toBeInTheDocument();
+  });
+
+  it('displays issue alert muted', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/combined-rules/',
+      headers: {Link: pageLinks},
+      body: [
+        TestStubs.ProjectAlertRule({
+          name: 'First Issue Alert',
+          projects: ['earth'],
+          snooze: true,
+        }),
+      ],
+    });
+    createWrapper();
+    expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
+    expect(screen.getByText('Muted')).toBeInTheDocument();
   });
 
   it('sorts by alert rule', async () => {

--- a/static/app/views/alerts/list/rules/index.spec.tsx
+++ b/static/app/views/alerts/list/rules/index.spec.tsx
@@ -7,6 +7,7 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {Organization} from 'sentry/types';
+import {IssueAlertStatus} from 'sentry/types/alerts';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import AlertRulesList from 'sentry/views/alerts/list/rules';
 import {IncidentStatus} from 'sentry/views/alerts/types';
@@ -318,7 +319,7 @@ describe('AlertRulesList', () => {
         TestStubs.ProjectAlertRule({
           name: 'First Issue Alert',
           projects: ['earth'],
-          status: 1,
+          status: IssueAlertStatus.DISABLED,
         }),
       ],
     });
@@ -336,7 +337,7 @@ describe('AlertRulesList', () => {
           name: 'First Issue Alert',
           projects: ['earth'],
           // both disabled and muted
-          status: 1,
+          status: IssueAlertStatus.DISABLED,
           snooze: true,
         }),
       ],

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -29,6 +29,7 @@ import {
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Actor, Project} from 'sentry/types';
+import {IssueAlertStatus} from 'sentry/types/alerts';
 import type {ColorOrAlias} from 'sentry/utils/theme';
 import {getThresholdUnits} from 'sentry/views/alerts/rules/metric/constants';
 import {
@@ -116,20 +117,20 @@ function RuleListRow({
 
   function renderAlertRuleStatus(): React.ReactNode {
     if (isIssueAlert(rule)) {
-      if (rule.status === 1) {
+      if (rule.status === IssueAlertStatus.DISABLED) {
         return (
-          <IssueAlertStatus>
+          <IssueAlertStatusWrapper>
             <IconFlag size="sm" color="red300" />
             {t('Disabled')}
-          </IssueAlertStatus>
+          </IssueAlertStatusWrapper>
         );
       }
       if (rule.snooze) {
         return (
-          <IssueAlertStatus>
+          <IssueAlertStatusWrapper>
             <IconMute size="sm" color="subText" />
             {t('Muted')}
-          </IssueAlertStatus>
+          </IssueAlertStatusWrapper>
         );
       }
       return null;
@@ -427,7 +428,7 @@ const FlexCenter = styled('div')`
   align-items: center;
 `;
 
-const IssueAlertStatus = styled('div')`
+const IssueAlertStatusWrapper = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(1)};

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -29,7 +29,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Actor, Project} from 'sentry/types';
-import {IssueAlertStatus} from 'sentry/types/alerts';
 import type {ColorOrAlias} from 'sentry/utils/theme';
 import {getThresholdUnits} from 'sentry/views/alerts/rules/metric/constants';
 import {
@@ -117,7 +116,7 @@ function RuleListRow({
 
   function renderAlertRuleStatus(): React.ReactNode {
     if (isIssueAlert(rule)) {
-      if (rule.status === IssueAlertStatus.DISABLED) {
+      if (rule.status === 'disabled') {
         return (
           <IssueAlertStatusWrapper>
             <IconFlag size="sm" color="red300" />

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -18,7 +18,14 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconArrow, IconChevron, IconEllipsis, IconUser} from 'sentry/icons';
+import {
+  IconArrow,
+  IconChevron,
+  IconEllipsis,
+  IconFlag,
+  IconMute,
+  IconUser,
+} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Actor, Project} from 'sentry/types';
@@ -109,6 +116,22 @@ function RuleListRow({
 
   function renderAlertRuleStatus(): React.ReactNode {
     if (isIssueAlert(rule)) {
+      if (rule.status === 1) {
+        return (
+          <IssueAlertStatus>
+            <IconFlag size="sm" color="red300" />
+            {t('Disabled')}
+          </IssueAlertStatus>
+        );
+      }
+      if (rule.snooze) {
+        return (
+          <IssueAlertStatus>
+            <IconMute size="sm" color="subText" />
+            {t('Muted')}
+          </IssueAlertStatus>
+        );
+      }
       return null;
     }
 
@@ -402,6 +425,12 @@ function RuleListRow({
 const FlexCenter = styled('div')`
   display: flex;
   align-items: center;
+`;
+
+const IssueAlertStatus = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
 `;
 
 const AlertNameWrapper = styled('div')<{isIssueAlert?: boolean}>`


### PR DESCRIPTION
fixes #55099

- Displays if an issue alert is disabled or muted
- If the alert is disabled and muted it shows disabled

![Screenshot 2023-08-30 at 2 49 58 PM](https://github.com/getsentry/sentry/assets/1400464/a0a6eca0-5e99-4841-8b18-39563c7b0a28)
![Screenshot 2023-08-30 at 3 11 43 PM](https://github.com/getsentry/sentry/assets/1400464/48a44faa-6dc2-4917-8d3c-3b25d72e0477)
