### PR TITLE
chore(api): Switch to using serializers over TypedDict for response

### DIFF
--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -17,12 +17,11 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import GlobalParams, MonitorParams
-from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models import Project
 from sentry.monitors.logic.mark_failed import mark_failed
 from sentry.monitors.logic.mark_ok import mark_ok
 from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorEnvironment
-from sentry.monitors.serializers import MonitorCheckInSerializerResponse
+from sentry.monitors.serializers import MonitorCheckInSerializer
 from sentry.monitors.utils import get_new_timeout_at, valid_duration
 from sentry.monitors.validators import MonitorCheckInValidator
 
@@ -45,9 +44,7 @@ class MonitorIngestCheckInDetailsEndpoint(MonitorIngestEndpoint):
         ],
         request=MonitorCheckInValidator,
         responses={
-            200: inline_sentry_response_serializer(
-                "MonitorCheckIn", MonitorCheckInSerializerResponse
-            ),
+            200: MonitorCheckInSerializer,
             208: RESPONSE_ALREADY_REPORTED,
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -15,7 +15,6 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.parameters import GlobalParams, MonitorParams
-from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.models import Project, ProjectKey
 from sentry.monitors.logic.mark_failed import mark_failed
@@ -29,7 +28,7 @@ from sentry.monitors.models import (
     MonitorEnvironmentValidationFailed,
     MonitorLimitsExceeded,
 )
-from sentry.monitors.serializers import MonitorCheckInSerializerResponse
+from sentry.monitors.serializers import MonitorCheckInSerializer
 from sentry.monitors.utils import get_timeout_at, signal_first_checkin, signal_first_monitor_created
 from sentry.monitors.validators import MonitorCheckInValidator
 from sentry.ratelimits.config import RateLimitConfig
@@ -72,12 +71,8 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
         ],
         request=MonitorCheckInValidator,
         responses={
-            200: inline_sentry_response_serializer(
-                "MonitorCheckIn", MonitorCheckInSerializerResponse
-            ),
-            201: inline_sentry_response_serializer(
-                "MonitorCheckIn", MonitorCheckInSerializerResponse
-            ),
+            200: MonitorCheckInSerializer,
+            201: MonitorCheckInSerializer,
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,
             404: RESPONSE_NOT_FOUND,

--- a/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
@@ -7,6 +7,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.api.paginator import OffsetPaginator
@@ -25,7 +26,9 @@ from .base import MonitorEndpoint
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
 class OrganizationMonitorCheckInIndexEndpoint(MonitorEndpoint):
-    public = {"GET"}
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
 
     @extend_schema(
         operation_id="Retrieve Check-Ins for a Monitor",

--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -20,11 +20,10 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import GlobalParams, MonitorParams
-from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.models import RegionScheduledDeletion, Rule, RuleActivity, RuleActivityType
 from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorStatus
-from sentry.monitors.serializers import MonitorSerializer, MonitorSerializerResponse
+from sentry.monitors.serializers import MonitorSerializer
 from sentry.monitors.utils import create_alert_rule, update_alert_rule
 from sentry.monitors.validators import MonitorValidator
 
@@ -48,7 +47,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
             GlobalParams.ENVIRONMENT,
         ],
         responses={
-            200: inline_sentry_response_serializer("Monitor", MonitorSerializerResponse),
+            200: MonitorSerializer,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
@@ -76,7 +75,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
         ],
         request=MonitorValidator,
         responses={
-            200: inline_sentry_response_serializer("Monitor", MonitorSerializerResponse),
+            200: MonitorSerializer,
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -182,7 +182,7 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
         parameters=[GlobalParams.ORG_SLUG],
         request=MonitorValidator,
         responses={
-            201: inline_sentry_response_serializer("Monitor", MonitorSerializerResponse),
+            201: MonitorSerializer,
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -22,7 +22,7 @@ class MonitorEnvironmentSerializerResponse(TypedDict):
 
 @register(MonitorEnvironment)
 class MonitorEnvironmentSerializer(Serializer):
-    def serialize(self, obj, attrs, user) -> MonitorEnvironmentSerializerResponse:
+    def serialize(self, obj, attrs, user, **kwargs) -> MonitorEnvironmentSerializerResponse:
         return {
             "name": obj.environment.name,
             "status": obj.get_status_display(),
@@ -102,12 +102,12 @@ class MonitorSerializer(Serializer):
 
         return attrs
 
-    def serialize(self, obj, attrs, user) -> MonitorSerializerResponse:
+    def serialize(self, obj, attrs, user, **kwargs) -> MonitorSerializerResponse:
         config = obj.config.copy()
         if "schedule_type" in config:
             config["schedule_type"] = obj.get_schedule_type_display()
 
-        result = {
+        result: MonitorSerializerResponse = {
             "id": str(obj.guid),
             "status": obj.get_status_display(),
             "type": obj.get_type_display(),
@@ -132,7 +132,7 @@ class MonitorSerializer(Serializer):
 
 
 class MonitorCheckInSerializerResponseOptional(TypedDict, total=False):
-    group_ids: List[str]
+    groups: List[str]
 
 
 class MonitorCheckInSerializerResponse(MonitorCheckInSerializerResponseOptional):
@@ -183,8 +183,8 @@ class MonitorCheckInSerializer(Serializer):
 
         return attrs
 
-    def serialize(self, obj, attrs, user) -> MonitorCheckInSerializerResponse:
-        result = {
+    def serialize(self, obj, attrs, user, **kwargs) -> MonitorCheckInSerializerResponse:
+        result: MonitorCheckInSerializerResponse = {
             "id": str(obj.guid),
             "environment": obj.monitor_environment.environment.name
             if obj.monitor_environment


### PR DESCRIPTION
Per https://develop.sentry.dev/api/public/#success-responses:

> Note that we HIGHLY recommend using the first method when your endpoint returns a single object and utilizes an existing serializer. The first method ensures the documentation stays up-to-date as the endpoint evolves, and provides a higher quality API experience for our users.