### PR TITLE
feat(stat-detectors): Remove Users count and Release stats

### DIFF
--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -26,6 +26,7 @@ import {
   AvatarUser,
   CurrentRelease,
   Group,
+  IssueType,
   Organization,
   OrganizationSummary,
   Project,
@@ -190,14 +191,16 @@ export default function GroupSidebar({
   return (
     <Container>
       <AssignedTo group={group} event={event} project={project} onAssign={trackAssign} />
-      <GroupReleaseStats
-        organization={organization}
-        project={project}
-        environments={environments}
-        allEnvironments={allEnvironmentsGroupData}
-        group={group}
-        currentRelease={currentRelease}
-      />
+      {group.issueType !== IssueType.PERFORMANCE_DURATION_REGRESSION && (
+        <GroupReleaseStats
+          organization={organization}
+          project={project}
+          environments={environments}
+          allEnvironments={allEnvironmentsGroupData}
+          group={group}
+          currentRelease={currentRelease}
+        />
+      )}
       {event && (
         <ErrorBoundary mini>
           <ExternalIssueList project={project} group={group} event={event} />

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -21,7 +21,7 @@ import {TabList} from 'sentry/components/tabs';
 import {IconChat} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Event, Group, Organization, Project} from 'sentry/types';
+import {Event, Group, IssueType, Organization, Project} from 'sentry/types';
 import {getMessage} from 'sentry/utils/events';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {projectCanLinkToReplay} from 'sentry/utils/replays/projectSupportsReplay';
@@ -274,26 +274,30 @@ function GroupHeader({
               <EventMessage message={message} />
             </StyledTagAndMessageWrapper>
           </TitleWrapper>
-          <StatsWrapper>
+          <StatsWrapper
+            hasGrid={group.issueType !== IssueType.PERFORMANCE_DURATION_REGRESSION}
+          >
             <div className="count">
               <h6 className="nav-header">{t('Events')}</h6>
               <Link disabled={disableActions} to={eventRoute}>
                 <Count className="count" value={group.count} />
               </Link>
             </div>
-            <div className="count">
-              <h6 className="nav-header">{t('Users')}</h6>
-              {userCount !== 0 ? (
-                <Link
-                  disabled={disableActions}
-                  to={`${baseUrl}tags/user/${location.search}`}
-                >
-                  <Count className="count" value={userCount} />
-                </Link>
-              ) : (
-                <span>0</span>
-              )}
-            </div>
+            {group.issueType !== IssueType.PERFORMANCE_DURATION_REGRESSION && (
+              <div className="count">
+                <h6 className="nav-header">{t('Users')}</h6>
+                {userCount !== 0 ? (
+                  <Link
+                    disabled={disableActions}
+                    to={`${baseUrl}tags/user/${location.search}`}
+                  >
+                    <Count className="count" value={userCount} />
+                  </Link>
+                ) : (
+                  <span>0</span>
+                )}
+              </div>
+            )}
           </StatsWrapper>
         </HeaderRow>
         {/* Environment picker for mobile */}
@@ -343,10 +347,14 @@ const StyledEventOrGroupTitle = styled(EventOrGroupTitle)`
   font-size: inherit;
 `;
 
-const StatsWrapper = styled('div')`
-  display: grid;
-  grid-template-columns: repeat(2, min-content);
-  gap: calc(${space(3)} + ${space(3)});
+const StatsWrapper = styled('div')<{hasGrid?: boolean}>`
+  ${p =>
+    p.hasGrid &&
+    `
+    display: grid;
+    grid-template-columns: repeat(2, min-content);
+    gap: calc(${space(3)} + ${space(3)});
+    `}
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     justify-content: flex-end;


### PR DESCRIPTION
These aren't relevant for the statistical detector issue details page. Since we're using metrics data for the analysis we can't get a good idea of the users affected, and by the nature of a statistical issue repeatedly occurring, the stats on the sidebar are no longer useful in this context.