### PR TITLE
feat(healthchecks): Add features to devservices health checks

### DIFF
--- a/tests/tools/test_devservices_healthcheck.py
+++ b/tests/tools/test_devservices_healthcheck.py
@@ -31,11 +31,6 @@ def test_run_with_retries_ok() -> None:
     run_with_retries(lambda: subprocess.run("date", check=True), 1, 10)
 
 
-def test_unknown_service() -> None:
-    with pytest.raises(HealthcheckError):
-        check_health(["this service does not exist"])
-
-
 def test_postgres_not_running(mock_subprocess_run: mock.MagicMock) -> None:
     mock_subprocess_run.return_value.stdout = ""
     mock_subprocess_run.return_value.code = 0

--- a/tests/tools/test_devservices_healthcheck.py
+++ b/tests/tools/test_devservices_healthcheck.py
@@ -47,12 +47,14 @@ def test_postgres_not_running(mock_subprocess_run: mock.MagicMock) -> None:
 
 def test_postgres_healthcheck_failing(mock_subprocess_run: mock.MagicMock) -> None:
     running = mock.Mock()
-    running.stdout = "'running'\n"
+    running.stdout = "running\n"
     running.code = 0
 
     mock_subprocess_run.side_effect = [
         running,
-        Exception("injected error"),
+        HealthcheckError("injected error"),
+        HealthcheckError("injected error"),
+        HealthcheckError("injected error"),
     ]
 
     with pytest.raises(HealthcheckError):
@@ -62,7 +64,7 @@ def test_postgres_healthcheck_failing(mock_subprocess_run: mock.MagicMock) -> No
 
 def test_postgres_running(mock_subprocess_run: mock.MagicMock) -> None:
     running = mock.Mock()
-    running.stdout = "'running'\n"
+    running.stdout = "running\n"
     running.code = 0
 
     healthcheck = mock.Mock()
@@ -78,7 +80,7 @@ def test_postgres_running(mock_subprocess_run: mock.MagicMock) -> None:
 
 def test_kafka_zookeper_running(mock_subprocess_run: mock.MagicMock) -> None:
     running = mock.Mock()
-    running.stdout = "'running'\n"
+    running.stdout = "running\n"
     running.code = 0
 
     healthcheck = mock.Mock()
@@ -91,7 +93,7 @@ def test_kafka_zookeper_running(mock_subprocess_run: mock.MagicMock) -> None:
             "container",
             "inspect",
             "-f",
-            "'{{.State.Status}}'",
+            "{{.State.Status}}",
             "sentry_zookeeper",
         ):
             return running
@@ -100,7 +102,7 @@ def test_kafka_zookeper_running(mock_subprocess_run: mock.MagicMock) -> None:
             "container",
             "inspect",
             "-f",
-            "'{{.State.Status}}'",
+            "{{.State.Status}}",
             "sentry_kafka",
         ):
             return running

--- a/tests/tools/test_devservices_healthcheck.py
+++ b/tests/tools/test_devservices_healthcheck.py
@@ -1,6 +1,6 @@
 import subprocess
 import time
-from typing import Generator
+from typing import Generator, List
 from unittest import mock
 
 import pytest
@@ -9,13 +9,13 @@ from tools.devservices_healthcheck import HealthcheckError, check_health, run_wi
 
 
 @pytest.fixture(autouse=True)
-def no_sleep() -> Generator:
+def no_sleep() -> Generator[None, None, None]:
     with mock.patch.object(time, "sleep"):
         yield
 
 
 @pytest.fixture
-def mock_subprocess_run() -> Generator:
+def mock_subprocess_run() -> Generator[mock.Mock, None, None]:
     with mock.patch.object(subprocess, "run", autospec=True) as mock_run:
         yield mock_run
 
@@ -86,7 +86,7 @@ def test_kafka_zookeper_running(mock_subprocess_run: mock.MagicMock) -> None:
     healthcheck = mock.Mock()
 
     def run(
-        cmd_args: list, capture_output: bool = False, text: bool = False, check: bool = False
+        cmd_args: List[str], capture_output: bool = False, text: bool = False, check: bool = False
     ) -> mock.Mock:
         if cmd_args == (
             "docker",

--- a/tests/tools/test_devservices_healthcheck.py
+++ b/tests/tools/test_devservices_healthcheck.py
@@ -1,5 +1,6 @@
 import subprocess
 import time
+from typing import Generator
 from unittest import mock
 
 import pytest
@@ -8,34 +9,34 @@ from tools.devservices_healthcheck import HealthcheckError, check_health, run_wi
 
 
 @pytest.fixture(autouse=True)
-def no_sleep():
+def no_sleep() -> Generator:
     with mock.patch.object(time, "sleep"):
         yield
 
 
 @pytest.fixture
-def mock_subprocess_run():
+def mock_subprocess_run() -> Generator:
     with mock.patch.object(subprocess, "run", autospec=True) as mock_run:
         yield mock_run
 
 
-def test_run_with_retries_fail():
+def test_run_with_retries_fail() -> None:
     with pytest.raises(HealthcheckError):
         run_with_retries(
             lambda: subprocess.run(("ls", "/tmp/this-does-not-exist"), check=True), 1, 10
         )
 
 
-def test_run_with_retries_ok():
-    run_with_retries(lambda: subprocess.run(("date"), check=True), 1, 10)
+def test_run_with_retries_ok() -> None:
+    run_with_retries(lambda: subprocess.run("date", check=True), 1, 10)
 
 
-def test_unknown_service():
+def test_unknown_service() -> None:
     with pytest.raises(HealthcheckError):
         check_health(["this service does not exist"])
 
 
-def test_postgres_not_running(mock_subprocess_run):
+def test_postgres_not_running(mock_subprocess_run: mock.MagicMock) -> None:
     mock_subprocess_run.return_value.stdout = ""
     mock_subprocess_run.return_value.code = 0
 
@@ -44,7 +45,7 @@ def test_postgres_not_running(mock_subprocess_run):
     assert mock_subprocess_run.call_count == 3
 
 
-def test_postgres_healthcheck_failing(mock_subprocess_run):
+def test_postgres_healthcheck_failing(mock_subprocess_run: mock.MagicMock) -> None:
     running = mock.Mock()
     running.stdout = "'running'\n"
     running.code = 0
@@ -59,7 +60,7 @@ def test_postgres_healthcheck_failing(mock_subprocess_run):
     assert mock_subprocess_run.call_count == 4
 
 
-def test_postgres_running(mock_subprocess_run):
+def test_postgres_running(mock_subprocess_run: mock.MagicMock) -> None:
     running = mock.Mock()
     running.stdout = "'running'\n"
     running.code = 0
@@ -75,25 +76,53 @@ def test_postgres_running(mock_subprocess_run):
     assert mock_subprocess_run.call_count == 2
 
 
-def test_kafka_zookeper_running(mock_subprocess_run):
+def test_kafka_zookeper_running(mock_subprocess_run: mock.MagicMock) -> None:
     running = mock.Mock()
     running.stdout = "'running'\n"
     running.code = 0
 
     healthcheck = mock.Mock()
 
-    def run(cmd_args, capture_output=False, text=False, check=False):
-        cmd = " ".join(cmd_args)
-        if cmd == "docker container inspect -f '{{.State.Status}}' sentry_zookeeper":
+    def run(
+        cmd_args: list, capture_output: bool = False, text: bool = False, check: bool = False
+    ) -> mock.Mock:
+        if cmd_args == (
+            "docker",
+            "container",
+            "inspect",
+            "-f",
+            "'{{.State.Status}}'",
+            "sentry_zookeeper",
+        ):
             return running
-        elif cmd == "docker container inspect -f '{{.State.Status}}' sentry_kafka":
+        elif cmd_args == (
+            "docker",
+            "container",
+            "inspect",
+            "-f",
+            "'{{.State.Status}}'",
+            "sentry_kafka",
+        ):
             return running
-        elif (
-            cmd == "docker exec sentry_kafka kafka-topics --zookeeper sentry_zookeeper:2181 --list"
-            or cmd == "docker exec sentry_kafka kafka-topics --zookeeper 127.0.0.1:2181 --list"
+        elif cmd_args == (
+            "docker",
+            "exec",
+            "sentry_kafka",
+            "kafka-topics",
+            "--zookeeper",
+            "sentry_zookeeper:2181",
+            "--list",
+        ) or (
+            "docker",
+            "exec",
+            "sentry_kafka",
+            "kafka-topics",
+            "--zookeeper",
+            "127.0.0.1:2181",
+            "--list",
         ):
             return healthcheck
-        raise AssertionError("unexpected command")
+        raise AssertionError(f"unexpected command '{cmd_args}'")
 
     mock_subprocess_run.side_effect = run
 

--- a/tests/tools/test_devservices_healthcheck.py
+++ b/tests/tools/test_devservices_healthcheck.py
@@ -4,13 +4,19 @@ from unittest import mock
 
 import pytest
 
-from tools.devservices_healthcheck import HealthcheckError, run_with_retries
+from tools.devservices_healthcheck import HealthcheckError, check_health, run_with_retries
 
 
 @pytest.fixture(autouse=True)
 def no_sleep():
     with mock.patch.object(time, "sleep"):
         yield
+
+
+@pytest.fixture
+def mock_subprocess_run():
+    with mock.patch.object(subprocess, "run", autospec=True) as mock_run:
+        yield mock_run
 
 
 def test_run_with_retries_fail():
@@ -22,3 +28,74 @@ def test_run_with_retries_fail():
 
 def test_run_with_retries_ok():
     run_with_retries(lambda: subprocess.run(("date"), check=True), 1, 10)
+
+
+def test_unknown_service():
+    with pytest.raises(HealthcheckError):
+        check_health(["this service does not exist"])
+
+
+def test_postgres_not_running(mock_subprocess_run):
+    mock_subprocess_run.return_value.stdout = ""
+    mock_subprocess_run.return_value.code = 0
+
+    with pytest.raises(HealthcheckError):
+        check_health(["postgres"])
+    assert mock_subprocess_run.call_count == 3
+
+
+def test_postgres_healthcheck_failing(mock_subprocess_run):
+    running = mock.Mock()
+    running.stdout = "'running'\n"
+    running.code = 0
+
+    mock_subprocess_run.side_effect = [
+        running,
+        Exception("injected error"),
+    ]
+
+    with pytest.raises(HealthcheckError):
+        check_health(["postgres"])
+    assert mock_subprocess_run.call_count == 4
+
+
+def test_postgres_running(mock_subprocess_run):
+    running = mock.Mock()
+    running.stdout = "'running'\n"
+    running.code = 0
+
+    healthcheck = mock.Mock()
+
+    mock_subprocess_run.side_effect = [
+        running,
+        healthcheck,
+    ]
+
+    check_health(["postgres"])
+    assert mock_subprocess_run.call_count == 2
+
+
+def test_kafka_zookeper_running(mock_subprocess_run):
+    running = mock.Mock()
+    running.stdout = "'running'\n"
+    running.code = 0
+
+    healthcheck = mock.Mock()
+
+    def run(cmd_args, capture_output=False, text=False, check=False):
+        cmd = " ".join(cmd_args)
+        if cmd == "docker container inspect -f '{{.State.Status}}' sentry_zookeeper":
+            return running
+        elif cmd == "docker container inspect -f '{{.State.Status}}' sentry_kafka":
+            return running
+        elif (
+            cmd == "docker exec sentry_kafka kafka-topics --zookeeper sentry_zookeeper:2181 --list"
+            or cmd == "docker exec sentry_kafka kafka-topics --zookeeper 127.0.0.1:2181 --list"
+        ):
+            return healthcheck
+        raise AssertionError("unexpected command")
+
+    mock_subprocess_run.side_effect = run
+
+    check_health(["kafka"])
+    assert mock_subprocess_run.call_count == 3

--- a/tests/tools/test_devservices_healthcheck.py
+++ b/tests/tools/test_devservices_healthcheck.py
@@ -1,9 +1,10 @@
+import subprocess
 import time
 from unittest import mock
 
 import pytest
 
-from tools.devservices_healthcheck import run_cmd
+from tools.devservices_healthcheck import HealthcheckError, run_with_retries
 
 
 @pytest.fixture(autouse=True)
@@ -12,11 +13,12 @@ def no_sleep():
         yield
 
 
-def test_cmd_run_fail():
-    with pytest.raises(SystemExit) as exinfo:
-        run_cmd(["ls", "/tmp/there-is-nothing-here"], retries=1)
-    assert exinfo.value.code != 0
+def test_run_with_retries_fail():
+    with pytest.raises(HealthcheckError):
+        run_with_retries(
+            lambda: subprocess.run(("ls", "/tmp/this-does-not-exist"), check=True), 1, 10
+        )
 
 
-def test_cmd_run_ok():
-    run_cmd(["date"])
+def test_run_with_retries_ok():
+    run_with_retries(lambda: subprocess.run(("date"), check=True), 1, 10)

--- a/tools/devservices_healthcheck.py
+++ b/tools/devservices_healthcheck.py
@@ -102,9 +102,6 @@ def run_with_retries(cmd: Callable[[], object], retries: int, timeout: int) -> N
 
 
 def get_services_to_check(id: str) -> list[str]:
-    if all_service_healthchecks.get(id) is None:
-        raise HealthcheckError(f"Service '{id}' does not have a health check")
-
     checks = []
     hc = all_service_healthchecks[id]
     for dep in hc.deps:

--- a/tools/devservices_healthcheck.py
+++ b/tools/devservices_healthcheck.py
@@ -50,7 +50,7 @@ def check_kafka():
             "kafka-topics",
             "--zookeeper",
             # TODO: sentry_zookeeper:2181 doesn't work in CI, but 127.0.0.1 doesn't work locally
-            os.environ.get("ZK_HOST", "sentry_zookeeper:2181"),
+            os.environ.get("ZK_HOST", "127.0.0.1:2181"),
             "--list",
         ),
         check=True,

--- a/tools/devservices_healthcheck.py
+++ b/tools/devservices_healthcheck.py
@@ -13,16 +13,15 @@ class HealthcheckError(Exception):
 
 
 class HealthCheck:
-    id: str
-    container_name: str
-    check_by_default: bool
-    check: Callable[[], None]
-    deps: list[str]
-    retries: int
-    timeout_secs: int
-
     def __init__(
-        self, id, container_name, check_by_default, check=None, deps=None, retries=3, timeout_secs=5
+        self,
+        id: str,
+        container_name: str,
+        check_by_default: bool,
+        check: Callable[[], object] | None = None,
+        deps: list[str] = None,
+        retries: int = 3,
+        timeout_secs: int = 5,
     ):
         self.id = id
         self.container_name = container_name
@@ -32,7 +31,7 @@ class HealthCheck:
         self.retries = retries
         self.timeout_secs = timeout_secs
 
-    def check_container(self):
+    def check_container(self) -> None:
         response = subprocess.run(
             ("docker", "container", "inspect", "-f", "'{{.State.Status}}'", self.container_name),
             capture_output=True,
@@ -58,7 +57,7 @@ def check_kafka():
     )
 
 
-def check_postgres():
+def check_postgres() -> None:
     subprocess.run(
         ("docker", "exec", "sentry_postgres", "pg_isready", "-U", "postgres"), check=True
     )

--- a/tools/devservices_healthcheck.py
+++ b/tools/devservices_healthcheck.py
@@ -153,6 +153,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument(
         "--service",
         action="append",
+        choices=list(dict.fromkeys(all_service_healthchecks)),
         help="The services you wish to check on. Defaults to all services.",
     )
 

--- a/tools/devservices_healthcheck.py
+++ b/tools/devservices_healthcheck.py
@@ -89,7 +89,7 @@ all_service_healthchecks = {
 }
 
 
-def run_with_retries(cmd: Callable[[], None], retries: int, timeout: int) -> None:
+def run_with_retries(cmd: Callable[[], object], retries: int, timeout: int) -> None:
     for retry in range(1, retries + 1):
         try:
             cmd()

--- a/tools/devservices_healthcheck.py
+++ b/tools/devservices_healthcheck.py
@@ -19,7 +19,7 @@ class HealthCheck:
         container_name: str,
         check_by_default: bool,
         check: Callable[[], object] | None = None,
-        deps: list[str] = None,
+        deps: list[str] | None = None,
         retries: int = 3,
         timeout_secs: int = 5,
     ):

--- a/tools/devservices_healthcheck.py
+++ b/tools/devservices_healthcheck.py
@@ -1,47 +1,179 @@
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
 import time
+from collections.abc import Sequence
+from typing import Callable
 
 
-def run_cmd(
-    args: list[str],
-    *,
-    retries: int = 3,
-    timeout: int = 5,
-) -> None:
+class HealthcheckError(Exception):
+    pass
+
+
+class HealthCheck:
+    id: str
+    container_name: str
+    check_by_default: bool
+    check: Callable[[], None]
+    deps: list[str]
+    retries: int
+    timeout_secs: int
+
+    def __init__(
+        self, id, container_name, check_by_default, check=None, deps=None, retries=3, timeout_secs=5
+    ):
+        self.id = id
+        self.container_name = container_name
+        self.check_by_default = check_by_default
+        self.check = check
+        self.deps = deps or []
+        self.retries = retries
+        self.timeout_secs = timeout_secs
+
+    def check_container(self):
+        response = subprocess.run(
+            ("docker", "container", "inspect", "-f", "'{{.State.Status}}'", self.container_name),
+            capture_output=True,
+            text=True,
+        )
+        if response.stdout.strip() != "'running'":
+            raise HealthcheckError(f"Container '{self.container_name}' is not running.")
+
+
+def check_kafka():
+    subprocess.run(
+        (
+            "docker",
+            "exec",
+            "sentry_kafka",
+            "kafka-topics",
+            "--zookeeper",
+            # TODO: sentry_zookeeper:2181 doesn't work in CI, but 127.0.0.1 doesn't work locally
+            os.environ.get("ZK_HOST", "sentry_zookeeper:2181"),
+            "--list",
+        ),
+        check=True,
+    )
+
+
+def check_postgres():
+    subprocess.run(
+        ("docker", "exec", "sentry_postgres", "pg_isready", "-U", "postgres"), check=True
+    )
+
+
+# Available health checks
+all_service_healthchecks = {
+    "postgres": HealthCheck(
+        "postgres",
+        "sentry_postgres",
+        True,
+        lambda: subprocess.run(
+            ["docker", "exec", "sentry_postgres", "pg_isready", "-U", "postgres"], check=True
+        ),
+    ),
+    "kafka": HealthCheck(
+        "kafka",
+        "sentry_kafka",
+        os.getenv("NEED_KAFKA") == "true",
+        check_kafka,
+        deps=["zookeeper"],
+    ),
+    "zookeeper": HealthCheck(
+        "zookeeper",
+        "sentry_zookeeper",
+        os.getenv("NEED_KAFKA") == "true",
+    ),
+}
+
+
+def run_with_retries(cmd: Callable[[], None], retries: int, timeout: int) -> None:
     for retry in range(1, retries + 1):
-        returncode = subprocess.call(args)
-
-        if returncode != 0:
-            time.sleep(timeout)
+        try:
+            cmd()
+        except Exception as e:
+            if retry == retries:
+                print(f"Command failed, no more retries: {e}")
+                raise HealthcheckError(f"Command failed: {e}")
+            else:
+                print(f"Command failed, retrying in {timeout}s (attempt {retry+1} of {retries})...")
+                time.sleep(timeout)
         else:
             return
 
-    raise SystemExit(1)
+
+def get_services_to_check(id: str) -> list[str]:
+    if all_service_healthchecks.get(id) is None:
+        raise HealthcheckError(f"Service '{id}' does not have a health check")
+
+    checks = []
+    hc = all_service_healthchecks[id]
+    for dep in hc.deps:
+        dep_checks = get_services_to_check(dep)
+        for d in dep_checks:
+            checks.append(d)
+    checks.append(id)
+    return checks
 
 
-def main() -> None:
-    # Available health checks
-    postgres_healthcheck = ["docker", "exec", "sentry_postgres", "pg_isready", "-U", "postgres"]
-    kafka_healthcheck = [
-        "docker",
-        "exec",
-        "sentry_kafka",
-        "kafka-topics",
-        "--zookeeper",
-        # TODO: sentry_zookeeper:2181 doesn't work in CI, but 127.0.0.1 doesn't work locally
-        os.environ.get("ZK_HOST", "127.0.0.1:2181"),
-        "--list",
-    ]
+def check_health(ids: list[str]) -> None:
+    checks = []
+    for id in ids:
+        s = get_services_to_check(id)
+        checks += s
 
-    healthchecks = [postgres_healthcheck]
-    if os.getenv("NEED_KAFKA") == "true":
-        healthchecks.append(kafka_healthcheck)
+    # dict.fromkeys is used to remove duplicates while maintaining order
+    for name in dict.fromkeys(checks):
+        print(f"Checking service {name}")
+        hc = all_service_healthchecks[name]
+        print(f"Checking '{hc.container_name}' is running...")
+        ls = " ".join(list(set(checks)))
+        try:
+            run_with_retries(hc.check_container, hc.retries, hc.timeout_secs)
+        except HealthcheckError:
+            raise HealthcheckError(
+                f"Container '{hc.container_name}' is not running.\n"
+                + f"    Start service: sentry devservices up {hc.id}\n"
+                + f"    Restart all services: sentry devservices down {ls} && sentry devservices up {ls}"
+            )
 
-    for check in healthchecks:
-        run_cmd(check)
+        if hc.check is not None:
+            print(f"Checking '{hc.container_name}' container health...")
+            try:
+                run_with_retries(hc.check, hc.retries, hc.timeout_secs)
+            except HealthcheckError:
+                raise HealthcheckError(
+                    f"Container '{hc.container_name}' does not appear to be healthy.\n"
+                    + f"    Restart service: sentry devservices down {hc.id} && sentry devservices up {hc.id}\n"
+                    + f"    Restart all services: sentry devservices down {ls} && sentry devservices up {ls}"
+                )
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--service",
+        action="append",
+        help="The services you wish to check on. Defaults to all services.",
+    )
+
+    args = parser.parse_args(argv)
+    services = args.service
+
+    healthchecks = services
+    if healthchecks is None:
+        healthchecks = []
+        for k in all_service_healthchecks:
+            if all_service_healthchecks[k].check_by_default:
+                healthchecks.append(k)
+
+    try:
+        check_health(healthchecks)
+    except HealthcheckError as e:
+        print(e)
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Allow services to indicate dependencies (kafka relies on zookeeper)
2. Use docker inspect to check if a service is simply running
3. Restructure logic so check_health can be called via pytest plugin or fixture
4. Adds a `service` flag that can be used to specific which services to check

One other subtle tweak here is I use the `CI` environment variable to alternate between zookeeper localhost vs docker network name. I'm hoping we can remove this at some point, but it's easiest way to make the tool work locally and on CI.