### PR TITLE
feat(onboarding): Add profiling to platform node-azurefunctions

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -64,6 +64,10 @@ export const platformProductAvailability = {
     ProductSolution.SESSION_REPLAY,
   ],
   node: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
+  'node-azurefunctions': [
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.PROFILING,
+  ],
   'node-connect': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   python: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'python-aiohttp': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],

--- a/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
@@ -9,7 +9,11 @@ describe('GettingStartedWithAzurefunctions', function () {
     const {container} = render(<GettingStartedWithAzurefunctions dsn="test-dsn" />);
 
     // Steps
-    for (const step of steps()) {
+    for (const step of steps({
+      installSnippet: 'test-install-snippet',
+      importContent: 'test-import-content',
+      initContent: 'test-init-content',
+    })) {
       expect(
         screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
       ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/node/azurefunctions.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.tsx
@@ -25,7 +25,7 @@ export const steps = ({
 }: StepProps): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: <p>{tct('Add Sentry Node SDK as a dependency:', {code: <code />})}</p>,
+    description: t('Add the Sentry Node SDK as a dependency:'),
     configurations: [
       {
         language: 'bash',

--- a/static/app/gettingStartedDocs/node/connect.tsx
+++ b/static/app/gettingStartedDocs/node/connect.tsx
@@ -1,7 +1,7 @@
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {
   getDefaultInitParams,
   getDefaultNodeImports,
@@ -25,7 +25,7 @@ export const steps = ({
 }: StepProps): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: <p>{tct('Add Sentry Node SDK as a dependency:', {code: <code />})}</p>,
+    description: t('Add the Sentry Node SDK as a dependency:'),
     configurations: [
       {
         language: 'bash',

--- a/static/app/gettingStartedDocs/node/connect.tsx
+++ b/static/app/gettingStartedDocs/node/connect.tsx
@@ -25,9 +25,7 @@ export const steps = ({
 }: StepProps): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: (
-      <p>{tct('Add [code:@sentry/node] as a dependency:', {code: <code />})}</p>
-    ),
+    description: <p>{tct('Add Sentry Node SDK as a dependency:', {code: <code />})}</p>,
     configurations: [
       {
         language: 'bash',
@@ -46,7 +44,7 @@ ${importContent}
 
 // Configure Sentry before doing anything else
 Sentry.init({
-${initContent},
+${initContent}
 });
 
 function mainHandler(req, res) {


### PR DESCRIPTION
Add profiling product selection to platform `node-azurefunctions`.

Closes https://github.com/getsentry/sentry/issues/55443