### PR TITLE
Add a requires_kafka fixture and add it to symbolicator

### DIFF
--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -71,6 +71,15 @@ def _requires_relay() -> None:
 
 
 @pytest.fixture(scope="session")
+def _requires_kafka() -> None:
+    kafka_conf = settings.SENTRY_DEVSERVICES["kafka"](settings, {})
+    (port,) = kafka_conf["ports"].values()
+
+    if not _service_available("127.0.0.1", port):
+        pytest.skip("requires kafka server running")
+
+
+@pytest.fixture(scope="session")
 def _requires_symbolicator() -> None:
     symbolicator_conf = settings.SENTRY_DEVSERVICES["symbolicator"](settings, {})
     (port,) = symbolicator_conf["ports"].values()
@@ -82,3 +91,4 @@ def _requires_symbolicator() -> None:
 requires_snuba = pytest.mark.usefixtures("_requires_snuba")
 requires_relay = pytest.mark.usefixtures("_requires_relay")
 requires_symbolicator = pytest.mark.usefixtures("_requires_symbolicator")
+requires_kafka = pytest.mark.usefixtures("_requires_kafka")

--- a/tests/relay_integration/lang/javascript/test_example.py
+++ b/tests/relay_integration/lang/javascript/test_example.py
@@ -17,7 +17,7 @@ from sentry.testutils.skips import requires_kafka, requires_symbolicator
 # to `system.internal-url-prefix` inside `initialize` method below, or add `127.0.0.1 host.docker.internal`
 # entry to your `/etc/hosts`
 
-# TODO: Symbolicator tests also need zookeeper
+
 pytestmark = [requires_symbolicator, requires_kafka]
 
 

--- a/tests/relay_integration/lang/javascript/test_example.py
+++ b/tests/relay_integration/lang/javascript/test_example.py
@@ -6,7 +6,7 @@ from sentry.models import File, Release, ReleaseFile
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_symbolicator
+from sentry.testutils.skips import requires_kafka, requires_symbolicator
 
 # IMPORTANT:
 #
@@ -16,6 +16,9 @@ from sentry.testutils.skips import requires_symbolicator
 # If you are using a local instance of Symbolicator, you need to either change `system.url-prefix`
 # to `system.internal-url-prefix` inside `initialize` method below, or add `127.0.0.1 host.docker.internal`
 # entry to your `/etc/hosts`
+
+# TODO: Symbolicator tests also need zookeeper
+pytestmark = [requires_symbolicator, requires_kafka]
 
 
 def get_fixture_path(name):

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -43,7 +43,7 @@ from sentry.utils import json
 # to `system.internal-url-prefix` inside `initialize` method below, or add `127.0.0.1 host.docker.internal`
 # entry to your `/etc/hosts`
 
-# TODO: Symbolicator tests also need zookeeper
+
 pytestmark = [requires_symbolicator, requires_kafka]
 
 BASE64_SOURCEMAP = "data:application/json;base64," + (

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -31,7 +31,7 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_symbolicator
+from sentry.testutils.skips import requires_kafka, requires_symbolicator
 from sentry.utils import json
 
 # IMPORTANT:
@@ -42,6 +42,9 @@ from sentry.utils import json
 # If you are using a local instance of Symbolicator, you need to either change `system.url-prefix`
 # to `system.internal-url-prefix` inside `initialize` method below, or add `127.0.0.1 host.docker.internal`
 # entry to your `/etc/hosts`
+
+# TODO: Symbolicator tests also need zookeeper
+pytestmark = [requires_symbolicator, requires_kafka]
 
 BASE64_SOURCEMAP = "data:application/json;base64," + (
     b64encode(

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -13,7 +13,7 @@ from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_symbolicator
+from sentry.testutils.skips import requires_kafka, requires_symbolicator
 from sentry.utils.safe import get_path
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
 
@@ -27,8 +27,8 @@ from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_loc
 # or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
 
 
-# TODO: Symbolicator tests also need kafka + zookeeper
-pytestmark = requires_symbolicator
+# TODO: Symbolicator tests also need zookeeper
+pytestmark = [requires_symbolicator, requires_kafka]
 
 
 @pytest.mark.snuba

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -27,7 +27,6 @@ from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_loc
 # or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
 
 
-# TODO: Symbolicator tests also need zookeeper
 pytestmark = [requires_symbolicator, requires_kafka]
 
 

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -36,7 +36,6 @@ from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_loc
 # or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
 
 
-# TODO: Symbolicator tests also need zookeeper
 pytestmark = [requires_symbolicator, requires_kafka]
 
 REAL_RESOLVING_EVENT_DATA = {

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -22,7 +22,7 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_symbolicator
+from sentry.testutils.skips import requires_kafka, requires_symbolicator
 from sentry.utils import json
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
 
@@ -36,8 +36,8 @@ from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_loc
 # or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
 
 
-# TODO: Symbolicator tests also need kafka + zookeeper
-pytestmark = requires_symbolicator
+# TODO: Symbolicator tests also need zookeeper
+pytestmark = [requires_symbolicator, requires_kafka]
 
 REAL_RESOLVING_EVENT_DATA = {
     "platform": "cocoa",

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -25,7 +25,6 @@ from tests.symbolicator import normalize_native_exception
 # or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
 
 
-# TODO: Symbolicator tests also need zookeeper
 pytestmark = [requires_symbolicator, requires_kafka]
 
 

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -11,7 +11,7 @@ from sentry.models import EventAttachment, File
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_symbolicator
+from sentry.testutils.skips import requires_kafka, requires_symbolicator
 from sentry.utils.safe import get_path
 from tests.symbolicator import normalize_native_exception
 
@@ -25,8 +25,8 @@ from tests.symbolicator import normalize_native_exception
 # or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
 
 
-# TODO: Symbolicator tests also need kafka + zookeeper
-pytestmark = requires_symbolicator
+# TODO: Symbolicator tests also need zookeeper
+pytestmark = [requires_symbolicator, requires_kafka]
 
 
 def get_unreal_crash_file():


### PR DESCRIPTION
The symbolicator tests fails if kafka is not started, this PR adds a `requires_kafka` marker and adds it to the symbolicator tests.

I'm not sure if one marker is preferred instead of two (i.e. `requires_symbolicator` could check symbolicator and kafka is up, the downside there is if you really do just need symbolicator, requires_symbolicator will require more services than a test actually needs).