### PR TITLE
feat(stat-detectors): Add span op breakdown for event comparison

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -5,8 +5,10 @@ import {Button} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {MINIMAP_HEIGHT} from 'sentry/components/events/interfaces/spans/constants';
+import {noFilter} from 'sentry/components/events/interfaces/spans/filter';
 import {ActualMinimap} from 'sentry/components/events/interfaces/spans/header';
 import WaterfallModel from 'sentry/components/events/interfaces/spans/waterfallModel';
+import OpsBreakdown from 'sentry/components/events/opsBreakdown';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import TextOverflow from 'sentry/components/textOverflow';
 import {IconEllipsis, IconJson, IconLink} from 'sentry/icons';
@@ -168,7 +170,7 @@ function EventDisplay({
           </MinimapPositioningContainer>
         </MinimapContainer>
 
-        <FakeSpanOpBreakdown>span op breakdown</FakeSpanOpBreakdown>
+        <OpsBreakdown event={eventData} operationNameFilters={noFilter} hideHeader />
       </ComparisonContentWrapper>
     </div>
   );
@@ -201,14 +203,7 @@ const MinimapContainer = styled('div')`
   height: ${MINIMAP_HEIGHT}px;
   max-height: ${MINIMAP_HEIGHT}px;
   position: relative;
-`;
-
-const FakeSpanOpBreakdown = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 120px;
-  background: antiquewhite;
+  border-bottom: 1px solid ${p => p.theme.border};
 `;
 
 const ComparisonContentWrapper = styled('div')`


### PR DESCRIPTION
If we allow breakdowns by specific span ops instead of span categories, we basically get this for free. I'm putting up this PR because this is still useful until we decide if we want to filter to specifically span category

![Screenshot 2023-08-31 at 9 15 53 AM](https://github.com/getsentry/sentry/assets/22846452/52be3be1-0007-48b9-a287-b70cd0b6717b)
