### PR TITLE
fix(stat-detectors): Overflow should be set to auto

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -253,7 +253,7 @@ const MinimapPositioningContainer = styled('div')`
   width: 100%;
 
   ${MinimapBackground} {
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 `;
 


### PR DESCRIPTION
Mistakenly set `overflow-y: scroll` which shows the scroll bar even if there isn't anything overflowing.