### PR TITLE
feat(backup): Support merge_users import flag

### DIFF
--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -263,8 +263,8 @@ class ForeignKeyComparator(JSONScrubbingComparator):
             if self.left_pk_map is None or self.right_pk_map is None:
                 raise RuntimeError("must call `set_primary_key_maps` before comparing")
 
-            left_fk_as_ordinal = self.left_pk_map.get(field_model_name, left["fields"][f])
-            right_fk_as_ordinal = self.right_pk_map.get(field_model_name, right["fields"][f])
+            left_fk_as_ordinal = self.left_pk_map.get_pk(field_model_name, left["fields"][f])
+            right_fk_as_ordinal = self.right_pk_map.get_pk(field_model_name, right["fields"][f])
             if left_fk_as_ordinal is None or right_fk_as_ordinal is None:
                 if left_fk_as_ordinal is None:
                     findings.append(

--- a/src/sentry/backup/exports.py
+++ b/src/sentry/backup/exports.py
@@ -7,6 +7,7 @@ from django.core.serializers import serialize
 from django.core.serializers.json import DjangoJSONEncoder
 
 from sentry.backup.dependencies import (
+    ImportKind,
     PrimaryKeyMap,
     dependencies,
     normalize_model_name,
@@ -134,12 +135,12 @@ def _export(
                     if fk is None:
                         # Null deps are allowed.
                         continue
-                    if pk_map.get(dependency_model_name, fk) is None:
+                    if pk_map.get_pk(dependency_model_name, fk) is None:
                         # The foreign key value exists, but not found! An upstream model must have
                         # been filtered out, so we can filter this one out as well.
                         break
                 else:
-                    pk_map.insert(model_name, item.pk, item.pk)
+                    pk_map.insert(model_name, item.pk, item.pk, ImportKind.Inserted)
                     yield item
 
     def yield_objects():

--- a/src/sentry/backup/helpers.py
+++ b/src/sentry/backup/helpers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 from functools import lru_cache
-from typing import Type
+from typing import NamedTuple, Type
 
 from django.db import models
 
@@ -61,3 +61,13 @@ class Filter:
         self.model = model
         self.field = field
         self.values = values if values is not None else set()
+
+
+class ImportFlags(NamedTuple):
+    """
+    Flags that affect how importing a relocation JSON file proceeds.
+    """
+
+    # If a username already exists, should we re-use that user, or create a new one with a randomly
+    # suffixed username (ex: "some-user" would become "some-user-ad21")
+    merge_users: bool = False

--- a/src/sentry/backup/mixins.py
+++ b/src/sentry/backup/mixins.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import Optional, Tuple
 
-from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
+from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope
 
 
@@ -17,9 +18,9 @@ class SanitizeUserImportsMixin:
     """
 
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope
-    ) -> Optional[Tuple[int, int]]:
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
+    ) -> Optional[Tuple[int, int, ImportKind]]:
         if scope != ImportScope.Global:
             return None
 
-        return super().write_relocation_import(pk_map, scope)  # type: ignore[misc]
+        return super().write_relocation_import(pk_map, scope, flags)  # type: ignore[misc]

--- a/src/sentry/backup/validate.py
+++ b/src/sentry/backup/validate.py
@@ -6,7 +6,7 @@ from difflib import unified_diff
 from typing import Dict, Tuple
 
 from sentry.backup.comparators import ComparatorMap, ForeignKeyComparator, get_default_comparators
-from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
 from sentry.backup.findings import (
     ComparatorFinding,
     ComparatorFindingKind,
@@ -139,8 +139,8 @@ def validate(
             raise RuntimeError("all InstanceIDs used for comparisons must have their ordinal set")
 
         left = left_models[id]
-        left_pk_map.insert(id.model, left_models[id]["pk"], id.ordinal)
-        right_pk_map.insert(id.model, right["pk"], id.ordinal)
+        left_pk_map.insert(id.model, left_models[id]["pk"], id.ordinal, ImportKind.Inserted)
+        right_pk_map.insert(id.model, right["pk"], id.ordinal, ImportKind.Inserted)
 
     # We only perform custom comparisons and JSON diffs on non-duplicate entries that exist in both
     # outputs.

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -12,6 +12,7 @@ from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
 from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import (
     ArrayField,
@@ -216,9 +217,9 @@ class Incident(Model):
         return self.current_end_date - self.date_started
 
     def _normalize_before_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
     ) -> Optional[int]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
         if old_pk is None:
             return None
 
@@ -296,9 +297,9 @@ class IncidentActivity(Model):
         db_table = "sentry_incidentactivity"
 
     def _normalize_before_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
     ) -> Optional[int]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
         if old_pk is None:
             return None
 

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -10,6 +10,7 @@ from django.db.models.signals import post_save
 from rest_framework import serializers
 
 from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import Model, region_silo_only_model
 from sentry.db.models.fields.foreignkey import FlexibleForeignKey
@@ -144,9 +145,9 @@ class Actor(Model):
 
     # TODO(hybrid-cloud): actor refactor. Remove this method when done.
     def _normalize_before_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
     ) -> Optional[int]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
         if old_pk is None:
             return None
 

--- a/src/sentry/models/email.py
+++ b/src/sentry/models/email.py
@@ -7,7 +7,8 @@ from django.forms import model_to_dict
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
+from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import CIEmailField, Model, control_silo_only_model, sane_repr
 
@@ -31,18 +32,18 @@ class Email(Model):
     __repr__ = sane_repr("email")
 
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope
-    ) -> Optional[Tuple[int, int]]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
+    ) -> Optional[Tuple[int, int, ImportKind]]:
+        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
         if old_pk is None:
             return None
 
         # Ensure that we never attempt to duplicate email entries, as they must always be unique.
-        (email, _) = self.__class__.objects.get_or_create(
+        (email, created) = self.__class__.objects.get_or_create(
             email=self.email, defaults=model_to_dict(self)
         )
         if email:
             self.pk = email.pk
             self.save()
 
-        return (old_pk, self.pk)
+        return (old_pk, self.pk, ImportKind.Inserted if created else ImportKind.Existing)

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Tuple
 from django.db import models
 
 from sentry import projectoptions
-from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
+from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields import PickledObjectField
@@ -162,17 +163,17 @@ class ProjectOption(Model):
     __repr__ = sane_repr("project_id", "key", "value")
 
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope
-    ) -> Optional[Tuple[int, int]]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
+    ) -> Optional[Tuple[int, int, ImportKind]]:
+        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
         if old_pk is None:
             return None
 
-        (key, _) = self.__class__.objects.get_or_create(
+        (key, created) = self.__class__.objects.get_or_create(
             project=self.project, key=self.key, defaults={"value": self.value}
         )
         if key:
             self.pk = key.pk
             self.save()
 
-        return (old_pk, self.pk)
+        return (old_pk, self.pk, ImportKind.Inserted if created else ImportKind.Existing)

--- a/src/sentry/models/options/user_option.py
+++ b/src/sentry/models/options/user_option.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Tuple
 from django.conf import settings
 from django.db import models
 
-from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
+from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, control_silo_only_model, sane_repr
 from sentry.db.models.fields import PickledObjectField
@@ -205,8 +206,8 @@ class UserOption(Model):
     __repr__ = sane_repr("user_id", "project_id", "organization_id", "key", "value")
 
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope
-    ) -> Optional[Tuple[int, int]]:
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
+    ) -> Optional[Tuple[int, int, ImportKind]]:
         # TODO(getsentry/team-ospo#190): This circular import is a bit gross. See if we can't find a
         # better place for this logic to live.
         from sentry.api.endpoints.user_details import UserOptionsSerializer
@@ -214,4 +215,4 @@ class UserOption(Model):
         serializer_options = UserOptionsSerializer(data={self.key: self.value}, partial=True)
         serializer_options.is_valid(raise_exception=True)
 
-        return super().write_relocation_import(pk_map, scope)
+        return super().write_relocation_import(pk_map, scope, flags)

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -10,7 +10,8 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from sentry.app import env
-from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
+from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
@@ -368,11 +369,11 @@ class Team(Model, SnowflakeIdMixin):
 
     # TODO(hybrid-cloud): actor refactor. Remove this method when done.
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope
-    ) -> Optional[Tuple[int, int]]:
-        written = super().write_relocation_import(pk_map, scope)
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
+    ) -> Optional[Tuple[int, int, ImportKind]]:
+        written = super().write_relocation_import(pk_map, scope, flags)
         if written is not None:
-            (_, new_pk) = written
+            (_, new_pk, _) = written
 
             # `Actor` and `Team` have a direct circular dependency between them for the time being
             # due to an ongoing refactor (that is, `Actor` foreign keys directly into `Team`, and

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -16,6 +16,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 
 from sentry.backup.dependencies import PrimaryKeyMap
+from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
@@ -360,9 +361,9 @@ class Monitor(Model):
         return None
 
     def _normalize_before_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
     ) -> Optional[int]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope)
+        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
         if old_pk is None:
             return None
 

--- a/tests/sentry/backup/test_comparators.py
+++ b/tests/sentry/backup/test_comparators.py
@@ -14,7 +14,7 @@ from sentry.backup.comparators import (
     SecretHexComparator,
     UUID4Comparator,
 )
-from sentry.backup.dependencies import PrimaryKeyMap, dependencies
+from sentry.backup.dependencies import ImportKind, PrimaryKeyMap, dependencies
 from sentry.backup.findings import ComparatorFindingKind, InstanceID
 from sentry.utils.json import JSONData
 
@@ -606,9 +606,9 @@ def test_good_foreign_key_comparator():
     )
     id = InstanceID("sentry.useremail", 0)
     left_pk_map = PrimaryKeyMap()
-    left_pk_map.insert("sentry.user", 12, 1)
+    left_pk_map.insert("sentry.user", 12, 1, ImportKind.Inserted)
     right_pk_map = PrimaryKeyMap()
-    right_pk_map.insert("sentry.user", 34, 1)
+    right_pk_map.insert("sentry.user", 34, 1, ImportKind.Inserted)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -713,9 +713,9 @@ def test_bad_foreign_key_comparator_set_primary_key_maps_not_called():
     )
     id = InstanceID("sentry.useremail", 0)
     left_pk_map = PrimaryKeyMap()
-    left_pk_map.insert("sentry.user", 12, 1)
+    left_pk_map.insert("sentry.user", 12, 1, ImportKind.Inserted)
     right_pk_map = PrimaryKeyMap()
-    right_pk_map.insert("sentry.user", 34, 1)
+    right_pk_map.insert("sentry.user", 34, 1, ImportKind.Inserted)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -752,9 +752,9 @@ def test_bad_foreign_key_comparator_unequal_mapping():
     )
     id = InstanceID("sentry.useremail", 0)
     left_pk_map = PrimaryKeyMap()
-    left_pk_map.insert("sentry.user", 12, 1)
+    left_pk_map.insert("sentry.user", 12, 1, ImportKind.Inserted)
     right_pk_map = PrimaryKeyMap()
-    right_pk_map.insert("sentry.user", 34, 2)
+    right_pk_map.insert("sentry.user", 34, 2, ImportKind.Inserted)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import pytest
 from rest_framework.serializers import ValidationError
 
-from sentry.backup.helpers import get_exportable_sentry_models
+from sentry.backup.helpers import ImportFlags, get_exportable_sentry_models
 from sentry.backup.imports import (
     import_in_global_scope,
     import_in_organization_scope,
@@ -408,38 +408,6 @@ class SignalingTests(ImportTestCase):
         assert ProjectOption.objects.filter(key="sentry:relay-rev-lastchange").exists()
         assert ProjectOption.objects.filter(key="sentry:option-epoch").exists()
 
-    def test_import_colliding_project_key(self):
-        owner = self.create_exhaustive_user("owner")
-        invited = self.create_exhaustive_user("invited")
-        member = self.create_exhaustive_user("member")
-        self.create_exhaustive_organization("some-org", owner, invited, [member])
-
-        # Take note of the `ProjectKey` that was created by the exhaustive organization - this is
-        # the one we'll be importing.
-        colliding = ProjectKey.objects.filter().first()
-        colliding_public_key = colliding.public_key
-        colliding_secret_key = colliding.secret_key
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
-
-            # After exporting and clearing the database, insert a copy of the same `ProjectKey` as
-            # the one found in the import.
-            project = self.create_project()
-            ProjectKey.objects.create(
-                project=project,
-                label="Test",
-                public_key=colliding_public_key,
-                secret_key=colliding_secret_key,
-            )
-
-            with open(tmp_path) as tmp_file:
-                import_in_organization_scope(tmp_file, printer=NOOP_PRINTER)
-
-        assert ProjectKey.objects.count() == 4
-        assert ProjectKey.objects.filter(public_key=colliding_public_key).count() == 1
-        assert ProjectKey.objects.filter(secret_key=colliding_secret_key).count() == 1
-
 
 @run_backup_tests_only_on_single_db
 class ScopingTests(ImportTestCase):
@@ -634,3 +602,191 @@ class FilterTests(ImportTestCase):
         assert UserIP.objects.count() == 0
         assert UserEmail.objects.count() == 0
         assert Email.objects.count() == 0
+
+
+@run_backup_tests_only_on_single_db
+class CollisionTests(ImportTestCase):
+    """
+    Ensure that collisions are properly handled in different flag modes.
+    """
+
+    def test_colliding_project_key(self):
+        owner = self.create_exhaustive_user("owner")
+        invited = self.create_exhaustive_user("invited")
+        member = self.create_exhaustive_user("member")
+        self.create_exhaustive_organization("some-org", owner, invited, [member])
+
+        # Take note of the `ProjectKey` that was created by the exhaustive organization - this is
+        # the one we'll be importing.
+        colliding = ProjectKey.objects.filter().first()
+        colliding_public_key = colliding.public_key
+        colliding_secret_key = colliding.secret_key
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+
+            # After exporting and clearing the database, insert a copy of the same `ProjectKey` as
+            # the one found in the import.
+            project = self.create_project()
+            ProjectKey.objects.create(
+                project=project,
+                label="Test",
+                public_key=colliding_public_key,
+                secret_key=colliding_secret_key,
+            )
+
+            with open(tmp_path) as tmp_file:
+                import_in_organization_scope(tmp_file, printer=NOOP_PRINTER)
+
+        assert ProjectKey.objects.count() == 4
+        assert ProjectKey.objects.filter(public_key=colliding_public_key).count() == 1
+        assert ProjectKey.objects.filter(secret_key=colliding_secret_key).count() == 1
+
+    def test_colliding_user_with_merging_enabled_in_user_scope(self):
+        self.create_exhaustive_user(username="owner", email="owner@example.com")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path) as tmp_file:
+                self.create_exhaustive_user(username="owner", email="owner@example.com")
+                import_in_user_scope(
+                    tmp_file,
+                    flags=ImportFlags(merge_users=True),
+                    printer=NOOP_PRINTER,
+                )
+
+        assert User.objects.count() == 1
+        assert UserIP.objects.count() == 1
+        assert UserEmail.objects.count() == 1
+        assert Authenticator.objects.count() == 1
+        assert Email.objects.count() == 1
+
+        assert User.objects.filter(username__iexact="owner").exists()
+        assert not User.objects.filter(username__iexact="owner-").exists()
+
+    def test_colliding_user_with_merging_disabled_in_user_scope(self):
+        self.create_exhaustive_user(username="owner", email="owner@example.com")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path) as tmp_file:
+                self.create_exhaustive_user(username="owner", email="owner@example.com")
+                import_in_user_scope(
+                    tmp_file,
+                    flags=ImportFlags(merge_users=False),
+                    printer=NOOP_PRINTER,
+                )
+
+        assert User.objects.count() == 2
+        assert UserIP.objects.count() == 2
+        assert UserEmail.objects.count() == 2
+        assert Authenticator.objects.count() == 1  # Only imported in global scope
+        assert Email.objects.count() == 1  # The two users still share the same email
+
+        assert User.objects.filter(username__iexact="owner").exists()
+        assert User.objects.filter(username__icontains="owner-").exists()
+
+    def test_colliding_user_with_merging_enabled_in_organization_scope(self):
+        owner = self.create_exhaustive_user(username="owner", email="owner@example.com")
+        self.create_organization("some-org", owner=owner)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path) as tmp_file:
+                owner = self.create_exhaustive_user(username="owner", email="owner@example.com")
+                self.create_organization("some-org", owner=owner)
+                import_in_organization_scope(
+                    tmp_file,
+                    flags=ImportFlags(merge_users=True),
+                    printer=NOOP_PRINTER,
+                )
+
+        assert User.objects.count() == 1
+        assert UserIP.objects.count() == 1
+        assert UserEmail.objects.count() == 1
+        assert Authenticator.objects.count() == 1  # Only imported in global scope
+        assert Email.objects.count() == 1  # Same email
+
+        assert User.objects.filter(username__iexact="owner").exists()
+        assert not User.objects.filter(username__icontains="owner-").exists()
+
+        assert Organization.objects.count() == 2
+        assert OrganizationMapping.objects.count() == 2
+        assert OrganizationMember.objects.count() == 2  # Same user in both orgs
+        assert OrganizationMemberMapping.objects.count() == 2  # Same user in both orgs
+
+        user = User.objects.get(username="owner")
+        existing = Organization.objects.get(slug="some-org")
+        imported = Organization.objects.filter(slug__icontains="some-org-").first()
+        assert (
+            OrganizationMember.objects.filter(user_id=user.id, organization=existing).count() == 1
+        )
+        assert (
+            OrganizationMember.objects.filter(user_id=user.id, organization=imported).count() == 1
+        )
+        assert (
+            OrganizationMemberMapping.objects.filter(user=user, organization_id=existing.id).count()
+            == 1
+        )
+        assert (
+            OrganizationMemberMapping.objects.filter(user=user, organization_id=imported.id).count()
+            == 1
+        )
+
+    def test_colliding_user_with_merging_disabled_in_organization_scope(self):
+        owner = self.create_exhaustive_user(username="owner", email="owner@example.com")
+        self.create_organization("some-org", owner=owner)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path) as tmp_file:
+                owner = self.create_exhaustive_user(username="owner", email="owner@example.com")
+                self.create_organization("some-org", owner=owner)
+                import_in_organization_scope(
+                    tmp_file,
+                    flags=ImportFlags(merge_users=False),
+                    printer=NOOP_PRINTER,
+                )
+
+        assert User.objects.count() == 2
+        assert UserIP.objects.count() == 2
+        assert UserEmail.objects.count() == 2
+        assert Authenticator.objects.count() == 1  # Only imported in global scope
+        assert Email.objects.count() == 1  # Same email
+
+        assert User.objects.filter(username__iexact="owner").exists()
+        assert User.objects.filter(username__icontains="owner-").exists()
+
+        assert Organization.objects.count() == 2
+        assert OrganizationMapping.objects.count() == 2
+        assert OrganizationMember.objects.count() == 2
+        assert OrganizationMemberMapping.objects.count() == 2
+
+        existing_user = User.objects.get(username="owner")
+        imported_user = User.objects.get(username__icontains="owner-")
+        existing_org = Organization.objects.get(slug="some-org")
+        imported_org = Organization.objects.filter(slug__icontains="some-org-").first()
+        assert (
+            OrganizationMember.objects.filter(
+                user_id=existing_user.id, organization=existing_org
+            ).count()
+            == 1
+        )
+        assert (
+            OrganizationMember.objects.filter(
+                user_id=imported_user.id, organization=imported_org
+            ).count()
+            == 1
+        )
+        assert (
+            OrganizationMemberMapping.objects.filter(
+                user=existing_user, organization_id=existing_org.id
+            ).count()
+            == 1
+        )
+        assert (
+            OrganizationMemberMapping.objects.filter(
+                user=imported_user, organization_id=imported_org.id
+            ).count()
+            == 1
+        )


### PR DESCRIPTION
This flag controls what we do when we encounter a `username` collision. When the flag is false (the default value), we simply create a new user with a randomized suffix on their username. When the flag is true, however, we re-use the existing user.

This is useful for region to region relocations, where we want to avoid creating a new batch of users every time an org moves between region silos.

Issue: getsentry/team-ospo#181