### PR TITLE
fix(backup): Add backup tests for NeglectedRule

### DIFF
--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -61,7 +61,7 @@ from sentry.models.projectownership import ProjectOwnership
 from sentry.models.projectredirect import ProjectRedirect
 from sentry.models.recentsearch import RecentSearch
 from sentry.models.relay import Relay, RelayUsage
-from sentry.models.rule import RuleActivity, RuleActivityType
+from sentry.models.rule import NeglectedRule, RuleActivity, RuleActivityType
 from sentry.models.savedsearch import SavedSearch, Visibility
 from sentry.models.search_common import SearchType
 from sentry.models.user import User
@@ -317,6 +317,13 @@ class BackupTestCase(TransactionTestCase):
         rule = self.create_project_rule(project=project)
         RuleActivity.objects.create(rule=rule, type=RuleActivityType.CREATED.value)
         self.snooze_rule(user_id=owner_id, owner_id=owner_id, rule=rule)
+        NeglectedRule.objects.create(
+            rule=rule,
+            organization=org,
+            disable_date=datetime.now(),
+            sent_initial_email_date=datetime.now(),
+            sent_final_email_date=datetime.now(),
+        )
 
         # Environment*
         self.create_environment(project=project)

--- a/tests/sentry/backup/test_models.py
+++ b/tests/sentry/backup/test_models.py
@@ -445,6 +445,13 @@ class ModelBackupTests(TransactionTestCase):
         rule = self.create_project_rule(project=self.project)
         RuleActivity.objects.create(rule=rule, type=RuleActivityType.CREATED.value)
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule)
+        NeglectedRule.objects.create(
+            rule=rule,
+            organization=self.organization,
+            disable_date=datetime.now(),
+            sent_initial_email_date=datetime.now(),
+            sent_final_email_date=datetime.now(),
+        )
         return self.import_export_then_validate()
 
     @targets(mark(RecentSearch, SavedSearch))


### PR DESCRIPTION
This model being missing from backup tests was not caught because backup tests are currently disabled in CI.