### PR TITLE
feat(stat-detectors): Remove event header from Issue Details

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -20,6 +20,7 @@ import {
   Group,
   GroupActivityReprocess,
   GroupReprocessing,
+  IssueType,
   Organization,
   Project,
 } from 'sentry/types';
@@ -220,13 +221,15 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
                         group={group}
                       />
                       <QuickTraceContext.Provider value={results}>
-                        {eventWithMeta && (
-                          <GroupEventHeader
-                            group={group}
-                            event={eventWithMeta}
-                            project={project}
-                          />
-                        )}
+                        {eventWithMeta &&
+                          group.issueType !==
+                            IssueType.PERFORMANCE_DURATION_REGRESSION && (
+                            <GroupEventHeader
+                              group={group}
+                              event={eventWithMeta}
+                              project={project}
+                            />
+                          )}
                         {renderContent()}
                       </QuickTraceContext.Provider>
                     </StyledLayoutMain>


### PR DESCRIPTION
Viewing individual events of occurrences for statistical detectors doesn't really make sense. We always want to show the latest occurrence so we are removing the GroupEventHeader for this issue