### PR TITLE
ref: move from freezegun to time-machine (part 1: introduce)

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -185,6 +185,7 @@ statsd==3.3
 stripe==2.61.0
 structlog==22.1.0
 symbolic==12.2.0
+time-machine==2.13.0
 tokenize-rt==5.0.0
 tomli==2.0.1
 toronado==0.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 covdefaults>=2.3.0
 docker>=3.7.0,<3.8.0
 freezegun>=1.2.2
+time-machine>=2.13.0
 honcho>=1.1.0
 openapi-core>=0.14.2
 pytest>=7.2.1

--- a/src/sentry/testutils/helpers/datetime.py
+++ b/src/sentry/testutils/helpers/datetime.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import time
 from datetime import datetime, timedelta
 
+import time_machine
 from django.utils import timezone
 
 __all__ = ["iso_format", "before_now", "timestamp_format"]
@@ -28,3 +31,7 @@ class MockClock:
     def __call__(self):
         self.time += timedelta(seconds=1)
         return self.time
+
+
+def freeze_time(t: str | datetime = "2023-09-13 01:02:00") -> time_machine.travel:
+    return time_machine.travel(t, tick=False)

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -10,7 +10,6 @@ from hashlib import md5
 from typing import TypeVar
 from unittest import mock
 
-import freezegun
 import pytest
 from django.conf import settings
 from sentry_sdk import Hub
@@ -272,8 +271,6 @@ def pytest_configure(config: pytest.Config) -> None:
 
     # force celery registration
     from sentry.celery import app  # NOQA
-
-    freezegun.configure(extend_ignore_list=["sentry.utils.retries"])  # type: ignore[attr-defined]
 
 
 def register_extensions() -> None:

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -7,8 +7,6 @@ from django.contrib.auth.models import AnonymousUser
 from django.http.request import HttpRequest
 from django.test import RequestFactory, override_settings
 from django.urls import re_path, reverse
-from freezegun import freeze_time
-from freezegun.api import FrozenDateTimeFactory
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
@@ -19,6 +17,7 @@ from sentry.models import ApiKey, ApiToken, SentryAppInstallation, User
 from sentry.ratelimits.config import RateLimitConfig, get_default_rate_limits_for_group
 from sentry.ratelimits.utils import get_rate_limit_config, get_rate_limit_key, get_rate_limit_value
 from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import control_silo_test
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -110,10 +109,9 @@ class RatelimitMiddlewareTest(TestCase):
         # Requests outside the current window should not be rate limited
         default_rate_limit_mock.return_value = RateLimit(1, 1)
         with freeze_time("2000-01-01") as frozen_time:
-            assert isinstance(frozen_time, FrozenDateTimeFactory)
             self.middleware.process_view(request, self._test_endpoint, [], {})
             assert not request.will_be_rate_limited
-            frozen_time.tick(1)
+            frozen_time.shift(1)
             self.middleware.process_view(request, self._test_endpoint, [], {})
             assert not request.will_be_rate_limited
 
@@ -128,10 +126,9 @@ class RatelimitMiddlewareTest(TestCase):
 
         default_rate_limit_mock.return_value = RateLimit(1, 1)
         with freeze_time("2000-01-01") as frozen_time:
-            assert isinstance(frozen_time, FrozenDateTimeFactory)
             self.middleware.process_view(request, self._test_endpoint, [], {})
             assert not request.will_be_rate_limited
-            frozen_time.tick(1)
+            frozen_time.shift(1)
             self.middleware.process_view(request, self._test_endpoint, [], {})
             assert not request.will_be_rate_limited
 

--- a/tests/sentry/processing/realtime_metrics/test_redis.py
+++ b/tests/sentry/processing/realtime_metrics/test_redis.py
@@ -1,13 +1,13 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, Dict
 
 import pytest
-from freezegun import freeze_time
 from redis import StrictRedis
 
 from sentry.exceptions import InvalidConfiguration
 from sentry.processing import realtime_metrics
 from sentry.processing.realtime_metrics.redis import RedisRealtimeMetricsStore
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils import redis
 
 
@@ -60,7 +60,7 @@ def test_record_project_duration_same_bucket(
 ) -> None:
     with freeze_time(datetime.fromtimestamp(1147)) as frozen_datetime:
         store.record_project_duration(17, 1.0)
-        frozen_datetime.tick(delta=timedelta(seconds=2))
+        frozen_datetime.shift(2)
         store.record_project_duration(17, 1.0)
 
     assert redis_cluster.get("symbolicate_event_low_priority:budget:10:17:1140") == "2000"
@@ -71,7 +71,7 @@ def test_record_project_duration_different_buckets(
 ) -> None:
     with freeze_time(datetime.fromtimestamp(1147)) as frozen_datetime:
         store.record_project_duration(17, 1.0)
-        frozen_datetime.tick(delta=timedelta(seconds=5))
+        frozen_datetime.shift(5)
         store.record_project_duration(17, 1.0)
 
     assert redis_cluster.get("symbolicate_event_low_priority:budget:10:17:1140") == "1000"

--- a/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
@@ -2,11 +2,10 @@ from datetime import timedelta
 
 from dateutil.parser import parse as parse_datetime
 from django.utils import timezone
-from freezegun import freeze_time
-from freezegun.api import FrozenDateTimeFactory
 
 from sentry.models import Activity, Group, GroupInbox, GroupInboxReason
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
 
@@ -73,7 +72,6 @@ class ProjectRulePreviewEndpointTest(APITestCase):
     def test_endpoint(self):
         time_to_freeze = timezone.now()
         with freeze_time(time_to_freeze) as frozen_time:
-            assert isinstance(frozen_time, FrozenDateTimeFactory)
             resp = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
@@ -90,7 +88,7 @@ class ProjectRulePreviewEndpointTest(APITestCase):
             result = parse_datetime(resp["endpoint"])
             endpoint = time_to_freeze.replace(tzinfo=result.tzinfo)
             assert result == endpoint
-            frozen_time.tick(1)
+            frozen_time.shift(1)
 
             resp = self.get_success_response(
                 self.organization.slug,


### PR DESCRIPTION
time-machine is faster since it does not iterate through modules to patch / unpatch

it's also actively maintained and typed properly
