### PR TITLE
fix(metrics): Fix forwarding of metrics in sentry sdk

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -405,6 +405,7 @@ def configure_sdk():
                 # install_id = options.get('sentry:install-id')
                 # if install_id:
                 #     event.setdefault('tags', {})['install-id'] = install_id
+                s4s_args = args
                 if method_name == "capture_envelope":
                     args_list = list(args)
                     envelope = args_list[0]
@@ -413,8 +414,8 @@ def configure_sdk():
                     if len(safe_items) != len(envelope.items):
                         relay_envelope = copy.copy(envelope)
                         relay_envelope.items = safe_items
-                        args = [relay_envelope, *args_list[1:]]
-                getattr(sentry4sentry_transport, method_name)(*args, **kwargs)
+                        s4s_args = [relay_envelope, *args_list[1:]]
+                getattr(sentry4sentry_transport, method_name)(*s4s_args, **kwargs)
 
             if sentry_saas_transport and options.get("store.use-relay-dsn-sample-rate") == 1:
                 # If this is an envelope ensure envelope and its items are distinct references


### PR DESCRIPTION
The multiplexing code accidentally also applied to `sentry_saas_transport`.