### PR TITLE
ref(invite): allow referrer query param in invite links

### DIFF
--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -305,7 +305,8 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
             save_team_assignments(om, teams)
 
         if settings.SENTRY_ENABLE_INVITES and result.get("sendInvite"):
-            om.send_invite_email()
+            referrer = request.query_params.get("referrer")
+            om.send_invite_email(referrer)
             member_invited.send_robust(
                 member=om, user=request.user, sender=self, referrer=request.data.get("referrer")
             )

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -626,7 +626,7 @@ class OrganizationMemberListPostTest(OrganizationMemberListTestBase, HybridCloud
         assert om.inviter_id == self.user.id
         self.assert_org_member_mapping(org_member=om)
 
-        mock_send_invite_email.assert_called_once_with()
+        mock_send_invite_email.assert_called_once()
 
     def test_no_teams(self):
         data = {"email": "jane@gmail.com", "role": "member"}
@@ -658,6 +658,27 @@ class OrganizationMemberListPostTest(OrganizationMemberListTestBase, HybridCloud
         self.assert_org_member_mapping(org_member=om)
 
         assert not mock_send_invite_email.mock_calls
+
+    @patch.object(OrganizationMember, "send_invite_email")
+    def test_referrer_param(self, mock_send_invite_email):
+        data = {
+            "email": "jane@gmail.com",
+            "role": "member",
+            "teams": [self.team.slug],
+        }
+        response = self.get_success_response(
+            self.organization.slug, **data, qs_params={"referrer": "test_referrer"}
+        )
+
+        om = OrganizationMember.objects.get(id=response.data["id"])
+        assert om.user_id is None
+        assert om.email == "jane@gmail.com"
+        assert om.role == "member"
+        assert list(om.teams.all()) == [self.team]
+        assert om.inviter_id == self.user.id
+        self.assert_org_member_mapping(org_member=om)
+
+        mock_send_invite_email.assert_called_with("test_referrer")
 
     @patch("sentry.ratelimits.for_organization_member_invite")
     def test_rate_limited(self, mock_rate_limit):

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -53,6 +53,12 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
         ):
             assert member.legacy_token == "df41d9dfd4ba25d745321e654e15b5d0"
 
+    def test_get_invite_link_with_referrer(self):
+        member = OrganizationMember(id=1, organization=self.organization, email="foo@example.com")
+
+        link = member.get_invite_link(referrer="test_referrer")
+        assert "?referrer=test_referrer" in link
+
     def test_send_invite_email(self):
         member = OrganizationMember(id=1, organization=self.organization, email="foo@example.com")
         with self.options({"system.url-prefix": "http://example.com"}), self.tasks():


### PR DESCRIPTION
Add an optional referrer query param in member invite links. This allows us to track the sources of invite links when users click on them.