### PR TITLE
Release threshold status API

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -357,7 +357,9 @@ class OrganizationEndpoint(Endpoint):
         except ValueError:
             raise ParseError(detail="Invalid project parameter. Values must be numbers.")
 
-    def get_environments(self, request: Request, organization: Organization) -> list[Environment]:
+    def get_environments(
+        self, request: Request, organization: Organization | RpcOrganization
+    ) -> list[Environment]:
         return get_environments(request, organization)
 
     def get_filter_params(

--- a/src/sentry/api/endpoints/release_threshold.py
+++ b/src/sentry/api/endpoints/release_threshold.py
@@ -46,10 +46,6 @@ class ReleaseThresholdEndpoint(ProjectEndpoint):
     def post(self, request: Request, project: Project) -> HttpResponse:
         serializer = ReleaseThresholdPOSTSerializer(
             data=request.data,
-            context={
-                "organization": project.organization,
-                "access": request.access,
-            },
         )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/release_threshold.py
+++ b/src/sentry/api/endpoints/release_threshold.py
@@ -16,14 +16,14 @@ from sentry.models.release_threshold.constants import (
     THRESHOLD_TYPE_STR_TO_INT,
     TRIGGER_TYPE_STRING_TO_INT,
     ReleaseThresholdType,
-    TriggerType,
 )
+from sentry.models.release_threshold.constants import TriggerType as ReleaseThresholdTriggerType
 from sentry.models.release_threshold.release_threshold import ReleaseThreshold
 
 
 class ReleaseThresholdPOSTSerializer(serializers.Serializer):
     threshold_type = serializers.ChoiceField(choices=ReleaseThresholdType.as_str_choices())
-    trigger_type = serializers.ChoiceField(choices=TriggerType.as_str_choices())
+    trigger_type = serializers.ChoiceField(choices=ReleaseThresholdTriggerType.as_str_choices())
     value = serializers.IntegerField()
     window_in_seconds = serializers.IntegerField()
     environment = EnvironmentField(required=False, allow_null=True)

--- a/src/sentry/api/endpoints/release_threshold.py
+++ b/src/sentry/api/endpoints/release_threshold.py
@@ -46,6 +46,10 @@ class ReleaseThresholdEndpoint(ProjectEndpoint):
     def post(self, request: Request, project: Project) -> HttpResponse:
         serializer = ReleaseThresholdPOSTSerializer(
             data=request.data,
+            context={
+                "organization": project.organization,
+                "access": request.access,
+            },
         )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_threshold_status_index.py
@@ -164,6 +164,17 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
         Determines whether a projects threshold has been breached or not
         True - healthy
         False - unhealthy
+
+        error count - over/under
+        new issue count - over/under
+        unhandled issue count - over/under/%unhandled total
+        regressed issue count - over/under/% of issues that have regressed
+        failure rate - % uptime
+        crash_free_session_rate - % over/%under
+        crash free user session - % over/%under
+
+        Could simply have over/under
+        - each threshold type is either a count or a %?
         """
         # TOTAL_ERROR_COUNT_STR = "total_error_count" - Can we even get a % over/under for errors?
         # NEW_ISSUE_COUNT_STR = "new_issue_count" - What is a % over/under for new issues??

--- a/src/sentry/api/endpoints/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_threshold_status_index.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from django.db.models import F, Q
+from django.http import HttpResponse
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import EnvironmentMixin, region_silo_endpoint
+from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
+from sentry.api.utils import get_date_range_from_params
+from sentry.models import Release
+from sentry.services.hybrid_cloud.organization import RpcOrganization
+
+if TYPE_CHECKING:
+    from sentry.models.organization import Organization
+
+
+class ReleaseStatusIndexSerializer(serializers.Serializer):
+    start = serializers.DateTimeField(
+        help_text="This defines the start of the time series range as an explicit datetime, either in UTC ISO8601 or epoch seconds."
+        "Use along with `end`",
+        required=True,
+    )
+    end = serializers.DateTimeField(
+        help_text=(
+            "This defines the inclusive end of the time series range as an explicit datetime, either in UTC ISO8601 or epoch seconds."
+            "Use along with `start`"
+        ),
+        required=True,
+    )
+    environments = serializers.ListField(required=False, allow_null=True, allow_empty=True)
+    projects = serializers.ListField(required=False, allow_null=True, allow_empty=True)
+    release_ids = serializers.ListField(required=False, allow_null=True, allow_empty=True)
+
+    def validate(self, data):
+        if data.start >= data.end:
+            raise serializers.ValidationError("Start datetime must be after End")
+
+
+@region_silo_endpoint
+class ReleaseStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMixin):
+    owner: ApiOwner = ApiOwner.ENTERPRISE
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    def get(self, request: Request, organization: Organization | RpcOrganization) -> HttpResponse:
+        """
+        List all derived statuses of releases that fall within the provided start/end datetimes
+        limit results?
+        We can probably just copy the OrganizationReleasesStatsEndpoint
+        Maybe we can tack in the threshold health into that api? but may be overcomplicating and expanding its scope...
+        inherit?
+        helper method?
+        """
+        data = request.data if len(request.GET) == 0 and hasattr(request, "data") else request.GET
+        start, end = get_date_range_from_params(params=data)
+        environments_list = request.GET.getlist("environment")
+        project_ids_list = request.GET.getlist("project")
+        release_ids_list = request.GET.getlist("release_id")
+
+        serializer = ReleaseStatusIndexSerializer(
+            data=request.query_params,
+            context={  # do we need to pass in extra context?
+                "organization": organization,
+                "access": request.access,
+            },
+        )
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        release_query = Q(organization=organization)
+        environments = self.get_environments(request, organization)
+        if environments:
+            environments_list = [env.name for env in environments]
+            release_query &= Q(
+                releaseprojectenvironment__environment__name__in=environments_list,
+            )
+        if project_ids_list:
+            release_query &= Q(
+                project_id__in=project_ids_list,
+            )
+        if release_ids_list:
+            release_query &= Q(
+                id__in=release_ids_list,
+            )
+
+        queryset = (
+            Release.objects.filter(release_query)
+            .annotate(
+                date=F("date_added"),  # transforms date_added into 'date'
+            )
+            .order_by("-date")
+            .distinct()
+        )
+        # NOTE: we're only filtering on date ADDED
+        # This is not synonymous with a deploy... which may be what we actually want.
+        queryset = queryset.filter(date__gte=start, date__lte=end)
+        if release_ids_list:
+            queryset = queryset.filter(id__in=release_ids_list)
+
+        queryset.prefetch_related("projects__release_thresholds")
+
+        # ========================================================================
+        # TODO:
+        # Determine which thresholds have succeeded/failed
+
+        release_threshold_health = defaultdict(list)
+
+        for release in queryset:
+            for project in release.projects.all():
+                for threshold in project.release_thresholds.all():
+                    # thresholds are per proj/env
+                    # releases can belong to multiple projects...
+                    # So - we'll need to calcualte the threshold health. index on project
+                    """
+                    health = {
+                        release_id: {
+                            project_id: [threshold1, threshold2],
+                            project_id: [threshold1, threshold2],
+                        }
+                    }
+                    """
+                    release_threshold_health[project.id].append(threshold.id)
+                    # print(threshold)
+        #             calculate_threshold_health(r, p, threshold)

--- a/src/sentry/api/endpoints/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_threshold_status_index.py
@@ -17,7 +17,7 @@ from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.models import Release
 
-# from sentry.models.release_threshold.constants import ReleaseThresholdType, TriggerType
+# from sentry.models.release_threshold.constants import ReleaseThresholdType, TriggerType as ReleaseThresholdTriggerType
 from sentry.services.hybrid_cloud.organization import RpcOrganization
 
 if TYPE_CHECKING:
@@ -164,37 +164,21 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
         Determines whether a projects threshold has been breached or not
         True - healthy
         False - unhealthy
-
-        error count - over/under
-        new issue count - over/under
-        unhandled issue count - over/under/%unhandled total
-        regressed issue count - over/under/% of issues that have regressed
-        failure rate - % uptime
-        crash_free_session_rate - % over/%under
-        crash free user session - % over/%under
-
-        Could simply have over/under
-        - each threshold type is either a count or a %?
         """
-        # TOTAL_ERROR_COUNT_STR = "total_error_count" - Can we even get a % over/under for errors?
-        # NEW_ISSUE_COUNT_STR = "new_issue_count" - What is a % over/under for new issues??
-        # UNHANDLED_ISSUE_COUNT_STR = "unhandled_issue_count" - count & % makes sense
-        # REGRESSED_ISSUE_COUNT_STR = "regressed_issue_count" - count & % makes sense
-        # FAILURE_RATE_STR = "failure_rate" - Count does not make sense
-        # CRASH_FREE_SESSION_RATE_STR = "crash_free_session_rate" - Count does not make sense
-        # CRASH_FREE_USER_RATE_STR = "crash_free_user_rate" - Count does not make sense
         # TODO:
         # for each threshold type - determine how to properly pull the data?
-        # PERCENT_OVER_STR = "percent_over"
-        # PERCENT_UNDER_STR = "percent_under"
-        # ABSOLUTE_OVER_STR = "absolute_over"
-        # ABSOLUTE_UNDER_STR = "absolute_under"
-
         # threshold_type = threshold.threshold_type
         # trigger_type = threshold.trigger_type
         # value = threshold.value
         # window = threshold.window_in_seconds
         # project = threshold.project
         # environment = threshold.environment
+
+        """
+        Does each threshold type turn into a query string?
+        DD - has query formula that is run
+
+        Dig to see where we fetch this data today
+        """
 
         return True

--- a/src/sentry/api/endpoints/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_threshold_status_index.py
@@ -42,8 +42,9 @@ class ReleaseStatusIndexSerializer(serializers.Serializer):
     release_ids = serializers.ListField(required=False, allow_null=True, allow_empty=True)
 
     def validate(self, data):
-        if data.start >= data.end:
+        if data["start"] >= data["end"]:
             raise serializers.ValidationError("Start datetime must be after End")
+        return data
 
 
 @region_silo_endpoint
@@ -56,11 +57,13 @@ class ReleaseStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMi
     def get(self, request: Request, organization: Organization | RpcOrganization) -> HttpResponse:
         """
         List all derived statuses of releases that fall within the provided start/end datetimes
-        limit results?
-        We can probably just copy the OrganizationReleasesStatsEndpoint
-        Maybe we can tack in the threshold health into that api? but may be overcomplicating and expanding its scope...
-        inherit?
-        helper method?
+        ``````````````````
+
+        :param start: timestamp of the beginning of the specified date range
+        :param end: timestamp of the end of the specified date range
+
+        TODO:
+        - should we limit/paginate results? (this could get really bulky)
         """
         data = request.data if len(request.GET) == 0 and hasattr(request, "data") else request.GET
         start, end = get_date_range_from_params(params=data)
@@ -134,12 +137,12 @@ class ReleaseStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMi
                 project_threshold_statuses = []
                 for threshold in project.release_thresholds.all():
                     is_healthy = self.is_threshold_healthy(threshold)
-                    project_threshold_statuses.append[
+                    project_threshold_statuses.append(
                         {
                             **serialize(threshold),
                             "is_healthy": is_healthy,
                         }
-                    ]
+                    )
                 release_threshold_health[release.id] = project_threshold_statuses
 
         return Response(release_threshold_health, status=200)

--- a/src/sentry/api/endpoints/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_threshold_status_index.py
@@ -63,6 +63,26 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
     def get(self, request: Request, organization: Organization | RpcOrganization) -> HttpResponse:
         """
         List all derived statuses of releases that fall within the provided start/end datetimes
+
+        Constructs a nested response key'd off release_id, project_id, and lists _all_ thresholds for specified project
+        Each returned threshold value will contain the full serialized release_threshold instance as well as it's derived health status
+
+        health = {
+            release_id: {
+                project_id: [
+                    {
+                        threshold_id,
+                        project,
+                        ...,
+                        is_healthy: True/False
+                    },
+                    {...},
+                ],
+                project2_id: [],
+                ...
+            },
+            ...
+        }
         ``````````````````
 
         :param start: timestamp of the beginning of the specified date range
@@ -114,28 +134,8 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
 
         # ========================================================================
         # TODO:
+        # Fetch relevant snuba/sessions data
         # Determine which thresholds have succeeded/failed
-        """
-        Constructs a nested response key'd off release_id, project_id, and lists _all_ threshold for specified project
-        Each returned threshold value will contain the full serialized release_threshold instance as well as it's derived health status
-
-        health = {
-            release_id: {
-                project_id: [
-                    {
-                        threshold_id,
-                        project,
-                        ...,
-                        is_healthy: True/False
-                    },
-                    {...},
-                ],
-                project2_id: [],
-                ...
-            },
-            ...
-        }
-        """
 
         release_threshold_health = defaultdict()
         for release in queryset:

--- a/src/sentry/api/endpoints/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_threshold_status_index.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from sentry.models.organization import Organization
 
 
-class ReleaseStatusIndexSerializer(serializers.Serializer):
+class ReleaseThresholdStatusIndexSerializer(serializers.Serializer):
     start = serializers.DateTimeField(
         help_text="This defines the start of the time series range as an explicit datetime, either in UTC ISO8601 or epoch seconds."
         "Use along with `end`",
@@ -48,7 +48,7 @@ class ReleaseStatusIndexSerializer(serializers.Serializer):
 
 
 @region_silo_endpoint
-class ReleaseStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMixin):
+class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMixin):
     owner: ApiOwner = ApiOwner.ENTERPRISE
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
@@ -71,7 +71,7 @@ class ReleaseStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMi
         project_ids_list = request.GET.getlist("project")
         release_ids_list = request.GET.getlist("release_id")
 
-        serializer = ReleaseStatusIndexSerializer(
+        serializer = ReleaseThresholdStatusIndexSerializer(
             data=request.query_params,
             context={  # do we need to pass in extra context?
                 "organization": organization,

--- a/src/sentry/api/endpoints/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_threshold_status_index.py
@@ -144,7 +144,13 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
                 project_list = release.projects.all()
             for project in project_list:
                 project_threshold_statuses = []
-                for threshold in project.release_thresholds.all():
+                if environments_list:
+                    thresholds_list = project.release_thresholds.filter(
+                        environment__name__in=environments_list
+                    )
+                else:
+                    thresholds_list = project.release_thresholds.all()
+                for threshold in thresholds_list:
                     is_healthy = self.is_threshold_healthy(threshold)
                     project_threshold_statuses.append(
                         {

--- a/src/sentry/api/endpoints/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_threshold_status_index.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, DefaultDict
 
 from django.db.models import F, Q
 from django.http import HttpResponse
@@ -135,7 +135,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
         # Fetch relevant snuba/sessions data
         # Determine which thresholds have succeeded/failed
 
-        release_threshold_health = defaultdict()
+        release_threshold_health: DefaultDict[int, Any] = defaultdict()
         for release in queryset:
             release_project = defaultdict(list)
             if project_ids_list:

--- a/src/sentry/api/endpoints/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_threshold_status_index.py
@@ -16,8 +16,6 @@ from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.models import Release
-
-# from sentry.models.release_threshold.constants import ReleaseThresholdType, TriggerType as ReleaseThresholdTriggerType
 from sentry.services.hybrid_cloud.organization import RpcOrganization
 
 if TYPE_CHECKING:
@@ -57,7 +55,7 @@ class ReleaseThresholdStatusIndexSerializer(serializers.Serializer):
 class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMixin):
     owner: ApiOwner = ApiOwner.ENTERPRISE
     publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.EXPERIMENTAL,
     }
 
     def get(self, request: Request, organization: Organization | RpcOrganization) -> HttpResponse:

--- a/src/sentry/api/endpoints/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_threshold_status_index.py
@@ -105,9 +105,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
         # NOTE: we're only filtering on date ADDED
         # This is not synonymous with a deploy... which may be what we actually want.
         release_query = Q(organization=organization, date_added__gte=start, date_added__lte=end)
-        environments = self.get_environments(request, organization)
-        if environments:
-            environments_list = [env.name for env in environments]
+        if environments_list:
             release_query &= Q(
                 releaseprojectenvironment__environment__name__in=environments_list,
             )

--- a/src/sentry/api/helpers/environments.py
+++ b/src/sentry/api/helpers/environments.py
@@ -9,6 +9,7 @@ from sentry.models import Environment
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
+    from sentry.services.hybrid_cloud.organization import RpcOrganization
 
 environment_visibility_filter_options = {
     "all": lambda queryset: queryset,
@@ -17,7 +18,9 @@ environment_visibility_filter_options = {
 }
 
 
-def get_environments(request: Request, organization: Organization) -> list[Environment]:
+def get_environments(
+    request: Request, organization: Organization | RpcOrganization
+) -> list[Environment]:
     requested_environments = set(request.GET.getlist("environment"))
 
     if not requested_environments:

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -24,6 +24,7 @@ from sentry.api.endpoints.organization_projects_experiment import (
 from sentry.api.endpoints.organization_spans_aggregation import OrganizationSpansAggregationEndpoint
 from sentry.api.endpoints.release_threshold import ReleaseThresholdEndpoint
 from sentry.api.endpoints.release_threshold_details import ReleaseThresholdDetailsEndpoint
+from sentry.api.endpoints.release_threshold_status_index import ReleaseStatusIndexEndpoint
 from sentry.api.endpoints.source_map_debug_blue_thunder_edition import (
     SourceMapDebugBlueThunderEditionEndpoint,
 )
@@ -1613,6 +1614,12 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_slug>[^\/]+)/releases/$",
         OrganizationReleasesEndpoint.as_view(),
         name="sentry-api-0-organization-releases",
+    ),
+    # TODO: also integrate release threshold status into the releases response?
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/release-statuses/$",
+        ReleaseStatusIndexEndpoint.as_view(),
+        name="sentry-api-0-organization-release-statuses",
     ),
     re_path(
         r"^(?P<organization_slug>[^\/]+)/releases/stats/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -24,7 +24,7 @@ from sentry.api.endpoints.organization_projects_experiment import (
 from sentry.api.endpoints.organization_spans_aggregation import OrganizationSpansAggregationEndpoint
 from sentry.api.endpoints.release_threshold import ReleaseThresholdEndpoint
 from sentry.api.endpoints.release_threshold_details import ReleaseThresholdDetailsEndpoint
-from sentry.api.endpoints.release_threshold_status_index import ReleaseStatusIndexEndpoint
+from sentry.api.endpoints.release_threshold_status_index import ReleaseThresholdStatusIndexEndpoint
 from sentry.api.endpoints.source_map_debug_blue_thunder_edition import (
     SourceMapDebugBlueThunderEditionEndpoint,
 )
@@ -1617,9 +1617,9 @@ ORGANIZATION_URLS = [
     ),
     # TODO: also integrate release threshold status into the releases response?
     re_path(
-        r"^(?P<organization_slug>[^\/]+)/release-statuses/$",
-        ReleaseStatusIndexEndpoint.as_view(),
-        name="sentry-api-0-organization-release-statuses",
+        r"^(?P<organization_slug>[^\/]+)/release-threshold-statuses/$",
+        ReleaseThresholdStatusIndexEndpoint.as_view(),
+        name="sentry-api-0-organization-release-threshold-statuses",
     ),
     re_path(
         r"^(?P<organization_slug>[^\/]+)/releases/stats/$",

--- a/src/sentry/models/release_threshold/__init__.py
+++ b/src/sentry/models/release_threshold/__init__.py
@@ -1,0 +1,3 @@
+from .releasethreshold import ReleaseThreshold
+
+__all__ = ("ReleaseThreshold",)

--- a/src/sentry/models/release_threshold/__init__.py
+++ b/src/sentry/models/release_threshold/__init__.py
@@ -1,3 +1,0 @@
-from .releasethreshold import ReleaseThreshold
-
-__all__ = ("ReleaseThreshold",)

--- a/src/sentry/models/release_threshold/constants.py
+++ b/src/sentry/models/release_threshold/constants.py
@@ -41,32 +41,24 @@ class ReleaseThresholdType:
 
 
 class TriggerType:
-    PERCENT_OVER = 0
-    PERCENT_UNDER = 1
-    ABSOLUTE_OVER = 2
-    ABSOLUTE_UNDER = 3
+    OVER = 0
+    UNDER = 1
 
-    PERCENT_OVER_STR = "percent_over"
-    PERCENT_UNDER_STR = "percent_under"
-    ABSOLUTE_OVER_STR = "absolute_over"
-    ABSOLUTE_UNDER_STR = "absolute_under"
+    OVER_STR = "over"
+    UNDER_STR = "under"
 
     @classmethod
     def as_choices(cls):  # choices for model column
         return (
-            (cls.PERCENT_OVER_STR, cls.PERCENT_OVER),
-            (cls.PERCENT_UNDER_STR, cls.PERCENT_UNDER),
-            (cls.ABSOLUTE_OVER_STR, cls.ABSOLUTE_OVER),
-            (cls.ABSOLUTE_UNDER_STR, cls.ABSOLUTE_UNDER),
+            (cls.OVER_STR, cls.OVER),
+            (cls.UNDER_STR, cls.UNDER),
         )
 
     @classmethod
     def as_str_choices(cls):  # choices for serializer
         return (
-            (cls.PERCENT_OVER_STR, cls.PERCENT_OVER_STR),
-            (cls.PERCENT_UNDER_STR, cls.PERCENT_UNDER_STR),
-            (cls.ABSOLUTE_OVER_STR, cls.ABSOLUTE_OVER_STR),
-            (cls.ABSOLUTE_UNDER_STR, cls.ABSOLUTE_UNDER_STR),
+            (cls.OVER_STR, cls.OVER_STR),
+            (cls.UNDER_STR, cls.UNDER_STR),
         )
 
 
@@ -91,15 +83,11 @@ THRESHOLD_TYPE_STR_TO_INT = {
 }
 
 TRIGGER_TYPE_INT_TO_STR = {
-    TriggerType.PERCENT_OVER: TriggerType.PERCENT_OVER_STR,
-    TriggerType.PERCENT_UNDER: TriggerType.PERCENT_UNDER_STR,
-    TriggerType.ABSOLUTE_OVER: TriggerType.ABSOLUTE_OVER_STR,
-    TriggerType.ABSOLUTE_UNDER: TriggerType.ABSOLUTE_UNDER_STR,
+    TriggerType.OVER: TriggerType.OVER_STR,
+    TriggerType.UNDER: TriggerType.UNDER_STR,
 }
 
 TRIGGER_TYPE_STRING_TO_INT = {
-    TriggerType.PERCENT_OVER_STR: TriggerType.PERCENT_OVER,
-    TriggerType.PERCENT_UNDER_STR: TriggerType.PERCENT_UNDER,
-    TriggerType.ABSOLUTE_OVER_STR: TriggerType.ABSOLUTE_OVER,
-    TriggerType.ABSOLUTE_UNDER_STR: TriggerType.ABSOLUTE_UNDER,
+    TriggerType.OVER_STR: TriggerType.OVER,
+    TriggerType.UNDER_STR: TriggerType.UNDER,
 }

--- a/src/sentry/models/release_threshold/release_threshold.py
+++ b/src/sentry/models/release_threshold/release_threshold.py
@@ -4,7 +4,8 @@ from django.utils import timezone
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model
 from sentry.db.models.fields.bounded import BoundedPositiveIntegerField
-from sentry.models.release_threshold.constants import ReleaseThresholdType, TriggerType
+from sentry.models.release_threshold.constants import ReleaseThresholdType
+from sentry.models.release_threshold.constants import TriggerType as ReleaseThresholdTriggerType
 
 
 @region_silo_only_model
@@ -12,7 +13,7 @@ class ReleaseThreshold(Model):
     __relocation_scope__ = RelocationScope.Excluded
 
     threshold_type = BoundedPositiveIntegerField(choices=ReleaseThresholdType.as_choices())
-    trigger_type = BoundedPositiveIntegerField(choices=TriggerType.as_choices())
+    trigger_type = BoundedPositiveIntegerField(choices=ReleaseThresholdTriggerType.as_choices())
 
     value = models.IntegerField()
     window_in_seconds = models.IntegerField()

--- a/tests/sentry/api/endpoints/test_release_threshold.py
+++ b/tests/sentry/api/endpoints/test_release_threshold.py
@@ -28,7 +28,7 @@ class ReleaseThresholdTest(APITestCase):
             self.url,
             data={
                 "threshold_type": "total_error_count",
-                "trigger_type": "absolute_over",
+                "trigger_type": "over",
                 # value is missing
                 "window_in_seconds": 1800,
                 "environment": "canary",
@@ -43,7 +43,7 @@ class ReleaseThresholdTest(APITestCase):
             self.url,
             data={
                 "threshold_type": "indiana_jones_and_the_temple_of_doom",
-                "trigger_type": "absolute_over",
+                "trigger_type": "over",
                 "value": 100,
                 "window_in_seconds": 1800,
                 "environment": "canary",
@@ -80,7 +80,7 @@ class ReleaseThresholdTest(APITestCase):
             url_with_invalid_project,
             data={
                 "threshold_type": "total_error_count",
-                "trigger_type": "absolute_over",
+                "trigger_type": "over",
                 "value": 100,
                 "window_in_seconds": 1800,
                 "environment": "production",
@@ -93,7 +93,7 @@ class ReleaseThresholdTest(APITestCase):
             self.url,
             data={
                 "threshold_type": "total_error_count",
-                "trigger_type": "absolute_over",
+                "trigger_type": "over",
                 "value": 100,
                 "window_in_seconds": 1800,
                 "environment": "Sentry belongs in a museum.",
@@ -107,7 +107,7 @@ class ReleaseThresholdTest(APITestCase):
             self.url,
             data={
                 "threshold_type": "total_error_count",
-                "trigger_type": "absolute_over",
+                "trigger_type": "over",
                 "value": 100,
                 "window_in_seconds": 1800,
             },
@@ -115,7 +115,7 @@ class ReleaseThresholdTest(APITestCase):
         assert response.status_code == 201
         data = response.data
         assert data["threshold_type"] == "total_error_count"
-        assert data["trigger_type"] == "absolute_over"
+        assert data["trigger_type"] == "over"
         assert data["value"] == 100
         assert data["window_in_seconds"] == 1800
         assert data["project"]["id"] == str(self.project.id)
@@ -129,7 +129,7 @@ class ReleaseThresholdTest(APITestCase):
             self.url,
             data={
                 "threshold_type": "total_error_count",
-                "trigger_type": "absolute_over",
+                "trigger_type": "over",
                 "value": 100,
                 "window_in_seconds": 1800,
                 "environment": "canary",
@@ -139,7 +139,7 @@ class ReleaseThresholdTest(APITestCase):
         assert response.status_code == 201
         data = response.data
         assert data["threshold_type"] == "total_error_count"
-        assert data["trigger_type"] == "absolute_over"
+        assert data["trigger_type"] == "over"
         assert data["value"] == 100
         assert data["window_in_seconds"] == 1800
         assert data["project"]["id"] == str(self.project.id)
@@ -171,7 +171,7 @@ class ReleaseThresholdTest(APITestCase):
         assert len(response.data) == 0
         ReleaseThreshold.objects.create(
             threshold_type=0,
-            trigger_type=2,
+            trigger_type=0,
             value=100,
             window_in_seconds=1800,
             project=self.project,
@@ -185,7 +185,7 @@ class ReleaseThresholdTest(APITestCase):
         created_threshold = response.data[0]
 
         assert created_threshold["threshold_type"] == "total_error_count"
-        assert created_threshold["trigger_type"] == "absolute_over"
+        assert created_threshold["trigger_type"] == "over"
         assert created_threshold["value"] == 100
         assert created_threshold["window_in_seconds"] == 1800
         assert created_threshold["project"]["id"] == str(self.project.id)
@@ -201,7 +201,7 @@ class ReleaseThresholdTest(APITestCase):
 
         ReleaseThreshold.objects.create(
             threshold_type=0,
-            trigger_type=2,
+            trigger_type=0,
             value=100,
             window_in_seconds=1800,
             project=self.project,
@@ -210,7 +210,7 @@ class ReleaseThresholdTest(APITestCase):
 
         ReleaseThreshold.objects.create(
             threshold_type=0,
-            trigger_type=2,
+            trigger_type=1,
             value=100,
             window_in_seconds=1800,
             project=self.project,
@@ -224,7 +224,7 @@ class ReleaseThresholdTest(APITestCase):
         created_threshold = response.data[0]
 
         assert created_threshold["threshold_type"] == "total_error_count"
-        assert created_threshold["trigger_type"] == "absolute_over"
+        assert created_threshold["trigger_type"] == "over"
         assert created_threshold["value"] == 100
         assert created_threshold["window_in_seconds"] == 1800
         assert created_threshold["project"]["id"] == str(self.project.id)

--- a/tests/sentry/api/endpoints/test_release_threshold_details.py
+++ b/tests/sentry/api/endpoints/test_release_threshold_details.py
@@ -67,7 +67,7 @@ class ReleaseThresholdDetailsTest(APITestCase):
         assert response.status_code == 200
         assert response.data["id"] == str(self.basic_threshold.id)
         assert response.data["threshold_type"] == "total_error_count"
-        assert response.data["trigger_type"] == "percent_over"
+        assert response.data["trigger_type"] == "over"
         assert response.data["value"] == 100
         assert response.data["window_in_seconds"] == 1800
         assert response.data["environment"]["name"] == "canary"

--- a/tests/sentry/api/endpoints/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/test_release_threshold_status.py
@@ -226,7 +226,7 @@ class ReleaseThresholdStatusTest(APITestCase):
         We'll filter for _only_ canary releases, so the response should look like
         {
             [release1]: {
-                [p1.id]: [threshold-p1-canary, threshold2-p1-canary, threshold-p1-prod]
+                [p1.id]: [threshold-p1-canary, threshold2-p1-canary]
                 [p2.id]: [threshold-p2-canary]
             }
         }
@@ -234,15 +234,15 @@ class ReleaseThresholdStatusTest(APITestCase):
         now = str(datetime.now())
         yesterday = str(datetime.now() - timedelta(hours=24))
         response = self.get_success_response(
-            self.organization.slug, start=yesterday, end=now, environment="canary"
+            self.organization.slug, start=yesterday, end=now, environment=["canary"]
         )
 
         assert len(response.data) == 1  # only the canary release
         assert len(response.data.get(self.release1.id)) == 2  # 2 projects (p1 & p2) in release 1
 
         assert (
-            len(response.data.get(self.release1.id, {}).get(self.project1.id)) == 3
-        )  # p1 2x canary, 1x prod
+            len(response.data.get(self.release1.id, {}).get(self.project1.id)) == 2
+        )  # p1 2x canary
         assert (
             response.data.get(self.release1.id, {})
             .get(self.project1.id)[0]  # first threshold
@@ -250,13 +250,6 @@ class ReleaseThresholdStatusTest(APITestCase):
             .get("name")
             == self.canary_environment.name
         )  # assert environment is 'canary'
-        assert (
-            response.data.get(self.release1.id, {})
-            .get(self.project1.id)[2]
-            .get("environment", {})
-            .get("name")
-            == self.production_environment.name
-        )  # assert environment is 'production'
         assert (
             len(response.data.get(self.release1.id, {}).get(self.project2.id)) == 1
         )  # p2 1x canary

--- a/tests/sentry/api/endpoints/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/test_release_threshold_status.py
@@ -154,9 +154,15 @@ class ReleaseThresholdStatusTest(APITestCase):
         """
         now = str(datetime.now())
         yesterday = str(datetime.now() - timedelta(hours=24))
+        last_week = str(datetime.now() - timedelta(days=7))
+        release_old = Release.objects.create(
+            version="0", organization=self.organization, date_added=last_week
+        )
+
         response = self.get_success_response(self.organization.slug, start=yesterday, end=now)
 
         assert len(response.data) == 2  # 2 releases
+        assert release_old.id not in response.data  # old release is filtered out of response
         assert len(response.data.get(self.release1.id)) == 2  # 2 projects (p1 & p2) in release 1
 
         assert (

--- a/tests/sentry/api/endpoints/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/test_release_threshold_status.py
@@ -267,7 +267,7 @@ class ReleaseThresholdStatusTest(APITestCase):
 
     def test_get_success_release_id_filter(self):
         """
-        Tests fetching thresholds within the past 24hrs filtered on environment
+        Tests fetching thresholds within the past 24hrs filtered on release_id's
 
         Set up creates
         - 2 releases
@@ -333,7 +333,10 @@ class ReleaseThresholdStatusTest(APITestCase):
 
     def test_get_success_project_id_filter(self):
         """
-        Tests fetching thresholds within the past 24hrs filtered on environment
+        Tests fetching thresholds within the past 24hrs filtered on project_id's
+        NOTE: in order to determine *release* health, we still need all projects (& thresholds) associated with that release
+        So - filtering on project will give us all the releases associated with that project
+        but we still need all the other projects associated with the release to determine health status
 
         Set up creates
         - 2 releases

--- a/tests/sentry/api/endpoints/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/test_release_threshold_status.py
@@ -1,0 +1,391 @@
+from datetime import datetime, timedelta
+
+from django.urls import reverse
+
+from sentry.models import (
+    Environment,
+    Release,
+    ReleaseEnvironment,
+    ReleaseProjectEnvironment,
+    ReleaseThreshold,
+)
+from sentry.models.release_threshold.constants import ReleaseThresholdType
+from sentry.testutils.cases import APITestCase
+
+
+class ReleaseThresholdStatusTest(APITestCase):
+    endpoint = "sentry-api-0-organization-release-threshold-statuses"
+    method = "get"
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user(is_staff=True, is_superuser=True)
+        # 3 projects
+        self.project1 = self.create_project(name="foo", organization=self.organization)
+        self.project2 = self.create_project(name="bar", organization=self.organization)
+        self.project3 = self.create_project(name="biz", organization=self.organization)
+
+        # 2 environments
+        self.canary_environment = Environment.objects.create(
+            organization_id=self.organization.id, name="canary"
+        )
+        self.production_environment = Environment.objects.create(
+            organization_id=self.organization.id, name="production"
+        )
+
+        # release created for proj1, and proj2
+        self.release1 = Release.objects.create(version="1", organization=self.organization)
+        # add_project get_or_creates a ReleaseProject
+        self.release1.add_project(self.project1)
+        # cannot add multiple projects to a release??? :think:
+        self.release1.add_project(self.project2)
+
+        # release created for proj1
+        self.release2 = Release.objects.create(version="2", organization=self.organization)
+        self.release2.add_project(self.project1)
+
+        # Not sure what Release Environments are for...
+        # project superfluous/deprecated in ReleaseEnvironment
+        # probably attaches the release to a particular environment?
+        # release1 canary
+        ReleaseEnvironment.objects.create(
+            organization_id=self.organization.id,
+            release_id=self.release1.id,
+            environment_id=self.canary_environment.id,
+        )
+        # Release Project Environments are required to query releases by project
+        # Even though both environment & project are here, this seems to just attach a release to a project
+        # You can have multiple ReleaseProjectEnvironment's per release (this attaches multiple projects to the release&env)
+        # release1 project1 canary
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release1.id,
+            project_id=self.project1.id,
+            environment_id=self.canary_environment.id,
+        )
+        # release1 project2 canary
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release1.id,
+            project_id=self.project2.id,
+            environment_id=self.canary_environment.id,
+        )
+
+        # release2 prod
+        ReleaseEnvironment.objects.create(
+            organization_id=self.organization.id,
+            release_id=self.release2.id,
+            environment_id=self.production_environment.id,
+        )
+        # release2 project1 prod
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release2.id,
+            project_id=self.project1.id,
+            environment_id=self.production_environment.id,
+        )
+
+        # thresholds for project1 in canary
+        ReleaseThreshold.objects.create(
+            threshold_type=ReleaseThresholdType.TOTAL_ERROR_COUNT,
+            trigger_type=2,
+            value=100,
+            window_in_seconds=100,
+            project=self.project1,
+            environment=self.canary_environment,
+        )
+        ReleaseThreshold.objects.create(
+            threshold_type=ReleaseThresholdType.NEW_ISSUE_COUNT,
+            trigger_type=2,
+            value=100,
+            window_in_seconds=100,
+            project=self.project1,
+            environment=self.canary_environment,
+        )
+        # threshold for project1 in production
+        ReleaseThreshold.objects.create(
+            threshold_type=ReleaseThresholdType.TOTAL_ERROR_COUNT,
+            trigger_type=2,
+            value=100,
+            window_in_seconds=100,
+            project=self.project1,
+            environment=self.production_environment,
+        )
+        # threshold for project2 in canary
+        ReleaseThreshold.objects.create(
+            threshold_type=ReleaseThresholdType.TOTAL_ERROR_COUNT,
+            trigger_type=2,
+            value=100,
+            window_in_seconds=100,
+            project=self.project2,
+            environment=self.canary_environment,
+        )
+
+        self.login_as(user=self.user)
+        self.url = reverse(
+            "sentry-api-0-organization-release-threshold-statuses",
+            kwargs={"organization_slug": self.organization.slug},
+        )
+
+    def test_get_success(self):
+        """
+        Tests fetching all thresholds (env+project agnostic) within the past 24hrs.
+
+        Set up creates
+        - 2 releases
+            - release1 - canary # env only matters for how we filter releases
+                - r1-proj1-canary # NOTE: is it possible to have a ReleaseProjectEnvironment without a corresponding ReleaseEnvironment??
+                - r1-proj2-canary
+            - release2 - prod # env only matters for how we filter releases
+                - r2-proj1-prod
+        - 4 thresholds
+            - project1 canary
+            - project1 canary
+            - project1 prod
+            - project2 canary
+
+        so response should look like
+        {
+            [release1]: {
+                [p1.id]: [threshold-p1-canary, threshold2-p1-canary, threshold-p1-prod]
+                [p2.id]: [threshold-p2-canary]
+            }
+            [release2]: [
+                [p1.id]: [threshold-p1-canary, threshold2-p1-canary, threshold-p1-prod]
+            ]
+        }
+        """
+        now = str(datetime.now())
+        yesterday = str(datetime.now() - timedelta(hours=24))
+        response = self.get_success_response(self.organization.slug, start=yesterday, end=now)
+
+        assert len(response.data) == 2  # 2 releases
+        assert len(response.data.get(self.release1.id)) == 2  # 2 projects (p1 & p2) in release 1
+
+        assert (
+            len(response.data.get(self.release1.id, {}).get(self.project1.id)) == 3
+        )  # p1 2x canary, 1x prod
+        assert (
+            response.data.get(self.release1.id, {})
+            .get(self.project1.id)[0]  # first threshold
+            .get("environment", {})
+            .get("name")
+            == self.canary_environment.name
+        )  # assert environment is 'canary'
+        assert (
+            response.data.get(self.release1.id, {})
+            .get(self.project1.id)[2]
+            .get("environment", {})
+            .get("name")
+            == self.production_environment.name
+        )  # assert environment is 'production'
+        assert (
+            len(response.data.get(self.release1.id, {}).get(self.project2.id)) == 1
+        )  # p2 1x canary
+        assert (
+            response.data.get(self.release1.id, {})
+            .get(self.project2.id)[0]  # first threshold
+            .get("environment", {})
+            .get("name")
+            == self.canary_environment.name
+        )  # assert environment is 'canary'
+
+        assert len(response.data.get(self.release2.id)) == 1  # 1 project (p1) in release 2
+        assert (
+            len(response.data.get(self.release1.id, {}).get(self.project1.id)) == 3
+        )  # p1 2x canary, 1x prod
+        assert (
+            response.data.get(self.release1.id, {})
+            .get(self.project1.id)[0]  # first threshold
+            .get("environment", {})
+            .get("name")
+            == self.canary_environment.name
+        )  # assert environment is 'canary'
+        assert (
+            response.data.get(self.release1.id, {})
+            .get(self.project1.id)[2]
+            .get("environment", {})
+            .get("name")
+            == self.production_environment.name
+        )  # assert environment is 'production'
+
+    def test_get_success_environment_filter(self):
+        """
+        Tests fetching thresholds within the past 24hrs filtered on environment
+
+        Set up creates
+        - 2 releases
+            - release1 - canary # env only matters for how we filter releases
+                - r1-proj1-canary # NOTE: is it possible to have a ReleaseProjectEnvironment without a corresponding ReleaseEnvironment??
+                - r1-proj2-canary
+            - release2 - prod # env only matters for how we filter releases
+                - r2-proj1-prod
+        - 4 thresholds
+            - project1 canary
+            - project1 canary
+            - project1 prod
+            - project2 canary
+
+        We'll filter for _only_ canary releases, so the response should look like
+        {
+            [release1]: {
+                [p1.id]: [threshold-p1-canary, threshold2-p1-canary, threshold-p1-prod]
+                [p2.id]: [threshold-p2-canary]
+            }
+        }
+        """
+        now = str(datetime.now())
+        yesterday = str(datetime.now() - timedelta(hours=24))
+        response = self.get_success_response(
+            self.organization.slug, start=yesterday, end=now, environment="canary"
+        )
+
+        assert len(response.data) == 1  # only the canary release
+        assert len(response.data.get(self.release1.id)) == 2  # 2 projects (p1 & p2) in release 1
+
+        assert (
+            len(response.data.get(self.release1.id, {}).get(self.project1.id)) == 3
+        )  # p1 2x canary, 1x prod
+        assert (
+            response.data.get(self.release1.id, {})
+            .get(self.project1.id)[0]  # first threshold
+            .get("environment", {})
+            .get("name")
+            == self.canary_environment.name
+        )  # assert environment is 'canary'
+        assert (
+            response.data.get(self.release1.id, {})
+            .get(self.project1.id)[2]
+            .get("environment", {})
+            .get("name")
+            == self.production_environment.name
+        )  # assert environment is 'production'
+        assert (
+            len(response.data.get(self.release1.id, {}).get(self.project2.id)) == 1
+        )  # p2 1x canary
+        assert (
+            response.data.get(self.release1.id, {})
+            .get(self.project2.id)[0]  # first threshold
+            .get("environment", {})
+            .get("name")
+            == self.canary_environment.name
+        )  # assert environment is 'canary'
+
+        assert (
+            len(response.data.get(self.release2.id, {})) == 0
+        )  # release2 should not exist in the response
+
+    def test_get_success_release_id_filter(self):
+        """
+        Tests fetching thresholds within the past 24hrs filtered on environment
+
+        Set up creates
+        - 2 releases
+            - release1 - canary # env only matters for how we filter releases
+                - r1-proj1-canary # NOTE: is it possible to have a ReleaseProjectEnvironment without a corresponding ReleaseEnvironment??
+                - r1-proj2-canary
+            - release2 - prod # env only matters for how we filter releases
+                - r2-proj1-prod
+        - 4 thresholds
+            - project1 canary
+            - project1 canary
+            - project1 prod
+            - project2 canary
+
+        We'll filter for _only_ release1, so the response should look like
+        {
+            [release1]: {
+                [p1.id]: [threshold-p1-canary, threshold2-p1-canary, threshold-p1-prod]
+                [p2.id]: [threshold-p2-canary]
+            }
+        }
+        """
+        now = str(datetime.now())
+        yesterday = str(datetime.now() - timedelta(hours=24))
+        response = self.get_success_response(
+            self.organization.slug, start=yesterday, end=now, release_id=[self.release1.id]
+        )
+
+        assert len(response.data) == 1  # only fetched release1
+        assert len(response.data.get(self.release1.id)) == 2  # 2 projects (p1 & p2) in release 1
+
+        assert (
+            len(response.data.get(self.release1.id, {}).get(self.project1.id)) == 3
+        )  # p1 2x canary, 1x prod
+        assert (
+            response.data.get(self.release1.id, {})
+            .get(self.project1.id)[0]  # first threshold
+            .get("environment", {})
+            .get("name")
+            == self.canary_environment.name
+        )  # assert environment is 'canary'
+        assert (
+            response.data.get(self.release1.id, {})
+            .get(self.project1.id)[2]
+            .get("environment", {})
+            .get("name")
+            == self.production_environment.name
+        )  # assert environment is 'production'
+        assert (
+            len(response.data.get(self.release1.id, {}).get(self.project2.id)) == 1
+        )  # p2 1x canary
+        assert (
+            response.data.get(self.release1.id, {})
+            .get(self.project2.id)[0]  # first threshold
+            .get("environment", {})
+            .get("name")
+            == self.canary_environment.name
+        )  # assert environment is 'canary'
+
+        assert (
+            len(response.data.get(self.release2.id, {})) == 0
+        )  # release2 should not exist in the response
+
+    def test_get_success_project_id_filter(self):
+        """
+        Tests fetching thresholds within the past 24hrs filtered on environment
+
+        Set up creates
+        - 2 releases
+            - release1 - canary # env only matters for how we filter releases
+                - r1-proj1-canary # NOTE: is it possible to have a ReleaseProjectEnvironment without a corresponding ReleaseEnvironment??
+                - r1-proj2-canary
+            - release2 - prod # env only matters for how we filter releases
+                - r2-proj1-prod
+        - 4 thresholds
+            - project1 canary
+            - project1 canary
+            - project1 prod
+            - project2 canary
+
+        We'll filter for _only_ project2, so the response should look like
+        since project2 was only ever added to release1
+        {
+            [release1]: { # NOTE: fetches only the releases that include p2
+                [p1.id]: [threshold-p1-canary, threshold2-p1-canary, threshold-p1-prod]
+                [p2.id]: [threshold-p2-canary]
+            }
+        }
+        """
+        now = str(datetime.now())
+        yesterday = str(datetime.now() - timedelta(hours=24))
+        response = self.get_success_response(
+            self.organization.slug, start=yesterday, end=now, project=[self.project2.id]
+        )
+
+        assert len(response.data) == 1  # only fetched release1
+        assert (
+            len(response.data.get(self.release1.id)) == 1
+        )  # p1 has been filtered out of the response
+
+        assert (
+            len(response.data.get(self.release1.id, {}).get(self.project2.id)) == 1
+        )  # p2 1x canary
+        assert (
+            response.data.get(self.release1.id, {})
+            .get(self.project2.id)[0]  # first threshold
+            .get("environment", {})
+            .get("name")
+            == self.canary_environment.name
+        )  # assert environment is 'canary'
+
+        assert (
+            len(response.data.get(self.release2.id, {})) == 0
+        )  # release2 should not exist in the response

--- a/tests/sentry/api/endpoints/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/test_release_threshold_status.py
@@ -2,14 +2,9 @@ from datetime import datetime, timedelta
 
 from django.urls import reverse
 
-from sentry.models import (
-    Environment,
-    Release,
-    ReleaseEnvironment,
-    ReleaseProjectEnvironment,
-    ReleaseThreshold,
-)
+from sentry.models import Environment, Release, ReleaseEnvironment, ReleaseProjectEnvironment
 from sentry.models.release_threshold.constants import ReleaseThresholdType
+from sentry.models.release_threshold.release_threshold import ReleaseThreshold
 from sentry.testutils.cases import APITestCase
 
 
@@ -37,7 +32,6 @@ class ReleaseThresholdStatusTest(APITestCase):
         self.release1 = Release.objects.create(version="1", organization=self.organization)
         # add_project get_or_creates a ReleaseProject
         self.release1.add_project(self.project1)
-        # cannot add multiple projects to a release??? :think:
         self.release1.add_project(self.project2)
 
         # release created for proj1
@@ -85,7 +79,7 @@ class ReleaseThresholdStatusTest(APITestCase):
         # thresholds for project1 in canary
         ReleaseThreshold.objects.create(
             threshold_type=ReleaseThresholdType.TOTAL_ERROR_COUNT,
-            trigger_type=2,
+            trigger_type=1,
             value=100,
             window_in_seconds=100,
             project=self.project1,
@@ -93,7 +87,7 @@ class ReleaseThresholdStatusTest(APITestCase):
         )
         ReleaseThreshold.objects.create(
             threshold_type=ReleaseThresholdType.NEW_ISSUE_COUNT,
-            trigger_type=2,
+            trigger_type=1,
             value=100,
             window_in_seconds=100,
             project=self.project1,
@@ -102,7 +96,7 @@ class ReleaseThresholdStatusTest(APITestCase):
         # threshold for project1 in production
         ReleaseThreshold.objects.create(
             threshold_type=ReleaseThresholdType.TOTAL_ERROR_COUNT,
-            trigger_type=2,
+            trigger_type=1,
             value=100,
             window_in_seconds=100,
             project=self.project1,
@@ -111,7 +105,7 @@ class ReleaseThresholdStatusTest(APITestCase):
         # threshold for project2 in canary
         ReleaseThreshold.objects.create(
             threshold_type=ReleaseThresholdType.TOTAL_ERROR_COUNT,
-            trigger_type=2,
+            trigger_type=1,
             value=100,
             window_in_seconds=100,
             project=self.project2,


### PR DESCRIPTION
Initial PR to introduce GET api for release threshold api

API properly fetches all thresholds given a start/end, list of release ids, or list of project ids and returns the threshold info along with its derived status.
threshold statuses are key'd off of release and project (environment is included in the threshold data)
<img width="1331" alt="Screenshot 2023-09-15 at 10 54 24 AM" src="https://github.com/getsentry/sentry/assets/6186377/efc9f19b-6336-4771-8045-026d48253aa8">



TODO:
- implement threshold status indicator