### PR TITLE
chore(api): Switch inbound data filter to body params

### DIFF
--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterable
 
-from drf_spectacular.utils import extend_schema, inline_serializer
-from rest_framework import serializers
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -18,7 +17,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.parameters import GlobalParams, ProjectParams
 from sentry.ingest import inbound_filters
-from sentry.ingest.inbound_filters import FilterStatKeys
+from sentry.ingest.inbound_filters import FilterStatKeys, _LegacyBrowserFilterSerializer
 
 
 @extend_schema(tags=["Projects"])
@@ -34,16 +33,8 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
             GlobalParams.ORG_SLUG,
             GlobalParams.PROJECT_SLUG,
             ProjectParams.FILTER_ID,
-            ProjectParams.ACTIVE,
-            ProjectParams.SUB_FILTERS,
         ],
-        request=inline_serializer(
-            name="FilterPutSerializer",
-            fields={
-                "active": serializers.CharField(required=False),
-                "subfilters": serializers.ListField(child=serializers.CharField(required=False)),
-            },
-        ),
+        request=_LegacyBrowserFilterSerializer,
         responses={
             204: RESPONSE_NO_CONTENT,
             400: RESPONSE_BAD_REQUEST,

--- a/src/sentry/api/fields/multiplechoice.py
+++ b/src/sentry/api/fields/multiplechoice.py
@@ -1,4 +1,3 @@
-from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 ERROR_MESSAGES = {
@@ -6,7 +5,6 @@ ERROR_MESSAGES = {
 }
 
 
-@extend_schema_field(field={"type": "array", "items": {"type": "integer"}})
 class MultipleChoiceField(serializers.Field):
     def __init__(self, choices=None, *args, **kwargs):
         self.choices = set(choices or ())

--- a/src/sentry/api/fields/multiplechoice.py
+++ b/src/sentry/api/fields/multiplechoice.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 ERROR_MESSAGES = {
@@ -5,6 +6,7 @@ ERROR_MESSAGES = {
 }
 
 
+@extend_schema_field(field={"type": "array", "items": {"type": "integer"}})
 class MultipleChoiceField(serializers.Field):
     def __init__(self, choices=None, *args, **kwargs):
         self.choices = set(choices or ())

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -302,14 +302,6 @@ incorrect or missing.
 """,
     )
 
-    ACTIVE = OpenApiParameter(
-        name="active",
-        location="query",
-        required=False,
-        type=bool,
-        description="Toggle the browser-extensions, localhost, filtered-transaction, or web-crawlers filter on or off.",
-    )
-
     BROWSER_SDK_VERSION = OpenApiParameter(
         name="browserSdkVersion",
         location="query",
@@ -430,25 +422,6 @@ disable entirely set `rateLimit` to null.
 }
 ```
         """,
-    )
-
-    SUB_FILTERS = OpenApiParameter(
-        name="subfilters",
-        location="query",
-        required=False,
-        type=build_typed_list(OpenApiTypes.STR),
-        description="""
-Specifies which legacy browser filters should be active. Anything excluded from the list will be
-disabled. The options are:
-- `ie_pre_9`: Internet Explorer Version 8 and lower
-- `ie9`: Internet Explorer Version 9
-- `ie10`: Internet Explorer Version 10
-- `ie11`: Internet Explorer Version 11
-- `safari_pre_6`: Safari Version 5 and lower
-- `opera_pre_15`: Opera Version 14 and lower
-- `opera_mini_pre_8`: Opera Mini Version 8 and lower
-- `android_pre_4`: Android Version 3 and lower
-""",
     )
 
     @staticmethod

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 
-from sentry.api.fields.multiplechoice import MultipleChoiceField
 from sentry.models import ProjectOption
 from sentry.relay.utils import to_camel_case_name
 from sentry.signals import inbound_filter_toggled
@@ -220,7 +219,7 @@ _browser_extensions_filter = _FilterSpec(
 
 
 class _LegacyBrowserFilterSerializer(_FilterSerializer):
-    subfilters = MultipleChoiceField(
+    subfilters = serializers.MultipleChoiceField(
         help_text="""
 Specifies which legacy browser filters should be active. Anything excluded from the list will be
 disabled. The options are:

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -161,7 +161,10 @@ def _filter_from_filter_id(filter_id):
 
 
 class _FilterSerializer(serializers.Serializer):
-    active = serializers.BooleanField()
+    active = serializers.BooleanField(
+        help_text="Toggle the browser-extensions, localhost, filtered-transaction, or web-crawlers filter on or off.",
+        required=False,
+    )
 
 
 class _FilterSpec:
@@ -218,6 +221,18 @@ _browser_extensions_filter = _FilterSpec(
 
 class _LegacyBrowserFilterSerializer(_FilterSerializer):
     subfilters = MultipleChoiceField(
+        help_text="""
+Specifies which legacy browser filters should be active. Anything excluded from the list will be
+disabled. The options are:
+- `ie_pre_9`: Internet Explorer Version 8 and lower
+- `ie9`: Internet Explorer Version 9
+- `ie10`: Internet Explorer Version 10
+- `ie11`: Internet Explorer Version 11
+- `safari_pre_6`: Safari Version 5 and lower
+- `opera_pre_15`: Opera Version 14 and lower
+- `opera_mini_pre_8`: Opera Mini Version 8 and lower
+- `android_pre_4`: Android Version 3 and lower
+""",
         choices=[
             "ie_pre_9",
             "ie9",
@@ -227,7 +242,8 @@ class _LegacyBrowserFilterSerializer(_FilterSerializer):
             "android_pre_4",
             "safari_pre_6",
             "opera_mini_pre_8",
-        ]
+        ],
+        required=False,
     )
 
 


### PR DESCRIPTION
Switch all query params to body params in [Update An Inbound Data Filter](https://docs.sentry.io/api/projects/update-an-inbound-data-filter/). Everything is the exact same except the old query params are now body params

### Before
<img width="495" alt="Screenshot 2023-09-20 at 11 48 33 AM" src="https://github.com/getsentry/sentry/assets/67301797/c47b4655-a59b-402e-a3d7-b93533cb0e60">

### After
<img width="490" alt="Screenshot 2023-09-20 at 11 48 23 AM" src="https://github.com/getsentry/sentry/assets/67301797/59d63325-a71a-4200-99b5-dde7cbffe405">