### PR TITLE
feat(hybrid-cloud): Enable split db in tests by default

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -89,10 +89,6 @@ jobs:
           # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
           fetch-depth: '2'
 
-      - name: Update environment for split databases
-        run: |
-          echo "SENTRY_USE_SPLIT_DBS=1" >> "$GITHUB_ENV"
-
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
@@ -133,11 +129,6 @@ jobs:
           # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
           fetch-depth: '2'
 
-      - name: Update environment for split databases
-        id: silo_env
-        run: |
-          echo "SENTRY_USE_SPLIT_DBS=1" >> "$GITHUB_ENV"
-
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
@@ -168,10 +159,6 @@ jobs:
         pg-version: ['14']
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
-
-      - name: Update environment for split databases
-        run: |
-          echo "SENTRY_USE_SPLIT_DBS=1" >> "$GITHUB_ENV"
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
@@ -259,10 +246,6 @@ jobs:
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
-      - name: Update environment for split databases
-        run: |
-          echo "SENTRY_USE_SPLIT_DBS=1" >> "$GITHUB_ENV"
-
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
@@ -285,10 +268,6 @@ jobs:
           # Avoid codecov error message related to SHA resolution:
           # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
           fetch-depth: '2'
-
-      - name: Update environment for split databases
-        run: |
-          echo "SENTRY_USE_SPLIT_DBS=1" >> "$GITHUB_ENV"
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
@@ -338,10 +317,6 @@ jobs:
           # Avoid codecov error message related to SHA resolution:
           # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
           fetch-depth: '2'
-
-      - name: Update environment for split databases
-        run: |
-          echo "SENTRY_USE_SPLIT_DBS=1" >> "$GITHUB_ENV"
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3575,9 +3575,10 @@ SENTRY_ISSUE_PLATFORM_FUTURES_MAX_LIMIT = 10000
 
 SENTRY_GROUP_ATTRIBUTES_FUTURES_MAX_LIMIT = 10000
 
+
 # USE_SPLIT_DBS is leveraged in tests as we validate db splits further.
 # Split databases are also required for the USE_SILOS devserver flow.
-if USE_SILOS or env("SENTRY_USE_SPLIT_DBS", default=False):
+if USE_SILOS:
     # Add connections for the region & control silo databases.
     DATABASES["control"] = DATABASES["default"].copy()
     DATABASES["control"]["NAME"] = "control"

--- a/src/sentry/testutils/hybrid_cloud.py
+++ b/src/sentry/testutils/hybrid_cloud.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import functools
-import os
 import threading
 from typing import Any, Callable, Iterator, List, Set, Type, TypedDict
 
@@ -247,4 +246,5 @@ def simulate_on_commit(request: Any):
 
 
 def use_split_dbs() -> bool:
-    return bool(os.environ.get("SENTRY_USE_SPLIT_DBS"))
+    # TODO: refactor out use_split_dbs() in any and all tests once split database is permanently set in stone.
+    return True

--- a/src/sentry/testutils/pytest/selenium.py
+++ b/src/sentry/testutils/pytest/selenium.py
@@ -434,6 +434,7 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+
     if hasattr(config, "workerinput"):
         return  # xdist worker
 

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -28,6 +28,18 @@ TEST_ROOT = os.path.normpath(
 TEST_REDIS_DB = 9
 
 
+def configure_split_db(_settings):
+    # Add connections for the region & control silo databases.
+    _settings.DATABASES["control"] = _settings.DATABASES["default"].copy()
+    _settings.DATABASES["control"]["NAME"] = "control"
+
+    # Use the region database in the default connection as region
+    # silo database is the 'default' elsewhere in application logic.
+    _settings.DATABASES["default"]["NAME"] = "region"
+
+    _settings.DATABASE_ROUTERS = ("sentry.db.router.SiloRouter",)
+
+
 def pytest_configure(config):
     import warnings
 
@@ -81,6 +93,8 @@ def pytest_configure(config):
             # an actual migration.
         else:
             raise RuntimeError("oops, wrong database: %r" % test_db)
+
+    configure_split_db(settings)
 
     # Ensure we can test secure ssl settings
     settings.SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -29,6 +29,8 @@ TEST_REDIS_DB = 9
 
 
 def configure_split_db(_settings):
+    if "control" in _settings.DATABASES:
+        return
     # Add connections for the region & control silo databases.
     _settings.DATABASES["control"] = _settings.DATABASES["default"].copy()
     _settings.DATABASES["control"]["NAME"] = "control"

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -3,6 +3,9 @@ import subprocess
 import sys
 import time
 
+from django.conf import settings
+
+from sentry.testutils.pytest.sentry import configure_split_db
 from sentry.utils import json
 
 
@@ -69,3 +72,5 @@ def pytest_configure(config):
         raise Exception(
             "Unable to run `yarn` -- make sure your development environment is setup correctly: https://docs.sentry.io/development/contribute/environment/#macos---nodejs"
         )
+
+    configure_split_db(settings)

--- a/tests/relay_integration/lang/javascript/test_example.py
+++ b/tests/relay_integration/lang/javascript/test_example.py
@@ -28,7 +28,6 @@ def load_fixture(name):
 
 
 @pytest.mark.django_db(transaction=True)
-@region_silo_test(stable=True)
 class TestExample(RelayStoreHelper):
     @pytest.fixture(autouse=True)
     def initialize(
@@ -44,6 +43,7 @@ class TestExample(RelayStoreHelper):
 
     @requires_symbolicator
     @pytest.mark.symbolicator
+    @region_silo_test(stable=True)
     def test_sourcemap_expansion(self):
         release = Release.objects.create(
             organization_id=self.project.organization_id, version="abc"

--- a/tests/relay_integration/lang/javascript/test_example.py
+++ b/tests/relay_integration/lang/javascript/test_example.py
@@ -27,7 +27,6 @@ def load_fixture(name):
         return f.read()
 
 
-@pytest.mark.django_db(transaction=True)
 @django_db_all(transaction=True)
 class TestExample(RelayStoreHelper):
     @pytest.fixture(autouse=True)

--- a/tests/relay_integration/lang/javascript/test_example.py
+++ b/tests/relay_integration/lang/javascript/test_example.py
@@ -6,6 +6,7 @@ from sentry.models import File, Release, ReleaseFile
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.relay import RelayStoreHelper
+from sentry.testutils.skips import requires_symbolicator
 
 # IMPORTANT:
 #
@@ -15,7 +16,6 @@ from sentry.testutils.relay import RelayStoreHelper
 # If you are using a local instance of Symbolicator, you need to either change `system.url-prefix`
 # to `system.internal-url-prefix` inside `initialize` method below, or add `127.0.0.1 host.docker.internal`
 # entry to your `/etc/hosts`
-from sentry.testutils.skips import requires_symbolicator
 
 
 def get_fixture_path(name):

--- a/tests/relay_integration/lang/javascript/test_example.py
+++ b/tests/relay_integration/lang/javascript/test_example.py
@@ -4,6 +4,7 @@ import pytest
 
 from sentry.models import File, Release, ReleaseFile
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.relay import RelayStoreHelper
 
 # IMPORTANT:
@@ -14,7 +15,6 @@ from sentry.testutils.relay import RelayStoreHelper
 # If you are using a local instance of Symbolicator, you need to either change `system.url-prefix`
 # to `system.internal-url-prefix` inside `initialize` method below, or add `127.0.0.1 host.docker.internal`
 # entry to your `/etc/hosts`
-from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_symbolicator
 
 
@@ -28,6 +28,7 @@ def load_fixture(name):
 
 
 @pytest.mark.django_db(transaction=True)
+@django_db_all(transaction=True)
 class TestExample(RelayStoreHelper):
     @pytest.fixture(autouse=True)
     def initialize(
@@ -43,7 +44,6 @@ class TestExample(RelayStoreHelper):
 
     @requires_symbolicator
     @pytest.mark.symbolicator
-    @region_silo_test(stable=True)
     def test_sourcemap_expansion(self):
         release = Release.objects.create(
             organization_id=self.project.organization_id, version="abc"

--- a/tests/relay_integration/lang/javascript/test_example.py
+++ b/tests/relay_integration/lang/javascript/test_example.py
@@ -5,7 +5,6 @@ import pytest
 from sentry.models import File, Release, ReleaseFile
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_symbolicator
 
 # IMPORTANT:
 #
@@ -15,6 +14,8 @@ from sentry.testutils.skips import requires_symbolicator
 # If you are using a local instance of Symbolicator, you need to either change `system.url-prefix`
 # to `system.internal-url-prefix` inside `initialize` method below, or add `127.0.0.1 host.docker.internal`
 # entry to your `/etc/hosts`
+from sentry.testutils.silo import region_silo_test
+from sentry.testutils.skips import requires_symbolicator
 
 
 def get_fixture_path(name):
@@ -27,6 +28,7 @@ def load_fixture(name):
 
 
 @pytest.mark.django_db(transaction=True)
+@region_silo_test(stable=True)
 class TestExample(RelayStoreHelper):
     @pytest.fixture(autouse=True)
     def initialize(

--- a/tests/sentry/db/test_transactions.py
+++ b/tests/sentry/db/test_transactions.py
@@ -5,7 +5,6 @@ import pytest
 from django.db import IntegrityError, router, transaction
 from django.test import override_settings
 
-from sentry.conf.server import env
 from sentry.db.postgres.transactions import (
     django_test_transaction_water_mark,
     in_test_assert_no_transaction,
@@ -42,14 +41,9 @@ class CaseMixin:
                 User.objects.create(username="user2")
                 User.objects.create(username="user3")
 
-        if env("SENTRY_USE_SPLIT_DBS", 0):
-            assert [(s["transaction"]) for s in queries] == [None, "default", "default", "control"]
-        else:
-            assert [(s["transaction"]) for s in queries] == [None, "default", "default", "default"]
+        assert [(s["transaction"]) for s in queries] == [None, "default", "default", "control"]
 
     def test_bad_transaction_boundaries(self):
-        if not env("SENTRY_USE_SPLIT_DBS", 0):
-            return
 
         Factories.create_organization()
         Factories.create_user()

--- a/tests/sentry/silo/test_silo_aware_transaction_patch.py
+++ b/tests/sentry/silo/test_silo_aware_transaction_patch.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from django.db import router
 from django.test import override_settings
@@ -14,10 +12,6 @@ from sentry.silo.patches.silo_aware_transaction_patch import (
 from sentry.testutils.cases import TestCase
 
 
-def is_running_in_split_db_mode() -> bool:
-    return bool(os.environ.get("SENTRY_USE_SPLIT_DBS"))
-
-
 class TestSiloAwareTransactionPatchInSingleDbMode(TestCase):
     def test_correctly_accepts_using_for_atomic(self):
         transaction_in_test = siloed_atomic(using="foobar")
@@ -29,31 +23,26 @@ class TestSiloAwareTransactionPatchInSingleDbMode(TestCase):
 
 
 class TestSiloAwareTransactionPatchInSplitDbMode(TestCase):
-    @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
     def test_fails_if_silo_mismatch_with_using_in_region_silo(self):
         with override_settings(SILO_MODE=SiloMode.REGION), pytest.raises(
             MismatchedSiloTransactionError
         ):
             siloed_atomic(using=router.db_for_write(OrganizationMapping))
 
-    @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
     def test_fails_if_silo_mismatch_with_using_in_control_silo(self):
         with override_settings(SILO_MODE=SiloMode.CONTROL), pytest.raises(
             MismatchedSiloTransactionError
         ):
             siloed_atomic(using=router.db_for_write(Organization))
 
-    @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
     def test_fails_if_no_using_provided(self):
         with pytest.raises(TransactionMissingDBException):
             siloed_atomic()
 
-    @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
     def test_accepts_control_silo_routing_in_control_silo(self):
         with override_settings(SILO_MODE=SiloMode.CONTROL):
             siloed_atomic(using=router.db_for_write(OrganizationMapping))
 
-    @pytest.mark.skipif(not is_running_in_split_db_mode(), reason="only runs in split db mode")
     def test_accepts_control_silo_routing_in_region_silo(self):
         with override_settings(SILO_MODE=SiloMode.REGION):
             siloed_atomic(using=router.db_for_write(Organization))


### PR DESCRIPTION
Enable split db in tests by default. I've also removed any and all references to `SENTRY_USE_SPLIT_DBS`.