### PR TITLE
feat(slug): Prevent numeric sentry-doc integration slugs

### DIFF
--- a/src/sentry/api/endpoints/integrations/doc_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/doc_integrations/index.py
@@ -40,12 +40,13 @@ class DocIntegrationsEndpoint(DocIntegrationsBaseEndpoint):
         data = request.json_body
         data["is_draft"] = True
         data["metadata"] = self.generate_incoming_metadata(request)
-
         serializer = DocIntegrationSerializer(data=data)
-        if serializer.is_valid():
-            doc_integration = serializer.save()
-            return Response(
-                serialize(doc_integration, request.user),
-                status=status.HTTP_201_CREATED,
-            )
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        doc_integration = serializer.save()
+        return Response(
+            serialize(doc_integration, request.user),
+            status=status.HTTP_201_CREATED,
+        )

--- a/src/sentry/api/serializers/rest_framework/doc_integration.py
+++ b/src/sentry/api/serializers/rest_framework/doc_integration.py
@@ -1,3 +1,5 @@
+import random
+import string
 from typing import Any, MutableMapping
 
 from django.db import router, transaction
@@ -6,6 +8,7 @@ from jsonschema.exceptions import ValidationError as SchemaValidationError
 from rest_framework import serializers
 from rest_framework.serializers import Serializer, ValidationError
 
+from sentry import options
 from sentry.api.fields.avatar import AvatarField
 from sentry.api.serializers.rest_framework.sentry_app import URLField
 from sentry.api.validators.doc_integration import validate_metadata_schema
@@ -59,6 +62,12 @@ class DocIntegrationSerializer(Serializer):
 
     def create(self, validated_data: MutableMapping[str, Any]) -> DocIntegration:
         slug = self._generate_slug(validated_data["name"])
+
+        # If option is set, add random 3 lowercase letter suffix to prevent numeric slug
+        # eg: 123 -> 123-abc
+        if options.get("api.prevent-numeric-slugs") and slug.isnumeric():
+            slug = f"{slug}-{''.join(random.choice(string.ascii_lowercase) for _ in range(3))}"
+
         features = validated_data.pop("features") if validated_data.get("features") else []
         with transaction.atomic(router.db_for_write(DocIntegration)):
             doc_integration = DocIntegration.objects.create(slug=slug, **validated_data)

--- a/src/sentry/api/serializers/rest_framework/doc_integration.py
+++ b/src/sentry/api/serializers/rest_framework/doc_integration.py
@@ -65,7 +65,7 @@ class DocIntegrationSerializer(Serializer):
 
         # If option is set, add random 3 lowercase letter suffix to prevent numeric slug
         # eg: 123 -> 123-abc
-        if options.get("api.prevent-numeric-slugs") and slug.isnumeric():
+        if options.get("api.prevent-numeric-slugs") and slug.isdecimal():
             slug = f"{slug}-{''.join(random.choice(string.ascii_lowercase) for _ in range(3))}"
 
         features = validated_data.pop("features") if validated_data.get("features") else []

--- a/tests/sentry/api/endpoints/test_doc_integrations.py
+++ b/tests/sentry/api/endpoints/test_doc_integrations.py
@@ -9,6 +9,7 @@ from sentry.api.serializers.base import serialize
 from sentry.models import DocIntegration, IntegrationFeature
 from sentry.models.integrations.integration_feature import IntegrationTypes
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.json import JSONData
 
@@ -129,6 +130,20 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
         payload = {**self.payload, "name": self.doc_1.name}
         response = self.get_error_response(status_code=status.HTTP_400_BAD_REQUEST, **payload)
         assert "name" in response.data.keys()
+
+    @override_options({"api.prevent-numeric-slugs": True})
+    def test_generated_slug_not_entirely_numeric(self):
+        """
+        Tests that generated slug based on name is not entirely numeric
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        payload = {**self.payload, "name": "1234"}
+        response = self.get_success_response(status_code=status.HTTP_201_CREATED, **payload)
+
+        slug = response.data["slug"]
+        assert len(slug) == 8
+        assert not slug.isnumeric()
+        assert slug.startswith("1234-")
 
     def test_create_invalid_metadata(self):
         """

--- a/tests/sentry/api/endpoints/test_doc_integrations.py
+++ b/tests/sentry/api/endpoints/test_doc_integrations.py
@@ -141,9 +141,8 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
         response = self.get_success_response(status_code=status.HTTP_201_CREATED, **payload)
 
         slug = response.data["slug"]
-        assert len(slug) == 8
-        assert not slug.isnumeric()
         assert slug.startswith("1234-")
+        assert not slug.isdecimal()
 
     def test_create_invalid_metadata(self):
         """


### PR DESCRIPTION
Prevent numeric DocIntegration slugs. Currently, there is no way to update the slug with a PUT request but there are no existing numeric slugs for this model so we don't need to manually update anything.