### PR TITLE
fix(metrics): Add minimetrics to ci tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ test-js-ci: node-version-check
 test-python-ci: create-db
 	@echo "--> Running CI Python tests"
 	pytest tests/integration tests/sentry tests/sentry_plugins \
+		tests/minimetrics \
 		--ignore tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py \
 		--ignore tests/sentry/region_to_control/test_region_to_control_kafka.py \
 		--cov . --cov-report="xml:.artifacts/python.coverage.xml"


### PR DESCRIPTION
This PR adds `tests/minimetrics` to the CI config. Note that the `minimetrics` top-level package is temporary and will be embedded into the SDKs in the future.