### PR TITLE
ref: prevent test pollution from not-always-registered signal in #55091

### DIFF
--- a/src/sentry/tasks/integrations/slack/find_channel_id_for_rule.py
+++ b/src/sentry/tasks/integrations/slack/find_channel_id_for_rule.py
@@ -10,7 +10,7 @@ from sentry.integrations.slack.utils import (
 )
 from sentry.mediators import project_rules
 from sentry.models import Project, Rule, RuleActivity, RuleActivityType
-from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
+from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import ApiRateLimitedError, DuplicateDisplayNameError
 from sentry.silo import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -51,7 +51,6 @@ def find_channel_id_for_rule(
             channel_name = strip_channel_name(action["channel"])
             break
 
-    integration: RpcIntegration
     integrations = integration_service.get_integrations(
         organization_id=organization.id, providers=["slack"], integration_ids=[integration_id]
     )

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -1,8 +1,8 @@
-from functools import cached_property
 from unittest.mock import patch
 from urllib.parse import parse_qs
 from uuid import uuid4
 
+import pytest
 import responses
 
 from sentry.incidents.models import AlertRule, AlertRuleTriggerAction
@@ -27,9 +27,8 @@ class SlackTasksTest(TestCase):
         self.integration = install_slack(self.organization)
         self.uuid = uuid4().hex
 
-        self.mck = responses.mock
-        self.mck.__enter__()
-
+    @pytest.fixture(autouse=True)
+    def setup_responses(self):
         responses.add(
             method=responses.POST,
             url="https://slack.com/api/chat.scheduleMessage",
@@ -46,11 +45,9 @@ class SlackTasksTest(TestCase):
             content_type="application/json",
             body=json.dumps({"ok": True}),
         )
+        with responses.mock:
+            yield
 
-    def tearDown(self):
-        self.mck.__exit__(None, None, None)
-
-    @cached_property
     def metric_alert_data(self):
         return {
             "aggregate": "count()",
@@ -94,7 +91,6 @@ class SlackTasksTest(TestCase):
                 {
                     "channel": "#my-channel",
                     "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
-                    "name": "Send a notification to the funinthesun Slack workspace to #secrets and show tags [] in notification",
                     "tags": "",
                     "workspace": self.integration.id,
                 }
@@ -142,7 +138,6 @@ class SlackTasksTest(TestCase):
                 {
                     "channel": "#my-channel",
                     "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
-                    "name": "Send a notification to the funinthesun Slack workspace to #secrets and show tags [] in notification",
                     "tags": "",
                     "workspace": self.integration.id,
                 }
@@ -176,7 +171,7 @@ class SlackTasksTest(TestCase):
         return_value=("#", "chan-id", False),
     )
     def test_task_new_alert_rule(self, mock_get_channel_id, mock_set_value):
-        alert_rule_data = self.metric_alert_data
+        alert_rule_data = self.metric_alert_data()
 
         data = {
             "data": alert_rule_data,
@@ -206,7 +201,7 @@ class SlackTasksTest(TestCase):
         return_value=("#", None, False),
     )
     def test_task_failed_id_lookup(self, mock_get_channel_id, mock_set_value):
-        alert_rule_data = self.metric_alert_data
+        alert_rule_data = self.metric_alert_data()
 
         data = {
             "data": alert_rule_data,
@@ -231,7 +226,7 @@ class SlackTasksTest(TestCase):
         return_value=("#", None, True),
     )
     def test_task_timeout_id_lookup(self, mock_get_channel_id, mock_set_value):
-        alert_rule_data = self.metric_alert_data
+        alert_rule_data = self.metric_alert_data()
 
         data = {
             "data": alert_rule_data,
@@ -256,7 +251,7 @@ class SlackTasksTest(TestCase):
         return_value=("#", "chan-id", False),
     )
     def test_task_existing_metric_alert(self, mock_get_channel_id, mock_set_value):
-        alert_rule_data = self.metric_alert_data
+        alert_rule_data = self.metric_alert_data()
         alert_rule = self.create_alert_rule(
             organization=self.organization, projects=[self.project], name="New Rule", user=self.user
         )


### PR DESCRIPTION
the hook in #55091 is not consistently registered causing `name` to inconsistently be removed depending on whether the module has been imported or not (a common side-effect from other tests in the module):

```console
$ pytest -qq tests/sentry/integrations/slack/test_tasks.py::SlackTasksTest::test_task_existing_rule tests/sentry/integrations/slack/test_uninstall.py::SlackUninstallTest::test_uninstall_slack_only
F.                                                                                                                        [100%]
=========================================================== FAILURES ============================================================
____________________________________________ SlackTasksTest.test_task_existing_rule _____________________________________________
tests/sentry/integrations/slack/test_tasks.py:162: in test_task_existing_rule
    assert updated_rule.data["actions"] == [
E   AssertionError: assert [{'channel': ...cation', ...}] == [{'channel': ...gs': '', ...}]
E     At index 0 diff: {'channel': '#my-channel', 'id': 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction', 'name': 'Send a notification to the funinthesun Slack workspace to #secrets and show tags [] in notification', 'tags': '', 'workspace': 1, 'channel_id': 'chan-id'} != {'channel': '#my-channel', 'channel_id': 'chan-id', 'id': 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction', 'tags': '', 'workspace': 1}
E     Use -v to get more diff
==================================================== short test summary info ====================================================
FAILED tests/sentry/integrations/slack/test_tasks.py::SlackTasksTest::test_task_existing_rule - AssertionError: assert [{'channel': ...cation', ...}] == [{'channel': ...gs': '', ...}]
```

<!-- Describe your PR here. -->