### PR TITLE
feat(performance-tracing-w/o-performance): Fixed guide rendering logic for error rows.

### DIFF
--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -102,16 +102,16 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
           ),
         },
         {
-          title: t('Transactions'),
+          title: t('Events'),
           target: 'trace_view_guide_row',
           description: t(
-            `You can quickly see all the transactions in a trace alongside the project, transaction duration, and any related errors.`
+            `You can quickly see errors and transactions in a trace alongside the project, transaction duration and any errors or performance issues related to the transaction.`
           ),
         },
         {
-          title: t('Transactions Details'),
+          title: t('Event Details'),
           target: 'trace_view_guide_row_details',
-          description: t('Click on any transaction to see more details.'),
+          description: t('Click on any transaction or error row to see more details.'),
         },
       ],
     },

--- a/static/app/views/performance/traceDetails/traceView.tsx
+++ b/static/app/views/performance/traceDetails/traceView.tsx
@@ -354,7 +354,7 @@ export default function TraceView({
             isLast={isLastError}
             index={lastIndex + index + 1}
             isVisible={isVisible}
-            hasGuideAnchor
+            hasGuideAnchor={index === 0 && transactionGroups.length === 0}
             renderedChildren={[]}
           />
         </Fragment>


### PR DESCRIPTION
Fixes duplication of guidance/hint overlay on orphan error rows:
<img width="402" alt="Screenshot 2023-09-11 at 9 54 23 AM" src="https://github.com/getsentry/sentry/assets/60121741/d5f21b90-e813-4229-8c38-552cb4b72547">

Project: [Performance tracing w/o performance](https://www.notion.so/sentry/Performance-views-for-tracing-without-performance-only-errors-bd68d3d84df34bd89c0ae8bc32827c98)
GH issue: https://github.com/getsentry/sentry/issues/55689