### PR TITLE
chore(hybrid-cloud): Add view decorators to integration routes

### DIFF
--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -12,6 +12,7 @@ from sentry.models import Commit, CommitAuthor, Integration, Organization, Repos
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils import json
+from sentry.web.frontend.base import region_silo_view
 
 logger = logging.getLogger("sentry.webhooks")
 
@@ -101,6 +102,7 @@ class PushEventWebhook(Webhook):
                     pass
 
 
+@region_silo_view
 class BitbucketServerWebhookEndpoint(View):
     _handlers = {"repo:refs_changed": PushEventWebhook}
 

--- a/src/sentry/integrations/discord/views/link_identity.py
+++ b/src/sentry/integrations/discord/views/link_identity.py
@@ -14,7 +14,7 @@ from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
 from sentry.web.decorators import transaction_start
-from sentry.web.frontend.base import BaseView
+from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
 
@@ -27,6 +27,7 @@ def build_linking_url(integration: RpcIntegration, discord_id: str) -> str:
     return absolute_uri(reverse(endpoint, kwargs={"signed_params": sign(**kwargs)}))
 
 
+@control_silo_view
 class DiscordLinkIdentityView(BaseView):
     """
     Django view for linking user to Discord account.

--- a/src/sentry/integrations/discord/views/unlink_identity.py
+++ b/src/sentry/integrations/discord/views/unlink_identity.py
@@ -15,7 +15,7 @@ from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
 from sentry.web.decorators import transaction_start
-from sentry.web.frontend.base import BaseView
+from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
 from ..utils import logger
@@ -30,6 +30,7 @@ def build_unlinking_url(integration: RpcIntegration, discord_id: str) -> str:
     return absolute_uri(reverse(endpoint, kwargs={"signed_params": sign(**kwargs)}))
 
 
+@control_silo_view
 class DiscordUnlinkIdentityView(BaseView):
     """
     Django view for unlinking user from Discord account.

--- a/src/sentry/integrations/jira/views/extension_configuration.py
+++ b/src/sentry/integrations/jira/views/extension_configuration.py
@@ -1,5 +1,6 @@
 from sentry.utils import json
 from sentry.utils.signing import unsign
+from sentry.web.frontend.base import control_silo_view
 from sentry.web.frontend.integration_extension_configuration import (
     IntegrationExtensionConfigurationView,
 )
@@ -8,6 +9,7 @@ from sentry.web.frontend.integration_extension_configuration import (
 INSTALL_EXPIRATION_TIME = 60 * 60 * 24
 
 
+@control_silo_view
 class JiraExtensionConfigurationView(IntegrationExtensionConfigurationView):
     """
     Handle the UI for adding the Jira integration to a Sentry org.

--- a/src/sentry/integrations/jira/views/sentry_installation.py
+++ b/src/sentry/integrations/jira/views/sentry_installation.py
@@ -7,10 +7,12 @@ from sentry.utils import json
 from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign
+from sentry.web.frontend.base import control_silo_view
 
 from . import UNABLE_TO_VERIFY_INSTALLATION, JiraSentryUIBaseView
 
 
+@control_silo_view
 class JiraSentryInstallationView(JiraSentryUIBaseView):
     """
     Handles requests (from the Sentry integration in Jira) for HTML to display when

--- a/src/sentry/integrations/jira/views/sentry_issue_details.py
+++ b/src/sentry/integrations/jira/views/sentry_issue_details.py
@@ -17,6 +17,7 @@ from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
 from sentry.utils.sdk import configure_scope
+from sentry.web.frontend.base import region_silo_view
 
 from ..utils import handle_jira_api_error, set_badge
 from . import UNABLE_TO_VERIFY_INSTALLATION, JiraSentryUIBaseView
@@ -84,6 +85,7 @@ def build_context(group: Group) -> Mapping[str, Any]:
     }
 
 
+@region_silo_view
 class JiraSentryIssueDetailsView(JiraSentryUIBaseView):
     """
     Handles requests (from the Sentry integration in Jira) for HTML to display when you

--- a/src/sentry/integrations/msteams/link_identity.py
+++ b/src/sentry/integrations/msteams/link_identity.py
@@ -11,7 +11,7 @@ from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
 from sentry.web.decorators import transaction_start
-from sentry.web.frontend.base import BaseView
+from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
 from .card_builder.identity import build_linked_card
@@ -32,6 +32,7 @@ def build_linking_url(integration, organization, teams_user_id, team_id, tenant_
     )
 
 
+@control_silo_view
 class MsTeamsLinkIdentityView(BaseView):
     @transaction_start("MsTeamsLinkIdentityView")
     @method_decorator(never_cache)

--- a/src/sentry/integrations/msteams/unlink_identity.py
+++ b/src/sentry/integrations/msteams/unlink_identity.py
@@ -9,7 +9,7 @@ from sentry.models import Identity
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
 from sentry.web.decorators import transaction_start
-from sentry.web.frontend.base import BaseView
+from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
 from .card_builder.identity import build_unlinked_card
@@ -30,6 +30,7 @@ def build_unlinking_url(conversation_id, service_url, teams_user_id):
     )
 
 
+@control_silo_view
 class MsTeamsUnlinkIdentityView(BaseView):
     @transaction_start("MsTeamsUnlinkIdentityView")
     @method_decorator(never_cache)

--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -11,7 +11,7 @@ from sentry.notifications.notifications.integration_nudge import IntegrationNudg
 from sentry.types.integrations import ExternalProviderEnum, ExternalProviders
 from sentry.utils.signing import unsign
 from sentry.web.decorators import transaction_start
-from sentry.web.frontend.base import BaseView
+from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
 from ..utils import send_slack_response
@@ -35,6 +35,7 @@ def build_linking_url(
     )
 
 
+@control_silo_view
 class SlackLinkIdentityView(BaseView):
     """
     Django view for linking user to slack account. Creates an entry on Identity table.

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -18,7 +18,7 @@ from sentry.services.hybrid_cloud.notifications import notifications_service
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.signing import unsign
 from sentry.web.decorators import transaction_start
-from sentry.web.frontend.base import BaseView
+from sentry.web.frontend.base import BaseView, region_silo_view
 from sentry.web.helpers import render_to_response
 
 from ..utils import is_valid_role, logger
@@ -62,6 +62,7 @@ class SelectTeamForm(forms.Form):
         self.fields["team"].widget.choices = self.fields["team"].choices
 
 
+@region_silo_view
 class SlackLinkTeamView(BaseView):
     """
     Django view for linking team to slack channel. Creates an entry on ExternalActor table.

--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -9,7 +9,7 @@ from sentry.models import Identity
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.signing import unsign
 from sentry.web.decorators import transaction_start
-from sentry.web.frontend.base import BaseView
+from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
 from ..utils import logger, send_slack_response
@@ -31,6 +31,7 @@ def build_unlinking_url(
     )
 
 
+@control_silo_view
 class SlackUnlinkIdentityView(BaseView):
     """
     Django view for unlinking user from slack account. Deletes from Identity table.

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -11,7 +11,7 @@ from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils.signing import unsign
 from sentry.web.decorators import transaction_start
-from sentry.web.frontend.base import BaseView
+from sentry.web.frontend.base import BaseView, region_silo_view
 from sentry.web.helpers import render_to_response
 
 from . import build_linking_url as base_build_linking_url
@@ -37,6 +37,7 @@ def build_team_unlinking_url(
     )
 
 
+@region_silo_view
 class SlackUnlinkTeamView(BaseView):
     """
     Django view for unlinking team from slack channel. Deletes from ExternalActor table.

--- a/src/sentry/web/frontend/msteams_extension_configuration.py
+++ b/src/sentry/web/frontend/msteams_extension_configuration.py
@@ -1,4 +1,5 @@
 from sentry.utils.signing import unsign
+from sentry.web.frontend.base import control_silo_view
 
 from .integration_extension_configuration import IntegrationExtensionConfigurationView
 
@@ -6,6 +7,7 @@ from .integration_extension_configuration import IntegrationExtensionConfigurati
 INSTALL_EXPIRATION_TIME = 60 * 60 * 24
 
 
+@control_silo_view
 class MsTeamsExtensionConfigurationView(IntegrationExtensionConfigurationView):
     provider = "msteams"
     external_provider_key = "msteams"

--- a/src/sentry/web/frontend/vsts_extension_configuration.py
+++ b/src/sentry/web/frontend/vsts_extension_configuration.py
@@ -1,6 +1,9 @@
+from sentry.web.frontend.base import control_silo_view
+
 from .integration_extension_configuration import IntegrationExtensionConfigurationView
 
 
+@control_silo_view
 class VstsExtensionConfigurationView(IntegrationExtensionConfigurationView):
     provider = "vsts"
     external_provider_key = "vsts-extension"


### PR DESCRIPTION
Just adding the decorators to give an idea of what models can be accessed when making changes. Prior to this, the designation only lived in the parser (where no one would check)