### PR TITLE
Fix(fly): fetch the first active user

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -174,7 +174,7 @@ class DatabaseBackedUserService(UserService):
 
     def get_or_create_user_by_email(self, *, email: str) -> RpcUser:
         with transaction.atomic(router.db_for_write(User)):
-            user_query = User.objects.filter(email__iexact=email)
+            user_query = User.objects.filter(email__iexact=email, is_active=True)
             # Create User if it doesn't exist
             if not user_query.exists():
                 user = User.objects.create(
@@ -186,7 +186,7 @@ class DatabaseBackedUserService(UserService):
                 # Users are not supposed to have the same email but right now our auth pipeline let this happen
                 # So let's not break the user experience
                 if user_query.count() > 1:
-                    logger.error(f"email {email} has more than 1 user")
+                    logger.warning("Email has multiple users", extra={"email": email})
                 user = user_query[0]
             return serialize_rpc_user(user)
 

--- a/tests/sentry/services/hybrid_cloud/user/test_impl.py
+++ b/tests/sentry/services/hybrid_cloud/user/test_impl.py
@@ -14,3 +14,17 @@ class DatabaseBackedUserService(TestCase):
         user = user_service.get_or_create_user_by_email(email="test@email.com")
         assert user1.id == user.id
         assert user2.id != user.id
+
+    def test_get_active_user(self):
+        inactive_user = self.create_user(
+            email="test@email.com", username="inactive", is_active=False
+        )
+        active_user = self.create_user(email="test@email.com", username="active")
+        user = user_service.get_or_create_user_by_email(email="test@email.com")
+        assert active_user.id == user.id
+        assert inactive_user.id != user.id
+
+    def test_get_user_ci(self):
+        user = self.create_user(email="tESt@email.com")
+        fetched_user = user_service.get_or_create_user_by_email(email="TesT@email.com")
+        assert user.id == fetched_user.id


### PR DESCRIPTION
1. We should only fetch active users here
2. Grouping errors so we don't get too many issues 