### PR TITLE
feat(alerts): Wrap metric alert query with "AND"

### DIFF
--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -207,9 +207,10 @@ export default function MetricDetailsBody({
                   timePeriod={timePeriod}
                   query={
                     dataset === Dataset.ERRORS
-                      ? query
+                      ? // Not using (query) AND (event.type:x) because issues doesn't support it yet
+                        `${extractEventTypeFilterFromRule(rule)} ${query}`.trim()
                       : isCrashFreeAlert(dataset)
-                      ? `${query} error.unhandled:true`
+                      ? `${query} error.unhandled:true`.trim()
                       : undefined
                   }
                 />

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -85,7 +85,7 @@ export default function MetricDetailsBody({
     const {dataset, query} = rule;
 
     if (isCrashFreeAlert(dataset)) {
-      return query?.trim().split(' ') ?? null;
+      return query.trim().split(' ');
     }
 
     const eventType = extractEventTypeFilterFromRule(rule);

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -77,16 +77,16 @@ export default function MetricDetailsBody({
     return getInterval({start: timePeriod.start, end: timePeriod.end}, 'high');
   }
 
-  function getFilter() {
+  function getFilter(): string[] | null {
     const {dataset, query} = rule ?? {};
     if (!rule) {
       return null;
     }
 
     const eventType = isCrashFreeAlert(dataset)
-      ? null
+      ? ``
       : extractEventTypeFilterFromRule(rule);
-    return [eventType, query].join(' ').split(' ');
+    return (query ? `(${eventType}) AND (${query})` : eventType).split(' ');
   }
 
   const handleTimePeriodChange = (datetime: ChangeData) => {
@@ -130,7 +130,10 @@ export default function MetricDetailsBody({
 
   const {dataset, aggregate, query} = rule;
 
-  const queryWithTypeFilter = `${query} ${extractEventTypeFilterFromRule(rule)}`.trim();
+  const eventType = extractEventTypeFilterFromRule(rule);
+  const queryWithTypeFilter = (
+    query ? `(${query}) AND (${eventType}})` : eventType
+  ).trim();
   const relativeOptions = {
     ...SELECTOR_RELATIVE_PERIODS,
     ...(rule.timeWindow > 1 ? {[TimePeriod.FOURTEEN_DAYS]: t('Last 14 days')} : {}),
@@ -204,7 +207,7 @@ export default function MetricDetailsBody({
                   timePeriod={timePeriod}
                   query={
                     dataset === Dataset.ERRORS
-                      ? queryWithTypeFilter
+                      ? query
                       : isCrashFreeAlert(dataset)
                       ? `${query} error.unhandled:true`
                       : undefined

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -78,10 +78,11 @@ export default function MetricDetailsBody({
   }
 
   function getFilter(): string[] | null {
-    const {dataset, query} = rule ?? {};
     if (!rule) {
       return null;
     }
+
+    const {dataset, query} = rule;
 
     if (isCrashFreeAlert(dataset)) {
       return query?.trim().split(' ') ?? null;

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -83,10 +83,12 @@ export default function MetricDetailsBody({
       return null;
     }
 
-    const eventType = isCrashFreeAlert(dataset)
-      ? ``
-      : extractEventTypeFilterFromRule(rule);
-    return (query ? `(${eventType}) AND (${query})` : eventType).split(' ');
+    if (isCrashFreeAlert(dataset)) {
+      return query?.trim().split(' ') ?? null;
+    }
+
+    const eventType = extractEventTypeFilterFromRule(rule);
+    return (query ? `(${eventType}) AND (${query.trim()})` : eventType).split(' ');
   }
 
   const handleTimePeriodChange = (datetime: ChangeData) => {

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -135,7 +135,7 @@ export default function MetricDetailsBody({
 
   const eventType = extractEventTypeFilterFromRule(rule);
   const queryWithTypeFilter = (
-    query ? `(${query}) AND (${eventType}})` : eventType
+    query ? `(${query}) AND (${eventType})` : eventType
   ).trim();
   const relativeOptions = {
     ...SELECTOR_RELATIVE_PERIODS,

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -137,7 +137,9 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
   get chartQuery(): string {
     const {query, eventTypes, dataset} = this.state;
     const eventTypeFilter = getEventTypeFilter(this.state.dataset, eventTypes);
-    const queryWithTypeFilter = `${query} ${eventTypeFilter}`.trim();
+    const queryWithTypeFilter = (
+      query ? `(${query}) AND (${eventTypeFilter})` : eventTypeFilter
+    ).trim();
     return isCrashFreeAlert(dataset) ? query : queryWithTypeFilter;
   }
 

--- a/static/app/views/alerts/rules/metric/utils/getEventTypeFilter.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getEventTypeFilter.tsx
@@ -3,7 +3,7 @@ import {convertDatasetEventTypesToSource} from 'sentry/views/alerts/utils';
 import {DATASET_EVENT_TYPE_FILTERS, DATASOURCE_EVENT_TYPE_FILTERS} from '../constants';
 import {Dataset, Datasource, EventTypes, MetricRule} from '../types';
 
-export function extractEventTypeFilterFromRule(metricRule: MetricRule) {
+export function extractEventTypeFilterFromRule(metricRule: MetricRule): string {
   const {dataset, eventTypes} = metricRule;
   return getEventTypeFilter(dataset, eventTypes);
 }
@@ -11,7 +11,7 @@ export function extractEventTypeFilterFromRule(metricRule: MetricRule) {
 export function getEventTypeFilter(
   dataset: Dataset,
   eventTypes: EventTypes[] | undefined
-) {
+): string {
   if (eventTypes) {
     return DATASOURCE_EVENT_TYPE_FILTERS[
       convertDatasetEventTypesToSource(dataset, eventTypes) ?? Datasource.ERROR


### PR DESCRIPTION
fixes #55788

the discover query looked like `event.type:${dataset} ${query}`

but it worked like this `(event.type:${dataset}) AND (${query})` after being saved. This is because the query starts to work differently when used with additional AND/OR operators inside the query.

This updates the frontend to wrap the query similar to how it works on the backend