### PR TITLE
fix(discord): Add embed links permission to Discord bot

### DIFF
--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -101,8 +101,9 @@ class DiscordIntegrationProvider(IntegrationProvider):
     # https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
     oauth_scopes = frozenset(["applications.commands", "bot", "identify"])
 
-    # Visit the bot tab of your app in the Discord developer portal for a tool to generate this
-    bot_permissions = 2048
+    # https://discord.com/developers/docs/topics/permissions#permissions
+    # Permissions value that can Send Messages (0x800) and Embed Links (0x4000):
+    bot_permissions = 0x800 | 0x4000
 
     setup_dialog_config = {"width": 600, "height": 900}
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/55631

Invites the bot with both the Send Messages and Embed Links permissions.

The bot needs this permission is because it uses embeds for issues and not regular messages, so it requires the Embed Links permission and if not given, the notification will fail to send to your Discord channel.


![Screenshot 2023-09-12 at 11 11 47 AM](https://github.com/getsentry/sentry/assets/22582037/f969ba66-edd1-4d50-9be0-3b11b70b01c1)
