### PR TITLE
ref(alerts): Add neglected rule data

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -9,7 +9,6 @@ from sentry.constants import ObjectStatus
 from sentry.models import (
     ACTOR_TYPES,
     Environment,
-    Organization,
     Rule,
     RuleActivity,
     RuleActivityType,
@@ -197,9 +196,10 @@ class RuleSerializer(Serializer):
         else:
             d["snooze"] = False
 
-        org = Organization.objects.get(id=obj.project.organization_id)
         try:
-            neglected_rule = NeglectedRule.objects.get(rule=obj, organization=org, opted_out=False)
+            neglected_rule = NeglectedRule.objects.get(
+                rule=obj, organization=obj.project.organization_id, opted_out=False
+            )
             d["disableReason"] = "noisy"
             d["disableDate"] = neglected_rule.disable_date
         except (NeglectedRule.DoesNotExist, NeglectedRule.MultipleObjectsReturned):

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -198,9 +198,11 @@ class RuleSerializer(Serializer):
             d["snooze"] = False
 
         org = Organization.objects.get(id=obj.project.organization_id)
-        neglected_rule = NeglectedRule.objects.filter(rule=obj, organization=org, opted_out=False)
-        if neglected_rule.exists():
+        try:
+            neglected_rule = NeglectedRule.objects.get(rule=obj, organization=org, opted_out=False)
             d["disableReason"] = "noisy"
-            d["disableDate"] = neglected_rule[0].disable_date
+            d["disableDate"] = neglected_rule.disable_date
+        except (NeglectedRule.DoesNotExist, NeglectedRule.MultipleObjectsReturned):
+            pass
 
         return d

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -175,8 +175,6 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
             organization=self.organization,
             opted_out=False,
             disable_date=now + timedelta(days=14),
-            sent_initial_email_date=now,
-            sent_final_email_date=now,
         )
         response = self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping
 from unittest.mock import patch
 
@@ -10,7 +10,14 @@ from rest_framework import status
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.slack.utils.channel import strip_channel_name
-from sentry.models import Environment, Integration, Rule, RuleActivity, RuleActivityType
+from sentry.models import (
+    Environment,
+    Integration,
+    NeglectedRule,
+    Rule,
+    RuleActivity,
+    RuleActivityType,
+)
 from sentry.models.actor import Actor, get_actor_for_user
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.silo import SiloMode
@@ -159,6 +166,30 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
         assert response.data["conditions"][0]["id"] == conditions[0]["id"]
         assert len(response.data["filters"]) == 1
         assert response.data["filters"][0]["id"] == conditions[1]["id"]
+
+    @responses.activate
+    def test_neglected_rule(self):
+        now = datetime.now().replace(tzinfo=timezone.utc)
+        NeglectedRule.objects.create(
+            rule=self.rule,
+            organization=self.organization,
+            opted_out=False,
+            disable_date=now + timedelta(days=14),
+            sent_initial_email_date=now,
+            sent_final_email_date=now,
+        )
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, self.rule.id, status_code=200
+        )
+        assert response.data["disableReason"] == "noisy"
+        assert response.data["disableDate"] == now + timedelta(days=14)
+
+        another_rule = self.create_project_rule(project=self.project)
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, another_rule.id, status_code=200
+        )
+        assert not response.data.get("disableReason")
+        assert not response.data.get("disableDate")
 
     @responses.activate
     def test_with_snooze_rule(self):


### PR DESCRIPTION
If a row exists in the `NeglectedRule` table, add data about that to the rule details response so that we can display information about it. 

Closes #56192 