### PR TITLE
feat(alerts): Display a noisy alert banner for no conditions

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -57,6 +57,8 @@ type ReleasesTour = BaseTour & {project_id: string};
 
 export type TeamInsightsEventParameters = {
   'alert_builder.filter': {query: string; session_id?: string};
+  'alert_builder.noisy_warning_agreed': {};
+  'alert_builder.noisy_warning_viewed': {};
   'alert_details.viewed': {alert_id: number};
   'alert_rule_details.viewed': {alert: string; has_chartcuterie: string; rule_id: number};
   'alert_rules.viewed': {sort: string};
@@ -136,6 +138,8 @@ export type TeamInsightsEventKey = keyof TeamInsightsEventParameters;
 
 export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
   'alert_builder.filter': 'Alert Builder: Filter',
+  'alert_builder.noisy_warning_viewed': 'Alert Builder: Noisy Warning Viewed',
+  'alert_builder.noisy_warning_agreed': 'Alert Builder: Noisy Warning Agreed',
   'alert_details.viewed': 'Alert Details: Viewed',
   'alert_rule_details.viewed': 'Alert Rule Details: Viewed',
   'alert_rules.viewed': 'Alert Rules: Viewed',

--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -658,6 +658,10 @@ describe('ProjectAlertsCreate', function () {
     expect(
       screen.getByText(/Alerts without conditions can fire too frequently/)
     ).toBeInTheDocument();
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'alert_builder.noisy_warning_viewed',
+      expect.anything()
+    );
 
     await userEvent.click(screen.getByText('Save Rule'));
 
@@ -669,5 +673,9 @@ describe('ProjectAlertsCreate', function () {
     await userEvent.click(screen.getByText('Save Rule'));
 
     expect(mock).toHaveBeenCalled();
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'alert_builder.noisy_warning_agreed',
+      expect.anything()
+    );
   });
 });

--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -645,7 +645,7 @@ describe('ProjectAlertsCreate', function () {
     ).toBeInTheDocument();
   });
 
-  it('displays noisy alert checkbox for no coniditions', async function () {
+  it('displays noisy alert checkbox for no conditions + filters', async function () {
     const mock = MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/rules/',
       method: 'POST',

--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -644,4 +644,30 @@ describe('ProjectAlertsCreate', function () {
       screen.getByText('The issue changes state from archived to escalating')
     ).toBeInTheDocument();
   });
+
+  it('displays noisy alert checkbox for no coniditions', async function () {
+    const mock = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/rules/',
+      method: 'POST',
+      body: TestStubs.ProjectAlertRule(),
+    });
+
+    createWrapper({organization: {features: ['noisy-alert-warning']}});
+    await userEvent.click((await screen.findAllByLabelText('Delete Node'))[0]);
+
+    expect(
+      screen.getByText(/Alerts without conditions can fire too frequently/)
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Save Rule'));
+
+    expect(mock).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      screen.getByRole('checkbox', {name: 'Yes, I don’t mind if this alert gets noisy'})
+    );
+    await userEvent.click(screen.getByText('Save Rule'));
+
+    expect(mock).toHaveBeenCalled();
+  });
 });

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -885,7 +885,12 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
     );
   }
 
-  getTeamId = () => {};
+  getTeamId = () => {
+    const {rule} = this.state;
+    const owner = rule?.owner;
+    // ownership follows the format team:<id>, just grab the id
+    return owner && owner.split(':')[1];
+  };
 
   handleOwnerChange = ({value}: {value: string}) => {
     const ownerValue = value && `team:${value}`;

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -18,6 +18,7 @@ import {updateOnboardingTask} from 'sentry/actionCreators/onboardingTasks';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {Alert} from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
+import Checkbox from 'sentry/components/checkbox';
 import Confirm from 'sentry/components/confirm';
 import SelectControl from 'sentry/components/forms/controls/selectControl';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
@@ -167,6 +168,7 @@ type State = DeprecatedAsyncView['state'] & {
   project: Project;
   sendingNotification: boolean;
   uuid: null | string;
+  acceptedNoisyAlert?: boolean;
   duplicateTargetRule?: UnsavedIssueAlertRule | IssueAlertRule | null;
   ownership?: null | IssueOwnership;
   rule?: UnsavedIssueAlertRule | IssueAlertRule | null;
@@ -588,6 +590,12 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
       delete rule.environment;
     }
 
+    // Check conditions exist or they've accepted a noisy alert
+    if (this.displayNoConditionsWarning() && !this.state.acceptedNoisyAlert) {
+      this.setState({detailedError: {acceptedNoisyAlert: [t('Required')]}});
+      return;
+    }
+
     addLoadingMessage();
 
     try {
@@ -939,6 +947,53 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
           disabled={disabled}
         />
       </StyledField>
+    );
+  }
+
+  displayNoConditionsWarning(): boolean {
+    const {rule} = this.state;
+    return (
+      this.props.organization.features.includes('noisy-alert-warning') &&
+      !!rule &&
+      !isSavedAlertRule(rule) &&
+      rule.conditions.length === 0
+    );
+  }
+
+  renderAcknowledgeNoConditions(disabled: boolean) {
+    const {detailedError, acceptedNoisyAlert} = this.state;
+
+    return (
+      <Alert type="warning" showIcon>
+        <div>
+          {t(
+            'Alerts without conditions can fire too frequently. Are you sure you want to save this alert rule?'
+          )}
+        </div>
+        <AcknowledgeField
+          label={null}
+          help={null}
+          error={detailedError?.acceptedNoisyAlert?.[0]}
+          disabled={disabled}
+          required
+          stacked
+          flexibleControlStateSize
+          inline
+        >
+          <AcknowledgeLabel>
+            <Checkbox
+              size="md"
+              name="acceptedNoisyAlert"
+              checked={acceptedNoisyAlert}
+              onChange={() => {
+                this.setState({acceptedNoisyAlert: !acceptedNoisyAlert});
+              }}
+              disabled={disabled}
+            />
+            {t('Yes, I don’t mind if this alert gets noisy')}
+          </AcknowledgeLabel>
+        </AcknowledgeField>
+      </Alert>
     );
   }
 
@@ -1470,6 +1525,8 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
                 {this.renderRuleName(disabled)}
                 {this.renderTeamSelect(disabled)}
               </StyledFieldWrapper>
+              {this.displayNoConditionsWarning() &&
+                this.renderAcknowledgeNoConditions(disabled)}
             </ContentIndent>
           </List>
         </StyledForm>
@@ -1705,7 +1762,6 @@ const StyledFieldWrapper = styled('div')`
     grid-template-columns: 2fr 1fr;
     gap: ${space(1)};
   }
-  margin-bottom: 60px;
 `;
 
 const ContentIndent = styled('div')`
@@ -1716,4 +1772,27 @@ const ContentIndent = styled('div')`
 
 const Main = styled(Layout.Main)`
   padding: ${space(2)} ${space(4)};
+`;
+
+const AcknowledgeLabel = styled('label')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+  line-height: 2;
+  font-weight: normal;
+`;
+
+const AcknowledgeField = styled(FieldGroup)`
+  padding: 0;
+  display: flex;
+  align-items: center;
+  margin-top: ${space(1)};
+
+  & > div {
+    padding-left: 0;
+    display: flex;
+    align-items: baseline;
+    flex: unset;
+    gap: ${space(1)};
+  }
 `;

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -956,7 +956,8 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
       this.props.organization.features.includes('noisy-alert-warning') &&
       !!rule &&
       !isSavedAlertRule(rule) &&
-      rule.conditions.length === 0
+      rule.conditions.length === 0 &&
+      rule.filters.length === 0
     );
   }
 


### PR DESCRIPTION
Displays a banner when an alert rule has no conditions. They must accept via a checkbox to continue saving the alert. This check is frontend only.

![image](https://github.com/getsentry/sentry/assets/1400464/7a63efa3-f9c6-41fa-9729-10018d32b31d)


behind a flag