### PR TITLE
fix(hybridcloud) Fix 500s from serializing users

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/expand/roles.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/roles.py
@@ -44,7 +44,7 @@ class OrganizationMemberWithRolesSerializer(OrganizationMemberWithTeamsSerialize
         users_by_id = {
             u["id"]: u
             for u in user_service.serialize_many(
-                filter=dict(user_ids=[om.user_id for om in item_list]),
+                filter=dict(user_ids=[om.user_id for om in item_list if om.user_id is not None]),
                 serializer=UserSerializeType.DETAILED,
             )
         }

--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -30,7 +30,6 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
     Authenticator,
     AuthIdentity,
-    OrganizationMember,
     OrganizationStatus,
     User,
     UserAvatar,
@@ -39,6 +38,8 @@ from sentry.models import (
     UserPermission,
     UserRoleUser,
 )
+from sentry.models.organizationmapping import OrganizationMapping
+from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
 from sentry.services.hybrid_cloud.user import RpcUser
@@ -271,18 +272,23 @@ class DetailedUserSerializer(UserSerializer):
             lambda x: not x.interface.is_backup_interface,
         )
 
-        memberships = manytoone_to_dict(
-            OrganizationMember.objects.filter(
-                user_id__in={u.id for u in item_list},
-                organization__status=OrganizationStatus.ACTIVE,
-            ),
-            "user_id",
-        )
+        memberships = OrganizationMemberMapping.objects.filter(
+            user_id__in={u.id for u in item_list}
+        ).values_list("user_id", "organization_id", named=True)
+        active_organizations = OrganizationMapping.objects.filter(
+            organization_id__in={m.organization_id for m in memberships},
+            status=OrganizationStatus.ACTIVE,
+        ).values_list("organization_id", flat=True)
+
+        active_memberships = defaultdict(int)
+        for membership in memberships:
+            if membership.organization_id in active_organizations:
+                active_memberships[membership.user_id] += 1
 
         for item in item_list:
             attrs[item]["authenticators"] = authenticators[item.id]
             # org can reset 2FA if the user is only in one org
-            attrs[item]["canReset2fa"] = len(memberships[item.id]) == 1
+            attrs[item]["canReset2fa"] = active_memberships[item.id] == 1
 
         return attrs
 

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -31,6 +31,7 @@ class OrganizationMemberTestBase(APITestCase):
         self.login_as(self.user)
 
 
+@region_silo_test(stable=True)
 class GetOrganizationMemberTest(OrganizationMemberTestBase):
     def test_me(self):
         response = self.get_success_response(self.organization.slug, "me")


### PR DESCRIPTION
When serializing users in RPC requests, we cannot access `OrganizationMember` as that is a region bound table. Instead we need to use OrganizationMemberMapping and OrganizationMapping to determine if it is safe to reset 2fa on a user.
