### PR TITLE
feat(backup): Support username collision resolution

### DIFF
--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -75,7 +75,11 @@ class UserOptionsSerializer(serializers.Serializer):
 
 class BaseUserSerializer(CamelSnakeModelSerializer):
     def validate_username(self, value):
-        if User.objects.filter(username__iexact=value).exclude(id=self.instance.id).exists():
+        if (
+            User.objects.filter(username__iexact=value)
+            .exclude(id=self.instance.id if hasattr(self.instance, "id") else 0)
+            .exists()
+        ):
             raise serializers.ValidationError("That username is already in use.")
         return value
 

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -111,11 +111,16 @@ class BaseModel(models.Model):
         self, pk_map: PrimaryKeyMap, _: ImportScope
     ) -> Optional[int]:
         """
-        A helper function that normalizes a deserialized model. Note that this modifies the model in place, so it should generally be done inside of the companion `write_relocation_import` method, to avoid data skew or corrupted local state.
+        A helper function that normalizes a deserialized model. Note that this modifies the model in
+        place, so it should generally be done inside of the companion `write_relocation_import`
+        method, to avoid data skew or corrupted local state.
 
-        The only reason this function is left as a standalone, rather than being folded into `write_relocation_import`, is that it is often useful to adjust just the normalization logic by itself. Overrides of this method should take care not to mutate the `pk_map`.
+        The only reason this function is left as a standalone, rather than being folded into
+        `write_relocation_import`, is that it is often useful to adjust just the normalization logic
+        by itself. Overrides of this method should take care not to mutate the `pk_map`.
 
-        The default normalization logic merely replaces foreign keys with their new values from the provided `pk_map`.
+        The default normalization logic merely replaces foreign keys with their new values from the
+        provided `pk_map`.
 
         The method returns the old `pk` that was replaced.
         """
@@ -128,7 +133,7 @@ class BaseModel(models.Model):
             if fk is not None:
                 new_fk = pk_map.get(normalize_model_name(model_relation.model), fk)
                 if new_fk is None:
-                    return
+                    return None
 
                 setattr(self, field_id, new_fk)
 

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -50,18 +50,15 @@ def resolve_combined_expression(instance: Model, node: BaseExpression) -> BaseEx
     return runner
 
 
-def slugify_instance(
+def unique_db_instance(
     inst: Model,
-    label: str,
+    base_value: str,
     reserved: Container[str] = (),
     max_length: int = 30,
     field_name: str = "slug",
     *args: Any,
     **kwargs: Any,
 ) -> None:
-    base_value = slugify(label)[:max_length]
-    base_value = base_value.strip("-")
-
     if base_value is not None:
         base_value = base_value.strip()
         if base_value in reserved:
@@ -107,6 +104,21 @@ def slugify_instance(
 
     # If at this point, we've exhausted all possibilities, we'll just end up hitting
     # an IntegrityError from database, which is ok, and unlikely to happen
+
+
+def slugify_instance(
+    inst: Model,
+    label: str,
+    reserved: Container[str] = (),
+    max_length: int = 30,
+    field_name: str = "slug",
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    value = slugify(label)[:max_length]
+    value = value.strip("-")
+
+    return unique_db_instance(inst, value, reserved, max_length, field_name, *args, **kwargs)
 
 
 class Creator:

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.models import UserManager as DjangoUserManager
@@ -9,6 +9,7 @@ from django.db import IntegrityError, models, router, transaction
 from django.db.models import Count, Subquery
 from django.db.models.query import QuerySet
 from django.dispatch import receiver
+from django.forms import model_to_dict
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -24,6 +25,8 @@ from sentry.db.models import (
     control_silo_only_model,
     sane_repr,
 )
+from sentry.db.models.utils import unique_db_instance
+from sentry.locks import locks
 from sentry.models.authenticator import Authenticator
 from sentry.models.avatars import UserAvatar
 from sentry.models.lostpasswordhash import LostPasswordHash
@@ -33,8 +36,11 @@ from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.types.region import find_regions_for_user
 from sentry.utils.http import absolute_uri
+from sentry.utils.retries import TimedRetryPolicy
 
 audit_logger = logging.getLogger("sentry.audit.user")
+
+MAX_USERNAME_LENGTH = 128
 
 
 class UserManager(BaseManager, DjangoUserManager):
@@ -73,7 +79,7 @@ class User(BaseModel, AbstractBaseUser):
     __relocation_scope__ = RelocationScope.User
 
     id = BoundedBigAutoField(primary_key=True)
-    username = models.CharField(_("username"), max_length=128, unique=True)
+    username = models.CharField(_("username"), max_length=MAX_USERNAME_LENGTH, unique=True)
     # this column is called first_name for legacy reasons, but it is the entire
     # display name
     name = models.CharField(_("name"), max_length=200, blank=True, db_column="first_name")
@@ -384,11 +390,44 @@ class User(BaseModel, AbstractBaseUser):
             self.is_staff = False
             self.is_superuser = False
 
-        # TODO(getsentry/team-ospo#181): Handle usernames that already exist. This will involve
-        # marking the user "unclaimed", wiping their password, and adding a random suffix to their
-        # username.
+        lock = locks.get(f"user:username:{self.id}", duration=5, name="username")
+        with TimedRetryPolicy(10)(lock.acquire):
+            unique_db_instance(
+                self,
+                self.username,
+                max_length=MAX_USERNAME_LENGTH,
+                field_name="username",
+            )
+
+        # TODO(getsentry/team-ospo#181): Create unclaimed users: set the (to be created) unclaimed
+        # flag, and wipe the password.
 
         return old_pk
+
+    def write_relocation_import(
+        self, pk_map: PrimaryKeyMap, scope: ImportScope
+    ) -> Optional[Tuple[int, int]]:
+        from sentry.api.endpoints.user_details import (
+            BaseUserSerializer,
+            SuperuserUserSerializer,
+            UserSerializer,
+        )
+
+        old_pk = self._normalize_before_relocation_import(pk_map, scope)
+        if old_pk is None:
+            return None
+
+        serializer_cls = BaseUserSerializer
+        if scope != ImportScope.Global:
+            serializer_cls = UserSerializer
+        else:
+            serializer_cls = SuperuserUserSerializer
+
+        serializer_user = serializer_cls(instance=self, data=model_to_dict(self), partial=True)
+        serializer_user.is_valid(raise_exception=True)
+
+        self.save(force_insert=True)
+        return (old_pk, self.pk)
 
 
 # HACK(dcramer): last_login needs nullable for Django 1.8


### PR DESCRIPTION
As of this PR, everything for supporting unclaimed users save the actual addition of the `is_unclaimed` flag itself and the email/UI copy to support that is ready.

Issue: getsentry/team-ospo#170
Issue: getsentry/team-ospo#181
Issue: getsentry/team-ospo#182