### PR TITLE
ref(txclusterer): Increase per project timeout to 0.15s

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -29,7 +29,7 @@ PROJECTS_PER_TASK = 100
 #: Estimated limit for a clusterer run per project, in seconds.
 #: NOTE: using this in a per-project basis may not be enough. Consider using
 #: this estimation for project batches instead.
-CLUSTERING_TIMEOUT_PER_PROJECT = 0.1
+CLUSTERING_TIMEOUT_PER_PROJECT = 0.15
 
 
 @instrumented_task(


### PR DESCRIPTION
In the past few months, transaction clustering tasks have been taking longer to run. Apparently, sometimes queries take [some more milliseconds](https://sentry.sentry.io/discover/sentry:8e66828df34d49fc8882dce4de8057c2/?field=title&field=event.type&field=transaction.duration&homepage=true&name=All+Events&project=1&query=transaction_clusterer.tasks.cluster_projects+event.type%3Atransaction&sort=-transaction.duration&statsPeriod=14d&yAxis=count%28%29) and cause enough delay per project for the task to hit the [soft timeout](https://sentry.sentry.io/discover/homepage/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&name=All+Events&project=1&query=transaction_clusterer.tasks.cluster_projects&sort=-timestamp&statsPeriod=14d&yAxis=count%28%29). See [distribution on task execution time](https://sentry.sentry.io/discover/homepage/?field=avg%28transaction.duration%29&field=p75%28transaction.duration%29&field=p95%28transaction.duration%29&field=p99%28transaction.duration%29&name=All+Events&project=1&query=transaction_clusterer.tasks.cluster_projects+event.type%3Atransaction&sort=-avg%28transaction.duration%29&statsPeriod=14d&yAxis=count%28%29).

This PR increases the limit `0.1`s -> `0.15`s per project for each task. This should address the timeouts, while still having short tasks.