### PR TITLE
ref(on-demand): Remove prefilling throttling feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1734,8 +1734,6 @@ SENTRY_FEATURES = {
     "organizations:sourcemaps-upload-release-as-artifact-bundle": False,
     # Signals that the organization supports the on demand metrics prefill.
     "organizations:on-demand-metrics-prefill": False,
-    # Signals that the organization can start prefilling on demand metrics.
-    "organizations:enable-on-demand-metrics-prefill": False,
     # Enable data forwarding functionality for projects.
     "projects:data-forwarding": True,
     # Enable functionality to discard groups.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -274,7 +274,6 @@ default_manager.add("organizations:sourcemaps-upload-release-as-artifact-bundle"
 default_manager.add("organizations:recap-server", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:notification-settings-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:on-demand-metrics-prefill", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:enable-on-demand-metrics-prefill", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:custom-metrics", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:release-ui-v2", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1572,10 +1572,7 @@ def get_filtered_actions(
 
 def schedule_update_project_config(alert_rule: AlertRule, projects: Sequence[Project]):
     enabled_features = on_demand_metrics_feature_flags(alert_rule.organization)
-    prefilling = (
-        "organizations:on-demand-metrics-prefill" in enabled_features
-        and "organizations:enable-on-demand-metrics-prefill" in enabled_features
-    )
+    prefilling = "organizations:on-demand-metrics-prefill" in enabled_features
 
     if not projects or not (
         "organizations:on-demand-metrics-extraction" in enabled_features or prefilling

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -58,10 +58,7 @@ def get_metric_extraction_config(project: Project) -> Optional[MetricExtractionC
     # For efficiency purposes, we fetch the flags in batch and propagate them downstream.
     enabled_features = on_demand_metrics_feature_flags(project.organization)
 
-    prefilling = (
-        "organizations:on-demand-metrics-prefill" in enabled_features
-        and "organizations:enable-on-demand-metrics-prefill" in enabled_features
-    )
+    prefilling = "organizations:on-demand-metrics-prefill" in enabled_features
 
     alert_specs = _get_alert_metric_specs(project, enabled_features, prefilling)
     widget_specs = _get_widget_metric_specs(project, enabled_features, prefilling)
@@ -81,7 +78,6 @@ def on_demand_metrics_feature_flags(organization: Organization) -> Set[str]:
         "organizations:on-demand-metrics-extraction",
         "organizations:on-demand-metrics-extraction-experimental",
         "organizations:on-demand-metrics-prefill",
-        "organizations:enable-on-demand-metrics-prefill",
     ]
 
     enabled_features = set()

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -2046,12 +2046,7 @@ class TestCustomMetricAlertRule(TestCase):
 
         mocked_schedule_invalidate_project_config.reset_mock()
 
-        with self.feature(
-            {
-                "organizations:on-demand-metrics-prefill": True,
-                "organizations:enable-on-demand-metrics-prefill": True,
-            }
-        ):
+        with self.feature({"organizations:on-demand-metrics-prefill": True}):
             self.create_alert_rule(
                 projects=[self.project],
                 dataset=Dataset.PerformanceMetrics,
@@ -2061,22 +2056,6 @@ class TestCustomMetricAlertRule(TestCase):
             mocked_schedule_invalidate_project_config.assert_called_once_with(
                 trigger="alerts:create-on-demand-metric", project_id=self.project.id
             )
-
-        mocked_schedule_invalidate_project_config.reset_mock()
-
-        with self.feature(
-            {
-                "organizations:on-demand-metrics-prefill": True,
-                "organizations:enable-on-demand-metrics-prefill": False,
-            }
-        ):
-            self.create_alert_rule(
-                projects=[self.project],
-                dataset=Dataset.PerformanceMetrics,
-                query="transaction.duration:>=50",
-            )
-
-            mocked_schedule_invalidate_project_config.assert_not_called()
 
     @patch("sentry.incidents.logic.schedule_invalidate_project_config")
     def test_create_custom_metric_turned_off(self, mocked_schedule_invalidate_project_config):

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -23,7 +23,6 @@ from sentry.testutils.pytest.fixtures import django_db_all
 ON_DEMAND_METRICS = "organizations:on-demand-metrics-extraction"
 ON_DEMAND_METRICS_WIDGETS = "organizations:on-demand-metrics-extraction-experimental"
 ON_DEMAND_METRICS_PREFILL = "organizations:on-demand-metrics-prefill"
-ON_DEMAND_METRIC_PREFILL_ENABLE = "organizations:enable-on-demand-metrics-prefill"
 
 
 def create_alert(
@@ -405,13 +404,12 @@ def test_get_metric_extraction_config_with_apdex(default_project):
 @pytest.mark.parametrize(
     "enabled_features, number_of_metrics",
     [
-        ([ON_DEMAND_METRICS], 1),  # Only alerts.
-        ([ON_DEMAND_METRICS_WIDGETS, ON_DEMAND_METRICS_PREFILL], 0),  # Nothing.
-        ([ON_DEMAND_METRICS, ON_DEMAND_METRICS_WIDGETS], 2),  # Alerts and widgets.
-        ([ON_DEMAND_METRICS_PREFILL, ON_DEMAND_METRIC_PREFILL_ENABLE], 1),  # Alerts.
-        ([ON_DEMAND_METRICS_PREFILL], 0),  # Nothing.
+        ([ON_DEMAND_METRICS], 1),  # Alerts.
+        ([ON_DEMAND_METRICS_PREFILL], 1),  # Alerts.
         ([ON_DEMAND_METRICS, ON_DEMAND_METRICS_PREFILL], 1),  # Alerts.
-        ([ON_DEMAND_METRICS, ON_DEMAND_METRIC_PREFILL_ENABLE], 1),  # Alerts.
+        ([ON_DEMAND_METRICS, ON_DEMAND_METRICS_WIDGETS], 2),  # Alerts and widgets.
+        ([ON_DEMAND_METRICS_WIDGETS], 0),  # Nothing.
+        ([ON_DEMAND_METRICS_PREFILL, ON_DEMAND_METRICS_WIDGETS], 1),  # Alerts.
         ([], 0),  # Nothing.
     ],
 )
@@ -441,7 +439,7 @@ def test_get_metric_extraction_config_with_transactions_dataset(default_project)
     )
 
     # We test with prefilling, and we expect that both alerts are fetched since we support both datasets.
-    with Feature({ON_DEMAND_METRICS_PREFILL: True, ON_DEMAND_METRIC_PREFILL_ENABLE: True}):
+    with Feature({ON_DEMAND_METRICS_PREFILL: True}):
         config = get_metric_extraction_config(default_project)
 
         assert config


### PR DESCRIPTION
This PR removes the feature flag `organizations:enable-on-demand-metrics-prefill` which was used to throttle the prefilling in order to assess its impact on our infrastructure.

Closes https://github.com/getsentry/sentry/issues/55629