### PR TITLE
fix(metrics) Metrics estimation endpoint - remove result scaling from everything except throughput

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
@@ -38,6 +38,9 @@ class OrganizationMetricsEstimationStatsEndpoint(OrganizationEventsV2EndpointBas
 
         measurement = request.GET.get("yAxis")
 
+        if measurement is None:
+            return Response({"detail": "missing required parameter yAxis"}, status=400)
+
         with sentry_sdk.start_span(
             op="discover.metrics.endpoint", description="get_full_metrics"
         ) as span:

--- a/tests/sentry/api/endpoints/test_organization_metrics_estimation_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_estimation_stats.py
@@ -8,9 +8,8 @@ from freezegun import freeze_time
 
 from sentry.api.endpoints.organization_metrics_estimation_stats import (
     CountResult,
-    discover_to_metrics_function_call,
+    _should_scale,
     estimate_volume,
-    to_metrics_columns,
 )
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.testutils.cases import APITestCase, BaseMetricsLayerTestCase
@@ -139,6 +138,64 @@ class OrganizationMetricsEstimationStatsEndpointTest(APITestCase, BaseMetricsLay
                 )
                 assert pytest.approx(count, 0.001) == expected
 
+    def test_apdex(self):
+        """
+        Tests that the apdex calculation works as expected.
+
+        This test adds some indexed data to the Db.
+        Since apdex cannot be extrapolated only indexed data is used.
+        """
+
+        # --- Create test data ---
+
+        # the number of transactions created in the last 3 minutes
+        transactions_long = [1, 2, 3, 4]
+        transactions_short = [2, 4, 5, 6]
+
+        num_minutes = len(transactions_long)
+
+        # create the transactions and the metrics in Snuba
+        for idx in range(num_minutes):
+            # put the transactions in the middle of the minute
+            seconds_before = (num_minutes - idx - 1) * MINUTE + SECOND * 30
+            # short transactions
+            for _ in range(transactions_short[idx]):
+                self.create_transaction(self.now - seconds_before, 10)
+            # long transactions
+            for _ in range(transactions_long[idx]):
+                self.create_transaction(self.now - seconds_before, 100)
+
+        # --- call the endpoint ---
+        response = self.get_response(
+            self.organization.slug,
+            interval="1m",
+            yAxis="apdex(50)",
+            statsPeriod="4m",
+            query="transaction.duration:>0.09 event.type:transaction",
+        )
+
+        assert response.status_code == 200, response.content
+
+        def apdex(satisfactory, tolerable):
+            return (satisfactory + 0.5 * tolerable) / (satisfactory + tolerable)
+
+        # --- check the results ---
+        timestamp = self.now.timestamp()
+        data = response.data
+        start = timestamp - 4 * 60
+        assert data["start"] == start
+        assert data["end"] == timestamp
+        for idx in range(4):
+            current_timestamp = start + idx * 60
+            current = data["data"][idx]
+            assert current[0] == current_timestamp
+            actual = current[1][0]["count"]
+
+            # calculate the expected apdex, short transactions are satisfactory,
+            # long transactions are tolerable
+            expected = apdex(transactions_short[idx], transactions_long[idx])
+            assert pytest.approx(actual, 0.001) == expected
+
 
 @pytest.mark.parametrize(
     "indexed, base_indexed, metrics, expected",
@@ -166,35 +223,19 @@ def test_estimate_volume(indexed, base_indexed, metrics, expected):
 
 
 @pytest.mark.parametrize(
-    "raw, converted",
+    "metric, should_scale",
     [
-        ["apdex()", "apdex()"],
-        ["apdex(300)", "apdex()"],
-        ["percentile(75)", "percentile(75)"],
-        ["max()", "max()"],
-        ["p100()", "p100()"],
-        ["epm()", "epm()"],
-        ["last_seen()", "last_seen()"],
+        ("count()", True),
+        ("p95(transaction.duration)", False),
+        ("apdex(300)", False),
+        ("failure_rate()", False),
+        ("percentile(measurements.lcp,0.55)", False),  # Largest Contentful Paint
+        ("p95(measurements.fid)", False),  # First Input Delay
+        ("avg(measurements.cls)", False),  # First Input Delay
     ],
 )
-def test_discover_to_metrics_function_call(raw: str, converted: str):
+def test_should_scale(metric: str, should_scale: bool):
     """
-    Tests the conversion from a discover function call to a metrics function call
+    Tests the _should_scale function
     """
-    actual = discover_to_metrics_function_call(raw)
-    assert actual == converted
-
-
-@pytest.mark.parametrize(
-    "discover, expected_metrics",
-    [
-        [["apdex()"], ["apdex()"]],
-        [["epm()", "apdex(300)", "max()"], ["epm()", "apdex()", "max()"]],
-    ],
-)
-def test_to_metrics_column(discover, expected_metrics):
-    """
-    Tests that it converts discover columns to metrics columns
-    """
-    actual_metrics = to_metrics_columns(discover)
-    assert actual_metrics == expected_metrics
+    assert _should_scale(metric) == should_scale


### PR DESCRIPTION
We scale the results returned by the indexed query with the ratio between metrics and indexed transactions.
This does make sense for counters but it does not make sense for anything else ( like ratios or percentiles).

This PR removes scaling from the estimation endpoint for everything except counters ( i.e. throughput)