### PR TITLE
fix(discord): Ensure creation of bot has view channel permissions

### DIFF
--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -102,8 +102,8 @@ class DiscordIntegrationProvider(IntegrationProvider):
     oauth_scopes = frozenset(["applications.commands", "bot", "identify"])
 
     # https://discord.com/developers/docs/topics/permissions#permissions
-    # Permissions value that can Send Messages (0x800) and Embed Links (0x4000):
-    bot_permissions = 0x800 | 0x4000
+    # Permissions value that can Send Messages (0x800), View Channel (0x400), and Embed Links (0x4000):
+    bot_permissions = 0x800 | 0x400 | 0x4000
 
     setup_dialog_config = {"width": 600, "height": 900}
 


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry/issues/55631

When setting up the Discord integration, request the **view channel**, send messages, and embed links permissions. Ensures that these permissions are present even if the server's @ everyone role does not include them.