### PR TITLE
feat(alerts): Hide noisy alert banner for webhooks

### DIFF
--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -655,6 +655,10 @@ describe('ProjectAlertsCreate', function () {
     createWrapper({organization: {features: ['noisy-alert-warning']}});
     await userEvent.click((await screen.findAllByLabelText('Delete Node'))[0]);
 
+    await selectEvent.select(screen.getByText('Add action...'), [
+      'Issue Owners, Team, or Member',
+    ]);
+
     expect(
       screen.getByText(/Alerts without conditions can fire too frequently/)
     ).toBeInTheDocument();
@@ -677,6 +681,27 @@ describe('ProjectAlertsCreate', function () {
       'alert_builder.noisy_warning_agreed',
       expect.anything()
     );
+  });
+
+  it('does not display noisy alert banner for legacy integrations', async function () {
+    createWrapper({organization: {features: ['noisy-alert-warning']}});
+    await userEvent.click((await screen.findAllByLabelText('Delete Node'))[0]);
+
+    await selectEvent.select(screen.getByText('Add action...'), [
+      'Send a notification to all legacy integrations',
+    ]);
+
+    expect(
+      screen.queryByText(/Alerts without conditions can fire too frequently/)
+    ).not.toBeInTheDocument();
+
+    await selectEvent.select(screen.getByText('Add action...'), [
+      'Issue Owners, Team, or Member',
+    ]);
+
+    expect(
+      screen.getByText(/Alerts without conditions can fire too frequently/)
+    ).toBeInTheDocument();
   });
 
   it('displays duplicate error banner with link', async function () {

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -812,26 +812,15 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
   };
 
   handleDeleteRow = (type: ConditionOrActionProperty, idx: number) => {
-    this.setState(
-      prevState => {
-        const clonedState = cloneDeep(prevState);
+    this.setState(prevState => {
+      const clonedState = cloneDeep(prevState);
 
-        const newTypeList = prevState.rule ? [...prevState.rule[type]] : [];
-        newTypeList.splice(idx, 1);
+      const newTypeList = prevState.rule ? [...prevState.rule[type]] : [];
+      newTypeList.splice(idx, 1);
 
-        set(clonedState, `rule[${type}]`, newTypeList);
-        return clonedState;
-      },
-      () => {
-        // After the row has been removed, check if warning is shown
-        if (this.displayNoConditionsWarning() && !this.trackNoisyWarningViewed) {
-          this.trackNoisyWarningViewed = true;
-          trackAnalytics('alert_builder.noisy_warning_viewed', {
-            organization: this.props.organization,
-          });
-        }
-      }
-    );
+      set(clonedState, `rule[${type}]`, newTypeList);
+      return clonedState;
+    });
   };
 
   handleAddCondition = (template: IssueAlertRuleActionTemplate) =>
@@ -1021,6 +1010,14 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
 
   renderAcknowledgeNoConditions(disabled: boolean) {
     const {detailedError, acceptedNoisyAlert} = this.state;
+
+    // Bit goofy to do in render but should only track onceish
+    if (!this.trackNoisyWarningViewed) {
+      this.trackNoisyWarningViewed = true;
+      trackAnalytics('alert_builder.noisy_warning_viewed', {
+        organization: this.props.organization,
+      });
+    }
 
     return (
       <Alert type="warning" showIcon>

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1002,12 +1002,20 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
 
   displayNoConditionsWarning(): boolean {
     const {rule} = this.state;
+    const acceptedNoisyActionIds = [
+      // Webhooks
+      'sentry.rules.actions.notify_event_service.NotifyEventServiceAction',
+      // Legacy integrations
+      'sentry.rules.actions.notify_event.NotifyEventAction',
+    ];
+
     return (
       this.props.organization.features.includes('noisy-alert-warning') &&
       !!rule &&
       !isSavedAlertRule(rule) &&
       rule.conditions.length === 0 &&
-      rule.filters.length === 0
+      rule.filters.length === 0 &&
+      !rule.actions.every(action => acceptedNoisyActionIds.includes(action.id))
     );
   }
 
@@ -1033,7 +1041,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
         >
           <AcknowledgeLabel>
             <Checkbox
-              size="md"
+              size="sm"
               name="acceptedNoisyAlert"
               checked={acceptedNoisyAlert}
               onChange={() => {


### PR DESCRIPTION
- Hides noisy alert banner for webhooks and legacy integration actions and when there's no actions
- Shrinks the size of the checkmark

the smaller checkbox
![image](https://github.com/getsentry/sentry/assets/1400464/296162e6-8774-4964-afd8-402bcd5d394a)
