### PR TITLE
feat(notifications): remove unused functions and delete new notification settings rows

### DIFF
--- a/src/sentry/models/integrations/external_actor.py
+++ b/src/sentry/models/integrations/external_actor.py
@@ -69,6 +69,7 @@ class ExternalActor(DefaultFieldsModel):
                 install = integration.get_installation(organization_id=self.organization.id)
                 team = self.team
                 install.notify_remove_external_team(external_team=self, team=team)
+                # Does the provider need to be an input?
                 notifications_service.remove_notification_settings_for_team(
                     team_id=team.id, provider=ExternalProviders(self.provider)
                 )

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -306,6 +306,11 @@ class NotificationsManager(BaseManager["NotificationSetting"]):  # noqa: F821
 
         return self.filter(query)
 
+    # only used in tests
+    def remove_for_user(self, user: User, type: NotificationSettingTypes | None = None) -> None:
+        """Bulk delete all Notification Settings for a USER, optionally by type."""
+        self._filter(user_ids=[user.id], type=type).delete()
+
     def remove_for_project(
         self, project_id: int, type: NotificationSettingTypes | None = None
     ) -> None:

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -306,19 +306,6 @@ class NotificationsManager(BaseManager["NotificationSetting"]):  # noqa: F821
 
         return self.filter(query)
 
-    def remove_for_user(self, user: User, type: NotificationSettingTypes | None = None) -> None:
-        """Bulk delete all Notification Settings for a USER, optionally by type."""
-        self._filter(user_ids=[user.id], type=type).delete()
-
-    def remove_for_team(
-        self,
-        team: Team,
-        type: NotificationSettingTypes | None = None,
-        provider: ExternalProviders | None = None,
-    ) -> None:
-        """Bulk delete all Notification Settings for a TEAM, optionally by type."""
-        self._filter(team_ids=[team.id], provider=provider, type=type).delete()
-
     def remove_for_project(
         self, project_id: int, type: NotificationSettingTypes | None = None
     ) -> None:

--- a/src/sentry/services/hybrid_cloud/notifications/impl.py
+++ b/src/sentry/services/hybrid_cloud/notifications/impl.py
@@ -172,8 +172,8 @@ class DatabaseBackedNotificationsService(NotificationsService):
             team_ids=team_ids, user_ids=user_ids, provider=provider
         ).delete()
         # delete all options for team/user
-        NotificationSettingOption.objects.filter(team_id__in=team_ids, user_id__in=user_ids)
-        NotificationSettingProvider.objects.filter(team_id__in=team_ids, user_id__in=user_ids)
+        NotificationSettingOption.objects.filter(team_id__in=team_ids, user_id__in=user_ids).delete()
+        NotificationSettingProvider.objects.filter(team_id__in=team_ids, user_id__in=user_ids).delete()
 
     def remove_notification_settings_for_team(
         self, *, team_id: int, provider: ExternalProviders

--- a/src/sentry/services/hybrid_cloud/notifications/impl.py
+++ b/src/sentry/services/hybrid_cloud/notifications/impl.py
@@ -172,12 +172,9 @@ class DatabaseBackedNotificationsService(NotificationsService):
             team_ids=team_ids, user_ids=user_ids, provider=provider
         ).delete()
         # delete all options for team/user
-        NotificationSettingOption.objects.filter(
-            team_id__in=team_ids, user_id__in=user_ids
-        ).delete()
-        NotificationSettingProvider.objects.filter(
-            team_id__in=team_ids, user_id__in=user_ids
-        ).delete()
+        query_args = {"team_id": team_id, "user_id": user_id}
+        NotificationSettingOption.objects.filter(**query_args).delete()
+        NotificationSettingProvider.objects.filter(**query_args).delete()
 
     def remove_notification_settings_for_team(
         self, *, team_id: int, provider: ExternalProviders

--- a/src/sentry/services/hybrid_cloud/notifications/impl.py
+++ b/src/sentry/services/hybrid_cloud/notifications/impl.py
@@ -172,8 +172,12 @@ class DatabaseBackedNotificationsService(NotificationsService):
             team_ids=team_ids, user_ids=user_ids, provider=provider
         ).delete()
         # delete all options for team/user
-        NotificationSettingOption.objects.filter(team_id__in=team_ids, user_id__in=user_ids).delete()
-        NotificationSettingProvider.objects.filter(team_id__in=team_ids, user_id__in=user_ids).delete()
+        NotificationSettingOption.objects.filter(
+            team_id__in=team_ids, user_id__in=user_ids
+        ).delete()
+        NotificationSettingProvider.objects.filter(
+            team_id__in=team_ids, user_id__in=user_ids
+        ).delete()
 
     def remove_notification_settings_for_team(
         self, *, team_id: int, provider: ExternalProviders

--- a/src/sentry/services/hybrid_cloud/notifications/service.py
+++ b/src/sentry/services/hybrid_cloud/notifications/service.py
@@ -106,13 +106,6 @@ class NotificationsService(RpcService):
 
     @rpc_method
     @abstractmethod
-    def remove_notification_settings_for_user(
-        self, *, user_id: int, provider: ExternalProviders
-    ) -> None:
-        pass
-
-    @rpc_method
-    @abstractmethod
     def get_many(self, *, filter: NotificationSettingFilterArgs) -> List[RpcNotificationSetting]:
         pass
 

--- a/tests/sentry/models/test_notificationsetting.py
+++ b/tests/sentry/models/test_notificationsetting.py
@@ -1,4 +1,6 @@
 from sentry.models.notificationsetting import NotificationSetting
+from sentry.models.notificationsettingoption import NotificationSettingOption
+from sentry.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.models.user import User
 from sentry.notifications.types import (
     NotificationScopeType,
@@ -8,6 +10,7 @@ from sentry.notifications.types import (
 from sentry.silo import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs_control
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import Feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.types.integrations import ExternalProviders
@@ -19,15 +22,18 @@ def _get_kwargs(kwargs):
     )
 
 
-def assert_no_notification_settings(**kwargs):
-    assert NotificationSetting.objects._filter(**kwargs).count() == 0
+def assert_no_notification_settings():
+    assert NotificationSetting.objects.all().count() == 0
+    assert NotificationSettingOption.objects.all().count() == 0
+    assert NotificationSettingProvider.objects.all().count() == 0
 
 
 def create_setting(**kwargs):
-    NotificationSetting.objects.update_settings(
-        value=NotificationSettingOptionValues.ALWAYS,
-        **_get_kwargs(kwargs),
-    )
+    with Feature({"organizations:notifications-double-write": True}):
+        NotificationSetting.objects.update_settings(
+            value=NotificationSettingOptionValues.ALWAYS,
+            **_get_kwargs(kwargs),
+        )
 
 
 @control_silo_test(stable=True)


### PR DESCRIPTION
This PR deletes rows from the `NotificationSettingOption` and `NotificationSettingProvider` when the project, team, or organization is removed. Not using a feature flag here since there's no harm in deleting rows that don't exist if the user still is using the old notification system. It also removes some unused cleanup functions.

Note that it seems we don't delete data when a user is deleted for the old `NotificationSetting` which seems like a gap. But it shouldn't be a huge deal.