### PR TITLE
fix(alerts): Skip metrics tag resolver error when deleting

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -518,7 +518,7 @@ class MetricsQueryBuilder(QueryBuilder):
                     resolved_item = self.resolve_tag_value(item)
                     if (
                         resolved_item is None
-                        and not self.builder_config.skip_field_validation_for_entity_deletion
+                        and not self.builder_config.skip_field_validation_for_entity_subscription_deletion
                     ):
                         raise IncompatibleMetricsQuery(f"{name} value {item} in filter not found")
                     resolved_value.append(resolved_item)

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -516,7 +516,10 @@ class MetricsQueryBuilder(QueryBuilder):
                 resolved_value = []
                 for item in value:
                     resolved_item = self.resolve_tag_value(item)
-                    if resolved_item is None:
+                    if (
+                        resolved_item is None
+                        and not self.builder_config.skip_field_validation_for_entity_deletion
+                    ):
                         raise IncompatibleMetricsQuery(f"{name} value {item} in filter not found")
                     resolved_value.append(resolved_item)
                 value = resolved_value

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1597,7 +1597,7 @@ class DiscoverDatasetConfig(DatasetConfig):
         return filter_aliases.semver_build_filter_converter(self.builder, search_filter)
 
     def _issue_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
-        if self.builder.builder_config.skip_field_validation_for_entity_deletion:
+        if self.builder.builder_config.skip_field_validation_for_entity_subscription_deletion:
             return None
 
         operator = search_filter.operator

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1597,7 +1597,7 @@ class DiscoverDatasetConfig(DatasetConfig):
         return filter_aliases.semver_build_filter_converter(self.builder, search_filter)
 
     def _issue_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
-        if self.builder.builder_config.skip_issue_validation:
+        if self.builder.builder_config.skip_field_validation_for_entity_deletion:
             return None
 
         operator = search_filter.operator

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -115,5 +115,5 @@ class QueryBuilderConfig:
     # of a top events request
     skip_tag_resolution: bool = False
     on_demand_metrics_enabled: bool = False
-    skip_issue_validation: bool = False
+    skip_field_validation_for_entity_deletion: bool = False
     allow_metric_aggregates: Optional[bool] = False

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -115,5 +115,5 @@ class QueryBuilderConfig:
     # of a top events request
     skip_tag_resolution: bool = False
     on_demand_metrics_enabled: bool = False
-    skip_field_validation_for_entity_deletion: bool = False
+    skip_field_validation_for_entity_subscription_deletion: bool = False
     allow_metric_aggregates: Optional[bool] = False

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -153,7 +153,7 @@ class BaseEntitySubscription(ABC, _EntitySubscription):
         project_ids: Sequence[int],
         environment: Optional[Environment],
         params: Optional[MutableMapping[str, Any]] = None,
-        skip_issue_validation: bool = False,
+        skip_field_validation_for_entity_deletion: bool = False,
     ) -> QueryBuilder:
         raise NotImplementedError
 
@@ -174,7 +174,7 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
         project_ids: Sequence[int],
         environment: Optional[Environment],
         params: Optional[MutableMapping[str, Any]] = None,
-        skip_issue_validation: bool = False,
+        skip_field_validation_for_entity_deletion: bool = False,
     ) -> QueryBuilder:
         from sentry.search.events.builder import QueryBuilder
 
@@ -197,7 +197,7 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
             config=QueryBuilderConfig(
                 skip_time_conditions=True,
                 parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
-                skip_issue_validation=skip_issue_validation,
+                skip_field_validation_for_entity_deletion=skip_field_validation_for_entity_deletion,
             ),
         )
 
@@ -258,7 +258,7 @@ class SessionsEntitySubscription(BaseEntitySubscription):
         project_ids: Sequence[int],
         environment: Optional[Environment],
         params: Optional[MutableMapping[str, Any]] = None,
-        skip_issue_validation: bool = False,
+        skip_field_validation_for_entity_deletion: bool = False,
     ) -> QueryBuilder:
         from sentry.search.events.builder import SessionsQueryBuilder
 
@@ -294,7 +294,7 @@ class SessionsEntitySubscription(BaseEntitySubscription):
                 functions_acl=["identity"],
                 skip_time_conditions=True,
                 parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
-                skip_issue_validation=skip_issue_validation,
+                skip_field_validation_for_entity_deletion=skip_field_validation_for_entity_deletion,
             ),
         )
 
@@ -375,7 +375,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
         project_ids: Sequence[int],
         environment: Optional[Environment],
         params: Optional[MutableMapping[str, Any]] = None,
-        skip_issue_validation: bool = False,
+        skip_field_validation_for_entity_deletion: bool = False,
     ) -> QueryBuilder:
         from sentry.search.events.builder import AlertMetricsQueryBuilder
 
@@ -398,7 +398,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
                 skip_time_conditions=True,
                 use_metrics_layer=self.use_metrics_layer,
                 on_demand_metrics_enabled=self.on_demand_metrics_enabled,
-                skip_issue_validation=skip_issue_validation,
+                skip_field_validation_for_entity_deletion=skip_field_validation_for_entity_deletion,
             ),
         )
 
@@ -683,7 +683,7 @@ def get_entity_key_from_snuba_query(
     snuba_query: SnubaQuery,
     organization_id: int,
     project_id: int,
-    skip_issue_validation: bool = False,
+    skip_field_validation_for_entity_deletion: bool = False,
 ) -> EntityKey:
     entity_subscription = get_entity_subscription_from_snuba_query(
         snuba_query,
@@ -694,6 +694,6 @@ def get_entity_key_from_snuba_query(
         [project_id],
         None,
         {"organization_id": organization_id},
-        skip_issue_validation=skip_issue_validation,
+        skip_field_validation_for_entity_deletion=skip_field_validation_for_entity_deletion,
     )
     return get_entity_key_from_query_builder(query_builder)

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -153,7 +153,7 @@ class BaseEntitySubscription(ABC, _EntitySubscription):
         project_ids: Sequence[int],
         environment: Optional[Environment],
         params: Optional[MutableMapping[str, Any]] = None,
-        skip_field_validation_for_entity_deletion: bool = False,
+        skip_field_validation_for_entity_subscription_deletion: bool = False,
     ) -> QueryBuilder:
         raise NotImplementedError
 
@@ -174,7 +174,7 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
         project_ids: Sequence[int],
         environment: Optional[Environment],
         params: Optional[MutableMapping[str, Any]] = None,
-        skip_field_validation_for_entity_deletion: bool = False,
+        skip_field_validation_for_entity_subscription_deletion: bool = False,
     ) -> QueryBuilder:
         from sentry.search.events.builder import QueryBuilder
 
@@ -197,7 +197,7 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
             config=QueryBuilderConfig(
                 skip_time_conditions=True,
                 parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
-                skip_field_validation_for_entity_deletion=skip_field_validation_for_entity_deletion,
+                skip_field_validation_for_entity_subscription_deletion=skip_field_validation_for_entity_subscription_deletion,
             ),
         )
 
@@ -258,7 +258,7 @@ class SessionsEntitySubscription(BaseEntitySubscription):
         project_ids: Sequence[int],
         environment: Optional[Environment],
         params: Optional[MutableMapping[str, Any]] = None,
-        skip_field_validation_for_entity_deletion: bool = False,
+        skip_field_validation_for_entity_subscription_deletion: bool = False,
     ) -> QueryBuilder:
         from sentry.search.events.builder import SessionsQueryBuilder
 
@@ -294,7 +294,7 @@ class SessionsEntitySubscription(BaseEntitySubscription):
                 functions_acl=["identity"],
                 skip_time_conditions=True,
                 parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
-                skip_field_validation_for_entity_deletion=skip_field_validation_for_entity_deletion,
+                skip_field_validation_for_entity_subscription_deletion=skip_field_validation_for_entity_subscription_deletion,
             ),
         )
 
@@ -375,7 +375,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
         project_ids: Sequence[int],
         environment: Optional[Environment],
         params: Optional[MutableMapping[str, Any]] = None,
-        skip_field_validation_for_entity_deletion: bool = False,
+        skip_field_validation_for_entity_subscription_deletion: bool = False,
     ) -> QueryBuilder:
         from sentry.search.events.builder import AlertMetricsQueryBuilder
 
@@ -398,7 +398,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
                 skip_time_conditions=True,
                 use_metrics_layer=self.use_metrics_layer,
                 on_demand_metrics_enabled=self.on_demand_metrics_enabled,
-                skip_field_validation_for_entity_deletion=skip_field_validation_for_entity_deletion,
+                skip_field_validation_for_entity_subscription_deletion=skip_field_validation_for_entity_subscription_deletion,
             ),
         )
 
@@ -683,7 +683,7 @@ def get_entity_key_from_snuba_query(
     snuba_query: SnubaQuery,
     organization_id: int,
     project_id: int,
-    skip_field_validation_for_entity_deletion: bool = False,
+    skip_field_validation_for_entity_subscription_deletion: bool = False,
 ) -> EntityKey:
     entity_subscription = get_entity_subscription_from_snuba_query(
         snuba_query,
@@ -694,6 +694,6 @@ def get_entity_key_from_snuba_query(
         [project_id],
         None,
         {"organization_id": organization_id},
-        skip_field_validation_for_entity_deletion=skip_field_validation_for_entity_deletion,
+        skip_field_validation_for_entity_subscription_deletion=skip_field_validation_for_entity_subscription_deletion,
     )
     return get_entity_key_from_query_builder(query_builder)

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -179,7 +179,7 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
             subscription.snuba_query,
             subscription.project.organization_id,
             subscription.project_id,
-            skip_issue_validation=True,
+            skip_field_validation_for_entity_deletion=True,
         )
         _delete_from_snuba(
             query_dataset,

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -179,7 +179,7 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
             subscription.snuba_query,
             subscription.project.organization_id,
             subscription.project_id,
-            skip_field_validation_for_entity_deletion=True,
+            skip_field_validation_for_entity_subscription_deletion=True,
         )
         _delete_from_snuba(
             query_dataset,

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -266,6 +266,18 @@ class DeleteSubscriptionFromSnubaTest(BaseSnubaTaskTest, TestCase):
         delete_subscription_from_snuba(sub.id)
         assert not QuerySubscription.objects.filter(id=sub.id).exists()
 
+    def test_invalid_metrics_subscription_query(self):
+        subscription_id = f"1/{uuid4().hex}"
+        sub = self.create_subscription(
+            QuerySubscription.Status.DELETING,
+            dataset=Dataset.Metrics,
+            subscription_id=subscription_id,
+            query="release:1",
+            aggregate="percentage(sessions_crashed, sessions) as _crash_rate_alert_aggregate",
+        )
+        delete_subscription_from_snuba(sub.id)
+        assert not QuerySubscription.objects.filter(id=sub.id).exists()
+
 
 class BuildSnqlQueryTest(TestCase):
     aggregate_mappings: dict[SnubaQuery.Type, dict[Dataset, dict[str, Any]]] = {


### PR DESCRIPTION
The MetricsQueryBuilder is used to retreive an entity for deleting a subscription. There is some validation logic which occassionally gets in the way of deletion, so we've modified a config parameter to use to silence these errors so that we enable a successful deletion.

I'll need to monitor if there are other areas that raise validation issues and I'll add more skip conditions if they're raised.

Fixes #SENTRY-15KV