### PR TITLE
feat(backup): Generate new UUIDs and secrets when needed

### DIFF
--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from functools import lru_cache
@@ -390,6 +391,93 @@ class IgnoredComparator(JSONScrubbingComparator):
         return []
 
 
+class RegexComparator(JSONScrubbingComparator, ABC):
+    """Comparator that ensures that both sides match a certain regex."""
+
+    def __init__(self, regex: re.Pattern, *fields: str):
+        self.regex = regex
+        super().__init__(*fields)
+
+    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+        findings = []
+        fields = sorted(self.fields)
+        for f in fields:
+            if left["fields"].get(f) is None and right["fields"].get(f) is None:
+                continue
+
+            lv = left["fields"][f]
+            if not self.regex.fullmatch(lv):
+                findings.append(
+                    ComparatorFinding(
+                        kind=self.get_kind(),
+                        on=on,
+                        left_pk=left["pk"],
+                        right_pk=right["pk"],
+                        reason=f"""the left value ("{lv}") of `{f}` was not matched by this regex: {self.regex.pattern}""",
+                    )
+                )
+
+            rv = right["fields"][f]
+            if not self.regex.fullmatch(rv):
+                findings.append(
+                    ComparatorFinding(
+                        kind=self.get_kind(),
+                        on=on,
+                        left_pk=left["pk"],
+                        right_pk=right["pk"],
+                        reason=f"""the right value ("{rv}") of `{f}` was not matched by this regex: {self.regex.pattern}""",
+                    )
+                )
+        return findings
+
+
+class SecretHexComparator(RegexComparator):
+    """Certain 16-byte hexadecimal API keys are regenerated during an import operation."""
+
+    def __init__(self, bytes: int, *fields: str):
+        super().__init__(re.compile(f"""^[0-9a-f]{{{bytes * 2}}}$"""), *fields)
+
+
+# Note: we could also use the `uuid` Python uuid module for this, but it is finicky and accepts some
+# weird syntactic variations that are not very common and may cause weird failures when they are
+# rejected elsewhere.
+class UUID4Comparator(RegexComparator):
+    """UUIDs must be regenerated on import (otherwise they would not be unique...). This comparator ensures that they retain their validity, but are not equivalent."""
+
+    def __init__(self, *fields: str):
+        super().__init__(
+            re.compile(
+                "^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}\\Z$", re.I
+            ),
+            *fields,
+        )
+
+    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+        # First, ensure that the two sides are not equivalent.
+        findings = []
+        fields = sorted(self.fields)
+        for f in fields:
+            if left["fields"].get(f) is None and right["fields"].get(f) is None:
+                continue
+
+            lv = left["fields"][f]
+            rv = right["fields"][f]
+            if lv == rv:
+                findings.append(
+                    ComparatorFinding(
+                        kind=self.get_kind(),
+                        on=on,
+                        left_pk=left["pk"],
+                        right_pk=right["pk"],
+                        reason=f"""the left value ({lv}) of the UUID field `{f}` was equal to the right value ({rv})""",
+                    )
+                )
+
+        # Now, make sure both UUIDs are valid.
+        findings.extend(super().compare(on, left, right))
+        return findings
+
+
 def auto_assign_datetime_equality_comparators(comps: ComparatorMap) -> None:
     """Automatically assigns the DateAddedComparator to any `DateTimeField` that is not already claimed by the `DateUpdatedComparator`."""
 
@@ -469,15 +557,21 @@ def get_default_comparators():
             "sentry.apiapplication": [HashObfuscatingComparator("client_id", "client_secret")],
             "sentry.authidentity": [HashObfuscatingComparator("ident", "token")],
             "sentry.alertrule": [DateUpdatedComparator("date_modified")],
+            "sentry.incident": [UUID4Comparator("detection_uuid")],
+            "sentry.incidentactivity": [UUID4Comparator("notification_uuid")],
             "sentry.incidenttrigger": [DateUpdatedComparator("date_modified")],
             "sentry.integration": [DateUpdatedComparator("date_updated")],
+            "sentry.monitor": [UUID4Comparator("guid")],
             "sentry.orgauthtoken": [
                 HashObfuscatingComparator("token_hashed", "token_last_characters")
             ],
             "sentry.organization": [AutoSuffixComparator("slug")],
             "sentry.organizationintegration": [DateUpdatedComparator("date_updated")],
             "sentry.organizationmember": [HashObfuscatingComparator("token")],
-            "sentry.projectkey": [HashObfuscatingComparator("public_key", "secret_key")],
+            "sentry.projectkey": [
+                HashObfuscatingComparator("public_key", "secret_key"),
+                SecretHexComparator(16, "public_key", "secret_key"),
+            ],
             "sentry.querysubscription": [DateUpdatedComparator("date_updated")],
             "sentry.relay": [HashObfuscatingComparator("relay_id", "public_key")],
             "sentry.relayusage": [HashObfuscatingComparator("relay_id", "public_key")],

--- a/src/sentry/backup/findings.py
+++ b/src/sentry/backup/findings.py
@@ -83,6 +83,20 @@ class ComparatorFindingKind(IntEnum):
     # `None`.
     IgnoredComparatorExistenceCheck = auto()
 
+    # Secret token fields did not match their regex specification.
+    SecretHexComparator = auto()
+
+    # Failed to compare a secret token field because one of the fields being compared was not
+    # present or `None`.
+    SecretHexComparatorExistenceCheck = auto()
+
+    # UUID4 fields did not match their regex specification.
+    UUID4Comparator = auto()
+
+    # Failed to compare a UUID4 field because one of the fields being compared was not present or
+    # `None`.
+    UUID4ComparatorExistenceCheck = auto()
+
 
 class ComparatorFinding(NamedTuple):
     """Store all information about a single failed matching between expected and actual output."""

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from collections import namedtuple
 from enum import Enum
+from typing import Optional
+from uuid import uuid4
 
 from django.conf import settings
 from django.core.cache import cache
@@ -9,7 +11,8 @@ from django.db import IntegrityError, models, router, transaction
 from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
-from sentry.backup.scopes import RelocationScope
+from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import (
     ArrayField,
     FlexibleForeignKey,
@@ -212,6 +215,18 @@ class Incident(Model):
     def duration(self):
         return self.current_end_date - self.date_started
 
+    def _normalize_before_relocation_import(
+        self, pk_map: PrimaryKeyMap, scope: ImportScope
+    ) -> Optional[int]:
+        old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        if old_pk is None:
+            return None
+
+        # Generate a new UUID, if one exists.
+        if self.detection_uuid:
+            self.detection_uuid = uuid4()
+        return old_pk
+
 
 @region_silo_only_model
 class PendingIncidentSnapshot(Model):
@@ -279,6 +294,18 @@ class IncidentActivity(Model):
     class Meta:
         app_label = "sentry"
         db_table = "sentry_incidentactivity"
+
+    def _normalize_before_relocation_import(
+        self, pk_map: PrimaryKeyMap, scope: ImportScope
+    ) -> Optional[int]:
+        old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        if old_pk is None:
+            return None
+
+        # Generate a new UUID, if one exists.
+        if self.notification_uuid:
+            self.notification_uuid = uuid4()
+        return old_pk
 
 
 @region_silo_only_model

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Dict, Optional
+from uuid import uuid4
 
 import jsonschema
 import pytz
@@ -14,7 +15,8 @@ from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.utils import timezone
 
-from sentry.backup.scopes import RelocationScope
+from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
     BaseManager,
@@ -356,6 +358,17 @@ class Monitor(Model):
             return alert_rule_data
 
         return None
+
+    def _normalize_before_relocation_import(
+        self, pk_map: PrimaryKeyMap, scope: ImportScope
+    ) -> Optional[int]:
+        old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        if old_pk is None:
+            return None
+
+        # Generate a new UUID.
+        self.guid = uuid4()
+        return old_pk
 
 
 @receiver(pre_save, sender=Monitor)


### PR DESCRIPTION
UUIDs should always be unique (it's right in the name!). When we import a `UUIDField`, we should generate a new UUID for it, and update all relevant references.

Similarly, we enforce `ProjectKey` API token uniqueness. When importing a colliding token, which will likely happen, we generate new API keys for that project. This may break some user flows during cross-region relocation, so there is a note to revisit this decision later.

Issue: getsentry/team-ospo#193