### PR TITLE
chore(hybrid-cloud): Update user details endpoint for split silo mode

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from copy import copy
 from datetime import datetime, timedelta, timezone
@@ -42,11 +44,15 @@ from sentry.models import (
     UserEmail,
 )
 from sentry.services.hybrid_cloud import IDEMPOTENCY_KEY_LENGTH
-from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.auth import auth_service
-from sentry.services.hybrid_cloud.organization_actions.impl import (
-    mark_organization_as_pending_deletion_with_outbox_message,
+from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.services.hybrid_cloud.organization.model import (
+    RpcOrganization,
+    RpcOrganizationDeleteResponse,
+    RpcOrganizationDeleteState,
 )
+from sentry.services.hybrid_cloud.user.serial import serialize_generic_user
+from sentry.utils.audit import create_audit_entry
 from sentry.utils.cache import memoize
 
 ERR_DEFAULT_ORG = "You cannot remove the default organization."
@@ -482,6 +488,32 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 
+def post_org_pending_deletion(
+    *, request: Request, org_delete_response: RpcOrganizationDeleteResponse
+):
+    if org_delete_response.response_state == RpcOrganizationDeleteState.PENDING_DELETION:
+        updated_organization = org_delete_response.updated_organization
+        assert updated_organization
+
+        entry = create_audit_entry(
+            request=request,
+            organization=updated_organization,
+            target_object=updated_organization.id,
+            event=audit_log.get_event_id("ORG_REMOVE"),
+            data=updated_organization.get_audit_log_data(),
+            transaction_id=org_delete_response.schedule_guid,
+        )
+
+        delete_confirmation_args: DeleteConfirmationArgs = dict(
+            username=request.user.get_username(),
+            ip_address=entry.ip_address,
+            deletion_datetime=entry.datetime,
+            countdown=ONE_DAY,
+            organization=updated_organization,
+        )
+        send_delete_confirmation(delete_confirmation_args)
+
+
 @region_silo_endpoint
 class OrganizationDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
@@ -593,53 +625,37 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             return self.respond(context)
         return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def handle_delete(self, request: Request, organization):
+    def handle_delete(self, request: Request, organization: Organization):
         """
         This method exists as a way for getsentry to override this endpoint with less duplication.
         """
         if not request.user.is_authenticated:
             return self.respond({"detail": ERR_NO_USER}, status=401)
-        if organization.is_default:
-            return self.respond({"detail": ERR_DEFAULT_ORG}, status=400)
 
-        published_sentry_apps = app_service.get_published_sentry_apps_for_organization(
-            organization_id=organization.id
+        org_delete_response = organization_service.delete_organization(
+            organization_id=organization.id, user=serialize_generic_user(request.user)
         )
 
-        if len(published_sentry_apps) > 0:
+        if (
+            org_delete_response.response_state
+            == RpcOrganizationDeleteState.CANNOT_REMOVE_DEFAULT_ORG
+            or organization.is_default
+        ):
+            return self.respond({"detail": ERR_DEFAULT_ORG}, status=400)
+
+        if (
+            org_delete_response.response_state
+            == RpcOrganizationDeleteState.OWNS_PUBLISHED_INTEGRATION
+        ):
             return self.respond({"detail": ERR_3RD_PARTY_PUBLISHED_APP}, status=400)
 
-        user_name = request.user.get_username()
-        with transaction.atomic(router.db_for_write(RegionScheduledDeletion)):
-            updated_organization = mark_organization_as_pending_deletion_with_outbox_message(
-                org_id=organization.id
+        if org_delete_response.response_state == RpcOrganizationDeleteState.PENDING_DELETION:
+            organization.status = OrganizationStatus.PENDING_DELETION
+            post_org_pending_deletion(
+                request=request,
+                org_delete_response=org_delete_response,
             )
 
-            if updated_organization is not None:
-                schedule = RegionScheduledDeletion.schedule(
-                    organization, days=1, actor=request.user
-                )
-
-                entry = self.create_audit_entry(
-                    request=request,
-                    organization=updated_organization,
-                    target_object=updated_organization.id,
-                    event=audit_log.get_event_id("ORG_REMOVE"),
-                    data=updated_organization.get_audit_log_data(),
-                    transaction_id=schedule.guid,
-                )
-
-                delete_confirmation_args: DeleteConfirmationArgs = {
-                    "username": user_name,
-                    "ip_address": entry.ip_address,
-                    "deletion_datetime": entry.datetime,
-                    "countdown": ONE_DAY,
-                    "organization": updated_organization,
-                }
-                send_delete_confirmation(delete_confirmation_args)
-                Organization.objects.uncache_object(updated_organization.id)
-
-            organization.status = OrganizationStatus.PENDING_DELETION
         context = serialize(
             organization,
             request.user,
@@ -700,7 +716,7 @@ class DeleteConfirmationArgs(TypedDict):
     username: str
     ip_address: str
     deletion_datetime: datetime
-    organization: Organization
+    organization: RpcOrganization
     countdown: int
 
 

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -11,17 +11,22 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import roles
-from sentry.api import client
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import sudo_required
+from sentry.api.endpoints.organization_details import post_org_pending_deletion
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user import DetailedSelfUserSerializer
 from sentry.api.serializers.rest_framework import CamelSnakeModelSerializer, ListField
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import LANGUAGES
-from sentry.models import Organization, OrganizationMember, OrganizationStatus, User, UserOption
+from sentry.models import OrganizationStatus, User, UserOption
+from sentry.models.organizationmapping import OrganizationMapping
+from sentry.models.organizationmembermapping import OrganizationMemberMapping
+from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.services.hybrid_cloud.organization.model import RpcOrganizationDeleteState
+from sentry.services.hybrid_cloud.user.serial import serialize_generic_user
 
 audit_logger = logging.getLogger("sentry.audit.user")
 delete_logger = logging.getLogger("sentry.deletions.api")
@@ -250,37 +255,62 @@ class UserDetailsEndpoint(UserEndpoint):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         # from `frontend/remove_account.py`
-        org_list = Organization.objects.filter(
-            member_set__role__in=[x.id for x in roles.with_scope("org:admin")],
-            member_set__user_id=user.id,
+        org_mappings = OrganizationMapping.objects.filter(
+            organization_id__in=OrganizationMemberMapping.objects.filter(
+                user_id=user.id, role__in=[r.id for r in roles.with_scope("org:admin")]
+            ).values("organization_id"),
             status=OrganizationStatus.ACTIVE,
         )
 
         org_results = []
-        for org in org_list:
-            org_results.append({"organization": org, "single_owner": org.has_single_owner()})
+        for org in org_mappings:
+            first_two_owners = OrganizationMemberMapping.objects.filter(
+                organization_id=org.organization_id, role__in=[roles.get_top_dog().id]
+            )[:2]
+            has_single_owner = len(first_two_owners) == 1
+            org_results.append(
+                {
+                    "organization_id": org.organization_id,
+                    "single_owner": has_single_owner,
+                }
+            )
 
-        avail_org_slugs = {o["organization"].slug for o in org_results}
-        orgs_to_remove = set(serializer.validated_data.get("organizations")).intersection(
-            avail_org_slugs
-        )
+        avail_org_ids = {o["organization_id"] for o in org_results}
+        requested_org_slugs_to_remove = set(serializer.validated_data.get("organizations"))
+        requested_org_ids_to_remove = OrganizationMapping.objects.filter(
+            slug__in=requested_org_slugs_to_remove
+        ).values_list("organization_id", flat=True)
+
+        orgs_to_remove = set(requested_org_ids_to_remove).intersection(avail_org_ids)
 
         for result in org_results:
             if result["single_owner"]:
-                orgs_to_remove.add(result["organization"].slug)
+                orgs_to_remove.add(result["organization_id"])
 
-        for org_slug in orgs_to_remove:
-            client.delete(path=f"/organizations/{org_slug}/", request=request, is_sudo=True)
+        for org_id in orgs_to_remove:
+            org_delete_response = organization_service.delete_organization(
+                organization_id=org_id, user=serialize_generic_user(request.user)
+            )
+            if org_delete_response.response_state == RpcOrganizationDeleteState.PENDING_DELETION:
+                post_org_pending_deletion(
+                    request=request,
+                    org_delete_response=org_delete_response,
+                )
 
         remaining_org_ids = [
-            o.id for o in org_list if o.slug in avail_org_slugs.difference(orgs_to_remove)
+            o.organization_id
+            for o in org_mappings
+            if o.organization_id in avail_org_ids.difference(orgs_to_remove)
         ]
 
         if remaining_org_ids:
-            for member in OrganizationMember.objects.filter(
-                organization__in=remaining_org_ids, user_id=user.id
+            for member_mapping in OrganizationMemberMapping.objects.filter(
+                organization_id__in=remaining_org_ids, user_id=user.id
             ):
-                member.delete()
+                organization_service.delete_organization_member(
+                    organization_id=member_mapping.organization_id,
+                    organization_member_id=member_mapping.organizationmember_id,
+                )
 
         logging_data = {
             "actor_id": request.user.id,

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -3,20 +3,23 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 from enum import IntEnum
-from typing import Any, List, Mapping, Optional
+from typing import Any, List, Mapping, Optional, Sequence
 
 from django.dispatch import Signal
 from pydantic import Field
 from typing_extensions import TypedDict
 
+from sentry import roles
 from sentry.db.models import ValidateFunction, Value
 from sentry.models.options.option import HasOption
 from sentry.roles import team_roles
 from sentry.roles.manager import TeamRole
 from sentry.services.hybrid_cloud import RpcModel
 from sentry.services.hybrid_cloud.project import RpcProject
+from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.services.hybrid_cloud.util import flags_to_bits
 from sentry.signals import sso_enabled
+from sentry.silo.base import SiloMode
 from sentry.types.organization import OrganizationAbsoluteUrlMixin
 
 
@@ -229,6 +232,21 @@ class RpcOrganization(RpcOrganizationSummary):
             "default_role": self.default_role,
         }
 
+    def get_owners(self) -> Sequence[RpcUser]:
+        from sentry.models.organizationmember import OrganizationMember
+        from sentry.models.organizationmembermapping import OrganizationMemberMapping
+        from sentry.services.hybrid_cloud.user.service import user_service
+
+        if SiloMode.get_current_mode() == SiloMode.CONTROL:
+            owners = OrganizationMemberMapping.objects.filter(
+                organization_id=self.id, role__in=[roles.get_top_dog().id]
+            ).values_list("user_id", flat=True)
+        else:
+            owners = OrganizationMember.objects.filter(
+                organization_id=self.id, role__in=[roles.get_top_dog().id]
+            ).values_list("user_id", flat=True)
+        return user_service.get_many(filter={"user_ids": list(owners)})
+
 
 class RpcUserOrganizationContext(RpcModel):
     """
@@ -299,3 +317,23 @@ class RpcOrganizationSignal(IntEnum):
     @property
     def signal(self) -> Signal:
         return self.signal_map()[self]
+
+
+class RpcOrganizationDeleteState(IntEnum):
+    PENDING_DELETION = 1
+    CANNOT_REMOVE_DEFAULT_ORG = 2
+    OWNS_PUBLISHED_INTEGRATION = 3
+    NO_OP = 4
+
+
+class RpcOrganizationDeleteResponse(RpcModel):
+    response_state: RpcOrganizationDeleteState
+    updated_organization: Optional[RpcOrganization] = None
+    schedule_guid: str = ""
+
+
+class RpcAuditLogEntryActor(RpcModel):
+    actor_label: Optional[str]
+    actor_id: int
+    actor_key: Optional[str]
+    ip_address: Optional[str]

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -10,7 +10,9 @@ from django.dispatch import Signal
 
 from sentry.services.hybrid_cloud import OptionValue, silo_mode_delegation
 from sentry.services.hybrid_cloud.organization.model import (
+    RpcAuditLogEntryActor,
     RpcOrganization,
+    RpcOrganizationDeleteResponse,
     RpcOrganizationFlagsUpdate,
     RpcOrganizationMember,
     RpcOrganizationMemberFlags,
@@ -285,6 +287,20 @@ class OrganizationService(RpcService):
     @abstractmethod
     def send_sso_link_emails(
         self, *, organization_id: int, sending_user_email: str, provider_key: str
+    ) -> None:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def delete_organization(
+        self, *, organization_id: int, user: RpcUser
+    ) -> RpcOrganizationDeleteResponse:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def create_org_delete_log(
+        self, *, organization_id: int, audit_log_actor: RpcAuditLogEntryActor
     ) -> None:
         pass
 

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -7,10 +7,13 @@ from sentry.models import (
     UserPermission,
     UserRole,
 )
+from sentry.models.deletedorganization import DeletedOrganization
+from sentry.silo.base import SiloMode
+from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 class UserDetailsTest(APITestCase):
@@ -262,6 +265,9 @@ class UserDetailsDeleteTest(UserDetailsTest, HybridCloudTestMixin):
         self.get_error_response(self.user.id, status_code=400)
         self.get_error_response(self.user.id, organizations=None, status_code=400)
 
+        with assume_test_silo_mode(SiloMode.REGION):
+            assert DeletedOrganization.objects.count() == 0
+
         # test actual delete
         self.get_success_response(
             self.user.id,
@@ -273,23 +279,25 @@ class UserDetailsDeleteTest(UserDetailsTest, HybridCloudTestMixin):
             status_code=204,
         )
 
-        # deletes org_single_owner even though it wasn't specified in array
-        # because it has a single owner
-        assert (
-            Organization.objects.get(id=org_single_owner.id).status
-            == OrganizationStatus.PENDING_DELETION
-        )
-        # should delete org_with_other_owner, and org_as_other_owner
-        assert (
-            Organization.objects.get(id=org_with_other_owner.id).status
-            == OrganizationStatus.PENDING_DELETION
-        )
-        assert (
-            Organization.objects.get(id=org_as_other_owner.id).status
-            == OrganizationStatus.PENDING_DELETION
-        )
-        # should NOT delete `not_owned_org`
-        assert Organization.objects.get(id=not_owned_org.id).status == OrganizationStatus.ACTIVE
+        with assume_test_silo_mode(SiloMode.REGION):
+            # deletes org_single_owner even though it wasn't specified in array
+            # because it has a single owner
+            assert (
+                Organization.objects.get(id=org_single_owner.id).status
+                == OrganizationStatus.PENDING_DELETION
+            )
+            # should delete org_with_other_owner, and org_as_other_owner
+            assert (
+                Organization.objects.get(id=org_with_other_owner.id).status
+                == OrganizationStatus.PENDING_DELETION
+            )
+            assert (
+                Organization.objects.get(id=org_as_other_owner.id).status
+                == OrganizationStatus.PENDING_DELETION
+            )
+            # should NOT delete `not_owned_org`
+            assert Organization.objects.get(id=not_owned_org.id).status == OrganizationStatus.ACTIVE
+            assert DeletedOrganization.objects.count() == 3
 
         user = User.objects.get(id=self.user.id)
         assert not user.is_active
@@ -304,30 +312,38 @@ class UserDetailsDeleteTest(UserDetailsTest, HybridCloudTestMixin):
         self.create_member(user=user2, organization=org_with_other_owner, role="owner")
         self.create_member(user=self.user, organization=org_as_other_owner, role="owner")
 
-        member_records = list(
-            OrganizationMember.objects.filter(
-                organization__in=[org_with_other_owner.id, org_as_other_owner.id],
-                user_id=self.user.id,
+        with assume_test_silo_mode(SiloMode.REGION):
+            member_records = list(
+                OrganizationMember.objects.filter(
+                    organization__in=[org_with_other_owner.id, org_as_other_owner.id],
+                    user_id=self.user.id,
+                )
             )
-        )
+            assert DeletedOrganization.objects.count() == 0
 
         for member in member_records:
             self.assert_org_member_mapping(org_member=member)
 
-        with outbox_runner():
+        with self.tasks(), outbox_runner():
             self.get_success_response(self.user.id, organizations=[], status_code=204)
+
+        # Assume monolith silo mode to ensure all tasks are run correctly
+        with self.tasks(), assume_test_silo_mode(SiloMode.MONOLITH):
+            schedule_hybrid_cloud_foreign_key_jobs()
 
         for member in member_records:
             self.assert_org_member_mapping_not_exists(org_member=member)
 
-        # deletes org_single_owner even though it wasn't specified in array
-        # because it has a single owner
-        assert (
-            Organization.objects.get(id=org_single_owner.id).status
-            == OrganizationStatus.PENDING_DELETION
-        )
-        # should NOT delete `not_owned_org`
-        assert Organization.objects.get(id=not_owned_org.id).status == OrganizationStatus.ACTIVE
+        with assume_test_silo_mode(SiloMode.REGION):
+            # deletes org_single_owner even though it wasn't specified in array
+            # because it has a single owner
+            assert (
+                Organization.objects.get(id=org_single_owner.id).status
+                == OrganizationStatus.PENDING_DELETION
+            )
+            # should NOT delete `not_owned_org`
+            assert Organization.objects.get(id=not_owned_org.id).status == OrganizationStatus.ACTIVE
+            assert DeletedOrganization.objects.count() == 1
 
         user = User.objects.get(id=self.user.id)
         assert not user.is_active


### PR DESCRIPTION
This pull request applies changes for `tests/sentry/api/endpoints/test_user_details.py` to pass in split silo mode and split db mode.