### PR TITLE
chore(github-growth): stop writing to commitfilechange language column

### DIFF
--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -130,8 +130,6 @@ class PushEventWebhookTest(APITestCase):
 
         commit_filechanges = CommitFileChange.objects.all()
         assert len(commit_filechanges) == 2
-        assert commit_filechanges[0].language == "python"
-        assert commit_filechanges[1].language is None
 
     def test_auto_linking_missing_feature_flag(self):
         project = self.project  # force creation
@@ -221,8 +219,6 @@ class PushEventWebhookTest(APITestCase):
 
         commit_filechanges = CommitFileChange.objects.all()
         assert len(commit_filechanges) == 2
-        assert commit_filechanges[0].language == "python"
-        assert commit_filechanges[1].language is None
 
     def test_multiple_orgs(self):
         project = self.project  # force creation


### PR DESCRIPTION
The original premise for writing to the `CommitFileChange` table to store the `language` associated with a change made in a commit was so that we could see the languages being used by organizations.

We could instead save the languages associated with commits in the `Repository` table, so we wouldn't need to write to `CommitFileChange` rows -- we also aren't interested in the number of changes that are being made in a particular language, just that folks are working in some language. The CommitFileChange table is also massive (1 billion plus rows) and querying is very slow.

This PR removes writes to the language column in the CommitFileChange model in preparation for removing the column. Undoes #55880