### PR TITLE
fix(alerts): Display muted for metric alerts

### DIFF
--- a/static/app/views/alerts/list/rules/index.spec.tsx
+++ b/static/app/views/alerts/list/rules/index.spec.tsx
@@ -364,6 +364,22 @@ describe('AlertRulesList', () => {
     expect(screen.getByText('Muted')).toBeInTheDocument();
   });
 
+  it('displays metric alert muted', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/combined-rules/',
+      headers: {Link: pageLinks},
+      body: [
+        TestStubs.MetricRule({
+          projects: ['earth'],
+          snooze: true,
+        }),
+      ],
+    });
+    createWrapper();
+    expect(await screen.findByText('My Incident Rule')).toBeInTheDocument();
+    expect(screen.getByText('Muted')).toBeInTheDocument();
+  });
+
   it('sorts by alert rule', async () => {
     createWrapper({organization});
 

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -114,6 +114,15 @@ function RuleListRow({
     );
   }
 
+  function renderSnoozeStatus(): React.ReactNode {
+    return (
+      <IssueAlertStatusWrapper>
+        <IconMute size="sm" color="subText" />
+        {t('Muted')}
+      </IssueAlertStatusWrapper>
+    );
+  }
+
   function renderAlertRuleStatus(): React.ReactNode {
     if (isIssueAlert(rule)) {
       if (rule.status === 'disabled') {
@@ -125,14 +134,13 @@ function RuleListRow({
         );
       }
       if (rule.snooze) {
-        return (
-          <IssueAlertStatusWrapper>
-            <IconMute size="sm" color="subText" />
-            {t('Muted')}
-          </IssueAlertStatusWrapper>
-        );
+        return renderSnoozeStatus();
       }
       return null;
+    }
+
+    if (rule.snooze) {
+      return renderSnoozeStatus();
     }
 
     const criticalTrigger = rule.triggers.find(


### PR DESCRIPTION
In the alert list displays the muted state in the status column

![image](https://github.com/getsentry/sentry/assets/1400464/33561a8a-223c-4195-9153-0f22e3639feb)
