### PR TITLE
parameterize send_metrics.py with click to (partially) support sessions

### DIFF
--- a/bin/send_metrics.py
+++ b/bin/send_metrics.py
@@ -1,57 +1,25 @@
 # pylint: skip-file
 # flake8: noqa
 
-"""
-Script that sends generic metrics messages to sentry locally
-
-
-Overview
-
-This script is designed to be used when creating a new use case ID for the first
-time for the generic metrics platform.
-
-
-Usage
-
-
-python send_metrics.py
-
-Without any command line argument, the script will send 3 metrics
-(counter/set/distribution) for each use case ID registered in
-src/sentry/sentry_metrics/use_case_id_registry.py.
-
-
-python send_metrics.py hello world
-
-The script will treat any arguments supplied as a use case ID, and send 3 metrics
-(counter/set/distribution) for each use case ID specified.
-
-"""
-
 import datetime
 import itertools
 import json
 import pprint
 import random
 import string
-import sys
 
+import click
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from arroyo.types import Topic
 
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-
-BOOTSTRAP_HOST = "127.0.0.1:9092"
-TOPIC_NAME = "ingest-performance-metrics"
-
-conf = {"bootstrap.servers": BOOTSTRAP_HOST}
 
 make_counter_payload = lambda use_case, rand_str: {
     "name": f"c:{use_case}/{use_case}@none",
     "tags": {
         "environment": "production",
         "session.status": "init",
-        f"gen_metric_e2e_{use_case}_counter_k_{rand_str}": f"gen_metric_e2e_{use_case}_counter_v_{rand_str}",
+        f"metric_e2e_{use_case}_counter_k_{rand_str}": f"metric_e2e_{use_case}_counter_v_{rand_str}",
     },
     "timestamp": int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp()),
     "type": "c",
@@ -66,7 +34,7 @@ make_dist_payload = lambda use_case, rand_str: {
     "tags": {
         "environment": "production",
         "session.status": "healthy",
-        f"gen_metric_e2e_{use_case}_dist_k_{rand_str}": f"gen_metric_e2e_{use_case}_dist_v_{rand_str}",
+        f"metric_e2e_{use_case}_dist_k_{rand_str}": f"metric_e2e_{use_case}_dist_v_{rand_str}",
     },
     "timestamp": int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp()),
     "type": "d",
@@ -81,7 +49,7 @@ make_set_payload = lambda use_case, rand_str: {
     "tags": {
         "environment": "production",
         "session.status": "errored",
-        f"gen_metric_e2e_{use_case}_set_k_{rand_str}": f"gen_metric_e2e_{use_case}_set_v_{rand_str}",
+        f"metric_e2e_{use_case}_set_k_{rand_str}": f"metric_e2e_{use_case}_set_v_{rand_str}",
     },
     "timestamp": int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp()),
     "type": "s",
@@ -92,17 +60,19 @@ make_set_payload = lambda use_case, rand_str: {
 }
 
 make_psql = (
-    lambda rand_str: f"""
+    lambda rand_str, is_generic: f"""
     SELECT string,
        organization_id,
+       {"use_case_id," if is_generic else ""}
        date_added,
-       use_case_id
-    FROM sentry_perfstringindexer
-    WHERE string ~ 'gen_metric_e2e_.*{rand_str}';
+       last_seen
+    FROM {"sentry_perfstringindexer" if is_generic else "sentry_stringindexer"}
+    WHERE string ~ 'metric_e2e_.*{rand_str}';
 """
 )
 
-make_csql = lambda rand_str: "UNION ALL".join(
+
+make_csql = lambda rand_str, is_generic: "UNION ALL".join(
     [
         f"""
     SELECT use_case_id,
@@ -113,39 +83,70 @@ make_csql = lambda rand_str: "UNION ALL".join(
         tags.key,
         tags.raw_value
     FROM {table_name}
-    WHERE arrayExists(v -> match(v, 'gen_metric_e2e_.*{rand_str}'), tags.raw_value)
+    WHERE arrayExists(v -> match(v, 'metric_e2e_.*{rand_str}'), tags.raw_value)
     """
-        for table_name in [
-            "generic_metric_counters_raw_local",
-            "generic_metric_distributions_raw_local",
-            "generic_metric_sets_raw_local",
-        ]
+        for table_name in (
+            [
+                "generic_metric_counters_raw_local",
+                "generic_metric_distributions_raw_local",
+                "generic_metric_sets_raw_local",
+            ]
+            if is_generic
+            else [
+                "metrics_counters_v2_local",
+                "metrics_distributions_v2_local",
+                "metrics_sets_v2_local",
+            ]
+        )
     ]
 )
 
 
-def produce_msgs(messages):
+def produce_msgs(messages, is_generic, host, dryrun):
+    conf = {"bootstrap.servers": host}
+
     producer = KafkaProducer(conf)
     for i, message in enumerate(messages):
-        print(f"Sending message {i + 1} of {len(messages)}:")
+        print(f"{i + 1} / {len(messages)}")
         pprint.pprint(message)
-        producer.produce(
-            Topic(name=TOPIC_NAME),
-            KafkaPayload(key=None, value=json.dumps(message).encode("utf-8"), headers=[]),
-        )
-        print("Done")
+        if not dryrun:
+            producer.produce(
+                Topic(name=("ingest-performance-metrics" if is_generic else "ingest-metrics")),
+                KafkaPayload(key=None, value=json.dumps(message).encode("utf-8"), headers=[]),
+            )
+            print("Done")
         print()
 
     producer.close()
 
 
-if __name__ == "__main__":
-    rand_str = "".join(random.choices(string.ascii_uppercase + string.digits, k=8))
-    use_cases = (
-        [use_case_id.value for use_case_id in UseCaseID if use_case_id is not UseCaseID.SESSIONS]
-        if len(sys.argv) == 1
-        else sys.argv[1:]
-    )
+@click.command()
+@click.option(
+    "--use-cases",
+    multiple=True,
+    default=[
+        use_case_id.value for use_case_id in UseCaseID if use_case_id is not UseCaseID.SESSIONS
+    ],
+    show_default=True,
+    help="The use case IDs.",
+)
+@click.option("--rand-str", default=None, help="The random string prefix for each key value pairs.")
+@click.option("--host", default="127.0.0.1:9092", help="The host and port for kafka.")
+@click.option(
+    "--dryrun", is_flag=True, default=False, help="Print the messages without sending them."
+)
+def main(use_cases, rand_str, host, dryrun):
+    if UseCaseID.SESSIONS.value in use_cases and len(use_cases) > 1:
+        click.secho(
+            "ERROR: UseCaseID.SESSIONS is in use_cases and there are more than 1 use cases",
+            blink=True,
+            bold=True,
+        )
+        exit(1)
+
+    is_generic = UseCaseID.SESSIONS.value not in use_cases
+
+    rand_str = rand_str or "".join(random.choices(string.ascii_uppercase + string.digits, k=8))
     messages = list(
         itertools.chain.from_iterable(
             (
@@ -158,12 +159,19 @@ if __name__ == "__main__":
     )
     random.shuffle(messages)
 
-    produce_msgs(messages)
+    produce_msgs(messages, is_generic, host, dryrun)
+
     print(
-        f"Use the following SQL to verify postgres, there should be {(strs_per_use_case := 6)} strings for each use cases, {strs_per_use_case * len(use_cases)} in total."
+        f"Use the following SQL to verify postgres, there should be {(strs_per_use_case := 3)} strings for each use cases, {strs_per_use_case * len(use_cases)} in total."
     )
-    print(make_psql(rand_str))
-    print(
-        f"Use the following SQL to verify clickhouse, there should be {(metrics_per_use_case := 3)} metrics for each use cases, {metrics_per_use_case * len(use_cases)} in total."
-    )
-    print(make_csql(rand_str))
+    print(make_psql(rand_str, is_generic))
+
+    if is_generic:
+        print(
+            f"Use the following SQL to verify clickhouse, there should be {(metrics_per_use_case := 3)} metrics for each use cases, {metrics_per_use_case * len(use_cases)} in total."
+        )
+        print(make_csql(rand_str, is_generic))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Overview

Some additions to the `send_metrics.py` script to help diagnose metrics platform locally.

- Command line options

Usage
```
Usage: send_metrics.py [OPTIONS]

Options:
  --use-cases TEXT  The use case IDs.  [default: spans, transactions,
                    escalating_issues, custom]
  --rand-str TEXT   The random string prefix for each key value pairs.
  --host TEXT       The host and port for kafka.
  --dryrun          Print the messages without sending them.
  --help            Show this message and exit.
```

- Add support for non-generic (sessions) metrics