### PR TITLE
fix(commits): allow external_id querying in filechange and project release commits APIs

### DIFF
--- a/src/sentry/api/endpoints/filechange.py
+++ b/src/sentry/api/endpoints/filechange.py
@@ -50,10 +50,20 @@ class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
             )
         )
 
+        repo_id = request.query_params.get("repo_id")
         repo_name = request.query_params.get("repo_name")
 
-        # TODO: use id instead of name
-        if repo_name:
+        # prefer repo external ID to name
+        if repo_id:
+            try:
+                repo = Repository.objects.get(
+                    organization_id=organization.id, external_id=repo_id, status=ObjectStatus.ACTIVE
+                )
+                queryset = queryset.filter(commit__repository_id=repo.id)
+            except Repository.DoesNotExist:
+                raise ResourceDoesNotExist
+
+        elif repo_name:
             try:
                 repo = Repository.objects.get(
                     organization_id=organization.id, name=repo_name, status=ObjectStatus.ACTIVE

--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -25,4 +25,5 @@ class RepositorySerializer(Serializer):
             "dateCreated": obj.date_added,
             "integrationId": integration_id,
             "externalSlug": external_slug,
+            "externalId": obj.external_id,
         }

--- a/tests/sentry/api/endpoints/test_commit_filechange.py
+++ b/tests/sentry/api/endpoints/test_commit_filechange.py
@@ -85,3 +85,18 @@ class CommitFileChangeTest(APITestCase):
 
         assert response.data[0]["filename"] == ".gitignore"
         assert response.data[1]["filename"] == "/static/js/widget.js"
+
+    def test_query_does_not_exist(self):
+        self.get_error_response(
+            self.project.organization.slug,
+            self.release.version,
+            status_code=404,
+            qs_params={"repo_name": "hello"},
+        )
+
+        self.get_error_response(
+            self.project.organization.slug,
+            self.release.version,
+            status_code=404,
+            qs_params={"repo_id": "0"},
+        )

--- a/tests/sentry/api/endpoints/test_commit_filechange.py
+++ b/tests/sentry/api/endpoints/test_commit_filechange.py
@@ -18,11 +18,12 @@ class CommitFileChangeTest(APITestCase):
         )
         self.release.add_project(self.project)
         self.repo = Repository.objects.create(
-            organization_id=self.project.organization_id, name=self.project.name
+            organization_id=self.project.organization_id, name=self.project.name, external_id=123
         )
         Repository.objects.create(
             organization_id=self.project.organization_id,
             name=self.project.name,
+            external_id=123,
             status=ObjectStatus.HIDDEN,
         )
         commit = Commit.objects.create(
@@ -70,6 +71,16 @@ class CommitFileChangeTest(APITestCase):
             self.project.organization.slug,
             self.release.version,
             qs_params={"repo_name": self.repo.name},
+        )
+
+        assert response.data[0]["filename"] == ".gitignore"
+        assert response.data[1]["filename"] == "/static/js/widget.js"
+
+    def test_query_external_id(self):
+        response = self.get_success_response(
+            self.project.organization.slug,
+            self.release.version,
+            qs_params={"repo_id": self.repo.external_id},
         )
 
         assert response.data[0]["filename"] == ".gitignore"

--- a/tests/sentry/api/endpoints/test_project_release_commits.py
+++ b/tests/sentry/api/endpoints/test_project_release_commits.py
@@ -15,12 +15,15 @@ class ReleaseCommitsListTest(APITestCase):
         )
         self.release.add_project(self.project)
         self.repo = Repository.objects.create(
-            organization_id=self.project.organization_id, name=self.project.name
+            organization_id=self.project.organization_id,
+            name=self.project.name,
+            external_id=123,
         )
         Repository.objects.create(
             organization_id=self.project.organization_id,
             name=self.project.name,
             status=ObjectStatus.HIDDEN,
+            external_id=123,
         )
         self.commit = Commit.objects.create(
             organization_id=self.project.organization_id, repository_id=self.repo.id, key="a" * 40
@@ -58,6 +61,18 @@ class ReleaseCommitsListTest(APITestCase):
             self.project.slug,
             self.release.version,
             qs_params={"repo_name": self.repo.name},
+        )
+
+        assert len(response.data) == 2
+        assert response.data[0]["id"] == self.commit2.key
+        assert response.data[1]["id"] == self.commit.key
+
+    def test_query_external_id(self):
+        response = self.get_success_response(
+            self.project.organization.slug,
+            self.project.slug,
+            self.release.version,
+            qs_params={"repo_id": self.repo.external_id},
         )
 
         assert len(response.data) == 2

--- a/tests/sentry/api/endpoints/test_project_release_commits.py
+++ b/tests/sentry/api/endpoints/test_project_release_commits.py
@@ -78,3 +78,20 @@ class ReleaseCommitsListTest(APITestCase):
         assert len(response.data) == 2
         assert response.data[0]["id"] == self.commit2.key
         assert response.data[1]["id"] == self.commit.key
+
+    def test_query_does_not_exist(self):
+        self.get_error_response(
+            self.project.organization.slug,
+            self.project.slug,
+            self.release.version,
+            status_code=404,
+            qs_params={"repo_name": "hello"},
+        )
+
+        self.get_error_response(
+            self.project.organization.slug,
+            self.project.slug,
+            self.release.version,
+            status_code=404,
+            qs_params={"repo_id": "0"},
+        )


### PR DESCRIPTION
See this comment https://github.com/getsentry/sentry/pull/56101#issuecomment-1716684830

There are still a few collisions happening where there are multiple repos with the same name attached to an organization but with different external IDs, and these endpoints are trying to get a single repo with that name. Allow these endpoints to be able to fetch a repository with a `repo_id` query param that represents the external ID. It would be preferable to use the external ID because it doesn't change, whereas the name can change at anytime.

A follow up PR will change this on the frontend to pass in `repo_id` instead of `repo_name`.