### PR TITLE
fix(metrics): Add batching to killswitch metrics

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -123,7 +123,11 @@ class IndexerBatch:
                 "sentry-metrics.indexer.disabled-namespaces"
             ):
                 self.skipped_offsets.add(partition_offset)
-                metrics.incr("process_messages.namespace_disabled", tags={"namespace": namespace})
+                metrics.incr(
+                    "process_messages.namespace_disabled",
+                    sample_rate=0.001,
+                    tags={"namespace": namespace},
+                )
                 continue
             try:
                 parsed_payload: ParsedMessage = json.loads(

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -115,19 +115,18 @@ class IndexerBatch:
         self.skipped_offsets: Set[PartitionIdxOffset] = set()
         self.parsed_payloads_by_offset: MutableMapping[PartitionIdxOffset, ParsedMessage] = {}
 
+        disabled_msgs_cnt: MutableMapping[str, int] = defaultdict(int)
+
         for msg in self.outer_message.payload:
             assert isinstance(msg.value, BrokerValue)
             partition_offset = PartitionIdxOffset(msg.value.partition.index, msg.value.offset)
 
-            if namespace := self._extract_namespace(msg.payload.headers) in options.get(
+            if (namespace := self._extract_namespace(msg.payload.headers)) in options.get(
                 "sentry-metrics.indexer.disabled-namespaces"
             ):
+                assert namespace
                 self.skipped_offsets.add(partition_offset)
-                metrics.incr(
-                    "process_messages.namespace_disabled",
-                    sample_rate=0.001,
-                    tags={"namespace": namespace},
-                )
+                disabled_msgs_cnt[namespace] += 1
                 continue
             try:
                 parsed_payload: ParsedMessage = json.loads(
@@ -182,6 +181,13 @@ class IndexerBatch:
             _: IngestMetric = parsed_payload
 
             self.parsed_payloads_by_offset[partition_offset] = parsed_payload
+
+        for namespace, cnt in disabled_msgs_cnt.items():
+            metrics.incr(
+                "process_messages.namespace_disabled",
+                amount=cnt,
+                tags={"namespace": namespace},
+            )
 
     @metrics.wraps("process_messages.filter_messages")
     def filter_messages(self, keys_to_remove: Sequence[PartitionIdxOffset]) -> None:


### PR DESCRIPTION
### Overview

We observed lower message processing performance than we would like during incidents where we enable killswitch on  high volume use case.
This PR Incurment the number of message skipped by killswitch metric at the end of a batch instead of with each message.