### PR TITLE
fix(hybridcloud) Fix typed dict usage in organization details

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -689,7 +689,7 @@ def update_tracked_data(model):
         model.__data = UNSAVED
 
 
-class DeleteConfirmationArgs(TypedDict, total=False):
+class DeleteConfirmationArgs(TypedDict):
     username: str
     ip_address: str
     deletion_datetime: datetime

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -1,6 +1,5 @@
 import logging
 from copy import copy
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 from django.db import IntegrityError, models, router, transaction
@@ -8,6 +7,7 @@ from django.db.models.query_utils import DeferredAttribute
 from django.urls import reverse
 from django.utils import timezone as django_timezone
 from rest_framework import serializers, status
+from typing_extensions import TypedDict
 
 from bitfield.types import BitHandler
 from sentry import audit_log, roles
@@ -622,13 +622,13 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                     transaction_id=schedule.guid,
                 )
 
-                delete_confirmation_args: DeleteConfirmationArgs = dict(
-                    username=user_name,
-                    ip_address=entry.ip_address,
-                    deletion_datetime=entry.datetime,
-                    countdown=ONE_DAY,
-                    organization=updated_organization,
-                )
+                delete_confirmation_args: DeleteConfirmationArgs = {
+                    "username": user_name,
+                    "ip_address": entry.ip_address,
+                    "deletion_datetime": entry.datetime,
+                    "countdown": ONE_DAY,
+                    "organization": updated_organization,
+                }
                 send_delete_confirmation(delete_confirmation_args)
                 Organization.objects.uncache_object(updated_organization.id)
 
@@ -689,8 +689,7 @@ def update_tracked_data(model):
         model.__data = UNSAVED
 
 
-@dataclass
-class DeleteConfirmationArgs:
+class DeleteConfirmationArgs(TypedDict, total=False):
     username: str
     ip_address: str
     deletion_datetime: datetime


### PR DESCRIPTION
Align a typehint with the actual implementation. DeleteConfirmationArgs is a dict and not a dataclass.
