### PR TITLE
chore(hybridcloud) Cleanup release boundary code for loading organization list

### DIFF
--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -76,26 +76,18 @@ function App({children, params}: Props) {
   const loadOrganizations = useCallback(async () => {
     const regions = ConfigStore.get('regions');
     try {
-      if (!regions) {
-        // TODO(mark) remove this branch once the backend is out safely
-        const data = await api.requestPromise(`/organizations/`, {
-          query: {member: '1'},
-        });
-        OrganizationsStore.load(data);
-      } else {
-        // Get the current user's organizations from each multi-tenant region. Will
-        // include single-tenants if the user has membership on those.
-        const results = await Promise.all(
-          regions.map(region =>
-            api.requestPromise(`/organizations/`, {
-              query: {member: '1'},
-              host: region.url,
-            })
-          )
-        );
-        const data = results.reduce((acc, response) => acc.concat(response), []);
-        OrganizationsStore.load(data);
-      }
+      // Get the current user's organizations from each multi-tenant region. Will
+      // include single-tenants if the user has membership on those.
+      const results = await Promise.all(
+        regions.map(region =>
+          api.requestPromise(`/organizations/`, {
+            query: {member: '1'},
+            host: region.url,
+          })
+        )
+      );
+      const data = results.reduce((acc, response) => acc.concat(response), []);
+      OrganizationsStore.load(data);
     } catch {
       // TODO: do something?
     }


### PR DESCRIPTION
With the backend/initial HTML change safely out we don't need to conditionally handle `regions` anymore.
