### PR TITLE
ref: rename ue4 to unreal engine

### DIFF
--- a/static/app/gettingStartedDocs/unreal/unreal.tsx
+++ b/static/app/gettingStartedDocs/unreal/unreal.tsx
@@ -1,77 +1,77 @@
-import {Fragment} from 'react';
+import { Fragment } from 'react';
 import styled from '@emotion/styled';
 
-import {Alert} from 'sentry/components/alert';
+import { Alert } from 'sentry/components/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
-import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {t, tct} from 'sentry/locale';
+import { Layout, LayoutProps } from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import { ModuleProps } from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import { StepType } from 'sentry/components/onboarding/gettingStartedDoc/step';
+import { t, tct } from 'sentry/locale';
 
 // Configuration Start
 export const steps = ({
   dsn,
 }: Partial<Pick<ModuleProps, 'dsn'>> = {}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <Fragment>
+    {
+      type: StepType.INSTALL,
+      description: (
+        <Fragment>
+          <p>
+            {tct(
+              "Download the latest plugin sources from the [link:Releases] page and place it in the project's 'Plugins' directory. On the next project launch, UE will prompt to build Sentry module.",
+              {
+                link: (
+                  <ExternalLink href="https://github.com/getsentry/sentry-unreal/releases" />
+                ),
+              }
+            )}
+          </p>
+          <p>
+            {tct(
+              'After the successful build, in the editor navigate to the [strong:Project Settings > Plugins > Code Plugins] menu and check whether the Sentry plugin is enabled.',
+              {
+                strong: <strong />,
+              }
+            )}
+          </p>
+        </Fragment>
+      ),
+      configurations: [
+        {
+          language: 'csharp',
+          description: t(
+            "To access the plugin API from within C++, add Sentry support to the build script (MyProject.build.cs):'"
+          ),
+          code: 'PublicDependencyModuleNames.AddRange(new string[] { ..., "Sentry" });',
+        },
+      ],
+    },
+    {
+      type: StepType.CONFIGURE,
+      description: (
         <p>
           {tct(
-            "Download the latest plugin sources from the [link:Releases] page and place it in the project's 'Plugins' directory. On the next project launch, UE will prompt to build Sentry module.",
-            {
-              link: (
-                <ExternalLink href="https://github.com/getsentry/sentry-unreal/releases" />
-              ),
-            }
+            "Access the Sentry configuration window by going to editor's menu: [strong:Project Settings > Plugins > Sentry] and enter the following DSN:",
+            { strong: <strong /> }
           )}
         </p>
-        <p>
-          {tct(
-            'After the successful build, in the editor navigate to the [strong:Project Settings > Plugins > Code Plugins] menu and check whether the Sentry plugin is enabled.',
-            {
-              strong: <strong />,
-            }
-          )}
-        </p>
-      </Fragment>
-    ),
-    configurations: [
-      {
-        language: 'csharp',
-        description: t(
-          "To access the plugin API from within C++, add Sentry support to the build script (MyProject.build.cs):'"
-        ),
-        code: 'PublicDependencyModuleNames.AddRange(new string[] { ..., "Sentry" });',
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: (
-      <p>
-        {tct(
-          "Access the Sentry configuration window by going to editor's menu: [strong:Project Settings > Plugins > Sentry] and enter the following DSN:",
-          {strong: <strong />}
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'text',
-        code: dsn,
-      },
-    ],
-  },
-  {
-    type: StepType.VERIFY,
-    description: t(
-      'Once everything is configured you can call the plugin API from both C++ and blueprints:'
-    ),
-    configurations: [
-      {
-        language: 'cpp',
-        code: `
+      ),
+      configurations: [
+        {
+          language: 'text',
+          code: dsn,
+        },
+      ],
+    },
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'Once everything is configured you can call the plugin API from both C++ and blueprints:'
+      ),
+      configurations: [
+        {
+          language: 'cpp',
+          code: `
 #include "SentrySubsystem.h"
 
 void Verify()
@@ -84,145 +84,145 @@ void Verify()
     SentrySubsystem->CaptureMessage(TEXT("Capture message"));
 }
         `,
-      },
-    ],
-  },
-  {
-    title: t('Crash Reporter Client'),
-    description: (
-      <p>
-        {tct(
-          'For Windows and Mac, [link:Crash Reporter Client] provided along with Unreal Engine has to be configured in order to capture errors automatically.',
-          {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platforms/unreal/setup-crashreporter/" />
-            ),
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        description: (
-          <Fragment>
-            <h5>{t('Include the UE4 Crash Reporter')}</h5>
-            <p>
-              {tct(
-                'You can add the crash reporter client to your game in [strong:Project Settings].',
-                {strong: <strong />}
-              )}
-            </p>
-            <p>
-              {tct(
-                'The option is located under [strong:Project > Packaging]; select "show advanced" followed by checking the box for "Include Crash Reporter".',
-                {strong: <strong />}
-              )}
-            </p>
-          </Fragment>
-        ),
-      },
-      {
-        description: (
-          <Fragment>
-            <h5>{t('Debug Information')}</h5>
-            {t(
-              'To get the most out of Sentry, crash reports must include debug information. In order for Sentry to be able to process the crash report and translate memory addresses to meaningful information like function names, module names, and line numbers, the crash itself must include debug information. In addition, symbols need to be uploaded to Sentry.'
-            )}
-            <p>
-              {tct(
-                "The option is also located under [strong:Project > Packaging]; select 'show advanced' followed by checking the box for 'Include Debug Files'.",
-                {strong: <strong />}
-              )}
-            </p>
-          </Fragment>
-        ),
-      },
-      {
-        description: (
-          <Fragment>
-            <h5>{t('Configure the Crash Reporter Endpoint')}</h5>
-            <p>
-              {tct(
-                "Now that the crash reporter and debug files are included, UE4 needs to know where to send the crash. For that, add the Sentry 'Unreal Engine Endpoint' from the 'Client Keys' settings page to the game's configuration file. This will include which project in Sentry you want to see crashes displayed in. That's accomplished by configuring the [code:CrashReportClient] in the [italic:DefaultEngine.ini] file. Changing the engine is necessary for this to work. Edit the file:",
-                {
-                  code: <code />,
-                  italic: <i />,
-                }
-              )}
-            </p>
-            <AlertWithoutMarginBottom type="info">
-              engine-dir\Engine\Programs\CrashReportClient\Config\DefaultEngine.ini
-            </AlertWithoutMarginBottom>
-          </Fragment>
-        ),
-        configurations: [
-          {
-            description: t('Add the configuration section:'),
-            language: 'ini',
-            code: `
-    [CrashReportClient]
-    CrashReportClientVersion=1.0
-    DataRouterUrl="${dsn}"
-            `,
-            additionalInfo: (
-              <p>
-                {tct(
-                  'If a [crashReportCode:CrashReportClient] section already exists, simply changing the value of [dataRouterUrlCode:DataRouterUrl] is enough.',
-                  {crashReportCode: <code />, dataRouterUrlCode: <code />}
-                )}
-              </p>
-            ),
-          },
-        ],
-      },
-    ],
-  },
-  {
-    title: t('Upload Debug Symbols'),
-    description: (
-      <Fragment>
+        },
+      ],
+    },
+    {
+      title: t('Crash Reporter Client'),
+      description: (
         <p>
           {tct(
-            'To allow Sentry to fully process native crashes and provide you with symbolicated stack traces, you need to upload [debugInformationItalic:debug information files] (sometimes also referred to as [debugSymbolsItalic:debug symbols] or just [symbolsItalic:symbols]). We recommend uploading debug information during your build or release process.',
-            {
-              debugInformationItalic: <i />,
-              symbolsItalic: <i />,
-              debugSymbolsItalic: <i />,
-            }
-          )}
-        </p>
-        <p>
-          {tct(
-            "For all libraries where you'd like to receive symbolication, [strong:you need to provide debug information]. This includes dependencies and operating system libraries.",
-            {
-              strong: <strong />,
-            }
-          )}
-        </p>
-        <p>
-          {tct(
-            'In addition to debug information files, Sentry needs [italic:call frame information] (CFI) to extract accurate stack traces from minidumps of optimized release builds. CFI is usually part of the executables and not copied to debug symbols. Unless you are uploading Breakpad symbols, be sure to also include the binaries when uploading files to Sentry',
-            {italic: <i />}
-          )}
-        </p>
-        <p>
-          {tct(
-            'For more information on uploading debug information and their supported formats, check out our [link:Debug Information Files documentation].',
+            'For Windows and Mac, [link:Crash Reporter Client] provided along with Unreal Engine has to be configured in order to capture errors automatically.',
             {
               link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/native/data-management/debug-files/" />
+                <ExternalLink href="https://docs.sentry.io/platforms/unreal/setup-crashreporter/" />
               ),
             }
           )}
         </p>
-      </Fragment>
-    ),
-  },
-];
+      ),
+      configurations: [
+        {
+          description: (
+            <Fragment>
+              <h5>{t('Include the UE Crash Reporter')}</h5>
+              <p>
+                {tct(
+                  'You can add the crash reporter client to your game in [strong:Project Settings].',
+                  { strong: <strong /> }
+                )}
+              </p>
+              <p>
+                {tct(
+                  'The option is located under [strong:Project > Packaging]; select "show advanced" followed by checking the box for "Include Crash Reporter".',
+                  { strong: <strong /> }
+                )}
+              </p>
+            </Fragment>
+          ),
+        },
+        {
+          description: (
+            <Fragment>
+              <h5>{t('Debug Information')}</h5>
+              {t(
+                'To get the most out of Sentry, crash reports must include debug information. In order for Sentry to be able to process the crash report and translate memory addresses to meaningful information like function names, module names, and line numbers, the crash itself must include debug information. In addition, symbols need to be uploaded to Sentry.'
+              )}
+              <p>
+                {tct(
+                  "The option is also located under [strong:Project > Packaging]; select 'show advanced' followed by checking the box for 'Include Debug Files'.",
+                  { strong: <strong /> }
+                )}
+              </p>
+            </Fragment>
+          ),
+        },
+        {
+          description: (
+            <Fragment>
+              <h5>{t('Configure the Crash Reporter Endpoint')}</h5>
+              <p>
+                {tct(
+                  "Now that the crash reporter and debug files are included, UE needs to know where to send the crash. For that, add the Sentry 'Unreal Engine Endpoint' from the 'Client Keys' settings page to the game's configuration file. This will include which project in Sentry you want to see crashes displayed in. That's accomplished by configuring the [code:CrashReportClient] in the [italic:DefaultEngine.ini] file. Changing the engine is necessary for this to work. Edit the file:",
+                  {
+                    code: <code />,
+                    italic: <i />,
+                  }
+                )}
+              </p>
+              <AlertWithoutMarginBottom type="info">
+                engine-dir\Engine\Programs\CrashReportClient\Config\DefaultEngine.ini
+              </AlertWithoutMarginBottom>
+            </Fragment>
+          ),
+          configurations: [
+            {
+              description: t('Add the configuration section:'),
+              language: 'ini',
+              code: `
+    [CrashReportClient]
+    CrashReportClientVersion=1.0
+    DataRouterUrl="${dsn}"
+            `,
+              additionalInfo: (
+                <p>
+                  {tct(
+                    'If a [crashReportCode:CrashReportClient] section already exists, simply changing the value of [dataRouterUrlCode:DataRouterUrl] is enough.',
+                    { crashReportCode: <code />, dataRouterUrlCode: <code /> }
+                  )}
+                </p>
+              ),
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: t('Upload Debug Symbols'),
+      description: (
+        <Fragment>
+          <p>
+            {tct(
+              'To allow Sentry to fully process native crashes and provide you with symbolicated stack traces, you need to upload [debugInformationItalic:debug information files] (sometimes also referred to as [debugSymbolsItalic:debug symbols] or just [symbolsItalic:symbols]). We recommend uploading debug information during your build or release process.',
+              {
+                debugInformationItalic: <i />,
+                symbolsItalic: <i />,
+                debugSymbolsItalic: <i />,
+              }
+            )}
+          </p>
+          <p>
+            {tct(
+              "For all libraries where you'd like to receive symbolication, [strong:you need to provide debug information]. This includes dependencies and operating system libraries.",
+              {
+                strong: <strong />,
+              }
+            )}
+          </p>
+          <p>
+            {tct(
+              'In addition to debug information files, Sentry needs [italic:call frame information] (CFI) to extract accurate stack traces from minidumps of optimized release builds. CFI is usually part of the executables and not copied to debug symbols. Unless you are uploading Breakpad symbols, be sure to also include the binaries when uploading files to Sentry',
+              { italic: <i /> }
+            )}
+          </p>
+          <p>
+            {tct(
+              'For more information on uploading debug information and their supported formats, check out our [link:Debug Information Files documentation].',
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/platforms/native/data-management/debug-files/" />
+                ),
+              }
+            )}
+          </p>
+        </Fragment>
+      ),
+    },
+  ];
 // Configuration End
 
-export function GettingStartedWithUnreal({dsn, ...props}: ModuleProps) {
-  return <Layout steps={steps({dsn})} {...props} />;
+export function GettingStartedWithUnreal({ dsn, ...props }: ModuleProps) {
+  return <Layout steps={steps({ dsn })} {...props} />;
 }
 
 export default GettingStartedWithUnreal;

--- a/static/app/gettingStartedDocs/unreal/unreal.tsx
+++ b/static/app/gettingStartedDocs/unreal/unreal.tsx
@@ -1,77 +1,77 @@
-import { Fragment } from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import { Alert } from 'sentry/components/alert';
+import {Alert} from 'sentry/components/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
-import { Layout, LayoutProps } from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import { ModuleProps } from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
-import { StepType } from 'sentry/components/onboarding/gettingStartedDoc/step';
-import { t, tct } from 'sentry/locale';
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {t, tct} from 'sentry/locale';
 
 // Configuration Start
 export const steps = ({
   dsn,
 }: Partial<Pick<ModuleProps, 'dsn'>> = {}): LayoutProps['steps'] => [
-    {
-      type: StepType.INSTALL,
-      description: (
-        <Fragment>
-          <p>
-            {tct(
-              "Download the latest plugin sources from the [link:Releases] page and place it in the project's 'Plugins' directory. On the next project launch, UE will prompt to build Sentry module.",
-              {
-                link: (
-                  <ExternalLink href="https://github.com/getsentry/sentry-unreal/releases" />
-                ),
-              }
-            )}
-          </p>
-          <p>
-            {tct(
-              'After the successful build, in the editor navigate to the [strong:Project Settings > Plugins > Code Plugins] menu and check whether the Sentry plugin is enabled.',
-              {
-                strong: <strong />,
-              }
-            )}
-          </p>
-        </Fragment>
-      ),
-      configurations: [
-        {
-          language: 'csharp',
-          description: t(
-            "To access the plugin API from within C++, add Sentry support to the build script (MyProject.build.cs):'"
-          ),
-          code: 'PublicDependencyModuleNames.AddRange(new string[] { ..., "Sentry" });',
-        },
-      ],
-    },
-    {
-      type: StepType.CONFIGURE,
-      description: (
+  {
+    type: StepType.INSTALL,
+    description: (
+      <Fragment>
         <p>
           {tct(
-            "Access the Sentry configuration window by going to editor's menu: [strong:Project Settings > Plugins > Sentry] and enter the following DSN:",
-            { strong: <strong /> }
+            "Download the latest plugin sources from the [link:Releases] page and place it in the project's 'Plugins' directory. On the next project launch, UE will prompt to build Sentry module.",
+            {
+              link: (
+                <ExternalLink href="https://github.com/getsentry/sentry-unreal/releases" />
+              ),
+            }
           )}
         </p>
-      ),
-      configurations: [
-        {
-          language: 'text',
-          code: dsn,
-        },
-      ],
-    },
-    {
-      type: StepType.VERIFY,
-      description: t(
-        'Once everything is configured you can call the plugin API from both C++ and blueprints:'
-      ),
-      configurations: [
-        {
-          language: 'cpp',
-          code: `
+        <p>
+          {tct(
+            'After the successful build, in the editor navigate to the [strong:Project Settings > Plugins > Code Plugins] menu and check whether the Sentry plugin is enabled.',
+            {
+              strong: <strong />,
+            }
+          )}
+        </p>
+      </Fragment>
+    ),
+    configurations: [
+      {
+        language: 'csharp',
+        description: t(
+          "To access the plugin API from within C++, add Sentry support to the build script (MyProject.build.cs):'"
+        ),
+        code: 'PublicDependencyModuleNames.AddRange(new string[] { ..., "Sentry" });',
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: (
+      <p>
+        {tct(
+          "Access the Sentry configuration window by going to editor's menu: [strong:Project Settings > Plugins > Sentry] and enter the following DSN:",
+          {strong: <strong />}
+        )}
+      </p>
+    ),
+    configurations: [
+      {
+        language: 'text',
+        code: dsn,
+      },
+    ],
+  },
+  {
+    type: StepType.VERIFY,
+    description: t(
+      'Once everything is configured you can call the plugin API from both C++ and blueprints:'
+    ),
+    configurations: [
+      {
+        language: 'cpp',
+        code: `
 #include "SentrySubsystem.h"
 
 void Verify()
@@ -84,145 +84,145 @@ void Verify()
     SentrySubsystem->CaptureMessage(TEXT("Capture message"));
 }
         `,
-        },
-      ],
-    },
-    {
-      title: t('Crash Reporter Client'),
-      description: (
-        <p>
-          {tct(
-            'For Windows and Mac, [link:Crash Reporter Client] provided along with Unreal Engine has to be configured in order to capture errors automatically.',
-            {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/unreal/setup-crashreporter/" />
-              ),
-            }
-          )}
-        </p>
-      ),
-      configurations: [
-        {
-          description: (
-            <Fragment>
-              <h5>{t('Include the UE Crash Reporter')}</h5>
-              <p>
-                {tct(
-                  'You can add the crash reporter client to your game in [strong:Project Settings].',
-                  { strong: <strong /> }
-                )}
-              </p>
-              <p>
-                {tct(
-                  'The option is located under [strong:Project > Packaging]; select "show advanced" followed by checking the box for "Include Crash Reporter".',
-                  { strong: <strong /> }
-                )}
-              </p>
-            </Fragment>
-          ),
-        },
-        {
-          description: (
-            <Fragment>
-              <h5>{t('Debug Information')}</h5>
-              {t(
-                'To get the most out of Sentry, crash reports must include debug information. In order for Sentry to be able to process the crash report and translate memory addresses to meaningful information like function names, module names, and line numbers, the crash itself must include debug information. In addition, symbols need to be uploaded to Sentry.'
+      },
+    ],
+  },
+  {
+    title: t('Crash Reporter Client'),
+    description: (
+      <p>
+        {tct(
+          'For Windows and Mac, [link:Crash Reporter Client] provided along with Unreal Engine has to be configured in order to capture errors automatically.',
+          {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/unreal/setup-crashreporter/" />
+            ),
+          }
+        )}
+      </p>
+    ),
+    configurations: [
+      {
+        description: (
+          <Fragment>
+            <h5>{t('Include the UE Crash Reporter')}</h5>
+            <p>
+              {tct(
+                'You can add the crash reporter client to your game in [strong:Project Settings].',
+                {strong: <strong />}
               )}
-              <p>
-                {tct(
-                  "The option is also located under [strong:Project > Packaging]; select 'show advanced' followed by checking the box for 'Include Debug Files'.",
-                  { strong: <strong /> }
-                )}
-              </p>
-            </Fragment>
-          ),
-        },
-        {
-          description: (
-            <Fragment>
-              <h5>{t('Configure the Crash Reporter Endpoint')}</h5>
-              <p>
-                {tct(
-                  "Now that the crash reporter and debug files are included, UE needs to know where to send the crash. For that, add the Sentry 'Unreal Engine Endpoint' from the 'Client Keys' settings page to the game's configuration file. This will include which project in Sentry you want to see crashes displayed in. That's accomplished by configuring the [code:CrashReportClient] in the [italic:DefaultEngine.ini] file. Changing the engine is necessary for this to work. Edit the file:",
-                  {
-                    code: <code />,
-                    italic: <i />,
-                  }
-                )}
-              </p>
-              <AlertWithoutMarginBottom type="info">
-                engine-dir\Engine\Programs\CrashReportClient\Config\DefaultEngine.ini
-              </AlertWithoutMarginBottom>
-            </Fragment>
-          ),
-          configurations: [
-            {
-              description: t('Add the configuration section:'),
-              language: 'ini',
-              code: `
+            </p>
+            <p>
+              {tct(
+                'The option is located under [strong:Project > Packaging]; select "show advanced" followed by checking the box for "Include Crash Reporter".',
+                {strong: <strong />}
+              )}
+            </p>
+          </Fragment>
+        ),
+      },
+      {
+        description: (
+          <Fragment>
+            <h5>{t('Debug Information')}</h5>
+            {t(
+              'To get the most out of Sentry, crash reports must include debug information. In order for Sentry to be able to process the crash report and translate memory addresses to meaningful information like function names, module names, and line numbers, the crash itself must include debug information. In addition, symbols need to be uploaded to Sentry.'
+            )}
+            <p>
+              {tct(
+                "The option is also located under [strong:Project > Packaging]; select 'show advanced' followed by checking the box for 'Include Debug Files'.",
+                {strong: <strong />}
+              )}
+            </p>
+          </Fragment>
+        ),
+      },
+      {
+        description: (
+          <Fragment>
+            <h5>{t('Configure the Crash Reporter Endpoint')}</h5>
+            <p>
+              {tct(
+                "Now that the crash reporter and debug files are included, UE needs to know where to send the crash. For that, add the Sentry 'Unreal Engine Endpoint' from the 'Client Keys' settings page to the game's configuration file. This will include which project in Sentry you want to see crashes displayed in. That's accomplished by configuring the [code:CrashReportClient] in the [italic:DefaultEngine.ini] file. Changing the engine is necessary for this to work. Edit the file:",
+                {
+                  code: <code />,
+                  italic: <i />,
+                }
+              )}
+            </p>
+            <AlertWithoutMarginBottom type="info">
+              engine-dir\Engine\Programs\CrashReportClient\Config\DefaultEngine.ini
+            </AlertWithoutMarginBottom>
+          </Fragment>
+        ),
+        configurations: [
+          {
+            description: t('Add the configuration section:'),
+            language: 'ini',
+            code: `
     [CrashReportClient]
     CrashReportClientVersion=1.0
     DataRouterUrl="${dsn}"
             `,
-              additionalInfo: (
-                <p>
-                  {tct(
-                    'If a [crashReportCode:CrashReportClient] section already exists, simply changing the value of [dataRouterUrlCode:DataRouterUrl] is enough.',
-                    { crashReportCode: <code />, dataRouterUrlCode: <code /> }
-                  )}
-                </p>
+            additionalInfo: (
+              <p>
+                {tct(
+                  'If a [crashReportCode:CrashReportClient] section already exists, simply changing the value of [dataRouterUrlCode:DataRouterUrl] is enough.',
+                  {crashReportCode: <code />, dataRouterUrlCode: <code />}
+                )}
+              </p>
+            ),
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: t('Upload Debug Symbols'),
+    description: (
+      <Fragment>
+        <p>
+          {tct(
+            'To allow Sentry to fully process native crashes and provide you with symbolicated stack traces, you need to upload [debugInformationItalic:debug information files] (sometimes also referred to as [debugSymbolsItalic:debug symbols] or just [symbolsItalic:symbols]). We recommend uploading debug information during your build or release process.',
+            {
+              debugInformationItalic: <i />,
+              symbolsItalic: <i />,
+              debugSymbolsItalic: <i />,
+            }
+          )}
+        </p>
+        <p>
+          {tct(
+            "For all libraries where you'd like to receive symbolication, [strong:you need to provide debug information]. This includes dependencies and operating system libraries.",
+            {
+              strong: <strong />,
+            }
+          )}
+        </p>
+        <p>
+          {tct(
+            'In addition to debug information files, Sentry needs [italic:call frame information] (CFI) to extract accurate stack traces from minidumps of optimized release builds. CFI is usually part of the executables and not copied to debug symbols. Unless you are uploading Breakpad symbols, be sure to also include the binaries when uploading files to Sentry',
+            {italic: <i />}
+          )}
+        </p>
+        <p>
+          {tct(
+            'For more information on uploading debug information and their supported formats, check out our [link:Debug Information Files documentation].',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/native/data-management/debug-files/" />
               ),
-            },
-          ],
-        },
-      ],
-    },
-    {
-      title: t('Upload Debug Symbols'),
-      description: (
-        <Fragment>
-          <p>
-            {tct(
-              'To allow Sentry to fully process native crashes and provide you with symbolicated stack traces, you need to upload [debugInformationItalic:debug information files] (sometimes also referred to as [debugSymbolsItalic:debug symbols] or just [symbolsItalic:symbols]). We recommend uploading debug information during your build or release process.',
-              {
-                debugInformationItalic: <i />,
-                symbolsItalic: <i />,
-                debugSymbolsItalic: <i />,
-              }
-            )}
-          </p>
-          <p>
-            {tct(
-              "For all libraries where you'd like to receive symbolication, [strong:you need to provide debug information]. This includes dependencies and operating system libraries.",
-              {
-                strong: <strong />,
-              }
-            )}
-          </p>
-          <p>
-            {tct(
-              'In addition to debug information files, Sentry needs [italic:call frame information] (CFI) to extract accurate stack traces from minidumps of optimized release builds. CFI is usually part of the executables and not copied to debug symbols. Unless you are uploading Breakpad symbols, be sure to also include the binaries when uploading files to Sentry',
-              { italic: <i /> }
-            )}
-          </p>
-          <p>
-            {tct(
-              'For more information on uploading debug information and their supported formats, check out our [link:Debug Information Files documentation].',
-              {
-                link: (
-                  <ExternalLink href="https://docs.sentry.io/platforms/native/data-management/debug-files/" />
-                ),
-              }
-            )}
-          </p>
-        </Fragment>
-      ),
-    },
-  ];
+            }
+          )}
+        </p>
+      </Fragment>
+    ),
+  },
+];
 // Configuration End
 
-export function GettingStartedWithUnreal({ dsn, ...props }: ModuleProps) {
-  return <Layout steps={steps({ dsn })} {...props} />;
+export function GettingStartedWithUnreal({dsn, ...props}: ModuleProps) {
+  return <Layout steps={steps({dsn})} {...props} />;
 }
 
 export default GettingStartedWithUnreal;

--- a/static/app/views/settings/project/projectKeys/list/index.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.tsx
@@ -84,7 +84,7 @@ describe('ProjectKeys', function () {
       name: 'Minidump Endpoint URL',
     });
     const unrealEndpoint = screen.queryByRole('textbox', {
-      name: 'Unreal Engine 4 Endpoint URL',
+      name: 'Unreal Engine Endpoint URL',
     });
     const securityHeaderEndpoint = screen.queryByRole('textbox', {
       name: 'Security Header Endpoint URL',
@@ -114,7 +114,7 @@ describe('ProjectKeys', function () {
       name: 'Minidump Endpoint URL',
     });
     const unrealEndpoint = screen.queryByRole('textbox', {
-      name: 'Unreal Engine 4 Endpoint URL',
+      name: 'Unreal Engine Endpoint URL',
     });
     const securityHeaderEndpoint = screen.queryByRole('textbox', {
       name: 'Security Header Endpoint URL',
@@ -152,7 +152,7 @@ describe('ProjectKeys', function () {
       name: 'Minidump Endpoint URL',
     });
     const unrealEndpoint = screen.queryByRole('textbox', {
-      name: 'Unreal Engine 4 Endpoint URL',
+      name: 'Unreal Engine Endpoint URL',
     });
     const securityHeaderEndpoint = screen.queryByRole('textbox', {
       name: 'Security Header Endpoint URL',

--- a/static/app/views/settings/project/projectKeys/list/index.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.tsx
@@ -1,4 +1,4 @@
-import { initializeOrg } from 'sentry-test/initializeOrg';
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   renderGlobalModal,
@@ -10,7 +10,7 @@ import {
 import ProjectKeys from 'sentry/views/settings/project/projectKeys/list';
 
 describe('ProjectKeys', function () {
-  const { organization, project, routerProps } = initializeOrg();
+  const {organization, project, routerProps} = initializeOrg();
   const projectKeys = TestStubs.ProjectKeys();
   let deleteMock: jest.Mock;
 
@@ -39,7 +39,7 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         project={project}
-        params={{ projectId: project.slug }}
+        params={{projectId: project.slug}}
         organization={organization}
       />
     );
@@ -54,12 +54,12 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{ projectId: project.slug }}
+        params={{projectId: project.slug}}
         project={TestStubs.Project()}
       />
     );
 
-    const expandButton = screen.getByRole('button', { name: 'Expand' });
+    const expandButton = screen.getByRole('button', {name: 'Expand'});
     await userEvent.click(expandButton);
 
     expect(expandButton).not.toBeInTheDocument();
@@ -70,21 +70,21 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{ projectId: project.slug }}
-        project={TestStubs.Project({ platform: 'other' })}
+        params={{projectId: project.slug}}
+        project={TestStubs.Project({platform: 'other'})}
       />
     );
 
-    const allDsn = screen.getAllByRole('textbox', { name: 'DSN URL' });
+    const allDsn = screen.getAllByRole('textbox', {name: 'DSN URL'});
     expect(allDsn.length).toBe(1);
 
-    const expandButton = screen.getByRole('button', { name: 'Expand' });
-    const dsn = screen.getByRole('textbox', { name: 'DSN URL' });
+    const expandButton = screen.getByRole('button', {name: 'Expand'});
+    const dsn = screen.getByRole('textbox', {name: 'DSN URL'});
     const minidumpEndpoint = screen.queryByRole('textbox', {
       name: 'Minidump Endpoint URL',
     });
     const unrealEndpoint = screen.queryByRole('textbox', {
-      name: 'Unreal Engine Endpoint URL',
+      name: 'Unreal Engine 4 Endpoint URL',
     });
     const securityHeaderEndpoint = screen.queryByRole('textbox', {
       name: 'Security Header Endpoint URL',
@@ -103,18 +103,18 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{ projectId: project.slug }}
-        project={TestStubs.Project({ platform: 'javascript' })}
+        params={{projectId: project.slug}}
+        project={TestStubs.Project({platform: 'javascript'})}
       />
     );
 
-    const expandButton = screen.queryByRole('button', { name: 'Expand' });
-    const dsn = screen.getByRole('textbox', { name: 'DSN URL' });
+    const expandButton = screen.queryByRole('button', {name: 'Expand'});
+    const dsn = screen.getByRole('textbox', {name: 'DSN URL'});
     const minidumpEndpoint = screen.queryByRole('textbox', {
       name: 'Minidump Endpoint URL',
     });
     const unrealEndpoint = screen.queryByRole('textbox', {
-      name: 'Unreal Engine Endpoint URL',
+      name: 'Unreal Engine 4 Endpoint URL',
     });
     const securityHeaderEndpoint = screen.queryByRole('textbox', {
       name: 'Security Header Endpoint URL',
@@ -141,18 +141,18 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{ projectId: project.slug }}
-        project={TestStubs.Project({ platform: 'javascript-react' })}
+        params={{projectId: project.slug}}
+        project={TestStubs.Project({platform: 'javascript-react'})}
       />
     );
 
-    const expandButton = screen.queryByRole('button', { name: 'Expand' });
-    const dsn = screen.getByRole('textbox', { name: 'DSN URL' });
+    const expandButton = screen.queryByRole('button', {name: 'Expand'});
+    const dsn = screen.getByRole('textbox', {name: 'DSN URL'});
     const minidumpEndpoint = screen.queryByRole('textbox', {
       name: 'Minidump Endpoint URL',
     });
     const unrealEndpoint = screen.queryByRole('textbox', {
-      name: 'Unreal Engine Endpoint URL',
+      name: 'Unreal Engine 4 Endpoint URL',
     });
     const securityHeaderEndpoint = screen.queryByRole('textbox', {
       name: 'Security Header Endpoint URL',
@@ -216,12 +216,12 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{ projectId: project.slug }}
-        project={TestStubs.Project({ platform: 'other' })}
+        params={{projectId: project.slug}}
+        project={TestStubs.Project({platform: 'other'})}
       />
     );
 
-    const allDsn = screen.getAllByRole('textbox', { name: 'DSN URL' });
+    const allDsn = screen.getAllByRole('textbox', {name: 'DSN URL'});
     expect(allDsn.length).toBe(2);
   });
 
@@ -230,12 +230,12 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{ projectId: project.slug }}
+        params={{projectId: project.slug}}
         project={TestStubs.Project()}
       />
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
     renderGlobalModal();
     await userEvent.click(screen.getByTestId('confirm-button'));
 
@@ -247,7 +247,7 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{ projectId: project.slug }}
+        params={{projectId: project.slug}}
         project={TestStubs.Project()}
       />
     );
@@ -259,7 +259,7 @@ describe('ProjectKeys', function () {
 
     renderGlobalModal();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Disable' }));
+    await userEvent.click(screen.getByRole('button', {name: 'Disable'}));
     await userEvent.click(screen.getByTestId('confirm-button'));
 
     await waitFor(() => {
@@ -269,17 +269,17 @@ describe('ProjectKeys', function () {
     expect(enableMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        data: { isActive: false },
+        data: {isActive: false},
       })
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Enable' }));
+    await userEvent.click(screen.getByRole('button', {name: 'Enable'}));
     await userEvent.click(screen.getByTestId('confirm-button'));
 
     expect(enableMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        data: { isActive: true },
+        data: {isActive: true},
       })
     );
   });

--- a/static/app/views/settings/project/projectKeys/list/index.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.tsx
@@ -1,4 +1,4 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
+import { initializeOrg } from 'sentry-test/initializeOrg';
 import {
   render,
   renderGlobalModal,
@@ -10,7 +10,7 @@ import {
 import ProjectKeys from 'sentry/views/settings/project/projectKeys/list';
 
 describe('ProjectKeys', function () {
-  const {organization, project, routerProps} = initializeOrg();
+  const { organization, project, routerProps } = initializeOrg();
   const projectKeys = TestStubs.ProjectKeys();
   let deleteMock: jest.Mock;
 
@@ -39,7 +39,7 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         project={project}
-        params={{projectId: project.slug}}
+        params={{ projectId: project.slug }}
         organization={organization}
       />
     );
@@ -54,12 +54,12 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{projectId: project.slug}}
+        params={{ projectId: project.slug }}
         project={TestStubs.Project()}
       />
     );
 
-    const expandButton = screen.getByRole('button', {name: 'Expand'});
+    const expandButton = screen.getByRole('button', { name: 'Expand' });
     await userEvent.click(expandButton);
 
     expect(expandButton).not.toBeInTheDocument();
@@ -70,21 +70,21 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{projectId: project.slug}}
-        project={TestStubs.Project({platform: 'other'})}
+        params={{ projectId: project.slug }}
+        project={TestStubs.Project({ platform: 'other' })}
       />
     );
 
-    const allDsn = screen.getAllByRole('textbox', {name: 'DSN URL'});
+    const allDsn = screen.getAllByRole('textbox', { name: 'DSN URL' });
     expect(allDsn.length).toBe(1);
 
-    const expandButton = screen.getByRole('button', {name: 'Expand'});
-    const dsn = screen.getByRole('textbox', {name: 'DSN URL'});
+    const expandButton = screen.getByRole('button', { name: 'Expand' });
+    const dsn = screen.getByRole('textbox', { name: 'DSN URL' });
     const minidumpEndpoint = screen.queryByRole('textbox', {
       name: 'Minidump Endpoint URL',
     });
     const unrealEndpoint = screen.queryByRole('textbox', {
-      name: 'Unreal Engine 4 Endpoint URL',
+      name: 'Unreal Engine Endpoint URL',
     });
     const securityHeaderEndpoint = screen.queryByRole('textbox', {
       name: 'Security Header Endpoint URL',
@@ -103,18 +103,18 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{projectId: project.slug}}
-        project={TestStubs.Project({platform: 'javascript'})}
+        params={{ projectId: project.slug }}
+        project={TestStubs.Project({ platform: 'javascript' })}
       />
     );
 
-    const expandButton = screen.queryByRole('button', {name: 'Expand'});
-    const dsn = screen.getByRole('textbox', {name: 'DSN URL'});
+    const expandButton = screen.queryByRole('button', { name: 'Expand' });
+    const dsn = screen.getByRole('textbox', { name: 'DSN URL' });
     const minidumpEndpoint = screen.queryByRole('textbox', {
       name: 'Minidump Endpoint URL',
     });
     const unrealEndpoint = screen.queryByRole('textbox', {
-      name: 'Unreal Engine 4 Endpoint URL',
+      name: 'Unreal Engine Endpoint URL',
     });
     const securityHeaderEndpoint = screen.queryByRole('textbox', {
       name: 'Security Header Endpoint URL',
@@ -141,18 +141,18 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{projectId: project.slug}}
-        project={TestStubs.Project({platform: 'javascript-react'})}
+        params={{ projectId: project.slug }}
+        project={TestStubs.Project({ platform: 'javascript-react' })}
       />
     );
 
-    const expandButton = screen.queryByRole('button', {name: 'Expand'});
-    const dsn = screen.getByRole('textbox', {name: 'DSN URL'});
+    const expandButton = screen.queryByRole('button', { name: 'Expand' });
+    const dsn = screen.getByRole('textbox', { name: 'DSN URL' });
     const minidumpEndpoint = screen.queryByRole('textbox', {
       name: 'Minidump Endpoint URL',
     });
     const unrealEndpoint = screen.queryByRole('textbox', {
-      name: 'Unreal Engine 4 Endpoint URL',
+      name: 'Unreal Engine Endpoint URL',
     });
     const securityHeaderEndpoint = screen.queryByRole('textbox', {
       name: 'Security Header Endpoint URL',
@@ -216,12 +216,12 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{projectId: project.slug}}
-        project={TestStubs.Project({platform: 'other'})}
+        params={{ projectId: project.slug }}
+        project={TestStubs.Project({ platform: 'other' })}
       />
     );
 
-    const allDsn = screen.getAllByRole('textbox', {name: 'DSN URL'});
+    const allDsn = screen.getAllByRole('textbox', { name: 'DSN URL' });
     expect(allDsn.length).toBe(2);
   });
 
@@ -230,12 +230,12 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{projectId: project.slug}}
+        params={{ projectId: project.slug }}
         project={TestStubs.Project()}
       />
     );
 
-    await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
     renderGlobalModal();
     await userEvent.click(screen.getByTestId('confirm-button'));
 
@@ -247,7 +247,7 @@ describe('ProjectKeys', function () {
       <ProjectKeys
         {...routerProps}
         organization={organization}
-        params={{projectId: project.slug}}
+        params={{ projectId: project.slug }}
         project={TestStubs.Project()}
       />
     );
@@ -259,7 +259,7 @@ describe('ProjectKeys', function () {
 
     renderGlobalModal();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Disable'}));
+    await userEvent.click(screen.getByRole('button', { name: 'Disable' }));
     await userEvent.click(screen.getByTestId('confirm-button'));
 
     await waitFor(() => {
@@ -269,17 +269,17 @@ describe('ProjectKeys', function () {
     expect(enableMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        data: {isActive: false},
+        data: { isActive: false },
       })
     );
 
-    await userEvent.click(screen.getByRole('button', {name: 'Enable'}));
+    await userEvent.click(screen.getByRole('button', { name: 'Enable' }));
     await userEvent.click(screen.getByTestId('confirm-button'));
 
     expect(enableMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        data: {isActive: true},
+        data: { isActive: true },
       })
     );
   });

--- a/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
+++ b/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
@@ -1,14 +1,14 @@
-import { Fragment, useState } from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import TextCopyInput from 'sentry/components/textCopyInput';
-import { t, tct } from 'sentry/locale';
-import { space } from 'sentry/styles/space';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import { ProjectKey } from 'sentry/views/settings/project/projectKeys/types';
+import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
 
 type Props = {
   data: ProjectKey;

--- a/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
+++ b/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
@@ -1,14 +1,14 @@
-import {Fragment, useState} from 'react';
+import { Fragment, useState } from 'react';
 import styled from '@emotion/styled';
 
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import TextCopyInput from 'sentry/components/textCopyInput';
-import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
+import { t, tct } from 'sentry/locale';
+import { space } from 'sentry/styles/space';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
+import { ProjectKey } from 'sentry/views/settings/project/projectKeys/types';
 
 type Props = {
   data: ProjectKey;
@@ -146,12 +146,12 @@ function ProjectKeyCredentials({
 
       {showUnreal && (
         <FieldGroup
-          label={t('Unreal Engine 4 Endpoint')}
-          help={t('Use this endpoint to configure your UE4 Crash Reporter.')}
+          label={t('Unreal Engine Endpoint')}
+          help={t('Use this endpoint to configure your UE Crash Reporter.')}
           inline={false}
           flexibleControlStateSize
         >
-          <TextCopyInput aria-label={t('Unreal Engine 4 Endpoint URL')}>
+          <TextCopyInput aria-label={t('Unreal Engine Endpoint URL')}>
             {getDynamicText({
               value: data.dsn.unreal || '',
               fixed: '__UNREAL_ENDPOINT__',


### PR DESCRIPTION
We support UE4 and 5, to avoid confusion removing version:

https://twitter.com/JasonDeArte/status/1701711660250276002