### PR TITLE
Enforce size limits for FlatFileIndex

### DIFF
--- a/src/sentry/debug_files/artifact_bundle_indexing.py
+++ b/src/sentry/debug_files/artifact_bundle_indexing.py
@@ -403,6 +403,8 @@ def update_artifact_bundle_index(
         for bundle_id in bundles_to_remove or []:
             index.remove(bundle_id)
 
+        index.enforce_size_limits()
+
         # Store the updated index file
         new_json_index = index.to_json()
         flat_file_index.update_flat_file_index(new_json_index)
@@ -426,6 +428,15 @@ def update_artifact_bundle_index(
         return True
 
 
+# We have seen customers with up to 5_000 bundles per *release*.
+MAX_BUNDLES_PER_INDEX = 10_000
+# Older `sentry-cli` used to generate fully random DebugIds, and uploads can end up
+# having over 400_000 unique ids that do not have mutual sharing among them.
+MAX_DEBUGIDS_PER_INDEX = 200_000
+# We have seen uploads with over 25_000 unique files.
+MAX_URLS_PER_INDEX = 200_000
+
+
 Bundles = List[BundleMeta]
 FilesByUrl = Dict[str, List[int]]
 FilesByDebugID = Dict[str, List[int]]
@@ -437,6 +448,7 @@ T = TypeVar("T")
 class FlatFileIndex:
     def __init__(self):
         # By default, a flat file index is empty.
+        self._is_complete: bool = True
         self._bundles: Bundles = []
         self._files_by_url: FilesByUrl = {}
         self._files_by_debug_id: FilesByDebugID = {}
@@ -444,6 +456,7 @@ class FlatFileIndex:
     def from_json(self, raw_json: str | bytes) -> None:
         json_idx = json.loads(raw_json, use_rapid_json=True)
 
+        self._is_complete = json_idx.get("is_complete", True)
         bundles = json_idx.get("bundles", [])
         self._bundles = [
             BundleMeta(
@@ -468,12 +481,30 @@ class FlatFileIndex:
             for bundle in self._bundles
         ]
         json_idx: Dict[str, Any] = {
+            "is_complete": self._is_complete,
             "bundles": bundles,
             "files_by_url": self._files_by_url,
             "files_by_debug_id": self._files_by_debug_id,
         }
 
         return json.dumps(json_idx)
+
+    def enforce_size_limits(self):
+        """
+        This enforced reasonable limits on the data we put into the `FlatFileIndex` by removing
+        the oldest bundle from the index until the limits are met.
+        """
+        bundles_by_timestamp = [bundle for bundle in self._bundles]
+        bundles_by_timestamp.sort(reverse=True, key=lambda bundle: (bundle.timestamp, bundle.id))
+
+        while (
+            len(self._bundles) > MAX_BUNDLES_PER_INDEX
+            or len(self._files_by_debug_id) > MAX_DEBUGIDS_PER_INDEX
+            or len(self._files_by_url) > MAX_URLS_PER_INDEX
+        ):
+            bundle_to_remove = bundles_by_timestamp.pop()
+            self.remove(bundle_to_remove.id)
+            self._is_complete = False
 
     def merge_urls(self, bundle_meta: BundleMeta, urls: List[str]):
         bundle_index = self._add_or_update_bundle(bundle_meta)

--- a/tests/sentry/debug_files/test_artifact_bundle_indexing.py
+++ b/tests/sentry/debug_files/test_artifact_bundle_indexing.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from typing import Any, Dict
 from unittest.mock import patch
 
+import pytest
 from django.core.files.base import ContentFile
 from django.utils import timezone
 from freezegun import freeze_time
@@ -616,12 +617,11 @@ class FlatFileIndexTest(FlatFileTestCase):
             "files_by_debug_id": {},
         }
 
+    # The first "bundle limit" test needs 2 minutes to run, the complete test
+    # does not finish at all in reasonable time.
+    # I'm just losing my mind how python / pytest can be *this* slow?
+    @pytest.mark.skip(reason="does not complete in a reasonable amount of time")
     def test_flat_file_index_enforces_limits(self):
-        # The first "bundle limit" test needs 2 minutes to run, the complete test
-        # does not finish at all in reasonable time.
-        # I'm just losing my mind how python / pytest can be *this* slow?
-        return
-
         # bundle limit
         flat_file_index = FlatFileIndex()
 


### PR DESCRIPTION
This puts in limits for the total number of bundles within an index, as well as the total number of debug-ids and urls.