### PR TITLE
fix(crons): Prefer next_checkin over recomputing get_next_expected_checkin

### DIFF
--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -210,9 +210,7 @@ def check_missing(current_datetime=None):
             )
 
             monitor = monitor_environment.monitor
-            expected_time = None
-            if monitor_environment.last_checkin:
-                expected_time = monitor.get_next_expected_checkin(monitor_environment.last_checkin)
+            expected_time = monitor_environment.next_checkin
 
             # add missed checkin.
             #


### PR DESCRIPTION
This is the first part of fixing a regression described by GH-55395

There will be an additional follow up fix that correctly includes a test. This is difficult to test due to the fact that mark_failed currently uses wall-clock time.