### PR TITLE
fix(jira server): Only fetch issue types of projects that are available

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -705,11 +705,12 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
         project_id = params.get("project", defaults.get("project"))
         jira_projects = self.get_projects()
 
-        if not project_id:
+        if not project_id or project_id not in {proj["id"] for proj in jira_projects}:
             project_id = jira_projects[0]["id"]
 
         client = self.get_client()
         issue_type_choices = client.get_issue_types(project_id)
+
         issue_type_choices_formatted = [
             (choice["id"], choice["name"]) for choice in issue_type_choices["values"]
         ]

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -30,7 +30,7 @@ from sentry_plugins.jira.plugin import JiraPlugin
 
 from . import get_integration
 
-DFAULT_PROJECT_ID = 10000
+DEFAULT_PROJECT_ID = 10000
 DEFAULT_ISSUE_TYPE_ID = 10000
 
 
@@ -408,6 +408,56 @@ class JiraServerIntegrationTest(APITestCase):
                 "updatesForm": True,
             }
 
+    @responses.activate
+    def test_get_create_issue_config_with_default_project_not_available(self):
+        """Test that if you have a default project set that's not in the list of available jira projects
+        we try again with another project"""
+        event = self.store_event(
+            data={"message": "oh no", "timestamp": self.min_ago}, project_id=self.project.id
+        )
+        group = event.group
+        assert group is not None
+        assert self.installation.org_integration is not None
+        self.installation.org_integration = integration_service.update_organization_integration(
+            org_integration_id=self.installation.org_integration.id,
+            config={"project_issue_defaults": {str(group.project_id): {"project": "9999"}}},
+        )
+        responses.add(
+            responses.GET,
+            "https://jira.example.org/rest/api/2/project",
+            content_type="json",
+            body="""[
+                {"id": "10001", "key": "SAMP"},
+                {"id": "10002", "key": "SAHM"}
+            ]""",
+        )
+        responses.add(
+            responses.GET,
+            "https://jira.example.org/rest/api/2/issue/createmeta/10001/issuetypes",
+            body=StubService.get_stub_json("jira", "issue_types_response.json"),
+            content_type="json",
+        )
+        responses.add(
+            responses.GET,
+            f"https://jira.example.org/rest/api/2/issue/createmeta/10001/issuetypes/{DEFAULT_ISSUE_TYPE_ID}",
+            body=StubService.get_stub_json("jira", "issue_fields_response.json"),
+            content_type="json",
+        )
+        responses.add(
+            responses.GET,
+            "https://jira.example.org/rest/api/2/priority",
+            body=StubService.get_stub_json("jira", "priorities_response.json"),
+            content_type="json",
+        )
+        responses.add(
+            responses.GET,
+            "https://jira.example.org/rest/api/2/project/10001/versions",
+            body=StubService.get_stub_json("jira", "versions_response.json"),
+            content_type="json",
+        )
+
+        self.installation.get_create_issue_config(event.group, self.user)
+
     @patch("sentry.integrations.jira_server.client.JiraServerClient.get_issue_fields")
     def test_get_create_issue_config_with_default_project_deleted(self, mock_get_issue_fields):
         event = self.store_event(
@@ -443,9 +493,8 @@ class JiraServerIntegrationTest(APITestCase):
 
             fields = self.installation.get_create_issue_config(group, self.user)
             project_field = [field for field in fields if field["name"] == "project"][0]
-
             assert project_field == {
-                "default": "10004",
+                "default": "10000",  # a new default is set from actually available projects
                 "choices": [("10000", "EX"), ("10001", "ABC")],
                 "type": "select",
                 "name": "project",
@@ -517,14 +566,14 @@ class JiraServerIntegrationTest(APITestCase):
         )
         responses.add(
             responses.GET,
-            f"https://jira.example.org/rest/api/2/issue/createmeta/{DFAULT_PROJECT_ID}/issuetypes",
+            f"https://jira.example.org/rest/api/2/issue/createmeta/{DEFAULT_PROJECT_ID}/issuetypes",
             body=StubService.get_stub_json("jira", "issue_types_response.json"),
             content_type="json",
         )
         # Fail to return metadata
         responses.add(
             responses.GET,
-            f"https://jira.example.org/rest/api/2/issue/createmeta/{DFAULT_PROJECT_ID}/issuetypes/{DEFAULT_ISSUE_TYPE_ID}",
+            f"https://jira.example.org/rest/api/2/issue/createmeta/{DEFAULT_PROJECT_ID}/issuetypes/{DEFAULT_ISSUE_TYPE_ID}",
             content_type="json",
             status=401,
             body="",
@@ -573,7 +622,7 @@ class JiraServerIntegrationTest(APITestCase):
     def test_create_issue_labels_and_option(self):
         responses.add(
             responses.GET,
-            f"https://jira.example.org/rest/api/2/issue/createmeta/{DFAULT_PROJECT_ID}/issuetypes/{DEFAULT_ISSUE_TYPE_ID}",
+            f"https://jira.example.org/rest/api/2/issue/createmeta/{DEFAULT_PROJECT_ID}/issuetypes/{DEFAULT_ISSUE_TYPE_ID}",
             body=StubService.get_stub_json("jira", "issue_fields_response.json"),
             content_type="json",
         )


### PR DESCRIPTION
We're seeing an [ApiError](https://sentry.sentry.io/issues/4267026714/events/94d0399b3d3d438d92886c0e9c9a12cc/?project=1) when the saved default project is no longer available, so this first checks if the default project is in all projects and if not, selects one that is available.

Fixes SENTRY-12JS
Fixes #53013 (hopefully)