### PR TITLE
fix(alerts): Add optional notification_uuid to digest tuple/task

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -17,7 +17,9 @@ from sentry.utils.pipeline import Pipeline
 
 logger = logging.getLogger("sentry.digests")
 
-Notification = namedtuple("Notification", "event rules")
+Notification = namedtuple(
+    "Notification", "event rules notification_uuid", defaults=(None, None, None)
+)
 
 
 def split_key(

--- a/src/sentry/tasks/digests.py
+++ b/src/sentry/tasks/digests.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from typing import Optional
 
 from sentry.digests import get_option_key
 from sentry.digests.backends.base import InvalidState
@@ -42,7 +43,7 @@ def schedule_digests():
     queue="digests.delivery",
     silo_mode=SiloMode.REGION,
 )
-def deliver_digest(key, schedule_timestamp=None):
+def deliver_digest(key, schedule_timestamp=None, notification_uuid: Optional[str] = None):
     from sentry import digests
     from sentry.mail import mail_adapter
 

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -11,6 +11,7 @@ from django.core.mail.message import EmailMultiAlternatives
 from django.utils import timezone
 from sentry_relay.processing import parse_release
 
+from sentry.digests.notifications import Notification
 from sentry.event_manager import EventManager
 from sentry.models import (
     Group,
@@ -504,3 +505,17 @@ class ActivityNotificationTest(APITestCase):
             group_id=event.group_id,
             notification_uuid=notification_uuid,
         )
+
+
+class NotificationTupleTest(APITestCase):
+    def test_missing_notification_uuid(self):
+        rule = self.create_project_rule()
+        group = self.create_group()
+        notification = Notification(rule, group)
+        assert notification.notification_uuid is None
+
+    def test_notification_uuid(self):
+        rule = self.create_project_rule()
+        group = self.create_group()
+        notification = Notification(rule, group, notification_uuid=str(uuid.uuid4()))
+        assert notification.notification_uuid is not None


### PR DESCRIPTION
Adds two optional fields to prepare for notification_uuid parameters

fixes SENTRY-15Q1