### PR TITLE
fix(replay): Fix rendering of console objects that include "toString" fields

### DIFF
--- a/static/app/views/replays/detail/console/format.tsx
+++ b/static/app/views/replays/detail/console/format.tsx
@@ -64,7 +64,6 @@ export default function Format({onExpand, expandPaths, args}: FormatProps) {
   const len = args.length;
   const pieces: any[] = [];
 
-  // @ts-expect-error ts does not like that this can return an integer (e.g. for `%d`)
   const str = String(f).replace(formatRegExp, function (x) {
     if (x === '%%') {
       return '%';
@@ -74,7 +73,12 @@ export default function Format({onExpand, expandPaths, args}: FormatProps) {
     }
     switch (x) {
       case '%s':
-        return String(args[i++]);
+        const val = args[i++];
+        try {
+          return String(val);
+        } catch {
+          return 'toString' in val ? val.toString : JSON.stringify(val);
+        }
       case '%d':
         return Number(args[i++]);
       case '%j':


### PR DESCRIPTION
The data that we're talking about is this:
<img width="310" alt="SCR-20230908-hyxe" src="https://github.com/getsentry/sentry/assets/187460/52c5f4e8-4090-4691-acfe-ccd342f42929">

**Before:** 
Before we'd see a red error box, not the best box, but better than taking down the whole page:
<img width="597" alt="SCR-20230908-iaax" src="https://github.com/getsentry/sentry/assets/187460/2db24e7b-01d2-4587-a817-ecbc9d848e50">

**After:**
Now we render the content we were given:
<img width="374" alt="SCR-20230908-hyxw" src="https://github.com/getsentry/sentry/assets/187460/7c7c4e6b-b49c-46a7-9155-c199a76c096b">


Fixes https://github.com/getsentry/sentry/issues/55918