### PR TITLE
docs(api): Clarify how to use id param in bulk delete issue endpoint

### DIFF
--- a/api-docs/paths/events/project-issues.json
+++ b/api-docs/paths/events/project-issues.json
@@ -324,7 +324,7 @@
       {
         "name": "id",
         "in": "query",
-        "description": "A list of IDs of the issues to be removed. This parameter shall be repeated for each issue.",
+        "description": "A list of IDs of the issues to be removed. This parameter shall be repeated for each issue, e.g. `?id=1&id=2&id=3`. If this parameter is not provided, it will attempt to remove the first 1000 issues.",
         "schema": {
           "type": "integer"
         }

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -479,7 +479,9 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         any data mutation.
 
         :qparam int id: a list of IDs of the issues to be removed.  This
-                        parameter shall be repeated for each issue.
+                        parameter shall be repeated for each issue, e.g.
+                        `?id=1&id=2&id=3`. If this parameter is not provided,
+                        it will attempt to remove the first 1000 issues.
         :pparam string organization_slug: the slug of the organization the
                                           issues belong to.
         :auth: required


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/56315

The existing docs:

1. Do not describe the query param format for deleting multiple IDs 
2. Do not describe what happens when you do not provide an `id` param

After:
<img width="493" alt="Screenshot 2023-09-19 at 10 24 32 AM" src="https://github.com/getsentry/sentry/assets/67301797/95fcde13-93f0-47f7-914e-3848de6239e3">