### PR TITLE
feat(backup): Generate cloned QuerySubscription on import

### DIFF
--- a/src/sentry/backup/findings.py
+++ b/src/sentry/backup/findings.py
@@ -90,6 +90,13 @@ class ComparatorFindingKind(IntEnum):
     # present or `None`.
     SecretHexComparatorExistenceCheck = auto()
 
+    # Subscription ID fields did not match their regex specification.
+    SubscriptionIDComparator = auto()
+
+    # Failed to compare a subscription id field because one of the fields being compared was not
+    # present or `None`.
+    SubscriptionIDComparatorExistenceCheck = auto()
+
     # UUID4 fields did not match their regex specification.
     UUID4Comparator = auto()
 

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -1,13 +1,15 @@
 from datetime import timedelta
 from enum import Enum
+from typing import Optional, Tuple
 
 from django.db import models
 from django.utils import timezone
 
-from sentry.backup.scopes import RelocationScope
-from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model
+from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
+from sentry.backup.helpers import ImportFlags
+from sentry.backup.scopes import ImportScope, RelocationScope
+from sentry.db.models import BaseManager, FlexibleForeignKey, Model, region_silo_only_model
 from sentry.db.models.base import DefaultFieldsModel
-from sentry.db.models.manager import BaseManager
 
 
 class QueryAggregations(Enum):
@@ -97,3 +99,25 @@ class QuerySubscription(DefaultFieldsModel):
     class Meta:
         app_label = "sentry"
         db_table = "sentry_querysubscription"
+
+    # We want the `QuerySubscription` to get properly created in Snuba, so we'll run it through the
+    # purpose-built logic for that operation rather than copying the data verbatim. This will result
+    # in an identical duplicate of the `QuerySubscription` model with a unique `subscription_id`.
+    def write_relocation_import(
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
+    ) -> Optional[Tuple[int, int, ImportKind]]:
+        # TODO(getsentry/team-ospo#190): Prevents a circular import; could probably split up the
+        # source module in such a way that this is no longer an issue.
+        from sentry.snuba.subscriptions import create_snuba_subscription
+
+        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
+        if old_pk is None:
+            return None
+
+        subscription = create_snuba_subscription(self.project, self.type, self.snuba_query)
+
+        # Keep the original creation date.
+        subscription.date_added = self.date_added
+        subscription.save()
+
+        return (old_pk, subscription.pk, ImportKind.Inserted)


### PR DESCRIPTION
To avoid creating duplicate `subscription_id`s, rather than naively copying in imported model data, we instead take this data to construct a new call to `create_snuba_subscription`. This will generate an identical subscription (modulo creation/edit dates, which we overwrite), but with a new `subscription_id`.

Closes getsentry/team-ospo#193