### PR TITLE
ref: fix tests/sentry/sentry_metrics/test_kafka.py missing django mark

### DIFF
--- a/tests/sentry/sentry_metrics/test_kafka.py
+++ b/tests/sentry/sentry_metrics/test_kafka.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from unittest import TestCase
 
+import pytest
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker, LocalProducer
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
@@ -13,6 +14,7 @@ from sentry.utils import json
 
 
 class KafkaMetricsInterfaceTest(GenericMetricsTestMixIn, TestCase):
+    @pytest.mark.django_db
     def test_produce_metrics(self) -> None:
         generic_metrics_backend = KafkaMetricsBackend()
         # For testing, we are calling close() here because we


### PR DESCRIPTION
before this was failing when run alone:

```console
$ pytest tests/sentry/sentry_metrics/test_kafka.py
============================= test session starts ==============================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: fail-slow-0.3.0, rerunfailures-11.0, sentry-0.1.11, xdist-3.0.2, cov-4.0.0, repeat-0.9.1, django-4.4.0
collected 1 item                                                               

tests/sentry/sentry_metrics/test_kafka.py F                              [100%]

=================================== FAILURES ===================================
________________ KafkaMetricsInterfaceTest.test_produce_metrics ________________
tests/sentry/sentry_metrics/test_kafka.py:35: in test_produce_metrics
    generic_metrics_backend.set(
src/sentry/sentry_metrics/client/kafka.py:119: in set
    "retention_days": get_retention_from_org_id(org_id),
src/sentry/sentry_metrics/client/kafka.py:38: in get_retention_from_org_id
    retention = quotas.backend.get_event_retention(organization=org_id) or 90
src/sentry/quotas/base.py:300: in get_event_retention
    return _limit_from_settings(options.get("system.event-retention-days"))
src/sentry/options/manager.py:285: in get
    result = self.store.get(opt, silent=silent)
src/sentry/options/store.py:96: in get
    result = self.get_store(key, silent=silent)
src/sentry/options/store.py:187: in get_store
    value = self.model.objects.get(key=key.name).value
src/sentry/db/models/manager/base.py:255: in get
    return super().get(*args, **kwargs)
.venv/lib/python3.8/site-packages/django/db/models/manager.py:85: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
.venv/lib/python3.8/site-packages/django/db/models/query.py:431: in get
    num = len(clone)
.venv/lib/python3.8/site-packages/django/db/models/query.py:262: in __len__
    self._fetch_all()
.venv/lib/python3.8/site-packages/django/db/models/query.py:1324: in _fetch_all
    self._result_cache = list(self._iterable_class(self))
.venv/lib/python3.8/site-packages/django/db/models/query.py:51: in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
.venv/lib/python3.8/site-packages/django/db/models/sql/compiler.py:1173: in execute_sql
    cursor = self.connection.cursor()
.venv/lib/python3.8/site-packages/django/utils/asyncio.py:33: in inner
    return func(*args, **kwargs)
.venv/lib/python3.8/site-packages/django/db/backends/base/base.py:259: in cursor
    return self._cursor()
src/sentry/db/postgres/decorators.py:40: in inner
    return func(self, *args, **kwargs)
src/sentry/db/postgres/base.py:110: in _cursor
    return super()._cursor()
.venv/lib/python3.8/site-packages/django/db/backends/base/base.py:235: in _cursor
    self.ensure_connection()
E   RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
=========================== short test summary info ============================
FAILED tests/sentry/sentry_metrics/test_kafka.py::KafkaMetricsInterfaceTest::test_produce_metrics - RuntimeError: Database access not allowed, use the "django_db" mark, or the...
============================== 1 failed in 0.47s ===============================
```