### PR TITLE
fix(hc): Add missing region-mode snapshot

### DIFF
--- a/tests/sentry/api/endpoints/snapshots/ProjectFiltersTest__InRegionMode/test_get.pysnap
+++ b/tests/sentry/api/endpoints/snapshots/ProjectFiltersTest__InRegionMode/test_get.pysnap
@@ -1,0 +1,13 @@
+---
+source: tests/sentry/api/endpoints/test_project_filters.py
+---
+- active: false
+  id: browser-extensions
+- active: true
+  id: filtered-transaction
+- active: false
+  id: legacy-browsers
+- active: false
+  id: localhost
+- active: false
+  id: web-crawlers

--- a/tests/sentry/api/endpoints/test_project_filters.py
+++ b/tests/sentry/api/endpoints/test_project_filters.py
@@ -2,7 +2,7 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class ProjectFiltersTest(APITestCase):
     endpoint = "sentry-api-0-project-filters"
 


### PR DESCRIPTION
This matches the existing snapshot:
```
mkdir tests/sentry/api/endpoints/snapshots/ProjectFiltersTest__InRegionMode
cp tests/sentry/api/endpoints/snapshots/ProjectFiltersTest/test_get.pysnap \
   tests/sentry/api/endpoints/snapshots/ProjectFiltersTest__InRegionMode/test_get.pysnap
```