### PR TITLE
feat(minimetrics): Kill types for low hanging performance improvements

### DIFF
--- a/src/minimetrics/core.py
+++ b/src/minimetrics/core.py
@@ -211,6 +211,7 @@ class Aggregator:
             with self._lock:
                 buckets = self.buckets
                 force_flush = self._force_flush
+                flushed_metrics: Optional[Iterable[FlushedMetric]] = None
 
                 if force_flush:
                     flushed_metrics = buckets.items()

--- a/src/minimetrics/transport.py
+++ b/src/minimetrics/transport.py
@@ -1,13 +1,12 @@
 import re
-from typing import Iterable, Optional, Sequence
+from functools import partial
+from typing import Iterable, Optional
 
 import sentry_sdk
 from sentry_sdk.envelope import Envelope, Item
 
-from minimetrics.types import FlushedMetric, FlushedMetricValue, MetricTagsInternal, MetricUnit
+from minimetrics.types import FlushedMetric, MetricTagsInternal
 from sentry.utils import metrics
-
-sanitization_re = re.compile(r"[^a-zA-Z0-9_/.]+")
 
 
 class EncodingError(Exception):
@@ -18,45 +17,20 @@ class EncodingError(Exception):
     pass
 
 
+sanitize_value = partial(re.compile(r"[^a-zA-Z0-9_/.]").sub, "")
+
+
 class RelayStatsdEncoder:
-    MULTI_VALUE_SEPARATOR = ":"
-    TAG_SEPARATOR = ","
+    def encode(self, value: FlushedMetric) -> Optional[str]:
+        (timestamp, metric_type, metric_name, metric_unit, metric_tags), metric = value
+        metric_name = sanitize_value(metric_name) or "invalid-metric-name"
+        metric_values = ":".join(str(v) for v in metric.serialize_value())
+        metric_tags = self._get_metric_tags(metric_tags)
+        metric_tags_prefix = metric_tags and "|#" or ""
+        return f"{metric_name}@{metric_unit}:{metric_values}|{metric_type}{metric_tags_prefix}{metric_tags}|T{timestamp}"
 
-    def encode(self, value: FlushedMetric) -> str:
-        metric_name = self._sanitize_value(value.bucket_key.metric_name)
-        if not metric_name:
-            raise EncodingError(
-                f"The sanitized metric name {value.bucket_key.metric_name} is empty"
-            )
-        metric_unit = self._get_metric_unit(value.bucket_key.metric_unit)
-        metric_values = self._get_metric_values(value.metric.serialize_value())
-        metric_type = value.bucket_key.metric_type
-        metric_tags = self._get_metric_tags(value.bucket_key.metric_tags)
-        metric_timestamp = self._get_metric_timestamp(value.bucket_key.timestamp)
-
-        return f"{metric_name}{metric_unit}:{metric_values}|{metric_type}{metric_tags}{metric_timestamp}"
-
-    def encode_multiple(self, values: Sequence[FlushedMetric]) -> str:
-        def _safe_encode(value: FlushedMetric) -> Optional[str]:
-            try:
-                return self.encode(value)
-            except EncodingError:
-                sentry_sdk.capture_exception()
-                return None
-
-        return "\n".join(
-            encoded_value for value in values if (encoded_value := _safe_encode(value))
-        )
-
-    def _sanitize_value(self, value: str) -> str:
-        # Remove all non-alphanumerical chars which are different from _ / .
-        return sanitization_re.sub("", value)
-
-    def _get_metric_unit(self, unit: MetricUnit) -> str:
-        return f"@{unit}"
-
-    def _get_metric_values(self, value: Iterable[FlushedMetricValue]) -> str:
-        return self.MULTI_VALUE_SEPARATOR.join(str(v) for v in value)
+    def encode_multiple(self, values: Iterable[FlushedMetric]) -> str:
+        return "\n".join(self.encode(value) for value in values)
 
     def _get_metric_tags(self, tags: Optional[MetricTagsInternal]) -> str:
         if not tags:
@@ -64,24 +38,20 @@ class RelayStatsdEncoder:
 
         # We sanitize all the tag keys and tag values.
         sanitized_tags = (
-            (self._sanitize_value(tag_key), self._sanitize_value(tag_value))
-            for tag_key, tag_value in tags
+            (sanitize_value(tag_key), sanitize_value(tag_value)) for tag_key, tag_value in tags
         )
+
         # We then convert all tags whose tag key is not empty to the string representation.
-        tags_as_string = self.TAG_SEPARATOR.join(
+        return ",".join(
             f"{tag_key}:{tag_value}" for tag_key, tag_value in sanitized_tags if tag_key
         )
-        return f"|#{tags_as_string}"
-
-    def _get_metric_timestamp(self, timestamp: int) -> str:
-        return f"|T{timestamp}"
 
 
 class MetricEnvelopeTransport:
     def __init__(self, encoder: RelayStatsdEncoder):
         self._encoder = encoder
 
-    def send(self, flushed_metrics: Sequence[FlushedMetric]):
+    def send(self, flushed_metrics: Iterable[FlushedMetric]):
         client = sentry_sdk.Hub.current.client
         if client is None:
             return

--- a/src/minimetrics/types.py
+++ b/src/minimetrics/types.py
@@ -1,4 +1,4 @@
-from typing import Generic, Iterable, List, Literal, Mapping, NamedTuple, Tuple, TypeVar, Union
+from typing import Generic, Iterable, List, Literal, Mapping, Tuple, TypeVar, Union
 
 # Unit of the metrics.
 MetricUnit = Literal[
@@ -49,22 +49,15 @@ MetricTagsExternal = Mapping[MetricTagKey, MetricTagValueExternal]
 FlushedMetricValue = Union[int, float]
 
 
-class BucketKey(NamedTuple):
-    """
-    Key of the bucket.
-    """
-
-    timestamp: int
-    metric_type: MetricType
-    metric_name: str
-    metric_unit: MetricUnit
-    metric_tags: MetricTagsInternal
+BucketKey = Tuple[int, MetricType, str, MetricUnit, MetricTagsInternal]
 
 
 T = TypeVar("T")
 
 
 class Metric(Generic[T]):
+    __slots__ = ()
+
     @property
     def weight(self) -> int:
         raise NotImplementedError()
@@ -76,10 +69,4 @@ class Metric(Generic[T]):
         raise NotImplementedError()
 
 
-class FlushedMetric(NamedTuple):
-    """
-    Metric that is flushed by the flusher.
-    """
-
-    bucket_key: BucketKey
-    metric: Metric
+FlushedMetric = Tuple[BucketKey, Metric]

--- a/tests/minimetrics/test_core.py
+++ b/tests/minimetrics/test_core.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from freezegun import freeze_time
 
 from minimetrics.core import CounterMetric, DistributionMetric, MiniMetricsClient, SetMetric
-from minimetrics.types import BucketKey
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -30,14 +29,14 @@ def test_client_incr(_emit):
     client.aggregator.stop()
 
     assert len(client.aggregator.buckets) == 0
-    extracted_metrics_arg = _emit.call_args.args[0]
+    extracted_metrics_arg = list(_emit.call_args.args[0])
     assert len(extracted_metrics_arg) == 1
-    assert extracted_metrics_arg[0][0] == BucketKey(
-        timestamp=1693994400,
-        metric_type="c",
-        metric_name="button_clicked",
-        metric_unit="nanosecond",
-        metric_tags=(
+    assert extracted_metrics_arg[0][0] == (
+        1693994400,
+        "c",
+        "button_clicked",
+        "nanosecond",
+        (
             ("browser", "Chrome"),
             ("browser.version", "1.0"),
             ("user.classes", "1"),
@@ -66,14 +65,14 @@ def test_client_timing(_emit):
     client.aggregator.stop()
 
     assert len(client.aggregator.buckets) == 0
-    extracted_metrics_arg = _emit.call_args.args[0]
+    extracted_metrics_arg = list(_emit.call_args.args[0])
     assert len(extracted_metrics_arg) == 1
-    assert extracted_metrics_arg[0][0] == BucketKey(
-        timestamp=1693994400,
-        metric_type="d",
-        metric_name="execution_time",
-        metric_unit="second",
-        metric_tags=(
+    assert extracted_metrics_arg[0][0] == (
+        1693994400,
+        "d",
+        "execution_time",
+        "second",
+        (
             ("browser", "Chrome"),
             ("browser.version", "1.0"),
             ("user.classes", "1"),
@@ -103,14 +102,14 @@ def test_client_set(_emit):
     client.aggregator.stop()
 
     assert len(client.aggregator.buckets) == 0
-    extracted_metrics_arg = _emit.call_args.args[0]
+    extracted_metrics_arg = list(_emit.call_args.args[0])
     assert len(extracted_metrics_arg) == 1
-    assert extracted_metrics_arg[0][0] == BucketKey(
-        timestamp=1693994400,
-        metric_type="s",
-        metric_name="user",
-        metric_unit="none",
-        metric_tags=(
+    assert extracted_metrics_arg[0][0] == (
+        1693994400,
+        "s",
+        "user",
+        "none",
+        (
             ("browser", "Chrome"),
             ("browser.version", "1.0"),
             ("user.classes", "1"),
@@ -140,14 +139,14 @@ def test_client_gauge_as_counter(_emit):
     client.aggregator.stop()
 
     assert len(client.aggregator.buckets) == 0
-    extracted_metrics_arg = _emit.call_args.args[0]
+    extracted_metrics_arg = list(_emit.call_args.args[0])
     assert len(extracted_metrics_arg) == 1
-    assert extracted_metrics_arg[0][0] == BucketKey(
-        timestamp=1693994400,
-        metric_type="c",
-        metric_name="frontend_time",
-        metric_unit="second",
-        metric_tags=(
+    assert extracted_metrics_arg[0][0] == (
+        1693994400,
+        "c",
+        "frontend_time",
+        "second",
+        (
             ("browser", "Chrome"),
             ("browser.version", "1.0"),
             ("user.classes", "1"),

--- a/tests/minimetrics/test_transport.py
+++ b/tests/minimetrics/test_transport.py
@@ -1,13 +1,15 @@
+from typing import Any
 from unittest.mock import patch
 
 from minimetrics.core import CounterMetric, DistributionMetric, GaugeMetric, SetMetric
 from minimetrics.transport import MetricEnvelopeTransport, RelayStatsdEncoder
+from minimetrics.types import BucketKey
 
 
 def test_relay_encoder_with_counter():
     encoder = RelayStatsdEncoder()
 
-    bucket_key = (
+    bucket_key: BucketKey = (
         1693994400,
         "c",
         "button_click",
@@ -27,7 +29,7 @@ def test_relay_encoder_with_counter():
 def test_relay_encoder_with_distribution():
     encoder = RelayStatsdEncoder()
 
-    bucket_key = (
+    bucket_key: BucketKey = (
         1693994400,
         "d",
         "execution_time",
@@ -52,7 +54,7 @@ def test_relay_encoder_with_distribution():
 def test_relay_encoder_with_set():
     encoder = RelayStatsdEncoder()
 
-    bucket_key = (
+    bucket_key: BucketKey = (
         1693994400,
         "s",
         "users",
@@ -82,7 +84,7 @@ def test_relay_encoder_with_set():
 def test_relay_encoder_with_gauge():
     encoder = RelayStatsdEncoder()
 
-    bucket_key = (
+    bucket_key: BucketKey = (
         1693994400,
         "g",
         "startup_time",
@@ -107,7 +109,7 @@ def test_relay_encoder_with_gauge():
 def test_relay_encoder_with_invalid_chars():
     encoder = RelayStatsdEncoder()
 
-    bucket_key = (
+    bucket_key: BucketKey = (
         1693994400,
         "c",
         "büttòn_click",
@@ -193,7 +195,8 @@ def test_relay_encoder_with_multiple_metrics():
         CounterMetric(first=1),
     )
 
-    result = encoder.encode_multiple([flushed_metric_1, flushed_metric_2, flushed_metric_3])
+    metrics: Any = [flushed_metric_1, flushed_metric_2, flushed_metric_3]
+    result = encoder.encode_multiple(metrics)
 
     assert result == (
         "startup_time@second:10.0:10.0:10.0:10.0:1|g|#browser:Chrome,browser.version:1.0|T1693994400"
@@ -221,7 +224,8 @@ def test_send(sentry_sdk):
     )
 
     transport = MetricEnvelopeTransport(RelayStatsdEncoder())
-    transport.send([flushed_metric])
+    metrics: Any = [flushed_metric]
+    transport.send(metrics)
 
     args = sentry_sdk.Hub.current.client.transport.capture_envelope.call_args.args
     assert len(args) == 1

--- a/tests/minimetrics/test_transport.py
+++ b/tests/minimetrics/test_transport.py
@@ -1,27 +1,24 @@
 from unittest.mock import patch
 
-import pytest
-
 from minimetrics.core import CounterMetric, DistributionMetric, GaugeMetric, SetMetric
-from minimetrics.transport import EncodingError, MetricEnvelopeTransport, RelayStatsdEncoder
-from minimetrics.types import BucketKey, FlushedMetric
+from minimetrics.transport import MetricEnvelopeTransport, RelayStatsdEncoder
 
 
 def test_relay_encoder_with_counter():
     encoder = RelayStatsdEncoder()
 
-    bucket_key = BucketKey(
-        timestamp=1693994400,
-        metric_type="c",
-        metric_name="button_click",
-        metric_unit="none",
-        metric_tags=(
+    bucket_key = (
+        1693994400,
+        "c",
+        "button_click",
+        "none",
+        (
             ("browser", "Chrome"),
             ("browser.version", "1.0"),
         ),
     )
     metric = CounterMetric(first=2)
-    flushed_metric = FlushedMetric(bucket_key=bucket_key, metric=metric)
+    flushed_metric = (bucket_key, metric)
 
     result = encoder.encode(flushed_metric)
     assert result == "button_click@none:2|c|#browser:Chrome,browser.version:1.0|T1693994400"
@@ -30,12 +27,12 @@ def test_relay_encoder_with_counter():
 def test_relay_encoder_with_distribution():
     encoder = RelayStatsdEncoder()
 
-    bucket_key = BucketKey(
-        timestamp=1693994400,
-        metric_type="d",
-        metric_name="execution_time",
-        metric_unit="second",
-        metric_tags=(
+    bucket_key = (
+        1693994400,
+        "d",
+        "execution_time",
+        "second",
+        (
             ("browser", "Chrome"),
             ("browser.version", "1.0"),
         ),
@@ -43,7 +40,7 @@ def test_relay_encoder_with_distribution():
     metric = DistributionMetric(first=1.0)
     metric.add(0.5)
     metric.add(3.0)
-    flushed_metric = FlushedMetric(bucket_key=bucket_key, metric=metric)
+    flushed_metric = (bucket_key, metric)
 
     result = encoder.encode(flushed_metric)
     assert (
@@ -55,12 +52,12 @@ def test_relay_encoder_with_distribution():
 def test_relay_encoder_with_set():
     encoder = RelayStatsdEncoder()
 
-    bucket_key = BucketKey(
-        timestamp=1693994400,
-        metric_type="s",
-        metric_name="users",
-        metric_unit="none",
-        metric_tags=(
+    bucket_key = (
+        1693994400,
+        "s",
+        "users",
+        "none",
+        (
             ("browser", "Chrome"),
             ("browser.version", "1.0"),
         ),
@@ -68,7 +65,7 @@ def test_relay_encoder_with_set():
     metric = SetMetric(first=123)
     metric.add(456)
     metric.add("riccardo")
-    flushed_metric = FlushedMetric(bucket_key=bucket_key, metric=metric)
+    flushed_metric = (bucket_key, metric)
 
     result = encoder.encode(flushed_metric)
     pieces = result.split("|")
@@ -85,12 +82,12 @@ def test_relay_encoder_with_set():
 def test_relay_encoder_with_gauge():
     encoder = RelayStatsdEncoder()
 
-    bucket_key = BucketKey(
-        timestamp=1693994400,
-        metric_type="g",
-        metric_name="startup_time",
-        metric_unit="second",
-        metric_tags=(
+    bucket_key = (
+        1693994400,
+        "g",
+        "startup_time",
+        "second",
+        (
             ("browser", "Chrome"),
             ("browser.version", "1.0"),
         ),
@@ -98,7 +95,7 @@ def test_relay_encoder_with_gauge():
     metric = GaugeMetric(first=10.0)
     metric.add(5.0)
     metric.add(7.0)
-    flushed_metric = FlushedMetric(bucket_key=bucket_key, metric=metric)
+    flushed_metric = (bucket_key, metric)
 
     result = encoder.encode(flushed_metric)
     assert (
@@ -110,12 +107,12 @@ def test_relay_encoder_with_gauge():
 def test_relay_encoder_with_invalid_chars():
     encoder = RelayStatsdEncoder()
 
-    bucket_key = BucketKey(
-        timestamp=1693994400,
-        metric_type="c",
-        metric_name="büttòn_click",
-        metric_unit="second",
-        metric_tags=(
+    bucket_key = (
+        1693994400,
+        "c",
+        "büttòn_click",
+        "second",
+        (
             # Invalid tag key.
             ("browser\nname", "Chrome"),
             # Invalid tag value.
@@ -129,7 +126,7 @@ def test_relay_encoder_with_invalid_chars():
         ),
     )
     metric = CounterMetric(first=1)
-    flushed_metric = FlushedMetric(bucket_key=bucket_key, metric=metric)
+    flushed_metric = (bucket_key, metric)
 
     result = encoder.encode(flushed_metric)
     assert (
@@ -137,64 +134,63 @@ def test_relay_encoder_with_invalid_chars():
         == "bttn_click@second:1|c|#browsername:Chrome,browser.version:1.0,platform:Android,version:|T1693994400"
     )
 
-    bucket_key = BucketKey(
-        timestamp=1693994400,
-        metric_type="c",
-        metric_name="üòë",
-        metric_unit="second",
-        metric_tags=(),
+    bucket_key = (
+        1693994400,
+        "c",
+        "üòë",
+        "second",
+        (),
     )
     metric = CounterMetric(first=1)
-    flushed_metric = FlushedMetric(bucket_key=bucket_key, metric=metric)
+    flushed_metric = (bucket_key, metric)
 
-    with pytest.raises(EncodingError, match="The sanitized metric name üòë is empty"):
-        encoder.encode(flushed_metric)
+    assert encoder.encode(flushed_metric) == "invalid-metric-name@second:1|c|T1693994400"
 
 
 def test_relay_encoder_with_multiple_metrics():
     encoder = RelayStatsdEncoder()
 
-    flushed_metric_1 = FlushedMetric(
-        bucket_key=BucketKey(
-            timestamp=1693994400,
-            metric_type="g",
-            metric_name="startup_time",
-            metric_unit="second",
-            metric_tags=(
+    flushed_metric_1 = (
+        (
+            1693994400,
+            "g",
+            "startup_time",
+            "second",
+            (
                 ("browser", "Chrome"),
                 ("browser.version", "1.0"),
             ),
         ),
-        metric=GaugeMetric(first=10.0),
+        GaugeMetric(first=10.0),
     )
 
-    flushed_metric_2 = FlushedMetric(
-        bucket_key=BucketKey(
-            timestamp=1693994400,
-            metric_type="c",
-            metric_name="button_click",
-            metric_unit="none",
-            metric_tags=(
+    flushed_metric_2 = (
+        (
+            1693994400,
+            "c",
+            "button_click",
+            "none",
+            (
                 ("browser", "Chrome"),
                 ("browser.version", "1.0"),
             ),
         ),
-        metric=CounterMetric(first=1),
+        CounterMetric(first=1),
     )
 
-    flushed_metric_3 = FlushedMetric(
-        bucket_key=BucketKey(
-            timestamp=1693994400,
-            metric_type="c",
-            # This name will be completely scraped, resulting in no emission of the metric.
-            metric_name="öüâ",
-            metric_unit="none",
-            metric_tags=(
+    flushed_metric_3 = (
+        (
+            1693994400,
+            "c",
+            # This name will be completely scraped, resulting in an invalid metric.
+            "öüâ",
+            "none",
+            (
                 ("browser", "Chrome"),
                 ("browser.version", "1.0"),
             ),
         ),
-        metric=CounterMetric(first=1),
+        CounterMetric(first=1),
     )
 
     result = encoder.encode_multiple([flushed_metric_1, flushed_metric_2, flushed_metric_3])
@@ -203,23 +199,25 @@ def test_relay_encoder_with_multiple_metrics():
         "startup_time@second:10.0:10.0:10.0:10.0:1|g|#browser:Chrome,browser.version:1.0|T1693994400"
         + "\n"
         + "button_click@none:1|c|#browser:Chrome,browser.version:1.0|T1693994400"
+        + "\n"
+        + "invalid-metric-name@none:1|c|#browser:Chrome,browser.version:1.0|T1693994400"
     )
 
 
 @patch("minimetrics.transport.sentry_sdk")
 def test_send(sentry_sdk):
-    flushed_metric = FlushedMetric(
-        bucket_key=BucketKey(
-            timestamp=1693994400,
-            metric_type="c",
-            metric_name="button_click",
-            metric_unit="none",
-            metric_tags=(
+    flushed_metric = (
+        (
+            1693994400,
+            "c",
+            "button_click",
+            "none",
+            (
                 ("browser", "Chrome"),
                 ("browser.version", "1.0"),
             ),
         ),
-        metric=CounterMetric(first=1),
+        CounterMetric(first=1),
     )
 
     transport = MetricEnvelopeTransport(RelayStatsdEncoder())


### PR DESCRIPTION
Performance optimizations for the minimetrics system. Overall this should result in meaningful improvements.

- Removes the named tuples which perform really badly
- It also removes the exception code paths in the encoder, some unnecessary method invocations which are also adding overhead in the encoder.
- It also makes the flusher sleep for 5 seconds now rather than 2 which should result in fewer pointless iterations since the flush interval is only 10 seconds.
- Optimizes the force flush case to just replace the entire dictionary in one go