### PR TITLE
feat(minimetrics): faster encode and filter out statsd from s4s

### DIFF
--- a/src/minimetrics/transport.py
+++ b/src/minimetrics/transport.py
@@ -1,11 +1,12 @@
 import re
 from functools import partial
+from io import BytesIO
 from typing import Iterable
 
 import sentry_sdk
 from sentry_sdk.envelope import Envelope, Item
 
-from minimetrics.types import FlushedMetric, MetricTagsInternal
+from minimetrics.types import FlushedMetric
 from sentry.utils import metrics
 
 
@@ -21,30 +22,42 @@ sanitize_value = partial(re.compile(r"[^a-zA-Z0-9_/.]").sub, "")
 
 
 class RelayStatsdEncoder:
-    def encode(self, value: FlushedMetric) -> str:
+    def _encode(self, value: FlushedMetric, out: BytesIO):
+        _write = out.write
         (timestamp, metric_type, metric_name, metric_unit, metric_tags), metric = value
         metric_name = sanitize_value(metric_name) or "invalid-metric-name"
-        metric_values = ":".join(str(v) for v in metric.serialize_value())
-        serialized_metric_tags = self._get_metric_tags(metric_tags)
-        metric_tags_prefix = serialized_metric_tags and "|#" or ""
-        return f"{metric_name}@{metric_unit}:{metric_values}|{metric_type}{metric_tags_prefix}{serialized_metric_tags}|T{timestamp}"
+        _write(f"{metric_name}@{metric_unit}".encode())
 
-    def encode_multiple(self, values: Iterable[FlushedMetric]) -> str:
-        return "\n".join(self.encode(value) for value in values)
+        for value in metric.serialize_value():
+            _write(b":")
+            _write(str(value).encode("utf-8"))
 
-    def _get_metric_tags(self, tags: MetricTagsInternal) -> str:
-        if not tags:
-            return ""
+        _write(f"|{metric_type}".encode("ascii"))
 
-        # We sanitize all the tag keys and tag values.
-        sanitized_tags = (
-            (sanitize_value(tag_key), sanitize_value(tag_value)) for tag_key, tag_value in tags
-        )
+        if metric_tags:
+            _write(b"|#")
+            first = True
+            for tag_key, tag_value in metric_tags:
+                tag_key = sanitize_value(tag_key)
+                if not tag_key:
+                    continue
+                if first:
+                    first = False
+                else:
+                    _write(b",")
+                _write(tag_key.encode("utf-8"))
+                _write(b":")
+                _write(sanitize_value(tag_value).encode("utf-8"))
 
-        # We then convert all tags whose tag key is not empty to the string representation.
-        return ",".join(
-            f"{tag_key}:{tag_value}" for tag_key, tag_value in sanitized_tags if tag_key
-        )
+        _write(f"|T{timestamp}".encode("ascii"))
+
+    def encode_multiple(self, values: Iterable[FlushedMetric]) -> bytes:
+        out = BytesIO()
+        _write = out.write
+        for value in values:
+            self._encode(value, out)
+            _write(b"\n")
+        return out.getvalue()
 
 
 class MetricEnvelopeTransport:

--- a/src/minimetrics/transport.py
+++ b/src/minimetrics/transport.py
@@ -28,9 +28,9 @@ class RelayStatsdEncoder:
         metric_name = sanitize_value(metric_name) or "invalid-metric-name"
         _write(f"{metric_name}@{metric_unit}".encode())
 
-        for value in metric.serialize_value():
+        for serialized_value in metric.serialize_value():
             _write(b":")
-            _write(str(value).encode("utf-8"))
+            _write(str(serialized_value).encode("utf-8"))
 
         _write(f"|{metric_type}".encode("ascii"))
 

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -405,6 +405,15 @@ def configure_sdk():
                 # install_id = options.get('sentry:install-id')
                 # if install_id:
                 #     event.setdefault('tags', {})['install-id'] = install_id
+                if method_name == "capture_envelope":
+                    args_list = list(args)
+                    envelope = args_list[0]
+                    # Do not forward metrics to s4s
+                    safe_items = [x for x in envelope.items if x.data_category != "statsd"]
+                    if len(safe_items) != len(envelope.items):
+                        relay_envelope = copy.copy(envelope)
+                        relay_envelope.items = safe_items
+                        args = [relay_envelope, *args_list[1:]]
                 getattr(sentry4sentry_transport, method_name)(*args, **kwargs)
 
             if sentry_saas_transport and options.get("store.use-relay-dsn-sample-rate") == 1:


### PR DESCRIPTION
This changes the minimetrics code so that it directly encodes into bytes. This avoids a massive utf-8 encode later.

Additionally this filters out dual writing the stats to s4s.