### PR TITLE
feat(crons): Debounce requests to monitor-stats

### DIFF
--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -4,11 +4,13 @@ import styled from '@emotion/styled';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {Overlay} from 'sentry/components/overlay';
 import Panel from 'sentry/components/panels/panel';
+import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {fadeIn} from 'sentry/styles/animations';
 import {space} from 'sentry/styles/space';
 import {Event, Organization} from 'sentry/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import useRouter from 'sentry/utils/useRouter';
 import {CheckInTimeline} from 'sentry/views/monitors/components/overviewTimeline/checkInTimeline';
@@ -45,6 +47,7 @@ export function CronTimelineSection({event, organization}: Props) {
 
   const timeWindowConfig = getConfigFromTimeRange(start, end, timelineWidth);
   const rollup = Math.floor((timeWindowConfig.elapsedMinutes * 60) / timelineWidth);
+  const debouncedRollup = useDebouncedValue(rollup, DEFAULT_DEBOUNCE_DURATION);
 
   const monitorStatsQueryKey = `/organizations/${organization.slug}/monitors-stats/`;
   const {data: monitorStats, isLoading} = useApiQuery<Record<string, MonitorBucketData>>(
@@ -55,7 +58,7 @@ export function CronTimelineSection({event, organization}: Props) {
           until: Math.floor(end.getTime() / 1000),
           since: Math.floor(start.getTime() / 1000),
           monitor: monitorSlug,
-          resolution: `${rollup}s`,
+          resolution: `${debouncedRollup}s`,
         },
       },
     ],

--- a/static/app/views/monitors/components/cronDetailsTimeline.tsx
+++ b/static/app/views/monitors/components/cronDetailsTimeline.tsx
@@ -4,11 +4,13 @@ import moment from 'moment';
 
 import Panel from 'sentry/components/panels/panel';
 import Text from 'sentry/components/text';
+import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {parsePeriodToHours} from 'sentry/utils/dates';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
@@ -49,6 +51,7 @@ export function CronDetailsTimeline({monitor, organization}: Props) {
 
   const elapsedMinutes = config.elapsedMinutes;
   const rollup = Math.floor((elapsedMinutes * 60) / timelineWidth);
+  const debouncedRollup = useDebouncedValue(rollup, DEFAULT_DEBOUNCE_DURATION);
 
   const monitorStatsQueryKey = `/organizations/${organization.slug}/monitors-stats/`;
   const {data: monitorStats, isLoading} = useApiQuery<Record<string, MonitorBucketData>>(
@@ -59,7 +62,7 @@ export function CronDetailsTimeline({monitor, organization}: Props) {
           until: Math.floor(end.getTime() / 1000),
           since: Math.floor(start.getTime() / 1000),
           monitor: monitor.slug,
-          resolution: `${rollup}s`,
+          resolution: `${debouncedRollup}s`,
           ...location.query,
         },
       },

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -3,8 +3,10 @@ import styled from '@emotion/styled';
 
 import Panel from 'sentry/components/panels/panel';
 import {Sticky} from 'sentry/components/sticky';
+import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {space} from 'sentry/styles/space';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
@@ -36,6 +38,8 @@ export function OverviewTimeline({monitorList}: Props) {
 
   const timeWindowConfig = getConfigFromTimeRange(start, nowRef.current, timelineWidth);
   const rollup = Math.floor((timeWindowConfig.elapsedMinutes * 60) / timelineWidth);
+  const debouncedRollup = useDebouncedValue(rollup, DEFAULT_DEBOUNCE_DURATION);
+
   const monitorStatsQueryKey = `/organizations/${organization.slug}/monitors-stats/`;
   const {data: monitorStats, isLoading} = useApiQuery<Record<string, MonitorBucketData>>(
     [
@@ -45,7 +49,7 @@ export function OverviewTimeline({monitorList}: Props) {
           until: Math.floor(nowRef.current.getTime() / 1000),
           since: Math.floor(start.getTime() / 1000),
           monitor: monitorList.map(m => m.slug),
-          resolution: `${rollup}s`,
+          resolution: `${debouncedRollup}s`,
           ...location.query,
         },
       },


### PR DESCRIPTION
Debounces requests to fetch monitor-stats

This prevents us from making a bunch of network requests upon a user manually resizing their browser window, which previously would trigger a bunch of updates to `rollup`, in turn triggering `useApiRequest` to refetch.