### PR TITLE
Revert "instr(spans): Count how often spans don't have a group"

### DIFF
--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -80,11 +80,7 @@ def _build_snuba_span(relay_span: Mapping[str, Any]) -> MutableMapping[str, Any]
 
     if span_data:
         for relay_tag, snuba_tag in TAG_MAPPING.items():
-            tag_value = span_data.get(relay_tag)
-            if tag_value is None:
-                if snuba_tag == "group":
-                    metrics.incr("spans.missing_group")
-            else:
+            if relay_tag in span_data and (tag_value := span_data.get(relay_tag)) is not None:
                 sentry_tags[snuba_tag] = tag_value
 
     if "op" not in sentry_tags and (op := relay_span.get("op", "")) is not None:


### PR DESCRIPTION
Reverts getsentry/sentry#55759

No longer needed. We can always bring back this or a similar metric when we need it again.