### PR TITLE
fix(profiling): Remove <module> frame for python stacks

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -454,6 +454,22 @@ def _process_symbolicator_results_for_sample(
                 return stack[:-2]
             return stack
 
+    elif profile["platform"] == "python":
+
+        def truncate_stack_needed(
+            frames: List[dict[str, Any]],
+            stack: List[Any],
+        ) -> List[Any]:
+            # If the stack was collected from the main thread,
+            # it may have an extra frame for the `<module>` that
+            # is not valuable to show in the final profile and
+            # causes issues with aggregations.
+            #
+            # We choose to remove it here to improve the aggregation.
+            if frames[stack[-1]].get("function", "") == "<module>":
+                return stack[:-1]
+            return stack
+
     else:
 
         def truncate_stack_needed(


### PR DESCRIPTION
Stacks collected from the main thread of the process contains a `<module>` frame that indicates the start of the application. It doesn't provide any additional value to show this, and it causes issues with profiles aggregation. So we choose to remove it during ingestion.