### PR TITLE
feat(crons): Add Laravel upsert quickstart platform guide

### DIFF
--- a/static/app/views/monitors/components/cronsLandingPanel.tsx
+++ b/static/app/views/monitors/components/cronsLandingPanel.tsx
@@ -22,6 +22,7 @@ import {
 } from './platformPickerPanel';
 import {
   CeleryBeatAutoDiscovery,
+  LaravelUpsertPlatformGuide,
   PHPUpsertPlatformGuide,
   QuickStartProps,
 } from './quickStartEntries';
@@ -46,7 +47,7 @@ const platformGuides: Record<SupportedPlatform, PlatformGuide[]> = {
   ],
   'php-laravel': [
     {
-      Guide: () => null,
+      Guide: LaravelUpsertPlatformGuide,
       title: 'Upsert',
     },
   ],

--- a/static/app/views/monitors/components/quickStartEntries.tsx
+++ b/static/app/views/monitors/components/quickStartEntries.tsx
@@ -352,3 +352,53 @@ $checkInId = \Sentry\captureCheckIn(
     </Fragment>
   );
 }
+
+export function LaravelUpsertPlatformGuide() {
+  const basicConfigCode = `protected function schedule(Schedule $schedule)
+{
+    $schedule->command('emails:send')
+        ->everyHour()
+        ->sentryMonitor(); // add this line
+}`;
+
+  const advancedConfigCode = `protected function schedule(Schedule $schedule)
+{
+    $schedule->command('emails:send')
+        ->everyHour()
+        ->sentryMonitor(
+            // Specify the slug of the job monitor in case of duplicate commands or if the monitor was created in the UI
+            monitorSlug: null,
+            // Check-in margin in minutes
+            checkInMargin: 5,
+            // Max runtime in minutes
+            maxRuntime: 15,
+            // In case you want to configure the job monitor exclusively in the UI, you can turn off sending the monitor config with the check-in.
+            // Passing a monitor-slug is required in this case.
+            updateMonitorConfig: false,
+        )
+}`;
+
+  return (
+    <Fragment>
+      <div>
+        {tct('Use the [additionalDocs: Laravel SDK] to monitor your scheduled task.', {
+          additionalDocs: (
+            <ExternalLink href="https://docs.sentry.io/platforms/php/guides/laravel/crons/#job-monitoring" />
+          ),
+        })}
+      </div>
+      <div>
+        {t(
+          'To set up, add the "sentryMonitor()" macro to your scheduled tasks defined in your "app/Console/Kernel.php" file:'
+        )}
+      </div>
+      <CodeSnippet language="php">{basicConfigCode}</CodeSnippet>
+      <div>
+        {t(
+          'By default, the Laravel SDK will infer various parameters of your scheduled task. For greater control, we expose some optional parameters on the sentryMonitor() macro.'
+        )}
+      </div>
+      <CodeSnippet language="php">{advancedConfigCode}</CodeSnippet>
+    </Fragment>
+  );
+}


### PR DESCRIPTION
Taken from https://docs.sentry.io/platforms/php/guides/laravel/crons/#job-monitoring:

<img width="1239" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/35580810-b997-4eb0-b2ef-5f37bcb18359">
