### PR TITLE
feat(crons): Add feature flag for new onboarding

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1364,6 +1364,8 @@ SENTRY_FEATURES = {
     # Enable creating organizations within sentry (if SENTRY_SINGLE_ORGANIZATION
     # is not enabled).
     "organizations:create": True,
+    # Enable the new crons onboarding experience with platform specific options
+    "organizations:crons-new-onboarding": False,
     # Enable usage of customer domains on the frontend
     "organizations:customer-domains": False,
     # Enable the 'discover' interface.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -69,6 +69,7 @@ default_manager.add("organizations:api-keys", OrganizationFeature, FeatureHandle
 default_manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:integrations-auto-repo-linking", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:crash-rate-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:crons-new-onboarding", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:customer-domains", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:dashboards-mep", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:dashboards-rh-widget", OrganizationFeature, FeatureHandlerStrategy.REMOTE)


### PR DESCRIPTION
Adds feature flag for new onboarding

Added to allow for **incremental** changes to be made to the current onboarding to reach a state like this:

**Platform specific options immediately visible to user**
<img width="915" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/03413ff3-2df3-4538-af69-1f4185b527b1">

**Displays auto-discovery, upsert, and manual instrumentation options in the app:** 
<img width="732" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/4d4752eb-f67c-47cd-89d6-055be8bc8551">

