### PR TITLE
Bump snuba timeout

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -330,7 +330,7 @@ jobs:
     needs: files-changed
     name: snuba test
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
       # and reducing the risk that one of many runs would turn red again (read: intermittent tests)


### PR DESCRIPTION
The tests are hitting the 30minute timeout and causing failures on CI and causing deploy issues as a result