### PR TITLE
feat(statistical-detectors): Use relative change as the condition for…

### DIFF
--- a/src/sentry/statistical_detectors/algorithm.py
+++ b/src/sentry/statistical_detectors/algorithm.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("sentry.tasks.statistical_detectors.algorithm")
 
 
 @dataclass(frozen=True)
-class MovingAverageCrossOverDetectorState(DetectorState):
+class MovingAverageDetectorState(DetectorState):
     timestamp: Optional[datetime]
     count: int
     moving_avg_short: float
@@ -42,7 +42,7 @@ class MovingAverageCrossOverDetectorState(DetectorState):
         return d
 
     @classmethod
-    def from_redis_dict(cls, data: Any) -> MovingAverageCrossOverDetectorState:
+    def from_redis_dict(cls, data: Any) -> MovingAverageDetectorState:
         ts = data.get(cls.FIELD_TIMESTAMP)
         timestamp = None if ts is None else datetime.fromtimestamp(int(ts), timezone.utc)
         count = int(data[cls.FIELD_COUNT])
@@ -56,7 +56,7 @@ class MovingAverageCrossOverDetectorState(DetectorState):
         )
 
     @classmethod
-    def empty(cls) -> MovingAverageCrossOverDetectorState:
+    def empty(cls) -> MovingAverageDetectorState:
         return cls(
             timestamp=None,
             count=0,
@@ -66,17 +66,17 @@ class MovingAverageCrossOverDetectorState(DetectorState):
 
 
 @dataclass(frozen=True)
-class MovingAverageCrossOverDetectorConfig(DetectorConfig):
+class MovingAverageDetectorConfig(DetectorConfig):
     min_data_points: int
     short_moving_avg_factory: Callable[[], MovingAverage]
     long_moving_avg_factory: Callable[[], MovingAverage]
 
 
-class MovingAverageCrossOverDetector(DetectorAlgorithm):
+class MovingAverageDetector(DetectorAlgorithm):
     def __init__(
         self,
-        state: MovingAverageCrossOverDetectorState,
-        config: MovingAverageCrossOverDetectorConfig,
+        state: MovingAverageDetectorState,
+        config: MovingAverageDetectorConfig,
     ):
         self.moving_avg_short = config.short_moving_avg_factory()
         self.moving_avg_short.set(state.moving_avg_short, state.count)
@@ -88,6 +88,17 @@ class MovingAverageCrossOverDetector(DetectorAlgorithm):
         self.count = state.count
         self.config = config
 
+    @property
+    def state(self) -> MovingAverageDetectorState:
+        return MovingAverageDetectorState(
+            timestamp=self.timestamp,
+            count=self.count,
+            moving_avg_short=self.moving_avg_short.value,
+            moving_avg_long=self.moving_avg_short.value,
+        )
+
+
+class MovingAverageCrossOverDetector(MovingAverageDetector):
     def update(self, payload: DetectorPayload) -> Optional[TrendType]:
         if self.timestamp is not None and self.timestamp > payload.timestamp:
             # In the event that the timestamp is before the payload's timestamps,
@@ -135,11 +146,69 @@ class MovingAverageCrossOverDetector(DetectorAlgorithm):
 
         return TrendType.Unchanged
 
-    @property
-    def state(self) -> MovingAverageCrossOverDetectorState:
-        return MovingAverageCrossOverDetectorState(
-            timestamp=self.timestamp,
-            count=self.count,
-            moving_avg_short=self.moving_avg_short.value,
-            moving_avg_long=self.moving_avg_short.value,
-        )
+
+@dataclass(frozen=True)
+class MovingAverageRelativeChangeDetectorConfig(MovingAverageDetectorConfig):
+    threshold: float
+
+
+class MovingAverageRelativeChangeDetector(MovingAverageDetector):
+    def __init__(
+        self,
+        state: MovingAverageDetectorState,
+        config: MovingAverageRelativeChangeDetectorConfig,
+    ):
+        super().__init__(state, config)
+        self.threshold = abs(config.threshold)
+
+    def update(self, payload: DetectorPayload) -> Optional[TrendType]:
+        if self.timestamp is not None and self.timestamp > payload.timestamp:
+            # In the event that the timestamp is before the payload's timestamps,
+            # we do not want to process this payload.
+            #
+            # This should not happen other than in some error state.
+            logger.warning(
+                "Trend detection out of order. Processing %s, but last processed was %s",
+                payload.timestamp.isoformat(),
+                self.timestamp.isoformat(),
+            )
+            return None
+
+        old_moving_avg_short = self.moving_avg_short.value
+        old_moving_avg_long = self.moving_avg_long.value
+
+        self.moving_avg_short.update(payload.value)
+        self.moving_avg_long.update(payload.value)
+        self.timestamp = payload.timestamp
+        self.count += 1
+
+        # The heuristic isn't stable initially, so ensure we have a minimum
+        # number of data points before looking for a regression.
+        stablized = self.count > self.config.min_data_points
+
+        try:
+            relative_change_old = (old_moving_avg_short - old_moving_avg_long) / abs(
+                old_moving_avg_long
+            )
+            relative_change_new = (self.moving_avg_short.value - self.moving_avg_long.value) / abs(
+                self.moving_avg_long.value
+            )
+        except ZeroDivisionError:
+            relative_change_old = 0
+            relative_change_new = 0
+
+        if (
+            stablized
+            and relative_change_old < self.threshold
+            and relative_change_new > self.threshold
+        ):
+            return TrendType.Regressed
+
+        elif (
+            stablized
+            and relative_change_old > -self.threshold
+            and relative_change_new < -self.threshold
+        ):
+            return TrendType.Improved
+
+        return TrendType.Unchanged


### PR DESCRIPTION
… the filter

The moving average cross over was producing too many false positives for stable timeseries. Trying a different condition based on the relative change between 2 moving averages.