### PR TITLE
ref(severity): Use event title for severity input

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -57,6 +57,7 @@ from sentry.culprit import generate_culprit
 from sentry.dynamic_sampling import LatestReleaseBias, LatestReleaseParams
 from sentry.eventstore.processing import event_processing_store
 from sentry.eventtypes import EventType
+from sentry.eventtypes.error import ErrorEvent
 from sentry.eventtypes.transaction import TransactionEvent
 from sentry.grouping.api import (
     BackgroundGroupingConfigLoader,
@@ -148,6 +149,8 @@ SECURITY_REPORT_INTERFACES = ("csp", "hpkp", "expectct", "expectstaple")
 
 # Timeout for cached group crash report counts
 CRASH_REPORT_TIMEOUT = 24 * 3600  # one day
+
+NON_TITLE_EVENT_TITLES = ["<untitled>", "<unknown>"]
 
 
 @dataclass
@@ -2048,22 +2051,25 @@ def _get_severity_score(event: Event) -> float | None:
     logger_data = {"event_id": event.data["event_id"], "op": op}
     severity = None
 
-    metadata = event.get_event_metadata()
-    error_type = metadata.get("type")
-    error_msg = metadata.get("value")
-    message = ""
-    if error_type:
-        message = error_type if not error_msg else f"{error_type}: {error_msg}"
+    # We're using the title (which truncates the error message) rather than the full error type and
+    # message here because the `exception` property in event data (where they live) isn't mirrored
+    # to BigQuery for storage space reasons (stacktraces can be enormous). Since the ML model is
+    # trained on BQ data, we have to use the title to match.
+    #
+    # TODO: Figure out if there's a way to get the full error message to the model.
+    title = event.title
+    if title in NON_TITLE_EVENT_TITLES:
+        title = ErrorEvent().compute_title(dict(event.get_event_metadata()))
 
-    if message:
-        logger_data["event_message"] = message
+    if title not in NON_TITLE_EVENT_TITLES:
+        logger_data["event_message"] = title
         with metrics.timer(op):
             with sentry_sdk.start_span(op=op):
                 try:
                     response = severity_connection_pool.urlopen(
                         "POST",
                         "/issues/severity-score",
-                        body=json.dumps({"message": message or "<unknown event>"}),
+                        body=json.dumps({"message": title}),
                         headers={"content-type": "application/json;charset=utf-8"},
                     )
                     severity = json.loads(response.data).get("severity")
@@ -2083,9 +2089,9 @@ def _get_severity_score(event: Event) -> float | None:
                         extra=logger_data,
                     )
     else:
-        logger_data.update({"error_type": error_type, "error_msg": error_msg})
+        logger_data.update({"event_title": event.title, "computed_title": title})
         logger.warning(
-            "Unable to get severity score because event has no message",
+            f"Unable to get severity score because of unusable `message` value '{title}'",
             extra=logger_data,
         )
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -32,6 +32,7 @@ from sentry.dynamic_sampling import (
     get_redis_client_for_ds,
 )
 from sentry.event_manager import (
+    NON_TITLE_EVENT_TITLES,
     EventManager,
     HashDiscarded,
     _get_event_instance,
@@ -2538,28 +2539,54 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         "sentry.event_manager.severity_connection_pool.urlopen",
         return_value=HTTPResponse(body=json.dumps({"severity": 0.1231})),
     )
+    def test_get_severity_score_usable_event_title(
+        self,
+        mock_urlopen: MagicMock,
+    ) -> None:
+        manager = EventManager(
+            make_event(
+                exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]},
+            )
+        )
+        event = manager.save(self.project.id)
+        # `title` is a property with no setter, but it pulls from `metadata`, so it's equivalent
+        # to set it there. (We have to ignore mypy because `metadata` isn't supposed to be mutable.)
+        event.get_event_metadata()["title"] = "Dogs are great!"  # type: ignore[index]
+
+        _get_severity_score(event)
+
+        assert mock_urlopen.call_args.kwargs["body"] == '{"message":"Dogs are great!"}'
+
+    @patch(
+        "sentry.event_manager.severity_connection_pool.urlopen",
+        return_value=HTTPResponse(body=json.dumps({"severity": 0.1231})),
+    )
     @patch("sentry.event_manager.logger.warning")
-    def test_get_severity_score_no_message(
+    def test_get_severity_score_unusable_event_title(
         self,
         mock_logger_warning: MagicMock,
         mock_urlopen: MagicMock,
     ) -> None:
-        manager = EventManager(make_event())
-        event = manager.save(self.project.id)
+        for title in NON_TITLE_EVENT_TITLES:
+            manager = EventManager(make_event())
+            event = manager.save(self.project.id)
+            # `title` is a property with no setter, but it pulls from `metadata`, so it's equivalent
+            # to set it there. (We have to ignore mypy because `metadata` isn't supposed to be mutable.)
+            event.get_event_metadata()["title"] = title  # type: ignore[index]
 
-        severity = _get_severity_score(event)
+            severity = _get_severity_score(event)
 
-        mock_urlopen.assert_not_called()
-        mock_logger_warning.assert_called_with(
-            "Unable to get severity score because event has no message",
-            extra={
-                "event_id": event.event_id,
-                "op": "event_manager._get_severity_score",
-                "error_type": None,
-                "error_msg": None,
-            },
-        )
-        assert severity is None
+            mock_urlopen.assert_not_called()
+            mock_logger_warning.assert_called_with(
+                "Unable to get severity score because of unusable `message` value '<unknown>'",
+                extra={
+                    "event_id": event.event_id,
+                    "op": "event_manager._get_severity_score",
+                    "event_title": title,
+                    "computed_title": "<unknown>",
+                },
+            )
+            assert severity is None
 
     @patch(
         "sentry.event_manager.severity_connection_pool.urlopen",


### PR DESCRIPTION
During ingest processing, an error event's title is computed as `<error type> : <truncated error value>`. Though using an _untruncated_ error value would give us more information for training, the severity ML model uses BigQuery data, which includes the computed title but not the exception type and value themselves. (The latter are part of the `exception` object, which is removed when event data is mirrored to BQ in order to save storage space.) Therefore, the model uses the event title for training.

Currently, the data sent to the ML microservice is `<error type> : <full error value>`, again following the principle that more data is better. That doesn't match the model, though, so this switches to sending the event's title instead. It also flips the order of the logic in `_get_severity_score`, such that it bails early if there's no meaningful title, allowing the majority of the business logic to come out from under an `if`.