### PR TITLE
feat(browser-starfish): hookup prod interaction transactions

### DIFF
--- a/static/app/views/performance/browser/useInteractionsQuery.ts
+++ b/static/app/views/performance/browser/useInteractionsQuery.ts
@@ -1,0 +1,46 @@
+import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
+import EventView from 'sentry/utils/discover/eventView';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useBrowserModuleFilters} from 'sentry/views/performance/browser/useBrowserFilters';
+
+export const useInteractionsQuery = () => {
+  const pageFilters = usePageFilters();
+  const browserFilters = useBrowserModuleFilters();
+  const location = useLocation();
+  const {slug: orgSlug} = useOrganization();
+  const queryConditions = [
+    'has:interactionElement',
+    browserFilters.page ? `transaction:${browserFilters.page}` : '',
+  ];
+
+  const eventView = EventView.fromNewQueryWithPageFilters(
+    {
+      fields: [
+        'interactionElement',
+        'transaction',
+        'transaction.op',
+        'p75(transaction.duration)',
+        'count()',
+      ],
+      name: 'Interaction module - interactions table',
+      query: queryConditions.join(' '),
+      orderby: '-count',
+      version: 2,
+    },
+    pageFilters.selection
+  );
+
+  const result = useDiscoverQuery({eventView, limit: 50, location, orgSlug});
+
+  const data = result?.data?.data.map(row => ({
+    transaction: row.transaction.toString(),
+    interactionElement: row.interactionElement.toString(),
+    'transaction.op': row['transaction.op'].toString(),
+    'p75(transaction.duration)': row['p75(transaction.duration)'] as number,
+    'count()': row['count()'] as number,
+  }));
+
+  return {...result, data: data || []};
+};

--- a/static/app/views/performance/browser/useInteractionsQuery.ts
+++ b/static/app/views/performance/browser/useInteractionsQuery.ts
@@ -15,6 +15,7 @@ export const useInteractionsQuery = () => {
     browserFilters.page ? `transaction:${browserFilters.page}` : '',
   ];
 
+  // TODO - we should be using metrics data here
   const eventView = EventView.fromNewQueryWithPageFilters(
     {
       fields: [


### PR DESCRIPTION
Hook up the interactions table to prod interaction transactions. Rn we are just indexed data as metrics data isn't yet available afaik

Also just using the DOM selector instead of component name.

<img width="916" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/2c3e674b-57fc-42f0-88b4-086d28f2a43c">
