### PR TITLE
fix(platform-categories): Add missing platforms

### DIFF
--- a/src/sentry/utils/platform_categories.py
+++ b/src/sentry/utils/platform_categories.py
@@ -114,6 +114,7 @@ BACKEND = [
     "python-pyramid",
     "python-tornado",
     "python-rq",
+    "python-pymongo",
     "ruby",
     "ruby-rails",
     "ruby-rack",
@@ -253,6 +254,7 @@ RELEASE_HEALTH = [
     "python-pyramid",
     "python-tornado",
     "python-rq",
+    "python-pymongo",
     "rust",
     # serverless
     # desktop


### PR DESCRIPTION
Add missing platform `python-pymongo`

Closes https://github.com/getsentry/sentry/issues/55626