### PR TITLE
fix(docs) Update Issues API docs to use slug paths

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -153,25 +153,25 @@
     "/api/0/projects/{organization_slug}/{project_slug}/issues/": {
       "$ref": "paths/events/project-issues.json"
     },
-    "/api/0/issues/{issue_id}/tags/{key}/values/": {
+    "/api/0/organizations/{organization_slug}/issues/{issue_id}/tags/{key}/values/": {
       "$ref": "paths/events/tag-values.json"
     },
-    "/api/0/issues/{issue_id}/tags/{key}/": {
+    "/api/0/organizations/{organization_slug}/issues/{issue_id}/tags/{key}/": {
       "$ref": "paths/events/tag-details.json"
     },
-    "/api/0/issues/{issue_id}/hashes/": {
+    "/api/0/organizations/{organization_slug}/issues/{issue_id}/hashes/": {
       "$ref": "paths/events/issue-hashes.json"
     },
-    "/api/0/issues/{issue_id}/events/oldest/": {
+    "/api/0/organizations/{organization_slug}/issues/{issue_id}/events/oldest/": {
       "$ref": "paths/events/oldest-event.json"
     },
-    "/api/0/issues/{issue_id}/events/latest/": {
+    "/api/0/organizations/{organization_slug}/issues/{issue_id}/events/latest/": {
       "$ref": "paths/events/latest-event.json"
     },
-    "/api/0/issues/{issue_id}/events/": {
+    "/api/0/organizations/{organization_slug}/issues/{issue_id}/events/": {
       "$ref": "paths/events/issue-events.json"
     },
-    "/api/0/issues/{issue_id}/": {
+    "/api/0/organizations/{organization_slug}/issues/{issue_id}/": {
       "$ref": "paths/events/issue-details.json"
     },
     "/api/0/organizations/{organization_slug}/releases/": {

--- a/api-docs/paths/events/issue-details.json
+++ b/api-docs/paths/events/issue-details.json
@@ -5,6 +5,15 @@
     "operationId": "Retrieve an Issue",
     "parameters": [
       {
+        "name": "organization_slug",
+        "in": "path",
+        "description": "The slug of the organization the issue belongs to.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
         "name": "issue_id",
         "in": "path",
         "description": "The ID of the issue to retrieve.",
@@ -177,6 +186,15 @@
     "operationId": "Update an Issue",
     "parameters": [
       {
+        "name": "organization_slug",
+        "in": "path",
+        "description": "The slug of the organization the issue belongs to.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
         "name": "issue_id",
         "in": "path",
         "description": "The ID of the group to retrieve.",
@@ -286,6 +304,15 @@
     "description": "Removes an individual issue.",
     "operationId": "Remove an Issue",
     "parameters": [
+      {
+        "name": "organization_slug",
+        "in": "path",
+        "description": "The slug of the organization the issue belongs to.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
       {
         "name": "issue_id",
         "in": "path",

--- a/api-docs/paths/events/issue-events.json
+++ b/api-docs/paths/events/issue-events.json
@@ -5,6 +5,15 @@
     "operationId": "List an Issue's Events",
     "parameters": [
       {
+        "name": "organization_slug",
+        "in": "path",
+        "description": "The slug of the organization the issues belong to.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
         "name": "issue_id",
         "in": "path",
         "description": "The ID of the issue to retrieve.",

--- a/api-docs/paths/events/issue-events.json
+++ b/api-docs/paths/events/issue-events.json
@@ -7,7 +7,7 @@
       {
         "name": "organization_slug",
         "in": "path",
-        "description": "The slug of the organization the issues belong to.",
+        "description": "The slug of the organization the issues belongs to.",
         "required": true,
         "schema": {
           "type": "string"

--- a/api-docs/paths/events/issue-hashes.json
+++ b/api-docs/paths/events/issue-hashes.json
@@ -5,6 +5,15 @@
     "operationId": "List an Issue's Hashes",
     "parameters": [
       {
+        "name": "organization_slug",
+        "in": "path",
+        "description": "The slug of the organization the issue belong to.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
         "name": "issue_id",
         "in": "path",
         "description": "The ID of the issue to retrieve.",

--- a/api-docs/paths/events/latest-event.json
+++ b/api-docs/paths/events/latest-event.json
@@ -5,6 +5,15 @@
     "operationId": "Retrieve the Latest Event for an Issue",
     "parameters": [
       {
+        "name": "organization_slug",
+        "in": "path",
+        "description": "The slug of the organization the issue belong to.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
         "name": "issue_id",
         "in": "path",
         "description": "The ID of the issue.",

--- a/api-docs/paths/events/oldest-event.json
+++ b/api-docs/paths/events/oldest-event.json
@@ -5,6 +5,15 @@
     "operationId": "Retrieve the Oldest Event for an Issue",
     "parameters": [
       {
+        "name": "organization_slug",
+        "in": "path",
+        "description": "The slug of the organization the issue belong to.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
         "name": "issue_id",
         "in": "path",
         "description": "The ID of the issue.",

--- a/api-docs/paths/events/project-events.json
+++ b/api-docs/paths/events/project-events.json
@@ -7,7 +7,7 @@
       {
         "name": "organization_slug",
         "in": "path",
-        "description": "The slug of the organization the groups belong to.",
+        "description": "The slug of the organization the events belong to.",
         "required": true,
         "schema": {
           "type": "string"
@@ -16,7 +16,7 @@
       {
         "name": "project_slug",
         "in": "path",
-        "description": "The slug of the project the groups belong to.",
+        "description": "The slug of the project the events belong to.",
         "required": true,
         "schema": {
           "type": "string"

--- a/api-docs/paths/events/tag-details.json
+++ b/api-docs/paths/events/tag-details.json
@@ -5,6 +5,15 @@
     "operationId": "Retrieve Tag Details",
     "parameters": [
       {
+        "name": "organization_slug",
+        "in": "path",
+        "description": "The slug of the organization the issue belongs to.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
         "name": "issue_id",
         "in": "path",
         "description": "The ID of the issue to retrieve.",

--- a/api-docs/paths/events/tag-values.json
+++ b/api-docs/paths/events/tag-values.json
@@ -5,6 +5,15 @@
     "operationId": "List a Tag's Values Related to an Issue",
     "parameters": [
       {
+        "name": "organization_slug",
+        "in": "path",
+        "description": "The slug of the organization the issue belongs to.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
         "name": "issue_id",
         "in": "path",
         "description": "The ID of the issue to retrieve.",

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -159,6 +159,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         the issue (title, last seen, first seen), some overall numbers (number
         of comments, user reports) as well as the summarized event data.
 
+        :pparam string organization_slug: The slug of the organization.
         :pparam string issue_id: the ID of the issue to retrieve.
         :auth: required
         """

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -27,7 +27,11 @@ _DEFINED_TAG_SET = {t["name"] for t in OPENAPI_TAGS}
 # path prefixes to exclude
 # this is useful if we're duplicating an endpoint for legacy purposes
 # but do not want to document it
-EXCLUSION_PATH_PREFIXES = ["/api/0/monitors/"]
+EXCLUSION_PATH_PREFIXES = [
+    "/api/0/monitors/",
+    # Issue URLS have an expression of group|issue that resolves to `var`
+    "/api/0/{var}/{issue_id}/",
+]
 
 
 def __get_explicit_endpoints() -> List[Tuple[str, str, str, Any]]:
@@ -116,7 +120,7 @@ def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, 
             # if an endpoint doesn't have any registered public methods, don't check it.
             pass
 
-    # Register explicit ednpoints
+    # Register explicit endpoints
     filtered.extend(__get_explicit_endpoints())
     return filtered
 

--- a/tests/apidocs/endpoints/events/test_group_events.py
+++ b/tests/apidocs/endpoints/events/test_group_events.py
@@ -32,7 +32,7 @@ class ProjectGroupEventBase(APIDocsTestCase):
 class ProjectGroupEventsDocs(ProjectGroupEventBase):
     def setUp(self):
         super().setUp()
-        self.url = f"/api/0/issues/{self.group_id}/events/"
+        self.url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group_id}/events/"
 
     def test_get(self):
         response = self.client.get(self.url)
@@ -45,7 +45,9 @@ class ProjectGroupEventsDocs(ProjectGroupEventBase):
 class ProjectGroupEventsLatestDocs(ProjectGroupEventBase):
     def setUp(self):
         super().setUp()
-        self.url = f"/api/0/issues/{self.group_id}/events/latest/"
+        self.url = (
+            f"/api/0/organizations/{self.organization.slug}/issues/{self.group_id}/events/latest/"
+        )
 
     def test_get(self):
         response = self.client.get(self.url)
@@ -58,7 +60,9 @@ class ProjectGroupEventsLatestDocs(ProjectGroupEventBase):
 class ProjectGroupEventsOldestDocs(ProjectGroupEventBase):
     def setUp(self):
         super().setUp()
-        self.url = f"/api/0/issues/{self.group_id}/events/oldest/"
+        self.url = (
+            f"/api/0/organizations/{self.organization.slug}/issues/{self.group_id}/events/oldest/"
+        )
 
     def test_get(self):
         response = self.client.get(self.url)

--- a/tests/apidocs/endpoints/events/test_group_hashes.py
+++ b/tests/apidocs/endpoints/events/test_group_hashes.py
@@ -10,7 +10,7 @@ class ProjectGroupHashesDocs(APIDocsTestCase):
         self.create_event("a")
         event = self.create_event("b")
 
-        self.url = f"/api/0/issues/{event.group_id}/hashes/"
+        self.url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group_id}/hashes/"
 
         self.login_as(user=self.user)
 

--- a/tests/apidocs/endpoints/events/test_group_issue_details.py
+++ b/tests/apidocs/endpoints/events/test_group_issue_details.py
@@ -26,7 +26,7 @@ class ProjectGroupIssueDetailsDocs(APIDocsTestCase):
         for timestamp in last_release.values():
             event = self.create_event("c", release="1.0a", timestamp=iso_format(timestamp))
 
-        self.url = f"/api/0/issues/{event.group.id}/"
+        self.url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/"
 
         self.login_as(user=self.user)
 

--- a/tests/apidocs/endpoints/events/test_group_tagkey_values.py
+++ b/tests/apidocs/endpoints/events/test_group_tagkey_values.py
@@ -12,7 +12,7 @@ class GroupTagKeyValuesDocs(APIDocsTestCase):
 
         self.login_as(user=self.user)
 
-        self.url = f"/api/0/issues/{event.group_id}/tags/{key}/values/"
+        self.url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group_id}/tags/{key}/values/"
 
     def test_get(self):
         response = self.client.get(self.url)


### PR DESCRIPTION
Update the issues API docs to use the organization_slug scoped URL. This URL will be easier for us to maintain in the future as we are able to route requests to this endpoint via the control silo gateway.

Refs HC-866
Refs HC-867
Refs HC-868
Refs HC-869
Refs HC-870
Refs HC-871
Refs HC-872
Refs HC-873