### PR TITLE
feat(perf): Improve table rate formatting

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -116,8 +116,6 @@ type FieldFormatters = {
 
 export type FieldTypes = keyof FieldFormatters;
 
-const DEFAULT_RATE_SIG_DIGITS = 3;
-
 const EmptyValueContainer = styled('span')`
   color: ${p => p.theme.gray300};
 `;
@@ -235,7 +233,7 @@ export const FIELD_FORMATTERS: FieldFormatters = {
       const {unit} = baggage ?? {};
       return (
         <NumberContainer>
-          {formatRate(data[field], unit as RateUnits, DEFAULT_RATE_SIG_DIGITS)}
+          {formatRate(data[field], unit as RateUnits, {minimumValue: 0.01})}
         </NumberContainer>
       );
     },

--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -3,6 +3,7 @@ import {
   formatAbbreviatedNumber,
   formatFloat,
   formatPercentage,
+  formatRate,
   formatSecondsToClock,
   getDuration,
   getExactDuration,
@@ -213,6 +214,25 @@ describe('formatAbbreviatedNumber()', function () {
     expect(formatAbbreviatedNumber('1249.23421', 3)).toBe('1.25k');
     expect(formatAbbreviatedNumber('1239567891299', 3)).toBe('1240b');
     expect(formatAbbreviatedNumber('158.80421626984128', 3)).toBe('159');
+  });
+});
+
+describe('formatRate()', function () {
+  it('Formats 0 as "0"', () => {
+    expect(formatRate(0)).toBe('0/s');
+  });
+
+  it('Rounds the rate', () => {
+    expect(formatRate(0.3142)).toBe('0.314/s');
+    expect(formatRate(17)).toBe('17/s');
+    expect(formatRate(1023.142)).toBe('1k/s');
+  });
+
+  it('Abbreviates large numbers', () => {
+    expect(formatRate(1023.142)).toBe('1k/s');
+    expect(formatRate(1523142)).toBe('1.5m/s');
+    expect(formatRate(1020314200.132)).toBe('1b/s');
+    expect(formatRate(1023140200132.789)).toBe('1023b/s');
   });
 });
 

--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -1,3 +1,4 @@
+import {RateUnits} from 'sentry/utils/discover/fields';
 import {
   DAY,
   formatAbbreviatedNumber,
@@ -222,17 +223,33 @@ describe('formatRate()', function () {
     expect(formatRate(0)).toBe('0/s');
   });
 
-  it('Rounds the rate', () => {
-    expect(formatRate(0.3142)).toBe('0.314/s');
-    expect(formatRate(17)).toBe('17/s');
-    expect(formatRate(1023.142)).toBe('1k/s');
+  it('Accepts a unit', () => {
+    expect(formatRate(0.3142, RateUnits.PER_MINUTE)).toBe('0.314/min');
+    expect(formatRate(0.3142, RateUnits.PER_HOUR)).toBe('0.314/hr');
   });
 
-  it('Abbreviates large numbers', () => {
-    expect(formatRate(1023.142)).toBe('1k/s');
-    expect(formatRate(1523142)).toBe('1.5m/s');
-    expect(formatRate(1020314200.132)).toBe('1b/s');
-    expect(formatRate(1023140200132.789)).toBe('1023b/s');
+  it('Formats to 3 significant digits for numbers > minimum', () => {
+    expect(formatRate(0.3142)).toBe('0.314/s');
+    expect(formatRate(17)).toBe('17.0/s');
+    expect(formatRate(1023.142)).toBe('1.02K/s');
+  });
+
+  it('Obeys a minimum value option', () => {
+    expect(formatRate(0.000003142, undefined, {minimumValue: 0.01})).toBe('<0.01/s');
+    expect(formatRate(0.0023, undefined, {minimumValue: 0.01})).toBe('<0.01/s');
+    expect(formatRate(0.02, undefined, {minimumValue: 0.01})).toBe('0.0200/s');
+    expect(formatRate(0.271, undefined, {minimumValue: 0.01})).toBe('0.271/s');
+  });
+
+  it('Obeys a significant digits option', () => {
+    expect(formatRate(7.1, undefined, {significantDigits: 4})).toBe('7.100/s');
+  });
+
+  it('Abbreviates large numbers using SI prefixes', () => {
+    expect(formatRate(1023.142)).toBe('1.02K/s');
+    expect(formatRate(1523142)).toBe('1.52M/s');
+    expect(formatRate(1020314200.132)).toBe('1.02B/s');
+    expect(formatRate(1023140200132.789)).toBe('1.02T/s');
   });
 });
 


### PR DESCRIPTION
The rate formatter now uses `toLocaleString()` directly, instead of relying on `formatAbbreviatedNumber`, which has a bunch of idiosyncacies that won't work nicely for rates.

- 0 is always "0/s" for readability
- always three significant digits
- very small numbers show up as `<0.01` in tables

**Before:**
<img width="180" alt="Screenshot 2023-09-13 at 11 28 24 AM" src="https://github.com/getsentry/sentry/assets/989898/60f2e247-79aa-4533-9a51-3ef99f51f27d">
<img width="135" alt="Screenshot 2023-09-13 at 11 29 06 AM" src="https://github.com/getsentry/sentry/assets/989898/2f6b016a-d901-49be-ac68-d0fac556872b">

**After:**
<img width="156" alt="Screenshot 2023-09-13 at 11 28 30 AM" src="https://github.com/getsentry/sentry/assets/989898/df5160fc-9c61-42b7-93f0-0d6019d44ad3">
<img width="114" alt="Screenshot 2023-09-13 at 11 29 23 AM" src="https://github.com/getsentry/sentry/assets/989898/91ba650d-965b-40cc-ab90-432d5c0dd61f">
