### PR TITLE
Do not index DebugIds for Bundles containing none

### DIFF
--- a/src/sentry/debug_files/artifact_bundle_indexing.py
+++ b/src/sentry/debug_files/artifact_bundle_indexing.py
@@ -196,6 +196,7 @@ def get_deletion_key(flat_file_id: int) -> str:
 @sentry_sdk.tracing.trace
 def mark_bundle_for_flat_file_indexing(
     artifact_bundle: ArtifactBundle,
+    has_debug_ids: bool,
     project_ids: List[int],
     release: Optional[str],
     dist: Optional[str],
@@ -208,7 +209,8 @@ def mark_bundle_for_flat_file_indexing(
                 FlatFileIdentifier(project_id, release=release, dist=dist or NULL_STRING)
             )
 
-        identifiers.append(FlatFileIdentifier.for_debug_id(project_id))
+        if has_debug_ids:
+            identifiers.append(FlatFileIdentifier.for_debug_id(project_id))
 
     # Create / Update the indexing state in the database
     for identifier in identifiers:

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -775,7 +775,7 @@ class ArtifactBundlePostAssembler(PostAssembler[ArtifactBundleArchive]):
     @sentry_sdk.tracing.trace
     def _index_bundle_into_flat_file(self, artifact_bundle: ArtifactBundle):
         identifiers = mark_bundle_for_flat_file_indexing(
-            artifact_bundle, self.project_ids, self.release, self.dist
+            artifact_bundle, self.archive.has_debug_ids(), self.project_ids, self.release, self.dist
         )
 
         bundles_to_add = [BundleManifest.from_artifact_bundle(artifact_bundle, self.archive)]

--- a/tests/sentry/debug_files/test_artifact_bundle_indexing.py
+++ b/tests/sentry/debug_files/test_artifact_bundle_indexing.py
@@ -127,7 +127,7 @@ class FlatFileIndexingTest(FlatFileTestCase):
         artifact_bundle = self.mock_simple_artifact_bundle()
 
         identifiers = mark_bundle_for_flat_file_indexing(
-            artifact_bundle, [self.project.id], release, dist
+            artifact_bundle, False, [self.project.id], release, dist
         )
 
         with ArtifactBundleArchive(artifact_bundle.file.getfile()) as archive:
@@ -144,7 +144,7 @@ class FlatFileIndexingTest(FlatFileTestCase):
         artifact_bundle = self.mock_simple_artifact_bundle(with_debug_ids=True)
 
         identifiers = mark_bundle_for_flat_file_indexing(
-            artifact_bundle, [self.project.id], None, None
+            artifact_bundle, True, [self.project.id], None, None
         )
 
         with ArtifactBundleArchive(artifact_bundle.file.getfile()) as archive:
@@ -164,7 +164,7 @@ class FlatFileIndexingTest(FlatFileTestCase):
         artifact_bundle = self.mock_simple_artifact_bundle(with_debug_ids=True)
 
         identifiers = mark_bundle_for_flat_file_indexing(
-            artifact_bundle, [self.project.id], release, dist
+            artifact_bundle, True, [self.project.id], release, dist
         )
 
         with ArtifactBundleArchive(artifact_bundle.file.getfile()) as archive:
@@ -187,7 +187,7 @@ class FlatFileIndexingTest(FlatFileTestCase):
         artifact_bundle = self.mock_simple_artifact_bundle(with_debug_ids=True)
 
         identifiers = mark_bundle_for_flat_file_indexing(
-            artifact_bundle, [self.project.id], None, None
+            artifact_bundle, True, [self.project.id], None, None
         )
 
         with ArtifactBundleArchive(artifact_bundle.file.getfile()) as archive:
@@ -210,7 +210,7 @@ class FlatFileIndexingTest(FlatFileTestCase):
         artifact_bundle = self.mock_simple_artifact_bundle(with_debug_ids=True)
 
         identifiers = mark_bundle_for_flat_file_indexing(
-            artifact_bundle, [self.project.id], release, dist
+            artifact_bundle, True, [self.project.id], release, dist
         )
 
         with ArtifactBundleArchive(artifact_bundle.file.getfile()) as archive:
@@ -237,10 +237,10 @@ class FlatFileIndexingTest(FlatFileTestCase):
         artifact_bundle2 = self.mock_simple_artifact_bundle()
 
         identifiers1 = mark_bundle_for_flat_file_indexing(
-            artifact_bundle1, [self.project.id], release, dist
+            artifact_bundle1, False, [self.project.id], release, dist
         )
         identifiers2 = mark_bundle_for_flat_file_indexing(
-            artifact_bundle2, [self.project.id], release, dist
+            artifact_bundle2, False, [self.project.id], release, dist
         )
         assert identifiers1 == identifiers2
 
@@ -287,10 +287,10 @@ class FlatFileIndexingTest(FlatFileTestCase):
         artifact_bundle2 = self.mock_simple_artifact_bundle()
 
         identifiers1 = mark_bundle_for_flat_file_indexing(
-            artifact_bundle1, [self.project.id], release, dist
+            artifact_bundle1, False, [self.project.id], release, dist
         )
         identifiers2 = mark_bundle_for_flat_file_indexing(
-            artifact_bundle2, [self.project.id], release, dist
+            artifact_bundle2, False, [self.project.id], release, dist
         )
         assert identifiers1 == identifiers2
         identifier = identifiers1[0]


### PR DESCRIPTION
Previously, we would unconditionally create a flat file index for debug ids, even if a bundle did not contain any. This is unneeded work and just makes contention worse.

Especially when migrating ReleaseBundles over to ArtifactBundles, those won’t have any DebugIds.