### PR TITLE
fix(jira-server): try a second project for jira server if the first one fails

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -705,17 +705,24 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
         project_id = params.get("project", defaults.get("project"))
         jira_projects = self.get_projects()
 
+        try_other_projects = False
         if not project_id:
             project_id = jira_projects[0]["id"]
+            try_other_projects = True
 
         client = self.get_client()
         try:
             issue_type_choices = client.get_issue_types(project_id)
         except ApiError:
-            # re-fetch projects list w/o caching and try again
-            jira_projects = self.get_projects(False)
-            project_id = jira_projects[0]["id"]
-            issue_type_choices = client.get_issue_types(project_id)
+            if try_other_projects:
+                # try again with a different project
+                other_projects = list(filter(lambda x: x["id"] != str(project_id), jira_projects))
+                if not other_projects:
+                    raise
+                project_id = other_projects[0]["id"]
+                issue_type_choices = client.get_issue_types(project_id)
+            else:
+                raise
 
         issue_type_choices_formatted = [
             (choice["id"], choice["name"]) for choice in issue_type_choices["values"]

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -411,7 +411,7 @@ class JiraServerIntegrationTest(APITestCase):
     @responses.activate
     def test_get_create_issue_config_with_default_project_issue_types_erroring(self):
         """Test that if you have a default project set that's returning an error when
-        we try to get the issue types we re-fetch the projects list w/o caching and try again
+        we try to get the issue types we try a second project
         """
         event = self.store_event(
             data={"message": "oh no", "timestamp": self.min_ago}, project_id=self.project.id
@@ -421,7 +421,7 @@ class JiraServerIntegrationTest(APITestCase):
         assert self.installation.org_integration is not None
         self.installation.org_integration = integration_service.update_organization_integration(
             org_integration_id=self.installation.org_integration.id,
-            config={"project_issue_defaults": {str(group.project_id): {"project": "10000"}}},
+            config={"project_issue_defaults": {str(group.project_id): {}}},
         )
         responses.add(
             responses.GET,


### PR DESCRIPTION
When Sentry loads the initial config for Jira Server, we pick the first project we find if there isn't one set. Sometimes that project is in a bad state. So if the first request fails, we try the second project and use that instead.