### PR TITLE
chore(consts): Rm ObjectStatus.VISIBLE

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -461,12 +461,11 @@ def get_integration_id_for_event(
 
 
 class ObjectStatus:
-    VISIBLE = 0
+    ACTIVE = 0
     HIDDEN = 1
     PENDING_DELETION = 2
     DELETION_IN_PROGRESS = 3
 
-    ACTIVE = 0
     DISABLED = 1
 
     @classmethod


### PR DESCRIPTION
`ObjectStatus.VISIBLE` isn't used anywhere and we define an enum for 0 and 1 twice, so we can at least get rid of this one. Hidden and Disable are both used so they _could_ be consolidated as well, but I understand wanting to keep those names different.