### PR TITLE
chore(github-invite): pass referrer param when inviting

### DIFF
--- a/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
@@ -127,7 +127,7 @@ describe('InviteMissingMembersModal', function () {
     );
 
     const createMemberMock = MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/members/`,
+      url: `/organizations/${org.slug}/members/?referrer=github_nudge_invite`,
       method: 'POST',
       body: {},
     });
@@ -145,7 +145,7 @@ describe('InviteMissingMembersModal', function () {
     missingMembers.users.forEach((member, i) => {
       expect(createMemberMock).toHaveBeenNthCalledWith(
         i + 1,
-        `/organizations/${org.slug}/members/`,
+        `/organizations/${org.slug}/members/?referrer=github_nudge_invite`,
         expect.objectContaining({
           data: {email: member.email, role: 'member', teams: []},
         })
@@ -164,7 +164,7 @@ describe('InviteMissingMembersModal', function () {
     );
 
     const createMemberMock = MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/members/`,
+      url: `/organizations/${org.slug}/members/?referrer=github_nudge_invite`,
       method: 'POST',
       body: {},
     });
@@ -189,7 +189,7 @@ describe('InviteMissingMembersModal', function () {
 
     expect(createMemberMock).toHaveBeenNthCalledWith(
       1,
-      `/organizations/${org.slug}/members/`,
+      `/organizations/${org.slug}/members/?referrer=github_nudge_invite`,
       expect.objectContaining({
         data: {email: 'hello@sentry.io', role: 'admin', teams: []},
       })
@@ -197,7 +197,7 @@ describe('InviteMissingMembersModal', function () {
 
     expect(createMemberMock).toHaveBeenNthCalledWith(
       2,
-      `/organizations/${org.slug}/members/`,
+      `/organizations/${org.slug}/members/?referrer=github_nudge_invite`,
       expect.objectContaining({
         data: {email: 'abcd@sentry.io', role: 'member', teams: [team.slug]},
       })

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -52,6 +52,7 @@ export function InviteMissingMembersModal({
   }));
   const [memberInvites, setMemberInvites] =
     useState<MissingMemberInvite[]>(initialMemberInvites);
+  const referrer = missingMembers.integration + '_nudge_invite';
   const [inviteStatus, setInviteStatus] = useState<InviteStatus>({});
   const [sendingInvites, setSendingInvites] = useState(false);
   const [complete, setComplete] = useState(false);
@@ -137,10 +138,13 @@ export function InviteMissingMembersModal({
     };
 
     try {
-      await api.requestPromise(`/organizations/${organization?.slug}/members/`, {
-        method: 'POST',
-        data,
-      });
+      await api.requestPromise(
+        `/organizations/${organization?.slug}/members/?referrer=${referrer}`,
+        {
+          method: 'POST',
+          data,
+        }
+      );
     } catch (err) {
       const errorResponse = err.responseJSON;
 

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -607,7 +607,7 @@ describe('OrganizationMembersList', function () {
       });
 
       MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/members/',
+        url: '/organizations/org-slug/members/?referrer=github_nudge_invite',
         method: 'POST',
         body: newMember,
       });

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -177,10 +177,13 @@ class OrganizationMembersList extends DeprecatedAsyncView<Props, State> {
     const {organization} = this.props;
 
     try {
-      await this.api.requestPromise(`/organizations/${organization.slug}/members/`, {
-        method: 'POST',
-        data: {email},
-      });
+      await this.api.requestPromise(
+        `/organizations/${organization.slug}/members/?referrer=github_nudge_invite`,
+        {
+          method: 'POST',
+          data: {email},
+        }
+      );
       addSuccessMessage(tct('Sent invite to [email]', {email}));
       this.fetchMembersList();
       this.setState(state => ({


### PR DESCRIPTION
Requires #56176

We want to track when users click on invite links that come from the invite banner or modal. Add a referrer param to the OrganizationMember POST call from the frontend which will pass the referrer param to the invite link.

For ER-1816