### PR TITLE
fix(hybridcloud) Fix db splitter logic

### DIFF
--- a/bin/split-silo-database
+++ b/bin/split-silo-database
@@ -86,8 +86,24 @@ def main(database: str, reset: bool, verbose: bool, legacy_region_name: str):
 
     This operation will not modify the original source database.
     """
-    region_tables = ["django_migrations"]
-    control_tables = ["django_migrations"]
+    # We have a few tables that either need to be in both silos,
+    # or only in control. These tables don't have silo annotations
+    # as they are inherited from django and their silo assignments
+    # need to be manually defined.
+    region_tables = ["django_migrations", "django_content_type"]
+    control_tables = [
+        "django_migrations",
+        "django_admin_log",
+        "django_content_type",
+        "django_site",
+        "django_session",
+        "auth_user",
+        "auth_group",
+        "auth_permission",
+        "auth_group_permissions",
+        "auth_user_groups",
+        "auth_user_user_permissions",
+    ]
     for model in apps.get_models():
         silo_limit = getattr(model._meta, "silo_limit", None)
         if not silo_limit:


### PR DESCRIPTION
When I first built the db splitter, I forgot to test the scenario where a monolith database was split and then migrations needed to be applied. I was in this situation today and needed to adjust the db splitter.
