### PR TITLE
feat(stat-detectors): Show bad events in All Events tab

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -25,10 +25,24 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export function getSampleEventQuery({transaction, durationBaseline}) {
-  return `event.type:transaction transaction:"${transaction}" transaction.duration:>=${
-    durationBaseline * 0.7
-  }ms transaction.duration:<=${durationBaseline * 1.3}ms`;
+export function getSampleEventQuery({
+  transaction,
+  durationBaseline,
+  addUpperBound = true,
+}: {
+  durationBaseline: number;
+  transaction: string;
+  addUpperBound?: boolean;
+}) {
+  const baseQuery = `event.type:transaction transaction:"${transaction}" transaction.duration:>=${
+    durationBaseline * 0.5
+  }ms`;
+
+  if (addUpperBound) {
+    return `${baseQuery} transaction.duration:<=${durationBaseline * 1.5}ms`;
+  }
+
+  return baseQuery;
 }
 
 // A hook for getting "sample events" for a transaction

--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -25,6 +25,12 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
+export function getSampleEventQuery({transaction, durationBaseline}) {
+  return `event.type:transaction transaction:"${transaction}" transaction.duration:>=${
+    durationBaseline * 0.7
+  }ms transaction.duration:<=${durationBaseline * 1.3}ms`;
+}
+
 // A hook for getting "sample events" for a transaction
 // In its current state it will just fetch at most 5 events that match the
 // transaction name within a range of the duration baseline provided
@@ -48,9 +54,7 @@ function useFetchSampleEvents({
     start: new Date(start * 1000).toISOString(),
     end: new Date(end * 1000).toISOString(),
     fields: [{field: 'id'}],
-    query: `event.type:transaction transaction:"${transaction}" transaction.duration:>=${
-      durationBaseline * 0.7
-    }ms transaction.duration:<=${durationBaseline * 1.3}ms`,
+    query: getSampleEventQuery({transaction, durationBaseline}),
 
     createdBy: undefined,
     display: undefined,

--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -81,7 +81,10 @@ function AllEventsTable(props: Props) {
   eventView.statsPeriod = '90d';
 
   let idQuery = `issue.id:${issueId}`;
-  if (group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION) {
+  if (
+    group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION &&
+    groupIsOccurrenceBacked
+  ) {
     const {transaction, aggregateRange2, breakpoint, requestEnd} =
       data?.occurrence?.evidenceData ?? {};
 

--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useState} from 'react';
 import {Location} from 'history';
 
+import {getSampleEventQuery} from 'sentry/components/events/eventStatisticalDetector/eventComparison/eventDisplay';
 import LoadingError from 'sentry/components/loadingError';
 import {
   PlatformCategory,
@@ -8,7 +9,13 @@ import {
   profiling as PROFILING_PLATFORMS,
 } from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
-import {EventTransaction, Group, IssueCategory, Organization} from 'sentry/types';
+import {
+  EventTransaction,
+  Group,
+  IssueCategory,
+  IssueType,
+  Organization,
+} from 'sentry/types';
 import EventView, {decodeSorts} from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
@@ -71,13 +78,23 @@ function AllEventsTable(props: Props) {
     eventView.sorts = [{field: 'timestamp', kind: 'desc'}];
   }
 
-  const idQuery =
-    group.issueCategory === IssueCategory.PERFORMANCE && !groupIsOccurrenceBacked
-      ? `performance.issue_ids:${issueId} event.type:transaction`
-      : `issue.id:${issueId}`;
+  eventView.statsPeriod = '90d';
+
+  let idQuery = `issue.id:${issueId}`;
+  if (group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION) {
+    const {transaction, aggregateRange2, breakpoint, requestEnd} =
+      data?.occurrence?.evidenceData ?? {};
+
+    // Surface the "bad" events that occur after the breakpoint
+    idQuery = getSampleEventQuery({transaction, durationBaseline: aggregateRange2});
+
+    eventView.dataset = DiscoverDatasets.DISCOVER;
+    eventView.start = new Date(breakpoint * 1000).toISOString();
+    eventView.end = new Date(requestEnd * 1000).toISOString();
+    eventView.statsPeriod = undefined;
+  }
   eventView.project = [parseInt(group.project.id, 10)];
   eventView.query = `${idQuery} ${props.location.query.query || ''}`;
-  eventView.statsPeriod = '90d';
 
   if (error || isLoadingError) {
     return (

--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -81,7 +81,9 @@ function AllEventsTable(props: Props) {
   eventView.statsPeriod = '90d';
 
   let idQuery = `issue.id:${issueId}`;
-  if (
+  if (group.issueCategory === IssueCategory.PERFORMANCE && !groupIsOccurrenceBacked) {
+    idQuery = `performance.issue_ids:${issueId} event.type:transaction`;
+  } else if (
     group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION &&
     groupIsOccurrenceBacked
   ) {

--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -89,7 +89,11 @@ function AllEventsTable(props: Props) {
       data?.occurrence?.evidenceData ?? {};
 
     // Surface the "bad" events that occur after the breakpoint
-    idQuery = getSampleEventQuery({transaction, durationBaseline: aggregateRange2});
+    idQuery = getSampleEventQuery({
+      transaction,
+      durationBaseline: aggregateRange2,
+      addUpperBound: false,
+    });
 
     eventView.dataset = DiscoverDatasets.DISCOVER;
     eventView.start = new Date(breakpoint * 1000).toISOString();


### PR DESCRIPTION
Reuses logic for gathering regressed events and fetches those events in the All Events tab instead of occurrences of statistical detector issues.
