### PR TITLE
ref(hybrid-cloud): Updates organization_index endpoint to use rpc org provisioning

### DIFF
--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.db import IntegrityError, router, transaction
+from django.db import IntegrityError
 from django.db.models import Count, Q, Sum
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -7,7 +7,6 @@ from rest_framework.response import Response
 
 from sentry import analytics, audit_log, features, options
 from sentry import ratelimits as ratelimiter
-from sentry import roles
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationPermission
@@ -16,17 +15,14 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization import BaseOrganizationSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.db.models.query import in_iexact
-from sentry.models import (
-    Organization,
-    OrganizationMember,
-    OrganizationMemberTeam,
-    OrganizationStatus,
-    ProjectPlatform,
-)
+from sentry.models import Organization, OrganizationMember, OrganizationStatus, ProjectPlatform
 from sentry.search.utils import tokenize_query
 from sentry.services.hybrid_cloud import IDEMPOTENCY_KEY_LENGTH
-from sentry.services.hybrid_cloud.organization_actions.impl import (
-    create_organization_with_outbox_message,
+from sentry.services.hybrid_cloud.organization_provisioning import (
+    OrganizationOptions,
+    OrganizationProvisioningOptions,
+    PostProvisionOptions,
+    organization_provisioning_service,
 )
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.signals import org_setup_complete, terms_accepted
@@ -220,23 +216,24 @@ class OrganizationIndexEndpoint(Endpoint):
             result = serializer.validated_data
 
             try:
+                create_default_team = bool(result.get("defaultTeam"))
+                provision_args = OrganizationProvisioningOptions(
+                    provision_options=OrganizationOptions(
+                        name=result["name"],
+                        slug=result.get("slug") or result["name"],
+                        owning_user_id=request.user.id,
+                        create_default_team=create_default_team,
+                    ),
+                    post_provision_options=PostProvisionOptions(
+                        getsentry_options=None, sentry_options=None
+                    ),
+                )
 
-                with transaction.atomic(router.db_for_write(Organization)):
-                    org = create_organization_with_outbox_message(
-                        create_options={"name": result["name"], "slug": result.get("slug")}
-                    )
-                    om = OrganizationMember.objects.create(
-                        organization_id=org.id,
-                        user_id=request.user.id,
-                        role=roles.get_top_dog().id,
-                    )
-
-                    if result.get("defaultTeam"):
-                        team = org.team_set.create(name=org.name)
-
-                        OrganizationMemberTeam.objects.create(
-                            team=team, organizationmember=om, is_active=True
-                        )
+                rpc_org = organization_provisioning_service.provision_organization(
+                    region_name=settings.SENTRY_MONOLITH_REGION,
+                    org_provision_args=provision_args,
+                )
+                org = Organization.objects.get(id=rpc_org.id)
 
                 org_setup_complete.send_robust(
                     instance=org, user=request.user, sender=self.__class__, referrer="in-app"

--- a/src/sentry/services/hybrid_cloud/organization_actions/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_actions/impl.py
@@ -36,21 +36,20 @@ def create_organization_with_outbox_message(
 
 
 def create_organization_and_member_for_monolith(
-    organization_name: str,
-    user_id: int,
-    slug: str,
+    organization_name: str, user_id: int, slug: str, create_default_team: bool
 ) -> OrganizationAndMemberCreationResult:
     org = create_organization_with_outbox_message(
         create_options={"name": organization_name, "slug": slug}
     )
 
-    team = org.team_set.create(name=org.name)
-
     om = OrganizationMember.objects.create(
         user_id=user_id, organization=org, role=roles.get_top_dog().id
     )
 
-    OrganizationMemberTeam.objects.create(team=team, organizationmember=om, is_active=True)
+    team = None
+    if create_default_team:
+        team = org.team_set.create(name=org.name)
+        OrganizationMemberTeam.objects.create(team=team, organizationmember=om, is_active=True)
 
     return OrganizationAndMemberCreationResult(organization=org, org_member=om, team=team)
 

--- a/src/sentry/services/hybrid_cloud/organization_actions/model.py
+++ b/src/sentry/services/hybrid_cloud/organization_actions/model.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 from sentry.models import Organization, OrganizationMember, Team
 
@@ -7,4 +8,4 @@ from sentry.models import Organization, OrganizationMember, Team
 class OrganizationAndMemberCreationResult:
     organization: Organization
     org_member: OrganizationMember
-    team: Team
+    team: Optional[Team]

--- a/src/sentry/services/hybrid_cloud/organization_provisioning/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_provisioning/impl.py
@@ -65,6 +65,7 @@ class DatabaseBackedOrganizationProvisioningService(OrganizationProvisioningServ
                 user_id=provision_options.owning_user_id,
                 slug=provision_options.slug,
                 organization_name=provision_options.name,
+                create_default_team=provision_options.create_default_team,
             )
 
             org = org_creation_result.organization

--- a/src/sentry/services/hybrid_cloud/organization_provisioning/model.py
+++ b/src/sentry/services/hybrid_cloud/organization_provisioning/model.py
@@ -7,6 +7,7 @@ class OrganizationOptions(pydantic.BaseModel):
     name: str
     slug: str
     owning_user_id: int
+    create_default_team: bool = True
 
 
 class PostProvisionOptions(pydantic.BaseModel):

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -5,7 +5,14 @@ from typing import Any
 from unittest.mock import patch
 
 from sentry.auth.authenticators.totp import TotpInterface
-from sentry.models import Authenticator, Organization, OrganizationMember, OrganizationStatus
+from sentry.models import (
+    Authenticator,
+    Organization,
+    OrganizationMember,
+    OrganizationMemberTeam,
+    OrganizationStatus,
+    Team,
+)
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase, TwoFactorAPITestCase
 from sentry.testutils.helpers.options import override_options
@@ -119,8 +126,45 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         org = Organization.objects.get(id=organization_id)
         assert org.name == "hello world"
         assert org.slug == "foobar"
+        team_qs = Team.objects.filter(organization_id=organization_id)
+        assert not team_qs.exists()
 
         self.get_error_response(status_code=400, **data)
+
+    def test_org_ownership(self):
+        data = {"name": "hello world", "slug": "foobar"}
+        response = self.get_success_response(**data)
+
+        organization_id = response.data["id"]
+        org = Organization.objects.get(id=organization_id)
+        assert org.name == "hello world"
+        owners = [owner.id for owner in org.get_owners()]
+        assert [self.user.id] == owners
+
+    def test_with_default_team_false(self):
+        data = {"name": "hello world", "slug": "foobar", "defaultTeam": False}
+        response = self.get_success_response(**data)
+
+        organization_id = response.data["id"]
+        org = Organization.objects.get(id=organization_id)
+        assert org.name == "hello world"
+        assert org.slug == "foobar"
+        team_qs = Team.objects.filter(organization_id=organization_id)
+        assert not team_qs.exists()
+
+    def test_with_default_team_true(self):
+        data = {"name": "hello world", "slug": "foobar", "defaultTeam": True}
+        response = self.get_success_response(**data)
+
+        organization_id = response.data["id"]
+        Organization.objects.get(id=organization_id)
+        team = Team.objects.get(organization_id=organization_id)
+        assert team.name == "hello world"
+
+        org_member = OrganizationMember.objects.get(
+            organization_id=organization_id, user_id=self.user.id
+        )
+        OrganizationMemberTeam.objects.get(organizationmember_id=org_member.id, team_id=team.id)
 
     def test_slugs(self):
         valid_slugs = ["santry", "downtown-canada", "1234", "CaNaDa"]
@@ -225,15 +269,6 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         org = Organization.objects.get(id=organization_id)
         assert org.slug == data["slug"]
         assert org.name == data["name"]
-
-        # TODO(HC) Re-enable this check once organization mapping stabilizes
-        # with assume_test_silo_mode(SiloMode.CONTROL):
-        #     assert OrganizationMapping.objects.filter(
-        #         organization_id=organization_id,
-        #         slug=data["slug"],
-        #         name=data["name"],
-        #         idempotency_key=data["idempotencyKey"],
-        #     ).exists()
 
     def test_slug_already_taken(self):
         self.create_organization(slug="taken")


### PR DESCRIPTION
Updates the organization_index endpoint to use our new `organization_provisioning_service` when provisioning an organization and team.

Also adds some additional testing for team and org membership as well to ensure that orgs are correctly provisioned.