### PR TITLE
ref(rules): Return disabled rules

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -167,7 +167,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
             # Filter to only error alert rules
             alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
         issue_rules = Rule.objects.filter(
-            status=ObjectStatus.ACTIVE,
+            status__in=[ObjectStatus.ACTIVE, ObjectStatus.DISABLED],
             source__in=[RuleSource.ISSUE],
             project__in=projects,
         )


### PR DESCRIPTION
Return disabled rules in the combined-rules endpoint so that we can show them with their state on the alerts page. 
<img width="1154" alt="Screenshot 2023-09-12 at 12 09 17 PM" src="https://github.com/getsentry/sentry/assets/29959063/a0341247-53c4-4027-ae92-6257936621ac">
