### PR TITLE
ref(crons): Layout improvements to monitor form

### DIFF
--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -377,7 +377,9 @@ function MonitorForm({
               <NumberField
                 name="config.max_runtime"
                 placeholder={`Defaults to ${DEFAULT_MAX_RUNTIME} minutes`}
-                help={t('Number of a minutes before a check-in is marked timed out.')}
+                help={t(
+                  'Number of a minutes before an in-progress check-in is marked timed out.'
+                )}
                 label={t('Max Runtime')}
               />
             </PanelBody>


### PR DESCRIPTION
Following Vu's new designs:
https://www.figma.com/file/cfcxnhwGet0cHZKEZXY5kV/Crons?type=design&node-id=1346-1975&mode=design&t=MuJ0DCjxR1XkdtaW-0

Improving layout of monitor form, which will also make room for our two new threshold options

![image](https://github.com/getsentry/sentry/assets/9372512/b3771fe6-1906-4717-9dcc-7d15c6f747c1)
