### PR TITLE
ref(alerts): Add snooze status to combined rules for metric alerts

### DIFF
--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -223,3 +223,29 @@ class CombinedRuleSerializerTest(BaseAlertRuleSerializerTest, APITestCase, TestC
         assert result[1]["status"] == "active"
         assert not result[1]["snooze"]
         self.assert_alert_rule_serialized(other_alert_rule, result[2])
+
+    def test_alert_snoozed(self):
+        projects = [self.project, self.create_project()]
+        alert_rule = self.create_alert_rule(projects=projects)
+        issue_rule = self.create_issue_alert_rule(
+            data={
+                "project": self.project,
+                "name": "Issue Rule Test",
+                "conditions": [],
+                "actions": [],
+                "actionMatch": "all",
+            }
+        )
+        self.snooze_rule(owner_id=self.user.id, alert_rule=alert_rule)
+        other_alert_rule = self.create_alert_rule()
+
+        result = serialize(
+            [alert_rule, issue_rule, other_alert_rule], serializer=CombinedRuleSerializer()
+        )
+
+        self.assert_alert_rule_serialized(alert_rule, result[0])
+        assert result[0]["snooze"]
+        assert result[1]["id"] == str(issue_rule.id)
+        assert result[1]["status"] == "active"
+        assert not result[1]["snooze"]
+        self.assert_alert_rule_serialized(other_alert_rule, result[2])


### PR DESCRIPTION
Redo of https://github.com/getsentry/sentry/pull/55600 with the fix from https://github.com/getsentry/sentry/pull/55796