### PR TITLE
chore(hc): Add RPC response body size to metrics

### DIFF
--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -577,6 +577,14 @@ class _RemoteSiloCall:
             else service.deserialize_rpc_response(self.method_name, return_value)
         )
 
+    def _metrics_tags(self, **additional_tags: str | int) -> Mapping[str, str | int | None]:
+        return dict(
+            region=self.region.name if self.region else None,
+            service=self.service_name,
+            method=self.method_name,
+            **additional_tags,
+        )
+
     def _send_to_remote_silo(self, use_test_client: bool) -> Any:
         request_body = {
             "meta": {},  # reserved for future use
@@ -595,21 +603,23 @@ class _RemoteSiloCall:
             else:
                 response = self._fire_request(headers, data)
             metrics.incr(
-                "hybrid_cloud.dispatch_rpc.response_code", tags={"status": response.status_code}
+                "hybrid_cloud.dispatch_rpc.response_code",
+                tags=self._metrics_tags(status=response.status_code),
             )
 
             if response.status_code == 200:
                 response_json = response.json()
-                metrics.gauge("hybrid_cloud.dispatch_rpc.response_size", len(response_json))
+                metrics.gauge(
+                    "hybrid_cloud.dispatch_rpc.response_size",
+                    len(response_json),
+                    tags=self._metrics_tags(),
+                )
                 return response_json
             self._raise_from_response_status_error(response)
 
     @contextmanager
     def _open_request_context(self):
-        timer = metrics.timer(
-            "hybrid_cloud.dispatch_rpc.duration",
-            tags={"service": self.service_name, "method": self.method_name},
-        )
+        timer = metrics.timer("hybrid_cloud.dispatch_rpc.duration", tags=self._metrics_tags())
         span = sentry_sdk.start_span(
             op="hybrid_cloud.dispatch_rpc",
             description=f"rpc to {self.service_name}.{self.method_name}",

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -599,7 +599,9 @@ class _RemoteSiloCall:
             )
 
             if response.status_code == 200:
-                return response.json()
+                response_json = response.json()
+                metrics.gauge("hybrid_cloud.dispatch_rpc.response_size", len(response_json))
+                return response_json
             self._raise_from_response_status_error(response)
 
     @contextmanager

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -608,13 +608,12 @@ class _RemoteSiloCall:
             )
 
             if response.status_code == 200:
-                response_json = response.json()
                 metrics.gauge(
                     "hybrid_cloud.dispatch_rpc.response_size",
-                    len(response_json),
+                    len(response.content),
                     tags=self._metrics_tags(),
                 )
-                return response_json
+                return response.json()
             self._raise_from_response_status_error(response)
 
     @contextmanager


### PR DESCRIPTION
Include basic RPC parameters (region, service, method) as tags. Also add those tags consistently across adjacent metrics.