### PR TITLE
feat(github-invite): FE toggle for missing member detection

### DIFF
--- a/fixtures/js-stubs/organization.tsx
+++ b/fixtures/js-stubs/organization.tsx
@@ -55,6 +55,7 @@ export function Organization(params: Partial<TOrganization> = {}): TOrganization
     eventsMemberAdmin: false,
     githubOpenPRBot: false,
     githubPRBot: false,
+    githubNudgeInvite: false,
     isDefault: false,
     isDynamicallySampled: true,
     isEarlyAdopter: false,

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -17,6 +17,7 @@ export interface OrganizationSummary {
   codecovAccess: boolean;
   dateCreated: string;
   features: string[];
+  githubNudgeInvite: boolean;
   githubOpenPRBot: boolean;
   githubPRBot: boolean;
   id: string;

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -234,8 +234,9 @@ describe('IntegrationDetailedView', function () {
     ).toBeDisabled();
   });
 
-  it('can enable github comment bots', async function () {
+  it('can enable github features', async function () {
     org.features.push('integrations-open-pr-comment');
+    org.features.push('integrations-gh-invite');
 
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/config/integrations/?provider_key=github`,
@@ -285,6 +286,19 @@ describe('IntegrationDetailedView', function () {
         ENDPOINT,
         expect.objectContaining({
           data: {githubOpenPRBot: true},
+        })
+      );
+    });
+
+    await userEvent.click(
+      screen.getByRole('checkbox', {name: /Enable Missing Member Detection/})
+    );
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith(
+        ENDPOINT,
+        expect.objectContaining({
+          data: {githubNudgeInvite: true},
         })
       );
     });

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -360,6 +360,19 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
             ),
             visible: ({features}) => features.includes('integrations-open-pr-comment'),
           },
+          {
+            name: 'githubNudgeInvite',
+            type: 'boolean',
+            label: t('Enable Missing Member Detection'),
+            help: t(
+              'Allow Sentry to detect users committing to your GitHub repositories that are not part of your Sentry organization..'
+            ),
+            disabled: !hasIntegration,
+            disabledReason: t(
+              'You must have a GitHub integration to enable this feature.'
+            ),
+            visible: ({features}) => features.includes('integrations-gh-invite'),
+          },
         ],
       },
     ];
@@ -367,6 +380,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
     const initialData = {
       githubPRBot: organization.githubPRBot,
       githubOpenPRBot: organization.githubOpenPRBot,
+      githubNudgeInvite: organization.githubNudgeInvite,
     };
 
     return (

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -36,6 +36,7 @@ describe('inviteBanner', function () {
   it('render banners with feature flag', async function () {
     const org = TestStubs.Organization({
       features: ['integrations-gh-invite'],
+      githubNudgeInvite: true,
     });
 
     render(
@@ -127,6 +128,7 @@ describe('inviteBanner', function () {
   it('renders banner if snoozed_ts days is longer than threshold', async function () {
     const org = TestStubs.Organization({
       features: ['integrations-gh-invite'],
+      githubNudgeInvite: true,
     });
     const promptResponse = {
       dismissed_ts: undefined,
@@ -161,6 +163,7 @@ describe('inviteBanner', function () {
   it('does not render banner if snoozed_ts days is shorter than threshold', function () {
     const org = TestStubs.Organization({
       features: ['integrations-gh-invite'],
+      githubNudgeInvite: true,
     });
     const promptResponse = {
       dismissed_ts: undefined,

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -42,6 +42,7 @@ export function InviteBanner({
   const isEligibleForBanner =
     organization.features.includes('integrations-gh-invite') &&
     organization.access.includes('org:write') &&
+    organization.githubNudgeInvite &&
     missingMembers?.users?.length > 0;
   const [sendingInvite, setSendingInvite] = useState<boolean>(false);
   const [showBanner, setShowBanner] = useState<boolean>(false);

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -614,6 +614,7 @@ describe('OrganizationMembersList', function () {
 
       const org = TestStubs.Organization({
         features: ['integrations-gh-invite'],
+        githubNudgeInvite: true,
       });
 
       render(<OrganizationMembersList {...defaultProps} organization={org} />, {


### PR DESCRIPTION
Add a frontend toggle so orgs can control whether they are nudged to invite missing Github members.

For ER-1889