### PR TITLE
ref(starfish): More sophisticated API typing

### DIFF
--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
-import {SpanMetricsField, SpanMetricsFieldTypes} from 'sentry/views/starfish/types';
+import {MetricsResponse, SpanMetricsField} from 'sentry/views/starfish/types';
 import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatter';
 
 type Props = {
   span: Pick<
-    SpanMetricsFieldTypes,
+    MetricsResponse,
     SpanMetricsField.SPAN_OP | SpanMetricsField.SPAN_DESCRIPTION
   >;
 };

--- a/static/app/views/starfish/queries/useSpanMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.tsx
@@ -3,29 +3,24 @@ import {Location} from 'history';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {
+  MetricsProperty,
+  MetricsResponse,
+  SpanMetricsField,
+} from 'sentry/views/starfish/types';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
 const {SPAN_GROUP} = SpanMetricsField;
-
-export type SpanMetrics = {
-  [metric: string]: number | string;
-  'http_error_count()': number;
-  'p95(span.self_time)': number;
-  'span.op': string;
-  'spm()': number;
-  'time_spent_percentage()': number;
-};
 
 export type SpanSummaryQueryFilters = {
   'transaction.method'?: string;
   transactionName?: string;
 };
 
-export const useSpanMetrics = (
+export const useSpanMetrics = <T extends MetricsProperty[]>(
   group: string,
   queryFilters: SpanSummaryQueryFilters,
-  fields: string[] = [],
+  fields: T,
   referrer: string = 'span-metrics'
 ) => {
   const location = useLocation();
@@ -37,14 +32,20 @@ export const useSpanMetrics = (
     Boolean(group) && Object.values(queryFilters).every(value => Boolean(value));
 
   // TODO: Add referrer
-  const result = useSpansQuery<SpanMetrics[]>({
+  const result = useSpansQuery({
     eventView,
     initialData: [],
     enabled,
     referrer,
   });
 
-  return {...result, data: result?.data?.[0] ?? {}, isEnabled: enabled};
+  const data = (result?.data?.[0] ?? {}) as Pick<MetricsResponse, T[number]>;
+
+  return {
+    ...result,
+    data,
+    isEnabled: enabled,
+  };
 };
 
 function getEventView(

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -40,6 +40,7 @@ export type SpanMetricsFieldTypes = {
 };
 
 export type SpanNumberFields = 'span.self_time' | 'span.duration';
+
 export type SpanStringFields =
   | 'span.op'
   | 'span.description'
@@ -48,6 +49,7 @@ export type SpanStringFields =
   | 'span.domain'
   | 'span.group'
   | 'project.id';
+
 export type SpanFunctions =
   | 'sps'
   | 'spm'

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -78,7 +78,6 @@ export type Op = SpanIndexedFieldTypes[SpanIndexedField.SPAN_OP];
 export enum SpanFunction {
   SPS = 'sps',
   SPM = 'spm',
-  SPS_PERCENENT_CHANGE = 'sps_percent_change',
   TIME_SPENT_PERCENTAGE = 'time_spent_percentage',
   HTTP_ERROR_COUNT = 'http_error_count',
 }
@@ -113,12 +112,6 @@ export const STARFISH_AGGREGATION_FIELDS: Record<
   [SpanFunction.HTTP_ERROR_COUNT]: {
     desc: t('Count of 5XX http errors'),
     defaultOutputType: 'integer',
-    kind: FieldKind.FUNCTION,
-    valueType: FieldValueType.NUMBER,
-  },
-  [SpanFunction.SPS_PERCENENT_CHANGE]: {
-    desc: t('Spans per second percentage change'),
-    defaultOutputType: 'percentage',
     kind: FieldKind.FUNCTION,
     valueType: FieldValueType.NUMBER,
   },

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -60,8 +60,6 @@ export type MetricsResponse = {
 
 export type MetricsProperty = keyof MetricsResponse;
 
-export type SmallResponse = Pick<MetricsResponse, 'sps()'>;
-
 export enum SpanIndexedField {
   SPAN_SELF_TIME = 'span.self_time',
   SPAN_GROUP = 'span.group', // Span group computed from the normalized description. Matches the group in the metrics data set

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -28,17 +28,6 @@ export enum SpanMetricsField {
   PROJECT_ID = 'project.id',
 }
 
-export type SpanMetricsFieldTypes = {
-  [SpanMetricsField.SPAN_OP]: string;
-  [SpanMetricsField.SPAN_DESCRIPTION]: string;
-  [SpanMetricsField.SPAN_MODULE]: string;
-  [SpanMetricsField.SPAN_ACTION]: string;
-  [SpanMetricsField.SPAN_DOMAIN]: string;
-  [SpanMetricsField.SPAN_GROUP]: string;
-  [SpanMetricsField.SPAN_SELF_TIME]: number;
-  [SpanMetricsField.SPAN_DURATION]: number;
-};
-
 export type SpanNumberFields = 'span.self_time' | 'span.duration';
 
 export type SpanStringFields =

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -39,6 +39,38 @@ export type SpanMetricsFieldTypes = {
   [SpanMetricsField.SPAN_DURATION]: number;
 };
 
+export type SpanNumberFields = 'span.self_time' | 'span.duration';
+export type SpanStringFields =
+  | 'span.op'
+  | 'span.description'
+  | 'span.module'
+  | 'span.action'
+  | 'span.domain'
+  | 'span.group'
+  | 'project.id';
+export type SpanFunctions =
+  | 'sps'
+  | 'spm'
+  | 'count'
+  | 'time_spent_percentage'
+  | 'http_error_count';
+
+export type MetricsResponse = {
+  [Property in SpanNumberFields as `avg(${Property})`]: number;
+} & {
+  [Property in SpanNumberFields as `sum(${Property})`]: number;
+} & {
+  [Property in SpanFunctions as `${Property}()`]: number;
+} & {
+  [Property in SpanStringFields as `${Property}`]: string;
+} & {
+  'time_spent_percentage(local)': number;
+};
+
+export type MetricsProperty = keyof MetricsResponse;
+
+export type SmallResponse = Pick<MetricsResponse, 'sps()'>;
+
 export enum SpanIndexedField {
   SPAN_SELF_TIME = 'span.self_time',
   SPAN_GROUP = 'span.group', // Span group computed from the normalized description. Matches the group in the metrics data set

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -19,7 +19,6 @@ import {
   SpanSummaryQueryFilters,
   useSpanMetrics,
 } from 'sentry/views/starfish/queries/useSpanMetrics';
-import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
@@ -64,24 +63,16 @@ function SpanSummaryPage({params, location}: Props) {
   const {data: spanMetrics, isLoading: isSpanMetricsLoading} = useSpanMetrics(
     groupId,
     queryFilter,
-    [
-      SpanMetricsField.SPAN_OP,
-      SpanMetricsField.SPAN_GROUP,
-      SpanMetricsField.PROJECT_ID,
-      `${SpanFunction.SPS}()`,
-    ],
+    ['span.op', 'span.group', 'project.id', 'sps()'],
     'api.starfish.span-summary-page-metrics'
   );
 
   const span = {
-    [SpanMetricsField.SPAN_OP]: spanMetrics[SpanMetricsField.SPAN_OP],
-    [SpanMetricsField.SPAN_GROUP]: groupId,
+    ['span.op']: spanMetrics['span.op'],
+    ['span.group']: groupId,
   };
 
-  const title = [
-    getSpanOperationDescription(span[SpanMetricsField.SPAN_OP]),
-    t('Summary'),
-  ].join(' ');
+  const title = [getSpanOperationDescription(span['span.op']), t('Summary')].join(' ');
 
   const crumbs: Crumb[] = [];
   crumbs.push({
@@ -137,7 +128,7 @@ function SpanSummaryPage({params, location}: Props) {
                 )}
 
                 <SampleList
-                  groupId={span[SpanMetricsField.SPAN_GROUP]}
+                  groupId={span['span.group']}
                   transactionName={transaction}
                   transactionMethod={transactionMethod}
                 />

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -29,10 +29,10 @@ import {
   useSpanTransactionMetrics,
 } from 'sentry/views/starfish/queries/useSpanTransactionMetrics';
 import {
+  MetricsResponse,
   SpanIndexedField,
   SpanIndexedFieldTypes,
   SpanMetricsField,
-  SpanMetricsFieldTypes,
 } from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {useRoutingContext} from 'sentry/views/starfish/utils/routingContext';
@@ -50,10 +50,7 @@ type Row = {
 
 type Props = {
   sort: ValidSort;
-  span: Pick<
-    SpanMetricsFieldTypes,
-    SpanMetricsField.SPAN_GROUP | SpanMetricsField.SPAN_OP
-  >;
+  span: Pick<MetricsResponse, SpanMetricsField.SPAN_GROUP | SpanMetricsField.SPAN_OP>;
   endpoint?: string;
   endpointMethod?: string;
 };


### PR DESCRIPTION
tl;dr this PR introduces a new set of types that makes it possible to have much more sophisticated typing for API responses and improves DX.

## Changes

I wanted to accomplish two goals:

- it should be impossible to typo a field name (e.g., asking to fetch `spss()` should error)
- the server response types should take the fields into account (e.g., if I asked for `sps()`, the response should be typed as having that field, and no others)

To do this, I introduced a new typing setup, and applied it to `getSpanMetrics` as an example. The wins are immediate!

**e.g.,**

Autocomplete for requested fields is helpful and exhaustive.
<img width="650" alt="Screenshot 2023-08-30 at 5 44 44 PM" src="https://github.com/getsentry/sentry/assets/989898/93ba5a0d-c288-4c2f-84d7-f844a5bd64b3">

It is illegal to try to fetch a field that doesn't exist.

<img width="587" alt="Screenshot 2023-08-30 at 5 45 02 PM" src="https://github.com/getsentry/sentry/assets/989898/c8b85b97-1612-4d4b-9ddd-85cf2070ba4e">

The server response is _typed_. Only the fields that were requested are available on the returned object! You can't get `data['sps()']` if you didn't request that field.

<img width="582" alt="Screenshot 2023-08-30 at 5 45 20 PM" src="https://github.com/getsentry/sentry/assets/989898/48684d82-36d4-4a97-b6f9-f87e4a1640f2">

The server response fields have correct types (this was already the case, but it's cleaner now).

<img width="748" alt="Screenshot 2023-08-30 at 5 45 56 PM" src="https://github.com/getsentry/sentry/assets/989898/73be0ce9-7240-4dd0-a262-c59b39a1bfbb">

## Next Steps

This also has really good implications for the code!

1. No need to use enums like `SpanFunction.SPS` anymore. It's _much_ more ergonomic to use plain strings in most cases. If TypeScript's autocomplete is autofilling `sps()`, it sucks to have to import some other constant to do it instead of just using the autocomplete! I chose not to remove enums yet, but I think removing them is a pretty good idea. Fewer imports, much more readable code.
2. We can remove a lot of our manual types, since types are inferred correctly from server responses. That, or we can use `Pick` on `MetricsResponse`

IMO this is a pretty good first step. We can apply the same approach to our other hooks and eliminate a whole class of runtime errors that we ran into when we first released this internally.
