### PR TITLE
feat(starfish): Add a span waterfall aggregation endpoint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -260,6 +260,7 @@ yarn.lock                                                @getsentry/owners-js-de
 
 ## Starfish
 /src/sentry/api/endpoints/organization_events_facets_stats_performance.py           @getsentry/team-starfish
+/src/sentry/api/endpoints/organization_spans_aggregation.py                         @getsentry/team-starfish
 /src/sentry/api/endpoints/organization_events_starfish.py                           @getsentry/team-starfish
 /tests/snuba/api/endpoints/test_organization_events_facets_stats_performance.py     @getsentry/team-starfish
 

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -1,6 +1,6 @@
 import hashlib
 from collections import defaultdict, namedtuple
-from typing import Tuple, TypedDict
+from typing import List, TypedDict
 
 from rest_framework import status
 from rest_framework.request import Request
@@ -17,12 +17,6 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.utils.snuba import raw_snql_query
 
-
-class EventSpans(TypedDict):
-    transaction_id: str
-    spans: Tuple[str, str, str, str, str, int, int]
-
-
 EventSpan = namedtuple(
     "EventSpan",
     [
@@ -37,6 +31,13 @@ EventSpan = namedtuple(
         "exclusive_time",
     ],
 )
+
+
+class EventSpans(TypedDict):
+    transaction_id: str
+    spans: List[EventSpan]
+
+
 NULL_GROUP = "00"
 
 
@@ -202,6 +203,7 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
                 "description": description,
                 "start_ms": start_ms,
                 "avg(exclusive_time)": span_tree["exclusive_time"],
+                "is_segment": span_tree["is_segment"],
                 "avg(offset)": start_ms
                 - root_start_timestamp,  # offset of the span relative to the start timestamp of the root span
                 "count()": 1,

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -1,6 +1,7 @@
 import hashlib
+from ast import Dict
 from collections import defaultdict, namedtuple
-from typing import List, TypedDict
+from typing import List, TypedDict, Union
 
 from rest_framework import status
 from rest_framework.request import Request
@@ -47,7 +48,7 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
 
-    aggregated_tree = {}
+    aggregated_tree: Dict[str, Dict[str, Union[str, int, float]]] = {}
 
     def get(self, request: Request, organization: Organization) -> Response:
         if not features.has("organizations:starfish-view", organization, actor=request.user):
@@ -211,7 +212,7 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
 
         # Handles sibling spans that have the same group
         span_tree["children"].sort(key=lambda s: s["start_ms"])
-        span_hash_seen = defaultdict(lambda: 0)
+        span_hash_seen: Dict[str, int] = defaultdict(lambda: 0)
 
         for child in span_tree["children"]:
             child_span_hash = child["coalesced_group"]

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -167,7 +167,6 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
             In this example, given A, B, C, D are span groups, the fingerprint of span D would be
             the md5 hash of the value A-C-D and for span E would be md5 hash of the value A-C1-E.
         """
-
         coalesced_group = span_tree["coalesced_group"]
         description = span_tree["description"]
         start_ms = span_tree["start_ms"]
@@ -203,6 +202,7 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
                 "description": description,
                 "start_ms": start_ms,
                 "avg(exclusive_time)": span_tree["exclusive_time"],
+                "avg(duration)": span_tree["duration"],
                 "is_segment": span_tree["is_segment"],
                 "avg(offset)": start_ms
                 - root_start_timestamp,  # offset of the span relative to the start timestamp of the root span

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -173,7 +173,7 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
         if root_prefix is None:
             prefix = coalesced_group
         else:
-            if nth_span == 0:
+            if nth_span == 1:
                 prefix = f"{root_prefix}-{coalesced_group}"
             else:
                 prefix = f"{root_prefix}-{coalesced_group}{nth_span}"

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -43,7 +43,7 @@ NULL_GROUP = "00"
 @region_silo_endpoint
 class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.EXPERIMENTAL,
     }
 
     aggregated_tree = {}

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -1,7 +1,6 @@
 import hashlib
-from ast import Dict
 from collections import defaultdict, namedtuple
-from typing import List, TypedDict, Union
+from typing import Dict, List, TypedDict, Union
 
 from rest_framework import status
 from rest_framework.request import Request

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -1,0 +1,226 @@
+import hashlib
+from collections import defaultdict, namedtuple
+from typing import Tuple, TypedDict
+
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from snuba_sdk import Column, Function
+
+from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.models import Organization
+from sentry.search.events.builder import QueryBuilder
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.referrer import Referrer
+from sentry.utils.snuba import raw_snql_query
+
+
+class EventSpans(TypedDict):
+    transaction_id: str
+    spans: Tuple[str, str, str, str, str, int, int]
+
+
+EventSpan = namedtuple(
+    "EventSpan",
+    [
+        "span_id",
+        "is_segment",
+        "parent_span_id",
+        "group",
+        "group_raw",
+        "description",
+        "start_ms",
+        "duration",
+        "exclusive_time",
+    ],
+)
+NULL_GROUP = "00"
+
+
+@region_silo_endpoint
+class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.UNKNOWN,
+    }
+
+    aggregated_tree = {}
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        if not features.has("organizations:starfish-view", organization, actor=request.user):
+            return Response(status=404)
+
+        try:
+            params = self.get_snuba_params(request, organization)
+        except NoProjects:
+            return Response(status=404)
+
+        transaction = request.query_params.get("transaction", None)
+        if transaction is None:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST, data={"details": "Transaction not provided"}
+            )
+
+        builder = QueryBuilder(
+            dataset=Dataset.SpansIndexed,
+            params=params,
+            selected_columns=["transaction_id", "count()"],
+            query=f"transaction:{transaction}",
+            limit=100,
+        )
+        builder.columns.append(
+            Function(
+                "groupArray",
+                parameters=[
+                    Function(
+                        "tuple",
+                        parameters=[
+                            Column("span_id"),
+                            Column("is_segment"),
+                            Column("parent_span_id"),
+                            Column("group"),
+                            Column("group_raw"),
+                            Column("description"),
+                            Column("start_ms"),
+                            Column("duration"),
+                            Column("exclusive_time"),
+                        ],
+                    )
+                ],
+                alias="spans",
+            )
+        )
+        snql_query = builder.get_snql_query()
+        snql_query.tenant_ids = {"organization_id": organization.id}
+        results = raw_snql_query(snql_query, Referrer.API_ORGANIZATION_SPANS_AGGREGATION.value)
+        for event in results["data"]:
+            span_tree = {}
+            root_span_id = None
+            spans = event["spans"]
+
+            for span in spans:
+                span = EventSpan(*span)
+                span_id = getattr(span, "span_id")
+                is_root = getattr(span, "is_segment")
+                if is_root:
+                    root_span_id = span_id
+                if span_id not in span_tree:
+                    spans_dict = span._asdict()
+                    # Fallback to group_raw if group doesn't exist for now
+                    spans_dict["coalesced_group"] = (
+                        spans_dict["group_raw"]
+                        if spans_dict["group"] == NULL_GROUP
+                        else spans_dict["group"]
+                    )
+                    span_tree[span_id] = spans_dict
+                    span_tree[span_id]["children"] = []
+
+            for span in span_tree.values():
+                parent_id = span["parent_span_id"]
+                try:
+                    parent_span = span_tree[parent_id]
+                    children = parent_span["children"]
+                    children.append(span)
+                except KeyError:
+                    pass
+
+            try:
+                root_span = span_tree[root_span_id]
+            except KeyError:
+                continue
+
+            self.fingerprint_nodes(root_span)
+
+        return Response(data=self.aggregated_tree)
+
+    def fingerprint_nodes(
+        self,
+        span_tree,
+        root_prefix=None,
+        parent_start_ms=None,
+        parent_node_fingerprint=None,
+        nth_span=0,
+    ):
+        """
+        Build a fingerprint using current span group and span groups of all the spans in the path before it.
+        Example 1:
+            A
+            |--B
+            |--C
+               |--D
+
+            In this example, given A, B, C, D are span groups, the fingerprint of span D would be
+            the md5 hash of the value A-C-D.
+
+        Example 2:
+            A
+            |--B
+            |--C
+            |  |--D
+            |
+            |--C
+               |--E
+
+            In this example, given A, B, C, D are span groups, the fingerprint of span D would be
+            the md5 hash of the value A-C-D and for span E would be md5 hash of the value A-C1-E.
+        """
+
+        coalesced_group = span_tree["coalesced_group"]
+        description = span_tree["description"]
+        start_ms = span_tree["start_ms"]
+        if root_prefix is None:
+            prefix = coalesced_group
+        else:
+            if nth_span == 0:
+                prefix = f"{root_prefix}-{coalesced_group}"
+            else:
+                prefix = f"{root_prefix}-{coalesced_group}{nth_span}"
+        node_fingerprint = hashlib.md5(prefix.encode()).hexdigest()[:16]
+
+        try:
+            node = self.aggregated_tree[node_fingerprint]
+            count = node["count()"]
+            node["avg(exclusive_time)"] = incremental_average(
+                node["avg(exclusive_time)"], count, span_tree["exclusive_time"]
+            )
+            node["avg(duration)"] = incremental_average(
+                node["avg(duration)"], count, span_tree["duration"]
+            )
+            node["avg(offset)"] = incremental_average(
+                node["avg(offset)"],
+                count,
+                0 if parent_start_ms is None else start_ms - parent_start_ms,
+            )
+            node["count()"] += 1
+        except KeyError:
+            self.aggregated_tree[node_fingerprint] = {
+                "node_fingerprint": node_fingerprint,
+                "parent_node_fingerprint": parent_node_fingerprint,
+                "group": span_tree["group"],
+                "description": description,
+                "start_ms": start_ms,
+                "avg(exclusive_time)": span_tree["exclusive_time"],
+                "avg(offset)": 0
+                if parent_start_ms is None
+                else start_ms - parent_start_ms,  # offset of the child span from the parent
+                "avg(duration)": span_tree["duration"],
+                "count()": 1,
+            }
+
+        # Handles sibling spans that have the same group
+        span_tree["children"].sort(key=lambda s: s["start_ms"])
+        span_hash_seen = defaultdict(lambda: 0)
+
+        for child in span_tree["children"]:
+            child_span_hash = child["coalesced_group"]
+            span_hash_seen[child_span_hash] += 1
+            self.fingerprint_nodes(
+                child, prefix, start_ms, node_fingerprint, span_hash_seen[child_span_hash]
+            )
+
+
+def incremental_average(average, count, value):
+    average += (value - average) / (count + 1)
+    return average

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -21,6 +21,7 @@ from sentry.api.endpoints.organization_missing_org_members import OrganizationMi
 from sentry.api.endpoints.organization_projects_experiment import (
     OrganizationProjectsExperimentEndpoint,
 )
+from sentry.api.endpoints.organization_spans_aggregation import OrganizationSpansAggregationEndpoint
 from sentry.api.endpoints.release_threshold import ReleaseThresholdEndpoint
 from sentry.api.endpoints.source_map_debug_blue_thunder_edition import (
     SourceMapDebugBlueThunderEditionEndpoint,
@@ -1328,6 +1329,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_slug>[^\/]+)/events-trends-stats/$",
         OrganizationEventsTrendsStatsEndpoint.as_view(),
         name="sentry-api-0-organization-events-trends-stats",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/spans-aggregation/$",
+        OrganizationSpansAggregationEndpoint.as_view(),
+        name="sentry-api-0-organization-spans-aggregation",
     ),
     # This endpoint is for experimentation only
     # Once this feature is developed, the endpoint will replace /events-trends-stats

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -123,6 +123,7 @@ class Referrer(Enum):
     API_ORGANIZATION_EVENTS_SPANS_PERFORMANCE_EXAMPLES = (
         "api.organization-events-spans-performance-examples"
     )
+    API_ORGANIZATION_SPANS_AGGREGATION = "api.organization-spans-aggregation"
     API_ORGANIZATION_EVENTS_SPANS_PERFORMANCE_STATS = (
         "api.organization-events-spans-performance-stats"
     )

--- a/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
+++ b/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
@@ -65,6 +65,7 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
                             ["B2", 0, "root_2", "B", "B", "connect", 158, 10, 30.0],
                             ["C2", 0, "root_2", "C", "C", "resolve_conditions", 448, 0, 40.0],
                             ["D2", 0, "C2", "D", "D", "resolve_orderby", 429, 0, 10.0],
+                            ["D2-duplicate", 0, "C2", "D", "D", "resolve_orderby", 430, 0, 20.0],
                         ],
                     },
                 ]
@@ -91,3 +92,9 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
             fingerprint = hashlib.md5(b"A-C-D").hexdigest()[:16]
             assert data[fingerprint]["description"] == "resolve_orderby"
             assert data[fingerprint]["avg(exclusive_time)"] == 15.0
+            assert data[fingerprint]["count()"] == 2
+
+            fingerprint = hashlib.md5(b"A-C-D2").hexdigest()[:16]
+            assert data[fingerprint]["description"] == "resolve_orderby"
+            assert data[fingerprint]["avg(exclusive_time)"] == 20.0
+            assert data[fingerprint]["count()"] == 1

--- a/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
+++ b/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
@@ -62,9 +62,9 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
                                 0,
                                 0.0,
                             ],
-                            ["B2", 0, "root_2", "B", "B", "connect", 158, 50, 50.0],
+                            ["B2", 0, "root_2", "B", "B", "connect", 158, 10, 30.0],
                             ["C2", 0, "root_2", "C", "C", "resolve_conditions", 448, 0, 40.0],
-                            ["D2", 0, "C2", "D", "D", "resolve_orderby", 429, 0, 20.0],
+                            ["D2", 0, "C2", "D", "D", "resolve_orderby", 429, 0, 10.0],
                         ],
                     },
                 ]
@@ -83,3 +83,11 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
             assert root_fingerprint in data
             assert data[root_fingerprint]["description"] == "bind_organization_context"
             assert data[root_fingerprint]["count()"] == 2
+
+            fingerprint = hashlib.md5(b"A-B").hexdigest()[:16]
+            assert data[fingerprint]["description"] == "connect"
+            assert data[fingerprint]["avg(duration)"] == 30.0
+
+            fingerprint = hashlib.md5(b"A-C-D").hexdigest()[:16]
+            assert data[fingerprint]["description"] == "resolve_orderby"
+            assert data[fingerprint]["avg(exclusive_time)"] == 15.0

--- a/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
+++ b/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
@@ -1,0 +1,85 @@
+import hashlib
+from unittest import mock
+
+from django.urls import reverse
+
+from sentry.testutils.cases import APITestCase, SnubaTestCase
+
+
+class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
+    url_name = "sentry-api-0-organization-spans-aggregation"
+    FEATURES = [
+        "organizations:starfish-view",
+        "organizations:performance-view",
+    ]
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+        self.url = reverse(
+            self.url_name,
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+
+    @mock.patch("sentry.api.endpoints.organization_spans_aggregation.raw_snql_query")
+    def test_simple(self, mock_query):
+        mock_query.side_effect = [
+            {
+                "data": [
+                    {
+                        "transaction_id": "80fe542aea4945ffbe612646987ee449",
+                        "count": 71,
+                        "spans": [
+                            [
+                                "root_1",
+                                1,
+                                "parent_1",
+                                "A",
+                                "A",
+                                "bind_organization_context",
+                                422,
+                                0,
+                                0.0,
+                            ],
+                            ["B1", 0, "root_1", "B", "B", "connect", 158, 50, 50.0],
+                            ["C1", 0, "root_1", "C", "C", "resolve_conditions", 448, 0, 10.0],
+                            ["D1", 0, "C1", "D", "D", "resolve_orderby", 429, 0, 20.0],
+                        ],
+                    },
+                    {
+                        "transaction_id": "86b21833d1854d9b811000b91e7fccfa",
+                        "count": 71,
+                        "spans": [
+                            [
+                                "root_2",
+                                1,
+                                "parent_2",
+                                "A",
+                                "A",
+                                "bind_organization_context",
+                                422,
+                                0,
+                                0.0,
+                            ],
+                            ["B2", 0, "root_2", "B", "B", "connect", 158, 50, 50.0],
+                            ["C2", 0, "root_2", "C", "C", "resolve_conditions", 448, 0, 40.0],
+                            ["D2", 0, "C2", "D", "D", "resolve_orderby", 429, 0, 20.0],
+                        ],
+                    },
+                ]
+            }
+        ]
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={"transaction": "foo"},
+                format="json",
+            )
+
+            assert response.data
+            data = response.data
+            root_fingerprint = hashlib.md5(b"A").hexdigest()[:16]
+            assert root_fingerprint in data
+            assert data[root_fingerprint]["description"] == "bind_organization_context"
+            assert data[root_fingerprint]["count()"] == 2


### PR DESCRIPTION
An experimental endpoint that fetches 100 transaction events
for a given transaction name from the indexed spans dataset,
builds and aggregates the span trees. Span trees are aggregated
by fingerprinting each node on the tree and aggregating on those
fingerprints. It returns an array of aggregated span durations, exclusive_time
and offset, and parent child relationships of the fingerprints so
the frontend can build an aggregate span graph.

Tests in a follow up. We currently can't write tests against the
indexed spans dataset. I'll write some with hardcoded data
while we wait for that functionality to get added though.