### PR TITLE
fix(alerts): Don't set state on redirect to new alert

### DIFF
--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -108,6 +108,7 @@ const createWrapper = (props = {}) => {
     organization,
     project,
     onChangeTitleMock,
+    router,
   };
 };
 
@@ -366,7 +367,7 @@ describe('IssueRuleEditor', function () {
         statusCode: 202,
         body: {uuid},
       });
-      createWrapper();
+      const {router} = createWrapper();
       await userEvent.click(screen.getByText('Save Rule'), {delay: null});
 
       await waitFor(() => expect(addLoadingMessage).toHaveBeenCalledTimes(2));
@@ -375,7 +376,9 @@ describe('IssueRuleEditor', function () {
       await waitFor(() => expect(mockSuccess).toHaveBeenCalledTimes(1));
       jest.advanceTimersByTime(1000);
       await waitFor(() => expect(addSuccessMessage).toHaveBeenCalledTimes(1));
-      expect(screen.getByDisplayValue('Slack Rule')).toBeInTheDocument();
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/organizations/org-slug/alerts/rules/project-slug/1/details/',
+      });
     });
 
     it('pending status keeps loading true', async function () {

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -562,8 +562,6 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
   handleRuleSuccess = (isNew: boolean, rule: IssueAlertRule) => {
     const {organization, router} = this.props;
     const {project} = this.state;
-    this.setState({detailedError: null, loading: false, rule});
-
     // The onboarding task will be completed on the server side when the alert
     // is created
     updateOnboardingTask(null, organization, {


### PR DESCRIPTION
If we're redirecting you to a new page, we do not need to update state

fixes JAVASCRIPT-2NX6
but only kinda, I'm not sure how they got `[]` back from the api. I suspect some sort of extension
