### PR TITLE
chore(hybrid-cloud): Mark UserOrganizationsTest as region_silo_test

### DIFF
--- a/tests/sentry/api/endpoints/test_user_organizations.py
+++ b/tests/sentry/api/endpoints/test_user_organizations.py
@@ -1,8 +1,8 @@
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import region_silo_test
 
 
-@control_silo_test
+@region_silo_test
 class UserOrganizationsTest(APITestCase):
     endpoint = "sentry-api-0-user-organizations"
 


### PR DESCRIPTION
From https://github.com/getsentry/sentry/pull/54663, we will be doing a client-side fan out on fetching organizations from each region for a given user.

So we mark `UserOrganizationsTest` as `region_silo_test`.