### PR TITLE
fix(scim): allow idp-managed owners

### DIFF
--- a/src/sentry/scim/endpoints/constants.py
+++ b/src/sentry/scim/endpoints/constants.py
@@ -45,8 +45,6 @@ SCIM_400_UNSUPPORTED_ATTRIBUTE = {
 
 SCIM_400_INVALID_PATCH = "Invalid Patch Operation."
 
-SCIM_403_FORBIDDEN_UPDATE = "Organization owners cannot be modified."
-
 
 class TeamPatchOps(str, Enum):
     ADD = "add"

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -47,7 +47,6 @@ from ...services.hybrid_cloud.auth import auth_service
 from .constants import (
     SCIM_400_INVALID_ORGROLE,
     SCIM_400_INVALID_PATCH,
-    SCIM_403_FORBIDDEN_UPDATE,
     SCIM_409_USER_EXISTS,
     MemberPatchOps,
 )
@@ -308,7 +307,14 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         """
         # Do not allow modifications on members with the highest priority role
         if member.role == organization_roles.get_top_dog().id:
-            raise SCIMApiError(detail=SCIM_403_FORBIDDEN_UPDATE, status_code=403)
+            member.flags["idp:role-restricted"] = False
+            member.save()
+
+            context = serialize(
+                member, serializer=_scim_member_serializer_with_expansion(organization)
+            )
+            return Response(context, status=200)
+
         if request.data.get("sentryOrgRole"):
             # Don't update if the org role is the same
             if (
@@ -345,7 +351,8 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
 
         previous_role = member.role
         previous_restriction = member.flags["idp:role-restricted"]
-        member.role = requested_role
+        if member.role != organization_roles.get_top_dog().id:
+            member.role = requested_role
         member.flags["idp:role-restricted"] = idp_role_restricted
         member.save()
 

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -308,6 +308,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         # Do not allow modifications on members with the highest priority role
         if member.role == organization_roles.get_top_dog().id:
             member.flags["idp:role-restricted"] = False
+            member.flags["idp:provisioned"] = True
             member.save()
 
             context = serialize(
@@ -354,6 +355,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         if member.role != organization_roles.get_top_dog().id:
             member.role = requested_role
         member.flags["idp:role-restricted"] = idp_role_restricted
+        member.flags["idp:provisioned"] = True
         member.save()
 
         # only update metric if the role changed

--- a/tests/sentry/api/endpoints/test_scim_user_details.py
+++ b/tests/sentry/api/endpoints/test_scim_user_details.py
@@ -74,17 +74,45 @@ class SCIMMemberRoleUpdateTests(SCIMTestCase):
         self.restricted_custom_role_member.save()
 
     def test_owner(self):
-        """Owners cannot be edited by this API"""
+        """Owners cannot be edited by this API, but we will return a success response"""
         self.owner = self.create_member(
             user=self.create_user(), organization=self.organization, role="owner"
         )
-        self.get_error_response(
+        self.get_success_response(
             self.organization.slug,
             self.owner.id,
             method="put",
-            status_code=403,
             **generate_put_data(self.owner, role="member"),
         )
+        self.owner.refresh_from_db()
+        assert self.owner.role == "owner"
+
+    def test_owner_blank_role(self):
+        """A PUT request with a blank role should go through"""
+        self.owner = self.create_member(
+            user=self.create_user(), organization=self.organization, role="owner"
+        )
+        self.get_success_response(
+            self.organization.slug,
+            self.owner.id,
+            method="put",
+            **generate_put_data(self.owner),
+        )
+        self.owner.refresh_from_db()
+        assert self.owner.role == "owner"
+
+        # if the owner is somehow idp:role-restricted, unset it
+        self.owner.flags["idp:role-restricted"] = True
+        self.owner.save()
+        self.get_success_response(
+            self.organization.slug,
+            self.owner.id,
+            method="put",
+            **generate_put_data(self.owner),
+        )
+        self.owner.refresh_from_db()
+        assert self.owner.role == "owner"
+        assert not self.owner.flags["idp:role-restricted"]
 
     def test_invalid_role(self):
         self.get_error_response(

--- a/tests/sentry/api/endpoints/test_scim_user_details.py
+++ b/tests/sentry/api/endpoints/test_scim_user_details.py
@@ -86,6 +86,7 @@ class SCIMMemberRoleUpdateTests(SCIMTestCase):
         )
         self.owner.refresh_from_db()
         assert self.owner.role == "owner"
+        assert self.owner.flags["idp:provisioned"]
 
     def test_owner_blank_role(self):
         """A PUT request with a blank role should go through"""
@@ -100,6 +101,7 @@ class SCIMMemberRoleUpdateTests(SCIMTestCase):
         )
         self.owner.refresh_from_db()
         assert self.owner.role == "owner"
+        assert self.owner.flags["idp:provisioned"]
 
         # if the owner is somehow idp:role-restricted, unset it
         self.owner.flags["idp:role-restricted"] = True
@@ -113,6 +115,7 @@ class SCIMMemberRoleUpdateTests(SCIMTestCase):
         self.owner.refresh_from_db()
         assert self.owner.role == "owner"
         assert not self.owner.flags["idp:role-restricted"]
+        assert self.owner.flags["idp:provisioned"]
 
     def test_invalid_role(self):
         self.get_error_response(


### PR DESCRIPTION
Enabling a SCIM integration such as Okta for an organization with owners is difficult because we do not allow owners to be provisioned through SCIM. However, we should allow for owners to be set in Sentry and for those users to be managed in Okta.

Currently, when an org tries to set up an Okta integration, any existing owners that joined the org before the Okta integration was set up cannot be provisioned through Okta and will see the error "Organization owners cannot be modified" in the Sentry Okta app. This is because Okta is calling the PUT SCIM User endpoint to update the Sentry org member and we're returning a 403 if the member has the owner role. We should instead allow the PUT API to be called successfully with owners but don't allow any modifications to them besides being added / removed to the org from Okta.

Additionally, adding an existing user to the Okta app calls the PUT but does not mark the org member as `idp:provisioned`, which is the flag we are using to determine if the user is managed by an identity provider. We should set this if the PUT goes through successfully.