### PR TITLE
feat(releases): Implement threshold details GET

### DIFF
--- a/src/sentry/api/endpoints/release_threshold_details.py
+++ b/src/sentry/api/endpoints/release_threshold_details.py
@@ -24,18 +24,13 @@ class ReleaseThresholdDetailsEndpoint(ProjectEndpoint):
     def convert_args(
         self,
         request: Request,
-        organization_slug: str,
-        project_slug: str,
-        threshold_id: str,
         *args,
         **kwargs,
     ) -> Any:
-        parsed_args, parsed_kwargs = super().convert_args(
-            request, organization_slug, project_slug, *args, **kwargs
-        )
+        parsed_args, parsed_kwargs = super().convert_args(request, *args, **kwargs)
         try:
             parsed_kwargs["release_threshold"] = ReleaseThreshold.objects.get(
-                id=threshold_id,
+                id=kwargs["release_threshold"],
                 project=parsed_kwargs["project"],
             )
         except ReleaseThreshold.DoesNotExist:

--- a/src/sentry/api/endpoints/release_threshold_details.py
+++ b/src/sentry/api/endpoints/release_threshold_details.py
@@ -1,5 +1,4 @@
 from django.http import HttpResponse
-from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -8,14 +7,8 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
-from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.models import Project
 from sentry.models.release_threshold.releasethreshold import ReleaseThreshold
-
-
-class ReleaseThresholdDetailsGETSerializer(serializers.Serializer):
-    threshold_id = serializers.CharField()
-    project = ProjectField()
 
 
 @region_silo_endpoint
@@ -26,21 +19,9 @@ class ReleaseThresholdDetailsEndpoint(ProjectEndpoint):
     }
 
     def get(self, request: Request, project: Project, threshold_id: str) -> HttpResponse:
-        request.data["project"] = project.slug
-        request.data["threshold_id"] = threshold_id
-        serializer = ReleaseThresholdDetailsGETSerializer(
-            data=request.data,
-            context={
-                "organization": project.organization,
-                "access": request.access,
-            },
-        )
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
-        result = serializer.validated_data
         try:
             release_threshold = ReleaseThreshold.objects.get(
-                id=result.get("threshold_id"),
+                id=threshold_id,
                 project=project,
             )
             return Response(serialize(release_threshold, request.user), status=200)

--- a/src/sentry/api/endpoints/release_threshold_details.py
+++ b/src/sentry/api/endpoints/release_threshold_details.py
@@ -1,0 +1,48 @@
+from django.http import HttpResponse
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.serializers import serialize
+from sentry.api.serializers.rest_framework.project import ProjectField
+from sentry.models import Project
+from sentry.models.release_threshold.releasethreshold import ReleaseThreshold
+
+
+class ReleaseThresholdDetailsGETSerializer(serializers.Serializer):
+    threshold_id = serializers.CharField()
+    project = ProjectField()
+
+
+@region_silo_endpoint
+class ReleaseThresholdDetailsEndpoint(ProjectEndpoint):
+    owner: ApiOwner = ApiOwner.ENTERPRISE
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    def get(self, request: Request, project: Project, threshold_id: str) -> HttpResponse:
+        request.data["project"] = project.slug
+        request.data["threshold_id"] = threshold_id
+        serializer = ReleaseThresholdDetailsGETSerializer(
+            data=request.data,
+            context={
+                "organization": project.organization,
+                "access": request.access,
+            },
+        )
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+        result = serializer.validated_data
+        try:
+            release_threshold = ReleaseThreshold.objects.get(
+                id=result.get("threshold_id"),
+                project=project,
+            )
+            return Response(serialize(release_threshold, request.user), status=200)
+        except ReleaseThreshold.DoesNotExist:
+            return Response(status=404)

--- a/src/sentry/api/endpoints/release_threshold_details.py
+++ b/src/sentry/api/endpoints/release_threshold_details.py
@@ -1,3 +1,5 @@
+from typing import Any, Tuple
+
 from django.http import HttpResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -6,8 +8,9 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models import Project
+from sentry.models.project import Project
 from sentry.models.release_threshold.releasethreshold import ReleaseThreshold
 
 
@@ -18,12 +21,28 @@ class ReleaseThresholdDetailsEndpoint(ProjectEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, project: Project, threshold_id: str) -> HttpResponse:
+    def convert_args(
+        self,
+        request: Request,
+        organization_slug: str,
+        project_slug: str,
+        threshold_id: str,
+        *args,
+        **kwargs,
+    ) -> Tuple[Any, Any]:
+        parsed_args, parsed_kwargs = super().convert_args(
+            request, organization_slug, project_slug, *args, **kwargs
+        )
         try:
-            release_threshold = ReleaseThreshold.objects.get(
+            parsed_kwargs["release_threshold"] = ReleaseThreshold.objects.get(
                 id=threshold_id,
-                project=project,
+                project=parsed_kwargs["project"],
             )
-            return Response(serialize(release_threshold, request.user), status=200)
         except ReleaseThreshold.DoesNotExist:
-            return Response(status=404)
+            raise ResourceDoesNotExist
+        return parsed_args, parsed_kwargs
+
+    def get(
+        self, request: Request, project: Project, release_threshold: ReleaseThreshold
+    ) -> HttpResponse:
+        return Response(serialize(release_threshold, request.user), status=200)

--- a/src/sentry/api/endpoints/release_threshold_details.py
+++ b/src/sentry/api/endpoints/release_threshold_details.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple
+from typing import Any
 
 from django.http import HttpResponse
 from rest_framework.request import Request
@@ -29,7 +29,7 @@ class ReleaseThresholdDetailsEndpoint(ProjectEndpoint):
         threshold_id: str,
         *args,
         **kwargs,
-    ) -> Tuple[Any, Any]:
+    ) -> Any:
         parsed_args, parsed_kwargs = super().convert_args(
             request, organization_slug, project_slug, *args, **kwargs
         )

--- a/src/sentry/api/serializers/models/release_threshold.py
+++ b/src/sentry/api/serializers/models/release_threshold.py
@@ -10,6 +10,7 @@ from sentry.models.release_threshold.releasethreshold import ReleaseThreshold
 class ReleaseThresholdSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
+            "id": str(obj.id),
             "threshold_type": THRESHOLD_TYPE_INT_TO_STR[obj.threshold_type],
             "trigger_type": TRIGGER_TYPE_INT_TO_STR[obj.trigger_type],
             "value": obj.value,

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -22,10 +22,10 @@ from sentry.api.endpoints.organization_projects_experiment import (
     OrganizationProjectsExperimentEndpoint,
 )
 from sentry.api.endpoints.release_threshold import ReleaseThresholdEndpoint
+from sentry.api.endpoints.release_threshold_details import ReleaseThresholdDetailsEndpoint
 from sentry.api.endpoints.source_map_debug_blue_thunder_edition import (
     SourceMapDebugBlueThunderEditionEndpoint,
 )
-from sentry.api.endpoints.release_threshold_details import ReleaseThresholdDetailsEndpoint
 from sentry.api.utils import method_dispatch
 from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint
@@ -2131,7 +2131,7 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-project-release-thresholds",
     ),
     re_path(
-        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/thresholds/(?P<threshold_id>[^/]+)/$",
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/thresholds/(?P<release_threshold>[^/]+)/$",
         ReleaseThresholdDetailsEndpoint.as_view(),
         name="sentry-api-0-project-release-thresholds-details",
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -25,6 +25,7 @@ from sentry.api.endpoints.release_threshold import ReleaseThresholdEndpoint
 from sentry.api.endpoints.source_map_debug_blue_thunder_edition import (
     SourceMapDebugBlueThunderEditionEndpoint,
 )
+from sentry.api.endpoints.release_threshold_details import ReleaseThresholdDetailsEndpoint
 from sentry.api.utils import method_dispatch
 from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint
@@ -2128,6 +2129,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/thresholds/$",
         ReleaseThresholdEndpoint.as_view(),
         name="sentry-api-0-project-release-thresholds",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/thresholds/(?P<threshold_id>[^/]+)/$",
+        ReleaseThresholdDetailsEndpoint.as_view(),
+        name="sentry-api-0-project-release-thresholds-details",
     ),
     re_path(
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/commits/$",

--- a/tests/sentry/api/endpoints/test_release_threshold_details.py
+++ b/tests/sentry/api/endpoints/test_release_threshold_details.py
@@ -1,0 +1,73 @@
+from django.urls import reverse
+
+from sentry.models.environment import Environment
+from sentry.models.release_threshold.releasethreshold import ReleaseThreshold
+from sentry.testutils.cases import APITestCase
+
+
+class ReleaseThresholdDetailsTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user(is_staff=True, is_superuser=True)
+
+        self.canary_environment = Environment.objects.create(
+            organization_id=self.organization.id, name="canary"
+        )
+        self.production_environment = Environment.objects.create(
+            organization_id=self.organization.id, name="production"
+        )
+        self.login_as(user=self.user)
+
+        self.basic_threshold = ReleaseThreshold.objects.create(
+            threshold_type=0,
+            trigger_type=0,
+            value=100,
+            window_in_seconds=1800,
+            project=self.project,
+            environment=self.canary_environment,
+        )
+
+    def test_invalid_threshold_id(self):
+        url = reverse(
+            "sentry-api-0-project-release-thresholds-details",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": self.project.slug,
+                "threshold_id": 123,
+            },
+        )
+        response = self.client.get(url)
+
+        assert response.status_code == 404
+
+    def test_invalid_project(self):
+        url = reverse(
+            "sentry-api-0-project-release-thresholds-details",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": "kingdom_of_the_crystal_skull",
+                "threshold_id": self.basic_threshold.id,
+            },
+        )
+        response = self.client.get(url)
+
+        assert response.status_code == 404
+
+    def test_valid(self):
+        url = reverse(
+            "sentry-api-0-project-release-thresholds-details",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": self.project.slug,
+                "threshold_id": self.basic_threshold.id,
+            },
+        )
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.data["id"] == str(self.basic_threshold.id)
+        assert response.data["threshold_type"] == "total_error_count"
+        assert response.data["trigger_type"] == "percent_over"
+        assert response.data["value"] == 100
+        assert response.data["window_in_seconds"] == 1800
+        assert response.data["environment"]["name"] == "canary"

--- a/tests/sentry/api/endpoints/test_release_threshold_details.py
+++ b/tests/sentry/api/endpoints/test_release_threshold_details.py
@@ -33,7 +33,7 @@ class ReleaseThresholdDetailsTest(APITestCase):
             kwargs={
                 "organization_slug": self.organization.slug,
                 "project_slug": self.project.slug,
-                "threshold_id": 123,
+                "release_threshold": 123,
             },
         )
         response = self.client.get(url)
@@ -46,7 +46,7 @@ class ReleaseThresholdDetailsTest(APITestCase):
             kwargs={
                 "organization_slug": self.organization.slug,
                 "project_slug": "kingdom_of_the_crystal_skull",
-                "threshold_id": self.basic_threshold.id,
+                "release_threshold": self.basic_threshold.id,
             },
         )
         response = self.client.get(url)
@@ -59,7 +59,7 @@ class ReleaseThresholdDetailsTest(APITestCase):
             kwargs={
                 "organization_slug": self.organization.slug,
                 "project_slug": self.project.slug,
-                "threshold_id": self.basic_threshold.id,
+                "release_threshold": self.basic_threshold.id,
             },
         )
         response = self.client.get(url)


### PR DESCRIPTION
Basic `GET` endpoint for release thresholds -> pass in an org id, project id, and threshold id, get back the details of the matching threshold.