### PR TITLE
feat(metrics): Add more options to control forwarding

### DIFF
--- a/src/minimetrics/core.py
+++ b/src/minimetrics/core.py
@@ -292,7 +292,7 @@ class Aggregator:
             self._flush_event.set()
 
     def _emit(self, flushable_buckets: FlushableBuckets) -> Any:
-        if options.get("delightful_metrics.enable_envelope_forwarding"):
+        if options.get("delightful_metrics.enable_transport"):
             try:
                 self._transport.send(flushable_buckets)
             except Exception as e:

--- a/src/minimetrics/core.py
+++ b/src/minimetrics/core.py
@@ -292,7 +292,7 @@ class Aggregator:
             self._flush_event.set()
 
     def _emit(self, flushable_buckets: FlushableBuckets) -> Any:
-        if options.get("delightful_metrics.enable_transport"):
+        if options.get("delightful_metrics.enable_envelope_forwarding"):
             try:
                 self._transport.send(flushable_buckets)
             except Exception as e:

--- a/src/minimetrics/transport.py
+++ b/src/minimetrics/transport.py
@@ -7,6 +7,7 @@ import sentry_sdk
 from sentry_sdk.envelope import Envelope, Item
 
 from minimetrics.types import FlushableBuckets, FlushableMetric, MetricType
+from sentry import options
 from sentry.utils import metrics
 
 
@@ -87,8 +88,6 @@ class MetricEnvelopeTransport:
                     prev_buckets_weight + metric.weight,
                 )
 
-        encoded_metrics = self._encoder.encode_multiple(flushable_metrics)
-
         for metric_type, (buckets_count, buckets_weight) in stats_by_type.items():
             # We want to emit a metric on how many buckets and weight there was for a metric type.
             metrics.timing(
@@ -116,13 +115,16 @@ class MetricEnvelopeTransport:
                 sample_rate=1.0,
             )
 
-        metrics.timing(
-            key="minimetrics.encoded_metrics_size", value=len(encoded_metrics), sample_rate=1.0
-        )
+        if options.get("delightful_metrics.enable_envelope_serialization"):
+            encoded_metrics = self._encoder.encode_multiple(flushable_metrics)
+            metrics.timing(
+                key="minimetrics.encoded_metrics_size", value=len(encoded_metrics), sample_rate=1.0
+            )
+            metric_item = Item(payload=encoded_metrics, type="statsd")
+            envelope = Envelope(
+                headers=None,
+                items=[metric_item],
+            )
 
-        metric_item = Item(payload=encoded_metrics, type="statsd")
-        envelope = Envelope(
-            headers=None,
-            items=[metric_item],
-        )
-        transport.capture_envelope(envelope)
+            if options.get("delightful_metrics.enable_envelope_forwarding"):
+                transport.capture_envelope(envelope)

--- a/src/minimetrics/transport.py
+++ b/src/minimetrics/transport.py
@@ -126,5 +126,5 @@ class MetricEnvelopeTransport:
                 items=[metric_item],
             )
 
-            if options.get("delightful_metrics.enable_envelope_forwarding"):
+            if options.get("delightful_metrics.enable_capture_envelope"):
                 transport.capture_envelope(envelope)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1523,7 +1523,7 @@ register(
 )
 
 register(
-    "delightful_metrics.enable_transport",
+    "delightful_metrics.enable_envelope_forwarding",
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
@@ -1534,9 +1534,8 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-
 register(
-    "delightful_metrics.enable_envelope_forwarding",
+    "delightful_metrics.enable_capture_envelope",
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1523,6 +1523,19 @@ register(
 )
 
 register(
+    "delightful_metrics.enable_transport",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
+    "delightful_metrics.enable_envelope_serialization",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+
+register(
     "delightful_metrics.enable_envelope_forwarding",
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/tests/minimetrics/test_transport.py
+++ b/tests/minimetrics/test_transport.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from minimetrics.core import CounterMetric, DistributionMetric, GaugeMetric, SetMetric
 from minimetrics.transport import MetricEnvelopeTransport, RelayStatsdEncoder
 from minimetrics.types import BucketKey
+from sentry.testutils.helpers import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -198,6 +199,7 @@ def test_relay_encoder_with_multiple_metrics():
     )
 
 
+@override_options({"delightful_metrics.enable_capture_envelope": True})
 @patch("minimetrics.transport.sentry_sdk")
 @django_db_all
 def test_send(sentry_sdk):

--- a/tests/minimetrics/test_transport.py
+++ b/tests/minimetrics/test_transport.py
@@ -199,7 +199,12 @@ def test_relay_encoder_with_multiple_metrics():
     )
 
 
-@override_options({"delightful_metrics.enable_capture_envelope": True})
+@override_options(
+    {
+        "delightful_metrics.enable_envelope_serialization": True,
+        "delightful_metrics.enable_capture_envelope": True,
+    }
+)
 @patch("minimetrics.transport.sentry_sdk")
 @django_db_all
 def test_send(sentry_sdk):

--- a/tests/minimetrics/test_transport.py
+++ b/tests/minimetrics/test_transport.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from minimetrics.core import CounterMetric, DistributionMetric, GaugeMetric, SetMetric
 from minimetrics.transport import MetricEnvelopeTransport, RelayStatsdEncoder
 from minimetrics.types import BucketKey
+from sentry.testutils.pytest.fixtures import django_db_all
 
 
 def encode_metric(value):
@@ -198,6 +199,7 @@ def test_relay_encoder_with_multiple_metrics():
 
 
 @patch("minimetrics.transport.sentry_sdk")
+@django_db_all
 def test_send(sentry_sdk):
     flushed_metric = (
         1693994400,


### PR DESCRIPTION
This PR adds more options to control several parts of the minimetrics pipeline.