### PR TITLE
fix(performance-trace-view): Fixed row divider bug and hid duration bar in ONLY error case. 

### DIFF
--- a/static/app/views/performance/traceDetails/traceView.tsx
+++ b/static/app/views/performance/traceDetails/traceView.tsx
@@ -147,6 +147,7 @@ export default function TraceView({
     description: 'trace-view-content',
   });
   const hasOrphanErrors = orphanErrors && orphanErrors.length > 0;
+  const onlyOrphanErrors = hasOrphanErrors && (!traces || traces.length === 0);
 
   useEffect(() => {
     trackAnalytics('performance_views.trace_view.view', {
@@ -440,6 +441,7 @@ export default function TraceView({
                     hasGuideAnchor={false}
                     renderedChildren={transactionGroups}
                     barColor={pickBarColor('')}
+                    onlyOrphanErrors={onlyOrphanErrors}
                     numOfOrphanErrors={orphanErrors?.length}
                   />
                   <TraceHiddenMessage

--- a/static/app/views/performance/traceDetails/transactionGroup.tsx
+++ b/static/app/views/performance/traceDetails/transactionGroup.tsx
@@ -33,6 +33,7 @@ type Props = ScrollbarManagerChildrenProps & {
   isOrphanError?: boolean;
   measurements?: Map<number, VerticalMark>;
   numOfOrphanErrors?: number;
+  onlyOrphanErrors?: boolean;
 };
 
 type State = {
@@ -74,6 +75,7 @@ class TransactionGroup extends Component<Props, State> {
       measurements,
       generateBounds,
       numOfOrphanErrors,
+      onlyOrphanErrors,
       isOrphanError,
     } = this.props;
     const {isExpanded} = this.state;
@@ -99,6 +101,7 @@ class TransactionGroup extends Component<Props, State> {
           addContentSpanBarRef={addContentSpanBarRef}
           removeContentSpanBarRef={removeContentSpanBarRef}
           onWheel={onWheel}
+          onlyOrphanErrors={onlyOrphanErrors}
           numOfOrphanErrors={numOfOrphanErrors}
           isOrphanError={isOrphanError}
         />


### PR DESCRIPTION
This PR hides the duration bar from the root trace in the ONLY errors case and fixes row divider drag bug.

Can't drag the divider when on an error row:

https://github.com/getsentry/sentry/assets/60121741/b86df6de-7f6f-4c7c-b61b-25433bf153b9



Connected project: [Tracing w/o performance ](https://www.notion.so/sentry/Performance-views-for-tracing-without-performance-only-errors-bd68d3d84df34bd89c0ae8bc32827c98)



