### PR TITLE
fix(metrics): Override sdk data category

### DIFF
--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -49,6 +49,16 @@ def patch_sentry_sdk():
 
     client.close = new_close  # type:ignore
 
+    old_data_category = sentry_sdk.envelope.Item.data_category.fget
+
+    @property
+    def data_category(self):
+        if self.headers.get("type") == "statsd":
+            return "statsd"
+        return old_data_category(self)
+
+    sentry_sdk.envelope.Item.data_category = data_category
+
 
 class MiniMetricsMetricsBackend(MetricsBackend):
     def __init__(self, prefix: Optional[str] = None):

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -49,15 +49,15 @@ def patch_sentry_sdk():
 
     client.close = new_close  # type:ignore
 
-    old_data_category = sentry_sdk.envelope.Item.data_category.fget
+    old_data_category = sentry_sdk.envelope.Item.data_category.fget  # type:ignore
 
-    @property
+    @property  # type:ignore
     def data_category(self):
         if self.headers.get("type") == "statsd":
             return "statsd"
         return old_data_category(self)
 
-    sentry_sdk.envelope.Item.data_category = data_category
+    sentry_sdk.envelope.Item.data_category = data_category  # type:ignore
 
 
 class MiniMetricsMetricsBackend(MetricsBackend):

--- a/tests/minimetrics/test_transport.py
+++ b/tests/minimetrics/test_transport.py
@@ -223,3 +223,4 @@ def test_send(sentry_sdk):
     assert len(args) == 1
     arg = args[0]
     assert arg.items[0].type == "statsd"
+    assert arg.items[0].data_category == "statsd"

--- a/tests/minimetrics/test_transport.py
+++ b/tests/minimetrics/test_transport.py
@@ -72,7 +72,7 @@ def test_relay_encoder_with_set():
 
     result = encoder.encode(flushed_metric)
     assert (
-        result == "users@none:456:3455635177:123|s|#browser:Chrome,browser.version:1.0|T1693994400"
+        result == "users@none:456:123:3455635177|s|#browser:Chrome,browser.version:1.0|T1693994400"
     )
 
 


### PR DESCRIPTION
This PR fixes a data category for `statsd` items.