### PR TITLE
fix(hybrid-cloud): Update create_default_project for split silo

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -160,6 +160,12 @@ class DatabaseBackedUserService(UserService):
             return None
         return serialize_rpc_user(user)
 
+    def get_first_superuser(self) -> Optional[RpcUser]:
+        user = User.objects.filter(is_superuser=True).first()
+        if user is None:
+            return None
+        return serialize_rpc_user(user)
+
     class _UserFilterQuery(
         FilterQueryDatabaseImpl[User, UserFilterArgs, RpcUser, UserSerializeType],
     ):

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -132,5 +132,10 @@ class UserService(RpcService):
     ) -> Optional[RpcUser]:
         pass
 
+    @rpc_method
+    @abstractmethod
+    def get_first_superuser(self) -> Optional[RpcUser]:
+        pass
+
 
 user_service: UserService = cast(UserService, UserService.create_delegation())


### PR DESCRIPTION
Update to get `tests/sentry/eventstream/test_eventstream.py` passing for `SENTRY_USE_SPLIT_DBS=1 SENTRY_FORCE_SILOED_TESTS=1`