### PR TITLE
feat(stat-detector): Improve breakpoint chart styling

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
@@ -1,8 +1,5 @@
-import {useTheme} from '@emotion/react';
 import {LineSeriesOption} from 'echarts';
 
-import MarkArea from 'sentry/components/charts/components/markArea';
-import MarkLine from 'sentry/components/charts/components/markLine';
 import {Event} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import TrendsDiscoverQuery from 'sentry/utils/performance/trends/trendsDiscoverQuery';
@@ -26,12 +23,10 @@ type EventBreakpointChartProps = {
 };
 
 function EventBreakpointChart({event}: EventBreakpointChartProps) {
-  const theme = useTheme();
   const organization = useOrganization();
   const location = useLocation();
 
-  const {transaction, requestStart, requestEnd, breakpoint} =
-    event?.occurrence?.evidenceData ?? {};
+  const {transaction, requestStart, requestEnd} = event?.occurrence?.evidenceData ?? {};
 
   const eventView = EventView.fromLocation(location);
   eventView.query = `event.type:transaction transaction:"${transaction}"`;
@@ -52,66 +47,6 @@ function EventBreakpointChart({event}: EventBreakpointChartProps) {
   }, {}) as NormalizedTrendsTransaction;
 
   const additionalSeries: LineSeriesOption[] = [];
-
-  // Add the red marked area to the chart
-  additionalSeries.push({
-    name: 'Regression Area',
-    type: 'line',
-    markLine: MarkLine({
-      silent: true,
-      animation: false,
-      lineStyle: {color: theme.red300, type: 'solid', width: 2, opacity: 1.0},
-      label: {
-        show: false,
-      },
-      data: [
-        {
-          xAxis: breakpoint * 1000,
-        },
-      ],
-    }),
-    markArea: MarkArea({
-      silent: true,
-      itemStyle: {
-        color: theme.red300,
-        opacity: 0.2,
-      },
-      data: [
-        [
-          {
-            xAxis: breakpoint * 1000,
-          },
-          {xAxis: requestEnd * 1000},
-        ],
-      ],
-    }),
-    data: [],
-  });
-
-  additionalSeries.push({
-    name: 'Regression Axis Line',
-    type: 'line',
-    markLine: MarkLine({
-      silent: true,
-      lineStyle: {color: 'red', type: 'solid', width: 4},
-      data: [[{coord: [breakpoint, 57]}, {coord: [requestEnd, 57]}]],
-    }),
-    data: [],
-  });
-
-  additionalSeries.push({
-    name: 'Baseline Axis Line',
-    type: 'line',
-    markLine: MarkLine({
-      silent: true,
-      label: {
-        show: false,
-      },
-      lineStyle: {color: 'green', type: 'solid', width: 4},
-      data: [{yAxis: 100}],
-    }),
-    data: [],
-  });
 
   return (
     <DataSection>
@@ -144,6 +79,7 @@ function EventBreakpointChart({event}: EventBreakpointChartProps) {
               trendChangeType={TrendChangeType.REGRESSION}
               trendFunctionField={TrendFunctionField.P95}
               additionalSeries={additionalSeries}
+              applyRegressionFormatToInterval
               disableLegend
             />
           );

--- a/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
@@ -1,3 +1,8 @@
+import {useTheme} from '@emotion/react';
+import {LineSeriesOption} from 'echarts';
+
+import MarkArea from 'sentry/components/charts/components/markArea';
+import MarkLine from 'sentry/components/charts/components/markLine';
 import {Event} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import TrendsDiscoverQuery from 'sentry/utils/performance/trends/trendsDiscoverQuery';
@@ -21,10 +26,12 @@ type EventBreakpointChartProps = {
 };
 
 function EventBreakpointChart({event}: EventBreakpointChartProps) {
+  const theme = useTheme();
   const organization = useOrganization();
   const location = useLocation();
 
-  const {transaction, requestStart, requestEnd} = event?.occurrence?.evidenceData ?? {};
+  const {transaction, requestStart, requestEnd, breakpoint} =
+    event?.occurrence?.evidenceData ?? {};
 
   const eventView = EventView.fromLocation(location);
   eventView.query = `event.type:transaction transaction:"${transaction}"`;
@@ -43,6 +50,43 @@ function EventBreakpointChart({event}: EventBreakpointChartProps) {
     acc[camelToUnderscore(key)] = event?.occurrence?.evidenceData?.[key];
     return acc;
   }, {}) as NormalizedTrendsTransaction;
+
+  const additionalSeries: LineSeriesOption[] = [];
+
+  // Add the red marked area to the chart
+  additionalSeries.push({
+    name: 'Regression Area',
+    type: 'line',
+    markLine: MarkLine({
+      silent: true,
+      animation: false,
+      lineStyle: {color: theme.red300, type: 'solid', width: 2, opacity: 1.0},
+      label: {
+        show: false,
+      },
+      data: [
+        {
+          xAxis: breakpoint * 1000,
+        },
+      ],
+    }),
+    markArea: MarkArea({
+      silent: true,
+      itemStyle: {
+        color: theme.red300,
+        opacity: 0.2,
+      },
+      data: [
+        [
+          {
+            xAxis: breakpoint * 1000,
+          },
+          {xAxis: requestEnd * 1000},
+        ],
+      ],
+    }),
+    data: [],
+  });
 
   return (
     <DataSection>
@@ -74,6 +118,7 @@ function EventBreakpointChart({event}: EventBreakpointChartProps) {
               transaction={normalizedOccurrenceEvent}
               trendChangeType={TrendChangeType.REGRESSION}
               trendFunctionField={TrendFunctionField.P95}
+              additionalSeries={additionalSeries}
               disableLegend
             />
           );

--- a/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
@@ -88,6 +88,31 @@ function EventBreakpointChart({event}: EventBreakpointChartProps) {
     data: [],
   });
 
+  additionalSeries.push({
+    name: 'Regression Axis Line',
+    type: 'line',
+    markLine: MarkLine({
+      silent: true,
+      lineStyle: {color: 'red', type: 'solid', width: 4},
+      data: [[{coord: [breakpoint, 57]}, {coord: [requestEnd, 57]}]],
+    }),
+    data: [],
+  });
+
+  additionalSeries.push({
+    name: 'Baseline Axis Line',
+    type: 'line',
+    markLine: MarkLine({
+      silent: true,
+      label: {
+        show: false,
+      },
+      lineStyle: {color: 'green', type: 'solid', width: 4},
+      data: [{yAxis: 100}],
+    }),
+    data: [],
+  });
+
   return (
     <DataSection>
       <TrendsDiscoverQuery

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -107,7 +107,7 @@ function GroupEventDetailsContent({
         <Fragment>
           <RegressionMessage event={event} />
           <EventBreakpointChart event={event} />
-          {/* <EventSpanOpBreakdown event={event} /> */}
+          <EventSpanOpBreakdown event={event} />
           <EventComparison event={event} group={group} project={project} />
         </Fragment>
       </Feature>

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -107,7 +107,7 @@ function GroupEventDetailsContent({
         <Fragment>
           <RegressionMessage event={event} />
           <EventBreakpointChart event={event} />
-          <EventSpanOpBreakdown event={event} />
+          {/* <EventSpanOpBreakdown event={event} /> */}
           <EventComparison event={event} group={group} project={project} />
         </Fragment>
       </Feature>

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -46,6 +46,7 @@ type Props = ViewProps & {
   statsData: TrendsStats;
   trendChangeType: TrendChangeType;
   additionalSeries?: LineSeriesOption[];
+  applyRegressionFormatToInterval?: boolean;
   disableLegend?: boolean;
   disableXAxis?: boolean;
   grid?: LineChartProps['grid'];
@@ -106,6 +107,7 @@ export function Chart({
   project,
   organization,
   additionalSeries,
+  applyRegressionFormatToInterval = false,
 }: Props) {
   const location = useLocation();
   const router = useRouter();
@@ -202,7 +204,8 @@ export function Chart({
     smoothedResults || [],
     0.5,
     needsLabel,
-    transaction
+    transaction,
+    applyRegressionFormatToInterval
   );
 
   const yDiff = yMax - yMin;

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -1,6 +1,6 @@
 import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
-import type {LegendComponentOption} from 'echarts';
+import type {LegendComponentOption, LineSeriesOption} from 'echarts';
 
 import ChartZoom from 'sentry/components/charts/chartZoom';
 import {LineChart, LineChartProps} from 'sentry/components/charts/lineChart';
@@ -45,6 +45,7 @@ type Props = ViewProps & {
   projects: Project[];
   statsData: TrendsStats;
   trendChangeType: TrendChangeType;
+  additionalSeries?: LineSeriesOption[];
   disableLegend?: boolean;
   disableXAxis?: boolean;
   grid?: LineChartProps['grid'];
@@ -104,6 +105,7 @@ export function Chart({
   projects,
   project,
   organization,
+  additionalSeries,
 }: Props) {
   const location = useLocation();
   const router = useRouter();
@@ -245,6 +247,7 @@ export function Chart({
                   height={height}
                   {...zoomRenderProps}
                   {...chartOptions}
+                  additionalSeries={additionalSeries}
                   onLegendSelectChanged={handleLegendSelectChanged}
                   series={series}
                   seriesOptions={{


### PR DESCRIPTION
Adds some styling and label changes to the trends chart to render statistical detector styling

I added the logic to the util that generates the series because it avoids splitting up where we're customizing these series.

I was having difficulty adding the highlighting along the x-axis because our charts don't typically start at 0 so we have to compute either the y-coordinate pixel value of the x-axis, or calculate the minimum y-value of the data. I thought echarts supported `min` here but I think `min` represents the min of your data, and if we don't have data it won't render properly.

![Screenshot 2023-09-18 at 10 18 04 AM](https://github.com/getsentry/sentry/assets/22846452/7677cd5c-36fb-4cc0-b1c7-4603dc7d12e7)
