### PR TITLE
ref(cache):  Better handling of bad in cache values.

### DIFF
--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -284,7 +284,7 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
 
             if settings.DEBUG:
                 raise ValueError("Unexpected value type returned from cache")
-            logger.error("Cache response returned invalid value %r", inst)
+            logger.error("Cache response returned invalid value", extra={"instance": inst})
             if local_cache is not None and cache_key in local_cache:
                 del local_cache[cache_key]
             cache.delete(cache_key, version=self.cache_version)

--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -41,6 +41,11 @@ _local_cache_generation = 0
 _local_cache_enabled = False
 
 
+def flush_manager_local_cache():
+    global _local_cache
+    _local_cache = threading.local()
+
+
 class ModelManagerTriggerCondition(IntEnum):
     QUERY = auto()
     SAVE = auto()
@@ -263,67 +268,73 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
         intermediate value.  Callee is responsible for making sure
         the cache key is cleared on save.
         """
-        if not self.cache_fields or len(kwargs) > 1:
+        if not self.cache_fields:
+            raise ValueError("We cannot cache this query. Just hit the database.")
+
+        key, pk_name, value = self._get_cacheable_kv_from_kwargs(kwargs)
+        if key not in self.cache_fields and key != pk_name:
+            raise ValueError("We cannot cache this query. Just hit the database.")
+
+        cache_key = self.__get_lookup_cache_key(**{key: value})
+        local_cache = self._get_local_cache()
+
+        def validate_result(inst: Any) -> M:
+            if isinstance(inst, self.model) and (key != pk_name or int(value) != inst.pk):
+                return inst
+
+            if settings.DEBUG:
+                raise ValueError("Unexpected value type returned from cache")
+            logger.error("Cache response returned invalid value %r", inst)
+            if local_cache is not None and cache_key in local_cache:
+                del local_cache[cache_key]
+            cache.delete(cache_key, version=self.cache_version)
+            return self.using_replica().get(**kwargs) if use_replica else self.get(**kwargs)
+
+        if local_cache is not None and cache_key in local_cache:
+            return validate_result(local_cache[cache_key])
+
+        retval = cache.get(cache_key, version=self.cache_version)
+        # If we don't have a hit in the django level cache, collect
+        # the result, and store it both in django and local caches.
+        if retval is None:
+            result = self.using_replica().get(**kwargs) if use_replica else self.get(**kwargs)
+            assert result
+            # Ensure we're pushing it into the cache
+            self.__post_save(instance=result)
+            if local_cache is not None:
+                local_cache[cache_key] = result
+            return validate_result(result)
+
+        # If we didn't look up by pk we need to hit the reffed
+        # key
+        if key != pk_name:
+            result = self.get_from_cache(**{pk_name: retval})
+            if local_cache is not None:
+                local_cache[cache_key] = result
+            return validate_result(result)
+
+        retval = validate_result(retval)
+
+        kwargs = {**kwargs, "replica": True} if use_replica else {**kwargs}
+        retval._state.db = router.db_for_read(self.model, **kwargs)
+
+        return retval
+
+    def _get_cacheable_kv_from_kwargs(self, kwargs: Mapping[str, Any]):
+        if not kwargs:
             raise ValueError("We cannot cache this query. Just hit the database.")
 
         key, value = next(iter(kwargs.items()))
         pk_name = self.model._meta.pk.name
         if key == "pk":
             key = pk_name
-
         # We store everything by key references (vs instances)
         if isinstance(value, Model):
             value = value.pk
-
         # Kill __exact since it's the default behavior
         if key.endswith("__exact"):
             key = key.split("__exact", 1)[0]
-
-        if key in self.cache_fields or key == pk_name:
-            cache_key = self.__get_lookup_cache_key(**{key: value})
-            local_cache = self._get_local_cache()
-            if local_cache is not None:
-                result = local_cache.get(cache_key)
-                if result is not None:
-                    return result
-
-            retval = cache.get(cache_key, version=self.cache_version)
-            if retval is None:
-                result = self.using_replica().get(**kwargs) if use_replica else self.get(**kwargs)
-                # need to satisfy mypy
-                assert result
-                # Ensure we're pushing it into the cache
-                self.__post_save(instance=result)
-                if local_cache is not None:
-                    local_cache[cache_key] = result
-                return result
-
-            # If we didn't look up by pk we need to hit the reffed
-            # key
-            if key != pk_name:
-                result = self.get_from_cache(**{pk_name: retval})
-                if local_cache is not None:
-                    local_cache[cache_key] = result
-                return result
-
-            if not isinstance(retval, self.model):
-                if settings.DEBUG:
-                    raise ValueError("Unexpected value type returned from cache")
-                logger.error("Cache response returned invalid value %r", retval)
-                result = self.using_replica().get(**kwargs) if use_replica else self.get(**kwargs)
-
-            if key == pk_name and int(value) != retval.pk:
-                if settings.DEBUG:
-                    raise ValueError("Unexpected value returned from cache")
-                logger.error("Cache response returned invalid value %r", retval)
-                result = self.using_replica().get(**kwargs) if use_replica else self.get(**kwargs)
-
-            kwargs = {**kwargs, "replica": True} if use_replica else {**kwargs}
-            retval._state.db = router.db_for_read(self.model, **kwargs)
-
-            return retval
-        else:
-            raise ValueError("We cannot cache this query. Just hit the database.")
+        return key, pk_name, value
 
     def get_many_from_cache(self, values: Collection[str | int], key: str = "pk") -> Sequence[Any]:
         """

--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -279,7 +279,7 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
         local_cache = self._get_local_cache()
 
         def validate_result(inst: Any) -> M:
-            if isinstance(inst, self.model) and (key != pk_name or int(value) != inst.pk):
+            if isinstance(inst, self.model) and (key != pk_name or int(value) == inst.pk):
                 return inst
 
             if settings.DEBUG:

--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -321,7 +321,7 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
         return retval
 
     def _get_cacheable_kv_from_kwargs(self, kwargs: Mapping[str, Any]):
-        if not kwargs:
+        if not kwargs or len(kwargs) > 1:
             raise ValueError("We cannot cache this query. Just hit the database.")
 
         key, value = next(iter(kwargs.items()))

--- a/tests/sentry/models/test_manager.py
+++ b/tests/sentry/models/test_manager.py
@@ -1,0 +1,45 @@
+from sentry.db.models.manager.base import flush_manager_local_cache
+from sentry.models import Organization
+from sentry.testutils.cases import TestCase
+from sentry.utils.cache import cache
+
+
+class GetFromCacheTest(TestCase):
+    def setUp(self) -> None:
+        self.clear()
+
+    def clear(self):
+        cache.clear()
+        flush_manager_local_cache()
+
+    def test_get_cacheable_kv_from_kwargs(self):
+        org = self.create_organization()
+        assert Organization.objects._get_cacheable_kv_from_kwargs(dict(id=14)) == ("id", "id", 14)
+        assert Organization.objects._get_cacheable_kv_from_kwargs(dict(house=org)) == (
+            "house",
+            "id",
+            org.id,
+        )
+
+    def test_cache_pk(self):
+        org = self.create_organization()
+
+        self.clear()
+        assert Organization.objects.get_from_cache(slug=org.slug) == org
+        assert Organization.objects.get_from_cache(pk=org.id) == org
+        assert Organization.objects.get_from_cache(id=org.id) == org
+
+        cache.clear()
+        assert Organization.objects.get_from_cache(slug=org.slug) == org
+        assert Organization.objects.get_from_cache(pk=org.id) == org
+        assert Organization.objects.get_from_cache(id=org.id) == org
+
+        flush_manager_local_cache()
+        assert Organization.objects.get_from_cache(slug=org.slug) == org
+        assert Organization.objects.get_from_cache(pk=org.id) == org
+        assert Organization.objects.get_from_cache(id=org.id) == org
+
+        # Once to hit fully cached path.
+        assert Organization.objects.get_from_cache(slug=org.slug) == org
+        assert Organization.objects.get_from_cache(pk=org.id) == org
+        assert Organization.objects.get_from_cache(id=org.id) == org


### PR DESCRIPTION
https://sentry.my.sentry.io/organizations/sentry/issues/400280/

There are a myrid of these issues caused by `get_from_cache` in some strange edge case returning `int`.
I believe this may be related to some super edge case pollution when we store reffed vs instance entries.

Problem is that the existing logic
1. Does not check for bad cache values in all cases (in fact, checking exceptions in sentry, it looks like the current check is never being hit because the cache pollution happens in the local_cache before the check)
2. Is also kind complex.... (I tried to flatten it out and add a basic series of tests)

I still haven't cornered the exact cause of the cache pollution, unfortunately, despite several attempts and hypothesis.  For now, atleast, the exception will de-pollute the cache and provide a more useful error (and not break a user experience).

Welcome anyone who has better ideas about how the cache may become polluted (test case repro would be best!)