### PR TITLE
feat(hc): Force siloed plugin tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -253,6 +253,8 @@ jobs:
           snuba: true
 
       - name: Run test
+        env:
+          SENTRY_FORCE_SILOED_TESTS: 1
         run: |
           make test-plugins
 


### PR DESCRIPTION
The tests in the plugin job are currently all passing with split silos. Enforcing this on CI will ensure we don't see regressions here as we continue to get other jobs passing.

This environment variable effectively turns `@control_silo_test`/`@region_silo_test` decorators into `@control_silo_test(stable=True)`/`@region_silo_test(stable=True)` decorators.

Once all jobs are passing this environment variable will be completely removed from the codebase.

See also: #55963