### PR TITLE
fix(crons): Switches lock to blocking_acquire

### DIFF
--- a/tests/sentry/utils/locking/test_lock.py
+++ b/tests/sentry/utils/locking/test_lock.py
@@ -46,7 +46,7 @@ class LockTestCase(unittest.TestCase):
 
     @patch("sentry.utils.locking.lock.random.random", return_value=0.5)
     @patch("sentry.utils.locking.lock.Lock.acquire", side_effect=UnableToAcquireLock)
-    def test_blocking_aqcuire(self, mock_acquire, mock_random):
+    def test_blocking_acquire(self, mock_acquire, mock_random):
         backend = mock.Mock(spec=LockBackend)
         key = "lock"
         duration = 60


### PR DESCRIPTION
Reduces the lock timeout + switches lock to `blocking_acquire` so we can retry on lock. 

Supports up to 7 retries based on exponential backoff.