### PR TITLE
feat(stat-detectors): Use events-facets for tags sidebar

### DIFF
--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react';
 import isNil from 'lodash/isNil';
 
+import {Tag} from 'sentry/actionCreators/events';
 import {Client, RequestCallbacks, RequestOptions} from 'sentry/api';
 import GroupStore from 'sentry/stores/groupStore';
 import {Actor, Group, Member, Note, User} from 'sentry/types';
@@ -448,15 +449,18 @@ const makeFetchStatisticalDetectorTagsQueryKey = ({
 
 export const useFetchIssueTags = (
   parameters: FetchIssueTagsParameters,
-  {enabled = true, ...options}: Partial<UseApiQueryOptions<GroupTagsResponse>> = {}
+  {
+    enabled = true,
+    ...options
+  }: Partial<UseApiQueryOptions<GroupTagsResponse | Tag[]>> = {}
 ) => {
   let queryKey = makeFetchIssueTagsQueryKey(parameters);
   if (parameters.isStatisticalDetector) {
-    // TODO: This changes the type
+    // Statistical detector issues need to use a Discover query for tags
     queryKey = makeFetchStatisticalDetectorTagsQueryKey(parameters);
   }
 
-  return useApiQuery<GroupTagsResponse>(queryKey, {
+  return useApiQuery<GroupTagsResponse | Tag[]>(queryKey, {
     staleTime: 30000,
     enabled: defined(parameters.groupId) && enabled,
     ...options,

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -146,9 +146,9 @@ export default function TagFacets({
       return {};
     }
 
-    const keyed = keyBy(data, 'key');
+    let keyed = keyBy(data, 'key');
     if (isStatisticalDetector) {
-      transformTagFacetDataToGroupTagResponseItems(keyed as Record<string, Tag>);
+      keyed = transformTagFacetDataToGroupTagResponseItems(keyed as Record<string, Tag>);
     }
 
     const formatted =

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -127,7 +127,10 @@ export default function TagFacets({
             name,
             value: name,
             count,
-            url: '',
+
+            // These values aren't displayed in the sidebar
+            firstSeen: '',
+            lastSeen: '',
           })),
         };
       });

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -100,8 +100,11 @@ export default function TagFacets({
     groupId,
     orgSlug: organization.slug,
     environment: environments,
-    transaction: event?.occurrence?.evidenceData?.transaction,
     isStatisticalDetector,
+    statisticalDetectorParameters: {
+      transaction: event?.occurrence?.evidenceData?.transaction,
+      durationBaseline: event?.occurrence?.evidenceData?.aggregateRange2,
+    },
   });
 
   const tagsData = useMemo(() => {

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -239,6 +239,9 @@ export default function GroupSidebar({
         event={event}
         tagFormatter={TAGS_FORMATTER}
         project={project}
+        isStatisticalDetector={
+          group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION
+        }
       />
       {renderParticipantData()}
       {renderSeenByList()}

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -154,10 +154,14 @@ export const useFetchIssueTagsForDetailsPage = (
     groupId,
     orgSlug,
     environment = [],
+    transaction,
+    isStatisticalDetector = false,
   }: {
     environment: string[];
     orgSlug: string;
     groupId?: string;
+    isStatisticalDetector?: boolean;
+    transaction?: string;
   },
   {enabled = true}: {enabled?: boolean} = {}
 ) => {
@@ -168,6 +172,8 @@ export const useFetchIssueTagsForDetailsPage = (
       environment,
       readable: true,
       limit: 4,
+      transaction,
+      isStatisticalDetector,
     },
     {enabled}
   );

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -154,14 +154,17 @@ export const useFetchIssueTagsForDetailsPage = (
     groupId,
     orgSlug,
     environment = [],
-    transaction,
     isStatisticalDetector = false,
+    statisticalDetectorParameters,
   }: {
     environment: string[];
     orgSlug: string;
     groupId?: string;
     isStatisticalDetector?: boolean;
-    transaction?: string;
+    statisticalDetectorParameters?: {
+      durationBaseline: number;
+      transaction: string;
+    };
   },
   {enabled = true}: {enabled?: boolean} = {}
 ) => {
@@ -172,8 +175,8 @@ export const useFetchIssueTagsForDetailsPage = (
       environment,
       readable: true,
       limit: 4,
-      transaction,
       isStatisticalDetector,
+      statisticalDetectorParameters,
     },
     {enabled}
   );


### PR DESCRIPTION
Update `useFetchIssueTagsForDetailsPage` to use the `events-facets` endpoint to
get tags for statistical detectors. This required some data manipulation because the two
endpoints don't provide the same detail. It also filters the transactions to the definition
we're using as "problematic" for now.

Prior to formatting the tag data I added code to handle manipulating the data to derive the other values like total counts.

* Clicking the tags will bring you to the All Events tab with that tag loaded in the filter
* ⚠️ Clicking "Other" will bring you to the tags page with that tag pre-selected, but it currently does not work. I will follow it up in the next PR since I am scoping this to just the sidebar