### PR TITLE
fixes bug writing to notification settings in double write

### DIFF
--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -595,8 +595,29 @@ class NotificationsManager(BaseManager["NotificationSetting"]):  # noqa: F821
         ):
             return
 
-        # first update the NotificationSettingOption based on what's passed in
+        enabled_providers = defaultdict(set)
+        disabled_providers = defaultdict(set)
+        defaulted_providers = defaultdict(set)
+        all_settings = set()
+
+        # group the type, scope_type, scope_identifir, together and get store the explicitly enabled/disaled providers
         for (provider, type, scope_type, scope_identifier, value) in notification_settings:
+            # Group the type, scope_type, scope_identifier together
+            group_key = (type, scope_type, scope_identifier)
+            all_settings.add(group_key)
+            # Initialize the dictionaries to store the explicitly enabled/disabled providers
+
+            # Check the value and add the provider to the corresponding dictionary
+            if value == NotificationSettingOptionValues.NEVER:
+                disabled_providers[group_key].add(provider)
+            elif value == NotificationSettingOptionValues.DEFAULT:
+                defaulted_providers[group_key].add(provider)
+            else:
+                enabled_providers[group_key].add(provider)
+
+        # iterate through all the settings and create/update the NotificationSettingOption
+        for group_key in all_settings:
+            (type, scope_type, scope_identifier) = group_key
             query_args = {
                 "type": NOTIFICATION_SETTING_TYPES[type],
                 "scope_type": NOTIFICATION_SCOPE_TYPE[scope_type],
@@ -604,13 +625,21 @@ class NotificationsManager(BaseManager["NotificationSetting"]):  # noqa: F821
                 "user_id": user_id,
                 "team_id": team_id,
             }
-            # if default, delete the row
-            if value == NotificationSettingOptionValues.DEFAULT:
+
+            # if any settings are default, we should remove the row
+            if len(defaulted_providers[group_key]) > 0:
                 NotificationSettingOption.objects.filter(**query_args).delete()
-            else:
+            # if any of the providers are explicitly enabled, we should create/update the row
+            if len(enabled_providers[group_key]) > 0:
                 NotificationSettingOption.objects.create_or_update(
                     **query_args,
-                    values={"value": NOTIFICATION_SETTING_OPTION_VALUES[value]},
+                    values={"value": NotificationSettingsOptionEnum.ALWAYS.value},
+                )
+            # if any settings are explicitly disabled, we should create/update the row
+            elif len(disabled_providers[group_key]) > 0:
+                NotificationSettingOption.objects.create_or_update(
+                    **query_args,
+                    values={"value": NotificationSettingsOptionEnum.NEVER.value},
                 )
 
         # update the provider settings after we update the NotificationSettingOption

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -600,7 +600,7 @@ class NotificationsManager(BaseManager["NotificationSetting"]):  # noqa: F821
         defaulted_providers = defaultdict(set)
         all_settings = set()
 
-        # group the type, scope_type, scope_identifir, together and get store the explicitly enabled/disaled providers
+        # group the type, scope_type, scope_identifier, together and get store the explicitly enabled/disabled providers
         for (provider, type, scope_type, scope_identifier, value) in notification_settings:
             # Group the type, scope_type, scope_identifier together
             group_key = (type, scope_type, scope_identifier)

--- a/tests/sentry/api/endpoints/test_user_notification_settings.py
+++ b/tests/sentry/api/endpoints/test_user_notification_settings.py
@@ -180,6 +180,70 @@ class UserNotificationSettingsUpdateTest(UserNotificationSettingsTestBase):
             **query_args, value="never", provider="slack"
         )
 
+    @with_feature("organizations:notifications-double-write")
+    def test_double_write_with_email_off(self):
+        org = self.create_organization()
+        self.create_member(user=self.user, organization=org)
+        project2 = self.create_project(organization=org)
+
+        self.get_success_response(
+            "me",
+            deploy={
+                "user": {"me": {"email": "never", "slack": "always"}},  # enabled for slack
+                "project": {
+                    project2.id: {"email": "never", "slack": "always"},  # enabled
+                    self.project.id: {"email": "never", "slack": "never"},  # disabled
+                },
+            },
+            status_code=status.HTTP_204_NO_CONTENT,
+        )
+
+        # check user first
+        base_query_args = {
+            "user_id": self.user.id,
+            "team_id": None,
+            "type": "deploy",
+        }
+        query_args = {
+            **base_query_args,
+            "scope_type": "user",
+            "scope_identifier": self.user.id,
+        }
+        assert NotificationSettingOption.objects.filter(**query_args, value="always").exists()
+        assert NotificationSettingProvider.objects.filter(
+            **query_args, provider="email", value="never"
+        ).exists()
+        assert NotificationSettingProvider.objects.filter(
+            **query_args, provider="slack", value="always"
+        ).exists()
+        assert not NotificationSettingProvider.objects.filter(
+            **query_args,
+            provider="msteams",
+        ).exists()
+
+        # check project1
+        query_args = {
+            **base_query_args,
+            "scope_type": "project",
+            "scope_identifier": self.project.id,
+        }
+        assert NotificationSettingOption.objects.filter(**query_args, value="never").exists()
+        # should not make project scoped provider settings
+        assert not NotificationSettingProvider.objects.filter(
+            **query_args,
+        ).exists()
+
+        # check project 2
+        query_args = {
+            **base_query_args,
+            "scope_type": "project",
+            "scope_identifier": project2.id,
+        }
+        assert NotificationSettingOption.objects.filter(**query_args, value="always").exists()
+        assert not NotificationSettingProvider.objects.filter(
+            **query_args,
+        ).exists()
+
     def test_empty_payload(self):
         self.get_error_response("me", status_code=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
This fixes a bug for notification double writes where we would disable a setting when Email was disabled even though Slack might be enabled. Note that it's not being used yet by customers so we don't have to do any cleanup