### PR TITLE
Limit Bundles being backfilled

### DIFF
--- a/src/sentry/debug_files/artifact_bundle_indexing.py
+++ b/src/sentry/debug_files/artifact_bundle_indexing.py
@@ -270,6 +270,8 @@ def backfill_artifact_index_updates() -> bool:
     # we will randomize the order in which we update the indexes
     random.shuffle(indexes_needing_update)
 
+    index_not_fully_updated = False
+
     # First, we are processing all the indexes that need bundles *added* to them,
     # we also process *removals* at the same time.
     for index in indexes_needing_update:
@@ -278,7 +280,10 @@ def backfill_artifact_index_updates() -> bool:
         artifact_bundles = ArtifactBundle.objects.filter(
             flatfileindexstate__flat_file_index=index,
             flatfileindexstate__indexing_state=ArtifactBundleIndexingState.NOT_INDEXED.value,
-        ).select_related("file")
+        ).select_related("file")[:BACKFILL_BATCH_SIZE]
+
+        if len(artifact_bundles) >= BACKFILL_BATCH_SIZE:
+            index_not_fully_updated = True
 
         bundles_to_add = []
         for artifact_bundle in artifact_bundles:
@@ -337,6 +342,7 @@ def backfill_artifact_index_updates() -> bool:
     return (
         len(indexes_needing_update) >= BACKFILL_BATCH_SIZE
         or len(deletion_keys) >= BACKFILL_BATCH_SIZE
+        or index_not_fully_updated
     )
 
 


### PR DESCRIPTION
This limits the number of ArtifactBundles that are being processed in a single backfilling operation.

We have seen customers uploading thousands of single-file bundles which are all scheduled to be backfilled. However loading *all* the bundles in a single query, opening them up and collecting their manifests is costly, so lets limit that to the BATCH_SIZE.

This will hopefully fix SENTRY-15G4, probably fix SENTRY-15G3, and bring SENTRY-R8Z back down to background noise level.