### PR TITLE
Fix(fly): Don't break flow if 2 users returned for the same email

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -38,6 +38,8 @@ from sentry.services.hybrid_cloud.user import (
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
 from sentry.services.hybrid_cloud.user.service import UserService
 
+logger = logging.getLogger("user:provisioning")
+
 
 class DatabaseBackedUserService(UserService):
     def serialize_many(
@@ -184,7 +186,6 @@ class DatabaseBackedUserService(UserService):
                 # Users are not supposed to have the same email but right now our auth pipeline let this happen
                 # So let's not break the user experience
                 if user_query.count() > 1:
-                    logger = logging.getLogger("user:provisioning")
                     logger.error(f"email {email} has more than 1 user")
                 user = user_query[0]
             return serialize_rpc_user(user)

--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -191,7 +191,7 @@ class DatabaseBackedUserService(UserService):
             return serialize_rpc_user(user)
 
     def verify_any_email(self, *, email: str) -> bool:
-        user_email = UserEmail.objects.filter(email=email).first()
+        user_email = UserEmail.objects.filter(email__iexact=email).first()
         if user_email is None:
             return False
         if not user_email.is_verified:

--- a/tests/sentry/services/hybrid_cloud/user/test_impl.py
+++ b/tests/sentry/services/hybrid_cloud/user/test_impl.py
@@ -1,0 +1,16 @@
+from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test(stable=True)
+class DatabaseBackedUserService(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_get_or_create_user(self):
+        user1 = self.create_user(email="test@email.com", username="1")
+        user2 = self.create_user(email="test@email.com", username="2")
+        user = user_service.get_or_create_user_by_email(email="test@email.com")
+        assert user2.id == user.id
+        assert user1.id != user.id

--- a/tests/sentry/services/hybrid_cloud/user/test_impl.py
+++ b/tests/sentry/services/hybrid_cloud/user/test_impl.py
@@ -12,5 +12,5 @@ class DatabaseBackedUserService(TestCase):
         user1 = self.create_user(email="test@email.com", username="1")
         user2 = self.create_user(email="test@email.com", username="2")
         user = user_service.get_or_create_user_by_email(email="test@email.com")
-        assert user2.id == user.id
-        assert user1.id != user.id
+        assert user1.id == user.id
+        assert user2.id != user.id


### PR DESCRIPTION
Right now there are users who have the same email. Enterprise is working on rebuilding auth pipeline so this won't happen in the future but right now it happens and this line throws error in fly provisioning.