### PR TITLE
fix(github-invite): improve performance of missing members API

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_missing_org_members.py
+++ b/tests/sentry/api/endpoints/test_organization_missing_org_members.py
@@ -257,3 +257,18 @@ class OrganizationMissingMembersTestCase(APITestCase):
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
         ]
+
+    def test_limit_50_missing_members(self):
+        repo = self.create_repo(
+            project=self.project, provider="integrations:github", integration_id=self.integration.id
+        )
+        for i in range(50):
+            nonmember_commit_author = self.create_commit_author(
+                project=self.project, email=str(i) + "@example.com"
+            )
+            nonmember_commit_author.external_id = str(i)
+            nonmember_commit_author.save()
+            self.create_commit(repo=repo, author=nonmember_commit_author)
+
+        response = self.get_success_response(self.organization.slug)
+        assert len(response.data[0]["users"]) == 50


### PR DESCRIPTION
For orgs with many commit authors that are not members of their organization, the missing members API is timing out because there are too many commit authors to serialize ([SENTRY-14QD](https://sentry.sentry.io/issues/4381779733/?project=1)).

We should limit the number of missing members to the 50 most active missing members. I also pulled out an inner join into its own query so it's more readable.