### PR TITLE
ref: don't set target_id when clearing notification settings

### DIFF
--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -130,7 +130,7 @@ class NotificationSetting(Model):
     __repr__ = sane_repr(
         "scope_str",
         "scope_identifier",
-        "target",
+        "target_id",
         "provider_str",
         "type_str",
         "value_str",

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -18,7 +18,6 @@ from django.db.models import Q, QuerySet
 
 from sentry import analytics
 from sentry.db.models.manager import BaseManager
-from sentry.models.actor import get_actor_id_for_user
 from sentry.models.notificationsettingoption import NotificationSettingOption
 from sentry.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.models.team import Team
@@ -649,7 +648,6 @@ class NotificationsManager(BaseManager["NotificationSetting"]):  # noqa: F821
                     type=type.value,
                     scope_type=NotificationScopeType.USER.value,
                     scope_identifier=user.id,
-                    target_id=get_actor_id_for_user(user),
                     user_id=user.id,
                     defaults={"value": NotificationSettingOptionValues.NEVER.value},
                 )


### PR DESCRIPTION
target_id is always None otherwise when created: https://github.com/getsentry/sentry/blob/f24b7a071bfc9ca2386d828310fdd536731ad7ac/src/sentry/notifications/manager.py#L105-L113

by setting a target_id this can result in multiple rows for a single user's notifications.  this usually isn't a problem except for get_settings does not order the results leading to undefined behaviour: https://github.com/getsentry/sentry/blob/f24b7a071bfc9ca2386d828310fdd536731ad7ac/src/sentry/notifications/manager.py#L69-L71

this can reproduce a test failure with enough tests (which cause postgres to pack the table differently resulting in a different order).  I've attached a testlist which results in this failure mode by running:

```
pytest $(cat testlist.txt)
```

[testlist.txt](https://github.com/getsentry/sentry/files/12553253/testlist.txt)

eventually failing with:

```
=========================================================== FAILURES ============================================================
_______________________________________ SlackUninstallTest.test_uninstall_slack_and_email _______________________________________
tests/sentry/integrations/slack/test_uninstall.py:97: in test_uninstall_slack_and_email
    self.assert_settings(ExternalProviders.SLACK, NotificationSettingOptionValues.NEVER)
tests/sentry/integrations/slack/test_uninstall.py:72: in assert_settings
    assert self.get_setting(self.user, provider) == value
E   assert <NotificationSettingOptionValues.ALWAYS: 20> == <NotificationSettingOptionValues.NEVER: 10>
E    +  where <NotificationSettingOptionValues.ALWAYS: 20> = <bound method SlackUninstallTest.get_setting of <tests.sentry.integrations.slack.test_uninstall.SlackUninstallTest testMethod=test_uninstall_slack_and_email>>(<User at 0x12dd28520: id=1641>, <ExternalProviders.SLACK: 110>)
E    +    where <bound method SlackUninstallTest.get_setting of <tests.sentry.integrations.slack.test_uninstall.SlackUninstallTest testMethod=test_uninstall_slack_and_email>> = <tests.sentry.integrations.slack.test_uninstall.SlackUninstallTest testMethod=test_uninstall_slack_and_email>.get_setting
E    +    and   <User at 0x12dd28520: id=1641> = <tests.sentry.integrations.slack.test_uninstall.SlackUninstallTest testMethod=test_uninstall_slack_and_email>.user
----------------------------------------------------- Captured stderr call ------------------------------------------------------
%6|1694115645.304|FAIL|rdkafka#producer-1| [thrd:127.0.0.1:9092/bootstrap]: 127.0.0.1:9092/bootstrap: Disconnected while requesting ApiVersion: might be caused by incorrect security.protocol configuration (connecting to a SSL listener?) or broker version is < 0.10 (see api.version.request) (after 0ms in state APIVERSION_QUERY, 3 identical error(s) suppressed)
==================================================== short test summary info ====================================================
FAILED tests/sentry/integrations/slack/test_uninstall.py::SlackUninstallTest::test_uninstall_slack_and_email - assert <NotificationSettingOptionValues.ALWAYS: 20> == <NotificationSettingOptionValues.NEVER: 10>
========================================== 1 failed, 699 passed in 1158.45s (0:19:18) ===========================================
```

after this change the test passes

I also adjusted the repr for `NotificationSetting` since it was broken by a69b7f0a87d053d3fabfb449fea97840d61f2658 and made this very difficult to debug


<!-- Describe your PR here. -->