### PR TITLE
fix(github-invite): check for integration in missing members API

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from datetime import timedelta
 from email.headerregistry import Address
 from functools import reduce
-from typing import Sequence
+from typing import Dict, Sequence
 
 from django.db.models import Count, Q, QuerySet
 from django.utils import timezone
@@ -112,7 +112,9 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
 
             return dict
 
-        integration_provider_to_ids = reduce(provider_reducer, integrations, defaultdict(list))
+        integration_provider_to_ids: Dict[str, Sequence[int]] = reduce(
+            provider_reducer, integrations, defaultdict(list)
+        )
 
         shared_domain = self._get_shared_email_domain(organization)
 


### PR DESCRIPTION
We should only return information about commit authors that are not members of an organization if the org has active integrations that have the commit feature. If the org doesn't have such an active integration, then it's not useful to inform them of missing members because the commit author information might be outdated.

This will still only be for GIthub for now. I did some refactoring to allow for an easier transition to supporting multiple integrations with the commit feature.