### PR TITLE
feat(releases): Create endpoint for threshold creation

### DIFF
--- a/src/sentry/api/endpoints/release_threshold.py
+++ b/src/sentry/api/endpoints/release_threshold.py
@@ -1,0 +1,58 @@
+from django.http import HttpResponse
+from django.http.request import HttpRequest
+from rest_framework import serializers
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.serializers import serialize
+from sentry.api.serializers.rest_framework.environment import EnvironmentField
+from sentry.api.serializers.rest_framework.project import ProjectField
+from sentry.models import Project
+from sentry.models.releasethreshold import ReleaseThreshold, ReleaseThresholdType, TriggerType
+
+
+class ReleaseThresholdSerializer(serializers.Serializer):
+    threshold_type = serializers.ChoiceField(choices=ReleaseThresholdType.as_str_choices())
+    trigger_type = serializers.ChoiceField(choices=TriggerType.as_str_choices())
+    value = serializers.IntegerField()
+    window_in_seconds = serializers.IntegerField()
+    project = ProjectField()
+    environment = EnvironmentField(required=False, allow_null=True)
+
+    def validate_threshold_type(self, threshold_type):
+        return ReleaseThresholdType.STRING_TO_INT[threshold_type]
+
+    def validate_trigger_type(self, threshold_type):
+        return TriggerType.STRING_TO_INT[threshold_type]
+
+
+class ReleaseThresholdEndpoint(ProjectEndpoint):
+    owner: ApiOwner = ApiOwner.ENTERPRISE
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+
+    def post(self, request: HttpRequest, project: Project) -> HttpResponse:
+        request.data["project"] = project.slug
+        serializer = ReleaseThresholdSerializer(
+            data=request.data,
+            context={
+                "organization": project.organization,
+                "access": request.access,
+            },
+        )
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+        result = serializer.validated_data
+
+        release_threshold = ReleaseThreshold.objects.create(
+            threshold_type=result.get("threshold_type"),
+            trigger_type=result.get("trigger_type"),
+            value=result.get("value"),
+            window_in_seconds=result.get("window_in_seconds"),
+            project=result.get("project"),
+            environment=result.get("environment"),
+        )
+        return Response(serialize(release_threshold, request.user), status=201)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -21,6 +21,7 @@ from sentry.api.endpoints.organization_missing_org_members import OrganizationMi
 from sentry.api.endpoints.organization_projects_experiment import (
     OrganizationProjectsExperimentEndpoint,
 )
+from sentry.api.endpoints.release_threshold import ReleaseThresholdEndpoint
 from sentry.api.utils import method_dispatch
 from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint
@@ -2099,6 +2100,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/$",
         ProjectReleasesEndpoint.as_view(),
         name="sentry-api-0-project-releases",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/thresholds/$",
+        ReleaseThresholdEndpoint.as_view(),
+        name="sentry-api-0-project-releases-thresholds",
     ),
     re_path(
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/commits/$",

--- a/tests/sentry/api/endpoints/test_release_threshold.py
+++ b/tests/sentry/api/endpoints/test_release_threshold.py
@@ -1,0 +1,150 @@
+from django.urls import reverse
+
+from sentry.models.environment import Environment
+from sentry.testutils.cases import APITestCase
+
+
+class ReleaseThresholdCreateTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user(is_staff=True, is_superuser=True)
+
+        self.canary_environment = Environment.objects.create(
+            organization_id=self.organization.id, name="canary"
+        )
+        self.production_environment = Environment.objects.create(
+            organization_id=self.organization.id, name="production"
+        )
+        self.login_as(user=self.user)
+
+        self.url = reverse(
+            "sentry-api-0-project-releases-thresholds",
+            kwargs={"organization_slug": self.organization.slug, "project_slug": self.project.slug},
+        )
+
+    def test_missing_params(self):
+        response = self.client.post(
+            self.url,
+            data={
+                "threshold_type": "total_error_count",
+                "trigger_type": "absolute_over",
+                # value is missing
+                "window_in_seconds": 1800,
+                "environment": "canary",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.data == {"value": ["This field is required."]}
+
+    def test_invalid_threshold_type(self):
+        response = self.client.post(
+            self.url,
+            data={
+                "threshold_type": "indiana_jones_and_the_temple_of_doom",
+                "trigger_type": "absolute_over",
+                "value": 100,
+                "window_in_seconds": 1800,
+                "environment": "canary",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.data["threshold_type"][0].code == "invalid_choice"
+
+    def test_invalid_trigger_type(self):
+        response = self.client.post(
+            self.url,
+            data={
+                "threshold_type": "total_error_count",
+                "trigger_type": "short_round",
+                "value": 100,
+                "window_in_seconds": 1800,
+                "environment": "production",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.data["trigger_type"][0].code == "invalid_choice"
+
+    def test_invalid_project(self):
+        url_with_invalid_project = reverse(
+            "sentry-api-0-project-releases-thresholds",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": "Why did it have to be snakes?",
+            },
+        )
+        response = self.client.post(
+            url_with_invalid_project,
+            data={
+                "threshold_type": "total_error_count",
+                "trigger_type": "absolute_over",
+                "value": 100,
+                "window_in_seconds": 1800,
+                "environment": "production",
+            },
+        )
+        assert response.status_code == 404
+
+    def test_invalid_environment(self):
+        response = self.client.post(
+            self.url,
+            data={
+                "threshold_type": "total_error_count",
+                "trigger_type": "absolute_over",
+                "value": 100,
+                "window_in_seconds": 1800,
+                "environment": "Sentry belongs in a museum.",
+            },
+        )
+        assert response.status_code == 400
+        assert response.data["environment"][0].code == "invalid"
+
+    def test_valid_no_environment(self):
+        response = self.client.post(
+            self.url,
+            data={
+                "threshold_type": "total_error_count",
+                "trigger_type": "absolute_over",
+                "value": 100,
+                "window_in_seconds": 1800,
+            },
+        )
+        assert response.status_code == 201
+        data = response.data
+        assert data["threshold_type"] == "total_error_count"
+        assert data["trigger_type"] == "absolute_over"
+        assert data["value"] == 100
+        assert data["window_in_seconds"] == 1800
+        assert data["project"]["id"] == str(self.project.id)
+        assert data["project"]["slug"] == self.project.slug
+        assert data["project"]["name"] == self.project.name
+        assert data["environment"] is None
+        assert data["date_added"] is not None
+
+    def test_valid(self):
+        response = self.client.post(
+            self.url,
+            data={
+                "threshold_type": "total_error_count",
+                "trigger_type": "absolute_over",
+                "value": 100,
+                "window_in_seconds": 1800,
+                "environment": "canary",
+            },
+        )
+
+        assert response.status_code == 201
+        # {'threshold_type': 'total_error_count', 'trigger_type': 'absolute_over', 'value': 100, 'window_in_seconds': 1800, 'project': {'id': '4552578081357825', 'slug': 'bar', 'name': 'Bar', 'platform': None, 'dateCreated': datetime.datetime(2023, 9, 5, 21, 44, 58, 78647, tzinfo=<UTC>), 'isBookmarked': False, 'isMember': False, 'features': ['alert-filters', 'data-forwarding', 'minidump', 'race-free-group-creation', 'rate-limits'], 'firstEvent': None, 'firstTransactionEvent': False, 'access': set(), 'hasAccess': True, 'hasMinifiedStackTrace': False, 'hasMonitors': False, 'hasProfiles': False, 'hasReplays': False, 'hasSessions': False, 'isInternal': False, 'isPublic': False, 'avatar': {'avatarType': 'letter_avatar', 'avatarUuid': None}, 'color': '#87bf3f', 'status': 'active'}, 'environment': {'id': '1', 'name': 'canary'}, 'date_added': datetime.datetime(2023, 9, 5, 21, 44, 58, 749322, tzinfo=<UTC>)}
+        data = response.data
+        assert data["threshold_type"] == "total_error_count"
+        assert data["trigger_type"] == "absolute_over"
+        assert data["value"] == 100
+        assert data["window_in_seconds"] == 1800
+        assert data["project"]["id"] == str(self.project.id)
+        assert data["project"]["slug"] == self.project.slug
+        assert data["project"]["name"] == self.project.name
+        assert data["environment"]["id"] == str(self.canary_environment.id)
+        assert data["environment"]["name"] == self.canary_environment.name
+        assert data["date_added"] is not None

--- a/tests/sentry/api/endpoints/test_release_threshold.py
+++ b/tests/sentry/api/endpoints/test_release_threshold.py
@@ -136,7 +136,7 @@ class ReleaseThresholdCreateTest(APITestCase):
         )
 
         assert response.status_code == 201
-        # {'threshold_type': 'total_error_count', 'trigger_type': 'absolute_over', 'value': 100, 'window_in_seconds': 1800, 'project': {'id': '4552578081357825', 'slug': 'bar', 'name': 'Bar', 'platform': None, 'dateCreated': datetime.datetime(2023, 9, 5, 21, 44, 58, 78647, tzinfo=<UTC>), 'isBookmarked': False, 'isMember': False, 'features': ['alert-filters', 'data-forwarding', 'minidump', 'race-free-group-creation', 'rate-limits'], 'firstEvent': None, 'firstTransactionEvent': False, 'access': set(), 'hasAccess': True, 'hasMinifiedStackTrace': False, 'hasMonitors': False, 'hasProfiles': False, 'hasReplays': False, 'hasSessions': False, 'isInternal': False, 'isPublic': False, 'avatar': {'avatarType': 'letter_avatar', 'avatarUuid': None}, 'color': '#87bf3f', 'status': 'active'}, 'environment': {'id': '1', 'name': 'canary'}, 'date_added': datetime.datetime(2023, 9, 5, 21, 44, 58, 749322, tzinfo=<UTC>)}
+
         data = response.data
         assert data["threshold_type"] == "total_error_count"
         assert data["trigger_type"] == "absolute_over"


### PR DESCRIPTION
Basic `POST` endpoint to create new release thresholds.