### PR TITLE
fix(hybridcloud) Fix saving error in split silos

### DIFF
--- a/tests/sentry/api/endpoints/test_sentry_app_avatar.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_avatar.py
@@ -204,6 +204,7 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
         self.get_error_response(self.unpublished_app.slug, avatar_type="upload", status_code=400)
 
 
+@control_silo_test(stable=True)
 class SentryAppAvatarDeleteTest(SentryAppAvatarTestBase):
     def test_delete(self):
         """Test that when the related sentryapp is deleted (not really deleted, but date_deleted is set), the associated avatars are deleted"""

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -46,7 +46,6 @@ class SentryAppDetailsTest(APITestCase):
         self.url = reverse("sentry-api-0-sentry-app-details", args=[self.published_app.slug])
 
 
-# cannot be stable until we have org member mappings
 @control_silo_test(stable=True)
 class GetSentryAppDetailsTest(SentryAppDetailsTest):
     def test_superuser_sees_all_apps(self):

--- a/tests/sentry/api/endpoints/test_sentry_app_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_requests.py
@@ -10,7 +10,8 @@ from sentry.testutils.silo import region_silo_test
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
 
 
-class SentryAppRequestsTest(APITestCase):
+@region_silo_test(stable=True)
+class SentryAppRequestsGetTest(APITestCase):
     def setUp(self):
         self.superuser = self.create_user(email="superuser@example.com", is_superuser=True)
         self.user = self.create_user(email="user@example.com")
@@ -34,9 +35,6 @@ class SentryAppRequestsTest(APITestCase):
             name="Internal app", organization=self.org
         )
 
-
-@region_silo_test(stable=True)
-class GetSentryAppRequestsTest(SentryAppRequestsTest):
     def test_superuser_sees_unowned_published_requests(self):
         self.login_as(user=self.superuser, superuser=True)
 

--- a/tests/sentry/api/endpoints/test_sentry_app_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_stats.py
@@ -5,7 +5,8 @@ from sentry.testutils.silo import control_silo_test
 from sentry.utils.dates import to_timestamp
 
 
-class SentryAppStatsTest(APITestCase):
+@control_silo_test(stable=True)
+class GetSentryAppStatsTest(APITestCase):
     def setUp(self):
         self.superuser = self.create_user(email="superuser@example.com", is_superuser=True)
         self.user = self.create_user(email="user@example.com")
@@ -33,9 +34,6 @@ class SentryAppStatsTest(APITestCase):
             slug=self.unowned_published_app.slug, organization=self.create_organization()
         )
 
-
-@control_silo_test(stable=True)
-class GetSentryAppStatsTest(SentryAppStatsTest):
     def test_superuser_sees_unowned_published_stats(self):
         self.login_as(user=self.superuser, superuser=True)
 


### PR DESCRIPTION
When in split silo mode we get RpcUser on request.user. This object can't be fed into django and used as a relationship attribute. Instead we need to use the id. This also stabilizes the remaining sentryapps tests.

Fixes HC-TEST-CONTROL-6Q
