### PR TITLE
fix(stacktrace): Right-align repeated frames icon

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -326,9 +326,9 @@ export class DeprecatedLine extends Component<Props, State> {
                 />
               </div>
             </LeftLineTitle>
-            {this.renderRepeats()}
           </DefaultLineTitleWrapper>
           <DefaultLineTagWrapper>
+            {this.renderRepeats()}
             {organization?.features.includes('anr-analyze-frames') && anrCulprit ? (
               <Tag type="warning" to="" onClick={this.scrollToSuspectRootCause}>
                 {t('Suspect Frame')}
@@ -523,7 +523,6 @@ const LeftLineTitle = styled('div')`
 
 const RepeatedContent = styled(LeftLineTitle)`
   justify-content: center;
-  margin-right: ${space(1)};
 `;
 
 const NativeLineContent = styled('div')<{isFrameAfterLastNonApp: boolean}>`


### PR DESCRIPTION
We messed up the location of the repeated frames icons in https://github.com/getsentry/sentry/pull/55615

This PR right aligns the icon again.

![image](https://github.com/getsentry/sentry/assets/8118419/27f0460d-d140-4989-b9ec-697cbd4120ff)

(Image courtesy of user microwin7 on discord)