### PR TITLE
fix(hybridcloud) Update DSN host names to use region domains

### DIFF
--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -256,12 +256,12 @@ class ProjectKey(Model):
             urlparts = urlparse(endpoint)
             if urlparts.scheme and urlparts.netloc:
                 endpoint = "{}://{}.{}{}".format(
-                    urlparts.scheme,
+                    str(urlparts.scheme),
                     settings.SENTRY_ORG_SUBDOMAIN_TEMPLATE.format(
                         organization_id=self.project.organization_id
                     ),
-                    urlparts.netloc,
-                    urlparts.path,
+                    str(urlparts.netloc),
+                    str(urlparts.path),
                 )
 
         return endpoint

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -27,6 +27,7 @@ from sentry.db.models import (
     region_silo_only_model,
     sane_repr,
 )
+from sentry.silo.base import SiloMode
 from sentry.tasks.relay import schedule_invalidate_project_config
 
 _token_re = re.compile(r"^[a-f0-9]{32}$")
@@ -230,11 +231,15 @@ class ProjectKey(Model):
             )
 
     def get_endpoint(self, public=True):
+        from sentry.api.utils import generate_region_url
+
         if public:
             endpoint = settings.SENTRY_PUBLIC_ENDPOINT or settings.SENTRY_ENDPOINT
         else:
             endpoint = settings.SENTRY_ENDPOINT
 
+        if not endpoint and SiloMode.get_current_mode() == SiloMode.REGION:
+            endpoint = generate_region_url()
         if not endpoint:
             endpoint = options.get("system.url-prefix")
 

--- a/tests/sentry/models/test_projectkey.py
+++ b/tests/sentry/models/test_projectkey.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from django.test import override_settings
 
 from sentry.models.projectkey import ProjectKey, ProjectKeyManager, ProjectKeyStatus
 from sentry.testutils.cases import TestCase
@@ -18,17 +19,23 @@ class ProjectKeyTest(TestCase):
 
     def test_get_dsn_custom_prefix(self):
         key = ProjectKey(project_id=self.project.id, public_key="public", secret_key="secret")
-        with self.options({"system.url-prefix": "http://example.com"}):
+        with self.options(
+            {"system.url-prefix": "http://example.com", "system.region-api-url-template": ""}
+        ):
             self.assertEqual(key.get_dsn(), f"http://public:secret@example.com/{self.project.id}")
 
     def test_get_dsn_with_ssl(self):
         key = ProjectKey(project_id=self.project.id, public_key="public", secret_key="secret")
-        with self.options({"system.url-prefix": "https://example.com"}):
+        with self.options(
+            {"system.url-prefix": "https://example.com", "system.region-api-url-template": ""}
+        ):
             self.assertEqual(key.get_dsn(), f"https://public:secret@example.com/{self.project.id}")
 
     def test_get_dsn_with_port(self):
         key = ProjectKey(project_id=self.project.id, public_key="public", secret_key="secret")
-        with self.options({"system.url-prefix": "http://example.com:81"}):
+        with self.options(
+            {"system.url-prefix": "http://example.com:81", "system.region-api-url-template": ""}
+        ):
             self.assertEqual(
                 key.get_dsn(), f"http://public:secret@example.com:81/{self.project.id}"
             )
@@ -82,24 +89,58 @@ class ProjectKeyTest(TestCase):
         assert self.model(project=self.project, status=ProjectKeyStatus.ACTIVE).is_active is True
 
     def test_get_dsn(self):
-        key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")
-        assert key.dsn_private == f"http://abc:xyz@testserver/{self.project.id}"
-        assert key.dsn_public == f"http://abc@testserver/{self.project.id}"
-        assert (
-            key.csp_endpoint
-            == f"http://testserver/api/{self.project.id}/csp-report/?sentry_key=abc"
-        )
-        assert (
-            key.minidump_endpoint
-            == f"http://testserver/api/{self.project.id}/minidump/?sentry_key=abc"
-        )
-        assert key.unreal_endpoint == f"http://testserver/api/{self.project.id}/unreal/abc/"
-        assert key.js_sdk_loader_cdn_url == "http://testserver/js-sdk-loader/abc.min.js"
+        with self.options({"system.region-api-url-template": ""}):
+            key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")
+            assert key.dsn_private == f"http://abc:xyz@testserver/{self.project.id}"
+            assert key.dsn_public == f"http://abc@testserver/{self.project.id}"
+            assert (
+                key.csp_endpoint
+                == f"http://testserver/api/{self.project.id}/csp-report/?sentry_key=abc"
+            )
+            assert (
+                key.minidump_endpoint
+                == f"http://testserver/api/{self.project.id}/minidump/?sentry_key=abc"
+            )
+            assert key.unreal_endpoint == f"http://testserver/api/{self.project.id}/unreal/abc/"
+            assert key.js_sdk_loader_cdn_url == "http://testserver/js-sdk-loader/abc.min.js"
 
     def test_get_dsn_org_subdomain(self):
-        with self.feature("organizations:org-subdomains"):
+        with self.feature("organizations:org-subdomains"), self.options(
+            {"system.region-api-url-template": ""}
+        ):
             key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")
             host = f"o{key.project.organization_id}.ingest.testserver"
+
+            assert key.dsn_private == f"http://abc:xyz@{host}/{self.project.id}"
+            assert key.dsn_public == f"http://abc@{host}/{self.project.id}"
+            assert (
+                key.csp_endpoint
+                == f"http://{host}/api/{self.project.id}/csp-report/?sentry_key=abc"
+            )
+            assert (
+                key.minidump_endpoint
+                == f"http://{host}/api/{self.project.id}/minidump/?sentry_key=abc"
+            )
+            assert key.unreal_endpoint == f"http://{host}/api/{self.project.id}/unreal/abc/"
+
+    @override_settings(SENTRY_REGION="us", SILO_MODE="REGION")
+    def test_get_dsn_multiregion(self):
+        key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")
+        host = "us.testserver"
+
+        assert key.dsn_private == f"http://abc:xyz@{host}/{self.project.id}"
+        assert key.dsn_public == f"http://abc@{host}/{self.project.id}"
+        assert key.csp_endpoint == f"http://{host}/api/{self.project.id}/csp-report/?sentry_key=abc"
+        assert (
+            key.minidump_endpoint == f"http://{host}/api/{self.project.id}/minidump/?sentry_key=abc"
+        )
+        assert key.unreal_endpoint == f"http://{host}/api/{self.project.id}/unreal/abc/"
+
+    @override_settings(SENTRY_REGION="us", SILO_MODE="REGION")
+    def test_get_dsn_org_subdomain_and_multiregion(self):
+        with self.feature("organizations:org-subdomains"):
+            key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")
+            host = f"o{key.project.organization_id}.ingest.us.testserver"
 
             assert key.dsn_private == f"http://abc:xyz@{host}/{self.project.id}"
             assert key.dsn_public == f"http://abc@{host}/{self.project.id}"


### PR DESCRIPTION
Use region domains for DSN ingest keys when the application is deployed in region mode. Using ingest.[region].sentry.io will be required for all non-us regions.

cc @getsentry/ingest 