### PR TITLE
feat(ddm): support for 1m interval

### DIFF
--- a/static/app/utils/metrics.tsx
+++ b/static/app/utils/metrics.tsx
@@ -98,7 +98,7 @@ export function useMetricsData({
   const field = op ? `${op}(${mri})` : mri;
 
   const {start, end} = getUTCTimeRange(timeRange);
-  const interval = getMetricsInterval({start, end});
+  const interval = getInterval({start, end}, 'metrics');
 
   const query = getQueryString({projects, queryString});
 
@@ -108,6 +108,10 @@ export function useMetricsData({
     interval,
     query,
     groupBy,
+    start,
+    end,
+    // max result groups
+    per_page: 20,
   };
 
   return useApiQuery<MetricsData>(
@@ -136,22 +140,6 @@ const getUTCTimeRange = (timeRange: Record<string, any>) => {
     start: moment(absoluteTimeRange.start).utc().toISOString(),
     end: moment(absoluteTimeRange.end).utc().toISOString(),
   };
-};
-
-const getMetricsInterval = (timeRange: Record<string, any>) => {
-  const diff = moment(timeRange.end).diff(moment(timeRange.start), 'days');
-
-  if (diff >= 7 && diff <= 16) {
-    return '2h';
-  }
-  if (diff > 16 && diff <= 30) {
-    return '4h';
-  }
-  if (diff > 32 && diff <= 90) {
-    return '12h';
-  }
-
-  return getInterval(timeRange, 'medium');
 };
 
 type UseCase = 'sessions' | 'transactions' | 'custom';

--- a/static/app/views/ddm/metricsExplorer.tsx
+++ b/static/app/views/ddm/metricsExplorer.tsx
@@ -135,8 +135,9 @@ function QueryBuilder({setQuery}: QueryBuilderProps) {
 
   const reducer = (state: QueryBuilderState, action: QueryBuilderAction) => {
     if (action.type === 'mri') {
-      const operations = meta[`${action.value}`]?.operations.filter(isAllowedOp) || [''];
-      return {...state, mri: action.value, op: operations[0]};
+      const availableOps = meta[`${action.value}`]?.operations.filter(isAllowedOp);
+      const selectedOp = availableOps.includes(state.op) ? state.op : availableOps[0];
+      return {...state, mri: action.value, op: selectedOp};
     }
     if (['op', 'groupBy', 'projects', 'timeRange', 'queryString'].includes(action.type)) {
       return {...state, [action.type]: action.value};
@@ -342,7 +343,7 @@ function MetricsExplorerDisplay({displayType, ...metricsDataProps}: DisplayProps
   if (!data) {
     return (
       <DisplayWrapper>
-        {isLoading && <LoadingIndicator overlay />}
+        {isLoading && <LoadingIndicator />}
         {isError && <Alert type="error">Error while fetching metrics data</Alert>}
       </DisplayWrapper>
     );
@@ -440,15 +441,6 @@ function Chart({data, displayType}: {data: MetricsData; displayType: DisplayType
   const chartProps = {
     isGroupedByDate: true,
     series: chartSeries,
-    colors: [
-      theme.purple400,
-      theme.yellow400,
-      theme.pink400,
-      theme.green400,
-      theme.red400,
-      theme.blue400,
-      ...theme.charts.colors,
-    ],
     height: 300,
     legend: Legend({
       itemGap: 20,


### PR DESCRIPTION
Adds support for 1m granularity to metrics explorer
![image](https://github.com/getsentry/sentry/assets/86684834/8cd58163-bc8e-4259-bc72-68e8c3d80781)

- Fixes time range issue
- Uses consistent chart colors
- Minor UX fixes

Closes https://github.com/getsentry/sentry/issues/56371 
Closes https://github.com/getsentry/sentry/issues/55654
Closes https://github.com/getsentry/sentry/issues/56373
Closes https://github.com/getsentry/sentry/issues/56374
