### PR TITLE
fix(onboarding): Rust version not displayed in snippet

### DIFF
--- a/static/app/gettingStartedDocs/rust/rust.tsx
+++ b/static/app/gettingStartedDocs/rust/rust.tsx
@@ -29,7 +29,7 @@ export const steps = ({
 sentry = "${
           sourcePackageRegistries?.isLoading
             ? t('\u2026loading')
-            : sourcePackageRegistries?.data?.['sentry.rust'] ?? '0.31.5'
+            : sourcePackageRegistries?.data?.['sentry.rust'].version ?? '0.31.5'
         }"
         `,
       },

--- a/static/app/gettingStartedDocs/rust/rust.tsx
+++ b/static/app/gettingStartedDocs/rust/rust.tsx
@@ -29,7 +29,7 @@ export const steps = ({
 sentry = "${
           sourcePackageRegistries?.isLoading
             ? t('\u2026loading')
-            : sourcePackageRegistries?.data?.['sentry.rust'].version ?? '0.31.5'
+            : sourcePackageRegistries?.data?.['sentry.rust']?.version ?? '0.31.5'
         }"
         `,
       },


### PR DESCRIPTION
Fix Rust version not displayed correctly in snippet

Closes https://github.com/getsentry/sentry/issues/55769