### PR TITLE
Symfony Getting started docs: don't commit credentials in configs

### DIFF
--- a/static/app/gettingStartedDocs/php/symfony.tsx
+++ b/static/app/gettingStartedDocs/php/symfony.tsx
@@ -70,13 +70,13 @@ sensio_framework_extra:
       {
         description: (
           <p>
-            {tct('Add your DSN to [code:config/packages/sentry.yaml]:', {code: <code />})}
+            {tct('Add to [code:config/packages/sentry.yaml]:', {code: <code />})}
           </p>
         ),
         language: 'php',
         code: `
 sentry:
-  dsn: "%env(${dsn})%"
+  dsn: "%env(SENTRY_DSN)%"
         `,
       },
       {


### PR DESCRIPTION
The Symfony Getting started instructions are confused, telling the user to put the DSN to `.env`, but then, instead of using the environment variable, to copy the DSN verbatim to a configuration file, which is meant to be committed to a VCS.

And the syntax is not even correct - `%env(X)%` in Symfony configs is a reference to an environment variable.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
