### PR TITLE
feat(onboarding): Switch from manual setup to sentry-wizard for Android and iOS 

### DIFF
--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -28,7 +28,7 @@ export const steps = ({
     description: (
       <p>
         {tct(
-          'Add Sentry automatically to your app with the [wizardLink:Sentry wizard] (call this in your project directory).',
+          'Add Sentry automatically to your app with the [wizardLink:Sentry wizard] (call this inside your project directory).',
           {
             wizardLink: (
               <ExternalLink href="https://docs.sentry.io/platforms/android/#install" />

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -1,4 +1,8 @@
+import {Fragment} from 'react';
+
 import ExternalLink from 'sentry/components/links/externalLink';
+import List from 'sentry/components/list/';
+import ListItem from 'sentry/components/list/listItem';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
@@ -24,15 +28,88 @@ export const steps = ({
     description: (
       <p>
         {tct(
-          'Add the [sagpLink:Sentry Android Gradle plugin] to your [app:app] module:',
+          'Add Sentry automatically to your app with the [wizardLink:Sentry wizard].',
           {
-            sagpLink: (
-              <ExternalLink href="https://docs.sentry.io/platforms/android/configuration/gradle/" />
+            wizardLink: (
+              <ExternalLink href="https://docs.sentry.io/platforms/android/#install" />
             ),
-            app: <code />,
           }
         )}
       </p>
+    ),
+    configurations: [
+      {
+        language: 'bash',
+        code: `brew install getsentry/tools/sentry-wizard && sentry-wizard -i android`,
+      },
+      {
+        description: (
+          <Fragment>
+            {t('The Sentry wizard will automatically patch your application:')}
+            <List symbol="bullet">
+              <ListItem>
+                {tct(
+                  "Update your app's [buildGradle:build.gradle] file with the Sentry Gradle plugin and configure it.",
+                  {
+                    buildGradle: <code />,
+                  }
+                )}
+              </ListItem>
+              <ListItem>
+                {tct(
+                  'Update your [manifest: AndroidManifest.xml] with the default Sentry configuration',
+                  {
+                    manifest: <code />,
+                  }
+                )}
+              </ListItem>
+              <ListItem>
+                {tct(
+                  'Create [sentryProperties: sentry.properties] with an auth token to upload proguard mappings (this file is automatically added to [gitignore: .gitignore])',
+                  {
+                    sentryProperties: <code />,
+                    gitignore: <code />,
+                  }
+                )}
+              </ListItem>
+              <ListItem>
+                {t(
+                  "Add an example error to your app's Main Activity to verify your Sentry setup"
+                )}
+              </ListItem>
+            </List>
+            <p>
+              {tct(
+                'Alternatively, you can also [manualSetupLink:set up the SDK manually]. You can skip the steps below when using the wizard.',
+                {
+                  manualSetupLink: (
+                    <ExternalLink href="https://docs.sentry.io/platforms/android/manual-setup/" />
+                  ),
+                }
+              )}
+            </p>
+          </Fragment>
+        ),
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: (
+      <Fragment>
+        <strong>{t('Install the Sentry SDK:')}</strong>
+        <p>
+          {tct(
+            'Add the [sagpLink:Sentry Android Gradle plugin] to your [app:app] module:',
+            {
+              sagpLink: (
+                <ExternalLink href="https://docs.sentry.io/platforms/android/configuration/gradle/" />
+              ),
+              app: <code />,
+            }
+          )}
+        </p>
+      </Fragment>
     ),
     configurations: [
       {
@@ -51,28 +128,21 @@ plugins {
         `,
       },
       {
-        description: t(
-          'The plugin will automatically add the Sentry Android SDK to your app.'
+        description: (
+          <Fragment>
+            <strong>{t('Configure the Sentry SDK:')}</strong>
+            <p>
+              {tct(
+                'Configuration is done via the application [manifest: AndroidManifest.xml]. Under the hood Sentry uses a [provider:ContentProvider] to initialize the SDK based on the values provided below. This way the SDK can capture important crashes and metrics right from the app start.',
+                {
+                  manifest: <code />,
+                  provider: <code />,
+                }
+              )}
+            </p>
+            <p>{t("Here's an example config which should get you started:")}</p>
+          </Fragment>
         ),
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: (
-      <p>
-        {tct(
-          'Configuration is done via the application [manifest: AndroidManifest.xml]. Under the hood Sentry uses a [provider:ContentProvider] to initialize the SDK based on the values provided below. This way the SDK can capture important crashes and metrics right from the app start.',
-          {
-            manifest: <code />,
-            provider: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        description: t("Here's an example config which should get you started:"),
         language: 'xml',
         code: `
 <application>

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -28,7 +28,7 @@ export const steps = ({
     description: (
       <p>
         {tct(
-          'Add Sentry automatically to your app with the [wizardLink:Sentry wizard].',
+          'Add Sentry automatically to your app with the [wizardLink:Sentry wizard] (call this in your project directory).',
           {
             wizardLink: (
               <ExternalLink href="https://docs.sentry.io/platforms/android/#install" />

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -24,7 +24,7 @@ export const steps = ({
   hasProfiling,
 }: StepProps): LayoutProps['steps'] => [
   {
-    type: StepType.INSTALL,
+    title: t('Auto-Install'),
     description: (
       <p>
         {tct(
@@ -80,11 +80,12 @@ export const steps = ({
             </List>
             <p>
               {tct(
-                'Alternatively, you can also [manualSetupLink:set up the SDK manually]. You can skip the steps below when using the wizard.',
+                'Alternatively, you can also [manualSetupLink:set up the SDK manually]. [stepsBelow: You can skip the steps below when using the wizard].',
                 {
                   manualSetupLink: (
                     <ExternalLink href="https://docs.sentry.io/platforms/android/manual-setup/" />
                   ),
+                  stepsBelow: <strong />,
                 }
               )}
             </p>
@@ -94,7 +95,7 @@ export const steps = ({
     ],
   },
   {
-    type: StepType.CONFIGURE,
+    title: t('Or Manually Install and Configure'),
     description: (
       <Fragment>
         <strong>{t('Install the Sentry SDK:')}</strong>

--- a/static/app/gettingStartedDocs/apple/apple-ios.tsx
+++ b/static/app/gettingStartedDocs/apple/apple-ios.tsx
@@ -86,7 +86,7 @@ export const steps = ({
                 'Alternatively, you can also [manualSetupLink:set up the SDK manually]. You can skip the steps below when using the wizard.',
                 {
                   manualSetupLink: (
-                    <ExternalLink href="https://docs.sentry.io/platforms/android/manual-setup/" />
+                    <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/manual-setup/" />
                   ),
                 }
               )}

--- a/static/app/gettingStartedDocs/apple/apple-ios.tsx
+++ b/static/app/gettingStartedDocs/apple/apple-ios.tsx
@@ -27,7 +27,7 @@ export const steps = ({
     description: (
       <p>
         {tct(
-          'Add Sentry automatically to your app with the [wizardLink:Sentry wizard] (call this in your project directory).',
+          'Add Sentry automatically to your app with the [wizardLink:Sentry wizard] (call this inside your project directory).',
           {
             wizardLink: (
               <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/#install" />

--- a/static/app/gettingStartedDocs/apple/apple-ios.tsx
+++ b/static/app/gettingStartedDocs/apple/apple-ios.tsx
@@ -1,4 +1,8 @@
+import {Fragment} from 'react';
+
 import ExternalLink from 'sentry/components/links/externalLink';
+import List from 'sentry/components/list/';
+import ListItem from 'sentry/components/list/listItem';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
@@ -15,7 +19,6 @@ interface StepProps {
 // Configuration Start
 export const steps = ({
   dsn,
-  sourcePackageRegistries,
   hasPerformance,
   hasProfiling,
 }: StepProps): LayoutProps['steps'] => [
@@ -24,15 +27,92 @@ export const steps = ({
     description: (
       <p>
         {tct(
-          'We recommend installing the SDK with Swift Package Manager (SPM), but we also support [alternateMethods: alternate installation methods]. To integrate Sentry into your Xcode project using SPM, open your App in Xcode and open [addPackage: File > Add Packages]. Then add the SDK by entering the Git repo url in the top right search field:',
+          'Add Sentry automatically to your app with the [wizardLink:Sentry wizard].',
           {
-            alternateMethods: (
-              <ExternalLink href="https://docs.sentry.io/platforms/apple/install/" />
+            wizardLink: (
+              <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/#install" />
             ),
-            addPackage: <strong />,
           }
         )}
       </p>
+    ),
+    configurations: [
+      {
+        language: 'bash',
+        code: `brew install getsentry/tools/sentry-wizard && sentry-wizard -i ios`,
+      },
+      {
+        description: (
+          <Fragment>
+            {t('The Sentry wizard will automatically patch your application:')}
+            <List symbol="bullet">
+              <ListItem>
+                {t('Install the Sentry SDK via Swift Package Manager or Cocoapods')}
+              </ListItem>
+              <ListItem>
+                {tct(
+                  'Update your [appDelegate: AppDelegate] or SwiftUI App Initializer with the default Sentry configuration and an example error',
+                  {
+                    appDelegate: <code />,
+                  }
+                )}
+              </ListItem>
+              <ListItem>
+                {tct(
+                  'Add a new [phase: Upload Debug Symbols] phase to your [xcodebuild: xcodebuild] build script',
+                  {
+                    phase: <code />,
+                    xcodebuild: <code />,
+                  }
+                )}
+              </ListItem>
+              <ListItem>
+                {tct(
+                  'Create [sentryclirc: .sentryclirc] with an auth token to upload debug symbols (this file is automatically added to [gitignore: .gitignore])',
+                  {
+                    sentryclirc: <code />,
+                    gitignore: <code />,
+                  }
+                )}
+              </ListItem>
+              <ListItem>
+                {t(
+                  "When you're using Fastlane, it will add a Sentry lane for uploading debug symbols"
+                )}
+              </ListItem>
+            </List>
+            <p>
+              {tct(
+                'Alternatively, you can also [manualSetupLink:set up the SDK manually]. You can skip the steps below when using the wizard.',
+                {
+                  manualSetupLink: (
+                    <ExternalLink href="https://docs.sentry.io/platforms/android/manual-setup/" />
+                  ),
+                }
+              )}
+            </p>
+          </Fragment>
+        ),
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: (
+      <Fragment>
+        <strong>{t('Install the Sentry SDK:')}</strong>
+        <p>
+          {tct(
+            'We recommend installing the SDK with Swift Package Manager (SPM), but we also support [alternateMethods: alternate installation methods]. To integrate Sentry into your Xcode project using SPM, open your App in Xcode and open [addPackage: File > Add Packages]. Then add the SDK by entering the Git repo url in the top right search field:',
+            {
+              alternateMethods: (
+                <ExternalLink href="https://docs.sentry.io/platforms/apple/install/" />
+              ),
+              addPackage: <strong />,
+            }
+          )}
+        </p>
+      </Fragment>
     ),
     configurations: [
       {
@@ -43,41 +123,18 @@ https://github.com/getsentry/sentry-cocoa.git
       },
       {
         description: (
-          <p>
-            {tct(
-              'Alternatively, when your project uses a [packageSwift: Package.swift] file to manage dependencies, you can specify the target with:',
-              {
-                packageSwift: <code />,
-              }
-            )}
-          </p>
+          <Fragment>
+            <strong>{t('Configure the Sentry SDK:')}</strong>
+            <p>
+              {tct(
+                'Make sure you initialize the SDK as soon as possible in your application lifecycle e.g. in your AppDelegate [appDelegate: application:didFinishLaunchingWithOptions] method:',
+                {
+                  appDelegate: <code />,
+                }
+              )}
+            </p>
+          </Fragment>
         ),
-        language: 'swift',
-        partialLoading: sourcePackageRegistries?.isLoading,
-        code: `
-.package(url: "https://github.com/getsentry/sentry-cocoa", from: "${
-          sourcePackageRegistries?.isLoading
-            ? t('\u2026loading')
-            : sourcePackageRegistries?.data?.['sentry.cocoa']?.version ?? '8.9.3'
-        }"),
-        `,
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: (
-      <p>
-        {tct(
-          'Make sure you initialize the SDK as soon as possible in your application lifecycle e.g. in your AppDelegate [appDelegate: application:didFinishLaunchingWithOptions] method:',
-          {
-            appDelegate: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
         language: 'swift',
         code: `
 import Sentry

--- a/static/app/gettingStartedDocs/apple/apple-ios.tsx
+++ b/static/app/gettingStartedDocs/apple/apple-ios.tsx
@@ -23,7 +23,7 @@ export const steps = ({
   hasProfiling,
 }: StepProps): LayoutProps['steps'] => [
   {
-    type: StepType.INSTALL,
+    title: t('Auto-Install'),
     description: (
       <p>
         {tct(
@@ -83,11 +83,12 @@ export const steps = ({
             </List>
             <p>
               {tct(
-                'Alternatively, you can also [manualSetupLink:set up the SDK manually]. You can skip the steps below when using the wizard.',
+                'Alternatively, you can also [manualSetupLink:set up the SDK manually]. [stepsBelow: You can skip the steps below when using the wizard].',
                 {
                   manualSetupLink: (
                     <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/manual-setup/" />
                   ),
+                  stepsBelow: <strong />,
                 }
               )}
             </p>
@@ -97,7 +98,7 @@ export const steps = ({
     ],
   },
   {
-    type: StepType.CONFIGURE,
+    title: t('Or Manually Install and Configure'),
     description: (
       <Fragment>
         <strong>{t('Install the Sentry SDK:')}</strong>

--- a/static/app/gettingStartedDocs/apple/apple-ios.tsx
+++ b/static/app/gettingStartedDocs/apple/apple-ios.tsx
@@ -27,7 +27,7 @@ export const steps = ({
     description: (
       <p>
         {tct(
-          'Add Sentry automatically to your app with the [wizardLink:Sentry wizard].',
+          'Add Sentry automatically to your app with the [wizardLink:Sentry wizard] (call this in your project directory).',
           {
             wizardLink: (
               <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/#install" />


### PR DESCRIPTION
* Switches from manual setup to sentry-wizard for Android and iOS in getting started

<img width="1282" alt="image" src="https://github.com/getsentry/sentry/assets/4999776/7232c1b8-9035-4846-86e9-9b52a561e1c0">


Should be merged after https://github.com/getsentry/sentry-docs/pull/7767

Closes https://github.com/getsentry/sentry-java/issues/2877
Closes https://github.com/getsentry/sentry-cocoa/issues/3198