### PR TITLE
feat(code-snippet): Add tabs

### DIFF
--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -97,6 +97,7 @@ export function CodeSnippet({
             <TabsWrapper>
               {tabs.map(({label, value}) => (
                 <Tab
+                  type="button"
                   isSelected={selectedTab === value}
                   onClick={() => onTabClick?.(value)}
                   key={value}
@@ -213,7 +214,7 @@ const FlexSpacer = styled('div')`
 `;
 
 const CopyButton = styled(Button)<{isAlwaysVisible: boolean}>`
-  color: ${p => p.theme.subText};
+  color: #80708f;
 
   transition: opacity 0.1s ease-out;
   opacity: 0;
@@ -222,6 +223,9 @@ const CopyButton = styled(Button)<{isAlwaysVisible: boolean}>`
   div:hover > div > &, /* if Wrapper is hovered */
   &.focus-visible {
     opacity: 1;
+  }
+  &:hover {
+    color: #e0dce5;
   }
 `;
 

--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -215,11 +215,9 @@ const FlexSpacer = styled('div')`
 
 const CopyButton = styled(Button)<{isAlwaysVisible: boolean}>`
   color: #80708f;
-
   transition: opacity 0.1s ease-out;
   opacity: 0;
 
-  ${p => (p.isAlwaysVisible ? 'opacity: 1;' : '')}
   div:hover > div > &, /* if Wrapper is hovered */
   &.focus-visible {
     opacity: 1;
@@ -227,6 +225,7 @@ const CopyButton = styled(Button)<{isAlwaysVisible: boolean}>`
   &:hover {
     color: #e0dce5;
   }
+  ${p => (p.isAlwaysVisible ? 'opacity: 1;' : '')}
 `;
 
 const Code = styled('code')<{disableUserSelection?: boolean}>`

--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useEffect, useRef, useState} from 'react';
+import {Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import Prism from 'prismjs';
 
@@ -35,6 +36,22 @@ interface CodeSnippetProps {
   }[];
 }
 
+const darkColors = {
+  textColor: '#e0dce5',
+  subText: '#80708f',
+  border: '#40364a',
+};
+
+function getLightColors(theme: Theme) {
+  return {
+    textColor: theme.textColor,
+    subText: theme.subText,
+    border: theme.innerBorder,
+  };
+}
+
+type Colors = typeof darkColors | ReturnType<typeof getLightColors>;
+
 export function CodeSnippet({
   children,
   language,
@@ -50,6 +67,7 @@ export function CodeSnippet({
   tabs,
 }: CodeSnippetProps) {
   const ref = useRef<HTMLModElement | null>(null);
+  const theme = useTheme();
 
   useEffect(() => {
     const element = ref.current;
@@ -89,9 +107,11 @@ export function CodeSnippet({
       ? t('Copied')
       : t('Unable to copy');
 
+  const colors = dark ? darkColors : getLightColors(theme);
+
   return (
     <Wrapper className={`${dark ? 'prism-dark ' : ''}${className ?? ''}`}>
-      <Header isSolid={hasSolidHeader}>
+      <Header isSolid={hasSolidHeader} colors={colors}>
         {hasTabs && (
           <Fragment>
             <TabsWrapper>
@@ -101,6 +121,7 @@ export function CodeSnippet({
                   isSelected={selectedTab === value}
                   onClick={() => onTabClick?.(value)}
                   key={value}
+                  colors={colors}
                 >
                   {label}
                 </Tab>
@@ -117,6 +138,7 @@ export function CodeSnippet({
             size="xs"
             translucentBorder
             borderless
+            colors={colors}
             onClick={handleCopy}
             title={tooltipTitle}
             tooltipProps={{delay: 0, isHoverable: false, position: 'left'}}
@@ -153,13 +175,13 @@ const Wrapper = styled('div')`
   }
 `;
 
-const Header = styled('div')<{isSolid: boolean}>`
+const Header = styled('div')<{colors: Colors; isSolid: boolean}>`
   display: flex;
   align-items: center;
 
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.codeFontSize};
-  color: var(--prism-base);
+  color: ${p => p.colors.textColor};
   font-weight: 600;
   z-index: 2;
 
@@ -167,7 +189,7 @@ const Header = styled('div')<{isSolid: boolean}>`
     p.isSolid
       ? `
       margin: 0 ${space(0.5)};
-      border-bottom: solid 1px #80708F;
+      border-bottom: solid 1px ${p.colors.border};
     `
       : `
       justify-content: flex-end;
@@ -193,19 +215,19 @@ const TabsWrapper = styled('div')`
   display: flex;
 `;
 
-const Tab = styled('button')<{isSelected: boolean}>`
+const Tab = styled('button')<{colors: Colors; isSelected: boolean}>`
   box-sizing: border-box;
   display: block;
   margin: 0;
   border: none;
   background: none;
   padding: ${space(1)} ${space(1)};
-  color: #80708f;
+  color: ${p => p.colors.subText};
   ${p =>
     p.isSelected
       ? `border-bottom: 3px solid ${p.theme.purple300};
       padding-bottom: 5px;
-      color: #E0DCE5;`
+      color: ${p.colors.textColor};`
       : ''}
 `;
 
@@ -213,8 +235,8 @@ const FlexSpacer = styled('div')`
   flex-grow: 1;
 `;
 
-const CopyButton = styled(Button)<{isAlwaysVisible: boolean}>`
-  color: #80708f;
+const CopyButton = styled(Button)<{colors: Colors; isAlwaysVisible: boolean}>`
+  color: ${p => p.colors.subText};
   transition: opacity 0.1s ease-out;
   opacity: 0;
 
@@ -223,7 +245,7 @@ const CopyButton = styled(Button)<{isAlwaysVisible: boolean}>`
     opacity: 1;
   }
   &:hover {
-    color: #e0dce5;
+    color: ${p => p.colors.textColor};
   }
   ${p => (p.isAlwaysVisible ? 'opacity: 1;' : '')}
 `;

--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -116,7 +116,7 @@ export function CodeSnippet({
             type="button"
             size="xs"
             translucentBorder
-            borderless={!!filename}
+            borderless
             onClick={handleCopy}
             title={tooltipTitle}
             tooltipProps={{delay: 0, isHoverable: false, position: 'left'}}

--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useEffect, useRef, useState} from 'react';
-import {Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import Prism from 'prismjs';
 
@@ -36,22 +35,6 @@ interface CodeSnippetProps {
   }[];
 }
 
-const darkColors = {
-  textColor: '#e0dce5',
-  subText: '#80708f',
-  border: '#40364a',
-};
-
-function getLightColors(theme: Theme) {
-  return {
-    textColor: theme.textColor,
-    subText: theme.subText,
-    border: theme.innerBorder,
-  };
-}
-
-type Colors = typeof darkColors | ReturnType<typeof getLightColors>;
-
 export function CodeSnippet({
   children,
   language,
@@ -67,7 +50,6 @@ export function CodeSnippet({
   tabs,
 }: CodeSnippetProps) {
   const ref = useRef<HTMLModElement | null>(null);
-  const theme = useTheme();
 
   useEffect(() => {
     const element = ref.current;
@@ -107,11 +89,9 @@ export function CodeSnippet({
       ? t('Copied')
       : t('Unable to copy');
 
-  const colors = dark ? darkColors : getLightColors(theme);
-
   return (
     <Wrapper className={`${dark ? 'prism-dark ' : ''}${className ?? ''}`}>
-      <Header isSolid={hasSolidHeader} colors={colors}>
+      <Header isSolid={hasSolidHeader}>
         {hasTabs && (
           <Fragment>
             <TabsWrapper>
@@ -121,7 +101,6 @@ export function CodeSnippet({
                   isSelected={selectedTab === value}
                   onClick={() => onTabClick?.(value)}
                   key={value}
-                  colors={colors}
                 >
                   {label}
                 </Tab>
@@ -138,7 +117,6 @@ export function CodeSnippet({
             size="xs"
             translucentBorder
             borderless
-            colors={colors}
             onClick={handleCopy}
             title={tooltipTitle}
             tooltipProps={{delay: 0, isHoverable: false, position: 'left'}}
@@ -175,13 +153,13 @@ const Wrapper = styled('div')`
   }
 `;
 
-const Header = styled('div')<{colors: Colors; isSolid: boolean}>`
+const Header = styled('div')<{isSolid: boolean}>`
   display: flex;
   align-items: center;
 
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.codeFontSize};
-  color: ${p => p.colors.textColor};
+  color: var(--prism-base);
   font-weight: 600;
   z-index: 2;
 
@@ -189,7 +167,7 @@ const Header = styled('div')<{colors: Colors; isSolid: boolean}>`
     p.isSolid
       ? `
       margin: 0 ${space(0.5)};
-      border-bottom: solid 1px ${p.colors.border};
+      border-bottom: solid 1px var(--prism-highlight-accent);
     `
       : `
       justify-content: flex-end;
@@ -215,19 +193,19 @@ const TabsWrapper = styled('div')`
   display: flex;
 `;
 
-const Tab = styled('button')<{colors: Colors; isSelected: boolean}>`
+const Tab = styled('button')<{isSelected: boolean}>`
   box-sizing: border-box;
   display: block;
   margin: 0;
   border: none;
   background: none;
   padding: ${space(1)} ${space(1)};
-  color: ${p => p.colors.subText};
+  color: var(--prism-comment);
   ${p =>
     p.isSelected
       ? `border-bottom: 3px solid ${p.theme.purple300};
       padding-bottom: 5px;
-      color: ${p.colors.textColor};`
+      color: var(--prism-base);`
       : ''}
 `;
 
@@ -235,8 +213,8 @@ const FlexSpacer = styled('div')`
   flex-grow: 1;
 `;
 
-const CopyButton = styled(Button)<{colors: Colors; isAlwaysVisible: boolean}>`
-  color: ${p => p.colors.subText};
+const CopyButton = styled(Button)<{isAlwaysVisible: boolean}>`
+  color: var(--prism-comment);
   transition: opacity 0.1s ease-out;
   opacity: 0;
 
@@ -245,7 +223,7 @@ const CopyButton = styled(Button)<{colors: Colors; isAlwaysVisible: boolean}>`
     opacity: 1;
   }
   &:hover {
-    color: ${p => p.colors.textColor};
+    color: var(--prism-base);
   }
   ${p => (p.isAlwaysVisible ? 'opacity: 1;' : '')}
 `;


### PR DESCRIPTION
* Add tabs to the `CodeSnippet component`
* Restyle header so it has the same background as the snippet itself

Dark theme:
![Screenshot 2023-09-18 at 10 02 12](https://github.com/getsentry/sentry/assets/7033940/94c86619-f58e-4e9e-a447-f46260f80951)

Light theme:
<img width="1233" alt="Screenshot 2023-09-15 at 18 23 57" src="https://github.com/getsentry/sentry/assets/7033940/b7bc4a30-bac4-4b27-9ab9-2ff7f371ad6f">

Light theme (`dark=true`):
<img width="1233" alt="Screenshot 2023-09-15 at 18 25 03" src="https://github.com/getsentry/sentry/assets/7033940/f1b2d79d-9fb6-40fa-b737-65a966415b9f">
