### PR TITLE
ref: fix node memory after github breakage

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -67,7 +67,6 @@ runs:
 
         ### node configuration ###
         echo "NODE_ENV=development" >> $GITHUB_ENV
-        echo "NODE_OPTIONS=--max-old-space-size=4096" >> $GITHUB_ENV
 
         ### pytest configuration ###
         echo "PY_COLORS=1" >> "$GITHUB_ENV"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -15,6 +15,7 @@ concurrency:
 # hack for https://github.com/actions/cache/issues/810#issuecomment-1222550359
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+  NODE_OPTIONS: '--max-old-space-size=4096'
 
 jobs:
   files-changed:


### PR DESCRIPTION
github pulled the rug on `NODE_OPTIONS` through an action -- set this instead at top-level `env`