### PR TITLE
feat(backup): Add `RelocationScope.Config`

### DIFF
--- a/bin/model-dependency-graphviz
+++ b/bin/model-dependency-graphviz
@@ -76,6 +76,7 @@ class ClusterColor(Enum):
     Purple = "lavenderblush"
     Yellow = "khaki"
     Green = "honeydew"
+    Blue = "lightsteelblue1"
 
 
 @unique
@@ -126,6 +127,12 @@ def print_edge(
     return f""""{src.__name__}":e -> "{dest.__name__}":w {style.value};"""
 
 
+def get_most_permissive_relocation_scope(mr: ModelRelations) -> RelocationScope:
+    if isinstance(mr.relocation_scope, set):
+        return sorted(list(mr.relocation_scope), key=lambda obj: obj.value * -1)[0]
+    return mr.relocation_scope
+
+
 @click.command()
 @click.option("--show-excluded", default=False, is_flag=True, help="Show unexportable models too")
 def main(show_excluded: bool):
@@ -136,17 +143,27 @@ def main(show_excluded: bool):
     if not show_excluded:
         deps = list(filter(lambda m: m.relocation_scope != RelocationScope.Excluded, deps))
 
-    # Group by region scope.
-    user_scoped = filter(lambda m: m.relocation_scope == RelocationScope.User, deps)
-    org_scoped = filter(lambda m: m.relocation_scope == RelocationScope.Organization, deps)
-    global_scoped = filter(lambda m: m.relocation_scope == RelocationScope.Global, deps)
+    # Group by most permissive region scope.
+    user_scoped = filter(
+        lambda m: get_most_permissive_relocation_scope(m) == RelocationScope.User, deps
+    )
+    org_scoped = filter(
+        lambda m: get_most_permissive_relocation_scope(m) == RelocationScope.Organization, deps
+    )
+    config_scoped = filter(
+        lambda m: get_most_permissive_relocation_scope(m) == RelocationScope.Config, deps
+    )
+    global_scoped = filter(
+        lambda m: get_most_permissive_relocation_scope(m) == RelocationScope.Global, deps
+    )
 
     # Print nodes.
     clusters = "".join(
         [
             print_rel_scope_subgraph("User", 1, user_scoped, ClusterColor.Green),
             print_rel_scope_subgraph("Organization", 2, org_scoped, ClusterColor.Purple),
-            print_rel_scope_subgraph("Global", 3, global_scoped, ClusterColor.Yellow),
+            print_rel_scope_subgraph("Config", 3, config_scoped, ClusterColor.Blue),
+            print_rel_scope_subgraph("Global", 4, global_scoped, ClusterColor.Yellow),
         ]
     )
 

--- a/fixtures/backup/model_dependencies/detailed.json
+++ b/fixtures/backup/model_dependencies/detailed.json
@@ -192,7 +192,10 @@
       }
     },
     "model": "sentry.ApiAuthorization",
-    "relocation_scope": "Global",
+    "relocation_scope": [
+      "Config",
+      "Global"
+    ],
     "silos": [
       "Control"
     ]
@@ -239,7 +242,10 @@
       }
     },
     "model": "sentry.ApiToken",
-    "relocation_scope": "Global",
+    "relocation_scope": [
+      "Config",
+      "Global"
+    ],
     "silos": [
       "Control"
     ]
@@ -569,7 +575,7 @@
   "sentry.ControlOption": {
     "foreign_keys": {},
     "model": "sentry.ControlOption",
-    "relocation_scope": "Global",
+    "relocation_scope": "Config",
     "silos": [
       "Control"
     ]
@@ -1898,7 +1904,7 @@
   "sentry.Option": {
     "foreign_keys": {},
     "model": "sentry.Option",
-    "relocation_scope": "Global",
+    "relocation_scope": "Config",
     "silos": [
       "Region"
     ]
@@ -2567,7 +2573,7 @@
   "sentry.Relay": {
     "foreign_keys": {},
     "model": "sentry.Relay",
-    "relocation_scope": "Global",
+    "relocation_scope": "Config",
     "silos": [
       "Region"
     ]
@@ -2575,7 +2581,7 @@
   "sentry.RelayUsage": {
     "foreign_keys": {},
     "model": "sentry.RelayUsage",
-    "relocation_scope": "Global",
+    "relocation_scope": "Config",
     "silos": [
       "Region"
     ]
@@ -3309,7 +3315,7 @@
       }
     },
     "model": "sentry.UserPermission",
-    "relocation_scope": "Global",
+    "relocation_scope": "Config",
     "silos": [
       "Control"
     ]
@@ -3342,7 +3348,7 @@
   "sentry.UserRole": {
     "foreign_keys": {},
     "model": "sentry.UserRole",
-    "relocation_scope": "Global",
+    "relocation_scope": "Config",
     "silos": [
       "Control"
     ]
@@ -3359,7 +3365,7 @@
       }
     },
     "model": "sentry.UserRoleUser",
-    "relocation_scope": "Global",
+    "relocation_scope": "Config",
     "silos": [
       "Control"
     ]

--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -51,7 +51,7 @@ class ModelRelations(NamedTuple):
 
     model: Type[models.base.Model]
     foreign_keys: dict[str, ForeignField]
-    relocation_scope: RelocationScope
+    relocation_scope: RelocationScope | set[RelocationScope]
     silos: list[SiloMode]
 
     def flatten(self) -> set[Type[models.base.Model]]:
@@ -75,6 +75,9 @@ class DependenciesJSONEncoder(json.JSONEncoder):
             return obj.name
         if isinstance(obj, RelocationScope):
             return obj.name
+        if isinstance(obj, set) and all(isinstance(rs, RelocationScope) for rs in obj):
+            # Order by enum value, which should correspond to `RelocationScope` breadth.
+            return sorted(list(obj), key=lambda obj: obj.value)
         if isinstance(obj, SiloMode):
             return obj.name.lower().capitalize()
         if isinstance(obj, set):

--- a/src/sentry/backup/scopes.py
+++ b/src/sentry/backup/scopes.py
@@ -8,18 +8,29 @@ class RelocationScope(Enum):
     # A model that has been purposefully excluded from import/export functionality entirely.
     Excluded = auto()
 
-    # A model related to some global feature of Sentry. `Global` models are best understood via
-    # exclusion: they are all of the exportable `Control`-silo models that are **not** somehow tied
-    # to a specific user.
-    Global = auto()
+    # Any `Control`-silo model that is either a `User*` model, or directly owner by one, is in this
+    # scope. Models that deal with bestowing administration privileges are excluded, and are
+    # included in the `Config` scope instead.
+    User = auto()
 
     # For all models that transitively depend on either `User` or `Organization` root models, and
     # nothing else.
     Organization = auto()
 
-    # Any `Control`-silo model that is either a `User*` model, or directly owner by one, is in this
-    # scope.
-    User = auto()
+    # Models that deal with configuring or administering an entire Sentry instance. Some of these
+    # models transitively rely on `User` models (since their purpose is to mark certain users as
+    # administrators and give them elevated, instance-wide privileges), but otherwise these models
+    # have no dependencies on other scopes.
+    Config = auto()
+
+    # A model that is inextricably tied to a specific Sentry instance. Often, this applies to models
+    # that include the instance domain in their data (ex: OAuth or social login tokens related to
+    # the specific domain), which therefore are completely non-portable.
+    #
+    # In practice, this scope is reserved for models that are only useful when backing up or
+    # restoring an entire Sentry instance, since there is no reasonable way to use them outside of
+    # that specific context.
+    Global = auto()
 
 
 @unique
@@ -32,7 +43,13 @@ class ExportScope(Enum):
 
     User = {RelocationScope.User}
     Organization = {RelocationScope.User, RelocationScope.Organization}
-    Global = {RelocationScope.User, RelocationScope.Organization, RelocationScope.Global}
+    Config = {RelocationScope.User, RelocationScope.Config}
+    Global = {
+        RelocationScope.User,
+        RelocationScope.Organization,
+        RelocationScope.Config,
+        RelocationScope.Global,
+    }
 
 
 @unique
@@ -45,4 +62,10 @@ class ImportScope(Enum):
 
     User = {RelocationScope.User}
     Organization = {RelocationScope.User, RelocationScope.Organization}
-    Global = {RelocationScope.User, RelocationScope.Organization, RelocationScope.Global}
+    Config = {RelocationScope.User, RelocationScope.Config}
+    Global = {
+        RelocationScope.User,
+        RelocationScope.Organization,
+        RelocationScope.Config,
+        RelocationScope.Global,
+    }

--- a/src/sentry/models/apiauthorization.py
+++ b/src/sentry/models/apiauthorization.py
@@ -15,7 +15,7 @@ class ApiAuthorization(Model, HasApiScopes):
     overall approved applications (vs individual tokens).
     """
 
-    __relocation_scope__ = RelocationScope.Global
+    __relocation_scope__ = {RelocationScope.Global, RelocationScope.Config}
 
     # users can generate tokens without being application-bound
     application = FlexibleForeignKey("sentry.ApiApplication", null=True)
@@ -28,3 +28,10 @@ class ApiAuthorization(Model, HasApiScopes):
         unique_together = (("user", "application"),)
 
     __repr__ = sane_repr("user_id", "application_id")
+
+    def get_relocation_scope(self) -> RelocationScope:
+        if self.application_id is not None:
+            # TODO(getsentry/team-ospo#188): this should be extension scope once that gets added.
+            return RelocationScope.Global
+
+        return RelocationScope.Config

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -31,7 +31,7 @@ def generate_token():
 
 @control_silo_only_model
 class ApiToken(Model, HasApiScopes):
-    __relocation_scope__ = RelocationScope.Global
+    __relocation_scope__ = {RelocationScope.Global, RelocationScope.Config}
 
     # users can generate tokens without being application-bound
     application = FlexibleForeignKey("sentry.ApiApplication", null=True)
@@ -78,6 +78,13 @@ class ApiToken(Model, HasApiScopes):
             expires_at = timezone.now() + DEFAULT_EXPIRATION
 
         self.update(token=generate_token(), refresh_token=generate_token(), expires_at=expires_at)
+
+    def get_relocation_scope(self) -> RelocationScope:
+        if self.application_id is not None:
+            # TODO(getsentry/team-ospo#188): this should be extension scope once that gets added.
+            return RelocationScope.Global
+
+        return RelocationScope.Config
 
     @property
     def organization_id(self) -> int | None:

--- a/src/sentry/models/options/option.py
+++ b/src/sentry/models/options/option.py
@@ -47,7 +47,7 @@ class BaseOption(Model):
 
 @region_silo_only_model
 class Option(BaseOption):
-    __relocation_scope__ = RelocationScope.Global
+    __relocation_scope__ = RelocationScope.Config
 
     class Meta:
         app_label = "sentry"
@@ -58,7 +58,7 @@ class Option(BaseOption):
 
 @control_silo_only_model
 class ControlOption(BaseOption):
-    __relocation_scope__ = RelocationScope.Global
+    __relocation_scope__ = RelocationScope.Config
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/relay.py
+++ b/src/sentry/models/relay.py
@@ -9,7 +9,7 @@ from sentry.db.models import Model, region_silo_only_model
 
 @region_silo_only_model
 class RelayUsage(Model):
-    __relocation_scope__ = RelocationScope.Global
+    __relocation_scope__ = RelocationScope.Config
 
     relay_id = models.CharField(max_length=64)
     version = models.CharField(max_length=32, default="0.0.1")
@@ -25,7 +25,7 @@ class RelayUsage(Model):
 
 @region_silo_only_model
 class Relay(Model):
-    __relocation_scope__ = RelocationScope.Global
+    __relocation_scope__ = RelocationScope.Config
 
     relay_id = models.CharField(max_length=64, unique=True)
     public_key = models.CharField(max_length=200)

--- a/src/sentry/models/userpermission.py
+++ b/src/sentry/models/userpermission.py
@@ -14,9 +14,7 @@ class UserPermission(Model):
     Generally speaking, they should only apply to active superuser sessions.
     """
 
-    # It only makes sense to import/export this data when doing a full global backup/restore, so it
-    # lives in the `Global` scope, even though it only depends on the `User` model.
-    __relocation_scope__ = RelocationScope.Global
+    __relocation_scope__ = RelocationScope.Config
 
     user = FlexibleForeignKey("sentry.User")
     # permissions should be in the form of 'service-name.permission-name'

--- a/src/sentry/models/userrole.py
+++ b/src/sentry/models/userrole.py
@@ -16,9 +16,7 @@ class UserRole(DefaultFieldsModel):
     Roles are applied to administrative users and apply a set of `UserPermission`.
     """
 
-    # It only makes sense to import/export this data when doing a full global backup/restore, so it
-    # lives in the `Global` scope, even though it only depends on the `User` model.
-    __relocation_scope__ = RelocationScope.Global
+    __relocation_scope__ = RelocationScope.Config
 
     name = models.CharField(max_length=32, unique=True)
     permissions = ArrayField()
@@ -44,9 +42,7 @@ class UserRole(DefaultFieldsModel):
 
 @control_silo_only_model
 class UserRoleUser(DefaultFieldsModel):
-    # It only makes sense to import/export this data when doing a full global backup/restore, so it
-    # lives in the `Global` scope, even though it only depends on the `User` model.
-    __relocation_scope__ = RelocationScope.Global
+    __relocation_scope__ = RelocationScope.Config
 
     user = FlexibleForeignKey("sentry.User")
     role = FlexibleForeignKey("sentry.UserRole")

--- a/tests/sentry/backup/test_exports.py
+++ b/tests/sentry/backup/test_exports.py
@@ -35,7 +35,7 @@ class ScopingTests(ExportTestCase):
     def get_models_for_scope(scope: ExportScope) -> set[str]:
         matching_models = set()
         for model in get_exportable_sentry_models():
-            if model.__relocation_scope__ in scope.value:
+            if model.get_possible_relocation_scopes() & scope.value:
                 obj_name = model._meta.object_name
                 if obj_name is not None:
                     matching_models.add("sentry." + obj_name.lower())

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -438,7 +438,7 @@ class ScopingTests(ImportTestCase):
                 import_in_user_scope(tmp_file, printer=NOOP_PRINTER)
                 exportable = get_exportable_sentry_models()
                 for model in exportable:
-                    if model.__relocation_scope__ != RelocationScope.User:
+                    if RelocationScope.User not in model.get_possible_relocation_scopes():
                         assert model.objects.count() == 0
 
     def test_organization_import_scoping(self):
@@ -450,10 +450,10 @@ class ScopingTests(ImportTestCase):
                 import_in_organization_scope(tmp_file, printer=NOOP_PRINTER)
                 exportable = get_exportable_sentry_models()
                 for model in exportable:
-                    if model.__relocation_scope__ not in {
+                    if {
                         RelocationScope.User,
                         RelocationScope.Organization,
-                    }:
+                    } in model.get_possible_relocation_scopes():
                         assert model.objects.count() == 0
 
 

--- a/tests/sentry/backup/test_invariants.py
+++ b/tests/sentry/backup/test_invariants.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from django.db.models.fields.related import ManyToManyField
 
-from sentry.backup.dependencies import dependencies, normalize_model_name
+from sentry.backup.dependencies import ModelRelations, dependencies, normalize_model_name
 from sentry.backup.helpers import get_exportable_sentry_models, get_final_derivations_of
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BaseModel
@@ -40,18 +40,25 @@ def test_all_many_to_many_fields_explicitly_set_through_attribute():
     assert visited > 0
 
 
+def relocation_scopes_as_set(mr: ModelRelations):
+    return mr.relocation_scope if isinstance(mr.relocation_scope, set) else {mr.relocation_scope}
+
+
 def validate_dependency_scopes(allowed: set[RelocationScope]):
     deps = dependencies()
-    models = [mr.model for mr in filter((lambda mr: mr.relocation_scope in allowed), deps.values())]
-    for model in models:
+    models_being_validated = [
+        mr.model
+        for mr in filter((lambda mr: relocation_scopes_as_set(mr) & allowed), deps.values())
+    ]
+    for model in models_being_validated:
         model_name = normalize_model_name(model)
-        own_scope = deps[model_name].relocation_scope
+        own_scopes = relocation_scopes_as_set(deps[model_name])
         for ff in deps[model_name].foreign_keys.values():
             dependency_name = normalize_model_name(ff.model)
-            dependency_scope = deps[dependency_name].relocation_scope
-            if dependency_scope not in allowed:
+            dependency_scopes = relocation_scopes_as_set(deps[dependency_name])
+            if own_scopes.issuperset(dependency_scopes):
                 AssertionError(
-                    f"Model `{model_name}`, which has a relocation scope of `{own_scope.name}`, has a dependency on model `{dependency_name}`, which has the disallowed relocation scope of `{dependency_scope.name}`"
+                    f"Model `{model_name}`, which has a relocation scope set of `{own_scopes}`, has a dependency on model `{dependency_name}`, which has a relocation scope set of `{dependency_scopes}; the former must be a super set of the latter`"
                 )
 
 
@@ -65,3 +72,9 @@ def test_organization_relocation_scope_validity():
     # Models with an `Organization` or `User` relocation scope are only allowed to transitively
     # depend on other similarly-scoped models.
     validate_dependency_scopes({RelocationScope.Organization, RelocationScope.User})
+
+
+def test_config_relocation_scope_validity():
+    # Models with a `Config` or `User` relocation scope are only allowed to transitively depend on
+    # other similarly-scoped models.
+    validate_dependency_scopes({RelocationScope.Config, RelocationScope.User})

--- a/tests/sentry/backup/test_models.py
+++ b/tests/sentry/backup/test_models.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from sentry_relay.auth import generate_key_pair
 
 from sentry.backup.helpers import get_exportable_sentry_models
+from sentry.backup.scopes import RelocationScope
 from sentry.incidents.models import (
     AlertRule,
     AlertRuleActivity,
@@ -516,3 +517,32 @@ class ModelBackupTests(TransactionTestCase):
         role = UserRole.objects.create(name="test-role")
         UserRoleUser.objects.create(user=user, role=role)
         return self.import_export_then_validate()
+
+
+@run_backup_tests_only_on_single_db
+class DynamicRelocationScopeTests(TransactionTestCase):
+    """
+    For models that support different relocation scopes depending on properties of the model instance itself (ie, they have a set for their `__relocation_scope__`, rather than a single value), make sure that this dynamic deduction works correctly.
+    """
+
+    def test_api_auth_application_bound(self):
+        user = self.create_user()
+        app = ApiApplication.objects.create(name="test", owner=user)
+        auth = ApiAuthorization.objects.create(
+            application=app, user=self.create_user("example@example.com")
+        )
+        token = ApiToken.objects.create(
+            application=app, user=user, token=uuid4().hex, expires_at=None
+        )
+
+        # TODO(getsentry/team-ospo#188): this should be extension scope once that gets added.
+        assert auth.get_relocation_scope() == RelocationScope.Global
+        assert token.get_relocation_scope() == RelocationScope.Global
+
+    def test_api_auth_not_application_bound(self):
+        user = self.create_user()
+        auth = ApiAuthorization.objects.create(user=self.create_user("example@example.com"))
+        token = ApiToken.objects.create(user=user, token=uuid4().hex, expires_at=None)
+
+        assert auth.get_relocation_scope() == RelocationScope.Config
+        assert token.get_relocation_scope() == RelocationScope.Config


### PR DESCRIPTION
We add a new scope, which roughly corresponds to "all of the stuff you need to restore the configuration of administration setup of a Sentry instance".

To support this, we also need to support dynamic relocation scope deduction. This means that the `__relocation_scope__` class-level attribute can now be a single scope or a set of them. The latter case implies that the actual scope of any given instance of that model relies on information specific to that instance, and so will be deduced on a per-model basis.

Issue: getsentry/team-ospo#199