### PR TITLE
ref(alerts): Add rule id to dupe alert error msg

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -155,7 +155,8 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                     {
                         "name": [
                             f"This rule is an exact duplicate of '{duplicate_rule.label}' in this project and may not be created.",
-                        ]
+                        ],
+                        "ruleId": [duplicate_rule.id],
                     },
                     status=status.HTTP_400_BAD_REQUEST,
                 )

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -203,7 +203,8 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 {
                     "name": [
                         f"This rule is an exact duplicate of '{duplicate_rule.label}' in this project and may not be created.",
-                    ]
+                    ],
+                    "ruleId": [duplicate_rule.id],
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )


### PR DESCRIPTION
Add the rule's id to the duplicate alert error message so the front end can link to it. 