### PR TITLE
ref(metrcs) fix apdex calculation take 2

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
@@ -36,6 +36,8 @@ class OrganizationMetricsEstimationStatsEndpoint(OrganizationEventsV2EndpointBas
 
     def get(self, request: Request, organization: Organization) -> Response:
 
+        measurement = request.GET.get("yAxis")
+
         with sentry_sdk.start_span(
             op="discover.metrics.endpoint", description="get_full_metrics"
         ) as span:
@@ -48,23 +50,29 @@ class OrganizationMetricsEstimationStatsEndpoint(OrganizationEventsV2EndpointBas
                     organization,
                     get_stats_generator(use_discover=True, remove_on_demand=False),
                 )
-                # the closest we have to the stats in discover that can also be queried in metrics
-                base_discover = self.get_event_stats_data(
-                    request,
-                    organization,
-                    get_stats_generator(use_discover=True, remove_on_demand=True),
-                )
-                # the closest we have to the stats in metrics, with no on_demand metrics
-                base_metrics = self.get_event_stats_data(
-                    request,
-                    organization,
-                    get_stats_generator(use_discover=False, remove_on_demand=True),
-                )
 
-                estimated_volume = estimate_volume(
-                    discover_stats["data"], base_discover["data"], base_metrics["data"]
-                )
-                discover_stats["data"] = estimated_volume
+                if _should_scale(measurement):
+
+                    # we scale the indexed data with the ratio between indexed counts and metrics counts
+                    # in order to get an estimate of the true volume of transactions
+
+                    # the closest we have to the stats in discover that can also be queried in metrics
+                    base_discover = self.get_event_stats_data(
+                        request,
+                        organization,
+                        get_stats_generator(use_discover=True, remove_on_demand=True),
+                    )
+                    # the closest we have to the stats in metrics, with no on_demand metrics
+                    base_metrics = self.get_event_stats_data(
+                        request,
+                        organization,
+                        get_stats_generator(use_discover=False, remove_on_demand=True),
+                    )
+
+                    estimated_volume = estimate_volume(
+                        discover_stats["data"], base_discover["data"], base_metrics["data"]
+                    )
+                    discover_stats["data"] = estimated_volume
 
             except ValidationError:
                 return Response(
@@ -85,16 +93,14 @@ def get_stats_generator(use_discover: bool, remove_on_demand: bool):
         query: str,
         params: Dict[str, str],
         rollup: int,
-        zerofill_results: bool,
-        comparison_delta: Optional[datetime],
+        zerofill_results: bool,  # not used but required by get_event_stats_data
+        comparison_delta: Optional[datetime],  # not used but required by get_event_stats_data
     ) -> SnubaTSResult:
         # use discover or metrics_performance depending on the dataset
         if use_discover:
             module: ModuleType = discover
         else:
             module = metrics_performance
-            # (RaduW) horrible hack check function definition
-            query_columns = to_metrics_columns(query_columns)
 
         if remove_on_demand:
             query = to_standard_metrics_query(query)
@@ -182,42 +188,16 @@ def _is_data_aligned(left: List[MetricVolumeRow], right: List[MetricVolumeRow]) 
     return left[0][0] == right[0][0] and left[-1][0] == right[-1][0]
 
 
-def to_metrics_columns(query_columns: Sequence[str]):
+def _should_scale(metric: str) -> bool:
     """
-    (RaduW): This is a hack to convert the columns from discover to metrics
-    specifically this was done to convert 'apdex(XXX)' to 'apdex()'
-    for metrics we need to fix the acceptable rate at tag creation time
-    (i.e. in Relay) so at query creation time we can only work with whatever was
-    collected, so apdex() does not accept a parameter
+    Decides if the metric should be scaled ( based on the ratio between indexed and metrics data) or not
 
-    If things get more complicated create a more robust parsing solution.
-
+    We can only scale counters ( percentiles and ratios cannot be scaled based on the ratio
+    between indexed and metrics data)
     """
-    ret_val = []
-    for column in query_columns:
-        if fields.is_function(column):
-            column = discover_to_metrics_function_call(column)
-        ret_val.append(column)
-    return ret_val
+    if fields.is_function(metric):
+        function, params, alias = fields.parse_function(metric)
 
-
-def discover_to_metrics_function_call(column: str):
-    """
-    (RaduW): Hacky function cleanup, converts discover function calls to
-    metric function calls
-
-    """
-    if fields.is_function(column):
-        function, params, alias = fields.parse_function(column)
-
-        if function.lower() == "apdex":
-            ret_val = "apdex()"
-            if alias:
-                ret_val += f" AS {alias}"
-            else:
-                # (another hack) maintain the original name (since get_event_stats_data gets the column
-                # names from the request so it will not find the result unless it matches the original
-                # discover name)
-                ret_val += f" AS {fields.get_function_alias(column)}"
-            return ret_val
-    return column
+        if function and function.lower() == "count":
+            return True
+    return False

--- a/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
@@ -214,5 +214,10 @@ def discover_to_metrics_function_call(column: str):
             ret_val = "apdex()"
             if alias:
                 ret_val += f" AS {alias}"
+            else:
+                # (another hack) maintain the original name (since get_event_stats_data gets the column
+                # names from the request so it will not find the result unless it matches the original
+                # discover name)
+                ret_val += f" AS {fields.get_function_alias(column)}"
             return ret_val
     return column

--- a/tests/sentry/api/endpoints/test_organization_metrics_estimation_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_estimation_stats.py
@@ -141,8 +141,10 @@ class OrganizationMetricsEstimationStatsEndpointTest(APITestCase, BaseMetricsLay
 
     def test_apdex(self):
         """
-        Tests that the volume estimation endpoint correctly looks up the data in the Db and
-        returns the correct volume.
+        Tests that the apdex calculation works as expected.
+
+        This test adds some data to the Db (both transactions and metrics) and then
+        manually calculates the expected apdex that should be returned by the endpoint.
         """
 
         # --- Create test data ---

--- a/tests/sentry/api/endpoints/test_organization_metrics_estimation_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_estimation_stats.py
@@ -203,7 +203,7 @@ class OrganizationMetricsEstimationStatsEndpointTest(APITestCase, BaseMetricsLay
         # --- calculate the expected results ---
         # calculate apdex for metrics
         metrics_apdex = []
-        for idx in range(len(satisfied_transactions)):
+        for idx in range(num_minutes):
             satisfied = satisfied_transactions[idx]
             tolerated = tolerated_transactions[idx]
             frustrated = frustrated_transactions[idx]
@@ -211,7 +211,7 @@ class OrganizationMetricsEstimationStatsEndpointTest(APITestCase, BaseMetricsLay
 
         # calculate the base transaction apdex (using all transactions)
         base_apdex = []
-        for idx in range(len(transactions_short)):
+        for idx in range(num_minutes):
             base_apdex.append(
                 (transactions_short[idx] + 0.5 * transactions_long[idx])
                 / (transactions_short[idx] + transactions_long[idx])
@@ -222,7 +222,7 @@ class OrganizationMetricsEstimationStatsEndpointTest(APITestCase, BaseMetricsLay
         full_apdex = [1, 1, 1, 1]
 
         expected_apdex_estimation = []
-        for idx in range(len(metrics_apdex)):
+        for idx in range(num_minutes):
             # we expect to get the indexed_result * base_metrics / base_indexed
             expected_apdex_estimation.append(
                 full_apdex[idx] * (metrics_apdex[idx] / base_apdex[idx])


### PR DESCRIPTION
This PR fixes the metrics estimation endpoint for apdex calculation.

The endpoint overrides the name of the function from `apdex(xxx)` to `apdex()` for the metrics call in order to 
be compatible with the metrics functions but that caused the field to be "lost" when formating the result.

Now an `as` alias was added to the  `apdex()` column to keep the old name 

Resolves: https://github.com/getsentry/sentry/issues/55903 