### PR TITLE
chore(hybrid-cloud): Mark extract_user_ids_from_mentions to be a region silo function

### DIFF
--- a/src/sentry/api/serializers/rest_framework/mentions.py
+++ b/src/sentry/api/serializers/rest_framework/mentions.py
@@ -6,8 +6,10 @@ from rest_framework import serializers
 
 from sentry.models import ActorTuple, OrganizationMember, OrganizationMemberTeam, Team, User
 from sentry.services.hybrid_cloud.user import RpcUser
+from sentry.services.hybrid_cloud.util import region_silo_function
 
 
+@region_silo_function
 def extract_user_ids_from_mentions(organization_id, mentions):
     """
     Extracts user ids from a set of mentions. Mentions should be a list of

--- a/tests/sentry/api/serializers/rest_framework/test_mentions.py
+++ b/tests/sentry/api/serializers/rest_framework/test_mentions.py
@@ -1,10 +1,10 @@
 from sentry.api.serializers.rest_framework.mentions import extract_user_ids_from_mentions
 from sentry.models import ActorTuple, Team, User
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import region_silo_test
 
 
-@control_silo_test
+@region_silo_test(stable=True)
 class ExtractUserIdsFromMentionsTest(TestCase):
     def test_users(self):
         actor = ActorTuple(self.user.id, User)


### PR DESCRIPTION
`extract_user_ids_from_mentions()` is only used in region silo endpoints. So I've updated the associated tests to be region silo stable.