### PR TITLE
fix(roles): check truthy team.orgRole value

### DIFF
--- a/fixtures/js-stubs/team.tsx
+++ b/fixtures/js-stubs/team.tsx
@@ -8,7 +8,7 @@ export function Team(params: Partial<TeamType> = {}): TeamType {
     slug: 'team-slug',
     name: 'Team Name',
     access: ['team:read'],
-    orgRole: null, // TODO(cathy): Rename this
+    orgRole: undefined, // TODO(cathy): Rename this
     teamRole: null,
     isMember: true,
     memberCount: 0,

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -89,9 +89,9 @@ export interface Team {
   isPending: boolean;
   memberCount: number;
   name: string;
-  orgRole: string | null;
   slug: string;
   teamRole: string | null;
+  orgRole?: string | null;
 }
 
 // TODO: Rename to BaseRole

--- a/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
@@ -155,7 +155,7 @@ function TeamRow({
 }) {
   const hasOrgAdmin = organization.access.includes('org:admin');
   const isIdpProvisioned = team.flags['idp:provisioned'];
-  const isPermissionGroup = (team.orgRole && hasOrgAdmin) as boolean;
+  const isPermissionGroup = (team.orgRole && !hasOrgAdmin) as boolean;
   const isRemoveDisabled = disabled || isIdpProvisioned || isPermissionGroup;
 
   const buttonHelpText = getButtonHelpText(isIdpProvisioned, isPermissionGroup);

--- a/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
@@ -155,7 +155,7 @@ function TeamRow({
 }) {
   const hasOrgAdmin = organization.access.includes('org:admin');
   const isIdpProvisioned = team.flags['idp:provisioned'];
-  const isPermissionGroup = (team.orgRole && !hasOrgAdmin) as boolean;
+  const isPermissionGroup = !!team.orgRole && !hasOrgAdmin;
   const isRemoveDisabled = disabled || isIdpProvisioned || isPermissionGroup;
 
   const buttonHelpText = getButtonHelpText(isIdpProvisioned, isPermissionGroup);

--- a/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
@@ -155,7 +155,7 @@ function TeamRow({
 }) {
   const hasOrgAdmin = organization.access.includes('org:admin');
   const isIdpProvisioned = team.flags['idp:provisioned'];
-  const isPermissionGroup = team.orgRole !== null && !hasOrgAdmin;
+  const isPermissionGroup = (team.orgRole && hasOrgAdmin) as boolean;
   const isRemoveDisabled = disabled || isIdpProvisioned || isPermissionGroup;
 
   const buttonHelpText = getButtonHelpText(isIdpProvisioned, isPermissionGroup);

--- a/static/app/views/settings/components/teamSelect/utils.tsx
+++ b/static/app/views/settings/components/teamSelect/utils.tsx
@@ -129,9 +129,7 @@ function renderDropdownOption({
 }) {
   const hasOrgAdmin = organization.access.includes('org:admin');
   const isIdpProvisioned = isAddingTeamToMember && team.flags['idp:provisioned'];
-  const isPermissionGroup = (isAddingTeamToMember &&
-    team.orgRole &&
-    !hasOrgAdmin) as boolean;
+  const isPermissionGroup = isAddingTeamToMember && !!team.orgRole && !hasOrgAdmin;
   const buttonHelpText = getButtonHelpText(isIdpProvisioned, isPermissionGroup);
 
   return {

--- a/static/app/views/settings/components/teamSelect/utils.tsx
+++ b/static/app/views/settings/components/teamSelect/utils.tsx
@@ -129,7 +129,9 @@ function renderDropdownOption({
 }) {
   const hasOrgAdmin = organization.access.includes('org:admin');
   const isIdpProvisioned = isAddingTeamToMember && team.flags['idp:provisioned'];
-  const isPermissionGroup = isAddingTeamToMember && team.orgRole !== null && !hasOrgAdmin;
+  const isPermissionGroup = (isAddingTeamToMember &&
+    team.orgRole &&
+    !hasOrgAdmin) as boolean;
   const buttonHelpText = getButtonHelpText(isIdpProvisioned, isPermissionGroup);
 
   return {

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -184,7 +184,7 @@ class AllTeamsRow extends Component<Props, State> {
     // TODO(team-roles): team admins can also manage membership
     // org:admin is a unique scope that only org owners have
     const isOrgOwner = access.includes('org:admin');
-    const isPermissionGroup = (team.orgRole && (!canEditTeam || !isOrgOwner)) as boolean;
+    const isPermissionGroup = !!team.orgRole && (!canEditTeam || !isOrgOwner);
     const isIdpProvisioned = team.flags['idp:provisioned'];
 
     const buttonHelpText = getButtonHelpText(isIdpProvisioned, isPermissionGroup);

--- a/static/app/views/settings/organizationTeams/teamMembersRow.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembersRow.tsx
@@ -50,7 +50,7 @@ function TeamMembersRow({
       <div>
         <RemoveButton
           hasWriteAccess={hasWriteAccess}
-          hasOrgRoleFromTeam={team.orgRole !== null}
+          hasOrgRoleFromTeam={!!team.orgRole}
           isOrgOwner={isOrgOwner}
           isSelf={isSelf}
           onClick={() => removeMember(member)}


### PR DESCRIPTION
Applying an org role to all members of a team is not public, so we decided to hide the value from the API response in #53106. This also causes the values on the frontend to be read as `undefined` if the `orgRole` key doesn't exist. In the instances corrected in this PR, we only checked for if the `orgRole` key is `null` rather than `null` AND `undefined`. Both of these are falsy, so we can instead check the truthiness to restore the original behavior.