### PR TITLE
fix(crons): Reject invalid cron schedules

### DIFF
--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -324,7 +324,7 @@ class UpdateMonitorTest(MonitorTestCase):
             monitor.slug,
             method="PUT",
             status_code=400,
-            **{"config": {"schedule": "* * 31 2 *"}},
+            **{"config": {"schedule": "* * 31 9 *"}},
         )
 
     def test_crontab_unsupported(self):

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -319,6 +319,13 @@ class UpdateMonitorTest(MonitorTestCase):
             status_code=400,
             **{"config": {"schedule": "* * * *"}},
         )
+        self.get_error_response(
+            self.organization.slug,
+            monitor.slug,
+            method="PUT",
+            status_code=400,
+            **{"config": {"schedule": "* * 31 2 *"}},
+        )
 
     def test_crontab_unsupported(self):
         monitor = self._create_monitor()

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -493,9 +493,19 @@ class MonitorConsumerTest(TestCase):
         assert checkin.monitor_id == monitor.id
 
     def test_monitor_invalid_config(self):
+        # 6 value schedule
         self.send_checkin(
             "my-invalid-monitor",
             monitor_config={"schedule": {"type": "crontab", "value": "13 * * * * *"}},
+            environment="my-environment",
+        )
+
+        assert not MonitorCheckIn.objects.filter(guid=self.guid).exists()
+
+        # no next valid check-in
+        self.send_checkin(
+            "my-invalid-monitor",
+            monitor_config={"schedule": {"type": "crontab", "value": "* * 31 2 *"}},
             environment="my-environment",
         )
 


### PR DESCRIPTION
Checks to make sure that schedule isn't just parseable but actually has a valid next check-in

Fixes SENTRY-15RH
Fixes SENTRY-15R1