### PR TITLE
feat(indexer): Emit metric for number of dropped messages in LSU

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2078,6 +2078,7 @@ SENTRY_METRICS_INDEXER_SPANNER_OPTIONS: dict[str, Any] = {}
 
 SENTRY_METRICS_INDEXER_REINDEXED_INTS: dict[int, str] = {}
 
+LAST_SEEN_UPDATER_REINDEXED_ORGS: list[int] = []
 # Rate limits during string indexing for our metrics product.
 # Which cluster to use. Example: {"cluster": "default"}
 SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS: dict[str, str] = {}

--- a/src/sentry/sentry_metrics/consumers/last_seen_updater.py
+++ b/src/sentry/sentry_metrics/consumers/last_seen_updater.py
@@ -123,7 +123,9 @@ class LastSeenUpdaterStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         should_accept = not self.__prefilter.should_drop(message)
 
         if not should_accept:
-            self.__metrics.incr("last_seen_updater.dropped_message")
+            self.__metrics.incr("last_seen_updater.dropped_messages")
+        else:
+            self.__metrics.incr("last_seen_updater.retained_messages")
 
         return should_accept
 

--- a/src/sentry/sentry_metrics/consumers/last_seen_updater.py
+++ b/src/sentry/sentry_metrics/consumers/last_seen_updater.py
@@ -128,7 +128,7 @@ class LastSeenUpdaterStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             org_id = parsed_message["org_id"]
         except rapidjson.JSONDecodeError:
             logger.error("last_seen_updater.invalid_json", exc_info=True)
-            return False
+            return should_accept
 
         if not should_accept:
             if org_id in settings.LAST_SEEN_UPDATER_REINDEXED_ORGS:

--- a/src/sentry/sentry_metrics/consumers/last_seen_updater.py
+++ b/src/sentry/sentry_metrics/consumers/last_seen_updater.py
@@ -120,7 +120,12 @@ class LastSeenUpdaterStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         self.__prefilter = LastSeenUpdaterMessageFilter(metrics=self.__metrics)
 
     def __should_accept(self, message: Message[KafkaPayload]) -> bool:
-        return not self.__prefilter.should_drop(message)
+        should_accept = not self.__prefilter.should_drop(message)
+
+        if not should_accept:
+            self.__metrics.incr("last_seen_updater.dropped_message")
+
+        return should_accept
 
     def create_with_partitions(
         self,

--- a/tests/sentry/sentry_metrics/test_last_seen_updater.py
+++ b/tests/sentry/sentry_metrics/test_last_seen_updater.py
@@ -36,7 +36,8 @@ def mixed_payload():
                 "h": {
                     "3": "constant"
                 }
-            }
+            },
+            "org_id": 1234
         }
         """,
         encoding="utf-8",


### PR DESCRIPTION
Just a starter for how we can begin understanding INC-489 better. 

With this, we can get a count of how many messages we're not updating `last_seen` for. I wonder if there's a way to easily have this for certain orgs as well. 

See corresponding PR that changes the setting: https://github.com/getsentry/getsentry/pull/11598