### PR TITLE
feat(crons): Add node js quickstart platform guide

### DIFF
--- a/static/app/views/monitors/components/cronsLandingPanel.tsx
+++ b/static/app/views/monitors/components/cronsLandingPanel.tsx
@@ -28,6 +28,7 @@ import {
 import {
   CeleryBeatAutoDiscovery,
   LaravelUpsertPlatformGuide,
+  NodeJsUpsertPlatformGuide,
   PHPUpsertPlatformGuide,
   QuickStartProps,
 } from './quickStartEntries';
@@ -59,7 +60,7 @@ const platformGuides: Record<SupportedPlatform, PlatformGuide[]> = {
   python: [],
   node: [
     {
-      Guide: () => null,
+      Guide: NodeJsUpsertPlatformGuide,
       title: 'Upsert',
     },
   ],

--- a/static/app/views/monitors/components/quickStartEntries.tsx
+++ b/static/app/views/monitors/components/quickStartEntries.tsx
@@ -402,3 +402,43 @@ export function LaravelUpsertPlatformGuide() {
     </Fragment>
   );
 }
+
+export function NodeJsUpsertPlatformGuide() {
+  const upsertCode = `const checkInId = Sentry.captureCheckIn(
+  {
+    monitorSlug: '<monitor-slug>',
+    status: 'in_progress',
+  },
+  {
+    schedule: { // Specify your schedule options here
+      type: 'crontab',
+      value: '* * * * *',
+    },
+    checkinMargin: 1,
+    maxRuntime: 1,
+    timezone: 'America/Los_Angeles',
+  });
+
+Sentry.captureCheckIn({
+    checkInId,
+    monitorSlug: '<monitor-slug>',
+    status: 'ok',
+  });
+  `;
+
+  return (
+    <Fragment>
+      <div>
+        {tct(
+          'Use the [additionalDocs:Node SDK] to create and update your Monitors programmatically with code rather than creating them manually.',
+          {
+            additionalDocs: (
+              <ExternalLink href="https://docs.sentry.io/platforms/node/crons/" />
+            ),
+          }
+        )}
+      </div>
+      <CodeSnippet language="javascript">{upsertCode}</CodeSnippet>
+    </Fragment>
+  );
+}


### PR DESCRIPTION
Code snippet given from gabe directly, as node.js upsert is not documented yet:

<img width="1239" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/aa84fe77-2a8a-4a51-bf63-d3f2ccb2b59e">
