### PR TITLE
feat(onboarding) Add platform options to java-spring-boot

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/layout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/layout.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {ComponentProps, Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import HookOrDefault from 'sentry/components/hookOrDefault';
@@ -6,6 +6,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import {Step, StepProps} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {PlatformOptionsControl} from 'sentry/components/onboarding/platformOptionsControl';
 import {ProductSelection} from 'sentry/components/onboarding/productSelection';
 import {PlatformKey} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
@@ -32,6 +33,7 @@ export type LayoutProps = {
   newOrg?: boolean;
   nextSteps?: NextStep[];
   platformKey?: PlatformKey;
+  platformOptions?: ComponentProps<typeof PlatformOptionsControl>['platformOptions'];
 };
 
 export function Layout({
@@ -39,23 +41,22 @@ export function Layout({
   platformKey,
   newOrg,
   nextSteps = [],
+  platformOptions,
   introduction,
 }: LayoutProps) {
   const organization = useOrganization();
 
   return (
     <Wrapper>
-      {introduction && (
-        <Fragment>
-          <Introduction>{introduction}</Introduction>
-          <Divider />
-        </Fragment>
-      )}
+      {introduction && <Introduction>{introduction}</Introduction>}
       <ProductSelectionAvailabilityHook
         organization={organization}
         platform={platformKey}
-        withBottomMargin={newOrg}
       />
+      {platformOptions ? (
+        <PlatformOptionsControl platformOptions={platformOptions} />
+      ) : null}
+      <Divider withBottomMargin={newOrg} />
       <Steps>
         {steps.map(step => (
           <Step key={step.title ?? step.type} {...step} />
@@ -80,11 +81,12 @@ export function Layout({
   );
 }
 
-const Divider = styled('hr')`
+const Divider = styled('hr')<{withBottomMargin?: boolean}>`
   height: 1px;
   width: 100%;
   background: ${p => p.theme.border};
   border: none;
+  ${p => p.withBottomMargin && `margin-bottom: ${space(3)}`}
 `;
 
 const Steps = styled('div')`
@@ -97,6 +99,7 @@ const Introduction = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(1)};
+  padding-bottom: ${space(2)};
 `;
 
 const Wrapper = styled('div')`

--- a/static/app/components/onboarding/platformOptionsControl.spec.tsx
+++ b/static/app/components/onboarding/platformOptionsControl.spec.tsx
@@ -1,0 +1,114 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {
+  PlatformOption,
+  PlatformOptionsControl,
+} from 'sentry/components/onboarding/platformOptionsControl';
+
+describe('Onboarding Product Selection', function () {
+  const platformOptions: Record<string, PlatformOption> = {
+    springBoot: {
+      items: [
+        {label: 'V2', value: 'v2'},
+        {label: 'V3', value: 'v3'},
+      ],
+      label: 'Spring Boot',
+    },
+    packageManager: {
+      items: [
+        {label: 'Gradle', value: 'gradle'},
+        {label: 'Maven', value: 'maven'},
+      ],
+      label: 'Package Manager',
+    },
+    language: {
+      items: [
+        {label: 'Java', value: 'java'},
+        {label: 'Kotlin', value: 'kotlin'},
+      ],
+      label: 'Language',
+    },
+  };
+
+  it('renders default state', function () {
+    const {routerContext} = initializeOrg({
+      router: {
+        location: {
+          query: {
+            springBoot: 'v3',
+            packageManager: 'something-else',
+          },
+        },
+        params: {},
+      },
+    });
+
+    render(<PlatformOptionsControl platformOptions={platformOptions} />, {
+      context: routerContext,
+    });
+
+    // Find the Spring Boot option, preselected from the URL
+    const springBootV3 = screen.getByRole('radio', {name: 'V3'});
+    expect(springBootV3).toBeInTheDocument();
+    expect(springBootV3).toBeChecked();
+
+    const springBootV2 = screen.getByRole('radio', {name: 'V2'});
+    expect(springBootV2).toBeInTheDocument();
+    expect(springBootV2).not.toBeChecked();
+
+    // The pacakge manger control will fallback to the first option as the value in the URL is not valid
+    const packageManagerGradle = screen.getByRole('radio', {name: 'Gradle'});
+    expect(packageManagerGradle).toBeInTheDocument();
+    expect(packageManagerGradle).toBeChecked();
+
+    const packageManagerMaven = screen.getByRole('radio', {name: 'Maven'});
+    expect(packageManagerMaven).toBeInTheDocument();
+    expect(packageManagerMaven).not.toBeChecked();
+
+    // The language control will fallback to the first option as it is not present in the URL
+    const languageJava = screen.getByRole('radio', {name: 'Java'});
+    expect(languageJava).toBeInTheDocument();
+    expect(languageJava).toBeChecked();
+
+    const languageKotlin = screen.getByRole('radio', {name: 'Maven'});
+    expect(languageKotlin).toBeInTheDocument();
+    expect(languageKotlin).not.toBeChecked();
+  });
+
+  it('updates the url on change', async function () {
+    const {router, routerContext} = initializeOrg({
+      router: {
+        location: {
+          query: {
+            springBoot: 'v3',
+            packageManager: 'gradle',
+          },
+        },
+        params: {},
+      },
+    });
+
+    render(<PlatformOptionsControl platformOptions={platformOptions} />, {
+      context: routerContext,
+    });
+
+    const springBootV3 = screen.getByRole('radio', {name: 'V3'});
+    expect(springBootV3).toBeInTheDocument();
+    expect(springBootV3).toBeChecked();
+
+    const springBootV2 = screen.getByRole('radio', {name: 'V2'});
+    expect(springBootV2).toBeInTheDocument();
+    expect(springBootV2).not.toBeChecked();
+
+    await userEvent.click(springBootV2);
+
+    expect(router.replace).toHaveBeenCalledWith({
+      ...router.location,
+      query: {
+        springBoot: 'v2',
+        packageManager: 'gradle',
+      },
+    });
+  });
+});

--- a/static/app/components/onboarding/platformOptionsControl.tsx
+++ b/static/app/components/onboarding/platformOptionsControl.tsx
@@ -1,0 +1,112 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {SegmentedControl} from 'sentry/components/segmentedControl';
+import {space} from 'sentry/styles/space';
+import useRouter from 'sentry/utils/useRouter';
+
+export interface PlatformOption<K extends string = string> {
+  /**
+   * Array of items for the option. Each one representing a selectable value.
+   */
+  items: {
+    label: string;
+    value: K;
+  }[];
+  /**
+   * The name of the option
+   */
+  label: string;
+}
+
+/**
+ * Hook that returns the currently selected platform option values from the URL
+ * it will fallback to the first option value if the value in the URL is not valid or not present
+ */
+export function useUrlPlatformOptions<K extends string>(
+  platformOptions: Record<K, PlatformOption>
+): Record<K, string> {
+  const router = useRouter();
+  const {query} = router.location;
+
+  return useMemo(
+    () =>
+      Object.keys(platformOptions).reduce((acc, key) => {
+        const values = platformOptions[key as K].items.map(({value}) => value);
+        acc[key] = values.includes(query[key]) ? query[key] : values[0];
+        return acc;
+      }, {} as Record<K, string>),
+    [platformOptions, query]
+  );
+}
+
+type OptionControlProps = {
+  /**
+   * The platform options for which the control is rendered
+   */
+  option: PlatformOption;
+  /**
+   * Value of the currently selected item
+   */
+  value: string;
+  /**
+   * Click handler.
+   */
+  onChange?: (option: string) => void;
+};
+
+function OptionControl({option, value, onChange}: OptionControlProps) {
+  return (
+    <SegmentedControl onChange={onChange} value={value} aria-label={option.label}>
+      {option.items.map(({value: itemValue, label}) => (
+        <SegmentedControl.Item key={itemValue}>{label}</SegmentedControl.Item>
+      ))}
+    </SegmentedControl>
+  );
+}
+
+export type PlatformOptionsControlProps = {
+  /**
+   * Object with an option array for each platformOption
+   */
+  platformOptions: Record<string, PlatformOption>;
+  /**
+   * Object with default value for each option
+   */
+  defaultOptions?: Record<string, string[]>;
+};
+
+export function PlatformOptionsControl({platformOptions}: PlatformOptionsControlProps) {
+  const router = useRouter();
+  const urlOptionValues = useUrlPlatformOptions(platformOptions);
+
+  const handleChange = (key: string, value: string) => {
+    router.replace({
+      ...router.location,
+      query: {
+        ...router.location.query,
+        [key]: value,
+      },
+    });
+  };
+
+  return (
+    <Options>
+      {Object.entries(platformOptions).map(([key, platformOption]) => (
+        <OptionControl
+          key={key}
+          option={platformOption}
+          value={urlOptionValues[key] ?? platformOption.items[0]?.value}
+          onChange={value => handleChange(key, value)}
+        />
+      ))}
+    </Options>
+  );
+}
+
+const Options = styled('div')`
+  padding-top: ${space(2)};
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${space(1)};
+`;

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -150,6 +150,7 @@ export const platformProductAvailability = {
   'python-starlette': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'python-tryton': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'python-wsgi': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
+  'java-spring-boot': [ProductSolution.PERFORMANCE_MONITORING],
 } as Record<PlatformKey, ProductSolution[]>;
 
 type ProductProps = {
@@ -269,7 +270,6 @@ export function ProductSelection({
   platform,
   productsPerPlatform = platformProductAvailability,
   skipLazyLoader,
-  withBottomMargin,
 }: ProductSelectionProps) {
   const router = useRouter();
   const urlProducts = decodeList(router.location.query.product);
@@ -416,7 +416,6 @@ export function ProductSelection({
           })}
         </AlternativeInstallationAlert>
       )}
-      <Divider withBottomMargin={withBottomMargin} />
     </Fragment>
   );
 }
@@ -469,14 +468,6 @@ const ProductButtonInner = styled('div')`
   grid-template-columns: repeat(3, max-content);
   gap: ${space(1)};
   align-items: center;
-`;
-
-const Divider = styled('hr')<{withBottomMargin?: boolean}>`
-  height: 1px;
-  width: 100%;
-  background: ${p => p.theme.border};
-  border: none;
-  ${p => p.withBottomMargin && `margin-bottom: ${space(3)}`}
 `;
 
 const TooltipDescription = styled('div')`

--- a/static/app/gettingStartedDocs/java/spring-boot.spec.tsx
+++ b/static/app/gettingStartedDocs/java/spring-boot.spec.tsx
@@ -2,7 +2,12 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
 
-import {GettingStartedWithSpringBoot, steps} from './spring-boot';
+import {
+  GettingStartedWithSpringBoot,
+  PackageManager,
+  SpringBootVersion,
+  steps,
+} from './spring-boot';
 
 describe('GettingStartedWithSpringBoot', function () {
   it('renders doc correctly', function () {
@@ -11,6 +16,9 @@ describe('GettingStartedWithSpringBoot', function () {
     // Steps
     for (const step of steps({
       dsn: 'test-dsn',
+      springBootVersion: SpringBootVersion.V2,
+      packageManager: PackageManager.MAVEN,
+      hasPerformance: true,
     })) {
       expect(
         screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})

--- a/static/app/gettingStartedDocs/java/spring-boot.tsx
+++ b/static/app/gettingStartedDocs/java/spring-boot.tsx
@@ -5,16 +5,65 @@ import Link from 'sentry/components/links/link';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {
+  PlatformOption,
+  useUrlPlatformOptions,
+} from 'sentry/components/onboarding/platformOptionsControl';
+import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
+
+export enum SpringBootVersion {
+  V2 = 'v2',
+  V3 = 'v3',
+}
+
+export enum PackageManager {
+  GRADLE = 'gradle',
+  MAVEN = 'maven',
+}
+
+type PlaformOptionKey = 'springBootVersion' | 'packageManager';
 
 interface StepProps {
   dsn: string;
+  hasPerformance: boolean;
   organizationSlug?: string;
+  packageManager?: PackageManager;
   projectSlug?: string;
   sourcePackageRegistries?: ModuleProps['sourcePackageRegistries'];
+  springBootVersion?: SpringBootVersion;
 }
 
 // Configuration Start
+const platformOptions: Record<PlaformOptionKey, PlatformOption> = {
+  springBootVersion: {
+    label: t('Spring Boot Version'),
+    items: [
+      {
+        label: t('Spring Boot 3'),
+        value: SpringBootVersion.V3,
+      },
+      {
+        label: t('Spring Boot 2'),
+        value: SpringBootVersion.V2,
+      },
+    ],
+  },
+  packageManager: {
+    label: t('Package Manager'),
+    items: [
+      {
+        label: t('Gradle'),
+        value: PackageManager.GRADLE,
+      },
+      {
+        label: t('Maven'),
+        value: PackageManager.MAVEN,
+      },
+    ],
+  },
+};
+
 const introduction = (
   <p>
     {tct(
@@ -34,10 +83,12 @@ export const steps = ({
   sourcePackageRegistries,
   projectSlug,
   organizationSlug,
+  springBootVersion,
+  packageManager,
+  hasPerformance,
 }: StepProps): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: t('Install using either Maven or Gradle:'),
     configurations: [
       {
         description: (
@@ -55,11 +106,8 @@ export const steps = ({
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
             `,
       },
-      {
-        language: 'javascript', // TODO: This shouldn't be javascript but because of better formatting we use it for now
-        description: <h5>{t('Gradle')}</h5>,
-        configurations: [
-          {
+      packageManager === PackageManager.GRADLE
+        ? {
             description: (
               <p>
                 {tct(
@@ -101,48 +149,16 @@ sentry {
   authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }
             `,
-          },
-        ],
-      },
-      {
-        description: <h5>{t('Maven')}</h5>,
-        additionalInfo: (
-          <p>
-            {tct(
-              "There are two variants of Sentry available for Spring Boot. If you're using Spring Boot 2, use [springBootStarterLink:sentry-spring-boot-starter]. If you're using Spring Boot 3, use [springBootStarterJakartaLink:sentry-spring-boot-starter-jakarta] instead.",
+          }
+        : {
+            description: t('Install using Maven:'),
+            configurations: [
               {
-                springBootStarterLink: (
-                  <ExternalLink href="https://github.com/getsentry/sentry-java/tree/master/sentry-spring-boot-starter" />
-                ),
-                springBootStarterJakartaLink: (
-                  <ExternalLink href="https://github.com/getsentry/sentry-java/tree/master/sentry-spring-boot-starter-jakarta" />
-                ),
-              }
-            )}
-          </p>
-        ),
-        configurations: [
-          {
-            language: 'xml',
-            partialLoading: sourcePackageRegistries?.isLoading,
-            description: <strong>{t('Spring Boot 2')}</strong>,
-            code: `
-<dependency>
-    <groupId>io.sentry</groupId>
-    <artifactId>sentry-spring-boot-starter</artifactId>
-    <version>${
-      sourcePackageRegistries?.isLoading
-        ? t('\u2026loading')
-        : sourcePackageRegistries?.data?.['sentry.java.spring-boot']?.version ?? '6.28.0'
-    }</version>
-</dependency>
-          `,
-          },
-          {
-            language: 'xml',
-            partialLoading: sourcePackageRegistries?.isLoading,
-            description: <strong>{t('Spring Boot 3')}</strong>,
-            code: `
+                language: 'xml',
+                partialLoading: sourcePackageRegistries?.isLoading,
+                code:
+                  springBootVersion === SpringBootVersion.V3
+                    ? `
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
@@ -152,20 +168,29 @@ sentry {
         : sourcePackageRegistries?.data?.['sentry.java.spring-boot.jakarta']?.version ??
           '6.28.0'
     }</version>
-</dependency>
-        `,
-            additionalInfo: (
-              <p>
-                {tct(
-                  'If you use Logback for logging you may also want to send error logs to Sentry. Add a dependency to the [sentryLogbackCode:sentry-logback] module. Sentry Spring Boot Starter will auto-configure [sentryAppenderCode:SentryAppender].',
-                  {sentryAppenderCode: <code />, sentryLogbackCode: <code />}
-                )}
-              </p>
-            ),
-          },
-          {
-            language: 'xml',
-            code: `
+</dependency>`
+                    : `
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry-spring-boot-starter</artifactId>
+    <version>${
+      sourcePackageRegistries?.isLoading
+        ? t('\u2026loading')
+        : sourcePackageRegistries?.data?.['sentry.java.spring-boot']?.version ?? '6.28.0'
+    }</version>
+</dependency>`,
+                additionalInfo: (
+                  <p>
+                    {tct(
+                      'If you use Logback for logging you may also want to send error logs to Sentry. Add a dependency to the [sentryLogbackCode:sentry-logback] module. Sentry Spring Boot Starter will auto-configure [sentryAppenderCode:SentryAppender].',
+                      {sentryAppenderCode: <code />, sentryLogbackCode: <code />}
+                    )}
+                  </p>
+                ),
+              },
+              {
+                language: 'xml',
+                code: `
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-logback</artifactId>
@@ -176,13 +201,13 @@ sentry {
     }</version>
 </dependency>
           `,
-          },
-          {
-            language: 'xml',
-            description: t(
-              'To upload your source code to Sentry so it can be shown in stack traces, use our Maven plugin.'
-            ),
-            code: `
+              },
+              {
+                language: 'xml',
+                description: t(
+                  'To upload your source code to Sentry so it can be shown in stack traces, use our Maven plugin.'
+                ),
+                code: `
 <build>
   <plugins>
     <plugin>
@@ -220,9 +245,9 @@ sentry {
 ...
 </build>
         `,
+              },
+            ],
           },
-        ],
-      },
     ],
   },
   {
@@ -245,11 +270,14 @@ sentry {
           <p>{tct('Modify [code:src/main/application.properties]:', {code: <code />})}</p>
         ),
         code: `
-sentry.dsn=${dsn}
+sentry.dsn=${dsn}${
+          hasPerformance
+            ? `
 # Set traces-sample-rate to 1.0 to capture 100% of transactions for performance monitoring.
 # We recommend adjusting this value in production.
-sentry.traces-sample-rate=1.0
-        `,
+sentry.traces-sample-rate=1.0`
+            : ''
+        }`,
       },
       {
         language: 'properties',
@@ -258,11 +286,14 @@ sentry.traces-sample-rate=1.0
         ),
         code: `
 sentry:
-  dsn:${dsn}
+  dsn:${dsn}${
+          hasPerformance
+            ? `
   # Set traces-sample-rate to 1.0 to capture 100% of transactions for performance monitoring.
   # We recommend adjusting this value in production.
-  traces-sample-rate: 1.0
-        `,
+  sentry.traces-sample-rate=1.0`
+            : ''
+        }`,
       },
     ],
   },
@@ -341,8 +372,15 @@ export function GettingStartedWithSpringBoot({
   sourcePackageRegistries,
   projectSlug,
   organization,
+  activeProductSelection = [],
   ...props
 }: ModuleProps) {
+  const optionValues = useUrlPlatformOptions(platformOptions);
+
+  const hasPerformance = activeProductSelection.includes(
+    ProductSolution.PERFORMANCE_MONITORING
+  );
+
   const nextStepDocs = [...nextSteps];
 
   return (
@@ -352,9 +390,13 @@ export function GettingStartedWithSpringBoot({
         sourcePackageRegistries,
         projectSlug: projectSlug ?? '___PROJECT_SLUG___',
         organizationSlug: organization?.slug ?? '___ORG_SLUG___',
+        hasPerformance,
+        springBootVersion: optionValues.springBootVersion as SpringBootVersion,
+        packageManager: optionValues.packageManager as PackageManager,
       })}
       nextSteps={nextStepDocs}
       introduction={introduction}
+      platformOptions={platformOptions}
       {...props}
     />
   );

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -148,6 +148,7 @@ export function SetupDocsLoader({
         skipLazyLoader={close}
         platform={currentPlatform}
       />
+      <Divider />
       {projectKeyUpdateError && (
         <LoadingError
           message={t('Failed to update the project key with the selected products.')}
@@ -349,4 +350,11 @@ const ToggleButton = styled(Button)`
   :hover {
     color: ${p => p.theme.gray500};
   }
+`;
+
+const Divider = styled('hr')<{withBottomMargin?: boolean}>`
+  height: 1px;
+  width: 100%;
+  background: ${p => p.theme.border};
+  border: none;
 `;


### PR DESCRIPTION
* Add mechanism to toggle platform specific options that can influence the getting-started docs. e.g. package manager / framework version.
* Added platform options to the platform java-spring-boot

Closes https://github.com/getsentry/sentry/issues/56237