### PR TITLE
ref(alerts): Add snooze status to combined rules for metric alerts

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -126,9 +126,11 @@ class AlertRuleSerializer(Serializer):
                 .annotate(incident_id=Max("id"))
                 .values("incident_id")
             ):
-                incident_map[incident.alert_rule_id] = serialize(
-                    incident, user=user_by_user_id.get(user.get("id"))
-                )
+                user_from_id = None
+                if user:
+                    user_by_user_id.get(user.get("id"))
+
+                incident_map[incident.alert_rule_id] = serialize(incident, user=user_from_id)
             for alert_rule in alert_rules.values():
                 result[alert_rule]["latestIncident"] = incident_map.get(alert_rule.id, None)
 

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -223,3 +223,29 @@ class CombinedRuleSerializerTest(BaseAlertRuleSerializerTest, APITestCase, TestC
         assert result[1]["status"] == "active"
         assert not result[1]["snooze"]
         self.assert_alert_rule_serialized(other_alert_rule, result[2])
+
+    def test_alert_snoozed(self):
+        projects = [self.project, self.create_project()]
+        alert_rule = self.create_alert_rule(projects=projects)
+        issue_rule = self.create_issue_alert_rule(
+            data={
+                "project": self.project,
+                "name": "Issue Rule Test",
+                "conditions": [],
+                "actions": [],
+                "actionMatch": "all",
+            }
+        )
+        self.snooze_rule(owner_id=self.user.id, alert_rule=alert_rule)
+        other_alert_rule = self.create_alert_rule()
+
+        result = serialize(
+            [alert_rule, issue_rule, other_alert_rule], serializer=CombinedRuleSerializer()
+        )
+
+        self.assert_alert_rule_serialized(alert_rule, result[0])
+        assert result[0]["snooze"]
+        assert result[1]["id"] == str(issue_rule.id)
+        assert result[1]["status"] == "active"
+        assert not result[1]["snooze"]
+        self.assert_alert_rule_serialized(other_alert_rule, result[2])


### PR DESCRIPTION
Add `snooze` to the response for the combined rules endpoint for metric alert rules. 