### PR TITLE
chore(feedback): Update codeowners for new feedback project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -292,6 +292,14 @@ yarn.lock                                                @getsentry/owners-js-de
 ## End of Replays
 
 
+## Feedback v2
+/static/app/components/feedback/   @getsentry/replay-frontend
+/static/app/utils/feedback/        @getsentry/replay-frontend
+/static/app/views/feedback/        @getsentry/replay-frontend
+/src/sentry/feedback/              @getsentry/replay-backend
+/tests/sentry/feedback/            @getsentry/replay-backend
+
+
 ## Integrations
 /src/sentry/api/endpoints/integrations/                              @getsentry/issues
 /src/sentry/api/endpoints/project_stacktrace_link.py                 @getsentry/issues

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -293,11 +293,11 @@ yarn.lock                                                @getsentry/owners-js-de
 
 
 ## Feedback v2
-/static/app/components/feedback/   @getsentry/replay-frontend
-/static/app/utils/feedback/        @getsentry/replay-frontend
-/static/app/views/feedback/        @getsentry/replay-frontend
-/src/sentry/feedback/              @getsentry/replay-backend
-/tests/sentry/feedback/            @getsentry/replay-backend
+/static/app/components/feedback/   @getsentry/feedback-frontend
+/static/app/utils/feedback/        @getsentry/feedback-frontend
+/static/app/views/feedback/        @getsentry/feedback-frontend
+/src/sentry/feedback/              @getsentry/feedback-backend
+/tests/sentry/feedback/            @getsentry/feedback-backend
 ## End of Feedback v2
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -298,6 +298,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /static/app/views/feedback/        @getsentry/replay-frontend
 /src/sentry/feedback/              @getsentry/replay-backend
 /tests/sentry/feedback/            @getsentry/replay-backend
+## End of Feedback v2
 
 
 ## Integrations


### PR DESCRIPTION
Depends on https://github.com/getsentry/security-as-code/pull/349

Relates to https://github.com/getsentry/team-replay/issues/166