### PR TITLE
bug(replays): Remove explitic SplitDivider height so it flows to fill all space

### DIFF
--- a/static/app/views/replays/detail/layout/splitDivider.tsx
+++ b/static/app/views/replays/detail/layout/splitDivider.tsx
@@ -40,7 +40,6 @@ const SplitDivider = styled((props: Props & DOMAttributes<HTMLDivElement>) => (
   &[data-slide-direction='updown'] {
     cursor: ns-resize;
     width: 100%;
-    height: ${space(2)};
 
     & > svg {
       transform: rotate(90deg);

--- a/static/app/views/replays/detail/network/details/index.tsx
+++ b/static/app/views/replays/detail/network/details/index.tsx
@@ -120,8 +120,6 @@ const CloseButtonWrapper = styled('div')`
 `;
 
 const StyledSplitDivider = styled(SplitDivider)`
-  height: 100%;
-
   :hover,
   &[data-is-held='true'] {
     z-index: ${p => p.theme.zIndex.initial + 1};


### PR DESCRIPTION
**Before:**
<img width="600" alt="SCR-20230905-jhft" src="https://github.com/getsentry/sentry/assets/187460/d9121244-832c-47ea-8b39-e9395cbac567">

**After:**
![SCR-20230905-nfqz](https://github.com/getsentry/sentry/assets/187460/1552d48c-fba6-444a-b9d6-a1b93b510a13)


Fixes https://github.com/getsentry/sentry/issues/55698
