### PR TITLE
feat(issues): resolved_with in stacktrace frame

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -157,6 +157,7 @@ class Frame(Interface):
             "vars",
             "snapshot",
             "lock",
+            "resolved_with",
         ):
             data.setdefault(key, None)
 
@@ -189,6 +190,7 @@ class Frame(Interface):
                 "colno": self.colno,
                 "lock": self.lock,
                 "source_link": self.source_link or None,
+                "resolved_with": self.resolved_with or None,
             }
         )
 
@@ -220,6 +222,7 @@ class Frame(Interface):
             "errors": self.errors,
             "lock": self.lock,
             "sourceLink": self.source_link,
+            "resolvedWith": self.resolved_with,
         }
 
         if not is_public:
@@ -284,6 +287,7 @@ class Frame(Interface):
             "errors": meta.get("errors"),
             "lock": meta.get("lock"),
             "sourceLink": meta.get("source_link"),
+            "resolvedWith": meta.get("resolved_with"),
         }
 
     def is_url(self):

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_basic.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_basic.pysnap
@@ -25,6 +25,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null
@@ -55,6 +56,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_mechanism.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_mechanism.pysnap
@@ -28,6 +28,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_mixed_frames.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_mixed_frames.pysnap
@@ -25,6 +25,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null
@@ -55,6 +56,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_only_app_frames.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_only_app_frames.pysnap
@@ -25,6 +25,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null
@@ -55,6 +56,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_only_system_frames.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_only_system_frames.pysnap
@@ -25,6 +25,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null
@@ -55,6 +56,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_raw_stacks.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_raw_stacks.pysnap
@@ -24,6 +24,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null
@@ -48,6 +49,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_symbols.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_symbols.pysnap
@@ -25,6 +25,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: Class.myfunc
         symbolAddr: null

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_two_exceptions_having_mechanism.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_two_exceptions_having_mechanism.pysnap
@@ -30,6 +30,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null
@@ -65,6 +66,7 @@ get_api_context:
         package: null
         platform: null
         rawFunction: null
+        resolvedWith: null
         sourceLink: null
         symbol: null
         symbolAddr: null


### PR DESCRIPTION
Adds `resolvedWith` to stacktrace frame. Closes #56366 