### PR TITLE
feat(crons): Fan out `check_missing` task to each `monitor_environment`

### DIFF
--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -217,7 +217,9 @@ def check_missing_environment(monitor_environment_id: int):
             "monitor.missed-checkin", extra={"monitor_environment_id": monitor_environment_id}
         )
 
-        monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment_id)
+        monitor_environment = MonitorEnvironment.objects.select_related("monitor").get(
+            id=monitor_environment_id
+        )
         monitor = monitor_environment.monitor
         expected_time = monitor_environment.next_checkin
 

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -37,9 +37,6 @@ CHECKINS_LIMIT = 10_000
 # This key is used to store the last timestamp that the tasks were triggered.
 MONITOR_TASKS_LAST_TRIGGERED_KEY = "sentry.monitors.last_tasks_ts"
 
-# Size of the chunk to use for the check_missing_environment task
-MISSING_CHUNK_SIZE = 10
-
 
 def _get_monitor_checkin_producer() -> KafkaProducer:
     cluster_name = get_topic_definition(settings.KAFKA_INGEST_MONITORS)["cluster"]
@@ -207,7 +204,8 @@ def check_missing(current_datetime: datetime):
         )[:MONITOR_LIMIT]
     )
     metrics.gauge("sentry.monitors.tasks.check_missing.count", qs.count(), sample_rate=1.0)
-    check_missing_environment.chunks(qs.values_list("id", flat=True), MISSING_CHUNK_SIZE).delay()
+    for monitor_environment in qs:
+        check_missing_environment.delay(monitor_environment.id)
 
 
 @instrumented_task(

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -210,44 +210,40 @@ def check_missing(current_datetime: datetime):
 
 @instrumented_task(
     name="sentry.monitors.tasks.check_missing_environment",
+    max_retries=0,
 )
 def check_missing_environment(monitor_environment_id: int):
-    try:
-        logger.info(
-            "monitor.missed-checkin", extra={"monitor_environment_id": monitor_environment_id}
-        )
+    logger.info("monitor.missed-checkin", extra={"monitor_environment_id": monitor_environment_id})
 
-        monitor_environment = MonitorEnvironment.objects.select_related("monitor").get(
-            id=monitor_environment_id
-        )
-        monitor = monitor_environment.monitor
-        expected_time = monitor_environment.next_checkin
+    monitor_environment = MonitorEnvironment.objects.select_related("monitor").get(
+        id=monitor_environment_id
+    )
+    monitor = monitor_environment.monitor
+    expected_time = monitor_environment.next_checkin
 
-        # add missed checkin.
-        #
-        # XXX(epurkhiser): The date_added is backdated so that this missed
-        # check-in correctly reflects the time of when the checkin SHOULD
-        # have happened. It is the same as the expected_time.
-        MonitorCheckIn.objects.create(
-            project_id=monitor_environment.monitor.project_id,
-            monitor=monitor_environment.monitor,
-            monitor_environment=monitor_environment,
-            status=CheckInStatus.MISSED,
-            date_added=expected_time,
-            expected_time=expected_time,
-            monitor_config=monitor.get_validated_config(),
-        )
-        mark_failed(
-            monitor_environment,
-            reason=MonitorFailure.MISSED_CHECKIN,
-            occurrence_context={
-                "expected_time": expected_time.strftime(SUBTITLE_DATETIME_FORMAT)
-                if expected_time
-                else expected_time
-            },
-        )
-    except Exception:
-        logger.exception("Exception in check_monitors - mark missed", exc_info=True)
+    # add missed checkin.
+    #
+    # XXX(epurkhiser): The date_added is backdated so that this missed
+    # check-in correctly reflects the time of when the checkin SHOULD
+    # have happened. It is the same as the expected_time.
+    MonitorCheckIn.objects.create(
+        project_id=monitor_environment.monitor.project_id,
+        monitor=monitor_environment.monitor,
+        monitor_environment=monitor_environment,
+        status=CheckInStatus.MISSED,
+        date_added=expected_time,
+        expected_time=expected_time,
+        monitor_config=monitor.get_validated_config(),
+    )
+    mark_failed(
+        monitor_environment,
+        reason=MonitorFailure.MISSED_CHECKIN,
+        occurrence_context={
+            "expected_time": expected_time.strftime(SUBTITLE_DATETIME_FORMAT)
+            if expected_time
+            else expected_time
+        },
+    )
 
 
 @instrumented_task(

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -205,18 +205,19 @@ def check_missing(current_datetime: datetime):
     )
     metrics.gauge("sentry.monitors.tasks.check_missing.count", qs.count(), sample_rate=1.0)
     for monitor_environment in qs:
-        check_missing_environment.delay(monitor_environment)
+        check_missing_environment.delay(monitor_environment.id)
 
 
 @instrumented_task(
     name="sentry.monitors.tasks.check_missing_environment",
 )
-def check_missing_environment(monitor_environment: MonitorEnvironment):
+def check_missing_environment(monitor_environment_id: int):
     try:
         logger.info(
-            "monitor.missed-checkin", extra={"monitor_environment_id": monitor_environment.id}
+            "monitor.missed-checkin", extra={"monitor_environment_id": monitor_environment_id}
         )
 
+        monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment_id)
         monitor = monitor_environment.monitor
         expected_time = monitor_environment.next_checkin
 

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -205,39 +205,46 @@ def check_missing(current_datetime: datetime):
     )
     metrics.gauge("sentry.monitors.tasks.check_missing.count", qs.count(), sample_rate=1.0)
     for monitor_environment in qs:
-        try:
-            logger.info(
-                "monitor.missed-checkin", extra={"monitor_environment_id": monitor_environment.id}
-            )
+        check_missing_environment.delay(monitor_environment)
 
-            monitor = monitor_environment.monitor
-            expected_time = monitor_environment.next_checkin
 
-            # add missed checkin.
-            #
-            # XXX(epurkhiser): The date_added is backdated so that this missed
-            # check-in correctly reflects the time of when the checkin SHOULD
-            # have happened. It is the same as the expected_time.
-            MonitorCheckIn.objects.create(
-                project_id=monitor_environment.monitor.project_id,
-                monitor=monitor_environment.monitor,
-                monitor_environment=monitor_environment,
-                status=CheckInStatus.MISSED,
-                date_added=expected_time,
-                expected_time=expected_time,
-                monitor_config=monitor.get_validated_config(),
-            )
-            mark_failed(
-                monitor_environment,
-                reason=MonitorFailure.MISSED_CHECKIN,
-                occurrence_context={
-                    "expected_time": expected_time.strftime(SUBTITLE_DATETIME_FORMAT)
-                    if expected_time
-                    else expected_time
-                },
-            )
-        except Exception:
-            logger.exception("Exception in check_monitors - mark missed", exc_info=True)
+@instrumented_task(
+    name="sentry.monitors.tasks.check_missing_environment",
+)
+def check_missing_environment(monitor_environment: MonitorEnvironment):
+    try:
+        logger.info(
+            "monitor.missed-checkin", extra={"monitor_environment_id": monitor_environment.id}
+        )
+
+        monitor = monitor_environment.monitor
+        expected_time = monitor_environment.next_checkin
+
+        # add missed checkin.
+        #
+        # XXX(epurkhiser): The date_added is backdated so that this missed
+        # check-in correctly reflects the time of when the checkin SHOULD
+        # have happened. It is the same as the expected_time.
+        MonitorCheckIn.objects.create(
+            project_id=monitor_environment.monitor.project_id,
+            monitor=monitor_environment.monitor,
+            monitor_environment=monitor_environment,
+            status=CheckInStatus.MISSED,
+            date_added=expected_time,
+            expected_time=expected_time,
+            monitor_config=monitor.get_validated_config(),
+        )
+        mark_failed(
+            monitor_environment,
+            reason=MonitorFailure.MISSED_CHECKIN,
+            occurrence_context={
+                "expected_time": expected_time.strftime(SUBTITLE_DATETIME_FORMAT)
+                if expected_time
+                else expected_time
+            },
+        )
+    except Exception:
+        logger.exception("Exception in check_monitors - mark missed", exc_info=True)
 
 
 @instrumented_task(

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -81,10 +81,10 @@ class MonitorTaskCheckMissingTest(TestCase):
         check_missing(task_run_ts)
 
         # assert that task is called for the specific environment
-        assert check_missing_environment_mock.chunks.call_count == 1
-        assert set(check_missing_environment_mock.chunks.call_args[0][0]) == {
+        assert check_missing_environment_mock.delay.call_count == 1
+        assert check_missing_environment_mock.delay.mock_calls[0] == mock.call(
             monitor_environment.id
-        }
+        )
 
         check_missing_environment(monitor_environment.id)
 
@@ -144,8 +144,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         check_missing(task_run_ts)
 
         # assert that task is not called for the specific environment
-        assert check_missing_environment_mock.chunks.call_count == 1
-        assert set(check_missing_environment_mock.chunks.call_args[0][0]) == set()
+        assert check_missing_environment_mock.delay.call_count == 0
 
         assert not MonitorEnvironment.objects.filter(
             id=monitor_environment.id, status=MonitorStatus.MISSED_CHECKIN
@@ -158,10 +157,10 @@ class MonitorTaskCheckMissingTest(TestCase):
         check_missing(task_run_ts + timedelta(minutes=4))
 
         # assert that task is called for the specific environment
-        assert check_missing_environment_mock.chunks.call_count == 2
-        assert set(check_missing_environment_mock.chunks.call_args[0][0]) == {
+        assert check_missing_environment_mock.delay.call_count == 1
+        assert check_missing_environment_mock.delay.mock_calls[0] == mock.call(
             monitor_environment.id
-        }
+        )
 
         check_missing_environment(monitor_environment.id)
 
@@ -210,7 +209,7 @@ class MonitorTaskCheckMissingTest(TestCase):
             config={"schedule": "* * * * *"},
             status=state,
         )
-        # Expected checkin was a full minute ago, if this monitor wasn't in the
+        # Exepcted checkin was a full minute ago, if this monitor wasn't in the
         # `state` the monitor would usually end up marked as timed out
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
@@ -336,14 +335,10 @@ class MonitorTaskCheckMissingTest(TestCase):
         check_missing(task_run_ts)
 
         # assert that task is called for the specific environments
-        assert check_missing_environment_mock.chunks.call_count == 1
-        assert set(check_missing_environment_mock.chunks.call_args[0][0]) == {
-            successful_monitor_environment.id,
-            failing_monitor_environment.id,
-        }
+        assert check_missing_environment_mock.delay.call_count == 2
 
-        for monitor_environment_id in check_missing_environment_mock.chunks.call_args[0][0]:
-            check_missing_environment(monitor_environment_id)
+        for monitor_environment in [failing_monitor_environment, successful_monitor_environment]:
+            check_missing_environment(monitor_environment.id)
 
         # Logged the exception
         assert logger.exception.call_count == 1


### PR DESCRIPTION
Currently this task has a time-limit of 15s, this can be very sensitive to database issues where things "slow down" and the task hits it's time-limit.

This task currently works by finding all monitors that are past their expected check-in time and updates and marks the monitor as having missed a check-in. We can improve performance here by fanning out tasks for each monitor that it needs to mark as missed.

![image](https://github.com/getsentry/sentry/assets/1421724/7c890f77-4d86-4a5d-b5a5-642bf72ed9cb)

Currently we average around ~250 missed monitors per minute. This number will only grow linearly as the product usage grows. **This would be an extra 250 tasks to process each minute**.