### PR TITLE
test: Add test-snuba-full

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,18 @@ test-snuba: create-db
 		-vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
 	@echo ""
 
+# snuba-full runs on API changes in Snuba
+test-snuba-full: create-db
+	@echo "--> Running full snuba tests"
+	pytest tests/snuba \
+		tests/sentry/eventstream/kafka \
+		tests/sentry/post_process_forwarder \
+		tests/sentry/snuba \
+		tests/sentry/search/events \
+		tests/sentry/event_manager \
+		-vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
+	pytest tests -m -vv -m snuba_ci
+	@echo ""
 
 test-tools:
 	@echo "--> Running tools tests"


### PR DESCRIPTION
Subset of snuba tests (that involve API changes) will run the full test suite instead of the reduced one

Right now this mirrors the prior set of Snuba tests (but will probably be tweaked in the future)