### PR TITLE
fix(api): don't return all options in DetailedProjectSerializer

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -946,11 +946,10 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             )
 
         data = super().serialize(obj, attrs, user)
-        attrs["options"].update(format_options(attrs))
         data.update(
             {
                 "latestRelease": attrs["latest_release"],
-                "options": attrs["options"],
+                "options": format_options(attrs),
                 "digestsMinDelay": attrs["options"].get(
                     "digests:mail:minimum_delay", digests.minimum_delay
                 ),

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -690,6 +690,7 @@ class DetailedProjectSerializerTest(TestCase):
         assert "releases" in result["features"]
         assert result["platform"] == self.project.platform
         assert result["latestRelease"] == {"version": self.release.version}
+        assert "sentry:token" not in result["options"]
 
 
 @region_silo_test(stable=True)


### PR DESCRIPTION
Some options need to have parts redacted before returning. If we update the `attrs["options"]` dictionary and return it in `options` we are returning all of them rather than a subset -- we add these special options separately. The `format_options` functions is supposed to replaced what was originally a list of keys and values for the `options` key in `DetailedProjectSerializer`.