### PR TITLE
chore(hybrid-cloud): Adds Outbox net processing time metric

### DIFF
--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -544,7 +544,7 @@ class OutboxBase(Model):
             tags["category"] = OutboxCategory(self.category).name
             metrics.timing(
                 "outbox.coalesced_net_queue_time",
-                datetime.datetime.now().timestamp() - first_coalesced.date_added,
+                datetime.datetime.now().timestamp() - first_coalesced.date_added.timestamp(),
             )
 
         yield coalesced
@@ -563,7 +563,7 @@ class OutboxBase(Model):
             )
             metrics.timing(
                 "outbox.coalesced_net_processing_time",
-                datetime.datetime.now().timestamp() - first_coalesced.date_added,
+                datetime.datetime.now().timestamp() - first_coalesced.date_added.timestamp(),
                 tags=tags,
             )
 

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -554,6 +554,11 @@ class OutboxBase(Model):
                 datetime.datetime.now().timestamp() - first_coalesced.scheduled_from.timestamp(),
                 tags=tags,
             )
+            metrics.timing(
+                "outbox.coalesced_net_processing_time",
+                datetime.datetime.now().timestamp() - first_coalesced.date_added,
+                tags=tags,
+            )
 
     def _set_span_data_for_coalesced_message(self, span: Span, message: OutboxBase):
         tag_for_outbox = OutboxScope.get_tag_name(message.shard_scope)

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -542,17 +542,18 @@ class OutboxBase(Model):
 
         if coalesced is not None:
             tags["category"] = OutboxCategory(self.category).name
-            assert first_coalesced
+            assert first_coalesced, "first_coalesced incorrectly set for non-empty coalesce group"
             metrics.timing(
                 "outbox.coalesced_net_queue_time",
-                datetime.datetime.now().timestamp() - first_coalesced.date_added.timestamp(),
+                datetime.datetime.now(tz=datetime.timezone.utc).timestamp()
+                - first_coalesced.date_added.timestamp(),
             )
 
         yield coalesced
 
         # If the context block didn't raise we mark messages as completed by deleting them.
         if coalesced is not None:
-            assert first_coalesced
+            assert first_coalesced, "first_coalesced incorrectly set for non-empty coalesce group"
             deleted_count, _ = (
                 self.select_coalesced_messages().filter(id__lte=coalesced.id).delete()
             )
@@ -560,12 +561,14 @@ class OutboxBase(Model):
             metrics.incr("outbox.processed", deleted_count, tags=tags)
             metrics.timing(
                 "outbox.processing_lag",
-                datetime.datetime.now().timestamp() - first_coalesced.scheduled_from.timestamp(),
+                datetime.datetime.now(tz=datetime.timezone.utc).timestamp()
+                - first_coalesced.scheduled_from.timestamp(),
                 tags=tags,
             )
             metrics.timing(
                 "outbox.coalesced_net_processing_time",
-                datetime.datetime.now().timestamp() - first_coalesced.date_added.timestamp(),
+                datetime.datetime.now(tz=datetime.timezone.utc).timestamp()
+                - first_coalesced.date_added.timestamp(),
                 tags=tags,
             )
 


### PR DESCRIPTION
Adds a new `outbox.coalesced_net_processing_time` metric for showing how long any single coalesced message group has taken to fully process.

Adds another called `outbox.coalesced_net_queue_time` for recording how long coalesced messages have been queued for processing.
