### PR TITLE
fix(github-invite): fetch data for members page on modal close

### DIFF
--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -340,7 +340,7 @@ class OrganizationMembersList extends DeprecatedAsyncView<Props, State> {
         <InviteBanner
           missingMembers={githubMissingMembers}
           onSendInvite={this.handleInviteMissingMember}
-          onModalClose={this.fetchMembersList}
+          onModalClose={this.fetchData}
           allowedRoles={currentMember ? currentMember.roles : ORG_ROLES}
         />
         <ClassNames>


### PR DESCRIPTION
The page needs to be refreshed upon the modal closing so the list of missing members is correct if the user has invited members through the modal.

https://github.com/getsentry/sentry/assets/70817427/58cfbffa-4a4c-410e-88cd-862fbc72ad07

