### PR TITLE
ref(hc): Outbox shard lock improvements

### DIFF
--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -140,6 +140,37 @@ class ControlOutboxTest(TestCase):
             ),
         }
 
+    def test_prepare_next_from_shard_no_conflict_with_processing(self):
+        with outbox_runner():
+            org = Factories.create_organization()
+            user1 = Factories.create_user()
+            Factories.create_member(organization_id=org.id, user_id=user1.id)
+
+        with outbox_context(flush=False):
+            outbox = user1.outboxes_for_update()[0]
+            outbox.save()
+            with outbox.process_shard(None) as next_shard_row:
+                assert next_shard_row is not None
+
+                def test_with_other_connection():
+                    try:
+                        assert (
+                            ControlOutbox.prepare_next_from_shard(
+                                {
+                                    k: getattr(next_shard_row, k)
+                                    for k in ControlOutbox.sharding_columns
+                                }
+                            )
+                            is None
+                        )
+                    finally:
+                        for c in connections.all():
+                            c.close()
+
+                t = threading.Thread(target=test_with_other_connection)
+                t.start()
+                t.join()
+
     def test_control_outbox_for_webhooks(self):
         [outbox] = ControlOutbox.for_webhook_update(
             webhook_identifier=WebhookProviderIdentifier.GITHUB,


### PR DESCRIPTION
extracted from https://github.com/getsentry/sentry/pull/55747/files which had to be reverted due to the signal issue.

This is JUST the shard locking improvement part of that PR and is known to be safe, but was merely reverted due to being next to the signal processing for outbox backfill.

Basically, simply changes the shard selection logic so that if a row lock exists, it gracefully skips that selection (it's likely a web server then is flushing already).