### PR TITLE
feat(profiling): add profiling summary header elements

### DIFF
--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -40,7 +40,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {DEFAULT_PROFILING_DATETIME_SELECTION} from 'sentry/views/profiling/utils';
 
 import {LandingWidgetSelector} from './landing/landingWidgetSelector';
-import {ProfileCharts} from './landing/profileCharts';
+import {ProfilesChart} from './landing/profileCharts';
 import {ProfilesChartWidget} from './landing/profilesChartWidget';
 import {ProfilingSlowestTransactionsPanel} from './landing/profilingSlowestTransactionsPanel';
 import {ProfilingOnboardingPanel} from './profilingOnboardingPanel';
@@ -279,7 +279,7 @@ function ProfilingContent({location}: ProfilingContentProps) {
                   ) : (
                     <PanelsGrid>
                       <ProfilingSlowestTransactionsPanel />
-                      <ProfileCharts
+                      <ProfilesChart
                         referrer="api.profiling.landing-chart"
                         query={query}
                         selection={selection}

--- a/static/app/views/profiling/landing/profilesSummaryChart.tsx
+++ b/static/app/views/profiling/landing/profilesSummaryChart.tsx
@@ -1,14 +1,8 @@
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
 
-import {AreaChart, AreaChartProps} from 'sentry/components/charts/areaChart';
 import ChartZoom from 'sentry/components/charts/chartZoom';
-import {LineChartProps} from 'sentry/components/charts/lineChart';
-import {HeaderTitle} from 'sentry/components/charts/styles';
-import Panel from 'sentry/components/panels/panel';
-import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
+import {LineChart, LineChartProps} from 'sentry/components/charts/lineChart';
 import {PageFilters} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
@@ -21,21 +15,19 @@ import useRouter from 'sentry/utils/useRouter';
 // cover it up.
 const SERIES_ORDER = ['count()', 'p99()', 'p95()', 'p75()'] as const;
 
-interface ProfilesChartProps {
+interface ProfileSummaryChartProps {
   query: string;
   referrer: string;
-  compact?: boolean;
   hideCount?: boolean;
   selection?: PageFilters;
 }
 
-export function ProfilesChart({
+export function ProfilesSummaryChart({
   query,
   referrer,
   selection,
   hideCount,
-  compact = false,
-}: ProfilesChartProps) {
+}: ProfileSummaryChartProps) {
   const router = useRouter();
   const theme = useTheme();
 
@@ -105,9 +97,9 @@ export function ProfilesChart({
     return allSeries;
   }, [profileStats, seriesOrder]);
 
-  const chartProps: LineChartProps | AreaChartProps = useMemo(() => {
-    const baseProps: LineChartProps | AreaChartProps = {
-      height: compact ? 150 : 300,
+  const chartProps: LineChartProps = useMemo(() => {
+    const baseProps: LineChartProps = {
+      height: 150,
       series,
       grid: [
         {
@@ -175,42 +167,18 @@ export function ProfilesChart({
     };
 
     return baseProps;
-  }, [compact, hideCount, series, seriesOrder, theme.chartLabel]);
+  }, [hideCount, series, seriesOrder, theme.chartLabel]);
 
   return (
     <ChartZoom router={router} {...selection?.datetime}>
       {zoomRenderProps => (
-        <StyledPanel>
-          <TitleContainer>
-            {!hideCount && (
-              <StyledHeaderTitle compact>{t('Profiles by Count')}</StyledHeaderTitle>
-            )}
-            <StyledHeaderTitle compact>{t('Profiles Duration')}</StyledHeaderTitle>
-          </TitleContainer>
-          <AreaChart
-            {...chartProps}
-            isGroupedByDate
-            showTimeInTooltip
-            {...zoomRenderProps}
-          />
-        </StyledPanel>
+        <LineChart
+          {...chartProps}
+          isGroupedByDate
+          showTimeInTooltip
+          {...zoomRenderProps}
+        />
       )}
     </ChartZoom>
   );
 }
-
-const StyledPanel = styled(Panel)`
-  padding-top: ${space(2)};
-`;
-
-const TitleContainer = styled('div')`
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-`;
-
-const StyledHeaderTitle = styled(HeaderTitle)<{compact?: boolean}>`
-  flex-grow: 1;
-  margin-left: ${space(2)};
-  font-size: ${p => (p.compact ? p.theme.fontSizeSmall : undefined)};
-`;

--- a/static/app/views/profiling/profileSummary/content.tsx
+++ b/static/app/views/profiling/profileSummary/content.tsx
@@ -16,7 +16,7 @@ import {PageFilters, Project} from 'sentry/types';
 import {useProfileEvents} from 'sentry/utils/profiling/hooks/useProfileEvents';
 import {formatSort} from 'sentry/utils/profiling/hooks/utils';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {ProfileCharts} from 'sentry/views/profiling/landing/profileCharts';
+import {ProfilesChart} from 'sentry/views/profiling/landing/profileCharts';
 
 interface ProfileSummaryContentProps {
   location: Location;
@@ -68,7 +68,7 @@ function ProfileSummaryContent(props: ProfileSummaryContentProps) {
   return (
     <Fragment>
       <Layout.Main fullWidth>
-        <ProfileCharts
+        <ProfilesChart
           referrer="api.profiling.profile-summary-chart"
           query={props.query}
           hideCount

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -1,8 +1,186 @@
+import {useCallback, useMemo} from 'react';
+import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
 import type {Location} from 'history';
 
-import type {PageFilters, Project} from 'sentry/types';
+import {LinkButton} from 'sentry/components/button';
+import DatePageFilter from 'sentry/components/datePageFilter';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
+import SearchBar from 'sentry/components/events/searchBar';
+import IdBadge from 'sentry/components/idBadge';
+import * as Layout from 'sentry/components/layouts/thirds';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import {
+  ProfilingBreadcrumbs,
+  ProfilingBreadcrumbsProps,
+} from 'sentry/components/profiling/profilingBreadcrumbs';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import type {SmartSearchBarProps} from 'sentry/components/smartSearchBar';
+import SmartSearchBar from 'sentry/components/smartSearchBar';
+import {MAX_QUERY_LENGTH} from 'sentry/constants';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Organization, PageFilters, Project} from 'sentry/types';
+import {defined} from 'sentry/utils';
+import EventView from 'sentry/utils/discover/eventView';
+import {isAggregateField} from 'sentry/utils/discover/fields';
+import {useCurrentProjectFromRouteParam} from 'sentry/utils/profiling/hooks/useCurrentProjectFromRouteParam';
+import {useProfileFilters} from 'sentry/utils/profiling/hooks/useProfileFilters';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
+import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
+import {ProfilesSummaryChart} from 'sentry/views/profiling/landing/profilesSummaryChart';
 import {LegacySummaryPage} from 'sentry/views/profiling/profileSummary/legacySummaryPage';
+import {DEFAULT_PROFILING_DATETIME_SELECTION} from 'sentry/views/profiling/utils';
+
+interface ProfileSummaryHeaderProps {
+  location: Location;
+  organization: Organization;
+  project: Project | null;
+  query: string;
+  transaction: string | undefined;
+}
+function ProfileSummaryHeader(props: ProfileSummaryHeaderProps) {
+  const breadcrumbTrails: ProfilingBreadcrumbsProps['trails'] = useMemo(() => {
+    return [
+      {
+        type: 'landing',
+        payload: {
+          query: props.location.query,
+        },
+      },
+      {
+        type: 'profile summary',
+        payload: {
+          projectSlug: props.project?.slug ?? '',
+          query: props.location.query,
+          transaction: props.transaction ?? '',
+        },
+      },
+    ];
+  }, [props.location.query, props.project?.slug, props.transaction]);
+
+  const transactionSummaryTarget =
+    props.project &&
+    props.transaction &&
+    transactionSummaryRouteWithQuery({
+      orgSlug: props.organization.slug,
+      transaction: props.transaction,
+      projectID: props.project.id,
+      query: {query: props.query},
+    });
+
+  return (
+    <Layout.Header>
+      <Layout.HeaderContent>
+        <ProfilingBreadcrumbs
+          organization={props.organization}
+          trails={breadcrumbTrails}
+        />
+        <Layout.Title>
+          {props.project ? (
+            <IdBadge
+              hideName
+              project={props.project}
+              avatarSize={28}
+              avatarProps={{hasTooltip: true, tooltip: props.project.slug}}
+            />
+          ) : null}
+          {props.transaction}
+        </Layout.Title>
+      </Layout.HeaderContent>
+      {transactionSummaryTarget && (
+        <Layout.HeaderActions>
+          <LinkButton to={transactionSummaryTarget} size="sm">
+            {t('View Transaction Summary')}
+          </LinkButton>
+        </Layout.HeaderActions>
+      )}
+    </Layout.Header>
+  );
+}
+
+interface ProfileFiltersProps {
+  location: Location;
+  organization: Organization;
+  projectIds: EventView['project'];
+  query: string;
+  selection: PageFilters;
+  transaction: string | undefined;
+  usingTransactions: boolean;
+}
+
+function ProfileFilters(props: ProfileFiltersProps) {
+  const filtersQuery = useMemo(() => {
+    // To avoid querying for the filters each time the query changes,
+    // do not pass the user query to get the filters.
+    const search = new MutableSearch('');
+
+    if (defined(props.transaction)) {
+      search.setFilterValues('transaction_name', [props.transaction]);
+    }
+
+    return search.formatString();
+  }, [props.transaction]);
+
+  const profileFilters = useProfileFilters({
+    query: filtersQuery,
+    selection: props.selection,
+    disabled: props.usingTransactions,
+  });
+
+  const handleSearch: SmartSearchBarProps['onSearch'] = useCallback(
+    (searchQuery: string) => {
+      browserHistory.push({
+        ...props.location,
+        query: {
+          ...props.location.query,
+          query: searchQuery || undefined,
+          cursor: undefined,
+        },
+      });
+    },
+    [props.location]
+  );
+
+  return (
+    <ActionBar>
+      <PageFilterBar condensed>
+        <EnvironmentPageFilter />
+        <DatePageFilter alignDropdown="left" />
+      </PageFilterBar>
+      {props.usingTransactions ? (
+        <SearchBar
+          searchSource="profile_summary"
+          organization={props.organization}
+          projectIds={props.projectIds}
+          query={props.query}
+          onSearch={handleSearch}
+          maxQueryLength={MAX_QUERY_LENGTH}
+        />
+      ) : (
+        <SmartSearchBar
+          organization={props.organization}
+          hasRecentSearches
+          searchSource="profile_summary"
+          supportedTags={profileFilters}
+          query={props.query}
+          onSearch={handleSearch}
+          maxQueryLength={MAX_QUERY_LENGTH}
+        />
+      )}
+    </ActionBar>
+  );
+}
+
+const ActionBar = styled('div')`
+  display: grid;
+  gap: ${space(2)};
+  grid-template-columns: min-content auto;
+  margin-bottom: ${space(2)};
+`;
 
 interface ProfileSummaryPageProps {
   location: Location;
@@ -12,11 +190,119 @@ interface ProfileSummaryPageProps {
   selection: PageFilters;
 }
 
-export default function ProfileSummaryPage(props: ProfileSummaryPageProps) {
+function ProfileSummaryPage(props: ProfileSummaryPageProps) {
+  const organization = useOrganization();
+  const project = useCurrentProjectFromRouteParam();
+
+  const profilingUsingTransactions = organization.features.includes(
+    'profiling-using-transactions'
+  );
+
+  const transaction = decodeScalar(props.location.query.transaction);
+  const rawQuery = decodeScalar(props.location?.query?.query, '');
+
+  const projectIds: number[] = useMemo(() => {
+    if (!defined(project)) {
+      return [];
+    }
+
+    const projects = parseInt(project.id, 10);
+    if (isNaN(projects)) {
+      return [];
+    }
+
+    return [projects];
+  }, [project]);
+
+  const projectSlugs: string[] = useMemo(() => {
+    return defined(project) ? [project.slug] : [];
+  }, [project]);
+
+  const query = useMemo(() => {
+    const search = new MutableSearch(rawQuery);
+
+    if (defined(transaction)) {
+      search.setFilterValues('transaction', [transaction]);
+    }
+
+    // there are no aggregations happening on this page,
+    // so remove any aggregate filters
+    Object.keys(search.filters).forEach(field => {
+      if (isAggregateField(field)) {
+        search.removeFilter(field);
+      }
+    });
+
+    return search.formatString();
+  }, [rawQuery, transaction]);
+
+  return (
+    <SentryDocumentTitle
+      title={t('Profiling \u2014 Profile Summary')}
+      orgSlug={organization.slug}
+    >
+      <ProfileSummaryContainer>
+        <PageFiltersContainer
+          shouldForceProject={defined(project)}
+          forceProject={project}
+          specificProjectSlugs={projectSlugs}
+          defaultSelection={
+            profilingUsingTransactions
+              ? {datetime: DEFAULT_PROFILING_DATETIME_SELECTION}
+              : undefined
+          }
+        >
+          <ProfileSummaryHeader
+            organization={organization}
+            location={props.location}
+            project={project}
+            query={query}
+            transaction={transaction}
+          />
+          <ProfileFilters
+            projectIds={projectIds}
+            organization={organization}
+            location={props.location}
+            query={rawQuery}
+            selection={props.selection}
+            transaction={transaction}
+            usingTransactions={profilingUsingTransactions}
+          />
+          <ProfilesSummaryChart
+            referrer="api.profiling.profile-summary-chart"
+            query={query}
+            hideCount
+          />
+        </PageFiltersContainer>
+      </ProfileSummaryContainer>
+    </SentryDocumentTitle>
+  );
+}
+
+const ProfileSummaryContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 100%;
+
+  /*
+   * The footer component is a sibling of this div.
+   * Remove it so the flamegraph can take up the
+   * entire screen.
+   */
+  ~ footer {
+    display: none;
+  }
+`;
+
+export default function ProfileSummaryPageToggle(props: ProfileSummaryPageProps) {
   const organization = useOrganization();
 
   if (organization.features.includes('profiling-summary-redesign')) {
-    return <div data-test-id="profile-summary-redesign">New Page</div>;
+    return (
+      <ProfileSummaryContainer data-test-id="profile-summary-redesign">
+        <ProfileSummaryPage {...props} />
+      </ProfileSummaryContainer>
+    );
   }
 
   return (

--- a/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
+++ b/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
@@ -36,7 +36,23 @@ describe('ProfileSummaryPage', () => {
     expect(await screen.findByTestId(/profile-summary-legacy/i)).toBeInTheDocument();
   });
 
-  it('renders new page', () => {
+  it('renders new page', async () => {
+    const organization = TestStubs.Organization({
+      features: [],
+      projects: [TestStubs.Project()],
+    });
+    OrganizationStore.onUpdate(organization);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/profiling/filters/`,
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      body: [],
+    });
+
     render(
       <ProfileSummaryPage
         params={{}}
@@ -51,6 +67,6 @@ describe('ProfileSummaryPage', () => {
       }
     );
 
-    expect(screen.getByTestId(/profile-summary-redesign/i)).toBeInTheDocument();
+    expect(await screen.findByTestId(/profile-summary-redesign/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION

Adds a basic header/searchbar and profile chart layout. This is all rough layout and just plugging the data together. Aggregated flamegraph and suspect fns will follow 

<img width="1352" alt="CleanShot 2023-09-18 at 15 23 39@2x" src="https://github.com/getsentry/sentry/assets/9317857/4bfc48f5-0173-4c61-b9c1-62bf4a1cc060">
