### PR TITLE
ref(hybrid-cloud): Removes kludge for less strict pydantic validation, updates org mapping RPC type

### DIFF
--- a/src/sentry/services/hybrid_cloud/__init__.py
+++ b/src/sentry/services/hybrid_cloud/__init__.py
@@ -13,7 +13,6 @@ from typing import (
     Generic,
     Iterable,
     Mapping,
-    Optional,
     Protocol,
     Type,
     TypeVar,
@@ -21,7 +20,6 @@ from typing import (
 )
 
 import pydantic
-import sentry_sdk
 from django.db import router, transaction
 from django.db.models import Model
 from typing_extensions import Self
@@ -41,25 +39,6 @@ IDEMPOTENCY_KEY_LENGTH = 48
 REGION_NAME_LENGTH = 48
 
 DEFAULT_DATE = datetime.datetime(2000, 1, 1)
-
-
-def report_pydantic_type_validation_error(
-    field: pydantic.fields.ModelField,
-    value: Any,
-    errors: pydantic.error_wrappers.ErrorList,
-    model_class: Optional[Type[Any]],
-) -> None:
-    with sentry_sdk.push_scope() as scope:
-        scope.set_context(
-            "pydantic_validation",
-            {
-                "field": field.name,
-                "value_type": str(type(value)),
-                "errors": str(errors),
-                "model_class": str(model_class),
-            },
-        )
-        sentry_sdk.capture_message("Pydantic type validation error")
 
 
 class ValueEqualityEnum(Enum):

--- a/src/sentry/services/hybrid_cloud/__init__.py
+++ b/src/sentry/services/hybrid_cloud/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import datetime
-import functools
 import logging
 import threading
 from enum import Enum
@@ -16,10 +15,8 @@ from typing import (
     Mapping,
     Optional,
     Protocol,
-    Tuple,
     Type,
     TypeVar,
-    Union,
     cast,
 )
 
@@ -63,51 +60,6 @@ def report_pydantic_type_validation_error(
             },
         )
         sentry_sdk.capture_message("Pydantic type validation error")
-
-
-def _hack_pydantic_type_validation() -> None:
-    """Disable strict type checking on Pydantic models.
-
-    This is a temporary measure to ensure stability while we represent RpcModel
-    objects as Pydantic models. Previously, those objects were dataclasses whose type
-    annotations were checked statically but not at runtime. There may be bugs where
-    those objects are constructed with the wrong type (typically None on a
-    non-Optional field), but otherwise everything works.
-
-    To prevent these from being hard errors, override Pydantic's validation behavior.
-    Unfortunately, there is no way (that we know of) to do this only on RpcModel and
-    its subclasses. We have to kludge it by tampering with Pydantic's global
-    ModelField class, which would affect the behavior of all types extending
-    pydantic.BaseModel in the code base. (As of this writing, there are no such
-    classes other than RpcModel, but be warned.)
-
-    See https://github.com/pydantic/pydantic/issues/897
-
-    TODO: Remove this kludge when we are reasonably confident it is no longer
-          producing any warnings
-    """
-
-    builtin_validate = pydantic.fields.ModelField.validate
-
-    def validate(
-        field: pydantic.fields.ModelField,
-        value: Any,
-        *args: Any,
-        cls: Optional[Type[Union[pydantic.BaseModel, pydantic.dataclasses.Dataclass]]] = None,
-        **kwargs: Any,
-    ) -> Tuple[Optional[Any], Optional[pydantic.error_wrappers.ErrorList]]:
-        result, errors = builtin_validate(field, value, *args, cls=cls, **kwargs)
-        if in_test_environment():
-            return result, errors
-        if errors:
-            report_pydantic_type_validation_error(field, value, errors, cls)
-        return result, None
-
-    functools.update_wrapper(validate, builtin_validate)
-    pydantic.fields.ModelField.validate = validate  # type: ignore
-
-
-_hack_pydantic_type_validation()
 
 
 class ValueEqualityEnum(Enum):

--- a/src/sentry/services/hybrid_cloud/organization_mapping/model.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/model.py
@@ -32,7 +32,4 @@ class RpcOrganizationMappingUpdate(TypedDict, total=False):
     status: OrganizationStatus
     slug: str
     region_name: str
-
-
-class RpcOrganizationMappingBillingCustomerUpdate(TypedDict):
     customer_id: Optional[str]

--- a/tests/sentry/hybrid_cloud/test_rpc.py
+++ b/tests/sentry/hybrid_cloud/test_rpc.py
@@ -9,7 +9,6 @@ from django.db import router
 from django.test import override_settings
 
 from sentry.models import OrganizationMapping
-from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.services.hybrid_cloud.auth import AuthService
 from sentry.services.hybrid_cloud.organization import (
     OrganizationService,
@@ -88,26 +87,6 @@ class RpcServiceTest(TestCase):
             "invite_status",
         }
         assert serial_arguments["organization_id"] == organization.id
-
-    @mock.patch("sentry.services.hybrid_cloud.in_test_environment")
-    @mock.patch("sentry.services.hybrid_cloud.report_pydantic_type_validation_error")
-    def test_models_tolerate_invalid_types(self, mock_report, mock_in_test_environment):
-        # Check reporting of validation errors, rather than suppressing as in most tests
-        mock_in_test_environment.return_value = False
-
-        # Create an RpcModel instance whose fields don't obey type annotations and
-        # ensure that it does not raise an exception.
-        RpcActor(
-            id="hey, this isn't an int",
-            actor_id=None,  # this one is okay
-            actor_type=None,  # should not be Optional
-        )
-
-        assert mock_report.call_count == 2
-        field_names = {c.args[0].name for c in mock_report.call_args_list}
-        model_classes = [c.args[3] for c in mock_report.call_args_list]
-        assert field_names == {"id", "actor_type"}
-        assert model_classes == [RpcActor] * 2
 
     def test_dispatch_to_local_service(self):
         user = self.create_user()


### PR DESCRIPTION
## Pydantic Validation Changes:
Since most of our RPC signatures have stabilized, it seems like an opportune time to remove our patch of pydantic validation. Any failures that come of this change are likely things we need to fix anyway.

## Org Mapping RPC Update Type:
This PR removes a type that wasn't actually in use. Some upcoming changes in getsentry finally exercised the underlying RPC serialization code and showed it wasn't working as intended. Collapsing the types again into a single `typed_dict` seems like the easiest solution for now.