### PR TITLE
feat(hybrid-cloud): Add various methods to services

### DIFF
--- a/src/sentry/services/hybrid_cloud/app/impl.py
+++ b/src/sentry/services/hybrid_cloud/app/impl.py
@@ -12,8 +12,10 @@ from sentry.models import (
     SentryAppComponent,
     SentryAppInstallation,
     SentryAppInstallationToken,
+    User,
 )
 from sentry.models.integrations.sentry_app_installation import prepare_sentry_app_components
+from sentry.sentry_apps.apps import SentryAppCreator
 from sentry.services.hybrid_cloud.app import (
     AppService,
     RpcAlertRuleActionResult,
@@ -217,3 +219,37 @@ class DatabaseBackedAppService(AppService):
             owner_id=organization_id, status=SentryAppStatus.PUBLISHED
         )
         return [serialize_sentry_app(app) for app in published_apps]
+
+    def create_internal_integration_for_channel_request(
+        self,
+        *,
+        organization_id: int,
+        integration_creator: str,
+        integration_name: str,
+        integration_scopes: List[str],
+    ) -> RpcSentryAppInstallation:
+        # if the 'integration' already exists, don't recreate it...
+        admin_user = User.objects.get(email=integration_creator)
+
+        sentry_app_query = SentryApp.objects.filter(
+            owner_id=organization_id,
+            name=integration_name,
+            creator_user=admin_user,
+            creator_label=admin_user.email
+            or admin_user.username,  # email is not required for some users (sentry apps)
+        )
+        sentry_app = sentry_app_query[0] if sentry_app_query.exists() else None
+        if sentry_app:
+            installation = SentryAppInstallation.objects.get(sentry_app=sentry_app)
+        else:
+            sentry_app: SentryApp = SentryAppCreator(
+                name=integration_name,
+                author="test",
+                organization_id=organization_id,
+                is_internal=True,
+                scopes=integration_scopes,
+                verify_install=False,
+            ).run(user=admin_user)
+            installation = SentryAppInstallation.objects.get(sentry_app=sentry_app)
+
+        return serialize_sentry_app_installation(installation=installation, app=sentry_app)

--- a/src/sentry/services/hybrid_cloud/app/impl.py
+++ b/src/sentry/services/hybrid_cloud/app/impl.py
@@ -242,7 +242,7 @@ class DatabaseBackedAppService(AppService):
         if sentry_app:
             installation = SentryAppInstallation.objects.get(sentry_app=sentry_app)
         else:
-            sentry_app: SentryApp = SentryAppCreator(
+            sentry_app = SentryAppCreator(
                 name=integration_name,
                 author="test",
                 organization_id=organization_id,

--- a/src/sentry/services/hybrid_cloud/app/model.py
+++ b/src/sentry/services/hybrid_cloud/app/model.py
@@ -79,6 +79,7 @@ class RpcSentryAppInstallation(RpcModel):
     sentry_app: RpcSentryApp = Field(default_factory=lambda: RpcSentryApp())
     date_deleted: Optional[datetime.datetime] = None
     uuid: str = ""
+    api_token: Optional[str] = None
 
 
 class RpcSentryAppComponent(RpcModel):

--- a/src/sentry/services/hybrid_cloud/app/serial.py
+++ b/src/sentry/services/hybrid_cloud/app/serial.py
@@ -54,4 +54,5 @@ def serialize_sentry_app_installation(
         sentry_app=serialize_sentry_app(app),
         date_deleted=installation.date_deleted,
         uuid=installation.uuid,
+        api_token=installation.api_token.token if installation.api_token else None,
     )

--- a/src/sentry/services/hybrid_cloud/app/service.py
+++ b/src/sentry/services/hybrid_cloud/app/service.py
@@ -128,5 +128,17 @@ class AppService(RpcService):
     ) -> List[RpcSentryApp]:
         pass
 
+    @rpc_method
+    @abc.abstractmethod
+    def create_internal_integration_for_channel_request(
+        self,
+        *,
+        organization_id: int,
+        integration_creator: str,
+        integration_name: str,
+        integration_scopes: List[str],
+    ) -> RpcSentryAppInstallation:
+        pass
+
 
 app_service = cast(AppService, AppService.create_delegation())

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -167,6 +167,14 @@ class DatabaseBackedAuthService(AuthService):
                     data={},
                 )
 
+    def get_auth_provider_with_config(
+        self, *, provider: str, config: Mapping[str, Any]
+    ) -> Optional[RpcAuthProvider]:
+        existing_provider = AuthProvider.objects.filter(provider=provider, config=config).first()
+        if existing_provider is None:
+            return None
+        return serialize_auth_provider(existing_provider)
+
     def get_org_auth_config(
         self, *, organization_ids: List[int]
     ) -> List[RpcOrganizationAuthConfig]:

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -7,9 +7,10 @@ from django.contrib.auth.models import AnonymousUser
 from django.db import router, transaction
 from django.db.models import Count, F, Q
 
-from sentry import roles
+from sentry import audit_log, roles
 from sentry.auth.access import get_permissions_for_user
 from sentry.auth.system import SystemToken
+from sentry.db.postgres.transactions import enforce_constraints
 from sentry.middleware.auth import RequestAuthenticationMiddleware
 from sentry.middleware.placeholder import placeholder_get_response
 from sentry.models import (
@@ -22,6 +23,7 @@ from sentry.models import (
     User,
     outbox_context,
 )
+from sentry.models.auditlogentry import AuditLogEntry
 from sentry.services.hybrid_cloud.auth import (
     AuthenticatedToken,
     AuthenticationContext,
@@ -129,6 +131,49 @@ class DatabaseBackedAuthService(AuthService):
             return serialize_api_key(ApiKey.objects.get(key=key))
         except ApiKey.DoesNotExist:
             return None
+
+    def enable_partner_sso(
+        self, *, organization_id: int, provider_key: str, provider_config: Mapping[str, Any]
+    ) -> None:
+        with enforce_constraints(transaction.atomic(router.db_for_write(AuthProvider))):
+            auth_provider = AuthProvider.objects.create(
+                organization_id=organization_id, provider=provider_key, config=provider_config
+            )
+
+            # TODO: Analytics requires a user id
+            # At provisioning time, no user is available so we cannot provide any user
+            # sso_enabled.send_robust(
+            #     organization=sentry_org,
+            #     provider=provider_key,
+            #     sender="EnablePartnerSSO",
+            # )
+
+            AuditLogEntry.objects.create(
+                organization_id=organization_id,
+                actor_label=f"partner_provisioning_api:{provider_key}",
+                target_object=auth_provider.id,
+                event=audit_log.get_event_id("SSO_ENABLE"),
+                data=auth_provider.get_audit_log_data(),
+            )
+
+    def create_auth_identity(
+        self, *, provider: str, config: Mapping[str, Any], user_id: int, ident: str
+    ) -> None:
+        with enforce_constraints(transaction.atomic(router.db_for_write(AuthIdentity))):
+            auth_provider = AuthProvider.objects.filter(provider=provider, config=config).first()
+            if auth_provider is None:
+                return
+            # Add Auth identity for partner's SSO if it doesn't exist
+            auth_id_filter = AuthIdentity.objects.filter(
+                auth_provider=auth_provider, user_id=user_id
+            )
+            if not auth_id_filter.exists():
+                AuthIdentity.objects.create(
+                    auth_provider=auth_provider,
+                    user_id=user_id,
+                    ident=ident,
+                    data={},
+                )
 
     def get_org_auth_config(
         self, *, organization_ids: List[int]

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -140,14 +140,6 @@ class DatabaseBackedAuthService(AuthService):
                 organization_id=organization_id, provider=provider_key, config=provider_config
             )
 
-            # TODO: Analytics requires a user id
-            # At provisioning time, no user is available so we cannot provide any user
-            # sso_enabled.send_robust(
-            #     organization=sentry_org,
-            #     provider=provider_key,
-            #     sender="EnablePartnerSSO",
-            # )
-
             AuditLogEntry.objects.create(
                 organization_id=organization_id,
                 actor_label=f"partner_provisioning_api:{provider_key}",

--- a/src/sentry/services/hybrid_cloud/auth/service.py
+++ b/src/sentry/services/hybrid_cloud/auth/service.py
@@ -124,5 +124,12 @@ class AuthService(RpcService):
     ) -> None:
         pass
 
+    @rpc_method
+    @abc.abstractmethod
+    def get_auth_provider_with_config(
+        self, *, provider: str, config: Mapping[str, Any]
+    ) -> Optional[RpcAuthProvider]:
+        pass
+
 
 auth_service: AuthService = cast(AuthService, AuthService.create_delegation())

--- a/src/sentry/services/hybrid_cloud/auth/service.py
+++ b/src/sentry/services/hybrid_cloud/auth/service.py
@@ -110,5 +110,19 @@ class AuthService(RpcService):
     def get_organization_key(self, *, key: str) -> Optional[RpcApiKey]:
         pass
 
+    @rpc_method
+    @abc.abstractmethod
+    def enable_partner_sso(
+        self, *, organization_id: int, provider_key: str, provider_config: Mapping[str, Any]
+    ) -> None:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
+    def create_auth_identity(
+        self, *, provider: str, config: Mapping[str, Any], user_id: int, ident: str
+    ) -> None:
+        pass
+
 
 auth_service: AuthService = cast(AuthService, AuthService.create_delegation())

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -137,5 +137,15 @@ class UserService(RpcService):
     def get_first_superuser(self) -> Optional[RpcUser]:
         pass
 
+    @rpc_method
+    @abstractmethod
+    def get_or_create_user_by_email(self, *, email: str) -> RpcUser:
+        pass
+
+    @rpc_method
+    @abstractmethod
+    def verify_any_email(self, *, email: str) -> bool:
+        pass
+
 
 user_service: UserService = cast(UserService, UserService.create_delegation())

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -148,7 +148,7 @@ advanced_search = BetterSignal()  # ["project"]
 advanced_search_feature_gated = BetterSignal()  # ["organization", "user"]
 save_search_created = BetterSignal()  # ["project", "user"]
 inbound_filter_toggled = BetterSignal()  # ["project"]
-sso_enabled = BetterSignal()  # ["organization", "user", "provider"]
+sso_enabled = BetterSignal()  # ["organization_id", "user_id", "provider"]
 data_scrubber_enabled = BetterSignal()  # ["organization"]
 # ["project", "rule", "user", "rule_type", "is_api_token", "duplicate_rule", "wizard_v3"]
 alert_rule_created = BetterSignal()


### PR DESCRIPTION
Adding companion methods to `auth_service`, `user_service`, and `app_service` to support the partner provisioning flow in the hybrid cloud world (split silo and split db): https://github.com/getsentry/getsentry/blob/7a7929c57f2cc5bdb6bf1e90164f96c508268714/getsentry/web/channel_provisioning/process.py

The partner provisioning flow only runs in the region silo, so we cannot create models that resides exclusively in the control silo. Examples include: `AuditLogEntry`, `AuthIdentity`, and `AuthProvider`.


Required for https://github.com/getsentry/getsentry/pull/11575.