### PR TITLE
fix(hybridcloud) Refine URL generation for region

### DIFF
--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -68,7 +68,12 @@ class Region:
         REGION_ID.validate(self.snowflake_id)
 
     def to_url(self, path: str) -> str:
-        """Resolve a path into a customer facing URL on this region's silo."""
+        """Resolve a path into a customer facing URL on this region's silo.
+
+        In monolith mode, there is likely only the historical simulated
+        region. The public URL of the simulated region is the same
+        as the application base URL.
+        """
         from sentry.api.utils import generate_region_url
 
         if SiloMode.get_current_mode() == SiloMode.MONOLITH:

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -68,13 +68,10 @@ class Region:
         REGION_ID.validate(self.snowflake_id)
 
     def to_url(self, path: str) -> str:
-        """Resolve a path into a customer facing URL on this region's silo.
-
-        (This method is a placeholder. See the `address` attribute.)
-        """
+        """Resolve a path into a customer facing URL on this region's silo."""
         from sentry.api.utils import generate_region_url
 
-        if self.name == settings.SENTRY_MONOLITH_REGION:
+        if SiloMode.get_current_mode() == SiloMode.MONOLITH:
             base_url = options.get("system.url-prefix")
         else:
             base_url = generate_region_url(self.name)

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import Any, Iterable, List, Mapping, Tuple
+from typing import Any, Iterable, List, Mapping, MutableMapping, Tuple
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -333,7 +333,7 @@ class _ClientConfig:
         }
 
 
-def get_client_config(request=None) -> Mapping[str, Any]:
+def get_client_config(request=None) -> MutableMapping[str, Any]:
     """
     Provides initial bootstrap data needed to boot the frontend application.
     """

--- a/tests/sentry/types/test_region.py
+++ b/tests/sentry/types/test_region.py
@@ -95,7 +95,12 @@ class RegionMappingTest(TestCase):
 
     def test_region_to_url(self):
         region = Region("us", 1, "http://192.168.1.99", RegionCategory.MULTI_TENANT)
-        assert region.to_url("/avatar/abcdef/") == "http://us.testserver/avatar/abcdef/"
+        with override_settings(SILO_MODE=SiloMode.REGION, SENTRY_REGION="us"):
+            assert region.to_url("/avatar/abcdef/") == "http://us.testserver/avatar/abcdef/"
+        with override_settings(SILO_MODE=SiloMode.CONTROL, SENTRY_REGION=""):
+            assert region.to_url("/avatar/abcdef/") == "http://us.testserver/avatar/abcdef/"
+        with override_settings(SILO_MODE=SiloMode.MONOLITH, SENTRY_REGION=""):
+            assert region.to_url("/avatar/abcdef/") == "http://testserver/avatar/abcdef/"
 
     def test_json_config_injection(self):
         region_config = [

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -132,14 +132,22 @@ def test_client_config_in_silo_modes(request_factory: RequestFactory):
         request, _ = request
 
     base_line = get_client_config(request)
+    # Removing the region list as it varies based on silo mode.
+    # See Region.to_url()
+    base_line.pop("regions")
     cache.clear()
 
     with override_settings(SILO_MODE=SiloMode.REGION):
-        assert get_client_config(request) == base_line
+        result = get_client_config(request)
+        result.pop("regions")
+        assert result == base_line
         cache.clear()
 
     with override_settings(SILO_MODE=SiloMode.CONTROL):
-        assert get_client_config(request) == base_line
+        result = get_client_config(request)
+        result.pop("regions")
+        assert result == base_line
+        cache.clear()
 
 
 @django_db_all(transaction=True)
@@ -156,7 +164,7 @@ def test_client_config_deleted_user():
 
 @django_db_all
 @override_regions(regions=[])
-@override_settings(SILO_MODE=SiloMode.CONTROL, SENTRY_REGION=settings.SENTRY_MONOLITH_REGION)
+@override_settings(SILO_MODE=SiloMode.MONOLITH, SENTRY_REGION=settings.SENTRY_MONOLITH_REGION)
 def test_client_config_empty_region_data():
     request, user = make_user_request_from_org()
     request.user = user


### PR DESCRIPTION
The previous logic was incorrect. We always want to use system.url-prefix as the public URL when we are in monolith mode so that we don't expose region subdomains. However, when we are in siloed mode, we need region domains for all regions even the historical monolith one.
