### PR TITLE
ref(spans): Remove None values from tags and data in spans

### DIFF
--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -62,7 +62,9 @@ def _build_snuba_span(relay_span: Mapping[str, Any]) -> MutableMapping[str, Any]
     snuba_span["retention_days"] = retention_days
     snuba_span["segment_id"] = relay_span.get("segment_id", "0")
     snuba_span["span_id"] = relay_span.get("span_id", "0")
-    snuba_span["tags"] = relay_span.get("tags")
+    snuba_span["tags"] = {
+        k: v for k, v in (relay_span.get("tags", {}) or {}).items() if v is not None
+    }
     snuba_span["trace_id"] = uuid.UUID(relay_span["trace_id"]).hex
     snuba_span["version"] = SPAN_SCHEMA_VERSION
 
@@ -78,14 +80,17 @@ def _build_snuba_span(relay_span: Mapping[str, Any]) -> MutableMapping[str, Any]
 
     if span_data:
         for relay_tag, snuba_tag in TAG_MAPPING.items():
-            if relay_tag in span_data:
-                sentry_tags[snuba_tag] = span_data.get(relay_tag)
+            if relay_tag in span_data and (tag_value := span_data.get(relay_tag)) is not None:
+                sentry_tags[snuba_tag] = tag_value
 
-    if "op" not in sentry_tags:
-        sentry_tags["op"] = relay_span.get("op", "")
+    if "op" not in sentry_tags and (op := relay_span.get("op", "")) is not None:
+        sentry_tags["op"] = op
 
-    if "status" not in sentry_tags:
-        sentry_tags["status"] = relay_span.get("status", "")
+    if "status" not in sentry_tags and (status := relay_span.get("status", "")) is not None:
+        sentry_tags["status"] = status
+
+    if "status_code" in sentry_tags:
+        sentry_tags["status_code"] = int(sentry_tags["status_code"])
 
     snuba_span["sentry_tags"] = sentry_tags
 

--- a/tests/sentry/spans/test_spans_process_consumer.py
+++ b/tests/sentry/spans/test_spans_process_consumer.py
@@ -6,7 +6,7 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
 
 from sentry.receivers import create_default_projects
-from sentry.spans.consumers.process.factory import ProcessSpansStrategyFactory
+from sentry.spans.consumers.process.factory import ProcessSpansStrategyFactory, _build_snuba_span
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -71,3 +71,44 @@ def test_ingest_span(request):
     strategy.join(1)
     strategy.terminate()
     request.addfinalizer(factory.shutdown)
+
+
+def test_null_tags_and_data():
+    relay_span = {
+        "data": None,
+        "description": "f1323e9063f91b5745a7d33e580f9f92.jpg (56 KB)",
+        "event_id": "3f0bba60b0a7471abe18732abe6506c2",
+        "exclusive_time": 8.635998,
+        "hash": "eb630ce41d1553f8",
+        "op": "file.write",
+        "origin": "auto.file.ns_data",
+        "parent_span_id": "ac80578cd5d64fa9",
+        "project_id": 1,
+        "sampled": "true",
+        "span_id": "d0a0690671b04a29",
+        "start_timestamp": 1699208266.433295,
+        "status": "ok",
+        "tags": None,
+        "timestamp": 1699208266.441931,
+        "trace_id": "3f0bba60b0a7471abe18732abe6506c2",
+        "type": "trace",
+    }
+    snuba_span = _build_snuba_span(relay_span)
+
+    assert "tags" in snuba_span and len(snuba_span["tags"]) == 0
+
+    relay_span["tags"] = {"none_tag": None, "false_value": False}
+    snuba_span = _build_snuba_span(relay_span)
+
+    assert all([v is not None for v in snuba_span["tags"].values()])
+    assert "false_value" in snuba_span["tags"]
+    assert "sentry_tags" in snuba_span and len(snuba_span["sentry_tags"]) == 2
+
+    relay_span["data"] = {
+        "span.description": "",
+        "span.system": None,
+    }
+    snuba_span = _build_snuba_span(relay_span)
+
+    assert all([v is not None for v in snuba_span["sentry_tags"].values()])
+    assert "description" in snuba_span["sentry_tags"]

--- a/tests/sentry/spans/test_spans_process_consumer.py
+++ b/tests/sentry/spans/test_spans_process_consumer.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any, Dict
 from unittest.mock import Mock
 
 import msgpack
@@ -74,7 +75,7 @@ def test_ingest_span(request):
 
 
 def test_null_tags_and_data():
-    relay_span = {
+    relay_span: Dict[str, Any] = {
         "data": None,
         "description": "f1323e9063f91b5745a7d33e580f9f92.jpg (56 KB)",
         "event_id": "3f0bba60b0a7471abe18732abe6506c2",
@@ -97,7 +98,10 @@ def test_null_tags_and_data():
 
     assert "tags" in snuba_span and len(snuba_span["tags"]) == 0
 
-    relay_span["tags"] = {"none_tag": None, "false_value": False}
+    relay_span["tags"] = {
+        "none_tag": None,
+        "false_value": False,
+    }
     snuba_span = _build_snuba_span(relay_span)
 
     assert all([v is not None for v in snuba_span["tags"].values()])


### PR DESCRIPTION
This will filter unnecessary `None` values in `tags` and `data` fields.