### PR TITLE
feat(stat-detectors): Add param to fetch all tags

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -82,6 +82,9 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
 
             return list(resp.values())
 
+        if request.GET.get("includeAll"):
+            return Response(data_fn(0, 10000))
+
         return self.paginate(
             request=request,
             paginator=GenericOffsetPaginator(data_fn=data_fn),

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -925,7 +925,7 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
         # Test the default query fetches the first 10 results
         with self.feature(self.features):
             response = self.client.get(
-                self.url, format="json", data={"project": [test_project.id], "includeAll": True}
+                self.url, format="json", data={"project": test_project.id, "includeAll": True}
             )
 
         assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -912,3 +912,21 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
         assert response.status_code == 200, response.content
         assert links[1]["results"] == "false"  # There should be no more tags to fetch
         assert len(response.data) == 4  # 4 because projects and levels were added to the base 22
+
+    def test_get_all_tags(self):
+        test_project = self.create_project()
+        test_tags = {str(i): str(i) for i in range(22)}
+
+        self.store_event(
+            data={"event_id": uuid4().hex, "timestamp": self.min_ago_iso, "tags": test_tags},
+            project_id=test_project.id,
+        )
+
+        # Test the default query fetches the first 10 results
+        with self.feature(self.features):
+            response = self.client.get(
+                self.url, format="json", data={"project": [test_project.id], "includeAll": True}
+            )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 23


### PR DESCRIPTION
The statistical detector page will use the discover facets endpoint to get the tags because the current tags endpoint only fetches the tags for the issue events.