### PR TITLE
fix(commits): get active repos in filechange and project release commits APIs

### DIFF
--- a/src/sentry/api/endpoints/filechange.py
+++ b/src/sentry/api/endpoints/filechange.py
@@ -7,6 +7,7 @@ from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.constants import ObjectStatus
 from sentry.models import Release, ReleaseCommit, Repository
 from sentry.models.commitfilechange import CommitFileChange
 
@@ -51,9 +52,12 @@ class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
 
         repo_name = request.query_params.get("repo_name")
 
+        # TODO: use id instead of name
         if repo_name:
             try:
-                repo = Repository.objects.get(organization_id=organization.id, name=repo_name)
+                repo = Repository.objects.get(
+                    organization_id=organization.id, name=repo_name, status=ObjectStatus.ACTIVE
+                )
                 queryset = queryset.filter(commit__repository_id=repo.id)
             except Repository.DoesNotExist:
                 raise ResourceDoesNotExist

--- a/src/sentry/api/endpoints/project_release_commits.py
+++ b/src/sentry/api/endpoints/project_release_commits.py
@@ -6,6 +6,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
+from sentry.constants import ObjectStatus
 from sentry.models import Release, ReleaseCommit, Repository
 
 
@@ -49,9 +50,12 @@ class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
 
         repo_name = request.query_params.get("repo_name")
 
+        # TODO: use id instead of name
         if repo_name:
             try:
-                repo = Repository.objects.get(organization_id=organization_id, name=repo_name)
+                repo = Repository.objects.get(
+                    organization_id=organization_id, name=repo_name, status=ObjectStatus.ACTIVE
+                )
                 queryset = queryset.filter(commit__repository_id=repo.id)
             except Repository.DoesNotExist:
                 raise ResourceDoesNotExist

--- a/tests/sentry/api/endpoints/test_commit_filechange.py
+++ b/tests/sentry/api/endpoints/test_commit_filechange.py
@@ -1,5 +1,4 @@
-from django.urls import reverse
-
+from sentry.constants import ObjectStatus
 from sentry.models import Commit, Release, ReleaseCommit, Repository
 from sentry.models.commitfilechange import CommitFileChange
 from sentry.testutils.cases import APITestCase
@@ -8,42 +7,70 @@ from sentry.testutils.silo import region_silo_test
 
 @region_silo_test(stable=True)
 class CommitFileChangeTest(APITestCase):
-    def test_simple(self):
-        project = self.create_project(name="foo")
-        release = Release.objects.create(organization_id=project.organization_id, version="1")
-        release.add_project(project)
-        repo = Repository.objects.create(organization_id=project.organization_id, name=project.name)
+    endpoint = "sentry-api-0-release-commitfilechange"
+
+    def setUp(self):
+        super().setUp()
+
+        self.project = self.create_project(name="foo")
+        self.release = Release.objects.create(
+            organization_id=self.project.organization_id, version="1"
+        )
+        self.release.add_project(self.project)
+        self.repo = Repository.objects.create(
+            organization_id=self.project.organization_id, name=self.project.name
+        )
+        Repository.objects.create(
+            organization_id=self.project.organization_id,
+            name=self.project.name,
+            status=ObjectStatus.HIDDEN,
+        )
         commit = Commit.objects.create(
-            organization_id=project.organization_id, repository_id=repo.id, key="a" * 40
+            organization_id=self.project.organization_id, repository_id=self.repo.id, key="a" * 40
         )
         commit2 = Commit.objects.create(
-            organization_id=project.organization_id, repository_id=repo.id, key="b" * 40
+            organization_id=self.project.organization_id, repository_id=self.repo.id, key="b" * 40
         )
         ReleaseCommit.objects.create(
-            organization_id=project.organization_id, release=release, commit=commit, order=1
+            organization_id=self.project.organization_id,
+            release=self.release,
+            commit=commit,
+            order=1,
         )
         ReleaseCommit.objects.create(
-            organization_id=project.organization_id, release=release, commit=commit2, order=0
+            organization_id=self.project.organization_id,
+            release=self.release,
+            commit=commit2,
+            order=0,
         )
         CommitFileChange.objects.create(
-            organization_id=project.organization_id, commit=commit, filename=".gitignore", type="M"
+            organization_id=self.project.organization_id,
+            commit=commit,
+            filename=".gitignore",
+            type="M",
         )
         CommitFileChange.objects.create(
-            organization_id=project.organization_id,
+            organization_id=self.project.organization_id,
             commit=commit2,
             filename="/static/js/widget.js",
             type="A",
         )
-        url = reverse(
-            "sentry-api-0-release-commitfilechange",
-            kwargs={"organization_slug": project.organization.slug, "version": release.version},
-        )
 
         self.login_as(user=self.user)
 
-        response = self.client.get(url)
+    def test_simple(self):
+        response = self.get_success_response(self.project.organization.slug, self.release.version)
 
-        assert response.status_code == 200, response.content
         assert len(response.data) == 2
+        assert response.data[0]["filename"] == ".gitignore"
+        assert response.data[1]["filename"] == "/static/js/widget.js"
+
+    def test_query_name(self):
+        response = self.get_success_response(
+            self.project.organization.slug,
+            self.release.version,
+            qs_params={"repo_name": self.repo.name},
+        )
+
         assert response.data[0]["filename"] == ".gitignore"
         assert response.data[1]["filename"] == "/static/js/widget.js"

--- a/tests/sentry/api/endpoints/test_project_release_commits.py
+++ b/tests/sentry/api/endpoints/test_project_release_commits.py
@@ -1,41 +1,65 @@
-from django.urls import reverse
-
+from sentry.constants import ObjectStatus
 from sentry.models import Commit, Release, ReleaseCommit, Repository
 from sentry.testutils.cases import APITestCase
 
 
 class ReleaseCommitsListTest(APITestCase):
-    def test_simple(self):
-        project = self.create_project(name="foo")
-        release = Release.objects.create(organization_id=project.organization_id, version="1")
-        release.add_project(project)
-        repo = Repository.objects.create(organization_id=project.organization_id, name=project.name)
-        commit = Commit.objects.create(
-            organization_id=project.organization_id, repository_id=repo.id, key="a" * 40
+    endpoint = "sentry-api-0-project-release-commits"
+
+    def setUp(self):
+        super().setUp()
+
+        self.project = self.create_project(name="foo")
+        self.release = Release.objects.create(
+            organization_id=self.project.organization_id, version="1"
         )
-        commit2 = Commit.objects.create(
-            organization_id=project.organization_id, repository_id=repo.id, key="b" * 40
+        self.release.add_project(self.project)
+        self.repo = Repository.objects.create(
+            organization_id=self.project.organization_id, name=self.project.name
+        )
+        Repository.objects.create(
+            organization_id=self.project.organization_id,
+            name=self.project.name,
+            status=ObjectStatus.HIDDEN,
+        )
+        self.commit = Commit.objects.create(
+            organization_id=self.project.organization_id, repository_id=self.repo.id, key="a" * 40
+        )
+        self.commit2 = Commit.objects.create(
+            organization_id=self.project.organization_id, repository_id=self.repo.id, key="b" * 40
         )
         ReleaseCommit.objects.create(
-            organization_id=project.organization_id, release=release, commit=commit, order=1
+            organization_id=self.project.organization_id,
+            release=self.release,
+            commit=self.commit,
+            order=1,
         )
         ReleaseCommit.objects.create(
-            organization_id=project.organization_id, release=release, commit=commit2, order=0
-        )
-        url = reverse(
-            "sentry-api-0-project-release-commits",
-            kwargs={
-                "organization_slug": project.organization.slug,
-                "project_slug": project.slug,
-                "version": release.version,
-            },
+            organization_id=self.project.organization_id,
+            release=self.release,
+            commit=self.commit2,
+            order=0,
         )
 
         self.login_as(user=self.user)
 
-        response = self.client.get(url)
+    def test_simple(self):
+        response = self.get_success_response(
+            self.project.organization.slug, self.project.slug, self.release.version
+        )
 
-        assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert response.data[0]["id"] == commit2.key
-        assert response.data[1]["id"] == commit.key
+        assert response.data[0]["id"] == self.commit2.key
+        assert response.data[1]["id"] == self.commit.key
+
+    def test_query_name(self):
+        response = self.get_success_response(
+            self.project.organization.slug,
+            self.project.slug,
+            self.release.version,
+            qs_params={"repo_name": self.repo.name},
+        )
+
+        assert len(response.data) == 2
+        assert response.data[0]["id"] == self.commit2.key
+        assert response.data[1]["id"] == self.commit.key


### PR DESCRIPTION
This should help with [SENTRY-14ZA](https://sentry.sentry.io/issues/4401626153/?project=1)

At the moment, deleting a repo in the UI merely sets the repo's status to `ObjectStatus.HIDDEN`. We do this in case an org wants to re-link that repo sometime down the line. This, in addition to the changes made in #53286 which added our current constraint on the Repository table (org_id + provider + external_id) and removed a different constraint on org_id + name, have been causing `Repository.MultipleObjectsReturned` errors. We will need to work on enforcing the new constraint because while repo names may change, the external id should never change.