### PR TITLE
fix(metrics): Metrics Weight Calculations

### DIFF
--- a/src/minimetrics/core.py
+++ b/src/minimetrics/core.py
@@ -335,12 +335,12 @@ class Aggregator:
         with self._lock:
             metric = self.buckets.get(bucket_key)
             if metric is not None:
+                previous_weight = metric.weight
                 metric.add(value)
             else:
                 metric = self.buckets[bucket_key] = METRIC_TYPES[ty](value)
+                previous_weight = 0
 
-            # We first change the weight by taking the old one and the new one.
-            previous_weight = metric.weight
             self._buckets_total_weight += metric.weight - previous_weight
             # Given the new weight we consider whether we want to force flush.
             self.consider_force_flush()

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -18,29 +18,44 @@ def _to_minimetrics_external_metric_tags(tags: Optional[Tags]) -> Optional[Metri
     return cast(Optional[MetricTagsExternal], casted_tags)
 
 
+# This is needed to pass data between the sdk patcher and the
+# minimetrics backend.  This is not super clean but it allows us to
+# initialize these things in arbitrary order.
+minimetrics_client = None
+
+
+def patch_sentry_sdk(self):
+    client = sentry_sdk.Hub.main.client
+    if client is None:
+        return
+
+    old_flush = client.flush
+
+    def new_flush(*args, **kwargs):
+        client = minimetrics_client
+        if client is not None:
+            client.aggregator.consider_force_flush()
+        return old_flush(*args, **kwargs)
+
+    client.flush = new_flush  # type:ignore
+
+    old_close = client.close
+
+    def new_close(*args, **kwargs):
+        client = minimetrics_client
+        if client is not None:
+            client.aggregator.stop()
+        return old_close(*args, **kwargs)
+
+    client.close = new_close  # type:ignore
+
+
 class MiniMetricsMetricsBackend(MetricsBackend):
     def __init__(self, prefix: Optional[str] = None):
         super().__init__(prefix=prefix)
+        global minimetrics_client
         self.client = MiniMetricsClient()
-
-    def _patch_sdk(self):
-        client = sentry_sdk.Hub.main.client
-        if client is not None:
-            old_flush = client.flush
-
-            def new_flush(*args, **kwargs):
-                self.client.aggregator.consider_force_flush()
-                return old_flush(*args, **kwargs)
-
-            client.flush = new_flush  # type:ignore
-
-            old_close = client.close
-
-            def new_close(*args, **kwargs):
-                self.client.aggregator.stop()
-                return old_close(*args, **kwargs)
-
-            client.close = new_close  # type:ignore
+        minimetrics_client = self.client
 
     @staticmethod
     def _keep_metric(sample_rate: float) -> bool:

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -21,7 +21,7 @@ def _to_minimetrics_external_metric_tags(tags: Optional[Tags]) -> Optional[Metri
 # This is needed to pass data between the sdk patcher and the
 # minimetrics backend.  This is not super clean but it allows us to
 # initialize these things in arbitrary order.
-minimetrics_client = None
+minimetrics_client: Optional[MiniMetricsClient] = None
 
 
 def patch_sentry_sdk():

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -24,7 +24,7 @@ def _to_minimetrics_external_metric_tags(tags: Optional[Tags]) -> Optional[Metri
 minimetrics_client = None
 
 
-def patch_sentry_sdk(self):
+def patch_sentry_sdk():
     client = sentry_sdk.Hub.main.client
     if client is None:
         return

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -490,6 +490,10 @@ def configure_sdk():
         **sdk_options,
     )
 
+    from sentry.metrics.minimetrics import patch_sentry_sdk
+
+    patch_sentry_sdk()
+
 
 class RavenShim:
     """Wrapper around sentry-sdk in case people are writing their own


### PR DESCRIPTION
This calculates the weights correctly and initializes the minimetrics backend independently of the sentry SDK to ensure that they can happen in arbitrary order.