### PR TITLE
fix(statistical-detectors): Add limitby to functions query

### DIFF
--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentry_sdk
 
@@ -28,6 +28,7 @@ def query(
     orderby: Optional[List[str]] = None,
     offset: int = 0,
     limit: int = 50,
+    limitby: Optional[Tuple[str, int]] = None,
     referrer: str = "",
     auto_fields: bool = False,
     auto_aggregations: bool = False,
@@ -50,6 +51,7 @@ def query(
         selected_columns=selected_columns,
         orderby=orderby,
         limit=limit,
+        limitby=limitby,
         offset=offset,
         config=QueryBuilderConfig(
             auto_fields=False,

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -122,8 +122,8 @@ def detect_function_change_points(
 ) -> None:
     for project_id, function_id in functions:
         with sentry_sdk.push_scope() as scope:
-            scope.set_tag("project_id", project_id)
-            scope.set_tag("function_id", function_id)
+            scope.set_tag("regressed_project_id", project_id)
+            scope.set_tag("regressed_function_id", function_id)
             scope.set_context(
                 "statistical_detectors",
                 {
@@ -239,6 +239,7 @@ def query_functions(projects: List[Project], start: datetime) -> List[DetectorPa
         query="is_application:1",
         params=params,
         orderby=["project.id", "-count()"],
+        limitby=("project.id", FUNCTIONS_PER_PROJECT),
         limit=FUNCTIONS_PER_PROJECT * len(projects),
         referrer=Referrer.API_PROFILING_FUNCTIONS_STATISTICAL_DETECTOR.value,
         auto_aggregations=True,


### PR DESCRIPTION
Without the limitby, most if not all the results will be from the first project.