### PR TITLE
ref(hc): Do not run default project setup for non self hosted cases.

### DIFF
--- a/src/sentry/receivers/core.py
+++ b/src/sentry/receivers/core.py
@@ -16,6 +16,7 @@ from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.services.hybrid_cloud.util import region_silo_function
 from sentry.signals import post_upgrade, project_created
 from sentry.silo import SiloMode
+from sentry.utils.settings import is_self_hosted
 
 PROJECT_SEQUENCE_FIX = """
 SELECT setval('sentry_project_id_seq', (
@@ -39,6 +40,9 @@ def handle_db_failure(func, using=None):
 
 
 def create_default_projects(**kwds):
+    if not is_self_hosted():
+        return
+
     create_default_project(
         # This guards against sentry installs that have SENTRY_PROJECT set to None, so
         # that they don't error after every migration. Specifically for single tenant.


### PR DESCRIPTION
I am not 100% sure if this is the correct change, looking for feedback.

Obviously running create default projects for self hosted on `sentry upgrade` makes sense.  And obviously we should not do so for S4S (see inc-510).  But is S4S considered self hosted?  And what about ST?  

Looking for insight from someone who fully understands our sentry deployments.