### PR TITLE
chore(codeowners): Add issues team as rule serializer codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -309,6 +309,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/api/endpoints/organization_release_previous_commits.py   @getsentry/issues
 /src/sentry/api/endpoints/sentry_app/                                @getsentry/issues
 /src/sentry/api/endpoints/project_rule*.py                           @getsentry/issues
+src/sentry/api/serializers/models/rule.py 							 @getsentry/issues
 
 /static/app/views/organizationIntegrations                           @getsentry/issues
 /static/app/views/settings/project/projectOwnership/                 @getsentry/issues

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -309,7 +309,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/api/endpoints/organization_release_previous_commits.py   @getsentry/issues
 /src/sentry/api/endpoints/sentry_app/                                @getsentry/issues
 /src/sentry/api/endpoints/project_rule*.py                           @getsentry/issues
-src/sentry/api/serializers/models/rule.py 							 @getsentry/issues
+/src/sentry/api/serializers/models/rule.py 							 @getsentry/issues
 
 /static/app/views/organizationIntegrations                           @getsentry/issues
 /static/app/views/settings/project/projectOwnership/                 @getsentry/issues


### PR DESCRIPTION
I noticed I had to manually select the issues team to review my rule serializer changes, so I'm adding them as codeowners.