### PR TITLE
fix(opsgenie): fix alert rule migration behavior

### DIFF
--- a/src/sentry/tasks/integrations/migrate_opsgenie_plugin.py
+++ b/src/sentry/tasks/integrations/migrate_opsgenie_plugin.py
@@ -8,6 +8,10 @@ from sentry.services.hybrid_cloud.integration.service import integration_service
 from sentry.tasks.base import instrumented_task, retry
 
 ALERT_LEGACY_INTEGRATIONS = {"id": "sentry.rules.actions.notify_event.NotifyEventAction"}
+ALERT_LEGACY_INTEGRATIONS_WITH_NAME = {
+    "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+    "name": "Send a notification (for all legacy integrations)",
+}
 logger = logging.getLogger(__name__)
 
 
@@ -77,6 +81,7 @@ def migrate_opsgenie_plugin(integration_id: int, organization_id: int) -> None:
             rule
             for rule in Rule.objects.filter(project_id=project.id)
             if ALERT_LEGACY_INTEGRATIONS in rule.data["actions"]
+            or ALERT_LEGACY_INTEGRATIONS_WITH_NAME in rule.data["actions"]
         ]
         with transaction.atomic(router.db_for_write(Rule)):
             for rule in rules_to_migrate:

--- a/tests/sentry/integrations/opsgenie/test_integration.py
+++ b/tests/sentry/integrations/opsgenie/test_integration.py
@@ -199,7 +199,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
             ALERT_LEGACY_INTEGRATIONS,
             {
                 "id": "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
-                "account": org_integration.id,
+                "account": self.integration.id,
                 "team": id1,
             },
         ]
@@ -212,7 +212,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
             ALERT_LEGACY_INTEGRATIONS,
             {
                 "id": "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
-                "account": org_integration.id,
+                "account": self.integration.id,
                 "team": id2,
             },
         ]
@@ -294,7 +294,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
             ALERT_LEGACY_INTEGRATIONS,
             {
                 "id": "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
-                "account": org_integration.id,
+                "account": self.integration.id,
                 "team": str(self.organization_integration.id) + "-pikachu",
             },
         ]
@@ -333,7 +333,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
             ALERT_LEGACY_INTEGRATIONS,
             {
                 "id": "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
-                "account": org_integration.id,
+                "account": self.integration.id,
                 "team": id1,
             },
         ]
@@ -370,7 +370,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
                     ALERT_LEGACY_INTEGRATIONS,
                     {
                         "id": "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
-                        "account": org_integration.id,
+                        "account": self.integration.id,
                         "team": str(self.organization_integration.id) + "-pikachu",
                     },
                 ],
@@ -399,7 +399,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
             ALERT_LEGACY_INTEGRATIONS,
             {
                 "id": "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
-                "account": org_integration.id,
+                "account": self.integration.id,
                 "team": str(self.organization_integration.id) + "-pikachu",
             },
         ]

--- a/tests/sentry/integrations/opsgenie/test_integration.py
+++ b/tests/sentry/integrations/opsgenie/test_integration.py
@@ -181,8 +181,8 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
             self.installation.schedule_migrate_opsgenie_plugin()
 
         org_integration = OrganizationIntegration.objects.get(integration_id=self.integration.id)
-        id1 = str(self.organization.id) + "-thonk"
-        id2 = str(self.organization.id) + "-thinkies"
+        id1 = str(self.organization_integration.id) + "-thonk"
+        id2 = str(self.organization_integration.id) + "-thinkies"
         assert org_integration.config == {
             "team_table": [
                 {"id": id1, "team": "thonk [MIGRATED]", "integration_key": "123-key"},
@@ -242,7 +242,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
             self.installation.schedule_migrate_opsgenie_plugin()
 
         org_integration = OrganizationIntegration.objects.get(integration_id=self.integration.id)
-        id1 = str(self.organization.id) + "-thonk"
+        id1 = str(self.organization_integration.id) + "-thonk"
 
         assert org_integration.config == {
             "team_table": [
@@ -258,7 +258,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
         org_integration.config = {
             "team_table": [
                 {
-                    "id": str(self.organization.id) + "-pikachu",
+                    "id": str(self.organization_integration.id) + "-pikachu",
                     "team": "pikachu",
                     "integration_key": "123-key",
                 },
@@ -278,7 +278,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
         assert org_integration.config == {
             "team_table": [
                 {
-                    "id": str(self.organization.id) + "-pikachu",
+                    "id": str(self.organization_integration.id) + "-pikachu",
                     "team": "pikachu",
                     "integration_key": "123-key",
                 },
@@ -295,7 +295,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
             {
                 "id": "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
                 "account": org_integration.id,
-                "team": str(self.organization.id) + "-pikachu",
+                "team": str(self.organization_integration.id) + "-pikachu",
             },
         ]
 
@@ -323,7 +323,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
             self.installation.schedule_migrate_opsgenie_plugin()
 
         org_integration = OrganizationIntegration.objects.get(integration_id=self.integration.id)
-        id1 = str(self.organization.id) + "-thonk"
+        id1 = str(self.organization_integration.id) + "-thonk"
         rule_updated = Rule.objects.get(
             label="rule",
             project=self.project,
@@ -353,7 +353,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
         org_integration.config = {
             "team_table": [
                 {
-                    "id": str(self.organization.id) + "-pikachu",
+                    "id": str(self.organization_integration.id) + "-pikachu",
                     "team": "pikachu",
                     "integration_key": "123-key",
                 },
@@ -371,7 +371,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
                     {
                         "id": "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
                         "account": org_integration.id,
-                        "team": str(self.organization.id) + "-pikachu",
+                        "team": str(self.organization_integration.id) + "-pikachu",
                     },
                 ],
             },
@@ -383,7 +383,7 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
         assert org_integration.config == {
             "team_table": [
                 {
-                    "id": str(self.organization.id) + "-pikachu",
+                    "id": str(self.organization_integration.id) + "-pikachu",
                     "team": "pikachu",
                     "integration_key": "123-key",
                 },
@@ -400,6 +400,6 @@ class OpsgenieMigrationIntegrationTest(APITestCase):
             {
                 "id": "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
                 "account": org_integration.id,
-                "team": str(self.organization.id) + "-pikachu",
+                "team": str(self.organization_integration.id) + "-pikachu",
             },
         ]


### PR DESCRIPTION
Alert rules were not being correctly migrated because 1) the action for legacy alerts changed and 2) the account ID was incorrect. Fix these issues.