### PR TITLE
ref(jira server): Fetch fresh projects list if issuetypes call fails

### DIFF
--- a/fixtures/integrations/jira/stub_client.py
+++ b/fixtures/integrations/jira/stub_client.py
@@ -23,7 +23,7 @@ class StubJiraApiClient(StubService):
     def get_versions(self, project_id):
         return self._get_stub_data("versions_response.json")
 
-    def get_projects_list(self, cached):
+    def get_projects_list(self, cached=True):
         return self._get_stub_data("project_list_response.json")
 
     def get_issue(self, issue_key):

--- a/fixtures/integrations/jira/stub_client.py
+++ b/fixtures/integrations/jira/stub_client.py
@@ -23,7 +23,7 @@ class StubJiraApiClient(StubService):
     def get_versions(self, project_id):
         return self._get_stub_data("versions_response.json")
 
-    def get_projects_list(self):
+    def get_projects_list(self, cached):
         return self._get_stub_data("project_list_response.json")
 
     def get_issue(self, issue_key):

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -119,7 +119,7 @@ class JiraServerClient(IntegrationProxyClient):
     def update_comment(self, issue_key, comment_id, comment):
         return self.put(self.COMMENT_URL % (issue_key, comment_id), data={"body": comment})
 
-    def get_projects_list(self, cached=False):
+    def get_projects_list(self, cached=True):
         if not cached:
             return self.get(self.PROJECT_URL)
         return self.get_cached(self.PROJECT_URL)

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -119,7 +119,9 @@ class JiraServerClient(IntegrationProxyClient):
     def update_comment(self, issue_key, comment_id, comment):
         return self.put(self.COMMENT_URL % (issue_key, comment_id), data={"body": comment})
 
-    def get_projects_list(self):
+    def get_projects_list(self, cached=False):
+        if not cached:
+            return self.get(self.PROJECT_URL)
         return self.get_cached(self.PROJECT_URL)
 
     def get_issue_types(self, project_id):

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -650,11 +650,11 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
         fkwargs["type"] = fieldtype
         return fkwargs
 
-    def get_projects(self):
+    def get_projects(self, cached=False):
         client = self.get_client()
         no_projects_error_message = "Could not fetch project list from Jira Server. Ensure that Jira Server is available and your account is still active."
         try:
-            jira_projects = client.get_projects_list()
+            jira_projects = client.get_projects_list(cached)
         except ApiError as e:
             logger.info(
                 "jira_server.get_projects.error",
@@ -705,11 +705,17 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
         project_id = params.get("project", defaults.get("project"))
         jira_projects = self.get_projects()
 
-        if not project_id or project_id not in {proj["id"] for proj in jira_projects}:
+        if not project_id:
             project_id = jira_projects[0]["id"]
 
         client = self.get_client()
-        issue_type_choices = client.get_issue_types(project_id)
+        try:
+            issue_type_choices = client.get_issue_types(project_id)
+        except ApiError:
+            # re-fetch projects list w/o caching and try again
+            jira_projects = self.get_projects(False)
+            project_id = jira_projects[0]["id"]
+            issue_type_choices = client.get_issue_types(project_id)
 
         issue_type_choices_formatted = [
             (choice["id"], choice["name"]) for choice in issue_type_choices["values"]

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -650,7 +650,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
         fkwargs["type"] = fieldtype
         return fkwargs
 
-    def get_projects(self, cached=False):
+    def get_projects(self, cached=True):
         client = self.get_client()
         no_projects_error_message = "Could not fetch project list from Jira Server. Ensure that Jira Server is available and your account is still active."
         try:


### PR DESCRIPTION
Another stab at fixing https://github.com/getsentry/sentry/pull/55729 but this time we fetch a non-cached version of the projects list if the issuecreate call fails.