### PR TITLE
fix(alerts): Disallow wildcard in session dataset queries

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -395,11 +395,13 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const {query, customPerformanceMetrics, actionBarItems} = this.props;
+    const {query, customPerformanceMetrics, actionBarItems, disallowWildcard} =
+      this.props;
     const {
       query: lastQuery,
       customPerformanceMetrics: lastCustomPerformanceMetrics,
       actionBarItems: lastAcionBarItems,
+      disallowWildcard: lastDisallowWildcard,
     } = prevProps;
 
     if (
@@ -408,6 +410,9 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     ) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState(this.makeQueryState(addSpace(query ?? undefined)));
+    } else if (disallowWildcard !== lastDisallowWildcard) {
+      // Re-parse query to apply new options (without resetting it to the query prop value)
+      this.setState(this.makeQueryState(this.state.query));
     }
 
     if (lastAcionBarItems?.length !== actionBarItems?.length) {

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -408,7 +408,6 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
       (query !== lastQuery && (defined(query) || defined(lastQuery))) ||
       customPerformanceMetrics !== lastCustomPerformanceMetrics
     ) {
-      // eslint-disable-next-line react/no-did-update-set-state
       this.setState(this.makeQueryState(addSpace(query ?? undefined)));
     } else if (disallowWildcard !== lastDisallowWildcard) {
       // Re-parse query to apply new options (without resetting it to the query prop value)

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -16,6 +16,7 @@ import IdBadge from 'sentry/components/idBadge';
 import ListItem from 'sentry/components/list/listItem';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
+import {InvalidReason} from 'sentry/components/searchSyntax/parser';
 import {SearchInvalidTag} from 'sentry/components/smartSearchBar/searchInvalidTag';
 import {IconInfo} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -450,6 +451,12 @@ class RuleConditionsForm extends PureComponent<Props, State> {
               return (
                 <SearchContainer>
                   <StyledSearchBar
+                    disallowWildcard={dataset === Dataset.SESSIONS}
+                    invalidMessages={{
+                      [InvalidReason.WILDCARD_NOT_ALLOWED]: t(
+                        'The wildcard operator is not supported here.'
+                      ),
+                    }}
                     customInvalidTagMessage={item => {
                       if (
                         ![Dataset.GENERIC_METRICS, Dataset.TRANSACTIONS].includes(dataset)


### PR DESCRIPTION
* Alert editor: Disallow wildcard in session dataset queries
* `SmartSearchBar`: Re-parse query on wildcard option change

Closes https://github.com/getsentry/sentry/issues/55672