### PR TITLE
Do not store empty Bundles

### DIFF
--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -302,7 +302,6 @@ class PostAssembler(Generic[TArchive], ABC):
 
     def __init__(self, assemble_result: AssembleResult):
         self.assemble_result = assemble_result
-        self.archive = None  # type:ignore
         self._validate_bundle_guarded()
 
     def __enter__(self):
@@ -314,15 +313,9 @@ class PostAssembler(Generic[TArchive], ABC):
         if exc_type is not None:
             self.delete_bundle_file_object()
 
-        self.close()
-
-    def close(self):
-        if self.archive:
-            self.archive.close()
-            self.archive = None  # type:ignore
+        self.archive.close()
 
     def delete_bundle_file_object(self):
-        self.close()
         self.assemble_result.delete_bundle()
 
     def _validate_bundle_guarded(self):

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -892,7 +892,6 @@ class ArtifactBundleIndexingTest(TestCase):
             )
 
         index_artifact_bundles_for_release.assert_not_called()
-        post_assembler.close()
 
     @patch("sentry.tasks.assemble.index_artifact_bundles_for_release")
     def test_index_if_needed_with_lower_bundles_than_threshold(
@@ -921,7 +920,6 @@ class ArtifactBundleIndexingTest(TestCase):
             )
 
         index_artifact_bundles_for_release.assert_not_called()
-        post_assembler.close()
 
     @patch("sentry.tasks.assemble.index_artifact_bundles_for_release")
     def test_index_if_needed_with_higher_bundles_than_threshold(
@@ -963,7 +961,6 @@ class ArtifactBundleIndexingTest(TestCase):
             release=release,
             dist=dist,
         )
-        post_assembler.close()
 
     @patch("sentry.tasks.assemble.index_artifact_bundles_for_release")
     def test_index_if_needed_with_bundles_already_indexed(self, index_artifact_bundles_for_release):


### PR DESCRIPTION
This avoids storing empty bundles as `ArtifactBundle`s, and also avoids keeping an orphaned `File` around when it is being extracted and stored as individual `ReleaseFile`s.