### PR TITLE
ref: fix test pollution in test_scim_user_index

### DIFF
--- a/tests/sentry/api/endpoints/test_scim_user_index.py
+++ b/tests/sentry/api/endpoints/test_scim_user_index.py
@@ -15,13 +15,15 @@ from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, region_silo_test
 
-CREATE_USER_POST_DATA = {
-    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
-    "userName": "test.user@okta.local",
-    "name": {"givenName": "Test", "familyName": "User"},
-    "emails": [{"primary": True, "value": "test.user@okta.local", "type": "work"}],
-    "active": True,
-}
+
+def post_data():
+    return {
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "userName": "test.user@okta.local",
+        "name": {"givenName": "Test", "familyName": "User"},
+        "emails": [{"primary": True, "value": "test.user@okta.local", "type": "work"}],
+        "active": True,
+    }
 
 
 def merge_dictionaries(dict1, dict2):
@@ -51,7 +53,7 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
     def test_post_users_successful(self, mock_metrics):
         url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
         with outbox_runner():
-            response = self.client.post(url, CREATE_USER_POST_DATA)
+            response = self.client.post(url, post_data())
         assert response.status_code == 201, response.content
         member = OrganizationMember.objects.get(
             organization=self.organization, email="test.user@okta.local"
@@ -87,7 +89,7 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
         url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
         with outbox_runner():
             response = self.client.post(
-                url, merge_dictionaries(CREATE_USER_POST_DATA, {"sentryOrgRole": "member"})
+                url, merge_dictionaries(post_data(), {"sentryOrgRole": "member"})
             )
         assert response.status_code == 201, response.content
         member = OrganizationMember.objects.get(
@@ -138,7 +140,7 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
 
         url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
         with outbox_runner():
-            response = self.client.post(url, CREATE_USER_POST_DATA)
+            response = self.client.post(url, post_data())
 
         assert response.status_code == 201, response.content
         member = OrganizationMember.objects.get(
@@ -175,7 +177,7 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
             user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
         url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
-        response = self.client.post(url, CREATE_USER_POST_DATA)
+        response = self.client.post(url, post_data())
         assert response.status_code == 409, response.content
         assert response.data == {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
@@ -185,10 +187,11 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
         assert not member.flags["idp:role-restricted"]
 
     def test_post_users_with_role_valid(self):
-        CREATE_USER_POST_DATA["sentryOrgRole"] = "manager"
+        data = post_data()
+        data["sentryOrgRole"] = "manager"
         with outbox_runner():
             resp = self.get_success_response(
-                self.organization.slug, method="post", status_code=201, **CREATE_USER_POST_DATA
+                self.organization.slug, method="post", status_code=201, **data
             )
         member = OrganizationMember.objects.get(
             organization=self.organization, email="test.user@okta.local"
@@ -212,9 +215,10 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
         member.delete()
 
         # check role is case insensitive
-        CREATE_USER_POST_DATA["sentryOrgRole"] = "mAnaGer"
+        data = post_data()
+        data["sentryOrgRole"] = "mAnaGer"
         resp = self.get_success_response(
-            self.organization.slug, method="post", status_code=201, **CREATE_USER_POST_DATA
+            self.organization.slug, method="post", status_code=201, **data
         )
         member = OrganizationMember.objects.get(
             organization=self.organization, email="test.user@okta.local"
@@ -228,9 +232,9 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
         member.delete()
 
         # Empty org role -> default
-        CREATE_USER_POST_DATA["sentryOrgRole"] = ""
+        data["sentryOrgRole"] = ""
         resp = self.get_success_response(
-            self.organization.slug, method="post", status_code=201, **CREATE_USER_POST_DATA
+            self.organization.slug, method="post", status_code=201, **data
         )
         member = OrganizationMember.objects.get(
             organization=self.organization, email="test.user@okta.local"
@@ -244,9 +248,9 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
         member.delete()
 
         # no sentry org role -> default
-        del CREATE_USER_POST_DATA["sentryOrgRole"]
+        del data["sentryOrgRole"]
         resp = self.get_success_response(
-            self.organization.slug, method="post", status_code=201, **CREATE_USER_POST_DATA
+            self.organization.slug, method="post", status_code=201, **data
         )
         member = OrganizationMember.objects.get(
             organization=self.organization, email="test.user@okta.local"
@@ -258,9 +262,10 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
 
     def test_post_users_with_role_invalid(self):
         # Non-existant role
-        CREATE_USER_POST_DATA["sentryOrgRole"] = "nonexistant"
+        data = post_data()
+        data["sentryOrgRole"] = "nonexistant"
         resp = self.get_error_response(
-            self.organization.slug, method="post", status_code=400, **CREATE_USER_POST_DATA
+            self.organization.slug, method="post", status_code=400, **data
         )
         assert resp.data == {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
@@ -268,9 +273,9 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
         }
 
         # Unallowed role
-        CREATE_USER_POST_DATA["sentryOrgRole"] = "owner"
+        data["sentryOrgRole"] = "owner"
         resp = self.get_error_response(
-            self.organization.slug, method="post", status_code=400, **CREATE_USER_POST_DATA
+            self.organization.slug, method="post", status_code=400, **data
         )
         assert resp.data == {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],


### PR DESCRIPTION
originally failing with:

```console
$ pytest tests/sentry/api/endpoints/test_scim_user_index.py::SCIMMemberIndexTests__InRegionMode::test_post_users_with_role_invalid tests/sentry/api/endpoints/test_scim_user_index.py::SCIMMemberIndexTests::test_post_users_successful
====================================================== test session starts ======================================================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: fail-slow-0.3.0, rerunfailures-11.0, sentry-0.1.11, xdist-3.0.2, cov-4.0.0, repeat-0.9.1, django-4.4.0
collected 2 items                                                                                                               

tests/sentry/api/endpoints/test_scim_user_index.py .F                                                                     [100%]

=========================================================== FAILURES ============================================================
________________________________________ SCIMMemberIndexTests.test_post_users_successful ________________________________________
tests/sentry/api/endpoints/test_scim_user_index.py:55: in test_post_users_successful
    assert response.status_code == 201, response.content
E   AssertionError: b'{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"detail":"Invalid organization role."}'
E   assert 400 == 201
E    +  where 400 = <Response status_code=400, "application/json">.status_code
----------------------------------------------------- Captured stdout call ------------------------------------------------------
19:56:28 [WARNING] django.request: Bad Request: /api/0/organizations/baz/scim/v2/Users (status_code=400 request=<WSGIRequest: POST '/api/0/organizations/baz/scim/v2/Users'>)
==================================================== short test summary info ====================================================
FAILED tests/sentry/api/endpoints/test_scim_user_index.py::SCIMMemberIndexTests::test_post_users_successful - AssertionError: b'{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"detail":"Invalid organization role."}'
================================================== 1 failed, 1 passed in 4.78s =================================================
```