### PR TITLE
ref(crons): Add comments for unintuitive crons code

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -415,6 +415,7 @@ def _process_message(ts: datetime, wrapper: CheckinMessage | ClockPulseMessage) 
             f"checkin-creation:{guid.hex}", duration=LOCK_TIMEOUT, name="checkin_creation"
         )
         try:
+            # use lock.blocking_acquire() as default lock.acquire() fast fails if lock is in use
             with lock.blocking_acquire(
                 INITIAL_LOCK_DELAY, float(LOCK_TIMEOUT), exp_base=LOCK_EXP_BASE
             ), transaction.atomic(router.db_for_write(Monitor)):

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -59,6 +59,7 @@ def mark_failed_threshold(
     next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(next_checkin_base)
 
     # update monitor environment timestamps without updating status
+    # affected returns number of rows returned from the filter() call, not the number of rows that actually modify their values via update()
     affected = MonitorEnvironment.objects.filter(
         Q(last_checkin__lte=last_checkin) | Q(last_checkin__isnull=True), id=monitor_env.id
     ).update(
@@ -145,6 +146,7 @@ def mark_failed_no_threshold(
     next_checkin = monitor_env.monitor.get_next_expected_checkin(next_checkin_base)
     next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(next_checkin_base)
 
+    # affected returns number of rows returned from the filter() call, not the number of rows that actually modify their values via update()
     affected = MonitorEnvironment.objects.filter(
         Q(last_checkin__lte=last_checkin) | Q(last_checkin__isnull=True), id=monitor_env.id
     ).update(

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -59,7 +59,8 @@ def mark_failed_threshold(
     next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(next_checkin_base)
 
     # update monitor environment timestamps without updating status
-    # affected returns number of rows returned from the filter() call, not the number of rows that actually modify their values via update()
+    # affected returns number of rows returned from the filter() call
+    # not the number of rows that actually modify their values via update()
     affected = MonitorEnvironment.objects.filter(
         Q(last_checkin__lte=last_checkin) | Q(last_checkin__isnull=True), id=monitor_env.id
     ).update(
@@ -146,7 +147,8 @@ def mark_failed_no_threshold(
     next_checkin = monitor_env.monitor.get_next_expected_checkin(next_checkin_base)
     next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(next_checkin_base)
 
-    # affected returns number of rows returned from the filter() call, not the number of rows that actually modify their values via update()
+    # affected returns number of rows returned from the filter() call
+    # not the number of rows that actually modify their values via update()
     affected = MonitorEnvironment.objects.filter(
         Q(last_checkin__lte=last_checkin) | Q(last_checkin__isnull=True), id=monitor_env.id
     ).update(


### PR DESCRIPTION
Comments for code in crons that isn't obvious or intuitive