### PR TITLE
fix(UI): Let team admin add built-in/custom repos + delete debug files

### DIFF
--- a/static/app/views/settings/projectDebugFiles/debugFileRow.tsx
+++ b/static/app/views/settings/projectDebugFiles/debugFileRow.tsx
@@ -14,6 +14,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconClock, IconDelete, IconDownload} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {Project} from 'sentry/types';
 import {DebugFile} from 'sentry/types/debugFiles';
 
 import {getFeatureTooltip, getPrettyFileType} from './utils';
@@ -24,6 +25,7 @@ type Props = {
   downloadUrl: string;
   onDelete: (id: string) => void;
   orgSlug: string;
+  project: Project;
   showDetails: boolean;
 };
 
@@ -34,6 +36,7 @@ function DebugFileRow({
   downloadRole,
   onDelete,
   orgSlug,
+  project,
 }: Props) {
   const {id, data, debugId, uuid, size, dateCreated, objectName, symbolType, codeId} =
     debugFile;
@@ -110,7 +113,7 @@ function DebugFileRow({
               </Tooltip>
             )}
           </Role>
-          <Access access={['project:write']}>
+          <Access access={['project:write']} project={project}>
             {({hasAccess}) => (
               <Tooltip
                 disabled={hasAccess}

--- a/static/app/views/settings/projectDebugFiles/debugFileRow.tsx
+++ b/static/app/views/settings/projectDebugFiles/debugFileRow.tsx
@@ -110,7 +110,7 @@ function DebugFileRow({
               </Tooltip>
             )}
           </Role>
-          <Access access={['project:write']}>
+          <Access access={['project:write']} project={project}>
             {({hasAccess}) => (
               <Tooltip
                 disabled={hasAccess}

--- a/static/app/views/settings/projectDebugFiles/debugFileRow.tsx
+++ b/static/app/views/settings/projectDebugFiles/debugFileRow.tsx
@@ -110,7 +110,7 @@ function DebugFileRow({
               </Tooltip>
             )}
           </Role>
-          <Access access={['project:write']} project={project}>
+          <Access access={['project:write']}>
             {({hasAccess}) => (
               <Tooltip
                 disabled={hasAccess}

--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -169,13 +169,13 @@ class ProjectDebugSymbols extends DeprecatedAsyncView<Props, State> {
 
         {organization.features.includes('symbol-sources') && (
           <Fragment>
-            <PermissionAlert />
+            <PermissionAlert project={project} />
 
             <Sources
               api={this.api}
               location={location}
               router={router}
-              projSlug={project.slug}
+              project={project}
               organization={organization}
               customRepositories={
                 (project.symbolSources

--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -127,7 +127,7 @@ class ProjectDebugSymbols extends DeprecatedAsyncView<Props, State> {
 
   renderDebugFiles() {
     const {debugFiles, showDetails} = this.state;
-    const {organization, params} = this.props;
+    const {organization, params, project} = this.props;
 
     if (!debugFiles?.length) {
       return null;
@@ -145,6 +145,7 @@ class ProjectDebugSymbols extends DeprecatedAsyncView<Props, State> {
           onDelete={this.handleDelete}
           key={debugFile.id}
           orgSlug={organization.slug}
+          project={project}
         />
       );
     });

--- a/static/app/views/settings/projectDebugFiles/sources/builtInRepositories.spec.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/builtInRepositories.spec.tsx
@@ -15,7 +15,7 @@ describe('Built-in Repositories', function () {
       <BuiltInRepositories
         api={api}
         organization={organization}
-        projSlug={project.slug}
+        project={project}
         isLoading={false}
         builtinSymbolSourceOptions={builtinSymbolSourceOptions}
         builtinSymbolSources={builtinSymbolSources}

--- a/static/app/views/settings/projectDebugFiles/sources/builtInRepositories.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/builtInRepositories.tsx
@@ -21,7 +21,7 @@ type Props = {
   builtinSymbolSources: string[];
   isLoading: boolean;
   organization: Organization;
-  projSlug: Project['slug'];
+  project: Project;
 };
 
 function BuiltInRepositories({
@@ -29,7 +29,7 @@ function BuiltInRepositories({
   organization,
   builtinSymbolSourceOptions,
   builtinSymbolSources,
-  projSlug,
+  project,
   isLoading,
 }: Props) {
   // If the project details object has an unknown built-in source, this will be filtered here.
@@ -63,7 +63,7 @@ function BuiltInRepositories({
 
     try {
       const updatedProjectDetails: Project = await api.requestPromise(
-        `/projects/${organization.slug}/${projSlug}/`,
+        `/projects/${organization.slug}/${project.slug}/`,
         {
           method: 'PUT',
           data: {
@@ -86,7 +86,7 @@ function BuiltInRepositories({
         {isLoading ? (
           <LoadingIndicator />
         ) : (
-          <Access access={['project:write']}>
+          <Access access={['project:write']} project={project}>
             {({hasAccess}) => (
               <StyledSelectField
                 disabledReason={

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.spec.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.spec.tsx
@@ -69,7 +69,6 @@ function getProps(props?: Parameters<typeof initializeOrg>[0]) {
     organization,
     project,
     router,
-    projSlug: project.slug,
     isLoading: false,
     location: router.location,
     routerContext,

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.tsx
@@ -36,7 +36,7 @@ type Props = {
   isLoading: boolean;
   location: Location;
   organization: Organization;
-  projSlug: Project['slug'];
+  project: Project;
   router: InjectedRouter;
 };
 
@@ -44,7 +44,7 @@ function CustomRepositories({
   api,
   organization,
   customRepositories: repositories,
-  projSlug,
+  project,
   router,
   location,
   isLoading,
@@ -115,7 +115,7 @@ function CustomRepositories({
     const symbolSources = JSON.stringify(items.map(expandKeys));
 
     const promise: Promise<any> = api.requestPromise(
-      `/projects/${orgSlug}/${projSlug}/`,
+      `/projects/${orgSlug}/${project.slug}/`,
       {
         method: 'PUT',
         data: {symbolSources},
@@ -181,7 +181,7 @@ function CustomRepositories({
   async function handleSyncRepositoryNow(repoId: CustomRepo['id']) {
     try {
       await api.requestPromise(
-        `/projects/${orgSlug}/${projSlug}/appstoreconnect/${repoId}/refresh/`,
+        `/projects/${orgSlug}/${project.slug}/appstoreconnect/${repoId}/refresh/`,
         {
           method: 'POST',
         }
@@ -199,7 +199,7 @@ function CustomRepositories({
   return (
     <Feature features={['custom-symbol-sources']} organization={organization}>
       {({hasFeature}) => (
-        <Access access={['project:write']}>
+        <Access access={['project:write']} project={project}>
           {({hasAccess}) => {
             const addRepositoryButtonDisabled = !hasAccess || isLoading;
             return (

--- a/static/app/views/settings/projectDebugFiles/sources/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/index.tsx
@@ -17,7 +17,7 @@ type Props = {
   isLoading: boolean;
   location: Location;
   organization: Organization;
-  projSlug: Project['slug'];
+  project: Project;
   router: InjectedRouter;
 };
 
@@ -27,7 +27,7 @@ function Sources({
   customRepositories,
   builtinSymbolSources,
   builtinSymbolSourceOptions,
-  projSlug,
+  project,
   location,
   router,
   isLoading,
@@ -39,7 +39,7 @@ function Sources({
         organization={organization}
         builtinSymbolSources={builtinSymbolSources}
         builtinSymbolSourceOptions={builtinSymbolSourceOptions}
-        projSlug={projSlug}
+        project={project}
         isLoading={isLoading}
       />
       <CustomRepositories
@@ -48,7 +48,7 @@ function Sources({
         router={router}
         organization={organization}
         customRepositories={customRepositories}
-        projSlug={projSlug}
+        project={project}
         isLoading={isLoading}
       />
     </Fragment>


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry/pull/56148 - backend changes to let team admins delete debug files

In order to check the write access for Team Admins, I need the full project. Originally we were drilling down the project slug instead of the project itself, so I changed it to pass the full project for built-in + custom repo components

Recording of a Team Admin (unable to delete debug file because backend changes are in other PR)


https://github.com/getsentry/sentry/assets/67301797/98d2ee1d-67f7-415b-909d-f64fb2b82e7c



Fixes https://github.com/getsentry/sentry/issues/56116 and https://github.com/getsentry/sentry/issues/53919