### PR TITLE
ref(escalating-issues): Auto-transition tasks should update up to 500_000 groups per minute

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1131,8 +1131,8 @@ CELERYBEAT_SCHEDULE_REGION = {
     },
     "schedule_auto_transition_to_ongoing": {
         "task": "sentry.tasks.schedule_auto_transition_to_ongoing",
-        # Run job every 10 minutes
-        "schedule": crontab(minute="*/10"),
+        # Run job every minute
+        "schedule": crontab(minute="*/1"),
         "options": {"expires": 3600},
     },
     "github_comment_reactions": {

--- a/src/sentry/issues/ongoing.py
+++ b/src/sentry/issues/ongoing.py
@@ -10,12 +10,12 @@ from sentry.types.group import GroupSubStatus
 def bulk_transition_group_to_ongoing(
     from_status: int,
     from_substatus: int,
-    groups: List[Group],
+    group_ids: List[int],
     activity_data: Optional[Mapping[str, Any]] = None,
 ) -> None:
     # make sure we don't update the Group when its already updated by conditionally updating the Group
     groups_to_transistion = Group.objects.filter(
-        id__in=[group.id for group in groups], status=from_status, substatus=from_substatus
+        id__in=group_ids, status=from_status, substatus=from_substatus
     )
 
     Group.objects.update_group_status(
@@ -31,7 +31,7 @@ def bulk_transition_group_to_ongoing(
         group.status = GroupStatus.UNRESOLVED
         group.substatus = GroupSubStatus.ONGOING
 
-    bulk_remove_groups_from_inbox(groups)
+    bulk_remove_groups_from_inbox(groups_to_transistion)
 
     for group in groups_to_transistion:
         post_save.send_robust(

--- a/src/sentry/issues/update_inbox.py
+++ b/src/sentry/issues/update_inbox.py
@@ -54,7 +54,7 @@ def update_inbox(
                 bulk_transition_group_to_ongoing(
                     group.status,
                     group.substatus,
-                    [group],
+                    [group.id],
                     activity_data={"manually": True},
                 )
 

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime, timedelta, timezone
 from functools import wraps
-from typing import List
+from typing import List, Optional
 
 from django.db import OperationalError
 from django.db.models import Max
@@ -97,7 +97,9 @@ def schedule_auto_transition_to_ongoing() -> None:
 @retry(on=(OperationalError,))
 @log_error_if_queue_has_items
 def auto_transition_issues_new_to_ongoing(
+    project_ids: List[int],  # TODO(nisanthan): Remove in following PR
     first_seen_lte: int,
+    organization_id: int,  # TODO(nisanthan): Remove in following PR
     **kwargs,
 ) -> None:
     """
@@ -181,7 +183,9 @@ def run_auto_transition_issues_new_to_ongoing(
 @retry(on=(OperationalError,))
 @log_error_if_queue_has_items
 def auto_transition_issues_regressed_to_ongoing(
+    project_ids: List[int],  # TODO(nisanthan): Remove this arg in next PR
     date_added_lte: int,
+    project_id: Optional[int],  # TODO(nisanthan): Remove this arg in next PR
     **kwargs,
 ) -> None:
     """
@@ -255,7 +259,9 @@ def run_auto_transition_issues_regressed_to_ongoing(
 @retry(on=(OperationalError,))
 @log_error_if_queue_has_items
 def auto_transition_issues_escalating_to_ongoing(
+    project_ids: List[int],  # TODO(nisanthan): Remove this arg in next PR
     date_added_lte: int,
+    project_id: Optional[int],  # TODO(nisanthan): Remove this arg in next PR
     **kwargs,
 ) -> None:
     """

--- a/tests/sentry/issues/test_ongoing.py
+++ b/tests/sentry/issues/test_ongoing.py
@@ -9,7 +9,7 @@ class TransitionNewToOngoingTest(TestCase):
     def test_new_to_ongoing(self) -> None:
         group = self.create_group(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.NEW)
 
-        bulk_transition_group_to_ongoing(GroupStatus.UNRESOLVED, GroupSubStatus.NEW, [group])
+        bulk_transition_group_to_ongoing(GroupStatus.UNRESOLVED, GroupSubStatus.NEW, [group.id])
         assert Activity.objects.filter(
             group=group, type=ActivityType.AUTO_SET_ONGOING.value
         ).exists()
@@ -20,7 +20,9 @@ class TransitionNewToOngoingTest(TestCase):
     def test_regressed_to_ongoing(self) -> None:
         group = self.create_group(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.REGRESSED)
 
-        bulk_transition_group_to_ongoing(GroupStatus.UNRESOLVED, GroupSubStatus.REGRESSED, [group])
+        bulk_transition_group_to_ongoing(
+            GroupStatus.UNRESOLVED, GroupSubStatus.REGRESSED, [group.id]
+        )
         assert Activity.objects.filter(
             group=group, type=ActivityType.AUTO_SET_ONGOING.value
         ).exists()

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -157,15 +157,13 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
         now = datetime.now(tz=timezone.utc)
         project = self.create_project()
         groups_count = 110
-        for day, hours in [(8, 1) for _ in range(groups_count)]:
-            group = self.create_group(
+        for day, hours in [(TRANSITION_AFTER_DAYS, 1) for _ in range(groups_count)]:
+            self.create_group(
                 project=project,
                 status=GroupStatus.UNRESOLVED,
                 substatus=GroupSubStatus.NEW,
+                first_seen=now - timedelta(days=day, hours=hours),
             )
-            first_seen = now - timedelta(days=day, hours=hours)
-            group.first_seen = first_seen
-            group.save()
 
         # before
         assert (
@@ -270,6 +268,84 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
 
         assert GroupHistory.objects.filter(group=group, status=GroupHistoryStatus.ONGOING).exists()
 
+    @freeze_time("2023-07-12 18:40:00Z")
+    @mock.patch("sentry.utils.metrics.incr")
+    @mock.patch("sentry.tasks.auto_ongoing_issues.ITERATOR_CHUNK", new=2)
+    @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
+    def test_not_all_groups_get_updated(self, mock_backend, mock_metrics_incr):
+        now = datetime.now(tz=timezone.utc)
+        project = self.create_project()
+        groups_count = 110
+        for day, hours in [(TRANSITION_AFTER_DAYS, 1) for _ in range(groups_count)]:
+            group = self.create_group(
+                project=project,
+                status=GroupStatus.UNRESOLVED,
+                substatus=GroupSubStatus.REGRESSED,
+                first_seen=now - timedelta(days=day, hours=hours),
+            )
+            group_inbox = add_group_to_inbox(group, GroupInboxReason.REGRESSION)
+            group_inbox.date_added = now - timedelta(days=TRANSITION_AFTER_DAYS, hours=1)
+            group_inbox.save(update_fields=["date_added"])
+            group_history = record_group_history(
+                group, GroupHistoryStatus.REGRESSED, actor=None, release=None
+            )
+            group_history.date_added = now - timedelta(days=TRANSITION_AFTER_DAYS, hours=1)
+            group_history.save(update_fields=["date_added"])
+
+        mock_backend.get_size.return_value = 0
+
+        with self.tasks():
+            schedule_auto_transition_to_ongoing()
+
+        assert (
+            Group.objects.filter(
+                project=project,
+                status=GroupStatus.UNRESOLVED,
+                substatus=GroupSubStatus.REGRESSED,
+            ).count()
+            == 10
+        )
+        assert (
+            Group.objects.filter(
+                project=project,
+                status=GroupStatus.UNRESOLVED,
+                substatus=GroupSubStatus.ONGOING,
+            ).count()
+            == 100
+        )
+
+        mock_metrics_incr.assert_any_call(
+            "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.executed",
+            sample_rate=1.0,
+            tags={"count": 0},
+        )
+        mock_metrics_incr.assert_any_call(
+            "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.remaining",
+            sample_rate=1.0,
+            tags={"count": 0},
+        )
+
+        mock_metrics_incr.assert_any_call(
+            "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.executed",
+            sample_rate=1.0,
+            tags={"count": 100},
+        )
+        mock_metrics_incr.assert_any_call(
+            "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.remaining",
+            sample_rate=1.0,
+            tags={"count": 10},
+        )
+        mock_metrics_incr.assert_any_call(
+            "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.executed",
+            sample_rate=1.0,
+            tags={"count": 0},
+        )
+        mock_metrics_incr.assert_any_call(
+            "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.remaining",
+            sample_rate=1.0,
+            tags={"count": 0},
+        )
+
 
 @apply_feature_flag_on_cls("organizations:escalating-issues")
 class ScheduleAutoEscalatingOngoingIssuesTest(TestCase):
@@ -308,3 +384,82 @@ class ScheduleAutoEscalatingOngoingIssuesTest(TestCase):
         assert set_ongoing_activity.data == {"after_days": 7}
 
         assert GroupHistory.objects.filter(group=group, status=GroupHistoryStatus.ONGOING).exists()
+
+    @freeze_time("2023-07-12 18:40:00Z")
+    @mock.patch("sentry.utils.metrics.incr")
+    @mock.patch("sentry.tasks.auto_ongoing_issues.ITERATOR_CHUNK", new=2)
+    @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
+    def test_not_all_groups_get_updated(self, mock_backend, mock_metrics_incr):
+        now = datetime.now(tz=timezone.utc)
+        project = self.create_project()
+        groups_count = 110
+
+        for day, hours in [(TRANSITION_AFTER_DAYS, 1) for _ in range(groups_count)]:
+            group = self.create_group(
+                project=project,
+                status=GroupStatus.UNRESOLVED,
+                substatus=GroupSubStatus.ESCALATING,
+                first_seen=now - timedelta(days=day, hours=hours),
+            )
+            group_inbox = add_group_to_inbox(group, GroupInboxReason.ESCALATING)
+            group_inbox.date_added = now - timedelta(days=TRANSITION_AFTER_DAYS, hours=1)
+            group_inbox.save(update_fields=["date_added"])
+            group_history = record_group_history(
+                group, GroupHistoryStatus.ESCALATING, actor=None, release=None
+            )
+            group_history.date_added = now - timedelta(days=TRANSITION_AFTER_DAYS, hours=1)
+            group_history.save(update_fields=["date_added"])
+
+        mock_backend.get_size.return_value = 0
+
+        with self.tasks():
+            schedule_auto_transition_to_ongoing()
+
+        assert (
+            Group.objects.filter(
+                project=project,
+                status=GroupStatus.UNRESOLVED,
+                substatus=GroupSubStatus.ESCALATING,
+            ).count()
+            == 10
+        )
+        assert (
+            Group.objects.filter(
+                project=project,
+                status=GroupStatus.UNRESOLVED,
+                substatus=GroupSubStatus.ONGOING,
+            ).count()
+            == 100
+        )
+
+        mock_metrics_incr.assert_any_call(
+            "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.executed",
+            sample_rate=1.0,
+            tags={"count": 0},
+        )
+        mock_metrics_incr.assert_any_call(
+            "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.remaining",
+            sample_rate=1.0,
+            tags={"count": 0},
+        )
+
+        mock_metrics_incr.assert_any_call(
+            "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.executed",
+            sample_rate=1.0,
+            tags={"count": 0},
+        )
+        mock_metrics_incr.assert_any_call(
+            "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.remaining",
+            sample_rate=1.0,
+            tags={"count": 0},
+        )
+        mock_metrics_incr.assert_any_call(
+            "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.executed",
+            sample_rate=1.0,
+            tags={"count": 100},
+        )
+        mock_metrics_incr.assert_any_call(
+            "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.remaining",
+            sample_rate=1.0,
+            tags={"count": 10},
+        )


### PR DESCRIPTION
## Objective:

The current implementation of the auto-transition tasks is leading to spiky memory pressure on RabbitMQ. This is partly due to the hot shards of big orgs with a lot of groups. The alternative approach is to consistently send x number of messages of groups older than 7 days. No need to care about org or project bc all those groups have the same status and substatus changes. This iteration sends up to 50 child tasks with each task updating 10_000 groups. We will increase the number of tasks if the backlog of groups_to_be_updated is increasing.