### PR TITLE
ref(js): Remove various usages of IS_ACCEPTANCE_TEST

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -26,7 +26,6 @@ import * as echarts from 'echarts/core';
 import ReactEchartsCore from 'echarts-for-react/lib/core';
 
 import MarkLine from 'sentry/components/charts/components/markLine';
-import {IS_ACCEPTANCE_TEST} from 'sentry/constants';
 import {space} from 'sentry/styles/space';
 import {
   EChartChartReadyHandler,
@@ -500,7 +499,6 @@ function BaseChartUnwrapped({
 
   const chartOption = {
     ...options,
-    animation: IS_ACCEPTANCE_TEST ? false : options.animation ?? true,
     useUTC: utc,
     color,
     grid: Array.isArray(grid) ? grid.map(Grid) : Grid(grid),

--- a/static/app/components/overlay.tsx
+++ b/static/app/components/overlay.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import {HTMLMotionProps, motion, MotionProps, MotionStyle} from 'framer-motion';
 
 import {OverlayArrow, OverlayArrowProps} from 'sentry/components/overlayArrow';
-import {IS_ACCEPTANCE_TEST, NODE_ENV} from 'sentry/constants';
+import {NODE_ENV} from 'sentry/constants';
 import {defined} from 'sentry/utils';
 import PanelProvider from 'sentry/utils/panelProvider';
 import testableTransition from 'sentry/utils/testableTransition';
@@ -109,7 +109,7 @@ const Overlay = styled(
       },
       ref
     ) => {
-      const isTestEnv = IS_ACCEPTANCE_TEST || NODE_ENV === 'test';
+      const isTestEnv = NODE_ENV === 'test';
       const animationProps =
         !isTestEnv && animated
           ? {

--- a/static/app/components/sidebar/serviceIncidents.tsx
+++ b/static/app/components/sidebar/serviceIncidents.tsx
@@ -12,7 +12,6 @@ import ListItem from 'sentry/components/list/listItem';
 import Text from 'sentry/components/text';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IS_ACCEPTANCE_TEST} from 'sentry/constants';
 import {
   IconCheckmark,
   IconFatal,
@@ -66,11 +65,6 @@ function ServiceIncidents({
   }
 
   useEffect(() => void fetchData(), []);
-
-  // Never render incidents in acceptance tests
-  if (IS_ACCEPTANCE_TEST) {
-    return null;
-  }
 
   if (!serviceStatus) {
     return null;

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -3,7 +3,6 @@ import {createStore} from 'reflux';
 
 import getGuidesContent from 'sentry/components/assistant/getGuidesContent';
 import {Guide, GuidesContent, GuidesServerData} from 'sentry/components/assistant/types';
-import {IS_ACCEPTANCE_TEST} from 'sentry/constants';
 import ConfigStore from 'sentry/stores/configStore';
 import HookStore from 'sentry/stores/hookStore';
 import {Organization} from 'sentry/types';
@@ -246,7 +245,7 @@ const storeConfig: GuideStoreDefinition = {
         if (seen) {
           return false;
         }
-        if (user?.isSuperuser && !IS_ACCEPTANCE_TEST) {
+        if (user?.isSuperuser) {
           return true;
         }
         if (dateThreshold) {

--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -1,6 +1,5 @@
 import {css, Global, Theme} from '@emotion/react';
 
-import {IS_ACCEPTANCE_TEST} from 'sentry/constants';
 import {prismStyles} from 'sentry/styles/prism';
 
 const styles = (theme: Theme, isDark: boolean) => css`
@@ -65,15 +64,6 @@ const styles = (theme: Theme, isDark: boolean) => css`
       transition-delay: 0s !important;
     }
   }
-
-  ${IS_ACCEPTANCE_TEST
-    ? css`
-        input,
-        select {
-          caret-color: transparent;
-        }
-      `
-    : ''}
 
   /* Override css in LESS files here as we want to manually control dark mode for now */
   ${isDark

--- a/static/app/utils/marked.tsx
+++ b/static/app/utils/marked.tsx
@@ -2,7 +2,7 @@ import dompurify from 'dompurify';
 import marked from 'marked'; // eslint-disable-line no-restricted-imports
 import Prism from 'prismjs';
 
-import {IS_ACCEPTANCE_TEST, NODE_ENV} from 'sentry/constants';
+import {NODE_ENV} from 'sentry/constants';
 import {loadPrismLanguage} from 'sentry/utils/loadPrismLanguage';
 
 // Only https and mailto, (e.g. no javascript, vbscript, data protocols)
@@ -77,7 +77,7 @@ marked.setOptions({
   //      as a html error, instead of throwing an exception, however none of
   //      our tests are rendering failed markdown so this is likely a safe
   //      tradeoff to turn off off the deprecation warning.
-  silent: !!IS_ACCEPTANCE_TEST || NODE_ENV === 'test',
+  silent: NODE_ENV === 'test',
 });
 
 const sanitizedMarked = (...args: Parameters<typeof marked>) =>


### PR DESCRIPTION
We no longer have visual acceptance tests, so this is not necessary in
most places now.