### PR TITLE
fix(issue-stream): Prevent undefined values from being stored in actionTakenGroupData

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1026,7 +1026,9 @@ class IssueListOverview extends Component<Props, State> {
   };
 
   onActionTaken = (itemIds: string[]) => {
-    const actionTakenGroupData = itemIds.map(id => GroupStore.get(id) as Group);
+    const actionTakenGroupData = itemIds
+      .map(id => GroupStore.get(id) as Group | undefined)
+      .filter(defined);
     this.setState({
       actionTakenGroupData,
     });


### PR DESCRIPTION
Fixes JAVASCRIPT-2NN7

We need to cast to `Group` on this line because of the broad typing in GroupStore (ugh), but it should have been Group | undefined. Adding a filter here prevents errors downstream.