### PR TITLE
ref(crons): Prefer next_checkin over recomputing from last_checkin

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -457,11 +457,8 @@ def _process_message(ts: datetime, wrapper: CheckinMessage | ClockPulseMessage) 
                     if duration is not None:
                         date_added -= timedelta(milliseconds=duration)
 
-                    expected_time = None
-                    if monitor_environment.last_checkin:
-                        expected_time = monitor.get_next_expected_checkin(
-                            monitor_environment.last_checkin
-                        )
+                    # When was this check-in expected to have happened?
+                    expected_time = monitor_environment.next_checkin
 
                     monitor_config = monitor.get_validated_config()
                     timeout_at = get_timeout_at(monitor_config, status, date_added)

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -194,9 +194,7 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
             if duration is not None:
                 date_added -= timedelta(milliseconds=duration)
 
-            expected_time = None
-            if monitor_environment.last_checkin:
-                expected_time = monitor.get_next_expected_checkin(monitor_environment.last_checkin)
+            expected_time = monitor_environment.next_checkin
 
             status = getattr(CheckInStatus, result["status"].upper())
             monitor_config = monitor.get_validated_config()


### PR DESCRIPTION
This value is the same, we should probably only be computing these times at `mark_ok` or `mark_failed` times.