### PR TITLE
ref(crons): Simplify mark_failed interface

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -562,13 +562,9 @@ def _process_checkin(
             # 04
             # Update monitor status
             if check_in.status == CheckInStatus.ERROR:
-                mark_failed(
-                    monitor_environment,
-                    start_time,
-                    occurrence_context={"trace_id": trace_id},
-                )
+                mark_failed(check_in, ts=start_time)
             else:
-                mark_ok(check_in, start_time)
+                mark_ok(check_in, ts=start_time)
 
             metrics.incr(
                 "monitors.checkin.result",

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -121,7 +121,7 @@ class MonitorIngestCheckInDetailsEndpoint(MonitorIngestEndpoint):
             checkin.update(**params)
 
             if checkin.status == CheckInStatus.ERROR:
-                monitor_failed = mark_failed(monitor_environment, current_datetime)
+                monitor_failed = mark_failed(checkin, ts=current_datetime)
                 if not monitor_failed:
                     return self.respond(serialize(checkin, request.user), status=208)
             else:

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -211,7 +211,7 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
             signal_first_checkin(project, monitor)
 
             if checkin.status == CheckInStatus.ERROR:
-                monitor_failed = mark_failed(monitor_environment, last_checkin=checkin.date_added)
+                monitor_failed = mark_failed(checkin, ts=checkin.date_added)
                 if not monitor_failed:
                     if isinstance(request.auth, ProjectKey):
                         return self.respond(status=200)

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -22,38 +22,35 @@ from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorEnviron
 logger = logging.getLogger(__name__)
 
 
-class MonitorFailure:
-    UNKNOWN = "unknown"
-    MISSED_CHECKIN = "missed_checkin"
-    DURATION = "duration"
-
-
 def mark_failed(
-    monitor_env: MonitorEnvironment,
-    last_checkin=None,
-    reason=MonitorFailure.UNKNOWN,
-    occurrence_context=None,
+    failed_checkin: MonitorCheckIn,
+    ts: datetime | None,
 ):
+    monitor_env = failed_checkin.monitor_environment
     failure_issue_threshold = monitor_env.monitor.config.get("failure_issue_threshold", 0)
+
     if failure_issue_threshold:
-        return mark_failed_threshold(failure_issue_threshold, monitor_env, last_checkin)
+        return mark_failed_threshold(failed_checkin, ts, failure_issue_threshold)
     else:
-        return mark_failed_no_threshold(monitor_env, last_checkin, reason, occurrence_context)
+        return mark_failed_no_threshold(failed_checkin, ts)
 
 
 def mark_failed_threshold(
+    failed_checkin: MonitorCheckIn,
+    ts: datetime | None,
     failure_issue_threshold: int,
-    monitor_env: MonitorEnvironment,
-    last_checkin=None,
 ):
     from sentry.signals import monitor_environment_failed
 
+    monitor_env = failed_checkin.monitor_environment
+
     # update monitor environment timestamps on every check-in
-    if last_checkin is None:
+    if ts is None:
         next_checkin_base = timezone.now()
         last_checkin = monitor_env.last_checkin or timezone.now()
     else:
-        next_checkin_base = last_checkin
+        next_checkin_base = ts
+        last_checkin = ts
 
     next_checkin = monitor_env.monitor.get_next_expected_checkin(next_checkin_base)
     next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(next_checkin_base)
@@ -94,7 +91,8 @@ def mark_failed_threshold(
         MonitorStatus.MISSED_CHECKIN,
         MonitorStatus.TIMEOUT,
     ]:
-        # if monitor environment has a failed status, get the most recent check-in and send occurrence
+        # if monitor environment has a failed status, get the most recent
+        # check-in and send occurrence
         previous_checkins = [
             MonitorCheckIn.objects.filter(monitor_environment=monitor_env)
             .order_by("-date_added")
@@ -114,10 +112,9 @@ def mark_failed_threshold(
         monitor_env.environment.name,
         str(monitor_env.last_state_change),
     ]
+
     for previous_checkin in previous_checkins:
-        reason = get_reason_from_checkin(previous_checkin)
-        occurrence_context = get_occurrence_context_from_checkin(previous_checkin)
-        create_issue_platform_occurrence(monitor_env, reason, occurrence_context, fingerprint)
+        create_issue_platform_occurrence(previous_checkin, fingerprint)
 
     monitor_environment_failed.send(monitor_environment=monitor_env, sender=type(monitor_env))
 
@@ -125,24 +122,25 @@ def mark_failed_threshold(
 
 
 def mark_failed_no_threshold(
-    monitor_env: MonitorEnvironment,
-    last_checkin=None,
-    reason=MonitorFailure.UNKNOWN,
-    occurrence_context=None,
+    failed_checkin: MonitorCheckIn,
+    ts: datetime | None,
 ):
     from sentry.signals import monitor_environment_failed
 
-    if last_checkin is None:
+    monitor_env = failed_checkin.monitor_environment
+
+    if ts is None:
         next_checkin_base = timezone.now()
         last_checkin = monitor_env.last_checkin or timezone.now()
     else:
-        next_checkin_base = last_checkin
+        next_checkin_base = ts
+        last_checkin = ts
 
-    new_status = MonitorStatus.ERROR
-    if reason == MonitorFailure.MISSED_CHECKIN:
-        new_status = MonitorStatus.MISSED_CHECKIN
-    elif reason == MonitorFailure.DURATION:
-        new_status = MonitorStatus.TIMEOUT
+    failed_status_map = {
+        CheckInStatus.MISSED: MonitorStatus.MISSED_CHECKIN,
+        CheckInStatus.TIMEOUT: MonitorStatus.TIMEOUT,
+    }
+    new_status = failed_status_map.get(failed_checkin.status, MonitorStatus.ERROR)
 
     next_checkin = monitor_env.monitor.get_next_expected_checkin(next_checkin_base)
     next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(next_checkin_base)
@@ -175,21 +173,29 @@ def mark_failed_no_threshold(
         pass
 
     if use_issue_platform:
-        create_issue_platform_occurrence(monitor_env, reason, occurrence_context)
+        create_issue_platform_occurrence(failed_checkin)
     else:
-        create_legacy_event(monitor_env, reason)
+        create_legacy_event(failed_checkin)
 
     monitor_environment_failed.send(monitor_environment=monitor_env, sender=type(monitor_env))
 
     return True
 
 
-def create_legacy_event(monitor_env: MonitorEnvironment, reason: str):
+def create_legacy_event(failed_checkin: MonitorCheckIn):
     from sentry.coreapi import insert_data_to_database_legacy
     from sentry.event_manager import EventManager
     from sentry.models import Project
 
+    monitor_env = failed_checkin.monitor_environment
     context = get_monitor_environment_context(monitor_env)
+
+    # XXX(epurkhiser): This matches up with the occurrence_data reason
+    reason_map = {
+        CheckInStatus.MISSED: "missed_checkin",
+        CheckInStatus.TIMEOUT: "duration",
+    }
+    reason = reason_map.get(failed_checkin.status, "unknown")
 
     event_manager = EventManager(
         {
@@ -212,20 +218,16 @@ def create_legacy_event(monitor_env: MonitorEnvironment, reason: str):
 
 
 def create_issue_platform_occurrence(
-    monitor_env: MonitorEnvironment,
-    reason: str,
-    occurrence_context=None,
+    failed_checkin: MonitorCheckIn,
     fingerprint=None,
 ):
     from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
     from sentry.issues.producer import produce_occurrence_to_kafka
 
+    monitor_env = failed_checkin.monitor_environment
     current_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc)
 
-    if not occurrence_context:
-        occurrence_context = {}
-
-    occurrence_data = get_occurrence_data(reason, **occurrence_context)
+    occurrence_data = get_occurrence_data(failed_checkin)
 
     # Get last successful check-in to show in evidence display
     last_successful_checkin_timestamp = "None"
@@ -263,7 +265,10 @@ def create_issue_platform_occurrence(
         level=occurrence_data["level"],
     )
 
-    trace_id = occurrence_context.get("trace_id")
+    if failed_checkin.trace_id:
+        trace_id = failed_checkin.trace_id.hex
+    else:
+        trace_id = None
 
     produce_occurrence_to_kafka(
         occurrence,
@@ -286,13 +291,13 @@ def create_issue_platform_occurrence(
                 "monitor.id": str(monitor_env.monitor.guid),
                 "monitor.slug": monitor_env.monitor.slug,
             },
-            "trace_id": str(trace_id) if trace_id else None,
+            "trace_id": trace_id,
             "timestamp": current_timestamp.isoformat(),
         },
     )
 
 
-def get_monitor_environment_context(monitor_environment):
+def get_monitor_environment_context(monitor_environment: MonitorEnvironment):
     config = monitor_environment.monitor.config.copy()
     if "schedule_type" in config:
         config["schedule_type"] = monitor_environment.monitor.get_schedule_type_display()
@@ -307,43 +312,22 @@ def get_monitor_environment_context(monitor_environment):
     }
 
 
-def get_reason_from_checkin(checkin: MonitorCheckIn):
-    reason = MonitorFailure.UNKNOWN
+def get_occurrence_data(checkin: MonitorCheckIn):
     if checkin.status == CheckInStatus.MISSED:
-        reason = MonitorFailure.MISSED_CHECKIN
-    elif checkin.status == CheckInStatus.TIMEOUT:
-        reason = MonitorFailure.DURATION
-
-    return reason
-
-
-def get_occurrence_context_from_checkin(checkin: MonitorCheckIn):
-    status = checkin.status
-    if status == CheckInStatus.MISSED:
         expected_time = (
             checkin.expected_time.strftime(SUBTITLE_DATETIME_FORMAT)
             if checkin.expected_time
-            else None
+            else "the expected time"
         )
-        return {"expected_time": expected_time}
-    elif status == CheckInStatus.TIMEOUT:
-        duration = (checkin.monitor.config or {}).get("max_runtime") or TIMEOUT
-        return {"duration": duration, "trace_id": checkin.trace_id}
-
-    return {"trace_id": checkin.trace_id}
-
-
-def get_occurrence_data(reason: str, **kwargs):
-    if reason == MonitorFailure.MISSED_CHECKIN:
-        expected_time = kwargs.get("expected_time", "the expected time")
         return {
             "group_type": MonitorCheckInMissed,
             "level": "warning",
             "reason": "missed_checkin",
             "subtitle": f"No check-in reported on {expected_time}.",
         }
-    elif reason == MonitorFailure.DURATION:
-        duration = kwargs.get("duration", 30)
+
+    if checkin.status == CheckInStatus.TIMEOUT:
+        duration = (checkin.monitor.config or {}).get("max_runtime") or TIMEOUT
         return {
             "group_type": MonitorCheckInTimeout,
             "level": "error",

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -9,8 +9,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from sentry.constants import ObjectStatus
-from sentry.monitors.constants import SUBTITLE_DATETIME_FORMAT, TIMEOUT
-from sentry.monitors.logic.mark_failed import MonitorFailure, mark_failed
+from sentry.monitors.logic.mark_failed import mark_failed
 from sentry.monitors.types import ClockPulseMessage
 from sentry.silo import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -218,7 +217,7 @@ def check_missing(current_datetime: datetime):
             # XXX(epurkhiser): The date_added is backdated so that this missed
             # check-in correctly reflects the time of when the checkin SHOULD
             # have happened. It is the same as the expected_time.
-            MonitorCheckIn.objects.create(
+            checkin = MonitorCheckIn.objects.create(
                 project_id=monitor_environment.monitor.project_id,
                 monitor=monitor_environment.monitor,
                 monitor_environment=monitor_environment,
@@ -227,15 +226,10 @@ def check_missing(current_datetime: datetime):
                 expected_time=expected_time,
                 monitor_config=monitor.get_validated_config(),
             )
-            mark_failed(
-                monitor_environment,
-                reason=MonitorFailure.MISSED_CHECKIN,
-                occurrence_context={
-                    "expected_time": expected_time.strftime(SUBTITLE_DATETIME_FORMAT)
-                    if expected_time
-                    else expected_time
-                },
-            )
+            # TODO(epurkhiser): To properly fix GH-55874 we need to actually
+            # pass a timestamp here. But I'm not 100% sure what that should
+            # look like yet.
+            mark_failed(checkin, ts=None)
         except Exception:
             logger.exception("Exception in check_monitors - mark missed", exc_info=True)
 
@@ -273,14 +267,9 @@ def check_timeout(current_datetime: datetime):
                 status__in=[CheckInStatus.OK, CheckInStatus.ERROR],
             ).exists()
             if not has_newer_result:
-                mark_failed(
-                    monitor_environment,
-                    reason=MonitorFailure.DURATION,
-                    occurrence_context={
-                        "duration": (checkin.monitor.config or {}).get("max_runtime") or TIMEOUT,
-                        "trace_id": checkin.trace_id,
-                    },
-                )
+                # TODO(epurkhiser): We also need a timestamp here, but not sure
+                # what we want it to be
+                mark_failed(checkin, ts=None)
         except Exception:
             logger.exception("Exception in check_monitors - mark timeout", exc_info=True)
 

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -11,7 +11,7 @@ from sentry.issues.grouptype import (
     MonitorCheckInTimeout,
 )
 from sentry.monitors.constants import SUBTITLE_DATETIME_FORMAT
-from sentry.monitors.logic.mark_failed import MonitorFailure, mark_failed
+from sentry.monitors.logic.mark_failed import mark_failed
 from sentry.monitors.models import (
     CheckInStatus,
     Monitor,
@@ -43,7 +43,13 @@ class MarkFailedTestCase(TestCase):
             environment=self.environment,
             status=monitor.status,
         )
-        assert mark_failed(monitor_environment)
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.UNKNOWN,
+        )
+        assert mark_failed(checkin, ts=None)
 
         assert len(mock_insert_data_to_database_legacy.mock_calls) == 1
 
@@ -88,7 +94,13 @@ class MarkFailedTestCase(TestCase):
             environment=self.environment,
             status=monitor.status,
         )
-        assert mark_failed(monitor_environment, reason=MonitorFailure.DURATION)
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.TIMEOUT,
+        )
+        assert mark_failed(checkin, ts=None)
 
         assert len(mock_insert_data_to_database_legacy.mock_calls) == 1
 
@@ -133,7 +145,13 @@ class MarkFailedTestCase(TestCase):
             environment=self.environment,
             status=monitor.status,
         )
-        assert mark_failed(monitor_environment, reason=MonitorFailure.MISSED_CHECKIN)
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.MISSED,
+        )
+        assert mark_failed(checkin, ts=None)
 
         monitor.refresh_from_db()
         monitor_environment.refresh_from_db()
@@ -191,12 +209,17 @@ class MarkFailedTestCase(TestCase):
         )
 
         last_checkin = timezone.now()
-        trace_id = uuid.uuid4().hex
-        assert mark_failed(
-            monitor_environment,
-            last_checkin=last_checkin,
-            occurrence_context={"trace_id": trace_id},
+        trace_id = uuid.uuid4()
+
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.ERROR,
+            trace_id=trace_id,
+            date_added=last_checkin,
         )
+        assert mark_failed(checkin, ts=last_checkin)
 
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1
 
@@ -254,7 +277,7 @@ class MarkFailedTestCase(TestCase):
                     "monitor.id": str(monitor.guid),
                     "monitor.slug": monitor.slug,
                 },
-                "trace_id": trace_id,
+                "trace_id": trace_id.hex,
             },
         ) == dict(event)
 
@@ -284,12 +307,16 @@ class MarkFailedTestCase(TestCase):
             status=CheckInStatus.OK,
         )
         last_checkin = timezone.now()
-        assert mark_failed(
-            monitor_environment,
-            last_checkin=last_checkin,
-            reason=MonitorFailure.DURATION,
-            occurrence_context={"duration": monitor.config.get("max_runtime")},
+
+        failed_checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.TIMEOUT,
+            date_added=last_checkin,
+            duration=monitor.config.get("max_runtime"),
         )
+        assert mark_failed(failed_checkin, ts=last_checkin)
 
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1
 
@@ -369,12 +396,15 @@ class MarkFailedTestCase(TestCase):
         last_checkin = timezone.now()
         expected_time = monitor.get_next_expected_checkin(last_checkin)
 
-        assert mark_failed(
-            monitor_environment,
-            last_checkin=last_checkin,
-            reason=MonitorFailure.MISSED_CHECKIN,
-            occurrence_context={"expected_time": expected_time.strftime(SUBTITLE_DATETIME_FORMAT)},
+        failed_checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.MISSED,
+            date_added=last_checkin,
+            expected_time=expected_time,
         )
+        assert mark_failed(failed_checkin, ts=last_checkin)
 
         monitor.refresh_from_db()
         monitor_environment.refresh_from_db()
@@ -472,13 +502,13 @@ class MarkFailedTestCase(TestCase):
 
         for i in range(0, failure_issue_threshold - 1):
             status = next(failure_statuses)
-            MonitorCheckIn.objects.create(
+            checkin = MonitorCheckIn.objects.create(
                 monitor=monitor,
                 monitor_environment=monitor_environment,
                 project_id=self.project.id,
                 status=status,
             )
-            mark_failed(monitor_environment, reason=status)
+            mark_failed(checkin, ts=None)
 
         # failure has not hit threshold, monitor should be in an OK status
         monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
@@ -496,13 +526,13 @@ class MarkFailedTestCase(TestCase):
 
         for i in range(0, failure_issue_threshold):
             status = next(failure_statuses)
-            MonitorCheckIn.objects.create(
+            checkin = MonitorCheckIn.objects.create(
                 monitor=monitor,
                 monitor_environment=monitor_environment,
                 project_id=self.project.id,
                 status=status,
             )
-            mark_failed(monitor_environment, reason=status)
+            mark_failed(checkin, ts=None)
 
         # failure has hit threshold, monitor should be in a failed state
         monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
@@ -514,13 +544,13 @@ class MarkFailedTestCase(TestCase):
 
         # send another check-in to make sure we don't update last_state_change
         status = next(failure_statuses)
-        MonitorCheckIn.objects.create(
+        checkin = MonitorCheckIn.objects.create(
             monitor=monitor,
             monitor_environment=monitor_environment,
             project_id=self.project.id,
             status=status,
         )
-        mark_failed(monitor_environment, reason=status)
+        mark_failed(checkin, ts=None)
         monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
         assert monitor_environment.status == MonitorStatus.ERROR
         assert monitor_environment.last_state_change == monitor_environment.last_checkin

--- a/tests/sentry/monitors/logic/test_mark_ok.py
+++ b/tests/sentry/monitors/logic/test_mark_ok.py
@@ -69,7 +69,7 @@ class MarkOkTestCase(TestCase):
             project_id=self.project.id,
             status=CheckInStatus.ERROR,
         )
-        mark_failed(monitor_environment, failed_checkin.date_added)
+        mark_failed(failed_checkin, ts=failed_checkin.date_added)
         # assert occurrence was sent
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1
 


### PR DESCRIPTION
We can infer everything we need from the failed_checkin along with the
timestamp of when the monintor failed.