### PR TITLE
ref(hc): Outbox jobs process with fixed rate of celery jobs

### DIFF
--- a/src/sentry/tasks/deliver_from_outbox.py
+++ b/src/sentry/tasks/deliver_from_outbox.py
@@ -37,7 +37,7 @@ def enqueue_outbox_jobs(concurrency: int | None = None, **kwargs) -> bool:
 
 
 # The number of jobs created each turn of the scheduler to process batches of outboxes.
-# Tunning this up reduces latency but reduces throughput as well, since it means less
+# Increasing this value reduces latency but reduces throughput as well, since it means less
 # coalescing happening before processing. Tuning this down increases latency but also
 # increases throughput thanks to greater levels of latency.  There is a logarithmic
 # relationship between the id space of shard_identifiers and the amount of unique,

--- a/src/sentry/tasks/deliver_from_outbox.py
+++ b/src/sentry/tasks/deliver_from_outbox.py
@@ -53,8 +53,8 @@ def schedule_batch(silo_mode: SiloMode, drain_task: Task, concurrency: int | Non
             outbox_model: Type[OutboxBase] = OutboxBase.from_outbox_name(outbox_name)
 
             lo = outbox_model.objects.all().aggregate(Min("id"))["id__min"] or 0
-            hi = outbox_model.objects.all().aggregate(Max("id"))["id__max"] or 0
-            if hi == lo:
+            hi = outbox_model.objects.all().aggregate(Max("id"))["id__max"] or -1
+            if hi < lo:
                 return
 
             batch_size = math.ceil((hi - lo + 1) / concurrency)

--- a/src/sentry/tasks/deliver_from_outbox.py
+++ b/src/sentry/tasks/deliver_from_outbox.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-from typing import Callable
+import math
+from typing import Any, Type
 
+from celery import Task
 from django.conf import settings
+from django.db.models import Max, Min
 from sentry_sdk.api import capture_exception
 
 from sentry.models import ControlOutboxBase, OutboxBase, RegionOutboxBase
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
+from sentry.utils.env import in_test_environment
 
 
 @instrumented_task(
@@ -15,35 +19,54 @@ from sentry.tasks.base import instrumented_task
     queue="outbox.control",
     silo_mode=SiloMode.CONTROL,
 )
-def enqueue_outbox_jobs_control(**kwargs) -> bool:
-    return _run_enqueue_outbox_jobs(
+def enqueue_outbox_jobs_control(concurrency: int | None = None, **kwargs) -> bool:
+    return schedule_batch(
         silo_mode=SiloMode.CONTROL,
-        drain_task=drain_outbox_shard_control,
+        drain_task=drain_outbox_shards_control,
+        concurrency=concurrency,
     )
 
 
 @instrumented_task(name="sentry.tasks.enqueue_outbox_jobs", silo_mode=SiloMode.REGION)
-def enqueue_outbox_jobs(**kwargs) -> bool:
-    return _run_enqueue_outbox_jobs(
+def enqueue_outbox_jobs(concurrency: int | None = None, **kwargs) -> bool:
+    return schedule_batch(
         silo_mode=SiloMode.REGION,
-        drain_task=drain_outbox_shard,
+        drain_task=drain_outbox_shards,
+        concurrency=concurrency,
     )
 
 
-def _run_enqueue_outbox_jobs(silo_mode: SiloMode, drain_task: Callable) -> bool:
-    try:
-        processed: bool = False
-        for outbox_name in settings.SENTRY_OUTBOX_MODELS[silo_mode.name]:
-            outbox_model = OutboxBase.from_outbox_name(outbox_name)
+# The number of jobs created each turn of the scheduler to process batches of outboxes.
+# Tunning this up reduces latency but reduces throughput as well, since it means less
+# coalescing happening before processing. Tuning this down increases latency but also
+# increases throughput thanks to greater levels of latency.  There is a logarithmic
+# relationship between the id space of shard_identifiers and the amount of unique,
+# non coalesced work.
+CONCURRENCY = 5
 
-            for row in outbox_model.find_scheduled_shards():
-                if next_outbox := outbox_model.prepare_next_from_shard(row):
-                    processed = True
-                    drain_task.delay(
-                        outbox_name=outbox_name,
-                        **(next_outbox.key_from(outbox_model.sharding_columns)),
-                    )
-        return processed
+
+def schedule_batch(silo_mode: SiloMode, drain_task: Task, concurrency: int | None = None):
+    if not concurrency:
+        concurrency = CONCURRENCY
+    try:
+        for outbox_name in settings.SENTRY_OUTBOX_MODELS[silo_mode.name]:
+            outbox_model: Type[OutboxBase] = OutboxBase.from_outbox_name(outbox_name)
+
+            lo = outbox_model.objects.all().aggregate(Min("id"))["id__min"] or 0
+            hi = outbox_model.objects.all().aggregate(Max("id"))["id__max"] or 0
+            if hi == lo:
+                return
+
+            batch_size = math.ceil((hi - lo + 1) / concurrency)
+
+            # Notably, when l and h are close, this will result in creating tasks that are processing future ids --
+            # that's totally fine.
+            for i in range(concurrency):
+                drain_task.delay(
+                    outbox_name=outbox_name,
+                    outbox_identifier_low=lo + i * batch_size,
+                    outbox_identifier_hi=lo + (i + 1) * batch_size,
+                )
     except Exception:
         capture_exception()
         raise
@@ -54,45 +77,70 @@ def _run_enqueue_outbox_jobs(silo_mode: SiloMode, drain_task: Callable) -> bool:
     queue="outbox.control",
     silo_mode=SiloMode.CONTROL,
 )
-def drain_outbox_shard_control(
-    shard_scope: int,
-    shard_identifier: int,
-    outbox_name: str | None = None,
-    region_name: str | None = None,
-):
-    try:
-        assert region_name, "Cannot deliver outbox without a region name"
-        if outbox_name is None:
-            outbox_name = settings.SENTRY_OUTBOX_MODELS["CONTROL"][0]
-
-        assert outbox_name, "Could not determine outbox name"
-        outbox_model = ControlOutboxBase.from_outbox_name(outbox_name)
-
-        shard_outbox = outbox_model(
-            shard_scope=shard_scope, shard_identifier=shard_identifier, region_name=region_name
-        )
-        shard_outbox.drain_shard(flush_all=True)
-    except Exception:
-        capture_exception()
-        raise
+def drain_outbox_shard_control(**kwargs: Any):
+    return
 
 
+# Retiring this job.
 @instrumented_task(name="sentry.tasks.drain_outbox_shard", silo_mode=SiloMode.REGION)
-def drain_outbox_shard(
-    shard_scope: int,
-    shard_identifier: int,
+def drain_outbox_shard(**kwds: Any):
+    return
+
+
+@instrumented_task(name="sentry.tasks.drain_outbox_shards", silo_mode=SiloMode.REGION)
+def drain_outbox_shards(
+    outbox_identifier_low: int = 0,
+    outbox_identifier_hi: int = 0,
     outbox_name: str | None = None,
-    region_name: str | None = None,
 ):
     try:
         if outbox_name is None:
             outbox_name = settings.SENTRY_OUTBOX_MODELS["REGION"][0]
 
         assert outbox_name, "Could not determine outbox name"
-        outbox_model = RegionOutboxBase.from_outbox_name(outbox_name)
+        outbox_model: Type[RegionOutboxBase] = RegionOutboxBase.from_outbox_name(outbox_name)
 
-        shard_outbox = outbox_model(shard_scope=shard_scope, shard_identifier=shard_identifier)
-        shard_outbox.drain_shard(flush_all=True)
+        process_outbox_batch(outbox_identifier_hi, outbox_identifier_low, outbox_model)
     except Exception:
         capture_exception()
         raise
+
+
+@instrumented_task(name="sentry.tasks.drain_outbox_shards_control", silo_mode=SiloMode.CONTROL)
+def drain_outbox_shards_control(
+    outbox_identifier_low: int = 0,
+    outbox_identifier_hi: int = 0,
+    outbox_name: str | None = None,
+):
+    try:
+        if outbox_name is None:
+            outbox_name = settings.SENTRY_OUTBOX_MODELS["CONTROL"][0]
+
+        assert outbox_name, "Could not determine outbox name"
+        outbox_model: Type[ControlOutboxBase] = ControlOutboxBase.from_outbox_name(outbox_name)
+
+        process_outbox_batch(outbox_identifier_hi, outbox_identifier_low, outbox_model)
+    except Exception:
+        capture_exception()
+        raise
+
+
+def process_outbox_batch(
+    outbox_identifier_hi: int, outbox_identifier_low: int, outbox_model: Type[OutboxBase]
+):
+    for shard_attributes in outbox_model.find_scheduled_shards(
+        outbox_identifier_low, outbox_identifier_hi
+    ):
+        shard_outbox: ControlOutboxBase | None = outbox_model.prepare_next_from_shard(
+            shard_attributes
+        )
+        if not shard_outbox:
+            continue
+        try:
+            shard_outbox.drain_shard(flush_all=True)
+        except Exception:
+            capture_exception()
+            # In production, it's ok to just continue processing forward, but in tests we aim to surface
+            # problems aggressively.
+            if in_test_environment():
+                raise

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -454,7 +454,7 @@ class RegionOutboxTest(TestCase):
             def raise_exception(**kwds):
                 raise ValueError("This is just a test mock exception")
 
-            def run_with_error(conccurrency=1):
+            def run_with_error(concurrency=1):
                 mock_process_region_outbox.side_effect = raise_exception
                 mock_process_region_outbox.reset_mock()
                 with self.tasks():

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -459,7 +459,7 @@ class RegionOutboxTest(TestCase):
                 mock_process_region_outbox.reset_mock()
                 with self.tasks():
                     with raises(OutboxFlushError):
-                        enqueue_outbox_jobs(concurrency=conccurrency)
+                        enqueue_outbox_jobs(concurrency=concurrency)
                     assert mock_process_region_outbox.call_count == 1
 
             def ensure_converged():

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -560,7 +560,7 @@ class RegionOutboxTest(TestCase):
             assert future_scheduled_outbox.scheduled_for > start_time
             assert RegionOutbox.objects.count() == 1
 
-            assert len(RegionOutbox.find_scheduled_shards()) == 0  # type: ignore
+            assert len(RegionOutbox.find_scheduled_shards()) == 0
 
             with outbox_runner():
                 pass
@@ -585,7 +585,7 @@ class RegionOutboxTest(TestCase):
             assert past_scheduled_outbox.scheduled_for < start_time
             assert RegionOutbox.objects.count() == 2
 
-            assert len(RegionOutbox.find_scheduled_shards()) == 1  # type: ignore
+            assert len(RegionOutbox.find_scheduled_shards()) == 1
 
             with outbox_runner():
                 pass

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -454,12 +454,12 @@ class RegionOutboxTest(TestCase):
             def raise_exception(**kwds):
                 raise ValueError("This is just a test mock exception")
 
-            def run_with_error():
+            def run_with_error(conccurrency=1):
                 mock_process_region_outbox.side_effect = raise_exception
                 mock_process_region_outbox.reset_mock()
                 with self.tasks():
                     with raises(OutboxFlushError):
-                        enqueue_outbox_jobs()
+                        enqueue_outbox_jobs(concurrency=conccurrency)
                     assert mock_process_region_outbox.call_count == 1
 
             def ensure_converged():
@@ -560,7 +560,7 @@ class RegionOutboxTest(TestCase):
             assert future_scheduled_outbox.scheduled_for > start_time
             assert RegionOutbox.objects.count() == 1
 
-            assert RegionOutbox.find_scheduled_shards().count() == 0  # type: ignore
+            assert len(RegionOutbox.find_scheduled_shards()) == 0  # type: ignore
 
             with outbox_runner():
                 pass
@@ -585,7 +585,7 @@ class RegionOutboxTest(TestCase):
             assert past_scheduled_outbox.scheduled_for < start_time
             assert RegionOutbox.objects.count() == 2
 
-            assert RegionOutbox.find_scheduled_shards().count() == 1  # type: ignore
+            assert len(RegionOutbox.find_scheduled_shards()) == 1  # type: ignore
 
             with outbox_runner():
                 pass


### PR DESCRIPTION
Change outbox processing jobs to do "batches" of work.  Use a fixed rate of celery jobs (CONCURRENCY per schedule invocation) to do this processing, allowing the batches to grow as needed.

Thanks to coalescing, even if each individual job "grows" the batch size indefinitely, the rate of new unique shards approaches zero in the case of back pressure.

It's fine that shards may have duplicate work -- only one will acquire the lock to process it.  Sharding the id range is the least over head for net same effect as discretely partitioning the ids directly.

More complex forms of back pressure are possible to mediate the relationship between job utilitization and concurrency dynamically, but they depend on celery inspection -- the truth is that inspecting the celery backend state is not a stable api, and we may be moving off celery anyways.  This approach is *simple* and may be sufficient for our needs.