### PR TITLE
fix(alerts): Debug incident with uuid, remove unused date created

### DIFF
--- a/src/sentry/templates/sentry/emails/incidents/trigger.html
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.html
@@ -66,10 +66,6 @@
           <td width="25%">Filter</td>
           <td>{{ query }}</td>
         </tr>
-        <tr>
-          <td width="25%">Date Created</td>
-          <td>{{ alert_date_added }}</td>
-        </tr>
       </table>
 
       <p class="info-box">

--- a/src/sentry/web/frontend/debug/debug_incident_trigger_email.py
+++ b/src/sentry/web/frontend/debug/debug_incident_trigger_email.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from uuid import uuid4
 
 from django.utils import timezone
 
@@ -45,7 +46,13 @@ class DebugIncidentTriggerEmailView(MailPreviewView):
         trigger = AlertRuleTrigger(alert_rule=alert_rule)
 
         return generate_incident_trigger_email_context(
-            project, incident, trigger, TriggerStatus.ACTIVE, IncidentStatus(incident.status), user
+            project,
+            incident,
+            trigger,
+            TriggerStatus.ACTIVE,
+            IncidentStatus(incident.status),
+            user,
+            notification_uuid=str(uuid4()),
         )
 
     @property


### PR DESCRIPTION
- Alert Date created has been blank for over a year, just remove it. They can see this after opening the alert.
- Add uuid to the debug template route

![image](https://github.com/getsentry/sentry/assets/1400464/aac5b68a-d5b1-4a10-affc-cf7c8bd8fb7a)
