### PR TITLE
fix(member): Update get_email default

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -479,7 +479,7 @@ class OrganizationMember(Model):
                 user = user_service.get_user(user_id=self.user_id)
             if user and user.email:
                 return user.email
-        return self.email
+        return self.email or ""
 
     def get_avatar_type(self):
         if self.user_id:


### PR DESCRIPTION
Update the get_email default to an empty string for integration users without an email.