### PR TITLE
ref(rules): Return stringified status

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -5,6 +5,7 @@ from django.db.models import Max, Q, prefetch_related_objects
 from rest_framework import serializers
 
 from sentry.api.serializers import Serializer, register
+from sentry.constants import ObjectStatus
 from sentry.models import (
     ACTOR_TYPES,
     Environment,
@@ -175,7 +176,7 @@ class RuleSerializer(Serializer):
             "createdBy": attrs.get("created_by", None),
             "environment": environment.name if environment is not None else None,
             "projects": [obj.project.slug],
-            "status": obj.status,
+            "status": "active" if obj.status == ObjectStatus.ACTIVE else "disabled",
         }
         if "last_triggered" in attrs:
             d["lastTriggered"] = attrs["last_triggered"]

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -117,7 +117,7 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
         )
         assert response.data["id"] == str(self.rule.id)
         assert response.data["environment"] == self.environment.name
-        assert response.data["status"] == ObjectStatus.ACTIVE
+        assert response.data["status"] == "active"
 
     def test_with_filters(self):
         conditions: list[dict[str, Any]] = [

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -3,7 +3,6 @@ from sentry.api.serializers.models.alert_rule import (
     CombinedRuleSerializer,
     DetailedAlertRuleSerializer,
 )
-from sentry.constants import ObjectStatus
 from sentry.incidents.logic import create_alert_rule_trigger
 from sentry.incidents.models import AlertRule, AlertRuleThresholdType
 from sentry.models import Rule
@@ -221,6 +220,6 @@ class CombinedRuleSerializerTest(BaseAlertRuleSerializerTest, APITestCase, TestC
 
         self.assert_alert_rule_serialized(alert_rule, result[0])
         assert result[1]["id"] == str(issue_rule.id)
-        assert result[1]["status"] == ObjectStatus.ACTIVE
+        assert result[1]["status"] == "active"
         assert not result[1]["snooze"]
         self.assert_alert_rule_serialized(other_alert_rule, result[2])


### PR DESCRIPTION
Return the string "active" or "disabled" rather than the enum value. 