### PR TITLE
fix(rules): Don't allow access to alert rule if not project member

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -123,6 +123,12 @@ def update_alert_rule(request: Request, organization, alert_rule):
 
 
 def remove_alert_rule(request: Request, organization, alert_rule):
+    project = alert_rule.snuba_query.subscriptions.get().project
+    projects_for_user = project.objects.get_for_user_ids([request.user.id])
+
+    if not list(projects_for_user) == [project]:
+        return Response(status=status.HTTP_403_FORBIDDEN)
+
     try:
         delete_alert_rule(alert_rule, user=request.user, ip_address=request.META.get("REMOTE_ADDR"))
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -140,6 +140,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
 
     def check_project_access(func):
         def wrapper(self, request: Request, organization, alert_rule):
+            # a metric alert is only associated with one project at a time
             project = alert_rule.snuba_query.subscriptions.get().project
 
             if not request.access.has_project_access(project):

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -124,9 +124,8 @@ def update_alert_rule(request: Request, organization, alert_rule):
 
 def remove_alert_rule(request: Request, organization, alert_rule):
     project = alert_rule.snuba_query.subscriptions.get().project
-    projects_for_user = project.objects.get_for_user_ids([request.user.id])
 
-    if not list(projects_for_user) == [project]:
+    if not request.access.has_project_access(project):
         return Response(status=status.HTTP_403_FORBIDDEN)
 
     try:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -1187,7 +1187,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
         ).delete()
         with self.feature("organizations:incidents"):
             resp = self.get_response(self.organization.slug, alert_rule.id)
-        assert resp.status_code == 403
+        assert resp.status_code == 204
         another_alert_rule = self.alert_rule
         alert_rule.owner = self.team.actor
         another_alert_rule.save()
@@ -1197,6 +1197,10 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
 
     def test_project_permission(self):
         """Test that a user can't delete an alert in a project they do not have access to"""
+        # disable Open Membership
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
         team = self.create_team(organization=self.organization, members=[self.user])
         project = self.create_project(name="boo", organization=self.organization, teams=[team])
         alert_rule = self.create_alert_rule(projects=[project])

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -1187,10 +1187,34 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
         ).delete()
         with self.feature("organizations:incidents"):
             resp = self.get_response(self.organization.slug, alert_rule.id)
-        assert resp.status_code == 204
+        assert resp.status_code == 403
         another_alert_rule = self.alert_rule
         alert_rule.owner = self.team.actor
         another_alert_rule.save()
         self.create_team_membership(team=self.team, member=om)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug, alert_rule.id, status_code=204)
+
+    def test_project_permission(self):
+        """Test that a user can't delete an alert in a project they do not have access to"""
+        team = self.create_team(organization=self.organization, members=[self.user])
+        project = self.create_project(name="boo", organization=self.organization, teams=[team])
+        alert_rule = self.create_alert_rule(projects=[project])
+        alert_rule.owner = team.actor
+        alert_rule.save()
+
+        other_user = self.create_user()
+        self.login_as(other_user)
+        other_team = self.create_team(organization=self.organization, members=[other_user])
+        other_project = self.create_project(
+            name="ahh", organization=self.organization, teams=[other_team]
+        )
+        other_alert_rule = self.create_alert_rule(projects=[other_project])
+        other_alert_rule.owner = other_team.actor
+        other_alert_rule.save()
+
+        with self.feature("organizations:incidents"):
+            self.get_error_response(self.organization.slug, alert_rule.id, status_code=403)
+
+        with self.feature("organizations:incidents"):
+            self.get_success_response(self.organization.slug, other_alert_rule.id, status_code=204)


### PR DESCRIPTION
If the requesting user is not a member of the project teams for the given alert rule, do not allow them to access it.