### PR TITLE
feat(perf): Set database view badge as a constant

### DIFF
--- a/static/app/components/featureBadge.tsx
+++ b/static/app/components/featureBadge.tsx
@@ -10,8 +10,10 @@ import {Tooltip, TooltipProps} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space, ValidSize} from 'sentry/styles/space';
 
+export type BadgeType = 'alpha' | 'beta' | 'new' | 'experimental';
+
 type BadgeProps = {
-  type: 'alpha' | 'beta' | 'new' | 'experimental';
+  type: BadgeType;
   expiresAt?: Date;
   title?: string;
   tooltipProps?: Partial<TooltipProps>;

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -11,6 +11,7 @@ import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
+import {RELEASE_LEVEL} from 'sentry/views/performance/database/settings';
 import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {ActionSelector} from 'sentry/views/starfish/views/spans/selectors/actionSelector';
@@ -46,7 +47,7 @@ function DatabaseLandingPage() {
 
           <Layout.Title>
             {t('Database')}
-            <FeatureBadge type="alpha" />
+            <FeatureBadge type={RELEASE_LEVEL} />
           </Layout.Title>
         </Layout.HeaderContent>
       </Layout.Header>

--- a/static/app/views/performance/database/settings.ts
+++ b/static/app/views/performance/database/settings.ts
@@ -1,0 +1,3 @@
+import {BadgeType} from 'sentry/components/featureBadge';
+
+export const RELEASE_LEVEL: BadgeType = 'alpha';

--- a/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
@@ -6,6 +6,7 @@ import QuestionTooltip from 'sentry/components/questionTooltip';
 import TextOverflow from 'sentry/components/textOverflow';
 import {space} from 'sentry/styles/space';
 import {MEPTag} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
+import {RELEASE_LEVEL} from 'sentry/views/performance/database/settings';
 
 import {
   GenericPerformanceWidgetProps,
@@ -30,7 +31,7 @@ export function WidgetHeader<T extends WidgetDataConstraint>(
           ) : (
             <TextOverflow>{title}</TextOverflow>
           )}
-          {isStarfishDBWidget && <FeatureBadge type="alpha" />}
+          {isStarfishDBWidget && <FeatureBadge type={RELEASE_LEVEL} />}
           <MEPTag />
           {titleTooltip && (
             <QuestionTooltip position="top" size="sm" title={titleTooltip} />


### PR DESCRIPTION
Just so we can change this quickly.

- Export a type
- Declare release level in a constant
