### PR TITLE
fix(hybrid-cloud): Do not proxy sentry apps endpoint

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/organization_sentry_apps.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/organization_sentry_apps.py
@@ -2,22 +2,30 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import OrganizationEndpoint, add_integration_platform_metric_tag
+from sentry.api.base import control_silo_endpoint
+from sentry.api.bases import add_integration_platform_metric_tag
+from sentry.api.bases.organization import ControlSiloOrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.constants import SentryAppStatus
 from sentry.models import SentryApp
+from sentry.services.hybrid_cloud.organization import RpcOrganization
+from sentry.services.hybrid_cloud.organization.model import RpcUserOrganizationContext
 
 
-@region_silo_endpoint
-class OrganizationSentryAppsEndpoint(OrganizationEndpoint):
+@control_silo_endpoint
+class OrganizationSentryAppsEndpoint(ControlSiloOrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
 
     @add_integration_platform_metric_tag
-    def get(self, request: Request, organization) -> Response:
+    def get(
+        self,
+        request: Request,
+        organization_context: RpcUserOrganizationContext,
+        organization: RpcOrganization,
+    ) -> Response:
         queryset = SentryApp.objects.filter(owner_id=organization.id, application__isnull=False)
 
         if SentryAppStatus.as_int(request.GET.get("status")) is not None:

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -26,7 +26,7 @@ class OrganizationSentryAppsTest(APITestCase):
         self.url = reverse("sentry-api-0-organization-sentry-apps", args=[self.org.slug])
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
     def test_gets_all_apps_in_own_org(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
The sentry apps endpoint (`OrganizationSentryAppsEndpoint`) only queries on the model `SentryApp`, which only resides in the control silo. 

Previously it was proxying to the region silo, which was unnecessary, since the endpoint can be control-silo exclusive.