### PR TITLE
chore(hybrid-cloud): Stabilize SlackIssueAlertNotificationTest

### DIFF
--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -40,7 +40,7 @@ from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
`SlackIssueAlertNotificationTest` now passes in split silo mode.