### PR TITLE
fix(statistical-detectors): Trends link and stats period

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
@@ -32,6 +32,9 @@ function EventBreakpointChart({event}: EventBreakpointChartProps) {
   eventView.start = new Date(requestStart * 1000).toISOString();
   eventView.end = new Date(requestEnd * 1000).toISOString();
 
+  // If start and end were defined, then do not use default 14d stats period
+  eventView.statsPeriod = requestStart && requestEnd ? '' : eventView.statsPeriod;
+
   // The evidence data keys are returned to us in camelCase, but we need to
   // convert them to snake_case to match the NormalizedTrendsTransaction type
   const normalizedOccurrenceEvent = Object.keys(

--- a/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
+++ b/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
@@ -22,6 +22,7 @@ function EventStatisticalDetectorMessage({event}: EventStatisticalDetectorMessag
     orgSlug: organization.slug,
     transaction: transactionName,
     query: {},
+    trendFunction: 'p95',
     projectID: event.projectID,
     display: DisplayModes.TREND,
   });


### PR DESCRIPTION
- Navigate to trends page with `p95` pre-selected. Before it was always defaulted to `p50`
- Prioritize `requestStart` and `requestEnd` over `statsPeriod` for the breakpoint chart in the issue details
