### PR TITLE
feat(slug): Prevent numeric sentry app slugs

### DIFF
--- a/src/sentry/sentry_apps/apps.py
+++ b/src/sentry/sentry_apps/apps.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import dataclasses
+import random
+import string
 from itertools import chain
 from typing import Any, Iterable, List, Mapping, Set
 
@@ -12,7 +14,7 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 from sentry_sdk.api import push_scope
 
-from sentry import analytics, audit_log
+from sentry import analytics, audit_log, options
 from sentry.constants import SentryAppStatus
 from sentry.coreapi import APIError
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
@@ -294,6 +296,11 @@ class SentryAppCreator:
 
     def _generate_and_validate_slug(self) -> str:
         slug = generate_slug(self.name, is_internal=self.is_internal)
+
+        # If option is set, add random 3 lowercase letter suffix to prevent numeric slug
+        # eg: 123 -> 123-abc
+        if options.get("api.prevent-numeric-slugs") and slug.isnumeric():
+            slug = f"{slug}-{''.join(random.choice(string.ascii_lowercase) for _ in range(3))}"
 
         # validate globally unique slug
         queryset = SentryApp.with_deleted.filter(slug=slug)

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -1,11 +1,11 @@
-from django.urls import reverse
-
 from sentry.models import SentryAppInstallation
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
 class SentryAppInstallationsTest(APITestCase):
+    endpoint = "sentry-api-0-sentry-app-installations"
+
     def setUp(self):
         self.superuser = self.create_user(email="a@example.com", is_superuser=True)
         self.user = self.create_user(email="boop@example.com")
@@ -23,7 +23,6 @@ class SentryAppInstallationsTest(APITestCase):
             user=self.superuser,
             prevent_token_exchange=True,
         )
-
         self.installation2 = self.create_sentry_app_installation(
             slug=self.unpublished_app.slug,
             organization=self.org,
@@ -31,16 +30,15 @@ class SentryAppInstallationsTest(APITestCase):
             prevent_token_exchange=True,
         )
 
-        self.url = reverse("sentry-api-0-sentry-app-installations", args=[self.org.slug])
-
 
 @control_silo_test(stable=True)
 class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
+    method = "get"
+
     def test_superuser_sees_all_installs(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.get(self.url, format="json")
+        response = self.get_success_response(self.org.slug, status_code=200)
 
-        assert response.status_code == 200
         assert response.data == [
             {
                 "app": {"slug": self.unpublished_app.slug, "uuid": self.unpublished_app.uuid},
@@ -51,11 +49,8 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
             }
         ]
 
-        url = reverse("sentry-api-0-sentry-app-installations", args=[self.super_org.slug])
+        response = self.get_success_response(self.super_org.slug, status_code=200)
 
-        response = self.client.get(url, format="json")
-
-        assert response.status_code == 200
         assert response.data == [
             {
                 "app": {"slug": self.published_app.slug, "uuid": self.published_app.uuid},
@@ -68,9 +63,8 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
 
     def test_users_only_sees_installs_on_their_org(self):
         self.login_as(user=self.user)
-        response = self.client.get(self.url, format="json")
+        response = self.get_success_response(self.org.slug, status_code=200)
 
-        assert response.status_code == 200
         assert response.data == [
             {
                 "app": {"slug": self.unpublished_app.slug, "uuid": self.unpublished_app.uuid},
@@ -82,36 +76,34 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
         ]
 
         # Org the User is not a part of
-        url = reverse("sentry-api-0-sentry-app-installations", args=[self.super_org.slug])
-
-        response = self.client.get(url, format="json")
+        response = self.get_error_response(self.super_org.slug, status_code=404)
         assert response.status_code == 404
 
 
 @control_silo_test(stable=True)
 class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
+    method = "post"
+
     def test_install_unpublished_app(self):
         self.login_as(user=self.user)
         app = self.create_sentry_app(name="Sample", organization=self.org)
-        response = self.client.post(self.url, data={"slug": app.slug}, format="json")
+        response = self.get_success_response(self.org.slug, slug=app.slug, status_code=200)
         expected = {
             "app": {"slug": app.slug, "uuid": app.uuid},
             "organization": {"slug": self.org.slug},
         }
 
-        assert response.status_code == 200, response.content
         assert expected.items() <= response.data.items()
 
     def test_install_published_app(self):
         self.login_as(user=self.user)
         app = self.create_sentry_app(name="Sample", organization=self.org, published=True)
-        response = self.client.post(self.url, data={"slug": app.slug}, format="json")
+        response = self.get_success_response(self.org.slug, slug=app.slug, status_code=200)
         expected = {
             "app": {"slug": app.slug, "uuid": app.uuid},
             "organization": {"slug": self.org.slug},
         }
 
-        assert response.status_code == 200, response.content
         assert expected.items() <= response.data.items()
 
     def test_members_cannot_install_apps(self):
@@ -119,13 +111,13 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         self.create_member(organization=self.org, user=user, role="member")
         self.login_as(user)
         app = self.create_sentry_app(name="Sample", organization=self.org, published=True)
-        response = self.client.post(self.url, data={"slug": app.slug}, format="json")
-        assert response.status_code == 403
+        self.get_error_response(self.org.slug, slug=app.slug, status_code=403)
 
     def test_install_twice(self):
         self.login_as(user=self.user)
         app = self.create_sentry_app(name="Sample", organization=self.org)
-        self.client.post(self.url, data={"slug": app.slug}, format="json")
-        response = self.client.post(self.url, data={"slug": app.slug}, format="json")
+        self.get_success_response(self.org.slug, slug=app.slug, status_code=200)
+        response = self.get_success_response(self.org.slug, slug=app.slug, status_code=200)
+
         assert SentryAppInstallation.objects.filter(sentry_app=app).count() == 1
         assert response.status_code == 200

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -1,11 +1,11 @@
+from django.urls import reverse
+
 from sentry.models import SentryAppInstallation
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
 class SentryAppInstallationsTest(APITestCase):
-    endpoint = "sentry-api-0-sentry-app-installations"
-
     def setUp(self):
         self.superuser = self.create_user(email="a@example.com", is_superuser=True)
         self.user = self.create_user(email="boop@example.com")
@@ -23,6 +23,7 @@ class SentryAppInstallationsTest(APITestCase):
             user=self.superuser,
             prevent_token_exchange=True,
         )
+
         self.installation2 = self.create_sentry_app_installation(
             slug=self.unpublished_app.slug,
             organization=self.org,
@@ -30,15 +31,16 @@ class SentryAppInstallationsTest(APITestCase):
             prevent_token_exchange=True,
         )
 
+        self.url = reverse("sentry-api-0-sentry-app-installations", args=[self.org.slug])
+
 
 @control_silo_test(stable=True)
 class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
-    method = "get"
-
     def test_superuser_sees_all_installs(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.get_success_response(self.org.slug, status_code=200)
+        response = self.client.get(self.url, format="json")
 
+        assert response.status_code == 200
         assert response.data == [
             {
                 "app": {"slug": self.unpublished_app.slug, "uuid": self.unpublished_app.uuid},
@@ -49,8 +51,11 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
             }
         ]
 
-        response = self.get_success_response(self.super_org.slug, status_code=200)
+        url = reverse("sentry-api-0-sentry-app-installations", args=[self.super_org.slug])
 
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
         assert response.data == [
             {
                 "app": {"slug": self.published_app.slug, "uuid": self.published_app.uuid},
@@ -63,8 +68,9 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
 
     def test_users_only_sees_installs_on_their_org(self):
         self.login_as(user=self.user)
-        response = self.get_success_response(self.org.slug, status_code=200)
+        response = self.client.get(self.url, format="json")
 
+        assert response.status_code == 200
         assert response.data == [
             {
                 "app": {"slug": self.unpublished_app.slug, "uuid": self.unpublished_app.uuid},
@@ -76,34 +82,36 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
         ]
 
         # Org the User is not a part of
-        response = self.get_error_response(self.super_org.slug, status_code=404)
+        url = reverse("sentry-api-0-sentry-app-installations", args=[self.super_org.slug])
+
+        response = self.client.get(url, format="json")
         assert response.status_code == 404
 
 
 @control_silo_test(stable=True)
 class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
-    method = "post"
-
     def test_install_unpublished_app(self):
         self.login_as(user=self.user)
         app = self.create_sentry_app(name="Sample", organization=self.org)
-        response = self.get_success_response(self.org.slug, slug=app.slug, status_code=200)
+        response = self.client.post(self.url, data={"slug": app.slug}, format="json")
         expected = {
             "app": {"slug": app.slug, "uuid": app.uuid},
             "organization": {"slug": self.org.slug},
         }
 
+        assert response.status_code == 200, response.content
         assert expected.items() <= response.data.items()
 
     def test_install_published_app(self):
         self.login_as(user=self.user)
         app = self.create_sentry_app(name="Sample", organization=self.org, published=True)
-        response = self.get_success_response(self.org.slug, slug=app.slug, status_code=200)
+        response = self.client.post(self.url, data={"slug": app.slug}, format="json")
         expected = {
             "app": {"slug": app.slug, "uuid": app.uuid},
             "organization": {"slug": self.org.slug},
         }
 
+        assert response.status_code == 200, response.content
         assert expected.items() <= response.data.items()
 
     def test_members_cannot_install_apps(self):
@@ -111,13 +119,13 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         self.create_member(organization=self.org, user=user, role="member")
         self.login_as(user)
         app = self.create_sentry_app(name="Sample", organization=self.org, published=True)
-        self.get_error_response(self.org.slug, slug=app.slug, status_code=403)
+        response = self.client.post(self.url, data={"slug": app.slug}, format="json")
+        assert response.status_code == 403
 
     def test_install_twice(self):
         self.login_as(user=self.user)
         app = self.create_sentry_app(name="Sample", organization=self.org)
-        self.get_success_response(self.org.slug, slug=app.slug, status_code=200)
-        response = self.get_success_response(self.org.slug, slug=app.slug, status_code=200)
-
+        self.client.post(self.url, data={"slug": app.slug}, format="json")
+        response = self.client.post(self.url, data={"slug": app.slug}, format="json")
         assert SentryAppInstallation.objects.filter(sentry_app=app).count() == 1
         assert response.status_code == 200

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -21,6 +21,7 @@ from sentry.models.integrations.sentry_app import MASKED_VALUE
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
@@ -510,6 +511,14 @@ class PostSentryAppsTest(SentryAppsTest):
 
     def test_allows_empty_schema(self):
         self.get_success_response(**self.get_data(shema={}))
+
+    @override_options({"api.prevent-numeric-slugs": True})
+    def test_generated_slug_not_entirely_numeric(self):
+        response = self.get_success_response(**self.get_data(name="1234"), status_code=201)
+        slug = response.data["slug"]
+        assert len(slug) == 8
+        assert slug.startswith("1234-")
+        assert not slug.isnumeric()
 
     def test_missing_name(self):
         response = self.get_error_response(**self.get_data(name=None), status_code=400)


### PR DESCRIPTION
Prevent numeric sentry app slugs. Currently, there is no way to update the slug with a PUT request, so we will need to manually go in and update this eventually.

Skip updating `SentryAppInstallationsEndpoint` POST because this takes in the slugs of sentry apps. While numerical sentry app slugs still exist, we cannot change this or those apps would be uninstallable