### PR TITLE
feat(crons): Add platform quickstart navigation

### DIFF
--- a/static/app/views/monitors/components/cronsLandingPanel.tsx
+++ b/static/app/views/monitors/components/cronsLandingPanel.tsx
@@ -1,21 +1,118 @@
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import onboardingImg from 'sentry-images/spot/onboarding-preview.svg';
 
-import {LinkButton} from 'sentry/components/button';
+import {Button, LinkButton} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import OnboardingPanel from 'sentry/components/onboardingPanel';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
+import {PlatformKey} from 'sentry/data/platformCategories';
+import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 
 import {NewMonitorButton} from './newMonitorButton';
-import {PlatformPickerPanel} from './platformPickerPanel';
+import {
+  CRON_SDK_PLATFORMS,
+  PlatformPickerPanel,
+  SupportedPlatform,
+} from './platformPickerPanel';
+import {QuickStartProps} from './quickStartEntries';
+
+interface PlatformGuide {
+  Guide: React.ComponentType<QuickStartProps>;
+  title: string;
+}
+
+const platformGuides: Record<SupportedPlatform, PlatformGuide[]> = {
+  'python-celery': [
+    {
+      Guide: () => null,
+      title: 'Beat Auto Discovery',
+    },
+  ],
+  php: [
+    {
+      Guide: () => null,
+      title: 'Upsert',
+    },
+  ],
+  'php-laravel': [
+    {
+      Guide: () => null,
+      title: 'Upsert',
+    },
+  ],
+  python: [],
+  node: [
+    {
+      Guide: () => null,
+      title: 'Upsert',
+    },
+  ],
+};
 
 export function CronsLandingPanel() {
-  // TODO(davidenwang): This new panel will eventually be responsible for handling
-  // state and showing the correct instrumentation depending on the picked platform
+  const [platform, setPlatform] = useState<PlatformKey | null>(null);
 
-  return <PlatformPickerPanel />;
+  if (!platform) {
+    return <PlatformPickerPanel onSelect={setPlatform} />;
+  }
+
+  const platformText = CRON_SDK_PLATFORMS.find(
+    ({platform: sdkPlatform}) => sdkPlatform === platform
+  )?.label;
+
+  const guides = platformGuides[platform];
+
+  return (
+    <Panel>
+      <BackButton
+        icon={<IconChevron size="sm" direction="left" />}
+        onClick={() => setPlatform(null)}
+        borderless
+      >
+        {t('Back to Platforms')}
+      </BackButton>
+      <PanelBody withPadding>
+        <PlatformHeader>{t('Get Started with %s', platformText)}</PlatformHeader>
+        <Tabs>
+          <TabList>
+            {[
+              ...guides.map(({title}) => (
+                <TabList.Item key={title}>{title}</TabList.Item>
+              )),
+              <TabList.Item key="manual">{t('Manual')}</TabList.Item>,
+            ]}
+          </TabList>
+          <TabPanels>
+            {[
+              ...guides.map(({title, Guide}) => (
+                <TabPanels.Item key={title}>
+                  <Guide />
+                </TabPanels.Item>
+              )),
+              <TabPanels.Item key="manual">Manual</TabPanels.Item>,
+            ]}
+          </TabPanels>
+        </Tabs>
+      </PanelBody>
+    </Panel>
+  );
 }
+
+const PlatformHeader = styled('h3')``;
+
+const BackButton = styled(Button)`
+  font-weight: normal;
+  color: ${p => p.theme.subText};
+  margin: ${space(1)} 0 0 ${space(1)};
+  padding-left: ${space(0.5)};
+  padding-right: ${space(0.5)};
+`;
 
 export function OldCronsLandingPanel() {
   return (

--- a/static/app/views/monitors/components/cronsLandingPanel.tsx
+++ b/static/app/views/monitors/components/cronsLandingPanel.tsx
@@ -78,7 +78,7 @@ export function CronsLandingPanel() {
         {t('Back to Platforms')}
       </BackButton>
       <PanelBody withPadding>
-        <PlatformHeader>{t('Get Started with %s', platformText)}</PlatformHeader>
+        <h3>{t('Get Started with %s', platformText)}</h3>
         <Tabs>
           <TabList>
             {[
@@ -103,8 +103,6 @@ export function CronsLandingPanel() {
     </Panel>
   );
 }
-
-const PlatformHeader = styled('h3')``;
 
 const BackButton = styled(Button)`
   font-weight: normal;

--- a/static/app/views/monitors/components/platformPickerPanel.tsx
+++ b/static/app/views/monitors/components/platformPickerPanel.tsx
@@ -3,6 +3,7 @@ import {PlatformIcon} from 'platformicons';
 
 import onboardingImg from 'sentry-images/spot/onboarding-preview.svg';
 
+import {Button} from 'sentry/components/button';
 import OnboardingPanel from 'sentry/components/onboardingPanel';
 import {PlatformKey} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
@@ -10,12 +11,19 @@ import {space} from 'sentry/styles/space';
 
 import {NewMonitorButton} from './newMonitorButton';
 
+export type SupportedPlatform =
+  | 'python-celery'
+  | 'php'
+  | 'php-laravel'
+  | 'python'
+  | 'node';
+
 interface SDKPlatformInfo {
   label: string;
-  platform: PlatformKey;
+  platform: SupportedPlatform;
 }
 
-const CRON_SDK_PLATFORMS: SDKPlatformInfo[] = [
+export const CRON_SDK_PLATFORMS: SDKPlatformInfo[] = [
   {platform: 'python-celery', label: 'Celery'},
   {platform: 'php', label: 'PHP'},
   {platform: 'php-laravel', label: 'Laravel'},
@@ -23,7 +31,11 @@ const CRON_SDK_PLATFORMS: SDKPlatformInfo[] = [
   {platform: 'node', label: 'Node'},
 ];
 
-export function PlatformPickerPanel() {
+interface Props {
+  onSelect: (platform: PlatformKey) => void;
+}
+
+export function PlatformPickerPanel({onSelect}: Props) {
   return (
     <OnboardingPanel image={<img src={onboardingImg} />}>
       <OnboardingTitle>{t('Monitor Your Cron Jobs')}</OnboardingTitle>
@@ -38,6 +50,7 @@ export function PlatformPickerPanel() {
           <PlatformOption key={platform}>
             <PlatformButton
               priority="default"
+              onClick={() => onSelect(platform)}
               aria-label={t('Create %s Monitor', platform)}
             >
               <PlatformIcon platform={platform} format="lg" size="100%" />
@@ -76,7 +89,7 @@ const Actions = styled('div')`
   gap: ${space(2)};
 `;
 
-const PlatformButton = styled(NewMonitorButton)`
+const PlatformButton = styled(Button)`
   width: 64px;
   height: 64px;
   padding: ${space(1)};


### PR DESCRIPTION
Adds tab navigation for platform based quickstart/onboarding options in the monitor landing page.

Right now there is no content and will be added per platform.

<img width="1242" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/1383abea-75da-44fb-b3e8-ac38c6aa0cca">
