### PR TITLE
fix(metrics): Fix key error in cardinality limiter

### DIFF
--- a/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
+++ b/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
@@ -136,9 +136,12 @@ class TimeseriesCardinalityLimiter:
             )
 
         for prefix, hashes in request_hashes.items():
-            quota = prefix_to_quota[prefix]
+            quota = prefix_to_quota.get(prefix)
 
-            requested_quotas.append(RequestedQuota(prefix=prefix, unit_hashes=hashes, quota=quota))
+            if quota is not None:
+                requested_quotas.append(
+                    RequestedQuota(prefix=prefix, unit_hashes=hashes, quota=quota)
+                )
 
         timestamp, grants = self.backend.check_within_quotas(requested_quotas)
 


### PR DESCRIPTION
`quota` is added optionally to the lookup dict, but later code assumes that it's always there. This PR fixes this access.

Fixes SENTRY-15GV