### PR TITLE
fix(perf): Remove hard-coded widths from span sample table

### DIFF
--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -1,7 +1,10 @@
 import {CSSProperties} from 'react';
 import {Link} from 'react-router';
 
-import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  GridColumnHeader,
+} from 'sentry/components/gridEditable';
 import {useLocation} from 'sentry/utils/useLocation';
 import {DurationComparisonCell} from 'sentry/views/starfish/components/samplesTable/common';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
@@ -23,17 +26,17 @@ const COLUMN_ORDER: TableColumnHeader[] = [
   {
     key: 'transaction_id',
     name: 'Event ID',
-    width: 200,
+    width: COL_WIDTH_UNDEFINED,
   },
   {
     key: 'duration',
     name: 'Span Duration',
-    width: 200,
+    width: COL_WIDTH_UNDEFINED,
   },
   {
     key: 'avg_comparison',
     name: 'Compared to Average',
-    width: 200,
+    width: COL_WIDTH_UNDEFINED,
   },
 ];
 


### PR DESCRIPTION
Allows the table to shrink on smaller screens!
