### PR TITLE
ref(stacktrace): Allow for multiple tags inside stack trace

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -328,7 +328,7 @@ export class DeprecatedLine extends Component<Props, State> {
             </LeftLineTitle>
             {this.renderRepeats()}
           </DefaultLineTitleWrapper>
-          <DefaultLineAuxiliaryWrapper>
+          <DefaultLineTagWrapper>
             {organization?.features.includes('anr-analyze-frames') && anrCulprit ? (
               <Tag type="warning" to="" onClick={this.scrollToSuspectRootCause}>
                 {t('Suspect Frame')}
@@ -343,7 +343,7 @@ export class DeprecatedLine extends Component<Props, State> {
               <Tag type="info">{t('In App')}</Tag>
             )}
             {this.renderExpander()}
-          </DefaultLineAuxiliaryWrapper>
+          </DefaultLineTagWrapper>
         </DefaultLine>
       </StrictClick>
     );
@@ -420,7 +420,7 @@ export class DeprecatedLine extends Component<Props, State> {
               isHoverPreviewed={isHoverPreviewed}
             />
           </NativeLineContent>
-          <DefaultLineAuxiliaryWrapper>
+          <DefaultLineTagWrapper>
             <DefaultLineTitleWrapper
               stacktraceChangesEnabled={stacktraceChangesEnabled && !data.inApp}
             >
@@ -434,7 +434,7 @@ export class DeprecatedLine extends Component<Props, State> {
             ) : (
               <Tag type="info">{t('In App')}</Tag>
             )}
-          </DefaultLineAuxiliaryWrapper>
+          </DefaultLineTagWrapper>
         </DefaultLine>
       </StrictClick>
     );
@@ -566,7 +566,7 @@ const StyledIconRefresh = styled(IconRefresh)`
   margin-right: ${space(0.25)};
 `;
 
-const DefaultLineAuxiliaryWrapper = styled('div')`
+const DefaultLineTagWrapper = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(1)};

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -328,20 +328,22 @@ export class DeprecatedLine extends Component<Props, State> {
             </LeftLineTitle>
             {this.renderRepeats()}
           </DefaultLineTitleWrapper>
-          {organization?.features.includes('anr-analyze-frames') && anrCulprit ? (
-            <SuspectFrameTag type="warning" to="" onClick={this.scrollToSuspectRootCause}>
-              {t('Suspect Frame')}
-            </SuspectFrameTag>
-          ) : null}
-          {stacktraceChangesEnabled ? this.renderShowHideToggle() : null}
-          {!data.inApp ? (
-            stacktraceChangesEnabled ? null : (
-              <Tag>{t('System')}</Tag>
-            )
-          ) : (
-            <Tag type="info">{t('In App')}</Tag>
-          )}
-          {this.renderExpander()}
+          <DefaultLineAuxiliaryWrapper>
+            {organization?.features.includes('anr-analyze-frames') && anrCulprit ? (
+              <Tag type="warning" to="" onClick={this.scrollToSuspectRootCause}>
+                {t('Suspect Frame')}
+              </Tag>
+            ) : null}
+            {stacktraceChangesEnabled ? this.renderShowHideToggle() : null}
+            {!data.inApp ? (
+              stacktraceChangesEnabled ? null : (
+                <Tag>{t('System')}</Tag>
+              )
+            ) : (
+              <Tag type="info">{t('In App')}</Tag>
+            )}
+            {this.renderExpander()}
+          </DefaultLineAuxiliaryWrapper>
         </DefaultLine>
       </StrictClick>
     );
@@ -418,19 +420,21 @@ export class DeprecatedLine extends Component<Props, State> {
               isHoverPreviewed={isHoverPreviewed}
             />
           </NativeLineContent>
-          <DefaultLineTitleWrapper
-            stacktraceChangesEnabled={stacktraceChangesEnabled && !data.inApp}
-          >
-            {this.renderExpander()}
-          </DefaultLineTitleWrapper>
+          <DefaultLineAuxiliaryWrapper>
+            <DefaultLineTitleWrapper
+              stacktraceChangesEnabled={stacktraceChangesEnabled && !data.inApp}
+            >
+              {this.renderExpander()}
+            </DefaultLineTitleWrapper>
 
-          {!data.inApp ? (
-            stacktraceChangesEnabled ? null : (
-              <Tag>{t('System')}</Tag>
-            )
-          ) : (
-            <Tag type="info">{t('In App')}</Tag>
-          )}
+            {!data.inApp ? (
+              stacktraceChangesEnabled ? null : (
+                <Tag>{t('System')}</Tag>
+              )
+            ) : (
+              <Tag type="info">{t('In App')}</Tag>
+            )}
+          </DefaultLineAuxiliaryWrapper>
         </DefaultLine>
       </StrictClick>
     );
@@ -551,19 +555,21 @@ const DefaultLine = styled('div')<{
   isSubFrame: boolean;
   stacktraceChangesEnabled: boolean;
 }>`
-  display: grid;
-  grid-template-columns: ${p =>
-    p.stacktraceChangesEnabled && p.isNotInApp && !p.hasToggle
-      ? `1fr ${space(2)}`
-      : `1fr auto ${space(2)}`};
+  display: flex;
+  justify-content: space-between;
   align-items: center;
-  column-gap: ${space(1)};
   background: ${p =>
     p.stacktraceChangesEnabled && p.isSubFrame ? `${p.theme.surface100} !important` : ''};
 `;
 
 const StyledIconRefresh = styled(IconRefresh)`
   margin-right: ${space(0.25)};
+`;
+
+const DefaultLineAuxiliaryWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
 `;
 
 // the Button's label has the padding of 3px because the button size has to be 16x16 px.
@@ -588,10 +594,6 @@ const StyledLi = styled('li')`
       visibility: visible;
     }
   }
-`;
-
-const SuspectFrameTag = styled(Tag)`
-  margin-right: ${space(1)};
 `;
 
 const ToggleButton = styled(Button)`


### PR DESCRIPTION
Refactors the `DeprecatedLine` component to allow for multiple tags like "In App" in individual stack frames.

![Screenshot 2023-09-01 at 15 01 58](https://github.com/getsentry/sentry/assets/8118419/083143d0-798e-4b74-a3dc-3cd54008a0fb)