### PR TITLE
docs: Document our loadingTriangle component

### DIFF
--- a/static/app/components/container/negativeSpaceContainer.stories.tsx
+++ b/static/app/components/container/negativeSpaceContainer.stories.tsx
@@ -1,0 +1,33 @@
+import {Fragment} from 'react';
+
+import backgroundLighthouse from 'sentry-images/spot/background-lighthouse.svg';
+import onboardingFrameworkSelectionJavascript from 'sentry-images/spot/onboarding-framework-selection-javascript.svg';
+
+import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
+import storyBook from 'sentry/stories/storyBook';
+
+export default storyBook('NegativeSpaceContainer', story => {
+  story('Empty', () => (
+    <Fragment>
+      <p>
+        A <var>NegativeSpaceContainer</var> is a container that will preserve the aspect
+        ratio of whatever is inside it. It's a flex element, so the children are free to
+        expand/contract depending on whether things like <kbd>flex-grow: 1</kbd> are set.
+      </p>
+      <p>Here's one with nothing inside it:</p>
+      <NegativeSpaceContainer style={{width: '100%', height: '100px'}} />
+    </Fragment>
+  ));
+
+  story('Centered in a fixed space', () => (
+    <NegativeSpaceContainer style={{width: '600px', height: '200px'}}>
+      <img src={backgroundLighthouse} />
+    </NegativeSpaceContainer>
+  ));
+
+  story('Transparent Content', () => (
+    <NegativeSpaceContainer>
+      <img src={onboardingFrameworkSelectionJavascript} />
+    </NegativeSpaceContainer>
+  ));
+});

--- a/static/app/components/container/negativeSpaceContainer.tsx
+++ b/static/app/components/container/negativeSpaceContainer.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+
+const NegativeSpaceContainer = styled('div')`
+  width: 100%;
+  display: flex;
+  flex-grow: 1;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+
+  background-color: ${p => p.theme.backgroundSecondary};
+  background-image: repeating-linear-gradient(
+      -145deg,
+      transparent,
+      transparent 8px,
+      ${p => p.theme.backgroundSecondary} 8px,
+      ${p => p.theme.backgroundSecondary} 11px
+    ),
+    repeating-linear-gradient(
+      -45deg,
+      transparent,
+      transparent 15px,
+      ${p => p.theme.gray100} 15px,
+      ${p => p.theme.gray100} 16px
+    );
+`;
+
+export default NegativeSpaceContainer;

--- a/static/app/components/loadingTriangle.stories.tsx
+++ b/static/app/components/loadingTriangle.stories.tsx
@@ -1,0 +1,17 @@
+import LoadingTriangle from 'sentry/components/loadingTriangle';
+import SizingWindow from 'sentry/components/stories/sizingWindow';
+import storyBook from 'sentry/stories/storyBook';
+
+export default storyBook('LogoSentry', story => {
+  story('Default', () => (
+    <SizingWindow style={{height: '150px'}}>
+      <LoadingTriangle />
+    </SizingWindow>
+  ));
+
+  story('With children', () => (
+    <SizingWindow style={{height: '190px'}}>
+      <LoadingTriangle>This will take a while...</LoadingTriangle>
+    </SizingWindow>
+  ));
+});

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -2,11 +2,11 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useResizeObserver} from '@react-aria/utils';
 
+import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import BufferingOverlay from 'sentry/components/replays/player/bufferingOverlay';
 import FastForwardBadge from 'sentry/components/replays/player/fastForwardBadge';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import SizingWindow from 'sentry/components/stories/sizingWindow';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -114,17 +114,17 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
   }, [windowDimensions, videoDimensions]);
 
   return (
-    <FixedSizingWindow ref={windowEl} className="sentry-block">
+    <FixedContainer ref={windowEl} className="sentry-block">
       <div ref={viewEl} className={className} />
       {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
       {isBuffering ? <PositionedBuffering /> : null}
       {isPreview ? null : <PlayerDOMAlert />}
       {isFetching ? <PositionedLoadingIndicator /> : null}
-    </FixedSizingWindow>
+    </FixedContainer>
   );
 }
 
-const FixedSizingWindow = styled(SizingWindow)`
+const FixedContainer = styled(NegativeSpaceContainer)`
   border: none;
   resize: none;
   padding: 0;

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -6,6 +6,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import BufferingOverlay from 'sentry/components/replays/player/bufferingOverlay';
 import FastForwardBadge from 'sentry/components/replays/player/fastForwardBadge';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import SizingWindow from 'sentry/components/stories/sizingWindow';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -113,46 +114,20 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
   }, [windowDimensions, videoDimensions]);
 
   return (
-    <SizingWindow ref={windowEl} className="sentry-block">
+    <FixedSizingWindow ref={windowEl} className="sentry-block">
       <div ref={viewEl} className={className} />
       {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
       {isBuffering ? <PositionedBuffering /> : null}
       {isPreview ? null : <PlayerDOMAlert />}
       {isFetching ? <PositionedLoadingIndicator /> : null}
-    </SizingWindow>
+    </FixedSizingWindow>
   );
 }
 
-// Center the viewEl inside the windowEl.
-// This is useful when the window is inside a container that has large fixed
-// dimensions, like when in fullscreen mode.
-// If the container has a dimensions that can grow/shrink then it is
-// important to also set `overflow: hidden` on the container, so that the
-// SizingWindow can calculate size as things shrink.
-const SizingWindow = styled('div')`
-  width: 100%;
-  display: flex;
-  flex-grow: 1;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-  overflow: hidden;
-
-  background-color: ${p => p.theme.backgroundSecondary};
-  background-image: repeating-linear-gradient(
-      -145deg,
-      transparent,
-      transparent 8px,
-      ${p => p.theme.backgroundSecondary} 8px,
-      ${p => p.theme.backgroundSecondary} 11px
-    ),
-    repeating-linear-gradient(
-      -45deg,
-      transparent,
-      transparent 15px,
-      ${p => p.theme.gray100} 15px,
-      ${p => p.theme.gray100} 16px
-    );
+const FixedSizingWindow = styled(SizingWindow)`
+  border: none;
+  resize: none;
+  padding: 0;
 `;
 
 const PositionedFastForward = styled(FastForwardBadge)`

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -114,21 +114,15 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
   }, [windowDimensions, videoDimensions]);
 
   return (
-    <FixedContainer ref={windowEl} className="sentry-block">
+    <NegativeSpaceContainer ref={windowEl} className="sentry-block">
       <div ref={viewEl} className={className} />
       {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
       {isBuffering ? <PositionedBuffering /> : null}
       {isPreview ? null : <PlayerDOMAlert />}
       {isFetching ? <PositionedLoadingIndicator /> : null}
-    </FixedContainer>
+    </NegativeSpaceContainer>
   );
 }
-
-const FixedContainer = styled(NegativeSpaceContainer)`
-  border: none;
-  resize: none;
-  padding: 0;
-`;
 
 const PositionedFastForward = styled(FastForwardBadge)`
   position: absolute;

--- a/static/app/components/stories/sizingWindow.tsx
+++ b/static/app/components/stories/sizingWindow.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+const SizingWindow = styled('div')`
+  width: 100%;
+  display: flex;
+  flex-grow: 1;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+
+  background-color: ${p => p.theme.backgroundSecondary};
+  background-image: repeating-linear-gradient(
+      -145deg,
+      transparent,
+      transparent 8px,
+      ${p => p.theme.backgroundSecondary} 8px,
+      ${p => p.theme.backgroundSecondary} 11px
+    ),
+    repeating-linear-gradient(
+      -45deg,
+      transparent,
+      transparent 15px,
+      ${p => p.theme.gray100} 15px,
+      ${p => p.theme.gray100} 16px
+    );
+
+  border: 1px solid ${p => p.theme.yellow400};
+  border-radius: ${p => p.theme.borderRadius};
+
+  resize: both;
+  padding: ${space(2)};
+`;
+
+export default SizingWindow;

--- a/static/app/components/stories/sizingWindow.tsx
+++ b/static/app/components/stories/sizingWindow.tsx
@@ -1,32 +1,9 @@
 import styled from '@emotion/styled';
 
+import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
 import {space} from 'sentry/styles/space';
 
-const SizingWindow = styled('div')`
-  width: 100%;
-  display: flex;
-  flex-grow: 1;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-  overflow: hidden;
-
-  background-color: ${p => p.theme.backgroundSecondary};
-  background-image: repeating-linear-gradient(
-      -145deg,
-      transparent,
-      transparent 8px,
-      ${p => p.theme.backgroundSecondary} 8px,
-      ${p => p.theme.backgroundSecondary} 11px
-    ),
-    repeating-linear-gradient(
-      -45deg,
-      transparent,
-      transparent 15px,
-      ${p => p.theme.gray100} 15px,
-      ${p => p.theme.gray100} 16px
-    );
-
+const SizingWindow = styled(NegativeSpaceContainer)`
   border: 1px solid ${p => p.theme.yellow400};
   border-radius: ${p => p.theme.borderRadius};
 


### PR DESCRIPTION
Docs for the loadingTriangle

<img width="992" alt="SCR-20230918-pmnz" src="https://github.com/getsentry/sentry/assets/187460/0b718b2c-9de0-42c0-94be-28361b1e09ac">

It's leveraging this "NegativeSpaceContainer" which is extracted out of the replayPlayer, to create the SizingWindow helper. That helper is really important because it show the transparent parts in both light & dark themes.
The extracted component is also documented, because that's why we're here! document all the things!
<img width="992" alt="SCR-20230918-pmmu" src="https://github.com/getsentry/sentry/assets/187460/512bac59-b5bc-475b-b7c5-8526bfa00559">
