### PR TITLE
feat(stat-detectors): Add functionality to sample event buttons

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -22,7 +22,7 @@ import {getShortEventId} from 'sentry/utils/events';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {GroupEventCarouselActions} from 'sentry/views/issueDetails/groupEventCarousel';
+import {GroupEventActions} from 'sentry/views/issueDetails/groupEventCarousel';
 
 // A hook for getting "sample events" for a transaction
 // In its current state it will just fetch at most 5 events that match the
@@ -152,11 +152,7 @@ function EventDisplay({
               </ButtonLabelWrapper>
             }
           />
-          <GroupEventCarouselActions
-            event={eventData}
-            group={group}
-            projectSlug={project.slug}
-          />
+          <GroupEventActions event={eventData} group={group} projectSlug={project.slug} />
         </StyledEventSelectorControlBar>
         <ComparisonContentWrapper>
           <MinimapContainer>

--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -1,7 +1,6 @@
 import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {EventTags} from 'sentry/components/events/eventTags';
@@ -12,10 +11,9 @@ import WaterfallModel from 'sentry/components/events/interfaces/spans/waterfallM
 import OpsBreakdown from 'sentry/components/events/opsBreakdown';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import TextOverflow from 'sentry/components/textOverflow';
-import {IconEllipsis, IconJson, IconLink} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {EventTransaction, Project} from 'sentry/types';
+import {EventTransaction, Group, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
@@ -24,6 +22,7 @@ import {getShortEventId} from 'sentry/utils/events';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {GroupEventCarouselActions} from 'sentry/views/issueDetails/groupEventCarousel';
 
 // A hook for getting "sample events" for a transaction
 // In its current state it will just fetch at most 5 events that match the
@@ -76,6 +75,7 @@ type EventDisplayProps = {
   durationBaseline: number;
   end: number;
   eventSelectLabel: string;
+  group: Group;
   project: Project;
   start: number;
   transaction: string;
@@ -88,6 +88,7 @@ function EventDisplay({
   end,
   transaction,
   durationBaseline,
+  group,
 }: EventDisplayProps) {
   const location = useLocation();
   const organization = useOrganization();
@@ -151,9 +152,11 @@ function EventDisplay({
               </ButtonLabelWrapper>
             }
           />
-          <Button aria-label="icon" icon={<IconEllipsis />} size="sm" />
-          <Button aria-label="icon" icon={<IconJson />} size="sm" />
-          <Button aria-label="icon" icon={<IconLink />} size="sm" />
+          <GroupEventCarouselActions
+            event={eventData}
+            group={group}
+            projectSlug={project.slug}
+          />
         </StyledEventSelectorControlBar>
         <ComparisonContentWrapper>
           <MinimapContainer>

--- a/static/app/components/events/eventStatisticalDetector/eventComparison/index.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {EventDisplay} from 'sentry/components/events/eventStatisticalDetector/eventComparison/eventDisplay';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Event, Project} from 'sentry/types';
+import {Event, Group, Project} from 'sentry/types';
 
 import {DataSection} from '../../styles';
 
@@ -13,10 +13,11 @@ const COMPARISON_DESCRIPTION = t(
 
 type EventComparisonProps = {
   event: Event;
+  group: Group;
   project: Project;
 };
 
-function EventComparison({event, project}: EventComparisonProps) {
+function EventComparison({event, project, group}: EventComparisonProps) {
   const {
     aggregateRange1,
     aggregateRange2,
@@ -39,6 +40,7 @@ function EventComparison({event, project}: EventComparisonProps) {
             end={breakpoint}
             transaction={transaction}
             durationBaseline={aggregateRange1}
+            group={group}
           />
         </div>
         <div style={{gridColumnStart: 2}}>
@@ -49,6 +51,7 @@ function EventComparison({event, project}: EventComparisonProps) {
             end={requestEnd}
             transaction={transaction}
             durationBaseline={aggregateRange2}
+            group={group}
           />
         </div>
       </StyledGrid>

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -244,7 +244,6 @@ function EventNavigationDropdown({group, event, isDisabled}: GroupEventNavigatio
 type GroupEventCarouselActionsProps = {
   event: Event;
   group: Group;
-  // isDisabled: boolean;
   projectSlug: string;
 };
 

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -241,17 +241,13 @@ function EventNavigationDropdown({group, event, isDisabled}: GroupEventNavigatio
   );
 }
 
-type GroupEventCarouselActionsProps = {
+type GroupEventActionsProps = {
   event: Event;
   group: Group;
   projectSlug: string;
 };
 
-export function GroupEventCarouselActions({
-  event,
-  group,
-  projectSlug,
-}: GroupEventCarouselActionsProps) {
+export function GroupEventActions({event, group, projectSlug}: GroupEventActionsProps) {
   const theme = useTheme();
   const xlargeViewport = useMedia(`(min-width: ${theme.breakpoints.xlarge})`);
   const organization = useOrganization();
@@ -480,11 +476,7 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
         <QuickTrace event={event} organization={organization} location={location} />
       </div>
       <ActionsWrapper>
-        <GroupEventCarouselActions
-          event={event}
-          group={group}
-          projectSlug={projectSlug}
-        />
+        <GroupEventActions event={event} group={group} projectSlug={projectSlug} />
         <EventNavigationDropdown
           isDisabled={!hasPreviousEvent && !hasNextEvent}
           group={group}

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -286,6 +286,18 @@ export function GroupEventCarouselActions({
       }),
   });
 
+  const {onClick: copyEventDetailLink} = useCopyToClipboard({
+    successMessage: t('Event URL copied to clipboard'),
+    text:
+      window.location.origin +
+      normalizeUrl(
+        eventDetailsRoute({
+          eventSlug: generateEventSlug({project: projectSlug, id: event.id}),
+          orgSlug: organization.slug,
+        })
+      ),
+  });
+
   const {onClick: copyEventId} = useCopyToClipboard({
     successMessage: t('Event ID copied to clipboard'),
     text: event.id,
@@ -315,7 +327,7 @@ export function GroupEventCarouselActions({
             key: 'copy-event-url',
             label: t('Copy Event Link'),
             hidden: xlargeViewport,
-            onAction: copyLink,
+            onAction: isDurationRegressionIssue ? copyEventDetailLink : copyLink,
           },
           {
             key: 'json',
@@ -362,6 +374,17 @@ export function GroupEventCarouselActions({
           title={isHelpfulEventUiEnabled ? t('Copy link to this issue event') : undefined}
           size={BUTTON_SIZE}
           onClick={copyLink}
+          aria-label={t('Copy Link')}
+          icon={isHelpfulEventUiEnabled ? <IconLink /> : undefined}
+        >
+          {!isHelpfulEventUiEnabled && 'Copy Link'}
+        </Button>
+      )}
+      {xlargeViewport && isDurationRegressionIssue && (
+        <Button
+          title={isHelpfulEventUiEnabled ? t('Copy link to this event') : undefined}
+          size={BUTTON_SIZE}
+          onClick={copyEventDetailLink}
           aria-label={t('Copy Link')}
           icon={isHelpfulEventUiEnabled ? <IconLink /> : undefined}
         >

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -97,7 +97,7 @@ function GroupEventDetailsContent({
         <Fragment>
           <RegressionMessage event={event} />
           <EventBreakpointChart event={event} />
-          <EventComparison event={event} project={project} />
+          <EventComparison event={event} group={group} project={project} />
         </Fragment>
       </Feature>
     );


### PR DESCRIPTION
Refactors the buttons out from the GroupEventCarousel to reuse their functionality in the statistical detector Issue Details buttons.

For a duration issue, instead of copying the event issue link, I've changed it so it copies the event detail link in Discover.