### PR TITLE
ref(tests): Split error event tests into classes

### DIFF
--- a/tests/sentry/eventtypes/test_error.py
+++ b/tests/sentry/eventtypes/test_error.py
@@ -8,8 +8,8 @@ from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test(stable=True)
-class ErrorEventTest(TestCase):
-    def test_get_metadata(self):
+class GetMetadataTest(TestCase):
+    def test_simple(self):
         inst = ErrorEvent()
         data = {"exception": {"values": [{"type": "Exception", "value": "Foo"}]}}
         assert inst.get_metadata(data) == {
@@ -18,7 +18,7 @@ class ErrorEventTest(TestCase):
             "display_title_with_tree_label": False,
         }
 
-    def test_get_metadata_none(self):
+    def test_no_exception_type_or_value(self):
         inst = ErrorEvent()
         data: dict[str, dict[str, Any]] = {
             "exception": {"values": [{"type": None, "value": None, "stacktrace": {}}]}
@@ -29,7 +29,7 @@ class ErrorEventTest(TestCase):
             "display_title_with_tree_label": False,
         }
 
-    def test_get_metadata_function(self):
+    def test_pulls_top_function(self):
         inst = ErrorEvent()
         data = {
             "platform": "native",
@@ -54,7 +54,7 @@ class ErrorEventTest(TestCase):
             "display_title_with_tree_label": True,  # native!
         }
 
-    def test_get_metadata_function_none_frame(self):
+    def test_none_frame(self):
         inst = ErrorEvent()
         data = {"exception": {"values": [{"stacktrace": {"frames": [None]}}]}}
         assert inst.get_metadata(data) == {
@@ -63,7 +63,7 @@ class ErrorEventTest(TestCase):
             "display_title_with_tree_label": False,
         }
 
-    def test_get_metadata_multiple_exceptions_default(self):
+    def test_multiple_exceptions_default(self):
         inst = ErrorEvent()
         data = {
             "exception": {
@@ -79,7 +79,7 @@ class ErrorEventTest(TestCase):
             "display_title_with_tree_label": False,
         }
 
-    def test_get_metadata_multiple_exceptions_main_indicated(self):
+    def test_multiple_exceptions_main_indicated(self):
         inst = ErrorEvent()
         data = {
             "main_exception_id": 1,
@@ -96,17 +96,20 @@ class ErrorEventTest(TestCase):
             "display_title_with_tree_label": False,
         }
 
-    def test_get_title_none_value(self):
+
+@region_silo_test(stable=True)
+class GetTitleTest(TestCase):
+    def test_none_value(self):
         inst = ErrorEvent()
         result = inst.get_title({"type": "Error", "value": None})
         assert result == "Error"
 
-    def test_get_title_eliminates_values_with_newline(self):
+    def test_trims_value_at_newline(self):
         inst = ErrorEvent()
         result = inst.get_title({"type": "Error", "value": "foo\nbar"})
         assert result == "Error: foo"
 
-    def test_get_title_handles_empty_value(self):
+    def test_handles_empty_value(self):
         inst = ErrorEvent()
         result = inst.get_title({"type": "Error", "value": ""})
         assert result == "Error"


### PR DESCRIPTION
This splits the tests for `ErrorEvent` methods into a separate class for each method being tested, in anticipation of more tests (for other methods) being added to the file.