### PR TITLE
feat(crons): Add monitor form to landing page

### DIFF
--- a/static/app/views/monitors/components/cronsLandingPanel.tsx
+++ b/static/app/views/monitors/components/cronsLandingPanel.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
 import onboardingImg from 'sentry-images/spot/onboarding-preview.svg';
@@ -13,6 +14,10 @@ import {PlatformKey} from 'sentry/data/platformCategories';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import MonitorForm from 'sentry/views/monitors/components/monitorForm';
+import {Monitor} from 'sentry/views/monitors/types';
 
 import {NewMonitorButton} from './newMonitorButton';
 import {
@@ -56,6 +61,7 @@ const platformGuides: Record<SupportedPlatform, PlatformGuide[]> = {
 };
 
 export function CronsLandingPanel() {
+  const organization = useOrganization();
   const [platform, setPlatform] = useState<PlatformKey | null>(null);
 
   if (!platform) {
@@ -67,6 +73,11 @@ export function CronsLandingPanel() {
   )?.label;
 
   const guides = platformGuides[platform];
+
+  function onCreateMonitor(data: Monitor) {
+    const url = normalizeUrl(`/organizations/${organization.slug}/crons/${data.slug}/`);
+    browserHistory.push(url);
+  }
 
   return (
     <Panel>
@@ -97,7 +108,16 @@ export function CronsLandingPanel() {
                   </GuideContainer>
                 </TabPanels.Item>
               )),
-              <TabPanels.Item key="manual">Manual</TabPanels.Item>,
+              <TabPanels.Item key="manual">
+                <GuideContainer>
+                  <MonitorForm
+                    apiMethod="POST"
+                    apiEndpoint={`/organizations/${organization.slug}/monitors/`}
+                    onSubmitSuccess={onCreateMonitor}
+                    submitLabel={t('Next')}
+                  />
+                </GuideContainer>
+              </TabPanels.Item>,
             ]}
           </TabPanels>
         </Tabs>


### PR DESCRIPTION
Shows the manual monitor form creation when navigating to the manual tab for any of the landing page platform options.

![image](https://github.com/getsentry/sentry/assets/9372512/29c9b7cd-2d24-40c5-bf9c-32f803f457bd)
