### PR TITLE
ref(crons): Hide attachments if no check-ins have them

### DIFF
--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -79,21 +79,19 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
 
   const emptyCell = <Text>{'\u2014'}</Text>;
 
+  const hasAttachments = checkInList?.some(checkIn => defined(checkIn.attachmentId));
+  const headers = [
+    ...[t('Status'), t('Started'), t('Duration'), t('Issues')],
+    ...(hasAttachments ? [t('Attachment')] : []),
+    t('Timestamp'),
+  ];
+
   return (
     <Fragment>
       <SectionHeading>{t('Recent Check-Ins')}</SectionHeading>
-      <PanelTable
-        headers={[
-          t('Status'),
-          t('Started'),
-          t('Duration'),
-          t('Issues'),
-          t('Attachment'),
-          t('Timestamp'),
-        ]}
-      >
+      <PanelTable headers={headers}>
         {isLoading
-          ? [...new Array(6)].map((_, i) => (
+          ? [...new Array(headers.length)].map((_, i) => (
               <RowPlaceholder key={i}>
                 <Placeholder height="2rem" />
               </RowPlaceholder>
@@ -167,17 +165,18 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
                 ) : (
                   emptyCell
                 )}
-                {checkIn.attachmentId ? (
-                  <Button
-                    size="xs"
-                    icon={<IconDownload size="xs" />}
-                    href={generateDownloadUrl(checkIn)}
-                  >
-                    {t('Attachment')}
-                  </Button>
-                ) : (
-                  emptyCell
-                )}
+                {hasAttachments &&
+                  (checkIn.attachmentId ? (
+                    <Button
+                      size="xs"
+                      icon={<IconDownload size="xs" />}
+                      href={generateDownloadUrl(checkIn)}
+                    >
+                      {t('Attachment')}
+                    </Button>
+                  ) : (
+                    emptyCell
+                  ))}
                 <Timestamp date={checkIn.dateCreated} />
               </Fragment>
             ))}


### PR DESCRIPTION
Following feedback from users: removing attachments column from table if there are none to show.

<img width="903" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/fa193421-e4e2-4b2d-88be-dbee9171a59d">

