### PR TITLE
ref(org-tokens): Update description for org tokens

### DIFF
--- a/static/app/views/settings/account/apiTokens.tsx
+++ b/static/app/views/settings/account/apiTokens.tsx
@@ -88,11 +88,9 @@ export class ApiTokens extends DeprecatedAsyncView<Props, State> {
     return (
       <div>
         <SettingsPageHeader title={this.getTitle()} action={action} />
-        <AlertLink
-          to={`/settings/${organization?.slug ?? ''}/developer-settings/new-internal`}
-        >
+        <AlertLink to={`/settings/${organization?.slug ?? ''}/auth-tokens/`}>
           {t(
-            "Auth Tokens are tied to the logged in user, meaning they'll stop working if the user leaves the organization! We suggest using internal integrations to create/manage tokens tied to the organization instead."
+            "User Auth Tokens are tied to the logged in user, meaning they'll stop working if the user leaves the organization! We suggest using Organization Auth Tokens to create/manage tokens tied to the organization instead."
           )}
         </AlertLink>
         <TextBlock>

--- a/static/app/views/settings/organizationAuthTokens/index.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.tsx
@@ -163,7 +163,7 @@ export function OrganizationAuthTokensIndex({
 
           <TextBlock>
             {t(
-              "Authentication tokens allow you to perform actions against the Sentry API on behalf of your organization. They're the easiest way to get started using the API."
+              'Organization Auth Tokens can be used in many places to interact with Sentry programatically. For example, they can be used for sentry-cli, bundler plugins or similar uses cases.'
             )}
           </TextBlock>
           <TextBlock>

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
@@ -181,7 +181,7 @@ export function OrganizationAuthTokensNewAuthToken({
 
       <TextBlock>
         {t(
-          "Authentication tokens allow you to perform actions against the Sentry API on behalf of your organization. They're the easiest way to get started using the API."
+          'Organization Auth Tokens can be used in many places to interact with Sentry programatically. For example, they can be used for sentry-cli, bundler plugins or similar uses cases.'
         )}
       </TextBlock>
       <TextBlock>


### PR DESCRIPTION
This updates the copy on the org token page to be a bit more descriptive, and also updates the user token page to redirect people to org tokens instead of internal integrations:

<img width="1055" alt="Screenshot 2023-09-15 at 11 35 00" src="https://github.com/getsentry/sentry/assets/2411343/d35a1492-07be-4b46-9d5f-38330c7ec5a3">

<img width="1055" alt="Screenshot 2023-09-15 at 11 36 13" src="https://github.com/getsentry/sentry/assets/2411343/e6fe9746-41df-423d-8a53-d5caa98b0508">
