### PR TITLE
chore: Disable eslint when saving python files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,7 +60,8 @@
   "[python]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": true,
+      "source.fixAll.eslint": false
     },
     "editor.defaultFormatter": "ms-python.black-formatter"
   },


### PR DESCRIPTION
we don't need to run eslint fix on python files