### PR TITLE
fix(webpack): remove dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "diff-docs": "yarn install-api-docs && ts-node api-docs/openapi-diff.ts",
     "deref-api-docs": "ts-node api-docs/index.ts tests/apidocs/openapi-spectacular.json tests/apidocs/openapi-derefed.json",
     "build-chartcuterie-config": "NODE_ENV=production yarn webpack --config=config/webpack.chartcuterie.config.ts",
-    "build-acceptance": "IS_ACCEPTANCE_TEST=1 NODE_ENV=production yarn webpack --mode development",
+    "build-acceptance": "IS_ACCEPTANCE_TEST=1 NODE_ENV=production yarn webpack",
     "build-production": "NODE_ENV=production yarn webpack --mode production",
     "build": "NODE_OPTIONS=--max-old-space-size=4096 yarn webpack",
     "build-js-loader": "ts-node scripts/build-js-loader.ts",


### PR DESCRIPTION
Setting NODE_ENV=production conflicts with webpack --mode development. Asked if anyone knows the reasoning for mode override in slack, but running a quick CI check to see if our acceptance tests fail if --mode development is removed

<img width="723" alt="CleanShot 2023-09-14 at 13 32 20@2x" src="https://github.com/getsentry/sentry/assets/9317857/dc280885-7b2f-4fe2-80c1-a9684a2711d9">
