### PR TITLE
ref(projconfig): Bump transaction metric extraction and remove measurements config

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1734,6 +1734,8 @@ SENTRY_FEATURES = {
     "organizations:sourcemaps-upload-release-as-artifact-bundle": False,
     # Signals that the organization supports the on demand metrics prefill.
     "organizations:on-demand-metrics-prefill": False,
+    # Excludes measurement config from project config builds.
+    "organizations:projconfig-exclude-measurements": False,
     # Enable data forwarding functionality for projects.
     "projects:data-forwarding": True,
     # Enable functionality to discard groups.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -276,6 +276,7 @@ default_manager.add("organizations:notification-settings-v2", OrganizationFeatur
 default_manager.add("organizations:on-demand-metrics-prefill", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:custom-metrics", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:release-ui-v2", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:projconfig-exclude-measurements", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 
 # Project scoped features
 default_manager.add("projects:alert-filters", ProjectFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -47,7 +47,7 @@ from sentry.utils import metrics
 from sentry.utils.http import get_origins
 from sentry.utils.options import sample_modulo
 
-from .measurements import CUSTOM_MEASUREMENT_LIMIT, get_measurements_config
+from .measurements import CUSTOM_MEASUREMENT_LIMIT
 
 #: These features will be listed in the project config
 EXPOSABLE_FEATURES = [
@@ -352,9 +352,6 @@ def _get_project_config(
     # of events forwarded by Relay, because dynamic sampling will stop filtering
     # anything.
     add_experimental_config(config, "dynamicSampling", get_dynamic_sampling_config, project)
-
-    # Limit the number of custom measurements
-    add_experimental_config(config, "measurements", get_measurements_config)
 
     # Rules to replace high cardinality transaction names
     add_experimental_config(config, "txNameRules", get_transaction_names_config, project)

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -585,7 +585,7 @@ def _filter_option_to_config_setting(flt: _FilterSpec, setting: str) -> Mapping[
 #: When you increment this version, outdated Relays will stop extracting
 #: transaction metrics.
 #: See https://github.com/getsentry/relay/blob/4f3e224d5eeea8922fe42163552e8f20db674e86/relay-server/src/metrics_extraction/transactions.rs#L71
-TRANSACTION_METRICS_EXTRACTION_VERSION = 2
+TRANSACTION_METRICS_EXTRACTION_VERSION = 1
 
 
 class CustomMeasurementSettings(TypedDict):
@@ -639,8 +639,12 @@ def get_transaction_metrics_settings(
     except Exception:
         capture_exception()
 
+    version = TRANSACTION_METRICS_EXTRACTION_VERSION
+    if features.has("organizations:projconfig-exclude-measurements", project.organization):
+        version = 2
+
     return {
-        "version": TRANSACTION_METRICS_EXTRACTION_VERSION,
+        "version": version,
         "extractCustomTags": custom_tags,
         "customMeasurements": {"limit": CUSTOM_MEASUREMENT_LIMIT},
         "acceptTransactionNames": "clientBased",

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -47,7 +47,7 @@ from sentry.utils import metrics
 from sentry.utils.http import get_origins
 from sentry.utils.options import sample_modulo
 
-from .measurements import CUSTOM_MEASUREMENT_LIMIT
+from .measurements import CUSTOM_MEASUREMENT_LIMIT, get_measurements_config
 
 #: These features will be listed in the project config
 EXPOSABLE_FEATURES = [
@@ -352,6 +352,10 @@ def _get_project_config(
     # of events forwarded by Relay, because dynamic sampling will stop filtering
     # anything.
     add_experimental_config(config, "dynamicSampling", get_dynamic_sampling_config, project)
+
+    if not features.has("organizations:projconfig-exclude-measurements", project.organization):
+        # Limit the number of custom measurements
+        add_experimental_config(config, "measurements", get_measurements_config)
 
     # Rules to replace high cardinality transaction names
     add_experimental_config(config, "txNameRules", get_transaction_names_config, project)

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -584,7 +584,7 @@ def _filter_option_to_config_setting(flt: _FilterSpec, setting: str) -> Mapping[
 #: When you increment this version, outdated Relays will stop extracting
 #: transaction metrics.
 #: See https://github.com/getsentry/relay/blob/4f3e224d5eeea8922fe42163552e8f20db674e86/relay-server/src/metrics_extraction/transactions.rs#L71
-TRANSACTION_METRICS_EXTRACTION_VERSION = 1
+TRANSACTION_METRICS_EXTRACTION_VERSION = 2
 
 
 class CustomMeasurementSettings(TypedDict):

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
@@ -4,8 +4,9 @@ import pytest
 from django.urls import reverse
 
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
-from sentry.relay.config import ProjectConfig
+from sentry.relay.config import ProjectConfig, get_project_config
 from sentry.tasks.relay import build_project_config
+from sentry.testutils.helpers.features import Feature
 from sentry.testutils.hybrid_cloud import simulated_transaction_watermarks
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
@@ -171,3 +172,10 @@ def test_task_writes_config_into_cache(
     assert cache_set_many_mock.call_args.args == (
         {default_projectkey.public_key: {"is_mock_config": True}},
     )
+
+
+@django_db_all
+def test_exclude_measurements_for_orgs(default_project):
+    assert "measurements" in get_project_config(default_project).to_dict()["config"]
+    with Feature({"organizations:projconfig-exclude-measurements": True}):
+        assert "measurements" not in get_project_config(default_project).to_dict()["config"]

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/MONOLITH/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/MONOLITH/with_metrics.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2023-09-05T08:13:13.385426Z'
+creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 breakdownsV2:
@@ -918,4 +920,4 @@ transactionMetrics:
   customMeasurements:
     limit: 10
   extractCustomTags: []
-  version: 1
+  version: 2

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/REGION/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/REGION/with_metrics.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2023-09-05T08:13:14.082794Z'
+creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 breakdownsV2:
@@ -918,4 +920,4 @@ transactionMetrics:
   customMeasurements:
     limit: 10
   extractCustomTags: []
-  version: 1
+  version: 2

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -422,6 +422,7 @@ def test_project_config_with_breakdown(default_project, insta_snapshot, transact
     with Feature(
         {
             "organizations:transaction-metrics-extraction": transaction_metrics == "with_metrics",
+            "organizations:projconfig-exclude-measurements": True,
         }
     ):
         project_cfg = get_project_config(default_project, full_config=True)


### PR DESCRIPTION
Goes after deploying the Relay PR: https://github.com/getsentry/relay/pull/2465

As part of the global configs, changing the measurements config may result in inappropriate behavior from old relays. To avoid that, we're doing a version bump.