### PR TITLE
feat(code-mappings): Support frames starting with /

### DIFF
--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -305,7 +305,7 @@ class CodeMappingTreesHelper:
             return []
 
         stacktrace_root = f"{frame_filename.root}/"
-        source_path = self._get_code_mapping_source_path(matched_files[0], frame_filename)
+        source_path = _get_code_mapping_source_path(matched_files[0], frame_filename)
         if frame_filename.frame_type() != "packaged":
             stacktrace_root, source_path = self._normalized_stack_and_source_roots(
                 stacktrace_root, source_path

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -103,12 +103,10 @@ class FrameFilename:
         if frame_file_path[0] == "/":
             frame_file_path = frame_file_path.replace("/", "", 1)
 
-        if frame_file_path.startswith("./"):
-            frame_file_path = frame_file_path.replace("./", "", 1)
-
         # Using regexes would be better but this is easier to understand
         if (
-            frame_file_path[0] in ["[", "<"]
+            not frame_file_path
+            or frame_file_path[0] in ["[", "<"]
             or frame_file_path.find(" ") > -1
             or frame_file_path.find("\\") > -1  # Windows support
             or frame_file_path.find("/") == -1
@@ -179,10 +177,7 @@ def stacktrace_buckets(stacktraces: List[str]) -> Dict[str, List[FrameFilename]]
             buckets[bucket_key].append(frame_filename)
 
         except UnsupportedFrameFilename:
-            logger.info(
-                "Frame's filepath not supported.",
-                extra={"frame_file_path": stacktrace_frame_file_path},
-            )
+            logger.info(f"Frame's filepath not supported: {stacktrace_frame_file_path}")
         except Exception:
             logger.exception("Unable to split stacktrace path into buckets")
 

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -100,15 +100,20 @@ def filter_source_code_files(files: List[str]) -> List[str]:
 # XXX: Look at sentry.interfaces.stacktrace and maybe use that
 class FrameFilename:
     def __init__(self, frame_file_path: str) -> None:
+        if frame_file_path[0] == "/":
+            frame_file_path = frame_file_path.replace("/", "", 1)
+
+        if frame_file_path.startswith("./"):
+            frame_file_path = frame_file_path.replace("./", "", 1)
+
         # Using regexes would be better but this is easier to understand
         if (
-            not frame_file_path
-            or frame_file_path[0] in ["[", "<", "/"]
+            frame_file_path[0] in ["[", "<"]
             or frame_file_path.find(" ") > -1
             or frame_file_path.find("\\") > -1  # Windows support
             or frame_file_path.find("/") == -1
         ):
-            raise UnsupportedFrameFilename("Either garbage or will need work to support.")
+            raise UnsupportedFrameFilename("This path is not supported.")
 
         self.full_path = frame_file_path
         self.extension = get_extension(frame_file_path)

--- a/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from django.db import router
 from django.urls import reverse
 
+from sentry.integrations.utils.code_mapping import FrameFilename, _get_code_mapping_source_path
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.repository import Repository
@@ -41,6 +42,29 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
                 "repo_branch": "master",
                 "stacktrace_root": "/stack/root",
                 "source_path": "/source/root/",
+            }
+        ]
+        with patch(
+            "sentry.integrations.utils.code_mapping.CodeMappingTreesHelper.list_file_matches",
+            return_value=expected_matches,
+        ):
+            response = self.client.get(self.url, data=config_data, format="json")
+            assert mock_get_trees_for_org.call_count == 1
+            assert response.status_code == 200, response.content
+            assert response.data == expected_matches
+
+    @patch("sentry.integrations.github.GitHubIntegration.get_trees_for_org")
+    def test_get_start_with_backslash(self, mock_get_trees_for_org):
+        file = "stack/root/file.py"
+        frame_info = FrameFilename(f"/{file}")
+        config_data = {"stacktraceFilename": f"/{file}"}
+        expected_matches = [
+            {
+                "filename": file,
+                "repo_name": "getsentry/codemap",
+                "repo_branch": "master",
+                "stacktrace_root": f"{frame_info.root}",
+                "source_path": _get_code_mapping_source_path(file, frame_info),
             }
         ]
         with patch(

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -82,11 +82,13 @@ def test_buckets_logic():
         "app://foo.js",
         "./app/utils/handleXhrErrorResponse.tsx",
         "getsentry/billing/tax/manager.py",
+        "/cronscripts/monitoringsync.php",
     ] + UNSUPPORTED_FRAME_FILENAMES
     buckets = stacktrace_buckets(stacktraces)
     assert buckets == {
         "./app": [FrameFilename("./app/utils/handleXhrErrorResponse.tsx")],
         "app:": [FrameFilename("app://foo.js")],
+        "cronscripts": [FrameFilename("/cronscripts/monitoringsync.php")],
         "getsentry": [FrameFilename("getsentry/billing/tax/manager.py")],
     }
 

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -26,10 +26,6 @@ with open(
 
 UNSUPPORTED_FRAME_FILENAMES = [
     "async https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
-    "/_static/dist/sentry/entrypoints/app.js",
-    "/node_modules/@wix/wix-one-app-rich-content/src/rich-content-native/plugin-video/video.js",  # 3rd party
-    "/_static/dist/sentry/entrypoints/app.js",
-    "/_static/dist/sentry/chunks/node_modules_emotion_unitless_dist_emotion-unitless_esm_js-app_bootstrap_initializeMain_tsx-n-f02164.80704e8e56b0b331c4e2.js",
     "/gtm.js",  # Top source; starts with backslash
     "<anonymous>",
     "<frozen importlib._bootstrap>",


### PR DESCRIPTION
It seems that the SDK can sometimes send us frames with a baskslash at the beginning.
Code mappings are not derived without doing an exact match, thus, this cannot have side effects.