### PR TITLE
fix(stat-detectors): Width overflow on issue details

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/eventComparison/index.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/index.tsx
@@ -31,7 +31,7 @@ function EventComparison({event, project}: EventComparisonProps) {
       <strong>{t('Compare Events:')}</strong>
       <p>{COMPARISON_DESCRIPTION}</p>
       <StyledGrid>
-        <div style={{gridColumnStart: 1}}>
+        <StyledGridItem position="left">
           <EventDisplay
             eventSelectLabel={t('Baseline Event ID')}
             project={project}
@@ -40,8 +40,8 @@ function EventComparison({event, project}: EventComparisonProps) {
             transaction={transaction}
             durationBaseline={aggregateRange1}
           />
-        </div>
-        <div style={{gridColumnStart: 2}}>
+        </StyledGridItem>
+        <StyledGridItem position="right">
           <EventDisplay
             eventSelectLabel={t('Regressed Event ID')}
             project={project}
@@ -50,7 +50,7 @@ function EventComparison({event, project}: EventComparisonProps) {
             transaction={transaction}
             durationBaseline={aggregateRange2}
           />
-        </div>
+        </StyledGridItem>
       </StyledGrid>
     </DataSection>
   );
@@ -62,4 +62,9 @@ const StyledGrid = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: ${space(2)};
+`;
+
+const StyledGridItem = styled('div')<{position: 'left' | 'right'}>`
+  min-width: 0;
+  grid-column-start: ${p => (p.position === 'left' ? 1 : 2)};
 `;


### PR DESCRIPTION
The widgets were taking up some minimum amount of width, which caused it to overflow its parent when the browser was made more narrow.

Fixes this:
![Screenshot 2023-08-31 at 1 24 39 PM](https://github.com/getsentry/sentry/assets/22846452/1a8b6dd6-0772-474f-9868-2208095df4fa)
