### PR TITLE
feat(hc): Force siloed relay tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -262,8 +262,6 @@ jobs:
     name: relay test
     runs-on: ubuntu-20.04
     timeout-minutes: 30
-    env:
-      SENTRY_FORCE_SILOED_TESTS: 1
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
@@ -285,6 +283,8 @@ jobs:
           docker ps -a
 
       - name: Run test
+        env:
+          SENTRY_FORCE_SILOED_TESTS: 1
         run: |
           make test-relay-integration
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -262,6 +262,8 @@ jobs:
     name: relay test
     runs-on: ubuntu-20.04
     timeout-minutes: 30
+    env:
+      SENTRY_FORCE_SILOED_TESTS: 1
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:


### PR DESCRIPTION
The tests in the relay job are currently all passing with split silos. Enforcing this on CI will ensure we don't see regressions here as we continue to get other jobs passing.

This environment variable effectively turns `@control_silo_test`/`@region_silo_test` decorators into `@control_silo_test(stable=True)`/`@region_silo_test(stable=True)` decorators.

Once all jobs are passing this environment variable will be completely removed from the codebase.