### PR TITLE
Allow users to rm manually started services

### DIFF
--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -485,7 +485,7 @@ def rm(project: str, services: list[str]) -> None:
 
     configure()
 
-    containers = _prepare_containers(project, silent=True)
+    containers = _prepare_containers(project, skip_only_if=len(services) > 0, silent=True)
 
     if services:
         selected_containers = {}


### PR DESCRIPTION
If you run `sentry devservices up kafka` it'll be brought up, regardless of settings / options. If kafka then gets into a bad state (crashloop) the fix seems to require removing the volume.

Typically folks would use `sentry devservices rm kafka` to remove the container, image and volume, however this requires all services to be enabled via settings / config. This change will allow rm to work like up.

The alternative to this is to make `devservices up` require settings changes too, but that feels overkill if you want to use kafka (or another service) for testing or a short lived task.