### PR TITLE
Add requires_symbolicator fixture  to symbolicator tests

### DIFF
--- a/tests/symbolicator/__init__.py
+++ b/tests/symbolicator/__init__.py
@@ -1,6 +1,10 @@
 import re
 
+from sentry.testutils.skips import requires_symbolicator
 from sentry.utils.safe import get_path
+
+# TODO: Symbolicator tests also need kafka + zookeeper
+pytestmark = requires_symbolicator
 
 
 def strip_frame(frame):

--- a/tests/symbolicator/__init__.py
+++ b/tests/symbolicator/__init__.py
@@ -1,10 +1,6 @@
 import re
 
-from sentry.testutils.skips import requires_symbolicator
 from sentry.utils.safe import get_path
-
-# TODO: Symbolicator tests also need kafka + zookeeper
-pytestmark = requires_symbolicator
 
 
 def strip_frame(frame):

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -13,6 +13,7 @@ from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.relay import RelayStoreHelper
+from sentry.testutils.skips import requires_symbolicator
 from sentry.utils.safe import get_path
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
 
@@ -26,6 +27,7 @@ from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_loc
 # or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
 
 
+@requires_symbolicator
 @pytest.mark.snuba
 class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase):
     @pytest.fixture(autouse=True)

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -13,6 +13,7 @@ from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.relay import RelayStoreHelper
+from sentry.testutils.skips import requires_symbolicator
 from sentry.utils.safe import get_path
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
 
@@ -24,6 +25,10 @@ from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_loc
 # If you are using a local instance of Symbolicator, you need to
 # either change `system.url-prefix` option override inside `initialize` fixture to `system.internal-url-prefix`,
 # or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
+
+
+# TODO: Symbolicator tests also need kafka + zookeeper
+pytestmark = requires_symbolicator
 
 
 @pytest.mark.snuba

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -13,7 +13,6 @@ from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_symbolicator
 from sentry.utils.safe import get_path
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
 
@@ -27,7 +26,6 @@ from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_loc
 # or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
 
 
-@requires_symbolicator
 @pytest.mark.snuba
 class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase):
     @pytest.fixture(autouse=True)

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -22,6 +22,7 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
+from sentry.testutils.skips import requires_symbolicator
 from sentry.utils import json
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
 
@@ -34,6 +35,9 @@ from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_loc
 # either change `system.url-prefix` option override inside `initialize` fixture to `system.internal-url-prefix`,
 # or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
 
+
+# TODO: Symbolicator tests also need kafka + zookeeper
+pytestmark = requires_symbolicator
 
 REAL_RESOLVING_EVENT_DATA = {
     "platform": "cocoa",

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -22,6 +22,7 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
+from sentry.testutils.skips import requires_symbolicator
 from sentry.utils import json
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
 
@@ -84,6 +85,7 @@ def load_fixture(name):
         return fp.read()
 
 
+@requires_symbolicator
 class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
     @pytest.fixture(autouse=True)
     def initialize(self, live_server):

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -22,7 +22,6 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_symbolicator
 from sentry.utils import json
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
 
@@ -85,7 +84,6 @@ def load_fixture(name):
         return fp.read()
 
 
-@requires_symbolicator
 class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
     @pytest.fixture(autouse=True)
     def initialize(self, live_server):

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -11,7 +11,6 @@ from sentry.models import EventAttachment, File
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_symbolicator
 from sentry.utils.safe import get_path
 from tests.symbolicator import normalize_native_exception
 
@@ -33,7 +32,6 @@ def get_unreal_crash_apple_file():
     return get_fixture_path("native", "unreal_crash_apple")
 
 
-@requires_symbolicator
 class SymbolicatorUnrealIntegrationTest(RelayStoreHelper, TransactionTestCase):
     @pytest.fixture(autouse=True)
     def initialize(self, live_server):

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -11,6 +11,7 @@ from sentry.models import EventAttachment, File
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.relay import RelayStoreHelper
+from sentry.testutils.skips import requires_symbolicator
 from sentry.utils.safe import get_path
 from tests.symbolicator import normalize_native_exception
 
@@ -22,6 +23,10 @@ from tests.symbolicator import normalize_native_exception
 # If you are using a local instance of Symbolicator, you need to
 # either change `system.url-prefix` option override inside `initialize` fixture to `system.internal-url-prefix`,
 # or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
+
+
+# TODO: Symbolicator tests also need kafka + zookeeper
+pytestmark = requires_symbolicator
 
 
 def get_unreal_crash_file():

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -11,6 +11,7 @@ from sentry.models import EventAttachment, File
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.relay import RelayStoreHelper
+from sentry.testutils.skips import requires_symbolicator
 from sentry.utils.safe import get_path
 from tests.symbolicator import normalize_native_exception
 
@@ -32,6 +33,7 @@ def get_unreal_crash_apple_file():
     return get_fixture_path("native", "unreal_crash_apple")
 
 
+@requires_symbolicator
 class SymbolicatorUnrealIntegrationTest(RelayStoreHelper, TransactionTestCase):
     @pytest.fixture(autouse=True)
     def initialize(self, live_server):


### PR DESCRIPTION
When symbolicator isn't up, this will cause tests to be skipped.