### PR TITLE
ref(backup): Make normalization a standalone method

### DIFF
--- a/fixtures/backup/model_dependencies/detailed.json
+++ b/fixtures/backup/model_dependencies/detailed.json
@@ -1841,7 +1841,10 @@
       }
     },
     "model": "sentry.NotificationAction",
-    "relocation_scope": "Global",
+    "relocation_scope": [
+      "Organization",
+      "Global"
+    ],
     "silos": [
       "Region"
     ]
@@ -1858,7 +1861,10 @@
       }
     },
     "model": "sentry.NotificationActionProject",
-    "relocation_scope": "Global",
+    "relocation_scope": [
+      "Organization",
+      "Global"
+    ],
     "silos": [
       "Region"
     ]

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -127,10 +127,16 @@ def _import(
                             if f.model == type(o) and getattr(o, f.field, None) not in f.values:
                                 break
                         else:
-                            written = o.write_relocation_import(pk_map, scope, flags)
-                            if written is not None:
-                                old_pk, new_pk, import_kind = written
-                                pk_map.insert(model_name, old_pk, new_pk, import_kind)
+                            old_pk = o.normalize_before_relocation_import(pk_map, scope, flags)
+                            if old_pk is None:
+                                continue
+
+                            written = o.write_relocation_import(scope, flags)
+                            if written is None:
+                                continue
+
+                            new_pk, import_kind = written
+                            pk_map.insert(model_name, old_pk, new_pk, import_kind)
 
     # For all database integrity errors, let's warn users to follow our
     # recommended backup/restore workflow before reraising exception. Most of

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -216,10 +216,10 @@ class Incident(Model):
     def duration(self):
         return self.current_end_date - self.date_started
 
-    def _normalize_before_relocation_import(
+    def normalize_before_relocation_import(
         self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
     ) -> Optional[int]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
+        old_pk = super().normalize_before_relocation_import(pk_map, scope, flags)
         if old_pk is None:
             return None
 
@@ -296,10 +296,10 @@ class IncidentActivity(Model):
         app_label = "sentry"
         db_table = "sentry_incidentactivity"
 
-    def _normalize_before_relocation_import(
+    def normalize_before_relocation_import(
         self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
     ) -> Optional[int]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
+        old_pk = super().normalize_before_relocation_import(pk_map, scope, flags)
         if old_pk is None:
             return None
 

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -144,10 +144,10 @@ class Actor(Model):
         return self.get_actor_tuple().get_actor_identifier()
 
     # TODO(hybrid-cloud): actor refactor. Remove this method when done.
-    def _normalize_before_relocation_import(
+    def normalize_before_relocation_import(
         self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
     ) -> Optional[int]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
+        old_pk = super().normalize_before_relocation_import(pk_map, scope, flags)
         if old_pk is None:
             return None
 

--- a/src/sentry/models/email.py
+++ b/src/sentry/models/email.py
@@ -7,7 +7,7 @@ from django.forms import model_to_dict
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
+from sentry.backup.dependencies import ImportKind
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import CIEmailField, Model, control_silo_only_model, sane_repr
@@ -32,12 +32,8 @@ class Email(Model):
     __repr__ = sane_repr("email")
 
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
-    ) -> Optional[Tuple[int, int, ImportKind]]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
-        if old_pk is None:
-            return None
-
+        self, _s: ImportScope, _f: ImportFlags
+    ) -> Optional[Tuple[int, ImportKind]]:
         # Ensure that we never attempt to duplicate email entries, as they must always be unique.
         (email, created) = self.__class__.objects.get_or_create(
             email=self.email, defaults=model_to_dict(self)
@@ -46,4 +42,4 @@ class Email(Model):
             self.pk = email.pk
             self.save()
 
-        return (old_pk, self.pk, ImportKind.Inserted if created else ImportKind.Existing)
+        return (self.pk, ImportKind.Inserted if created else ImportKind.Existing)

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Tuple
 from django.db import models
 
 from sentry import projectoptions
-from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
+from sentry.backup.dependencies import ImportKind
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
@@ -163,12 +163,8 @@ class ProjectOption(Model):
     __repr__ = sane_repr("project_id", "key", "value")
 
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
-    ) -> Optional[Tuple[int, int, ImportKind]]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
-        if old_pk is None:
-            return None
-
+        self, _s: ImportScope, _f: ImportFlags
+    ) -> Optional[Tuple[int, ImportKind]]:
         (key, created) = self.__class__.objects.get_or_create(
             project=self.project, key=self.key, defaults={"value": self.value}
         )
@@ -176,4 +172,4 @@ class ProjectOption(Model):
             self.pk = key.pk
             self.save()
 
-        return (old_pk, self.pk, ImportKind.Inserted if created else ImportKind.Existing)
+        return (self.pk, ImportKind.Inserted if created else ImportKind.Existing)

--- a/src/sentry/models/options/user_option.py
+++ b/src/sentry/models/options/user_option.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Tuple
 from django.conf import settings
 from django.db import models
 
-from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
+from sentry.backup.dependencies import ImportKind
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, control_silo_only_model, sane_repr
@@ -206,8 +206,8 @@ class UserOption(Model):
     __repr__ = sane_repr("user_id", "project_id", "organization_id", "key", "value")
 
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
-    ) -> Optional[Tuple[int, int, ImportKind]]:
+        self, scope: ImportScope, flags: ImportFlags
+    ) -> Optional[Tuple[int, ImportKind]]:
         # TODO(getsentry/team-ospo#190): This circular import is a bit gross. See if we can't find a
         # better place for this logic to live.
         from sentry.api.endpoints.user_details import UserOptionsSerializer
@@ -215,4 +215,4 @@ class UserOption(Model):
         serializer_options = UserOptionsSerializer(data={self.key: self.value}, partial=True)
         serializer_options.is_valid(raise_exception=True)
 
-        return super().write_relocation_import(pk_map, scope, flags)
+        return super().write_relocation_import(scope, flags)

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -15,7 +15,7 @@ from django.utils.translation import gettext_lazy as _
 
 from bitfield import TypedClassBitField
 from sentry import features, options
-from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
+from sentry.backup.dependencies import ImportKind
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import (
@@ -286,12 +286,8 @@ class ProjectKey(Model):
         return self.scopes
 
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
-    ) -> Optional[Tuple[int, int, ImportKind]]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
-        if old_pk is None:
-            return None
-
+        self, _s: ImportScope, _f: ImportFlags
+    ) -> Optional[Tuple[int, ImportKind]]:
         # If there is a key collision, generate new keys.
         matching_public_key = self.__class__.objects.filter(public_key=self.public_key).first()
         if not self.public_key or matching_public_key:
@@ -307,4 +303,4 @@ class ProjectKey(Model):
             self.pk = key.pk
             self.save()
 
-        return (old_pk, self.pk, ImportKind.Inserted if created else ImportKind.Existing)
+        return (self.pk, ImportKind.Inserted if created else ImportKind.Existing)

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from sentry.app import env
-from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
+from sentry.backup.dependencies import ImportKind
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.constants import ObjectStatus
@@ -369,11 +369,11 @@ class Team(Model, SnowflakeIdMixin):
 
     # TODO(hybrid-cloud): actor refactor. Remove this method when done.
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
-    ) -> Optional[Tuple[int, int, ImportKind]]:
-        written = super().write_relocation_import(pk_map, scope, flags)
+        self, scope: ImportScope, flags: ImportFlags
+    ) -> Optional[Tuple[int, ImportKind]]:
+        written = super().write_relocation_import(scope, flags)
         if written is not None:
-            (_, new_pk, _) = written
+            (new_pk, _) = written
 
             # `Actor` and `Team` have a direct circular dependency between them for the time being
             # due to an ongoing refactor (that is, `Actor` foreign keys directly into `Team`, and

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -394,10 +394,10 @@ class User(BaseModel, AbstractBaseUser):
     def clear_lost_passwords(self):
         LostPasswordHash.objects.filter(user=self).delete()
 
-    def _normalize_before_relocation_import(
+    def normalize_before_relocation_import(
         self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
     ) -> Optional[int]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
+        old_pk = super().normalize_before_relocation_import(pk_map, scope, flags)
         if old_pk is None:
             return None
 
@@ -418,7 +418,54 @@ class User(BaseModel, AbstractBaseUser):
             self.is_superuser = False
             self.is_managed = False
 
-        lock = locks.get(f"user:username:{self.id}", duration=5, name="username")
+        return old_pk
+
+    def write_relocation_import(
+        self, scope: ImportScope, flags: ImportFlags
+    ) -> Optional[Tuple[int, ImportKind]]:
+        # Internal function that factors our some common logic.
+        def do_write():
+            from sentry.api.endpoints.user_details import (
+                BaseUserSerializer,
+                SuperuserUserSerializer,
+                UserSerializer,
+            )
+            from sentry.services.hybrid_cloud.lost_password_hash import lost_password_hash_service
+
+            serializer_cls = BaseUserSerializer
+            if scope != ImportScope.Global:
+                serializer_cls = UserSerializer
+            else:
+                serializer_cls = SuperuserUserSerializer
+
+            serializer_user = serializer_cls(instance=self, data=model_to_dict(self), partial=True)
+            serializer_user.is_valid(raise_exception=True)
+
+            self.save(force_insert=True)
+
+            # TODO(getsentry/team-ospo#190): the following is an RPC call which could fail for
+            # transient reasons (network etc). How do we handle that?
+            lost_password_hash_service.get_or_create(user_id=self.id)
+
+            # TODO(getsentry/team-ospo#191): we need to send an email informing the user of their
+            # new account with a resettable password - we'll need to figure out where in the process
+            # that actually goes, and how to prevent it from happening during the validation pass.
+
+            return (self.pk, ImportKind.Inserted)
+
+        # If there is no existing user with this `username`, no special renaming or merging
+        # shenanigans are needed, as we can just insert this exact model directly.
+        existing = User.objects.filter(username=self.username).first()
+        if not existing:
+            return do_write()
+
+        # Re-use the existing user if merging is enabled.
+        if flags.merge_users:
+            return (existing.pk, ImportKind.Existing)
+
+        # We already have a user with this `username`, but merging users has not been enabled. In
+        # this case, add a random suffix to the importing username.
+        lock = locks.get(f"user:username:{self.id}", duration=10, name="username")
         with TimedRetryPolicy(10)(lock.acquire):
             unique_db_instance(
                 self,
@@ -427,47 +474,8 @@ class User(BaseModel, AbstractBaseUser):
                 field_name="username",
             )
 
-        return old_pk
-
-    def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
-    ) -> Optional[Tuple[int, int, ImportKind]]:
-        from sentry.api.endpoints.user_details import (
-            BaseUserSerializer,
-            SuperuserUserSerializer,
-            UserSerializer,
-        )
-        from sentry.services.hybrid_cloud.lost_password_hash import lost_password_hash_service
-
-        if flags.merge_users:
-            existing = User.objects.filter(username=self.username).first()
-            if existing:
-                return (self.pk, existing.pk, ImportKind.Existing)
-
-        old_pk = self._normalize_before_relocation_import(pk_map, scope, flags)
-        if old_pk is None:
-            return None
-
-        serializer_cls = BaseUserSerializer
-        if scope != ImportScope.Global:
-            serializer_cls = UserSerializer
-        else:
-            serializer_cls = SuperuserUserSerializer
-
-        serializer_user = serializer_cls(instance=self, data=model_to_dict(self), partial=True)
-        serializer_user.is_valid(raise_exception=True)
-
-        self.save(force_insert=True)
-
-        # TODO(getsentry/team-ospo#190): the following is an RPC call which could fail for transient
-        # reasons (network etc). How do we handle that?
-        lost_password_hash_service.get_or_create(user_id=self.id)
-
-        # TODO(getsentry/team-ospo#191): we need to send an email informing the user of their new
-        # account with a resettable password - we'll need to figure out where in the process that
-        # actually goes, and how to prevent it from happening during the validation pass.
-
-        return (old_pk, self.pk, ImportKind.Inserted)
+            # Perform the remainder of the write while we're still holding the lock.
+            return do_write()
 
 
 # HACK(dcramer): last_login needs nullable for Django 1.8

--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -83,14 +83,14 @@ class UserEmail(Model):
         """@deprecated"""
         return cls.objects.get_primary_email(user)
 
-    def _normalize_before_relocation_import(
+    def normalize_before_relocation_import(
         self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
     ) -> Optional[int]:
         # If we are merging users, ignore this import and use the merged user's data.
         if pk_map.get_kind("sentry.User", self.user_id) == ImportKind.Existing:
             return None
 
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
+        old_pk = super().normalize_before_relocation_import(pk_map, scope, flags)
         if old_pk is None:
             return None
 
@@ -104,16 +104,12 @@ class UserEmail(Model):
         return old_pk
 
     def write_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
-    ) -> Optional[Tuple[int, int, ImportKind]]:
-        old_pk = self._normalize_before_relocation_import(pk_map, scope, flags)
-        if old_pk is None:
-            return None
-
+        self, _s: ImportScope, _f: ImportFlags
+    ) -> Optional[Tuple[int, ImportKind]]:
         useremail = self.__class__.objects.get(user=self.user, email=self.email)
         for f in self._meta.fields:
             if f.name not in ["id", "pk"]:
                 setattr(useremail, f.name, getattr(self, f.name))
         useremail.save()
 
-        return (old_pk, useremail.pk, ImportKind.Existing)
+        return (useremail.pk, ImportKind.Existing)

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -360,10 +360,10 @@ class Monitor(Model):
 
         return None
 
-    def _normalize_before_relocation_import(
+    def normalize_before_relocation_import(
         self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
     ) -> Optional[int]:
-        old_pk = super()._normalize_before_relocation_import(pk_map, scope, flags)
+        old_pk = super().normalize_before_relocation_import(pk_map, scope, flags)
         if old_pk is None:
             return None
 

--- a/tests/sentry/backup/test_models.py
+++ b/tests/sentry/backup/test_models.py
@@ -539,10 +539,43 @@ class DynamicRelocationScopeTests(TransactionTestCase):
         assert auth.get_relocation_scope() == RelocationScope.Global
         assert token.get_relocation_scope() == RelocationScope.Global
 
-    def test_api_auth_not_application_bound(self):
+    def test_api_auth_not_bound(self):
         user = self.create_user()
         auth = ApiAuthorization.objects.create(user=self.create_user("example@example.com"))
         token = ApiToken.objects.create(user=user, token=uuid4().hex, expires_at=None)
 
         assert auth.get_relocation_scope() == RelocationScope.Config
         assert token.get_relocation_scope() == RelocationScope.Config
+
+    def test_notification_action_integration_bound(self):
+        integration = self.create_integration(
+            self.organization, provider="slack", name="Slack 1", external_id="slack:1"
+        )
+        action = self.create_notification_action(
+            organization=self.organization, projects=[self.project], integration_id=integration.id
+        )
+        action_project = NotificationActionProject.objects.get(action=action)
+
+        # TODO(getsentry/team-ospo#188): this should be extension scope once that gets added.
+        assert action.get_relocation_scope() == RelocationScope.Global
+        assert action_project.get_relocation_scope() == RelocationScope.Global
+
+    def test_notification_action_sentry_app_bound(self):
+        app = self.create_sentry_app(name="test_app", organization=self.organization)
+        action = self.create_notification_action(
+            organization=self.organization, projects=[self.project], sentry_app_id=app.id
+        )
+        action_project = NotificationActionProject.objects.get(action=action)
+
+        # TODO(getsentry/team-ospo#188): this should be extension scope once that gets added.
+        assert action.get_relocation_scope() == RelocationScope.Global
+        assert action_project.get_relocation_scope() == RelocationScope.Global
+
+    def test_notification_action_not_bound(self):
+        action = self.create_notification_action(
+            organization=self.organization, projects=[self.project]
+        )
+        action_project = NotificationActionProject.objects.get(action=action)
+
+        assert action.get_relocation_scope() == RelocationScope.Organization
+        assert action_project.get_relocation_scope() == RelocationScope.Organization


### PR DESCRIPTION
Previously, the `_normalize_before_relocation_import()` method was intended to be called as part of `write_relocation_import()`. This change makes it standalone method that the import script calls on its own. This has a few benefits:

- Simpler function signatures, since we don't need to pipe all of `normalize...`'s arguments through `write...` anymore.
- A simple two-tuple return from `write...`.
- Less error prone: rather than every override of `write...` needing to remember to call `normalize...`, we just need to remember to do it once (in the `_import()` function that orchestrates all of the calls).
- Finally: the next change we make will call `get_relocation_scope` AFTER we normalize, so that we can look up ForeignKey references on the model being imported without failing.

Issue: getsentry/team-ospo#199