### PR TITLE
ref(rules): Fix duplicate rule check for envs

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -56,6 +56,14 @@ def find_duplicate_rule(rule_data, project, rule_id=None):
                 if not existing_rule.data.get(matcher) and not rule_data.get(matcher):
                     # neither rule has the matcher
                     continue
+
+                elif matcher == "environment":
+                    if existing_rule.environment_id and rule_data.get(matcher):
+                        keys += 1
+                        if existing_rule.environment_id == rule_data.get(matcher):
+                            matches += 1
+                    else:
+                        keys += 1
                 else:
                     # one rule has the matcher and the other one doesn't
                     keys += 1

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -430,6 +430,7 @@ class Factories:
         name="",
         action_match="all",
         filter_match="all",
+        **kwargs,
     ):
         action_data = action_data or [
             {
@@ -461,6 +462,7 @@ class Factories:
                 "action_match": action_match,
                 "filter_match": filter_match,
             },
+            **kwargs,
         )
 
     @staticmethod


### PR DESCRIPTION
Special case checking for duplicate environments since it's not in data like everything else. 

Tests should cover every possible case:
- no env - no env 
- no env - env 
- env - (same) env 
- env - other env