### PR TITLE
fix(integrations): slack unlink backend validation

### DIFF
--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -17,6 +17,8 @@ from sentry.web.helpers import render_to_response
 from . import build_linking_url as base_build_linking_url
 from . import never_cache, render_error_page
 
+ALLOWED_METHODS = ["GET", "POST"]
+
 
 def build_team_unlinking_url(
     integration: Integration,
@@ -46,6 +48,9 @@ class SlackUnlinkTeamView(BaseView):
     @transaction_start("SlackUnlinkIdentityView")
     @method_decorator(never_cache)
     def handle(self, request: Request, signed_params: str) -> HttpResponse:
+        if request.method not in ALLOWED_METHODS:
+            return render_error_page(request, body_text="HTTP 405: Method not allowed")
+
         try:
             params = unsign(signed_params)
         except (SignatureExpired, BadSignature):
@@ -88,7 +93,7 @@ class SlackUnlinkTeamView(BaseView):
 
         team = external_teams[0].team
 
-        if request.method != "POST":
+        if request.method == "GET":
             return render_to_response(
                 "sentry/integrations/slack/unlink-team.html",
                 request=request,

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -14,7 +14,7 @@ from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView, region_silo_view
 from sentry.web.helpers import render_to_response
 
-from ..utils import is_valid_role
+from ..utils import is_valid_role, logger
 from . import build_linking_url as base_build_linking_url
 from . import never_cache, render_error_page
 
@@ -71,6 +71,10 @@ class SlackUnlinkTeamView(BaseView):
         if organization is None:
             raise Http404
         if not is_valid_role(om):
+            logger.info(
+                "slack.action.invalid-role",
+                extra={"slack_id": integration.external_id, "user_id": request.user.id},
+            )
             raise Http404
 
         channel_name = params["channel_name"]

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -63,11 +63,6 @@ class SlackUnlinkTeamView(BaseView):
         if not integration:
             raise Http404
 
-        idp = identity_service.get_provider(
-            provider_ext_id=integration.external_id,
-            provider_type=EXTERNAL_PROVIDERS[ExternalProviders.SLACK],
-        )
-
         om = OrganizationMember.objects.get_for_integration(
             integration, request.user, organization_id=params["organization_id"]
         ).first()
@@ -103,6 +98,11 @@ class SlackUnlinkTeamView(BaseView):
                     "provider": integration.get_provider(),
                 },
             )
+
+        idp = identity_service.get_provider(
+            provider_ext_id=integration.external_id,
+            provider_type=EXTERNAL_PROVIDERS[ExternalProviders.SLACK],
+        )
 
         if not idp or not identity_service.get_identity(
             filter={"provider_id": idp.id, "identity_ext_id": params["slack_id"]}

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -50,7 +50,7 @@ class SlackUnlinkTeamView(BaseView):
     @method_decorator(never_cache)
     def handle(self, request: Request, signed_params: str) -> HttpResponse:
         if request.method not in ALLOWED_METHODS:
-            return render_error_page(request, body_text="HTTP 405: Method not allowed")
+            return HttpResponse(status=405)
 
         try:
             params = unsign(signed_params)

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -14,6 +14,7 @@ from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView, region_silo_view
 from sentry.web.helpers import render_to_response
 
+from ..utils import is_valid_role
 from . import build_linking_url as base_build_linking_url
 from . import never_cache, render_error_page
 
@@ -68,6 +69,8 @@ class SlackUnlinkTeamView(BaseView):
         ).first()
         organization = om.organization if om else None
         if organization is None:
+            raise Http404
+        if not is_valid_role(om):
             raise Http404
 
         channel_name = params["channel_name"]

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -312,3 +312,9 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
                 organization=team.organization, team_ids=[team.id]
             )
             assert len(external_actors) == 0
+
+    @responses.activate
+    def test_unlink_team_invalid_method(self):
+        """Test for an invalid method response"""
+        response = self.client.put(self.url, content_type="application/x-www-form-urlencoded")
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -93,6 +93,12 @@ class SlackIntegrationLinkTeamTestBase(TestCase):
         self.create_member(organization=self.organization, user=user, teams=[admin_team])
         self.login_as(user)
 
+    def _create_user_with_member_role_through_team(self):
+        user = self.create_user(email="foo@example.com")
+        member_team = self.create_team(org_role="member")
+        self.create_member(organization=self.organization, user=user, teams=[member_team])
+        self.login_as(user)
+
 
 @region_silo_test(stable=True)
 class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
@@ -227,6 +233,14 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
         self._create_user_with_valid_role_through_team()
 
         self.test_unlink_team()
+
+    @responses.activate
+    def test_unlink_team_with_member_role_through_team(self):
+        """Test that a team can not be unlinked from a Slack channel with a member role"""
+        self._create_user_with_member_role_through_team()
+
+        response = self.client.get(self.url, content_type="application/x-www-form-urlencoded")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @responses.activate
     def test_unlink_multiple_teams(self):


### PR DESCRIPTION
Currently, it is possible to pass the unlink URL which is sent to slack to low-privileged user. This PR prevents that by adding backend validation, so only admins/managers/owners can actually unlink the team with a given link.