### PR TITLE
Add zookeeper healthcheck and alter healthservice tool

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -178,7 +178,7 @@ runs:
             -d --network host \
             -e ZOOKEEPER_CLIENT_PORT=2181 \
             -e KAFKA_OPTS="-Dzookeeper.4lw.commands.whitelist=*" \
-            confluentinc/cp-zookeeper:4.1.0 \
+            ghcr.io/getsentry/image-mirror-confluentinc-cp-kafka:6.2.0 \
             &
 
           # This is the production version; do not change w/o changing it there as well

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -167,7 +167,7 @@ runs:
           services="${services} chartcuterie"
         fi
 
-        sentry devservices up $services &
+
 
         # TODO: Use devservices kafka. See https://github.com/getsentry/sentry/pull/20986#issuecomment-704510570
         if [ "$NEED_KAFKA" = "true" ]; then
@@ -194,8 +194,10 @@ runs:
           #   -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
           #   confluentinc/cp-kafka:5.1.2 \
           #  &
-          sentry devservices up zookeeper kafka &
+          services="${services} zookeeper kafka"
         fi
+
+        sentry devservices up $services &
 
         wait
 

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -173,27 +173,28 @@ runs:
         if [ "$NEED_KAFKA" = "true" ]; then
           # This is *not* the production version. Unclear reason as to why this was chosen
           # https://github.com/getsentry/ops/blob/c823e62f930ecc6c97bb08898c71e49edc7232f6/cookbooks/getsentry/attributes/default.rb#L631
-          docker run \
-            --name sentry_zookeeper \
-            -d --network host \
-            -e ZOOKEEPER_CLIENT_PORT=2181 \
-            -e KAFKA_OPTS="-Dzookeeper.4lw.commands.whitelist=*" \
-            ghcr.io/getsentry/image-mirror-confluentinc-cp-kafka:6.2.0 \
-            &
+          # docker run \
+          #   --name sentry_zookeeper \
+          #   -d --network host \
+          #   -e ZOOKEEPER_CLIENT_PORT=2181 \
+          #   -e KAFKA_OPTS="-Dzookeeper.4lw.commands.whitelist=*" \
+          #   ghcr.io/getsentry/image-mirror-confluentinc-cp-kafka:6.2.0 \
+          #   &
 
           # This is the production version; do not change w/o changing it there as well
           # https://github.com/getsentry/ops/blob/c823e62f930ecc6c97bb08898c71e49edc7232f6/cookbooks/getsentry/attributes/default.rb#L643
-          docker run \
-            --name sentry_kafka \
-            -d --network host \
-            -e KAFKA_ZOOKEEPER_CONNECT=127.0.0.1:2181 \
-            -e KAFKA_LISTENERS=INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9092 \
-            -e KAFKA_ADVERTISED_LISTENERS=INTERNAL://127.0.0.1:9093,EXTERNAL://127.0.0.1:9092 \
-            -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT \
-            -e KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL \
-            -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
-            confluentinc/cp-kafka:5.1.2 \
-            &
+          # docker run \
+          #   --name sentry_kafka \
+          #   -d --network host \
+          #   -e KAFKA_ZOOKEEPER_CONNECT=127.0.0.1:2181 \
+          #   -e KAFKA_LISTENERS=INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9092 \
+          #   -e KAFKA_ADVERTISED_LISTENERS=INTERNAL://127.0.0.1:9093,EXTERNAL://127.0.0.1:9092 \
+          #   -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT \
+          #   -e KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL \
+          #   -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+          #   confluentinc/cp-kafka:5.1.2 \
+          #  &
+          sentry devservices up zookeeper kafka &
         fi
 
         wait

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -177,6 +177,7 @@ runs:
             --name sentry_zookeeper \
             -d --network host \
             -e ZOOKEEPER_CLIENT_PORT=2181 \
+            -e KAFKA_OPTS="-Dzookeeper.4lw.commands.whitelist=*" \
             confluentinc/cp-zookeeper:4.1.0 \
             &
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2591,7 +2591,11 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
             # On Apple arm64, we upgrade to version 6.x to allow zookeeper to run properly on Apple's arm64
             # See details https://github.com/confluentinc/kafka-images/issues/80#issuecomment-855511438
             "image": "ghcr.io/getsentry/image-mirror-confluentinc-cp-zookeeper:6.2.0",
-            "environment": {"ZOOKEEPER_CLIENT_PORT": "2181"},
+            "ports": {"2181/tcp": 2181},
+            "environment": {
+                "ZOOKEEPER_CLIENT_PORT": "2181",
+                "KAFKA_OPTS": "-Dzookeeper.4lw.commands.whitelist=*",
+            },
             "volumes": {"zookeeper_6": {"bind": "/var/lib/zookeeper/data"}},
             "only_if": "kafka" in settings.SENTRY_EVENTSTREAM or settings.SENTRY_USE_RELAY,
         }

--- a/tools/devservices_healthcheck.py
+++ b/tools/devservices_healthcheck.py
@@ -49,8 +49,8 @@ def check_zookeeper():
 def check_kafka():
     # sentry_zookeeper:2181 doesn't work in CI, but 127.0.0.1 doesn't work locally
     zookeeper_origin = "sentry_zookeeper"
-    if os.getenv("CI") == "true":
-        zookeeper_origin = "127.0.0.1"
+    # if os.getenv("CI") == "true":
+    #     zookeeper_origin = "127.0.0.1"
 
     subprocess.run(
         (

--- a/tools/devservices_healthcheck.py
+++ b/tools/devservices_healthcheck.py
@@ -142,7 +142,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         run_with_retries(hc.check_container)
 
         print(f"Checking {hc.container_name} container health...")
-        run_with_retries(s.check)
+        run_with_retries(hc.check)
 
 
 if __name__ == "__main__":

--- a/tools/devservices_healthcheck.py
+++ b/tools/devservices_healthcheck.py
@@ -1,47 +1,148 @@
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
 import time
+from collections.abc import Sequence
+from typing import Callable
 
 
-def run_cmd(
-    args: list[str],
-    *,
-    retries: int = 3,
-    timeout: int = 5,
-) -> None:
+class HealthCheck:
+    id: str
+    container_name: str
+    check_by_default: bool
+    check: Callable[[], None]
+    deps: list[str]
+
+    def __init__(self, id, container_name, check_by_default, check, deps=None):
+        self.id = id
+        self.container_name = container_name
+        self.check_by_default = check_by_default
+        self.check = check
+        self.deps = deps or []
+
+    def check_container(self):
+        response = subprocess.run(
+            ("docker", "container", "inspect", "-f", "'{{.State.Status}}'", self.container_name),
+            capture_output=True,
+            text=True,
+        )
+        if response.stdout.strip() != "'running'":
+            raise SystemError(
+                f"Container '{self.container_name}' is not running. Try 'sentry devservices up {self.id}' to start it"
+            )
+
+
+def check_zookeeper():
+    ruok = subprocess.Popen(("echo", "ruok"), stdout=subprocess.PIPE)
+    response = subprocess.run(
+        ("nc", "127.0.0.1", "2181"),
+        stdin=ruok.stdout,
+        capture_output=True,
+        text=True,
+    )
+    if response.stdout != "imok":
+        raise SystemError(f"Zookeeper is not healthy. Response: {response.stdout}")
+
+
+def check_kafka():
+    # sentry_zookeeper:2181 doesn't work in CI, but 127.0.0.1 doesn't work locally
+    zookeeper_origin = "sentry_zookeeper"
+    if os.getenv("CI") == "true":
+        zookeeper_origin = "127.0.0.1"
+
+    subprocess.run(
+        (
+            "docker",
+            "exec",
+            "sentry_kafka",
+            "kafka-topics",
+            "--zookeeper",
+            f"{zookeeper_origin}:2181",
+            "--list",
+        ),
+        check=True,
+    )
+
+
+# Available health checks
+all_service_healthchecks = {
+    "postgres": HealthCheck(
+        "postgres",
+        "sentry_postgres",
+        True,
+        lambda: subprocess.run(
+            ["docker", "exec", "sentry_postgres", "pg_isready", "-U", "postgres"], check=True
+        ),
+    ),
+    "kafka": HealthCheck(
+        "kafka",
+        "sentry_kafka",
+        os.getenv("NEED_KAFKA") == "true",
+        check_kafka,
+        deps=["zookeeper"],
+    ),
+    "zookeeper": HealthCheck(
+        "zookeeper",
+        "sentry_zookeeper",
+        os.getenv("NEED_KAFKA") == "true",
+        check_zookeeper,
+    ),
+}
+
+
+def run_with_retries(cmd: Callable[[], None], retries: int = 3, timeout: int = 5) -> None:
     for retry in range(1, retries + 1):
-        returncode = subprocess.call(args)
-
-        if returncode != 0:
-            time.sleep(timeout)
+        try:
+            cmd()
+        except Exception as e:
+            if retry == retries:
+                print(e)
+            else:
+                print(f"Command failed, retrying in {timeout}s (attempt {retry+1} of {retries})...")
+                time.sleep(timeout)
         else:
             return
 
     raise SystemExit(1)
 
 
-def main() -> None:
-    # Available health checks
-    postgres_healthcheck = ["docker", "exec", "sentry_postgres", "pg_isready", "-U", "postgres"]
-    kafka_healthcheck = [
-        "docker",
-        "exec",
-        "sentry_kafka",
-        "kafka-topics",
-        "--zookeeper",
-        # TODO: sentry_zookeeper:2181 doesn't work in CI, but 127.0.0.1 doesn't work locally
-        "127.0.0.1:2181",
-        "--list",
-    ]
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--service",
+        action="append",
+        help="The services you wish to check on. Defaults to all services.",
+    )
 
-    healthchecks = [postgres_healthcheck]
-    if os.getenv("NEED_KAFKA") == "true":
-        healthchecks.append(kafka_healthcheck)
+    args = parser.parse_args(argv)
+    services = args.service
 
-    for check in healthchecks:
-        run_cmd(check)
+    print(f"Checking services: {services}")
+
+    healthchecks = []
+    for k in all_service_healthchecks:
+        s = all_service_healthchecks[k]
+        check = False
+        if services is None:
+            check = s.check_by_default
+        else:
+            check = k in services
+
+        if not check:
+            continue
+
+        for dep in s.deps:
+            healthchecks.append(all_service_healthchecks[dep])
+        healthchecks.append(s)
+
+    for hc in healthchecks:
+        print(f"Checking {hc.container_name} is running...")
+        run_with_retries(hc.check_container)
+
+        print(f"Checking {hc.container_name} container health...")
+        run_with_retries(s.check)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Things of note:

1. This checks a container is running before the health check, this shows a nice `try 'sentry devservices up <container name>'` if a container isn't running
1. The dependency between kafka and zookeeper is captured via the `deps=["zookeeper"]` call, so running `tools.devservices_healthcheck --service=kafka` will first check zookeeper is running before checking kafa.