### PR TITLE
Use periodic task to bump in-use ArtifactBundles

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1145,6 +1145,11 @@ CELERYBEAT_SCHEDULE_REGION = {
         "schedule": crontab(minute="*/1"),
         "options": {"expires": 60},
     },
+    "refresh-artifact-bundles-in-use": {
+        "task": "sentry.debug_files.tasks.refresh_artifact_bundles_in_use",
+        "schedule": crontab(minute="*/1"),
+        "options": {"expires": 60},
+    },
 }
 
 # Assign the configuration keys celery uses based on our silo mode.

--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -45,6 +45,10 @@ def get_redis_cluster_for_artifact_bundles():
     return redis.redis_clusters.get(cluster_key)
 
 
+def get_refresh_key() -> str:
+    return "artifact_bundles_in_use"
+
+
 def _generate_artifact_bundle_indexing_state_cache_key(
     organization_id: int, artifact_bundle_id: int
 ) -> str:
@@ -188,17 +192,34 @@ def maybe_renew_artifact_bundles_from_processing(project_id: int, used_download_
             continue
         artifact_bundle_ids.append(ty_id)
 
-    # FIXME: This function is being called for every processed event, so ideally
-    # we would heavily debounce this and avoid doing such a query directly.
+    redis_client = get_redis_cluster_for_artifact_bundles()
 
-    used_artifact_bundles = {
-        id: date_added
-        for id, date_added in ArtifactBundle.objects.filter(
-            projectartifactbundle__project_id=project_id, id__in=artifact_bundle_ids
-        ).values_list("id", "date_added")
-    }
+    redis_client.sadd(get_refresh_key(), *artifact_bundle_ids)
 
-    maybe_renew_artifact_bundles(used_artifact_bundles)
+
+@sentry_sdk.tracing.trace
+def refresh_artifact_bundles_in_use():
+    LOOP_TIMES = 100
+    IDS_PER_LOOP = 50
+
+    redis_client = get_redis_cluster_for_artifact_bundles()
+
+    now = timezone.now()
+    threshold_date = now - timedelta(days=AVAILABLE_FOR_RENEWAL_DAYS)
+
+    for _ in range(LOOP_TIMES):
+        artifact_bundle_ids = redis_client.spop(get_refresh_key(), IDS_PER_LOOP)
+        used_artifact_bundles = {
+            id: date_added
+            for id, date_added in ArtifactBundle.objects.filter(
+                id__in=artifact_bundle_ids, date_added__lte=threshold_date
+            ).values_list("id", "date_added")
+        }
+
+        maybe_renew_artifact_bundles(used_artifact_bundles)
+
+        if len(artifact_bundle_ids) < IDS_PER_LOOP:
+            break
 
 
 def maybe_renew_artifact_bundles(used_artifact_bundles: Dict[int, datetime]):

--- a/src/sentry/debug_files/tasks.py
+++ b/src/sentry/debug_files/tasks.py
@@ -13,3 +13,13 @@ def backfill_artifact_index_updates():
     hit_batch_size = do_backfill()
     if hit_batch_size:
         backfill_artifact_index_updates.delay()
+
+
+@instrumented_task(
+    name="sentry.debug_files.tasks.refresh_artifact_bundles_in_use",
+    queue="assemble",
+)
+def refresh_artifact_bundles_in_use():
+    from .artifact_bundles import refresh_artifact_bundles_in_use as do_refresh
+
+    do_refresh()

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django.utils import timezone
 
+from sentry.debug_files.artifact_bundles import refresh_artifact_bundles_in_use
 from sentry.models import (
     ArtifactBundle,
     DebugIdArtifactBundle,
@@ -2511,6 +2512,10 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
         assert frame.data["resolved_with"] == "index"
         assert frame.data["symbolicated"]
+
+        # explicitly trigger the task that is refreshing bundles, usually this
+        # happens on a schedule:
+        refresh_artifact_bundles_in_use()
 
         artifact_bundles = ArtifactBundle.objects.filter(
             organization_id=self.organization.id,


### PR DESCRIPTION
With FlatFileIndexes, Symbolicator can precisely return the actually used artifact bundles. Instead of eagerly querying and refreshing them, this is now adding them to a redis set which is being used to refresh bundles using a periodic task.