### PR TITLE
fix(crons): Increase check_missing timeout

### DIFF
--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -153,8 +153,8 @@ def clock_pulse(current_datetime=None):
 
 @instrumented_task(
     name="sentry.monitors.tasks.check_missing",
-    time_limit=15,
-    soft_time_limit=10,
+    time_limit=30,
+    soft_time_limit=25,
     silo_mode=SiloMode.REGION,
 )
 def check_missing(current_datetime: datetime):


### PR DESCRIPTION
Increase timeout for `check_missing` to be followed up by parallelization + timeout reduction + consumer investigation