### PR TITLE
chore(hybrid-cloud): Introduce SENTRY_USE_MONOLITH_DBS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,6 @@ test-python-ci: create-db
 		--ignore tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py \
 		--ignore tests/sentry/region_to_control/test_region_to_control_kafka.py \
 		--cov . --cov-report="xml:.artifacts/python.coverage.xml"
-	SENTRY_USE_MONOLITH_DBS=1 pytest tests/sentry/backup \
-		--cov . --cov-report="xml:.artifacts/python-backup-tests.coverage.xml"
 	@echo ""
 
 test-snuba: create-db

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,8 @@ test-python-ci: create-db
 		--ignore tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py \
 		--ignore tests/sentry/region_to_control/test_region_to_control_kafka.py \
 		--cov . --cov-report="xml:.artifacts/python.coverage.xml"
+	SENTRY_USE_MONOLITH_DBS=1 pytest tests/sentry/backup \
+		--cov . --cov-report="xml:.artifacts/python-backup-tests.coverage.xml"
 	@echo ""
 
 test-snuba: create-db

--- a/src/sentry/testutils/hybrid_cloud.py
+++ b/src/sentry/testutils/hybrid_cloud.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import os
 import threading
 from typing import Any, Callable, Iterator, List, Set, Type, TypedDict
 
@@ -252,4 +253,5 @@ def simulate_on_commit(request: Any):
 
 def use_split_dbs() -> bool:
     # TODO: refactor out use_split_dbs() in any and all tests once split database is permanently set in stone.
-    return True
+    SENTRY_USE_MONOLITH_DBS = bool(os.environ.get("SENTRY_USE_MONOLITH_DBS"))
+    return not SENTRY_USE_MONOLITH_DBS

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -29,7 +29,9 @@ TEST_REDIS_DB = 9
 
 
 def configure_split_db() -> None:
-    if "control" in settings.DATABASES:
+    SENTRY_USE_MONOLITH_DBS = bool(os.environ.get("SENTRY_USE_MONOLITH_DBS"))
+    already_configured = "control" in settings.DATABASES
+    if already_configured or SENTRY_USE_MONOLITH_DBS:
         return
     # Add connections for the region & control silo databases.
     settings.DATABASES["control"] = settings.DATABASES["default"].copy()


### PR DESCRIPTION
We have some backup tests that we'd like to ensure that it passes. But they can only run in non-split database mode. 

This pull request introduces `SENTRY_USE_MONOLITH_DBS` env variable to not skip these tests when `SENTRY_USE_MONOLITH_DBS=1`. 