### PR TITLE
feat(spans): Add features for specific modules

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1802,8 +1802,7 @@ SENTRY_FEATURES = {
     "projects:auto-associate-commits-to-release": False,
     # Starfish: extract metrics from the spans
     "projects:span-metrics-extraction": False,
-    "projects:span-metrics-extraction-db-module": False,
-    "projects:span-metrics-extraction-browser-module": False,
+    "projects:span-metrics-extraction-ga-modules": False,
     "projects:span-metrics-extraction-all-modules": False,
     # Metrics: Enable ingestion, storage, and rendering of custom metrics
     "organizations:custom-metrics": False,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1802,6 +1802,9 @@ SENTRY_FEATURES = {
     "projects:auto-associate-commits-to-release": False,
     # Starfish: extract metrics from the spans
     "projects:span-metrics-extraction": False,
+    "projects:span-metrics-extraction-db-module": False,
+    "projects:span-metrics-extraction-browser-module": False,
+    "projects:span-metrics-extraction-all-modules": False,
     # Metrics: Enable ingestion, storage, and rendering of custom metrics
     "organizations:custom-metrics": False,
     # Metrics: Enable creation of investigation dynamic sampling rules (rules that

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -303,6 +303,9 @@ default_manager.add("projects:similarity-indexing", ProjectFeature, FeatureHandl
 default_manager.add("projects:similarity-view", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:suspect-resolutions", ProjectFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("projects:span-metrics-extraction", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("projects:span-metrics-extraction-db-module", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("projects:span-metrics-extraction-browser-module", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("projects:span-metrics-extraction-all-modules", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 
 # Project plugin features
 default_manager.add("projects:plugins", ProjectPluginFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -303,8 +303,7 @@ default_manager.add("projects:similarity-indexing", ProjectFeature, FeatureHandl
 default_manager.add("projects:similarity-view", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:suspect-resolutions", ProjectFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("projects:span-metrics-extraction", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("projects:span-metrics-extraction-db-module", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("projects:span-metrics-extraction-browser-module", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("projects:span-metrics-extraction-ga-modules", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:span-metrics-extraction-all-modules", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 
 # Project plugin features

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -52,8 +52,7 @@ from .measurements import CUSTOM_MEASUREMENT_LIMIT, get_measurements_config
 #: These features will be listed in the project config
 EXPOSABLE_FEATURES = [
     "projects:span-metrics-extraction",
-    "projects:span-metrics-extraction-db-module",
-    "projects:span-metrics-extraction-browser-module",
+    "projects:span-metrics-extraction-ga-modules",
     "projects:span-metrics-extraction-all-modules",
     "organizations:transaction-name-mark-scrubbed-as-sanitized",
     "organizations:transaction-name-normalize",

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -52,6 +52,9 @@ from .measurements import CUSTOM_MEASUREMENT_LIMIT, get_measurements_config
 #: These features will be listed in the project config
 EXPOSABLE_FEATURES = [
     "projects:span-metrics-extraction",
+    "projects:span-metrics-extraction-db-module",
+    "projects:span-metrics-extraction-browser-module",
+    "projects:span-metrics-extraction-all-modules",
     "organizations:transaction-name-mark-scrubbed-as-sanitized",
     "organizations:transaction-name-normalize",
     "organizations:profiling",


### PR DESCRIPTION
We'd like to have a way to control which spans are ingested based on modules.

https://github.com/getsentry/relay/pull/2511