### PR TITLE
fix(hybridcloud) Fix more issue data fetch URLs

### DIFF
--- a/static/app/views/issueDetails/groupTagValues.spec.tsx
+++ b/static/app/views/issueDetails/groupTagValues.spec.tsx
@@ -21,7 +21,7 @@ function init(tagKey: string) {
 describe('GroupTagValues', () => {
   beforeEach(() => {
     MockApiClient.addMockResponse({
-      url: '/issues/1/tags/user/',
+      url: '/organizations/org-slug/issues/1/tags/user/',
       body: tags.find(({key}) => key === 'user'),
     });
   });
@@ -34,7 +34,7 @@ describe('GroupTagValues', () => {
     const {routerProps, routerContext, router, project} = init('user');
 
     MockApiClient.addMockResponse({
-      url: '/issues/1/tags/user/values/',
+      url: '/organizations/org-slug/issues/1/tags/user/values/',
       body: TestStubs.TagValues(),
     });
     render(
@@ -67,7 +67,7 @@ describe('GroupTagValues', () => {
     const {routerProps, routerContext, project} = init('user');
 
     MockApiClient.addMockResponse({
-      url: '/issues/1/tags/user/values/',
+      url: '/organizations/org-slug/issues/1/tags/user/values/',
       body: [],
     });
     const {container} = render(

--- a/static/app/views/issueDetails/groupTagValues.tsx
+++ b/static/app/views/issueDetails/groupTagValues.tsx
@@ -61,13 +61,13 @@ class GroupTagValues extends DeprecatedAsyncComponent<
   State & DeprecatedAsyncComponent['state']
 > {
   getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
-    const {environments: environment} = this.props;
+    const {environments: environment, organization} = this.props;
     const {groupId, tagKey} = this.props.params;
     return [
-      ['tag', `/issues/${groupId}/tags/${tagKey}/`],
+      ['tag', `/organizations/${organization.slug}/issues/${groupId}/tags/${tagKey}/`],
       [
         'tagValueList',
-        `/issues/${groupId}/tags/${tagKey}/values/`,
+        `/organizations/${organization.slug}/issues/${groupId}/tags/${tagKey}/values/`,
         {query: {environment, sort: this.getSort()}},
       ],
     ];

--- a/static/app/views/issueDetails/groupTags.spec.tsx
+++ b/static/app/views/issueDetails/groupTags.spec.tsx
@@ -9,7 +9,7 @@ describe('GroupTags', function () {
   let tagsMock;
   beforeEach(function () {
     tagsMock = MockApiClient.addMockResponse({
-      url: '/issues/1/tags/',
+      url: '/organizations/org-slug/issues/1/tags/',
       body: TestStubs.Tags(),
     });
   });
@@ -26,7 +26,7 @@ describe('GroupTags', function () {
     );
 
     expect(tagsMock).toHaveBeenCalledWith(
-      '/issues/1/tags/',
+      '/organizations/org-slug/issues/1/tags/',
       expect.objectContaining({
         query: {environment: ['dev']},
       })

--- a/static/app/views/issueDetails/groupTags.tsx
+++ b/static/app/views/issueDetails/groupTags.tsx
@@ -40,11 +40,11 @@ class GroupTags extends DeprecatedAsyncComponent<Props, State> {
   }
 
   getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
-    const {group, environments} = this.props;
+    const {group, environments, organization} = this.props;
     return [
       [
         'tagList',
-        `/issues/${group.id}/tags/`,
+        `/organizations/${organization.slug}/issues/${group.id}/tags/`,
         {
           query: {environment: environments},
         },


### PR DESCRIPTION
We need organization slug in order for the API gateway in control silo to route requests. While we won't rely on the proxy long term having routable URLs in the UI today will help us transition traffic in the future.