### PR TITLE
fix(crons): Move monitor logic outside of lock

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -304,109 +304,109 @@ def _process_message(ts: datetime, wrapper: CheckinMessage | ClockPulseMessage) 
         else:
             guid = check_in_id
 
+        try:
+            monitor_config = params.pop("monitor_config", None)
+
+            params["duration"] = (
+                # Duration is specified in seconds from the client, it is
+                # stored in the checkin model as milliseconds
+                int(params["duration"] * 1000)
+                if params.get("duration") is not None
+                else None
+            )
+
+            validator = MonitorCheckInValidator(
+                data=params,
+                partial=True,
+                context={
+                    "project": project,
+                },
+            )
+
+            if not validator.is_valid():
+                metrics.incr(
+                    "monitors.checkin.result",
+                    tags={**metric_kwargs, "status": "failed_checkin_validation"},
+                )
+                txn.set_tag("result", "failed_checkin_validation")
+                logger.info(
+                    "monitors.consumer.checkin_validation_failed",
+                    extra={"guid": guid.hex, **params},
+                )
+                return
+
+            validated_params = validator.validated_data
+
+            monitor = _ensure_monitor_with_config(
+                project,
+                monitor_slug,
+                params["monitor_slug"],
+                monitor_config,
+            )
+
+            if not monitor:
+                metrics.incr(
+                    "monitors.checkin.result",
+                    tags={**metric_kwargs, "status": "failed_validation"},
+                )
+                txn.set_tag("result", "failed_validation")
+                logger.info(
+                    "monitors.consumer.monitor_validation_failed",
+                    extra={"guid": guid.hex, **params},
+                )
+                return
+        except MonitorLimitsExceeded:
+            metrics.incr(
+                "monitors.checkin.result",
+                tags={**metric_kwargs, "status": "failed_monitor_limits"},
+            )
+            txn.set_tag("result", "failed_monitor_limits")
+            logger.info(
+                "monitors.consumer.monitor_limit_exceeded",
+                extra={"guid": guid.hex, "project": project.id, "slug": monitor_slug},
+            )
+            return
+
+        try:
+            monitor_environment = MonitorEnvironment.objects.ensure_environment(
+                project, monitor, environment
+            )
+        except MonitorEnvironmentLimitsExceeded:
+            metrics.incr(
+                "monitors.checkin.result",
+                tags={**metric_kwargs, "status": "failed_monitor_environment_limits"},
+            )
+            txn.set_tag("result", "failed_monitor_environment_limits")
+            logger.info(
+                "monitors.consumer.monitor_environment_limit_exceeded",
+                extra={
+                    "guid": guid.hex,
+                    "project": project.id,
+                    "slug": monitor_slug,
+                    "environment": environment,
+                },
+            )
+            return
+        except MonitorEnvironmentValidationFailed:
+            metrics.incr(
+                "monitors.checkin.result",
+                tags={**metric_kwargs, "status": "failed_monitor_environment_name_length"},
+            )
+            txn.set_tag("result", "failed_monitor_environment_name_length")
+            logger.info(
+                "monitors.consumer.monitor_environment_validation_failed",
+                extra={
+                    "guid": guid.hex,
+                    "project": project.id,
+                    "slug": monitor_slug,
+                    "environment": environment,
+                },
+            )
+            return
+
         lock = locks.get(f"checkin-creation:{guid.hex}", duration=2, name="checkin_creation")
         try:
             with lock.acquire(), transaction.atomic(router.db_for_write(Monitor)):
-                try:
-                    monitor_config = params.pop("monitor_config", None)
-
-                    params["duration"] = (
-                        # Duration is specified in seconds from the client, it is
-                        # stored in the checkin model as milliseconds
-                        int(params["duration"] * 1000)
-                        if params.get("duration") is not None
-                        else None
-                    )
-
-                    validator = MonitorCheckInValidator(
-                        data=params,
-                        partial=True,
-                        context={
-                            "project": project,
-                        },
-                    )
-
-                    if not validator.is_valid():
-                        metrics.incr(
-                            "monitors.checkin.result",
-                            tags={**metric_kwargs, "status": "failed_checkin_validation"},
-                        )
-                        txn.set_tag("result", "failed_checkin_validation")
-                        logger.info(
-                            "monitors.consumer.checkin_validation_failed",
-                            extra={"guid": guid.hex, **params},
-                        )
-                        return
-
-                    validated_params = validator.validated_data
-
-                    monitor = _ensure_monitor_with_config(
-                        project,
-                        monitor_slug,
-                        params["monitor_slug"],
-                        monitor_config,
-                    )
-
-                    if not monitor:
-                        metrics.incr(
-                            "monitors.checkin.result",
-                            tags={**metric_kwargs, "status": "failed_validation"},
-                        )
-                        txn.set_tag("result", "failed_validation")
-                        logger.info(
-                            "monitors.consumer.monitor_validation_failed",
-                            extra={"guid": guid.hex, **params},
-                        )
-                        return
-                except MonitorLimitsExceeded:
-                    metrics.incr(
-                        "monitors.checkin.result",
-                        tags={**metric_kwargs, "status": "failed_monitor_limits"},
-                    )
-                    txn.set_tag("result", "failed_monitor_limits")
-                    logger.info(
-                        "monitors.consumer.monitor_limit_exceeded",
-                        extra={"guid": guid.hex, "project": project.id, "slug": monitor_slug},
-                    )
-                    return
-
-                try:
-                    monitor_environment = MonitorEnvironment.objects.ensure_environment(
-                        project, monitor, environment
-                    )
-                except MonitorEnvironmentLimitsExceeded:
-                    metrics.incr(
-                        "monitors.checkin.result",
-                        tags={**metric_kwargs, "status": "failed_monitor_environment_limits"},
-                    )
-                    txn.set_tag("result", "failed_monitor_environment_limits")
-                    logger.info(
-                        "monitors.consumer.monitor_environment_limit_exceeded",
-                        extra={
-                            "guid": guid.hex,
-                            "project": project.id,
-                            "slug": monitor_slug,
-                            "environment": environment,
-                        },
-                    )
-                    return
-                except MonitorEnvironmentValidationFailed:
-                    metrics.incr(
-                        "monitors.checkin.result",
-                        tags={**metric_kwargs, "status": "failed_monitor_environment_name_length"},
-                    )
-                    txn.set_tag("result", "failed_monitor_environment_name_length")
-                    logger.info(
-                        "monitors.consumer.monitor_environment_validation_failed",
-                        extra={
-                            "guid": guid.hex,
-                            "project": project.id,
-                            "slug": monitor_slug,
-                            "environment": environment,
-                        },
-                    )
-                    return
-
                 status = getattr(CheckInStatus, validated_params["status"].upper())
                 trace_id = validated_params.get("contexts", {}).get("trace", {}).get("trace_id")
 


### PR DESCRIPTION
Potential fix for SENTRY-12FT

Moves `monitor/monitor_environment` logic outside of the locking mechanism to prevent deadlocks due to rollbacks