### PR TITLE
fix(source-map-debug): Fix SDK debug ID compat check

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
+++ b/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
@@ -434,7 +434,7 @@ def get_sdk_debug_id_support(event_data):
     try:
         sdk_release_registry = get_sdk_index()
         official_sdks = [
-            sdk.startswith("sentry.javascript.") for sdk in sdk_release_registry.keys()
+            sdk for sdk in sdk_release_registry.keys() if sdk.startswith("sentry.javascript.")
         ]
     except Exception as e:
         sentry_sdk.capture_exception(e)


### PR DESCRIPTION
We returned `list[bool]` instead of `list[str]`.