### PR TITLE
chore(test): Add requires kafka and relay to relay tests

### DIFF
--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -11,6 +11,9 @@ from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now, iso_format, timestamp_format
 from sentry.testutils.relay import RelayStoreHelper
+from sentry.testutils.skips import requires_kafka, requires_relay
+
+pytestmark = [requires_kafka, requires_relay]
 
 
 class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):

--- a/tests/relay_integration/test_message_filters.py
+++ b/tests/relay_integration/test_message_filters.py
@@ -7,7 +7,10 @@ from sentry.ingest.inbound_filters import (
 from sentry.models import ProjectOption
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.relay import RelayStoreHelper
+from sentry.testutils.skips import requires_kafka, requires_relay
 from sentry.utils.safe import set_path
+
+pytestmark = [requires_kafka, requires_relay]
 
 
 class FilterTests(RelayStoreHelper, TransactionTestCase):

--- a/tests/relay_integration/test_metrics_extraction.py
+++ b/tests/relay_integration/test_metrics_extraction.py
@@ -9,7 +9,10 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import Feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
+from sentry.testutils.skips import requires_kafka, requires_relay
 from sentry.utils import json
+
+pytestmark = [requires_kafka, requires_relay]
 
 
 class MetricsExtractionTest(RelayStoreHelper, TransactionTestCase):

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -12,7 +12,10 @@ from sentry.receivers import create_default_projects
 from sentry.testutils.asserts import assert_mock_called_once_with_partial
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.pytest.relay import adjust_settings_for_relay_tests
+from sentry.testutils.skips import requires_kafka, requires_relay
 from sentry.utils.sdk import bind_organization_context, configure_sdk
+
+pytestmark = [requires_kafka, requires_relay]
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Tested locally and this will skip relay tests if kafka and/or relay are not up.