### PR TITLE
fix(hc): Move Authenticator query out of atomic txn

### DIFF
--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -175,6 +175,8 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
                     status=status.HTTP_403_FORBIDDEN,
                 )
 
+        interfaces = Authenticator.objects.all_interfaces_for_user(user)
+
         with transaction.atomic(using=router.db_for_write(Authenticator)):
             authenticator.delete()
 
@@ -182,7 +184,6 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
             # remains are backup interfaces, then we kill them in the
             # process.
             if not interface.is_backup_interface:
-                interfaces = Authenticator.objects.all_interfaces_for_user(user)
                 backup_interfaces = [x for x in interfaces if x.is_backup_interface]
                 if len(backup_interfaces) == len(interfaces):
                     for iface in backup_interfaces:


### PR DESCRIPTION
This prevents a cross-silo query when in split DB mode, as exposed by failures in ResetOrganizationMember2faTest.

It should be okay to query for Authenticator interfaces before entering the transaction, which in the worst case risks that a concurrently added backup interface won't be cleaned up.