### PR TITLE
fix(alerts): run field validation for on demand alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -25,6 +25,7 @@ import {getDisplayName} from 'sentry/utils/environment';
 import {
   createOnDemandFilterWarning,
   hasOnDemandMetricAlertFeature,
+  isOnDemandQueryString,
 } from 'sentry/utils/onDemandMetrics';
 import withApi from 'sentry/utils/withApi';
 import withProjects from 'sentry/utils/withProjects';
@@ -486,7 +487,8 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                     // We only need strict validation for Transaction queries, everything else is fine
                     highlightUnsupportedTags={
                       organization.features.includes('alert-allow-indexed') ||
-                      hasOnDemandMetricAlertFeature(organization)
+                      (hasOnDemandMetricAlertFeature(organization) &&
+                        isOnDemandQueryString(initialData.query))
                         ? false
                         : [Dataset.GENERIC_METRICS, Dataset.TRANSACTIONS].includes(
                             dataset


### PR DESCRIPTION
Closes #55618 

Adds field validation for on demand alerts

<img width="1210" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/73c38b3c-dc38-4f7b-ae92-cb1ba23798a2">
