### PR TITLE
fix(helpful-event): Stop logging recommended event 404s

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -297,6 +297,11 @@ function useEventApiQuery({
           query: omit(qs.parse(window.location.search), 'query'),
         });
 
+        // 404s are expected if all events have exceeded retention
+        if (latestOrHelpfulEvent.error.status === 404) {
+          return;
+        }
+
         const scope = new Sentry.Scope();
         scope.setExtras({
           groupId,


### PR DESCRIPTION
JAVASCRIPT-2N99 is getting too many events, most are 404s which are expected