### PR TITLE
feat(releases): Add ReleaseThreshold serializer

### DIFF
--- a/src/sentry/api/serializers/models/__init__.py
+++ b/src/sentry/api/serializers/models/__init__.py
@@ -66,6 +66,7 @@ from .relay import *  # noqa: F401,F403
 from .relayusage import *  # noqa: F401,F403
 from .release import *  # noqa: F401,F403
 from .release_file import *  # noqa: F401,F403
+from .release_threshold import *  # noqa: F401,F403
 from .repository import *  # noqa: F401,F403
 from .repository_project_path_config import *  # noqa: F401,F403
 from .role import *  # noqa: F401,F403

--- a/src/sentry/api/serializers/models/release_threshold.py
+++ b/src/sentry/api/serializers/models/release_threshold.py
@@ -1,0 +1,16 @@
+from sentry.api.serializers import Serializer, register, serialize
+from sentry.models.releasethreshold import ReleaseThreshold, ReleaseThresholdType, TriggerType
+
+
+@register(ReleaseThreshold)
+class ReleaseThresholdSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        return {
+            "threshold_type": ReleaseThresholdType.INT_TO_STRING[obj.threshold_type],
+            "trigger_type": TriggerType.INT_TO_STRING[obj.trigger_type],
+            "value": obj.value,
+            "window_in_seconds": obj.window_in_seconds,
+            "project": serialize(obj.project),
+            "environment": serialize(obj.environment) if obj.environment else None,
+            "date_added": obj.date_added,
+        }


### PR DESCRIPTION
Adds an outbound serializer to send back the release thresholds that users create.