### PR TITLE
feat(replays): empty list pages for rage and dead click selectors

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1362,10 +1362,17 @@ function buildRoutes() {
   const replayChildRoutes = (
     <Fragment>
       <IndexRoute component={make(() => import('sentry/views/replays/list'))} />
-      <Route
-        path=":replaySlug/"
-        component={make(() => import('sentry/views/replays/details'))}
-      />
+      <Route>
+        path=":replaySlug/" component={make(() => import('sentry/views/replays/details'))}
+        <Route
+          path="dead-clicks/"
+          component={make(() => import('sentry/views/replays/deadClickList'))}
+        />
+        <Route
+          path=":rage-clicks/"
+          component={make(() => import('sentry/views/replays/rageClickList'))}
+        />
+      </Route>
     </Fragment>
   );
   const replayRoutes = (

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1362,17 +1362,18 @@ function buildRoutes() {
   const replayChildRoutes = (
     <Fragment>
       <IndexRoute component={make(() => import('sentry/views/replays/list'))} />
-      <Route>
-        path=":replaySlug/" component={make(() => import('sentry/views/replays/details'))}
-        <Route
-          path="dead-clicks/"
-          component={make(() => import('sentry/views/replays/deadClickList'))}
-        />
-        <Route
-          path=":rage-clicks/"
-          component={make(() => import('sentry/views/replays/rageClickList'))}
-        />
-      </Route>
+      <Route
+        path="dead-clicks/"
+        component={make(() => import('sentry/views/replays/deadClickList'))}
+      />
+      <Route
+        path="rage-clicks/"
+        component={make(() => import('sentry/views/replays/rageClickList'))}
+      />
+      <Route
+        path=":replaySlug/"
+        component={make(() => import('sentry/views/replays/details'))}
+      />
     </Fragment>
   );
   const replayRoutes = (

--- a/static/app/views/replays/deadClickList.tsx
+++ b/static/app/views/replays/deadClickList.tsx
@@ -13,7 +13,7 @@ export default function DeadClickList() {
   );
   return hasDeadCicks ? (
     <SentryDocumentTitle
-      title={t('Top Selectors with Rage Clicks')}
+      title={t('Top Selectors with Dead Clicks')}
       orgSlug={organization.slug}
     >
       <Layout.Header>

--- a/static/app/views/replays/deadClickList.tsx
+++ b/static/app/views/replays/deadClickList.tsx
@@ -1,3 +1,4 @@
+import Alert from 'sentry/components/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
@@ -10,9 +11,11 @@ export default function DeadClickList() {
   const hasDeadCicks = organization.features.includes(
     'session-replay-rage-dead-selectors'
   );
-
   return hasDeadCicks ? (
-    <SentryDocumentTitle title={`Top Selectors with Dead Clicks — ${organization.slug}`}>
+    <SentryDocumentTitle
+      title={t('Top Selectors with Rage Clicks')}
+      orgSlug={organization.slug}
+    >
       <Layout.Header>
         <Layout.HeaderContent>
           <Layout.Title>
@@ -30,5 +33,9 @@ export default function DeadClickList() {
         </Layout.Body>
       </PageFiltersContainer>
     </SentryDocumentTitle>
-  ) : null;
+  ) : (
+    <Layout.Page withPadding>
+      <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+    </Layout.Page>
+  );
 }

--- a/static/app/views/replays/deadClickList.tsx
+++ b/static/app/views/replays/deadClickList.tsx
@@ -1,0 +1,34 @@
+import * as Layout from 'sentry/components/layouts/thirds';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function DeadClickList() {
+  const organization = useOrganization();
+  const hasDeadCicks = organization.features.includes(
+    'session-replay-rage-dead-selectors'
+  );
+
+  return hasDeadCicks ? (
+    <SentryDocumentTitle title={`Top Selectors with Dead Clicks — ${organization.slug}`}>
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Layout.Title>
+            {t('Top Selectors with Dead Clicks')}
+            <PageHeadingQuestionTooltip
+              title={t('See the top selectors your users have dead clicked on.')}
+              docsUrl="https://docs.sentry.io/product/session-replay/replay-page-and-filters/"
+            />
+          </Layout.Title>
+        </Layout.HeaderContent>
+      </Layout.Header>
+      <PageFiltersContainer>
+        <Layout.Body>
+          <Layout.Main fullWidth>TODO</Layout.Main>
+        </Layout.Body>
+      </PageFiltersContainer>
+    </SentryDocumentTitle>
+  ) : null;
+}

--- a/static/app/views/replays/rageClickList.tsx
+++ b/static/app/views/replays/rageClickList.tsx
@@ -1,3 +1,4 @@
+import Alert from 'sentry/components/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
@@ -12,7 +13,10 @@ export default function RageClickList() {
   );
 
   return hasRageCicks ? (
-    <SentryDocumentTitle title={`Top Selectors with Rage Clicks — ${organization.slug}`}>
+    <SentryDocumentTitle
+      title={t('Top Selectors with Rage Clicks')}
+      orgSlug={organization.slug}
+    >
       <Layout.Header>
         <Layout.HeaderContent>
           <Layout.Title>
@@ -30,5 +34,9 @@ export default function RageClickList() {
         </Layout.Body>
       </PageFiltersContainer>
     </SentryDocumentTitle>
-  ) : null;
+  ) : (
+    <Layout.Page withPadding>
+      <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+    </Layout.Page>
+  );
 }

--- a/static/app/views/replays/rageClickList.tsx
+++ b/static/app/views/replays/rageClickList.tsx
@@ -1,0 +1,34 @@
+import * as Layout from 'sentry/components/layouts/thirds';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function RageClickList() {
+  const organization = useOrganization();
+  const hasRageCicks = organization.features.includes(
+    'session-replay-rage-dead-selectors'
+  );
+
+  return hasRageCicks ? (
+    <SentryDocumentTitle title={`Top Selectors with Rage Clicks — ${organization.slug}`}>
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Layout.Title>
+            {t('Top Selectors with Rage Clicks')}
+            <PageHeadingQuestionTooltip
+              title={t('See the top selectors your users have rage clicked on.')}
+              docsUrl="https://docs.sentry.io/product/session-replay/replay-page-and-filters/"
+            />
+          </Layout.Title>
+        </Layout.HeaderContent>
+      </Layout.Header>
+      <PageFiltersContainer>
+        <Layout.Body>
+          <Layout.Main fullWidth>TODO</Layout.Main>
+        </Layout.Body>
+      </PageFiltersContainer>
+    </SentryDocumentTitle>
+  ) : null;
+}


### PR DESCRIPTION
## The vision:

- These are the pages the user will see once they click "show more" on the widgets (on the Replays Index page). 
- It will be populated with a list of all selectors with rage/dead clicks.
- Clicking on a specific selector row will route back to the Replays Index page, with the search bar filter set.


<img width="1451" alt="SCR-20230914-kebx" src="https://github.com/getsentry/sentry/assets/56095982/10173e5e-fb06-42e4-9444-d83716c83f07">
<img width="1362" alt="SCR-20230914-kjts" src="https://github.com/getsentry/sentry/assets/56095982/ce491092-f4d5-4d8d-88e9-af6b922c6d33">


Orgs who don't fall under the feature flag will see this:
<img width="1419" alt="SCR-20230914-kujc" src="https://github.com/getsentry/sentry/assets/56095982/f2d0c302-1551-4291-aba9-8d1d29e3ef00">

Closes 
https://github.com/getsentry/team-replay/issues/181
