### PR TITLE
fix(slug): Switch to using isdecimal over isnumeric + isdigit

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -605,7 +605,7 @@ class PreventNumericSlugMixin:
         Validates that the slug is not entirely numeric. Requires a feature flag
         to be turned on.
         """
-        if options.get("api.prevent-numeric-slugs") and slug.isnumeric():
+        if options.get("api.prevent-numeric-slugs") and slug.isdecimal():
             raise serializers.ValidationError(DEFAULT_SLUG_ERROR_MESSAGE)
         return slug
 

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -79,7 +79,7 @@ def unique_db_instance(
     if not base_qs.filter(**{f"{field_name}__iexact": base_value}).exists():
         if options.get("api.prevent-numeric-slugs"):
             # if feature flag is on, we only return if the slug is not entirely numeric
-            if not base_value.isdigit():
+            if not base_value.isdecimal():
                 return
         else:
             return

--- a/src/sentry/sentry_apps/apps.py
+++ b/src/sentry/sentry_apps/apps.py
@@ -299,7 +299,7 @@ class SentryAppCreator:
 
         # If option is set, add random 3 lowercase letter suffix to prevent numeric slug
         # eg: 123 -> 123-abc
-        if options.get("api.prevent-numeric-slugs") and slug.isnumeric():
+        if options.get("api.prevent-numeric-slugs") and slug.isdecimal():
             slug = f"{slug}-{''.join(random.choice(string.ascii_lowercase) for _ in range(3))}"
 
         # validate globally unique slug

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -155,7 +155,8 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
 
         organization_id = response.data["id"]
         org = Organization.objects.get(id=organization_id)
-        assert org.slug.startswith("1234" + "-")
+        assert org.slug.startswith("1234-")
+        assert not org.slug.isdecimal()
 
     @patch(
         "sentry.api.endpoints.organization_member.requests.join.ratelimiter.is_limited",

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -262,4 +262,5 @@ class OrganizationTeamsCreateTest(APITestCase):
     def test_generated_slug_not_entirely_numeric(self):
         response = self.get_success_response(self.organization.slug, name="1234", status_code=201)
         team = Team.objects.get(id=response.data["id"])
-        assert team.slug.startswith("1234" + "-")
+        assert team.slug.startswith("1234-")
+        assert not team.slug.isdecimal()

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -516,9 +516,8 @@ class PostSentryAppsTest(SentryAppsTest):
     def test_generated_slug_not_entirely_numeric(self):
         response = self.get_success_response(**self.get_data(name="1234"), status_code=201)
         slug = response.data["slug"]
-        assert len(slug) == 8
         assert slug.startswith("1234-")
-        assert not slug.isnumeric()
+        assert not slug.isdecimal()
 
     def test_missing_name(self):
         response = self.get_error_response(**self.get_data(name=None), status_code=400)

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -1,4 +1,5 @@
 from sentry import audit_log
+from sentry.api.base import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.models import AuditLogEntry, DeletedTeam, RegionScheduledDeletion, Team, TeamStatus
 from sentry.services.hybrid_cloud.log.service import log_rpc_service
 from sentry.silo import SiloMode
@@ -88,10 +89,7 @@ class TeamUpdateTest(TeamDetailsTestBase):
     @override_options({"api.prevent-numeric-slugs": True})
     def test_invalid_numeric_slug(self):
         response = self.get_error_response(self.organization.slug, self.team.slug, slug="1234")
-        assert response.data["slug"][0] == (
-            "Enter a valid slug consisting of lowercase letters, numbers, underscores or "
-            "hyphens. It cannot be entirely numeric."
-        )
+        assert response.data["slug"][0] == DEFAULT_SLUG_ERROR_MESSAGE
 
     def test_member_without_team_role(self):
         user = self.create_user("foo@example.com")

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -83,8 +83,9 @@ class TeamProjectsCreateTest(APITestCase):
             name="1234",
             status_code=201,
         )
-
-        assert response.data["slug"].startswith("1234" + "-")
+        slug = response.data["slug"]
+        assert slug.startswith("1234-")
+        assert not slug.isdecimal()
 
     def test_invalid_platform(self):
         response = self.get_error_response(

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -234,7 +234,9 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         }
         response = self.get_success_response(self.organization.slug, **data, status_code=201)
 
-        assert response.data["slug"].startswith("1234" + "-")
+        slug = response.data["slug"]
+        assert slug.startswith("1234-")
+        assert not slug.isdecimal()
 
     @override_settings(MAX_MONITORS_PER_ORG=2)
     def test_monitor_organization_limit(self):


### PR DESCRIPTION
Per https://stackoverflow.com/a/54912545/19354746:

Essentially `isdigit` $\subseteq$ `isdecimal` $\subseteq$ `isnumeric`, so if something is digit it is also a decimal and numeric. We have false edge cases of something being numeric if we use `isdecimal` and `isnumeric`, such as `0.3.8` and `0,3,8` so we must switch to using `isdigit` for all numeric slug checks.