### PR TITLE
feat(workflow): Add referrers to release notifications

### DIFF
--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Iterable, Mapping, MutableMapping, Sequence
+from urllib.parse import urlencode
 
 from sentry_relay.processing import parse_release
 
@@ -82,7 +83,10 @@ class ReleaseActivityNotification(ActivityNotification):
             "release": self.release,
             "repos": self.repos,
             "setup_repo_link": self.organization.absolute_url(
-                f"/organizations/{self.organization.slug}/repos/"
+                f"/organizations/{self.organization.slug}/repos/",
+                query=urlencode(
+                    {"referrer": self.metrics_key, "notification_uuid": self.notification_uuid}
+                ),
             ),
             "text_description": f"Version {self.version_parsed} was deployed to {self.environment}",
             "version_parsed": self.version_parsed,
@@ -110,7 +114,10 @@ class ReleaseActivityNotification(ActivityNotification):
         projects = self.get_projects(recipient)
         release_links = [
             self.organization.absolute_url(
-                f"/organizations/{self.organization.slug}/releases/{self.version}/?project={p.id}"
+                f"/organizations/{self.organization.slug}/releases/{self.version}/?project={p.id}",
+                query=urlencode(
+                    {"referrer": self.metrics_key, "notification_uuid": self.notification_uuid}
+                ),
             )
             for p in projects
         ]
@@ -150,7 +157,7 @@ class ReleaseActivityNotification(ActivityNotification):
                         name=project.slug,
                         url=self.organization.absolute_url(
                             f"/organizations/{project.organization.slug}/releases/{release.version}/",
-                            query=f"project={project.id}&unselectedSeries=Healthy",
+                            query=f"project={project.id}&unselectedSeries=Healthy&referrer={self.metrics_key}&notification_uuid={self.notification_uuid}",
                         ),
                     )
                     for project in self.release.projects.all()

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -279,7 +279,7 @@ class ActivityNotificationTest(APITestCase):
             == f"Release {version_parsed} was deployed to {self.environment.name} for this project"
         )
         assert attachment["actions"][0]["url"].startswith(
-            f"http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={self.project.id}&unselectedSeries=Healthy"
+            f"http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={self.project.id}&unselectedSeries=Healthy&referrer=release_activity"
         )
         assert (
             attachment["footer"]

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -278,20 +278,21 @@ class ActivityNotificationTest(APITestCase):
             text
             == f"Release {version_parsed} was deployed to {self.environment.name} for this project"
         )
-        assert (
-            attachment["actions"][0]["url"]
-            == f"http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={self.project.id}&unselectedSeries=Healthy"
+        assert attachment["actions"][0]["url"].startswith(
+            f"http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={self.project.id}&unselectedSeries=Healthy"
         )
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/deploy/?referrer=release_activity-slack-user|Notification Settings>"
         )
+        notification_uuid = get_notification_uuid(attachment["actions"][0]["url"])
         assert analytics_called_with_args(
             record_analytics,
             "integrations.email.notification_sent",
             user_id=self.user.id,
             organization_id=self.organization.id,
             group_id=None,
+            notification_uuid=notification_uuid,
         )
         assert analytics_called_with_args(
             record_analytics,
@@ -299,6 +300,7 @@ class ActivityNotificationTest(APITestCase):
             user_id=self.user.id,
             organization_id=self.organization.id,
             group_id=None,
+            notification_uuid=notification_uuid,
         )
 
     @responses.activate


### PR DESCRIPTION
Adds uuid and referrer to the links in the release notification. the referrer is `release_activity`
