### PR TITLE
bug(useProjectSdkNeedsUpdate): Rewrite useProjectSdkNeedsUpdate

### DIFF
--- a/static/app/utils/useProjectSdkNeedsUpdate.spec.tsx
+++ b/static/app/utils/useProjectSdkNeedsUpdate.spec.tsx
@@ -32,22 +32,6 @@ function mockCurrentVersion(
   });
 }
 describe('useProjectSdkNeedsUpdate', () => {
-  // it('should return isFetching=true when sdk updates are not yet resolved', () => {
-  //   // mockUseProjectSdkUpdates.mockReturnValue({
-  //   //   type: 'initial',
-  //   // });
-
-  //   const {result} = reactHooks.renderHook(useProjectSdkNeedsUpdate, {
-  //     initialProps: {
-  //       minVersion: '1.0.0',
-  //       organization: MOCK_ORG,
-  //       projectId: [MOCK_PROJECT.id],
-  //     },
-  //   });
-  //   expect(result.current.isFetching).toBeTruthy();
-  //   expect(result.current.needsUpdate).toBeUndefined();
-  // });
-
   it('should not need an update if the sdk version is above the min version', async () => {
     mockCurrentVersion([
       {

--- a/static/app/utils/useProjectSdkNeedsUpdate.spec.tsx
+++ b/static/app/utils/useProjectSdkNeedsUpdate.spec.tsx
@@ -1,11 +1,18 @@
+import {ReactNode} from 'react';
+
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
+import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
 import useProjectSdkNeedsUpdate from 'sentry/utils/useProjectSdkNeedsUpdate';
-import {useProjectSdkUpdates} from 'sentry/utils/useProjectSdkUpdates';
 
-jest.mock('sentry/utils/useProjectSdkUpdates');
+const client = new QueryClient();
 
-const mockUseProjectSdkUpdates = jest.mocked(useProjectSdkUpdates);
+const MOCK_ORG = TestStubs.Organization();
+const MOCK_PROJECT = TestStubs.Project();
+
+function wrapper({children}: {children?: ReactNode}) {
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
 
 function mockCurrentVersion(
   mockUpdates: Array<{
@@ -13,10 +20,10 @@ function mockCurrentVersion(
     sdkVersion: string;
   }>
 ) {
-  mockUseProjectSdkUpdates.mockReturnValue({
-    type: 'resolved',
-    // @ts-expect-error the return type is overloaded and ts seems to want the first return type of ProjectSdkUpdate
-    data: mockUpdates.map(({projectId, sdkVersion}) => ({
+  MockApiClient.addMockResponse({
+    url: `/organizations/${MOCK_ORG.slug}/sdk-updates/`,
+    method: 'GET',
+    body: mockUpdates.map(({projectId, sdkVersion}) => ({
       projectId,
       sdkName: 'javascript',
       sdkVersion,
@@ -25,61 +32,70 @@ function mockCurrentVersion(
   });
 }
 describe('useProjectSdkNeedsUpdate', () => {
-  it('should return isFetching=true when sdk updates are not yet resolved', () => {
-    mockUseProjectSdkUpdates.mockReturnValue({
-      type: 'initial',
-    });
+  // it('should return isFetching=true when sdk updates are not yet resolved', () => {
+  //   // mockUseProjectSdkUpdates.mockReturnValue({
+  //   //   type: 'initial',
+  //   // });
 
-    const {result} = reactHooks.renderHook(useProjectSdkNeedsUpdate, {
-      initialProps: {
-        minVersion: '1.0.0',
-        organization: TestStubs.Organization(),
-        projectId: [TestStubs.Project().id],
-      },
-    });
-    expect(result.current.isFetching).toBeTruthy();
-    expect(result.current.needsUpdate).toBeUndefined();
-  });
+  //   const {result} = reactHooks.renderHook(useProjectSdkNeedsUpdate, {
+  //     initialProps: {
+  //       minVersion: '1.0.0',
+  //       organization: MOCK_ORG,
+  //       projectId: [MOCK_PROJECT.id],
+  //     },
+  //   });
+  //   expect(result.current.isFetching).toBeTruthy();
+  //   expect(result.current.needsUpdate).toBeUndefined();
+  // });
 
-  it('should not need an update if the sdk version is above the min version', () => {
+  it('should not need an update if the sdk version is above the min version', async () => {
     mockCurrentVersion([
       {
-        projectId: TestStubs.Project().id,
+        projectId: MOCK_PROJECT.id,
         sdkVersion: '3.0.0',
       },
     ]);
 
-    const {result} = reactHooks.renderHook(useProjectSdkNeedsUpdate, {
+    const {result, waitFor} = reactHooks.renderHook(useProjectSdkNeedsUpdate, {
+      wrapper,
       initialProps: {
         minVersion: '1.0.0',
-        organization: TestStubs.Organization(),
-        projectId: [TestStubs.Project().id],
+        organization: MOCK_ORG,
+        projectId: [MOCK_PROJECT.id],
       },
     });
-    expect(result.current.isFetching).toBeFalsy();
-    expect(result.current.needsUpdate).toBeFalsy();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBeFalsy();
+      expect(result.current.isFetching).toBeFalsy();
+      expect(result.current.needsUpdate).toBeFalsy();
+    });
   });
 
-  it('should be updated it the sdk version is too low', () => {
+  it('should be updated it the sdk version is too low', async () => {
     mockCurrentVersion([
       {
-        projectId: TestStubs.Project().id,
+        projectId: MOCK_PROJECT.id,
         sdkVersion: '3.0.0',
       },
     ]);
 
-    const {result} = reactHooks.renderHook(useProjectSdkNeedsUpdate, {
+    const {result, waitFor} = reactHooks.renderHook(useProjectSdkNeedsUpdate, {
+      wrapper,
       initialProps: {
         minVersion: '8.0.0',
-        organization: TestStubs.Organization(),
-        projectId: [TestStubs.Project().id],
+        organization: MOCK_ORG,
+        projectId: [MOCK_PROJECT.id],
       },
     });
-    expect(result.current.isFetching).toBeFalsy();
-    expect(result.current.needsUpdate).toBeTruthy();
+    await waitFor(() => {
+      expect(result.current.isError).toBeFalsy();
+      expect(result.current.isFetching).toBeFalsy();
+      expect(result.current.needsUpdate).toBeTruthy();
+    });
   });
 
-  it('should return needsUpdate if multiple projects', () => {
+  it('should return needsUpdate if multiple projects', async () => {
     mockCurrentVersion([
       {
         projectId: '1',
@@ -91,18 +107,23 @@ describe('useProjectSdkNeedsUpdate', () => {
       },
     ]);
 
-    const {result} = reactHooks.renderHook(useProjectSdkNeedsUpdate, {
+    const {result, waitFor} = reactHooks.renderHook(useProjectSdkNeedsUpdate, {
+      wrapper,
       initialProps: {
         minVersion: '8.0.0',
-        organization: TestStubs.Organization(),
+        organization: MOCK_ORG,
         projectId: ['1', '2'],
       },
     });
-    expect(result.current.isFetching).toBeFalsy();
-    expect(result.current.needsUpdate).toBeTruthy();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBeFalsy();
+      expect(result.current.isFetching).toBeFalsy();
+      expect(result.current.needsUpdate).toBeTruthy();
+    });
   });
 
-  it('should not return needsUpdate if some projects meet minSdk', () => {
+  it('should not return needsUpdate if some projects meet minSdk', async () => {
     mockCurrentVersion([
       {
         projectId: '1',
@@ -114,14 +135,19 @@ describe('useProjectSdkNeedsUpdate', () => {
       },
     ]);
 
-    const {result} = reactHooks.renderHook(useProjectSdkNeedsUpdate, {
+    const {result, waitFor} = reactHooks.renderHook(useProjectSdkNeedsUpdate, {
+      wrapper,
       initialProps: {
         minVersion: '8.0.0',
-        organization: TestStubs.Organization(),
+        organization: MOCK_ORG,
         projectId: ['1', '2'],
       },
     });
-    expect(result.current.isFetching).toBeFalsy();
-    expect(result.current.needsUpdate).toBeFalsy();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBeFalsy();
+      expect(result.current.isFetching).toBeFalsy();
+      expect(result.current.needsUpdate).toBeFalsy();
+    });
   });
 });

--- a/static/app/utils/useProjectSdkNeedsUpdate.tsx
+++ b/static/app/utils/useProjectSdkNeedsUpdate.tsx
@@ -20,7 +20,7 @@ function useProjectSdkNeedsUpdate({
   | {isError: false; isFetching: false; needsUpdate: boolean} {
   const {data, isLoading, isError} = useApiQuery<ProjectSdkUpdates[]>(
     [`/organizations/${organization.slug}/sdk-updates/`],
-    {staleTime: 5000}
+    {staleTime: 0}
   );
 
   if (isLoading) {

--- a/static/app/views/replays/detail/network/details/content.spec.tsx
+++ b/static/app/views/replays/detail/network/details/content.spec.tsx
@@ -8,7 +8,9 @@ import type {TabKey} from 'sentry/views/replays/detail/network/details/tabs';
 jest.mock('sentry/utils/useProjectSdkNeedsUpdate');
 
 function mockNeedsUpdate(needsUpdate: boolean) {
-  jest.mocked(useProjectSdkNeedsUpdate).mockReturnValue({isFetching: false, needsUpdate});
+  jest
+    .mocked(useProjectSdkNeedsUpdate)
+    .mockReturnValue({isError: false, isFetching: false, needsUpdate});
 }
 
 const [

--- a/static/app/views/replays/detail/network/details/onboarding.spec.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.spec.tsx
@@ -21,7 +21,7 @@ const [MOCK_ITEM] = hydrateSpans(TestStubs.ReplayRecord(), [
 describe('Setup', () => {
   jest
     .mocked(useProjectSdkNeedsUpdate)
-    .mockReturnValue({isFetching: false, needsUpdate: false});
+    .mockReturnValue({isError: false, isFetching: false, needsUpdate: false});
 
   describe('Setup is not complete', () => {
     it('should render the full snippet when no setup is done yet', () => {

--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -131,7 +131,7 @@ export function Setup({
     organization,
     projectId: [projectId],
   });
-  const sdkNeedsUpdate = !isFetching && needsUpdate;
+  const sdkNeedsUpdate = !isFetching && Boolean(needsUpdate);
 
   const url = item.description || 'http://example.com';
 

--- a/static/app/views/replays/list/listContent.spec.tsx
+++ b/static/app/views/replays/list/listContent.spec.tsx
@@ -75,6 +75,7 @@ describe('ReplayList', () => {
       hasSentOneReplay: false,
     });
     mockUseProjectSdkNeedsUpdate.mockReturnValue({
+      isError: false,
       isFetching: false,
       needsUpdate: false,
     });
@@ -96,6 +97,7 @@ describe('ReplayList', () => {
       hasSentOneReplay: true,
     });
     mockUseProjectSdkNeedsUpdate.mockReturnValue({
+      isError: false,
       isFetching: false,
       needsUpdate: false,
     });
@@ -117,6 +119,7 @@ describe('ReplayList', () => {
       hasSentOneReplay: false,
     });
     mockUseProjectSdkNeedsUpdate.mockReturnValue({
+      isError: false,
       isFetching: false,
       needsUpdate: false,
     });
@@ -138,6 +141,7 @@ describe('ReplayList', () => {
       hasSentOneReplay: true,
     });
     mockUseProjectSdkNeedsUpdate.mockReturnValue({
+      isError: false,
       isFetching: false,
       needsUpdate: true,
     });
@@ -166,6 +170,7 @@ describe('ReplayList', () => {
       hasSentOneReplay: true,
     });
     mockUseProjectSdkNeedsUpdate.mockReturnValue({
+      isError: false,
       isFetching: false,
       needsUpdate: false,
     });


### PR DESCRIPTION
There's a bug in the old code. When the api response is `[]` it gets stuck in `isLoading=true` state forever.

This rewrite simplifies everything, and removes an extra layer. Fixing the bug. 

Fixes https://github.com/getsentry/team-replay/issues/183