### PR TITLE
fix(hybridcloud) Add organization slug to more issue URLs

### DIFF
--- a/static/app/components/group/externalIssueActions.spec.tsx
+++ b/static/app/components/group/externalIssueActions.spec.tsx
@@ -49,7 +49,7 @@ describe('ExternalIssueActions', function () {
 
     it('opens modal', async function () {
       const integrationConfigMock = MockApiClient.addMockResponse({
-        url: '/groups/1/integrations/1/',
+        url: '/organizations/org-slug/issues/1/integrations/1/',
         body: {createIssueConfig: []},
       });
 
@@ -94,7 +94,7 @@ describe('ExternalIssueActions', function () {
 
     it('deletes when clicking x', async function () {
       const mockDelete = MockApiClient.addMockResponse({
-        url: '/groups/1/integrations/1/?externalIssue=100',
+        url: '/organizations/org-slug/issues/1/integrations/1/?externalIssue=100',
         method: 'DELETE',
       });
 

--- a/static/app/components/group/externalIssueActions.tsx
+++ b/static/app/components/group/externalIssueActions.tsx
@@ -49,7 +49,7 @@ function ExternalIssueActions({configurations, group, onChange}: Props) {
     // For example, we shouldn't have more than 1 jira ticket created for an issue for each jira configuration.
     const issue = externalIssues[0];
     const {id} = issue;
-    const endpoint = `/groups/${group.id}/integrations/${integration.id}/?externalIssue=${id}`;
+    const endpoint = `/organizations/${organization.slug}/issues/${group.id}/integrations/${integration.id}/?externalIssue=${id}`;
 
     api.request(endpoint, {
       method: 'DELETE',

--- a/static/app/components/group/externalIssueForm.spec.tsx
+++ b/static/app/components/group/externalIssueForm.spec.tsx
@@ -40,7 +40,7 @@ describe('ExternalIssueForm', () => {
 
   const renderComponent = async (action = 'Create') => {
     MockApiClient.addMockResponse({
-      url: `/groups/${group.id}/integrations/${integration.id}/`,
+      url: `/organizations/org-slug/issues/${group.id}/integrations/${integration.id}/`,
       body: formConfig,
       match: [MockApiClient.matchQuery({action: 'create'})],
     });
@@ -70,7 +70,7 @@ describe('ExternalIssueForm', () => {
         createIssueConfig: [],
       };
       MockApiClient.addMockResponse({
-        url: `/groups/${group.id}/integrations/${integration.id}/`,
+        url: `/organizations/org-slug/issues/${group.id}/integrations/${integration.id}/`,
         body: formConfig,
       });
     });
@@ -139,7 +139,7 @@ describe('ExternalIssueForm', () => {
         id: '5',
       };
       getFormConfigRequest = MockApiClient.addMockResponse({
-        url: `/groups/${group.id}/integrations/${integration.id}/`,
+        url: `/organizations/org-slug/issues/${group.id}/integrations/${integration.id}/`,
         body: formConfig,
         match: [MockApiClient.matchQuery({action: 'link'})],
       });
@@ -153,7 +153,7 @@ describe('ExternalIssueForm', () => {
     describe('options loaded', () => {
       beforeEach(() => {
         MockApiClient.addMockResponse({
-          url: `/groups/${group.id}/integrations/${integration.id}/?action=link`,
+          url: `/organizations/org-slug/issues/${group.id}/integrations/${integration.id}/?action=link`,
           body: formConfig,
         });
       });

--- a/static/app/components/group/externalIssueForm.tsx
+++ b/static/app/components/group/externalIssueForm.tsx
@@ -117,8 +117,8 @@ export default class ExternalIssueForm extends AbstractExternalIssueForm<Props, 
   };
 
   getEndPointString() {
-    const {group, integration} = this.props;
-    return `/groups/${group.id}/integrations/${integration.id}/`;
+    const {group, integration, organization} = this.props;
+    return `/organizations/${organization.slug}/issues/${group.id}/integrations/${integration.id}/`;
   }
 
   getTitle = () => {

--- a/static/app/stores/groupingStore.spec.tsx
+++ b/static/app/stores/groupingStore.spec.tsx
@@ -692,7 +692,7 @@ describe('Grouping Store', function () {
         MockApiClient.clearMockResponses();
         MockApiClient.addMockResponse({
           method: 'DELETE',
-          url: '/issues/groupId/hashes/',
+          url: '/organizations/org-slug/issues/groupId/hashes/',
           statusCode: 500,
           body: {},
         });

--- a/static/app/stores/groupingStore.spec.tsx
+++ b/static/app/stores/groupingStore.spec.tsx
@@ -590,7 +590,7 @@ describe('Grouping Store', function () {
         MockApiClient.clearMockResponses();
         MockApiClient.addMockResponse({
           method: 'DELETE',
-          url: '/issues/groupId/hashes/',
+          url: '/organizations/org-slug/issues/groupId/hashes/',
         });
       });
 
@@ -603,6 +603,7 @@ describe('Grouping Store', function () {
         expect(trigger).not.toHaveBeenCalled();
 
         GroupingStore.onUnmerge({
+          orgSlug: 'org-slug',
           groupId: 'groupId',
         });
 
@@ -630,6 +631,7 @@ describe('Grouping Store', function () {
         });
 
         const promise = GroupingStore.onUnmerge({
+          orgSlug: 'org-slug',
           groupId: 'groupId',
         });
 
@@ -663,6 +665,7 @@ describe('Grouping Store', function () {
 
         const promise = GroupingStore.onUnmerge({
           groupId: 'groupId',
+          orgSlug: 'org-slug',
         });
 
         unmergeState.set('2', {checked: false, busy: true});
@@ -699,6 +702,7 @@ describe('Grouping Store', function () {
 
         const promise = GroupingStore.onUnmerge({
           groupId: 'groupId',
+          orgSlug: 'org-slug',
         });
 
         unmergeState.set('2', {checked: false, busy: true});

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -165,6 +165,7 @@ interface GroupingStoreDefinition
   onToggleUnmerge(props: [string, string] | string): void;
   onUnmerge(props: {
     groupId: Group['id'];
+    orgSlug: Organization['slug'];
     errorMessage?: string;
     loadingMessage?: string;
     successMessage?: string;
@@ -459,7 +460,7 @@ const storeConfig: GroupingStoreDefinition = {
     this.triggerUnmergeState();
   },
 
-  onUnmerge({groupId, loadingMessage, successMessage, errorMessage}) {
+  onUnmerge({groupId, loadingMessage, orgSlug, successMessage, errorMessage}) {
     const ids = Array.from(this.unmergeList.keys()) as Array<string>;
 
     return new Promise((resolve, reject) => {
@@ -479,7 +480,7 @@ const storeConfig: GroupingStoreDefinition = {
       this.triggerUnmergeState();
       addLoadingMessage(loadingMessage);
 
-      this.api.request(`/issues/${groupId}/hashes/`, {
+      this.api.request(`/organizations/${orgSlug}/issues/${groupId}/hashes/`, {
         method: 'DELETE',
         query: {
           id: ids,

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
@@ -26,7 +26,7 @@ describe('GroupEventAttachments > Screenshots', function () {
     GroupStore.init();
 
     getAttachmentsMock = MockApiClient.addMockResponse({
-      url: '/issues/group-id/attachments/',
+      url: '/organizations/org-slug/issues/group-id/attachments/',
       body: [TestStubs.EventAttachment()],
     });
   });
@@ -45,7 +45,7 @@ describe('GroupEventAttachments > Screenshots', function () {
     expect(screen.getByRole('radio', {name: 'Screenshots'})).toBeInTheDocument();
     await userEvent.click(screen.getByRole('radio', {name: 'Screenshots'}));
     expect(getAttachmentsMock).toHaveBeenCalledWith(
-      '/issues/group-id/attachments/',
+      '/organizations/org-slug/issues/group-id/attachments/',
       expect.objectContaining({
         query: {per_page: MAX_SCREENSHOTS_PER_PAGE, screenshot: 1, types: undefined},
       })

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -90,7 +90,7 @@ class GroupEventAttachments extends DeprecatedAsyncComponent<Props, State> {
     return [
       [
         'eventAttachments',
-        `/organizations/${organization.slug}/issues/${params.groupId}/attachments/`,
+        `/organizations/${params.orgId}/issues/${params.groupId}/attachments/`,
         {
           query: {
             ...pick(location.query, ['cursor', 'environment', 'types']),

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -74,7 +74,7 @@ class GroupEventAttachments extends DeprecatedAsyncComponent<Props, State> {
       return [
         [
           'eventAttachments',
-          `/issues/${params.groupId}/attachments/`,
+          `/organizations/${params.orgId}/issues/${params.groupId}/attachments/`,
           {
             query: {
               ...location.query,
@@ -90,7 +90,7 @@ class GroupEventAttachments extends DeprecatedAsyncComponent<Props, State> {
     return [
       [
         'eventAttachments',
-        `/issues/${params.groupId}/attachments/`,
+        `/organizations/${organization.slug}/issues/${params.groupId}/attachments/`,
         {
           query: {
             ...pick(location.query, ['cursor', 'environment', 'types']),

--- a/static/app/views/issueDetails/groupMerged/index.spec.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.spec.tsx
@@ -27,7 +27,7 @@ describe('Issues -> Merged View', function () {
     GroupingStore.init();
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: '/issues/groupId/hashes/?limit=50&query=',
+      url: '/organizations/org-slug/issues/groupId/hashes/?limit=50&query=',
       body: mockData.merged,
     });
   });

--- a/static/app/views/issueDetails/groupMerged/index.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.tsx
@@ -77,7 +77,7 @@ class GroupMergedView extends Component<Props, State> {
   listener = GroupingStore.listen(this.onGroupingChange, undefined);
 
   getEndpoint() {
-    const {params, location} = this.props;
+    const {params, location, organization} = this.props;
     const {groupId} = params;
 
     const queryParams = {
@@ -86,7 +86,9 @@ class GroupMergedView extends Component<Props, State> {
       query: this.state.query,
     };
 
-    return `/issues/${groupId}/hashes/?${qs.stringify(queryParams)}`;
+    return `/organizations/${organization.slug}/issues/${groupId}/hashes/?${qs.stringify(
+      queryParams
+    )}`;
   }
 
   fetchData = () => {
@@ -100,16 +102,18 @@ class GroupMergedView extends Component<Props, State> {
   };
 
   handleUnmerge = () => {
+    const {organization, params} = this.props;
     GroupingStore.onUnmerge({
-      groupId: this.props.params.groupId,
+      groupId: params.groupId,
+      orgSlug: organization.slug,
       loadingMessage: t('Unmerging events\u2026'),
       successMessage: t('Events successfully queued for unmerging.'),
       errorMessage: t('Unable to queue events for unmerging.'),
     });
     const unmergeKeys = [...GroupingStore.getState().unmergeList.values()];
     trackAnalytics('issue_details.merged_tab.unmerge_clicked', {
-      organization: this.props.organization,
-      group_id: this.props.params.groupId,
+      organization,
+      group_id: params.groupId,
       event_ids_unmerged: unmergeKeys.join(','),
       total_unmerged: unmergeKeys.length,
     });

--- a/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
@@ -44,7 +44,7 @@ describe('Issues Similar View', function () {
 
   beforeEach(function () {
     mock = MockApiClient.addMockResponse({
-      url: '/issues/group-id/similar/?limit=50',
+      url: '/organizations/org-slug/issues/group-id/similar/?limit=50',
       body: mockData.similar,
     });
   });

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -56,7 +56,7 @@ function SimilarStackTrace({params, location, project}: Props) {
 
     if (hasSimilarityFeature) {
       reqs.push({
-        endpoint: `/issues/${groupId}/similar/?${qs.stringify({
+        endpoint: `/organizations/${orgId}/issues/${groupId}/similar/?${qs.stringify({
           ...location.query,
           limit: 50,
         })}`,
@@ -65,7 +65,7 @@ function SimilarStackTrace({params, location, project}: Props) {
     }
 
     GroupingStore.onFetch(reqs);
-  }, [location.query, groupId, hasSimilarityFeature]);
+  }, [location.query, groupId, orgId, hasSimilarityFeature]);
 
   const onGroupingChange = useCallback(
     ({


### PR DESCRIPTION
We need organization slug in order to route requests to the correct region when using the backwards compatibility API.