### PR TITLE
fix(hybridcloud) Fix user security settings not working in multi-region

### DIFF
--- a/static/app/actionCreators/organizations.spec.tsx
+++ b/static/app/actionCreators/organizations.spec.tsx
@@ -1,0 +1,43 @@
+import {fetchOrganizations} from 'sentry/actionCreators/organizations';
+import ConfigStore from 'sentry/stores/configStore';
+
+describe('fetchOrganizations', function () {
+  const api = new MockApiClient();
+  const usorg = TestStubs.Organization({slug: 'us-org'});
+  const deorg = TestStubs.Organization({slug: 'de-org'});
+
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('fetches from multiple regions', async function () {
+    ConfigStore.set('regions', [
+      {name: 'us', url: 'https://us.example.org'},
+      {name: 'de', url: 'https://de.example.org'},
+    ]);
+    const usMock = MockApiClient.addMockResponse({
+      url: '/organizations/',
+      body: [usorg],
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.host === 'https://us.example.org';
+        },
+      ],
+    });
+    const deMock = MockApiClient.addMockResponse({
+      url: '/organizations/',
+      body: [deorg],
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.host === 'https://de.example.org';
+        },
+      ],
+    });
+
+    const organizations = await fetchOrganizations(api);
+
+    expect(organizations).toHaveLength(2);
+    expect(usMock).toHaveBeenCalledTimes(1);
+    expect(deMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -4,6 +4,7 @@ import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicato
 import {resetPageFilters} from 'sentry/actionCreators/pageFilters';
 import {Client} from 'sentry/api';
 import {usingCustomerDomain} from 'sentry/constants';
+import ConfigStore from 'sentry/stores/configStore';
 import GuideStore from 'sentry/stores/guideStore';
 import LatestContextStore from 'sentry/stores/latestContextStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
@@ -202,4 +203,23 @@ export async function fetchOrganizationDetails(
   }
 
   return data;
+}
+
+/**
+ * Get all organizations for the current user.
+ *
+ * Will perform a fan-out across all multi-tenant regions,
+ * and single-tenant regions the user has membership in.
+ */
+export async function fetchOrganizations(api: Client, query?: Record<string, any>) {
+  const regions = ConfigStore.get('regions');
+  const results = await Promise.all(
+    regions.map(region =>
+      api.requestPromise(`/organizations/`, {
+        host: region.url,
+        query,
+      })
+    )
+  );
+  return results.reduce((acc, response) => acc.concat(response), []);
 }

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -8,6 +8,7 @@ import {
 } from 'sentry/actionCreators/developmentAlerts';
 import {fetchGuides} from 'sentry/actionCreators/guides';
 import {openCommandPalette} from 'sentry/actionCreators/modal';
+import {fetchOrganizations} from 'sentry/actionCreators/organizations';
 import {initApiClientErrorHandling} from 'sentry/api';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import GlobalModal from 'sentry/components/globalModal';
@@ -74,19 +75,8 @@ function App({children, params}: Props) {
    * Loads the users organization list into the OrganizationsStore
    */
   const loadOrganizations = useCallback(async () => {
-    const regions = ConfigStore.get('regions');
     try {
-      // Get the current user's organizations from each multi-tenant region. Will
-      // include single-tenants if the user has membership on those.
-      const results = await Promise.all(
-        regions.map(region =>
-          api.requestPromise(`/organizations/`, {
-            query: {member: '1'},
-            host: region.url,
-          })
-        )
-      );
-      const data = results.reduce((acc, response) => acc.concat(response), []);
+      const data = await fetchOrganizations(api, {member: '1'});
       OrganizationsStore.load(data);
     } catch {
       // TODO: do something?

--- a/static/app/views/settings/account/accountSecurity/accountSecurityDetails.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityDetails.spec.tsx
@@ -40,7 +40,7 @@ describe('AccountSecurityDetails', function () {
       });
     });
 
-    it('has enrolled circle indicator', function () {
+    it('has enrolled circle indicator', async function () {
       const params = {
         authId: '15',
       };
@@ -61,7 +61,7 @@ describe('AccountSecurityDetails', function () {
         {context: routerContext}
       );
 
-      expect(screen.getByTestId('auth-status-enabled')).toBeInTheDocument();
+      expect(await screen.findByTestId('auth-status-enabled')).toBeInTheDocument();
 
       // has created and last used dates
       expect(screen.getByText('Created at')).toBeInTheDocument();
@@ -94,7 +94,7 @@ describe('AccountSecurityDetails', function () {
         {context: routerContext}
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Remove'}));
+      await userEvent.click(await screen.findByRole('button', {name: 'Remove'}));
 
       renderGlobalModal();
 
@@ -134,7 +134,7 @@ describe('AccountSecurityDetails', function () {
         {context: routerContext}
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Remove'}));
+      await userEvent.click(await screen.findByRole('button', {name: 'Remove'}));
 
       renderGlobalModal();
 
@@ -143,7 +143,7 @@ describe('AccountSecurityDetails', function () {
       expect(deleteMock).toHaveBeenCalled();
     });
 
-    it('can not remove last 2fa method when org requires 2fa', function () {
+    it('can not remove last 2fa method when org requires 2fa', async function () {
       MockApiClient.addMockResponse({
         url: ORG_ENDPOINT,
         body: TestStubs.Organizations({require2FA: true}),
@@ -175,7 +175,7 @@ describe('AccountSecurityDetails', function () {
         {context: routerContext}
       );
 
-      expect(screen.getByRole('button', {name: 'Remove'})).toBeDisabled();
+      expect(await screen.findByRole('button', {name: 'Remove'})).toBeDisabled();
     });
   });
 
@@ -255,7 +255,9 @@ describe('AccountSecurityDetails', function () {
         {context: routerContext}
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Regenerate Codes'}));
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'Regenerate Codes'})
+      );
 
       renderGlobalModal();
 
@@ -270,7 +272,7 @@ describe('AccountSecurityDetails', function () {
       expect(deleteMock).toHaveBeenCalled();
     });
 
-    it('has copy, print and download buttons', function () {
+    it('has copy, print and download buttons', async function () {
       const params = {
         authId: '16',
       };
@@ -296,7 +298,7 @@ describe('AccountSecurityDetails', function () {
         {context: routerContext}
       );
 
-      expect(screen.getByRole('button', {name: 'print'})).toBeInTheDocument();
+      expect(await screen.findByRole('button', {name: 'print'})).toBeInTheDocument();
 
       expect(screen.getByRole('button', {name: 'download'})).toHaveAttribute(
         'href',

--- a/static/app/views/settings/account/accountSecurity/accountSecurityWrapper.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityWrapper.tsx
@@ -17,6 +17,7 @@ type Props = {
 
 type State = {
   emails: UserEmail[];
+  loadingOrganizations: boolean;
   authenticators?: Authenticator[] | null;
   organizations?: OrganizationSummary[];
 } & DeprecatedAsyncComponent['state'];
@@ -24,11 +25,16 @@ type State = {
 class AccountSecurityWrapper extends DeprecatedAsyncComponent<Props, State> {
   async fetchOrganizations() {
     try {
+      this.setState({loadingOrganizations: true});
       const organizations = await fetchOrganizations(this.api);
-      this.setState({organizations});
+      this.setState({organizations, loadingOrganizations: false});
     } catch (e) {
-      this.setState({error: true});
+      this.setState({error: true, loadingOrganizations: false});
     }
+  }
+
+  get shouldRenderLoading() {
+    return super.shouldRenderLoading || this.state.loadingOrganizations === true;
   }
 
   getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {

--- a/static/app/views/settings/account/accountSecurity/components/twoFactorRequired.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/twoFactorRequired.spec.tsx
@@ -113,7 +113,7 @@ describe('TwoFactorRequired', function () {
     Cookies.remove(INVITE_COOKIE);
   });
 
-  it('renders when 2FA is disabled and has pendingInvite cookie', function () {
+  it('renders when 2FA is disabled and has pendingInvite cookie', async function () {
     Cookies.set(INVITE_COOKIE, '/accept/5/abcde/');
     MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
@@ -127,7 +127,7 @@ describe('TwoFactorRequired', function () {
       {context: routerContext}
     );
 
-    expect(screen.getByTestId('require-2fa')).toBeInTheDocument();
+    expect(await screen.findByTestId('require-2fa')).toBeInTheDocument();
     Cookies.remove(INVITE_COOKIE);
   });
 });

--- a/static/app/views/settings/account/accountSecurity/index.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.spec.tsx
@@ -65,7 +65,7 @@ describe('AccountSecurity', function () {
     );
   }
 
-  it('renders empty', function () {
+  it('renders empty', async function () {
     MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [],
@@ -73,10 +73,12 @@ describe('AccountSecurity', function () {
 
     renderComponent();
 
-    expect(screen.getByText('No available authenticators to add')).toBeInTheDocument();
+    expect(
+      await screen.findByText('No available authenticators to add')
+    ).toBeInTheDocument();
   });
 
-  it('renders a primary interface that is enrolled', function () {
+  it('renders a primary interface that is enrolled', async function () {
     MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({configureButton: 'Info'})],
@@ -84,7 +86,7 @@ describe('AccountSecurity', function () {
 
     renderComponent();
 
-    expect(screen.getByText('Authenticator App')).toBeInTheDocument();
+    expect(await screen.findByText('Authenticator App')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Info'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Delete'})).toBeInTheDocument();
 
@@ -114,7 +116,7 @@ describe('AccountSecurity', function () {
     expect(deleteMock).not.toHaveBeenCalled();
 
     expect(
-      screen.getByRole('status', {name: 'Authentication Method Active'})
+      await screen.findByRole('status', {name: 'Authentication Method Active'})
     ).toBeInTheDocument();
 
     // next authenticators request should have totp disabled
@@ -168,7 +170,7 @@ describe('AccountSecurity', function () {
     renderComponent();
 
     expect(
-      screen.getAllByRole('status', {name: 'Authentication Method Active'})
+      await screen.findAllByRole('status', {name: 'Authentication Method Active'})
     ).toHaveLength(2);
 
     await userEvent.click(screen.getAllByRole('button', {name: 'Delete'})[0]);
@@ -203,7 +205,7 @@ describe('AccountSecurity', function () {
     expect(deleteMock).not.toHaveBeenCalled();
 
     expect(
-      screen.getByRole('status', {name: 'Authentication Method Active'})
+      await screen.findByRole('status', {name: 'Authentication Method Active'})
     ).toBeInTheDocument();
 
     await userEvent.hover(screen.getByRole('button', {name: 'Delete'}));
@@ -237,7 +239,7 @@ describe('AccountSecurity', function () {
     const openEmailModalFunc = jest.spyOn(ModalStore, 'openModal');
 
     expect(
-      screen.getByRole('status', {name: 'Authentication Method Inactive'})
+      await screen.findByRole('status', {name: 'Authentication Method Inactive'})
     ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', {name: 'Add'}));
@@ -245,7 +247,7 @@ describe('AccountSecurity', function () {
     await waitFor(() => expect(openEmailModalFunc).toHaveBeenCalled());
   });
 
-  it('renders a backup interface that is not enrolled', function () {
+  it('renders a backup interface that is not enrolled', async function () {
     MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: false})],
@@ -254,13 +256,13 @@ describe('AccountSecurity', function () {
     renderComponent();
 
     expect(
-      screen.getByRole('status', {name: 'Authentication Method Inactive'})
+      await screen.findByRole('status', {name: 'Authentication Method Inactive'})
     ).toBeInTheDocument();
 
     expect(screen.getByText('Recovery Codes')).toBeInTheDocument();
   });
 
-  it('renders a primary interface that is not enrolled', function () {
+  it('renders a primary interface that is not enrolled', async function () {
     MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({isEnrolled: false})],
@@ -269,13 +271,13 @@ describe('AccountSecurity', function () {
     renderComponent();
 
     expect(
-      screen.getByRole('status', {name: 'Authentication Method Inactive'})
+      await screen.findByRole('status', {name: 'Authentication Method Inactive'})
     ).toBeInTheDocument();
 
     expect(screen.getByText('Authenticator App')).toBeInTheDocument();
   });
 
-  it('does not render primary interface that disallows new enrollments', function () {
+  it('does not render primary interface that disallows new enrollments', async function () {
     MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [
@@ -287,12 +289,12 @@ describe('AccountSecurity', function () {
 
     renderComponent();
 
-    expect(screen.getByText('Authenticator App')).toBeInTheDocument();
+    expect(await screen.findByText('Authenticator App')).toBeInTheDocument();
     expect(screen.getByText('U2F (Universal 2nd Factor)')).toBeInTheDocument();
     expect(screen.queryByText('Text Message')).not.toBeInTheDocument();
   });
 
-  it('renders primary interface if new enrollments are disallowed, but we are enrolled', function () {
+  it('renders primary interface if new enrollments are disallowed, but we are enrolled', async function () {
     MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [
@@ -303,10 +305,10 @@ describe('AccountSecurity', function () {
     renderComponent();
 
     // Should still render the authenticator since we are already enrolled
-    expect(screen.getByText('Text Message')).toBeInTheDocument();
+    expect(await screen.findByText('Text Message')).toBeInTheDocument();
   });
 
-  it('renders a backup interface that is enrolled', function () {
+  it('renders a backup interface that is enrolled', async function () {
     MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: true})],
@@ -314,7 +316,7 @@ describe('AccountSecurity', function () {
 
     renderComponent();
 
-    expect(screen.getByText('Recovery Codes')).toBeInTheDocument();
+    expect(await screen.findByText('Recovery Codes')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'View Codes'})).toBeEnabled();
   });
 
@@ -333,7 +335,7 @@ describe('AccountSecurity', function () {
     renderComponent();
 
     await userEvent.type(
-      screen.getByRole('textbox', {name: 'Current Password'}),
+      await screen.findByRole('textbox', {name: 'Current Password'}),
       'oldpassword'
     );
     await userEvent.type(
@@ -374,7 +376,7 @@ describe('AccountSecurity', function () {
     renderComponent();
 
     await userEvent.type(
-      screen.getByRole('textbox', {name: 'New Password'}),
+      await screen.findByRole('textbox', {name: 'New Password'}),
       'newpassword'
     );
     await userEvent.type(
@@ -401,7 +403,9 @@ describe('AccountSecurity', function () {
 
     renderComponent();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Sign out of all devices'}));
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Sign out of all devices'})
+    );
 
     expect(mock).toHaveBeenCalled();
     await waitFor(() =>

--- a/tests/acceptance/test_account_settings.py
+++ b/tests/acceptance/test_account_settings.py
@@ -22,7 +22,9 @@ class AccountSettingsTest(AcceptanceTestCase):
         self.login_as(self.user)
 
     def test_account_security_settings(self):
-        with self.feature("organizations:onboarding"):
+        with self.options({"system.url-prefix": self.browser.live_server_url}), self.feature(
+            "organizations:onboarding"
+        ):
             self.browser.get("/settings/account/security/")
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 


### PR DESCRIPTION
In order to get all the organizations a user belongs to we need to fan out across the regions. I've extracted this into an actionCreator as this is the second time I've needed this logic and I suspect there will be more scenarios in the near future.

Fixes HC-894
