### PR TITLE
feat(backup): Support org slug remapping

### DIFF
--- a/fixtures/backup/duplicate-username-and-organization-slug.json
+++ b/fixtures/backup/duplicate-username-and-organization-slug.json
@@ -1,0 +1,186 @@
+[
+{
+  "model": "sentry.option",
+  "pk": 1,
+  "fields": {
+    "key": "sentry:last_worker_ping",
+    "last_updated": "2023-06-27T21:40:01.305Z",
+    "last_updated_by": "unknown",
+    "value": 1687902001.2623305
+  }
+},
+{
+  "model": "sentry.option",
+  "pk": 2,
+  "fields": {
+    "key": "sentry:last_worker_version",
+    "last_updated": "2023-06-27T21:40:01.312Z",
+    "last_updated_by": "unknown",
+    "value": "\"23.7.0.dev0\""
+  }
+},
+{
+  "model": "sentry.option",
+  "pk": 3,
+  "fields": {
+    "key": "sentry:install-id",
+    "last_updated": "2023-06-23T00:03:42.785Z",
+    "last_updated_by": "unknown",
+    "value": "\"1bc81f9440424e908a73ca377581cb52682db68a\""
+  }
+},
+{
+  "model": "sentry.option",
+  "pk": 4,
+  "fields": {
+    "key": "sentry:latest_version",
+    "last_updated": "2023-06-27T21:25:02.602Z",
+    "last_updated_by": "unknown",
+    "value": "\"23.6.1\""
+  }
+},
+{
+  "model": "sentry.email",
+  "pk": 1,
+  "fields": {
+    "email": "testing@example.com",
+    "date_added": "2023-06-22T22:59:55.531Z"
+  }
+},
+{
+  "model": "sentry.organization",
+  "pk": 1,
+  "fields": {
+    "name": "Testing",
+    "slug": "testing",
+    "status": 0,
+    "date_added": "2023-06-22T22:54:28.773Z",
+    "default_role": "member",
+    "is_test": false,
+    "flags": "1"
+  }
+},
+{
+  "model": "sentry.organization",
+  "pk": 2,
+  "fields": {
+    "name": "Testing (Duplicate Slug)",
+    "slug": "testing",
+    "status": 0,
+    "date_added": "2023-06-22T22:54:28.773Z",
+    "default_role": "member",
+    "is_test": false,
+    "flags": "1"
+  }
+},
+{
+  "model": "sentry.user",
+  "pk": 1,
+  "fields": {
+    "password": "pbkdf2_sha256$150000$iEvdIknqYjTr$+QsGn0tfIJ1FZLxQI37mVU1gL2KbL/wqjMtG/dFhsMA=",
+    "last_login": null,
+    "username": "testing@example.com",
+    "name": "User",
+    "email": "testing@example.com",
+    "is_staff": true,
+    "is_active": true,
+    "is_superuser": true,
+    "is_managed": false,
+    "is_sentry_app": null,
+    "is_password_expired": false,
+    "last_password_change": "2023-06-22T22:59:57.023Z",
+    "flags": "0",
+    "session_nonce": null,
+    "date_joined": "2023-06-22T22:59:55.488Z",
+    "last_active": "2023-06-22T22:59:55.489Z",
+    "avatar_type": 0,
+    "avatar_url": null
+  }
+},
+{
+  "model": "sentry.user",
+  "pk": 2,
+  "fields": {
+    "password": "pbkdf2_sha256$150000$iEvdIknqYjTr$+QsGn0tfIJ1FZLxQI37mVU1gL2KbL/wqjMtG/dFhsMA=",
+    "last_login": null,
+    "username": "testing@example.com",
+    "name": "User (Duplicate Username and Email)",
+    "email": "testing@example.com",
+    "is_staff": true,
+    "is_active": true,
+    "is_superuser": true,
+    "is_managed": false,
+    "is_sentry_app": null,
+    "is_password_expired": false,
+    "last_password_change": "2023-06-22T22:59:57.023Z",
+    "flags": "0",
+    "session_nonce": null,
+    "date_joined": "2023-06-22T22:59:55.488Z",
+    "last_active": "2023-06-22T22:59:55.489Z",
+    "avatar_type": 0,
+    "avatar_url": null
+  }
+},
+{
+  "model": "sentry.useremail",
+  "pk": 1,
+  "fields": {
+    "user": 1,
+    "email": "testing@example.com",
+    "validation_hash": "mCnWesSVvYQcq7qXQ36AZHwosAd6cghE",
+    "date_hash_added": "2023-06-22T22:59:55.521Z",
+    "is_verified": false
+  }
+},
+{
+  "model": "sentry.useremail",
+  "pk": 2,
+  "fields": {
+    "user": 2,
+    "email": "testing@example.com",
+    "validation_hash": "mCnWesSVvYQcq7qXQ36AZHwosAd6cghE",
+    "date_hash_added": "2023-06-22T22:59:55.521Z",
+    "is_verified": false
+  }
+},
+{
+  "model": "sentry.organizationmember",
+  "pk": 1,
+  "fields": {
+    "organization": 1,
+    "user_id": 1,
+    "email": null,
+    "role": "owner",
+    "flags": "0",
+    "token": null,
+    "date_added": "2023-06-22T22:59:55.561Z",
+    "token_expires_at": null,
+    "has_global_access": true,
+    "inviter_id": null,
+    "invite_status": 0,
+    "type": 50,
+    "user_is_active": true,
+    "user_email": "testing@example.com"
+  }
+},
+{
+  "model": "sentry.organizationmember",
+  "pk": 2,
+  "fields": {
+    "organization": 2,
+    "user_id": 2,
+    "email": null,
+    "role": "owner",
+    "flags": "0",
+    "token": null,
+    "date_added": "2023-06-22T22:59:55.561Z",
+    "token_expires_at": null,
+    "has_global_access": true,
+    "inviter_id": null,
+    "invite_status": 0,
+    "type": 50,
+    "user_is_active": true,
+    "user_email": "testing@example.com"
+  }
+}
+]

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -77,8 +77,10 @@ class BaseUserSerializer(CamelSnakeModelSerializer):
     def validate_username(self, value):
         if (
             User.objects.filter(username__iexact=value)
-            .exclude(id=self.instance.id if hasattr(self.instance, "id") else 0)
-            .exists()
+            # Django throws an exception if `id` is `None`, which it will be when we're importing
+            # new users via the relocation logic on the `User` model. So we cast `None` to `0` to
+            # make Django happy here.
+            .exclude(id=self.instance.id if hasattr(self.instance, "id") else 0).exists()
         ):
             raise serializers.ValidationError("That username is already in use.")
         return value

--- a/src/sentry/backup/findings.py
+++ b/src/sentry/backup/findings.py
@@ -34,6 +34,13 @@ class ComparatorFindingKind(IntEnum):
     # The JSON of two instances of a model, after certain fields have been scrubbed by all applicable comparators, were not byte-for-byte equivalent.
     UnequalJSON = auto()
 
+    # Failed to compare an auto suffixed field.
+    AutoSuffixComparator = auto()
+
+    # Failed to compare an auto suffixed field because one of the fields being compared was not
+    # present or `None`.
+    AutoSuffixComparatorExistenceCheck = auto()
+
     # Two datetime fields were not equal.
     DatetimeEqualityComparator = auto()
 

--- a/src/sentry/models/userip.py
+++ b/src/sentry/models/userip.py
@@ -58,8 +58,7 @@ class UserIP(Model):
 
         # Only preserve the submitted timing data in the global scope.
         if scope != ImportScope.Global:
-            self.first_seen = timezone.now()
-            self.last_seen = self.first_seen
+            self.first_seen = self.last_seen = timezone.now()
 
         return old_pk
 

--- a/tests/sentry/backup/test_comparators.py
+++ b/tests/sentry/backup/test_comparators.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 import pytest
 
 from sentry.backup.comparators import (
+    AutoSuffixComparator,
     DatetimeEqualityComparator,
     DateUpdatedComparator,
     EmailObfuscatingComparator,
@@ -61,6 +62,8 @@ def test_bad_comparator_only_one_side_existing():
     }
     res = cmp.existence(id, missing, present)
     assert res
+    assert len(res) == 1
+
     assert res[0]
     assert res[0].on == id
     assert res[0].kind == ComparatorFindingKind.DateUpdatedComparatorExistenceCheck
@@ -71,6 +74,8 @@ def test_bad_comparator_only_one_side_existing():
 
     res = cmp.existence(id, present, missing)
     assert res
+    assert len(res) == 1
+
     assert res[0]
     assert res[0].kind == ComparatorFindingKind.DateUpdatedComparatorExistenceCheck
     assert res[0].on == id
@@ -78,6 +83,132 @@ def test_bad_comparator_only_one_side_existing():
     assert res[0].right_pk == 1
     assert "right" in res[0].reason
     assert "my_date_field" in res[0].reason
+
+
+def test_good_auto_suffix_comparator():
+    cmp = AutoSuffixComparator("same", "suffixed")
+    id = InstanceID("test", 0)
+    left: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "same": "foo-bar",
+            "suffixed": "foo-bar",
+        },
+    }
+    right: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "same": "foo-bar",
+            "suffixed": "foo-bar-baz",
+        },
+    }
+    assert not cmp.compare(id, left, right)
+
+
+def test_bad_auto_suffix_comparator():
+    cmp = AutoSuffixComparator("same", "suffixed")
+    id = InstanceID("test", 0)
+    left: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "same": "foo-bar",
+            "suffixed": "foo-bar",
+        },
+    }
+    right: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "same": "unequal",
+            "suffixed": "foo-barbaz",
+        },
+    }
+    res = cmp.compare(id, left, right)
+    assert res
+    assert len(res) == 2
+
+    assert res[0]
+    assert res[0].kind == ComparatorFindingKind.AutoSuffixComparator
+    assert res[0].on == id
+    assert res[0].left_pk == 1
+    assert res[0].right_pk == 1
+    assert "foo-bar" in res[0].reason
+    assert "unequal" in res[0].reason
+
+    assert res[1]
+    assert res[1].kind == ComparatorFindingKind.AutoSuffixComparator
+    assert res[1].on == id
+    assert res[1].left_pk == 1
+    assert res[1].right_pk == 1
+    assert "foo-bar" in res[1].reason
+    assert "foo-barbaz" in res[1].reason
+
+
+def test_good_auto_suffix_comparator_existence():
+    cmp = AutoSuffixComparator("auto_suffix_field")
+    id = InstanceID("test", 0)
+    present: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "auto_suffix_field": "foo-bar",
+        },
+    }
+    missing: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {},
+    }
+    res = cmp.existence(id, missing, present)
+    assert res
+    assert len(res) == 1
+
+    assert res[0]
+    assert res[0].on == id
+    assert res[0].kind == ComparatorFindingKind.AutoSuffixComparatorExistenceCheck
+    assert res[0].left_pk == 1
+    assert res[0].right_pk == 1
+    assert "left" in res[0].reason
+    assert "auto_suffix_field" in res[0].reason
+
+
+def test_good_auto_suffix_comparator_scrubbed():
+    cmp = AutoSuffixComparator("same", "suffixed")
+    left: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "same": "foo-bar",
+            "suffixed": "foo-bar",
+        },
+    }
+    right: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "same": "foo-bar",
+            "suffixed": "foo-bar-baz",
+        },
+    }
+    cmp.scrub(left, right)
+    assert left["scrubbed"]
+    assert left["scrubbed"]["AutoSuffixComparator::same"] is ScrubbedData()
+    assert left["scrubbed"]["AutoSuffixComparator::suffixed"] is ScrubbedData()
+
+    assert right["scrubbed"]
+    assert right["scrubbed"]["AutoSuffixComparator::same"] is ScrubbedData()
+    assert right["scrubbed"]["AutoSuffixComparator::suffixed"] is ScrubbedData()
 
 
 def test_good_datetime_equality_comparator():
@@ -123,6 +254,8 @@ def test_bad_datetime_equality_comparator():
     }
     res = cmp.compare(id, left, right)
     assert res
+    assert len(res) == 1
+
     assert res[0]
     assert res[0].kind == ComparatorFindingKind.DatetimeEqualityComparator
     assert res[0].on == id
@@ -176,6 +309,8 @@ def test_bad_date_updated_comparator():
     }
     res = cmp.compare(id, left, right)
     assert res
+    assert len(res) == 1
+
     assert res[0]
     assert res[0].kind == ComparatorFindingKind.DateUpdatedComparator
     assert res[0].on == id
@@ -233,6 +368,7 @@ def test_bad_email_obfuscating_comparator():
     }
     res = cmp.compare(id, left, right)
     assert res
+    assert len(res) == 2
 
     assert res[0]
     assert res[0].kind == ComparatorFindingKind.EmailObfuscatingComparator
@@ -249,6 +385,36 @@ def test_bad_email_obfuscating_comparator():
     assert res[1].right_pk == 1
     assert "a...@...le.com" in res[1].reason
     assert "a...@...ng.com" in res[1].reason
+
+
+def test_good_email_obfuscating_comparator_existence():
+    cmp = EmailObfuscatingComparator("email_obfuscating_field")
+    id = InstanceID("test", 0)
+    present: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "email_obfuscating_field": "brian@testing.com",
+        },
+    }
+    missing: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {},
+    }
+    res = cmp.existence(id, missing, present)
+    assert res
+    assert len(res) == 1
+
+    assert res[0]
+    assert res[0].on == id
+    assert res[0].kind == ComparatorFindingKind.EmailObfuscatingComparatorExistenceCheck
+    assert res[0].left_pk == 1
+    assert res[0].right_pk == 1
+    assert "left" in res[0].reason
+    assert "email_obfuscating_field" in res[0].reason
 
 
 def test_good_email_obfuscating_comparator_scrubbed():
@@ -340,6 +506,7 @@ def test_bad_hash_obfuscating_comparator():
     }
     res = cmp.compare(id, left, right)
     assert res
+    assert len(res) == 2
 
     assert res[0]
     assert res[0].kind == ComparatorFindingKind.HashObfuscatingComparator
@@ -356,6 +523,36 @@ def test_bad_hash_obfuscating_comparator():
     assert res[1].right_pk == 1
     assert "123...39b" in res[1].reason
     assert "124...39c" in res[1].reason
+
+
+def test_good_hash_obfuscating_comparator_existence():
+    cmp = HashObfuscatingComparator("hash_obfuscating_field")
+    id = InstanceID("test", 0)
+    present: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "hash_obfuscating_field": "foo",
+        },
+    }
+    missing: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {},
+    }
+    res = cmp.existence(id, missing, present)
+    assert res
+    assert len(res) == 1
+
+    assert res[0]
+    assert res[0].on == id
+    assert res[0].kind == ComparatorFindingKind.HashObfuscatingComparatorExistenceCheck
+    assert res[0].left_pk == 1
+    assert res[0].right_pk == 1
+    assert "left" in res[0].reason
+    assert "hash_obfuscating_field" in res[0].reason
 
 
 def test_good_hash_obfuscating_comparator_scrubbed():
@@ -437,6 +634,48 @@ def test_good_foreign_key_comparator():
     cmp.set_primary_key_maps(left_pk_map, right_pk_map)
 
     assert not cmp.compare(id, left, right)
+
+
+def test_good_foreign_key_comparator_existence():
+    deps = dependencies()
+    cmp = ForeignKeyComparator(
+        {k: v.model for k, v in deps["sentry.UserEmail"].foreign_keys.items()}
+    )
+    id = InstanceID("test", 0)
+    present: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "user": 12,
+            "email": "testing@example.com",
+            "validation_hash": "ABC123",
+            "date_hash_added": "2023-06-23T00:00:00.000Z",
+            "is_verified": True,
+        },
+    }
+    missing: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "email": "testing@example.com",
+            "validation_hash": "ABC123",
+            "date_hash_added": "2023-06-23T00:00:00.000Z",
+            "is_verified": True,
+        },
+    }
+    res = cmp.existence(id, missing, present)
+    assert res
+    assert len(res) == 1
+
+    assert res[0]
+    assert res[0].on == id
+    assert res[0].kind == ComparatorFindingKind.ForeignKeyComparatorExistenceCheck
+    assert res[0].left_pk == 1
+    assert res[0].right_pk == 1
+    assert "left" in res[0].reason
+    assert "user" in res[0].reason
 
 
 def test_good_foreign_key_comparator_scrubbed():
@@ -542,6 +781,8 @@ def test_bad_foreign_key_comparator_unequal_mapping():
 
     res = cmp.compare(id, left, right)
     assert res
+    assert len(res) == 1
+
     assert res[0]
     assert res[0].kind == ComparatorFindingKind.ForeignKeyComparator
     assert res[0].on == id
@@ -588,6 +829,7 @@ def test_bad_foreign_key_comparator_missing_mapping():
 
     res = cmp.compare(id, left, right)
     assert len(res) == 2
+
     assert res[0]
     assert res[0].kind == ComparatorFindingKind.ForeignKeyComparator
     assert res[0].on == id
@@ -620,6 +862,36 @@ def test_good_ignored_comparator():
         },
     }
     assert not cmp.compare(id, model, model)
+
+
+def test_good_ignored_comparator_existence():
+    cmp = IgnoredComparator("ignored_field")
+    id = InstanceID("test", 0)
+    present: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "ignored_field": "foo",
+        },
+    }
+    missing: JSONData = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {},
+    }
+    res = cmp.existence(id, missing, present)
+    assert res
+    assert len(res) == 1
+
+    assert res[0]
+    assert res[0].on == id
+    assert res[0].kind == ComparatorFindingKind.IgnoredComparatorExistenceCheck
+    assert res[0].left_pk == 1
+    assert res[0].right_pk == 1
+    assert "left" in res[0].reason
+    assert "ignored_field" in res[0].reason
 
 
 def test_good_ignored_comparator_scrubbed():

--- a/tests/sentry/backup/test_roundtrip.py
+++ b/tests/sentry/backup/test_roundtrip.py
@@ -82,3 +82,13 @@ def test_user_pk_mapping(tmp_path):
     import_export_from_fixture_then_validate(
         tmp_path, "user-pk-mapping.json", get_default_comparators()
     )
+
+
+# The import should be robust to usernames and organization slugs that have had random suffixes
+# added on due to conflicts in the existing database.
+@run_backup_tests_only_on_single_db
+@django_db_all(transaction=True)
+def test_auto_suffix_username_and_organization_slug(tmp_path):
+    import_export_from_fixture_then_validate(
+        tmp_path, "duplicate-username-and-organization-slug.json", get_default_comparators()
+    )


### PR DESCRIPTION
We now handle organization slug collisions gracefully by extending the slug with a random suffix (we do this for new organizations already). Comparators have also been extended to recognize and pass auto-suffixed slugs of this kind.

Closes getsentry/team-ospo#170
Closes getsentry/team-ospo#182