### PR TITLE
ref(hc): Re-enable outboxes from check-auth

### DIFF
--- a/src/sentry/tasks/check_auth.py
+++ b/src/sentry/tasks/check_auth.py
@@ -105,7 +105,4 @@ def check_auth_identity(auth_identity_id, **kwargs):
             organization_service.update_membership_flags(organization_member=om)
 
     now = timezone.now()
-    with unguarded_write(using=router.db_for_write(AuthIdentity)):
-        AuthIdentity.objects.filter(id=auth_identity_id).update(last_verified=now, last_synced=now)
-        # Restore once outbox processing is improved
-        # auth_identity.update(last_verified=now, last_synced=now)
+    auth_identity.update(last_verified=now, last_synced=now)


### PR DESCRIPTION
After validating https://github.com/getsentry/sentry/pull/55964 in production.
The volume of outboxes themselves did not and should not impact performance of outboxes, but previously it did impact celery in terms of sheer jobs.  The job amount should now have a fixed rate regardless and thus if the above PR is working, this change should have no further impact.