### PR TITLE
feat(alerts): Add `alert.sent` analytics for issue alerts

### DIFF
--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Sequence
 from urllib.parse import urlencode
 
-from sentry import features
+from sentry import analytics, features
 from sentry.db.models import Model
 from sentry.digests import Digest
 from sentry.digests.utils import (
@@ -229,3 +229,17 @@ class DigestNotification(ProjectNotification):
             "alert_id": alert_id,
             **super().get_log_params(recipient),
         }
+
+    def record_notification_sent(self, recipient: RpcActor, provider: ExternalProviders) -> None:
+        super().record_notification_sent(recipient, provider)
+        log_params = self.get_log_params(recipient)
+        analytics.record(
+            "alert.sent",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            provider=provider.name,
+            alert_id=log_params["alert_id"] if log_params["alert_id"] else "",
+            alert_type="issue_alert",
+            external_id=str(recipient.id),
+            notification_uuid=self.notification_uuid,
+        )

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -7,7 +7,7 @@ from urllib.parse import urlencode
 
 import pytz
 
-from sentry import features
+from sentry import analytics, features
 from sentry.db.models import Model
 from sentry.eventstore.models import GroupEvent
 from sentry.issues.grouptype import GROUP_CATEGORIES_CUSTOM_EMAIL, GroupCategory
@@ -294,3 +294,17 @@ class AlertRuleNotification(ProjectNotification):
             "alert_id": self.rules[0].id if self.rules else None,
             **super().get_log_params(recipient),
         }
+
+    def record_notification_sent(self, recipient: RpcActor, provider: ExternalProviders) -> None:
+        super().record_notification_sent(recipient, provider)
+        log_params = self.get_log_params(recipient)
+        analytics.record(
+            "alert.sent",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            provider=provider.name,
+            alert_id=log_params["alert_id"] if log_params["alert_id"] else "",
+            alert_type="issue_alert",
+            external_id=str(recipient.id),
+            notification_uuid=self.notification_uuid,
+        )

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -191,7 +191,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
         assert isinstance(msg.alternatives[0][0], str)
         assert "my rule" in msg.alternatives[0][0]
         assert "notification_uuid" in msg.body
-        mock_record.assert_called_with(
+        mock_record.assert_any_call(
             "integrations.email.notification_sent",
             category="issue_alert",
             target_type=ANY,
@@ -205,6 +205,16 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             actor_type="User",
             notification_uuid=ANY,
             alert_id=rule.id,
+        )
+        mock_record.assert_called_with(
+            "alert.sent",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            provider="email",
+            alert_id=rule.id,
+            alert_type="issue_alert",
+            external_id=ANY,
+            notification_uuid=ANY,
         )
 
     def test_simple_snooze(self):

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -103,7 +103,7 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
         assert "N+1 Query" in mail.outbox[0].body
         assert "oh no" in mail.outbox[0].body
         assert self.build_occurrence_data()["issue_title"] in mail.outbox[0].body
-        mock_record.assert_called_with(
+        mock_record.assert_any_call(
             "integrations.email.notification_sent",
             category="digest",
             notification_uuid=ANY,
@@ -117,6 +117,16 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
             actor_type="User",
             group_id=None,
             user_id=ANY,
+        )
+        mock_record.assert_called_with(
+            "alert.sent",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            provider="email",
+            alert_id=self.rule.id,
+            alert_type="issue_alert",
+            external_id=ANY,
+            notification_uuid=ANY,
         )
 
     def test_sends_alert_rule_notification_to_each_member(self):


### PR DESCRIPTION
this is somewhat duplicate of notification_sent but allows for easier selection of all alerts and their CTR

fixes #54423
fixes #54419