### PR TITLE
fix(wizard): Remove duplicate DSN instructions

### DIFF
--- a/static/app/gettingStartedDocs/php/symfony.tsx
+++ b/static/app/gettingStartedDocs/php/symfony.tsx
@@ -69,18 +69,8 @@ sensio_framework_extra:
     configurations: [
       {
         description: (
-          <p>
-            {tct('Add your DSN to [code:config/packages/sentry.yaml]:', {code: <code />})}
-          </p>
+          <p>{tct('Add your DSN to your [code:.env] file:', {code: <code />})}</p>
         ),
-        language: 'php',
-        code: `
-sentry:
-  dsn: "%env(${dsn})%"
-        `,
-      },
-      {
-        description: <p>{tct('And in your [code:.env] file:', {code: <code />})}</p>,
         language: 'plain',
         code: `
 ###> sentry/sentry-symfony ###


### PR DESCRIPTION
By default, we already publish a config file to a user's application, which looks like this:

```yaml
when@prod:
    sentry:
        dsn: '%env(SENTRY_DSN)%'
```

Hence, updating the `.env` file suffices.