### PR TITLE
fix(integrations): Fix sending requests locally

### DIFF
--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -246,7 +246,6 @@ class BaseApiClient(TrackResponseMixin):
             try:
                 with build_session() as session:
                     finalized_request = self.finalize_request(_prepared_request)
-                    # import pdb; pdb.set_trace()
                     environment_settings = session.merge_environment_settings(
                         url=finalized_request.url,
                         proxies={},

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -246,9 +246,10 @@ class BaseApiClient(TrackResponseMixin):
             try:
                 with build_session() as session:
                     finalized_request = self.finalize_request(_prepared_request)
+                    # import pdb; pdb.set_trace()
                     environment_settings = session.merge_environment_settings(
                         url=finalized_request.url,
-                        proxies=None,
+                        proxies={},
                         stream=None,
                         verify=self.verify_ssl,
                         cert=None,


### PR DESCRIPTION
Since https://github.com/getsentry/sentry/pull/53836/files was merged we haven't been able to develop integrations locally because of this error `AttributeError: 'NoneType' object has no attribute 'setdefault'` since `proxies` is set to `None` rather than an empty dict. 