### PR TITLE
fix(alerts): on-demand warning icon

### DIFF
--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -258,12 +258,15 @@ function FilterKeyValueTableRow({
       keyName={
         <KeyWrapper>
           {isOnDemandSearchKey(keyName) && (
-            <OnDemandWarningIcon
-              msg={t(
-                'We don’t routinely collect metrics from this property. As such, historical data may be limited.'
-              )}
-            />
+            <span>
+              <OnDemandWarningIcon
+                msg={t(
+                  'We don’t routinely collect metrics from this property. As such, historical data may be limited.'
+                )}
+              />
+            </span>
           )}
+
           {keyName}
         </KeyWrapper>
       }


### PR DESCRIPTION
Fixes styling of on demand warning icon in alert details sidebar
Followup of #55838 

Before: 
<img width="334" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/d8000ce4-5657-465e-999c-1e1f58db6471">

After: 
<img width="334" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/d2421344-aaed-4b4b-bf69-74198c1feb29">

