### PR TITLE
feat(escalating-issues): Only send generic metrics events for errors

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -562,6 +562,7 @@ def post_process_group(
         sentry_sdk.set_tag("is_reprocessed", is_reprocessed)
 
         is_transaction_event = event.get_event_type() == "transaction"
+        is_error_event = event.get_event_type() == "error"
 
         # Simplified post processing for transaction events.
         # This should eventually be completely removed and transactions
@@ -592,7 +593,10 @@ def post_process_group(
         update_event_groups(event, group_states)
         bind_organization_context(event.project.organization)
         _capture_event_stats(event)
-        if features.has("organizations:escalating-metrics-backend", event.project.organization):
+        if (
+            features.has("organizations:escalating-metrics-backend", event.project.organization)
+            and is_error_event
+        ):
             _update_escalating_metrics(event)
 
         group_events: Mapping[int, GroupEvent] = {

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -562,7 +562,6 @@ def post_process_group(
         sentry_sdk.set_tag("is_reprocessed", is_reprocessed)
 
         is_transaction_event = event.get_event_type() == "transaction"
-        is_error_event = event.get_event_type() == "error"
 
         # Simplified post processing for transaction events.
         # This should eventually be completely removed and transactions
@@ -595,7 +594,7 @@ def post_process_group(
         _capture_event_stats(event)
         if (
             features.has("organizations:escalating-metrics-backend", event.project.organization)
-            and is_error_event
+            and not is_transaction_event
         ):
             _update_escalating_metrics(event)
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1830,6 +1830,7 @@ class PostProcessGroupPerformanceTest(
             )
         return cache_key
 
+    @patch("sentry.sentry_metrics.client.generic_metrics_backend.counter")
     @patch("sentry.tasks.post_process.run_post_process_job")
     @patch("sentry.rules.processor.RuleProcessor")
     @patch("sentry.signals.transaction_processed.send_robust")
@@ -1840,6 +1841,7 @@ class PostProcessGroupPerformanceTest(
         transaction_processed_signal_mock,
         mock_processor,
         run_post_process_job_mock,
+        generic_metrics_backend_mock,
     ):
         min_ago = before_now(minutes=1).replace(tzinfo=timezone.utc)
         event = self.store_transaction(
@@ -1864,6 +1866,7 @@ class PostProcessGroupPerformanceTest(
         assert event_processed_signal_mock.call_count == 0
         assert mock_processor.call_count == 0
         assert run_post_process_job_mock.call_count == 0
+        assert generic_metrics_backend_mock.call_count == 0
 
     @patch("sentry.tasks.post_process.handle_owner_assignment")
     @patch("sentry.tasks.post_process.handle_auto_assignment")


### PR DESCRIPTION
## Objective:
We do not need to send metrics to the Generic Metrics Backend for non-error event types.