### PR TITLE
fix(hc): Read org mapping in OrganizationEndpoint.convert_args

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -27,7 +27,7 @@ from sentry.utils.rust import RustInfoIntegration
 
 # Can't import models in utils because utils should be the bottom of the food chain
 if TYPE_CHECKING:
-    from sentry.models.organization import Organization
+    from sentry.models import Organization, OrganizationMapping
     from sentry.services.hybrid_cloud.organization import RpcOrganization
 
 
@@ -650,7 +650,9 @@ def capture_exception_with_scope_check(
     return sentry_sdk.capture_exception(error, scope=extra_scope)
 
 
-def bind_organization_context(organization: Organization | RpcOrganization) -> None:
+def bind_organization_context(
+    organization: Organization | RpcOrganization | OrganizationMapping,
+) -> None:
     # Callable to bind additional context for the Sentry SDK
     helper = settings.SENTRY_ORGANIZATION_CONTEXT_HELPER
 

--- a/tests/sentry/api/endpoints/test_external_user_details.py
+++ b/tests/sentry/api/endpoints/test_external_user_details.py
@@ -3,7 +3,7 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
-@control_silo_test  # TODO(hybrid-cloud): blocked on org membership mapping
+@control_silo_test(stable=True)
 class ExternalUserDetailsTest(APITestCase):
     endpoint = "sentry-api-0-organization-external-user-details"
     method = "put"


### PR DESCRIPTION
Opening this as a draft because I want to see how much stuff it breaks.

Currently, the `create_organization` test factory doesn't populate the `OrganizationMapping` table unless a region is supplied explicitly. The change to `convert_args` will require an `OrganizationMapping` for any org accessed through an endpoint. I'm contemplating changing the `create_organization` test factory to create a mapping for some arbitrary region by default, so I'd like to see if there are other broken tests to justify it.