### PR TITLE
fix: Wrap assemble status deletion in try

### DIFF
--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -116,18 +116,17 @@ class ArtifactBundle(Model):
 def delete_file_for_artifact_bundle(instance, **kwargs):
     from sentry.tasks.assemble import AssembleTask, delete_assemble_status
 
-    if (
-        instance.organization_id is not None
-        and instance.file is not None
-        and instance.file.checksum is not None
-    ):
-        delete_assemble_status(
-            AssembleTask.ARTIFACT_BUNDLE,
-            instance.organization_id,
-            instance.file.checksum,
-        )
+    try:
+        checksum = instance.file.checksum
+        if instance.organization_id is not None and checksum is not None:
+            delete_assemble_status(
+                AssembleTask.ARTIFACT_BUNDLE,
+                instance.organization_id,
+                instance.file.checksum,
+            )
 
-    instance.file.delete()
+    finally:
+        instance.file.delete()
 
 
 def delete_bundle_from_index(instance, **kwargs):

--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -114,15 +114,20 @@ class ArtifactBundle(Model):
 
 
 def delete_file_for_artifact_bundle(instance, **kwargs):
+    from sentry.models.files import File
     from sentry.tasks.assemble import AssembleTask, delete_assemble_status
 
+    checksum = None
     try:
         checksum = instance.file.checksum
+    except File.DoesNotExist:
+        pass
+    else:
         if instance.organization_id is not None and checksum is not None:
             delete_assemble_status(
                 AssembleTask.ARTIFACT_BUNDLE,
                 instance.organization_id,
-                instance.file.checksum,
+                checksum,
             )
 
     finally:


### PR DESCRIPTION
Checking the existence of `instance.file` with `is not None` didn't work, so I guess just `try`.