### PR TITLE
bug(replays): Fix dead & rage click conditions - BE matches SDK

### DIFF
--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -144,6 +144,7 @@ def get_user_actions(
                 is_target_tagname = payload["data"].get("node", {}).get("tagName") in (
                     "a",
                     "button",
+                    "input",
                 )
                 timeout = payload["data"].get("timeAfterClickMs", 0) or payload["data"].get(
                     "timeafterclickms", 0


### PR DESCRIPTION
These three places need to agree on:
1. what qualifies for dead-clicks (it should be `<a>`, `<button>`, `<input type=submit>` and `<input type=button>`)
2. what the thresholds are


This PR aligns which elements we care about: BE now matches the SDK 

The thresholds are already aligned on BE and FE
  - endReason is 'timeout' based on the sdk config
      - but the backend also has `7000` hard-coded here which i'm not yet sure about and will followup on.
  - 5 clicks or more, then it's rageful


Related to https://github.com/getsentry/sentry/pull/55562
Fixes https://github.com/getsentry/team-replay/issues/152