### PR TITLE
fix(replays api): change limit to be per_page

### DIFF
--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -260,7 +260,7 @@ Deletes a replay instance.
     - w
   - start (optional, string) - ISO 8601 format (`YYYY-MM-DDTHH:mm:ss.sssZ`)
   - end (optional, string) - ISO 8601 format. Required if `start` is set.
-  - limit (optional, number)
+  - per_page (optional, number)
     Default: 10
   - offset (optional, number)
     Default: 0

--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -260,7 +260,7 @@ Deletes a replay instance.
     - w
   - start (optional, string) - ISO 8601 format (`YYYY-MM-DDTHH:mm:ss.sssZ`)
   - end (optional, string) - ISO 8601 format. Required if `start` is set.
-  - per_page (optional, number)
+  - limit (optional, number)
     Default: 10
   - offset (optional, number)
     Default: 0


### PR DESCRIPTION
Instead of using the `limit` field, we should use the `per_page` field to explicitly define how many values we want to return from the API. The default is still 10.