### PR TITLE
chore(metrics): Add a new referrer for metric validations

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -667,6 +667,7 @@ class Referrer(Enum):
     TESTING_TEST = "testing.test"
     TEST_QUERY_PRIMARY = "test_query.primary"
     TEST_QUERY = "test_query"
+    METRIC_VALIDATION = "metric_validation"
 
 
 VALUES = {referrer.value for referrer in Referrer}


### PR DESCRIPTION
A validation script is being written in the getsentry repo which would validate data between clickhouse and postgres. Adding a new referrer in sentry to allow the script to run without any errors