### PR TITLE
chore(api): Switch to body params for create project

### DIFF
--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -22,7 +22,7 @@ from sentry.api.serializers.models.project import OrganizationProjectResponse, P
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
 from sentry.apidocs.examples.project_examples import ProjectExamples
 from sentry.apidocs.examples.team_examples import TeamExamples
-from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ProjectParams
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.models import Project
@@ -33,16 +33,32 @@ ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '
 
 
 class ProjectPostSerializer(serializers.Serializer, PreventNumericSlugMixin):
-    name = serializers.CharField(max_length=50, required=True)
+    name = serializers.CharField(
+        help_text="The name for the project.", max_length=50, required=True
+    )
     slug = serializers.RegexField(
         DEFAULT_SLUG_PATTERN,
+        help_text="""
+Optional slug for the project. If not provided a slug is automatically
+generated from the name.
+        """,
         max_length=50,
         required=False,
         allow_null=True,
         error_messages={"invalid": DEFAULT_SLUG_ERROR_MESSAGE},
     )
-    platform = serializers.CharField(required=False, allow_blank=True, allow_null=True)
-    default_rules = serializers.BooleanField(required=False, initial=True)
+    platform = serializers.CharField(
+        help_text="The platform for the project.", required=False, allow_blank=True, allow_null=True
+    )
+    default_rules = serializers.BooleanField(
+        help_text="""
+Defaults to true where the behavior is to alert the user on every new
+issue. Setting this to false will turn this off and the user must create
+their own alerts to be notified of new issues.
+        """,
+        required=False,
+        initial=True,
+    )
 
     def validate_platform(self, value):
         if Project.is_valid_platform(value):
@@ -136,12 +152,6 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
         parameters=[
             GlobalParams.ORG_SLUG,
             GlobalParams.TEAM_SLUG,
-            GlobalParams.name("The name for the project.", required=True),
-            GlobalParams.slug(
-                "Optional slug for the project. If not provided a slug is generated from the name."
-            ),
-            ProjectParams.platform("The platform for the project."),
-            ProjectParams.DEFAULT_RULES,
         ],
         request=ProjectPostSerializer,
         responses={

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -38,10 +38,8 @@ class ProjectPostSerializer(serializers.Serializer, PreventNumericSlugMixin):
     )
     slug = serializers.RegexField(
         DEFAULT_SLUG_PATTERN,
-        help_text="""
-Optional slug for the project. If not provided a slug is automatically
-generated from the name.
-        """,
+        help_text="""Uniquely identifies a project and is used for the interface.
+        If not provided, it is automatically generated from the name.""",
         max_length=50,
         required=False,
         allow_null=True,

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -322,14 +322,6 @@ The Sentry Javascript SDK version to use. The currently supported options are:
 """,
     )
 
-    DEFAULT_RULES = OpenApiParameter(
-        name="default_rules",
-        location="query",
-        required=False,
-        type=bool,
-        description="Defaults to true where the behavior is to alert the user on every new issue. Setting this to false will turn this off and the user must create their own alerts to be notified of new issues.",
-    )
-
     DYNAMIC_SDK_LOADER_OPTIONS = OpenApiParameter(
         name="dynamicSdkLoaderOptions",
         location="query",


### PR DESCRIPTION
We require `name` to be set despite it being a deprecated field. In a future PR I will not require `name` and fix our frontend to say `slug`, but until then I've clarified how `slug` is being used.

Before:
<img width="540" alt="Screenshot 2023-09-19 at 12 59 30 AM" src="https://github.com/getsentry/sentry/assets/67301797/b4f3f506-32e9-46c6-93dc-1513659e525d">

After:
<img width="540" alt="Screenshot 2023-09-19 at 2 00 13 AM" src="https://github.com/getsentry/sentry/assets/67301797/acc333af-b2f3-49fd-b64b-6fdfc1c6f82a">
