### PR TITLE
feat(perf): Add link to Database view to sidebar

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -44,6 +44,7 @@ import theme from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useProjects from 'sentry/utils/useProjects';
+import {RELEASE_LEVEL} from 'sentry/views/performance/database/settings';
 
 import {ProfilingOnboardingSidebar} from '../profiling/ProfilingOnboarding/profilingOnboardingSidebar';
 
@@ -215,13 +216,44 @@ function Sidebar({location, organization}: Props) {
       features={['performance-view']}
       organization={organization}
     >
-      <SidebarItem
-        {...sidebarItemProps}
-        icon={<IconLightning />}
-        label={<GuideAnchor target="performance">{t('Performance')}</GuideAnchor>}
-        to={`/organizations/${organization.slug}/performance/`}
-        id="performance"
-      />
+      {(() => {
+        // If Database View is enabled, show a Performance accordion with a Database sub-item
+        if (organization.features.includes('performance-database-view')) {
+          return (
+            <SidebarAccordion
+              {...sidebarItemProps}
+              icon={<IconLightning />}
+              label={<GuideAnchor target="performance">{t('Performance')}</GuideAnchor>}
+              to={`/organizations/${organization.slug}/performance/`}
+              id="performance"
+            >
+              <SidebarItem
+                {...sidebarItemProps}
+                isAlpha={RELEASE_LEVEL === 'alpha'}
+                isBeta={RELEASE_LEVEL === 'beta'}
+                isNew={RELEASE_LEVEL === 'new'}
+                label={
+                  <GuideAnchor target="performance-database">{t('Database')}</GuideAnchor>
+                }
+                to={`/organizations/${organization.slug}/performance/database/`}
+                id="performance-database"
+                icon={<SubitemDot collapsed={collapsed} />}
+              />
+            </SidebarAccordion>
+          );
+        }
+
+        // Otherwise, show a regular sidebar link to the Performance landing page
+        return (
+          <SidebarItem
+            {...sidebarItemProps}
+            icon={<IconLightning />}
+            label={<GuideAnchor target="performance">{t('Performance')}</GuideAnchor>}
+            to={`/organizations/${organization.slug}/performance/`}
+            id="performance"
+          />
+        );
+      })()}
     </Feature>
   );
 


### PR DESCRIPTION
If the Database view is enabled, render an accordion with a Databse sub-item. Otherwise, render a regular link.

**e.g.,**
<img width="236" alt="Screenshot 2023-09-15 at 2 45 42 PM" src="https://github.com/getsentry/sentry/assets/989898/3cbc327e-15ec-479c-bbc9-6aa62e1162fb">
