### PR TITLE
fix: Slice on unevaluated QuerySet for Organization.has_single_owner

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -346,9 +346,11 @@ class Organization(Model, OptionMixin, OrganizationAbsoluteUrlMixin, SnowflakeId
 
     def has_single_owner(self):
         owners = list(
-            self.get_members_with_org_roles([roles.get_top_dog().id]).values_list("id", flat=True)
+            self.get_members_with_org_roles([roles.get_top_dog().id])[:2].values_list(
+                "id", flat=True
+            )
         )
-        return len(owners[:2]) == 1
+        return len(owners) == 1
 
     def get_members_with_org_roles(
         self,


### PR DESCRIPTION
Found this while fixing tests for split silos.

This was a regression from https://github.com/getsentry/sentry/commit/131596d4571a61e70859d36ce0c4a2860f6578b8, and the implementation of `def has_single_owner` had this optimization prior to the refactor: https://github.com/getsentry/sentry/blame/1acfc6443fa031fb932115c69ddbe12c01bd8b8e/src/sentry/models/organization.py#L310-L316

Slicing on unevaluated QuerySet would add the appropriate `LIMIT` keywords on the generated SQL query:

- https://docs.djangoproject.com/en/4.2/ref/models/querysets/
- https://docs.djangoproject.com/en/4.2/topics/db/queries/#limiting-querysets

