### PR TITLE
feat(apis): deprecate public in favor of publish_status

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -25,7 +25,7 @@ from sentry_sdk import Scope
 from sentry import analytics, options, tsdb
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.apidocs.hooks import HTTP_METHOD_NAME, HTTP_METHODS_SET
+from sentry.apidocs.hooks import HTTP_METHOD_NAME
 from sentry.auth import access
 from sentry.models import Environment
 from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
@@ -154,7 +154,6 @@ class Endpoint(APIView):
 
     cursor_name = "cursor"
 
-    public: Optional[HTTP_METHODS_SET] = None
     owner: ApiOwner = ApiOwner.UNOWNED
     publish_status: dict[HTTP_METHOD_NAME, ApiPublishStatus] = {}
     rate_limits: RateLimitConfig | dict[

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -126,7 +126,6 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
-    public = {"GET"}
 
     enforce_rate_limit = True
 

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -74,7 +74,6 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.PUBLIC,
     }
-    public = {"GET", "PUT", "DELETE"}
     permission_classes = [RelaxedMemberPermission]
 
     def _get_member(

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -103,7 +103,6 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         "PUT": ApiPublishStatus.UNKNOWN,
         "POST": ApiPublishStatus.PUBLIC,
     }
-    public = {"DELETE", "POST"}
     permission_classes = (OrganizationTeamMemberPermission,)
 
     def _can_create_team_member(self, request: Request, team: Team) -> bool:

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -31,7 +31,6 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
-    public = {"GET"}
 
     @extend_schema(
         operation_id="List an Organization's Projects",

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -144,7 +144,6 @@ class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
             RateLimitCategory.ORGANIZATION: RateLimit(20, 1),
         }
     }
-    public = {"GET"}
 
     @extend_schema(
         operation_id="Retrieve Event Counts for an Organization (v2)",

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -72,7 +72,6 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PUBLIC,
     }
-    public = {"GET", "POST"}
     permission_classes = (OrganizationTeamsPermission,)
 
     def team_serializer_for_post(self):

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -388,7 +388,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.PUBLIC,
     }
-    public = {"GET", "PUT", "DELETE"}
     permission_classes = [RelaxedProjectPermission]
 
     def _get_unresolved_count(self, project):

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -27,7 +27,6 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
     publish_status = {
         "PUT": ApiPublishStatus.PUBLIC,
     }
-    public = {"PUT"}
 
     @extend_schema(
         operation_id="Update an Inbound Data Filter",

--- a/src/sentry/api/endpoints/project_key_details.py
+++ b/src/sentry/api/endpoints/project_key_details.py
@@ -32,7 +32,6 @@ class ProjectKeyDetailsEndpoint(ProjectEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.PUBLIC,
     }
-    public = {"GET", "PUT", "DELETE"}
 
     @extend_schema(
         operation_id="Retrieve a Client Key",

--- a/src/sentry/api/endpoints/project_keys.py
+++ b/src/sentry/api/endpoints/project_keys.py
@@ -31,7 +31,6 @@ class ProjectKeysEndpoint(ProjectEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PUBLIC,
     }
-    public = {"GET", "POST"}
 
     @extend_schema(
         operation_id="List a Project's Client Keys",

--- a/src/sentry/api/endpoints/project_team_details.py
+++ b/src/sentry/api/endpoints/project_team_details.py
@@ -30,7 +30,6 @@ class ProjectTeamDetailsEndpoint(ProjectEndpoint):
         "DELETE": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PUBLIC,
     }
-    public = {"POST", "DELETE"}
     permission_classes = (ProjectTeamsPermission,)
 
     @extend_schema(

--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -33,7 +33,6 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
-    public = {"GET"}
     owner = ApiOwner.ISSUES
 
     @extend_schema(

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -74,7 +74,6 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
         "GET": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PUBLIC,
     }
-    public = {"GET", "POST"}
     permission_classes = (TeamProjectPermission,)
 
     @extend_schema(

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -74,44 +74,6 @@ def __get_explicit_endpoints() -> List[Tuple[str, str, str, Any]]:
     ]
 
 
-# def codemod_deprecate_public(endpoints):
-#     classes = set()
-#     for (path, path_regex, method, callback) in endpoints:
-#         view_class = callback.view_class
-#         if view_class.public is not None:
-#             classes.add(view_class)
-
-#     # Not doing a full loop to just generate a few examples
-#     for endpoint_class in classes:
-#         # Read file and find the location you want to remove a line from
-#         class_name = endpoint_class.__name__
-#         file_path = inspect.getfile(endpoint_class)
-#         file_to_read = open(file_path)
-#         current_line = file_to_read.readline()
-#         previous_lines = [current_line]
-#         while f"class {class_name}(" not in current_line:
-#             current_line = file_to_read.readline()
-#             previous_lines.append(current_line)
-
-#         # found the class definition line
-#         while "public = " not in current_line:
-#             current_line = file_to_read.readline()
-#             previous_lines.append(current_line)
-
-#         # remove the line with public in it
-#         previous_lines.pop()
-#         next_lines = file_to_read.readlines()
-#         file_to_read.close()
-
-#         # Write new content to file
-#         file_to_write = open(file_path, "w")
-#         file_to_write.writelines(previous_lines)
-#         file_to_write.writelines(next_lines)
-
-#         file_to_write.truncate()
-#         file_to_write.close()
-
-
 def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, rename
     filtered = []
     for (path, path_regex, method, callback) in endpoints:

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -34,7 +34,6 @@ class MonitorIngestCheckInDetailsEndpoint(MonitorIngestEndpoint):
     publish_status = {
         "PUT": ApiPublishStatus.PUBLIC,
     }
-    public = {"PUT"}
 
     @extend_schema(
         operation_id="Update a Check-In",

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -47,7 +47,6 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PUBLIC,
     }
-    public = {"POST"}
 
     rate_limits = RateLimitConfig(
         limit_overrides={

--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -39,7 +39,6 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.PUBLIC,
     }
-    public = {"GET", "PUT", "DELETE"}
 
     @extend_schema(
         operation_id="Retrieve a Monitor",

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -70,7 +70,6 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PUBLIC,
     }
-    public = {"GET", "POST"}
     permission_classes = (OrganizationMonitorPermission,)
 
     @extend_schema(

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -31,8 +31,6 @@ class OrganizationReplayDetailsEndpoint(OrganizationEndpoint):
     organization that the user has access to.
     """
 
-    public = {"GET"}
-
     @extend_schema(
         operation_id="Retrieve a Replay Instance",
         parameters=[GlobalParams.ORG_SLUG, ReplayParams.REPLAY_ID, ReplayValidator],

--- a/src/sentry/replays/endpoints/organization_replay_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_index.py
@@ -30,7 +30,6 @@ class OrganizationReplayIndexEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
-    public = {"GET"}
 
     def get_replay_filter_params(self, request, organization):
 

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -149,7 +149,6 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         "PATCH": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (OrganizationSCIMMemberPermission,)
-    public = {"GET", "DELETE", "PATCH"}
 
     def convert_args(
         self,
@@ -379,7 +378,6 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         "POST": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (OrganizationSCIMMemberPermission,)
-    public = {"GET", "POST"}
 
     @extend_schema(
         operation_id="List an Organization's Members",

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -103,7 +103,6 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint):
         "POST": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (OrganizationSCIMTeamPermission,)
-    public = {"GET", "POST"}
 
     @extend_schema(
         operation_id="List an Organization's Paginated Teams",
@@ -240,7 +239,6 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         "PATCH": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (OrganizationSCIMTeamPermission,)
-    public = {"GET", "PATCH", "DELETE"}
 
     def convert_args(self, request: Request, organization_slug: str, team_id, *args, **kwargs):
         args, kwargs = super().convert_args(request, organization_slug)


### PR DESCRIPTION
Deprecating field public now that we have a more descriptive one: publish_status

[More context](https://www.notion.so/sentry/Tracking-API-Ownership-And-Publish-State-57e34e8defb4401fb081fdf257d6dbe5)
