### PR TITLE
chore(severity): Improve severity score logging

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2032,6 +2032,7 @@ severity_connection_pool = connection_from_url(
 
 
 def _get_severity_score(event: Event) -> float | None:
+    op = "event_manager._get_severity_score"
     severity = None
 
     metadata = event.get_event_metadata()
@@ -2047,8 +2048,8 @@ def _get_severity_score(event: Event) -> float | None:
     )
 
     if message:
-        with metrics.timer("event_manager._get_severity_score"):
-            with sentry_sdk.start_span(op="event_manager._get_severity_score"):
+        with metrics.timer(op):
+            with sentry_sdk.start_span(op=op):
                 try:
                     response = severity_connection_pool.urlopen(
                         "POST",

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2061,12 +2061,12 @@ def _get_severity_score(event: Event) -> float | None:
                 except MaxRetryError as e:
                     logger.warning(
                         f"Unable to get severity score from microservice after {SEVERITY_DETECTION_RETRIES} retr{'ies' if SEVERITY_DETECTION_RETRIES >1 else 'y'}. Got MaxRetryError caused by: {repr(e.reason)}.",
-                        extra={"event_id": event.data["event_id"], "reason": e.reason},
+                        extra={"event_id": event.data["event_id"]},
                     )
                 except Exception as e:
                     logger.warning(
                         f"Unable to get severity score from microservice. Got: {repr(e)}.",
-                        extra={"event_id": event.data["event_id"], "reason": e},
+                        extra={"event_id": event.data["event_id"]},
                     )
 
     return severity

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2033,6 +2033,7 @@ severity_connection_pool = connection_from_url(
 
 def _get_severity_score(event: Event) -> float | None:
     op = "event_manager._get_severity_score"
+    logger_data = {"event_id": event.data["event_id"], "op": op}
     severity = None
 
     metadata = event.get_event_metadata()
@@ -2061,12 +2062,12 @@ def _get_severity_score(event: Event) -> float | None:
                 except MaxRetryError as e:
                     logger.warning(
                         f"Unable to get severity score from microservice after {SEVERITY_DETECTION_RETRIES} retr{'ies' if SEVERITY_DETECTION_RETRIES >1 else 'y'}. Got MaxRetryError caused by: {repr(e.reason)}.",
-                        extra={"event_id": event.data["event_id"]},
+                        extra=logger_data,
                     )
                 except Exception as e:
                     logger.warning(
                         f"Unable to get severity score from microservice. Got: {repr(e)}.",
-                        extra={"event_id": event.data["event_id"]},
+                        extra=logger_data,
                     )
 
     return severity

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1624,6 +1624,17 @@ def _save_aggregate(
 
                 group = _create_group(project, event, **kwargs)
 
+                if features.has(
+                    "projects:first-event-severity-calculation", event.project
+                ) and not group.data.get("metadata", {}).get("severity"):
+                    logger.error(
+                        "Group created without severity score",
+                        extra={
+                            "event_id": event.data["event_id"],
+                            "group_id": group.id,
+                        },
+                    )
+
                 if root_hierarchical_grouphash is not None:
                     new_hashes = [root_hierarchical_grouphash]
                 else:
@@ -2498,6 +2509,17 @@ def _save_grouphash_and_group(
         if created:
             group = _create_group(project, event, **group_kwargs)
             group_hash.update(group=group)
+
+            if features.has(
+                "projects:first-event-severity-calculation", event.project
+            ) and not group.data.get("metadata", {}).get("severity"):
+                logger.error(
+                    "Group created without severity score",
+                    extra={
+                        "event_id": event.data["event_id"],
+                        "group_id": group.id,
+                    },
+                )
 
     if group is None:
         # If we failed to create the group it means another worker beat us to

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2049,6 +2049,7 @@ def _get_severity_score(event: Event) -> float | None:
     )
 
     if message:
+        logger_data["event_message"] = message
         with metrics.timer(op):
             with sentry_sdk.start_span(op=op):
                 try:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2043,11 +2043,6 @@ def _get_severity_score(event: Event) -> float | None:
     if error_type:
         message = error_type if not error_msg else f"{error_type}: {error_msg}"
 
-    logger.info(
-        "event_manager.get_severity_score",
-        extra={"event_message": message, "event_id": event.event_id},
-    )
-
     if message:
         logger_data["event_message"] = message
         with metrics.timer(op):
@@ -2070,6 +2065,17 @@ def _get_severity_score(event: Event) -> float | None:
                         f"Unable to get severity score from microservice. Got: {repr(e)}.",
                         extra=logger_data,
                     )
+                else:
+                    logger.info(
+                        f"Got severity score of {severity} for event {event.data['event_id']}",
+                        extra=logger_data,
+                    )
+    else:
+        logger_data.update({"error_type": error_type, "error_msg": error_msg})
+        logger.warning(
+            "Unable to get severity score because event has no message",
+            extra=logger_data,
+        )
 
     return severity
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -37,6 +37,7 @@ from sentry.event_manager import (
     HashDiscarded,
     _get_event_instance,
     _get_severity_score,
+    _save_aggregate,
     _save_grouphash_and_group,
     get_event_type,
     has_pending_commit_resolution,
@@ -3688,3 +3689,105 @@ class TestSaveGroupHashAndGroup(TransactionTestCase):
         assert created
         assert group_2.id != group_3.id
         assert Group.objects.filter(grouphash__hash=group_hash).count() == 1
+
+    @patch("sentry.event_manager.logger.error")
+    @patch("sentry.event_manager._get_severity_score", return_value=None)
+    def test_logs_error_on_no_severity_score_when_enabled(
+        self,
+        mock_get_severity_score: MagicMock,
+        mock_logger_error: MagicMock,
+    ):
+        with self.feature({"projects:first-event-severity-calculation": True}):
+            event = _get_event_instance(
+                make_event(
+                    exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]}
+                ),
+                self.project.id,
+            )
+
+            group, created = _save_grouphash_and_group(self.project, event, "dogs are great")
+
+            assert created is True
+            mock_get_severity_score.assert_called()
+            mock_logger_error.assert_called_with(
+                "Group created without severity score",
+                extra={
+                    "event_id": event.event_id,
+                    "group_id": group.id,
+                },
+            )
+
+    @patch("sentry.event_manager.logger.error")
+    @patch("sentry.event_manager._get_severity_score", return_value=None)
+    def test_no_error_logged_on_no_severity_score_when_disabled(
+        self,
+        mock_get_severity_score: MagicMock,
+        mock_logger_error: MagicMock,
+    ):
+        with self.feature({"projects:first-event-severity-calculation": False}):
+            event = _get_event_instance(
+                make_event(
+                    exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]}
+                ),
+                self.project.id,
+            )
+
+            _save_grouphash_and_group(self.project, event, "dogs are great")
+
+            logger_messages = [call.args[0] for call in mock_logger_error.mock_calls]
+
+            mock_get_severity_score.assert_not_called()
+            assert "Group created without severity score" not in logger_messages
+
+
+class TestSaveAggregate(TestCase):
+    @patch("sentry.event_manager._save_aggregate", wraps=_save_aggregate)
+    @patch("sentry.event_manager.logger.error")
+    @patch("sentry.event_manager._get_severity_score", return_value=None)
+    def test_logs_error_on_no_severity_score_when_enabled(
+        self,
+        mock_get_severity_score: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_save_aggregate: MagicMock,
+    ):
+        with self.feature({"projects:first-event-severity-calculation": True}):
+            manager = EventManager(
+                make_event(
+                    exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]}
+                )
+            )
+            event = manager.save(self.project.id)
+
+            mock_save_aggregate.assert_called()
+            mock_get_severity_score.assert_called()
+            mock_logger_error.assert_called_with(
+                "Group created without severity score",
+                extra={
+                    "event_id": event.event_id,
+                    "group_id": event.group_id,
+                },
+            )
+
+    @patch("sentry.event_manager._save_aggregate", wraps=_save_aggregate)
+    @patch("sentry.event_manager.logger.error")
+    @patch("sentry.event_manager._get_severity_score", return_value=None)
+    def test_no_error_logged_on_no_severity_score_when_disabled(
+        self,
+        mock_get_severity_score: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_save_aggregate: MagicMock,
+    ):
+        with self.feature({"projects:first-event-severity-calculation": False}):
+            manager = EventManager(
+                make_event(
+                    exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]}
+                )
+            )
+            manager.save(self.project.id)
+
+            logger_messages = [call.args[0] for call in mock_logger_error.mock_calls]
+
+            mock_save_aggregate.assert_called()
+            mock_get_severity_score.assert_not_called()
+
+            assert "Group created without severity score" not in logger_messages


### PR DESCRIPTION
This improves our logging around attaching a severity score to new groups, in order to debug the fact that some groups are ending up with no score.

Key changes:
- `_get_severity_score` now logs its results (not just that the API is being called).
- All `_get_severity_score` logs now include in their extra data the same `op` value, so it's easy to search for them in GCP.
- If the feature is enabled and a group is created without a severity score, an error is now logged to Sentry, so we know to go digging into the GCP logs.