### PR TITLE
chore(notifications): rename approval notifications to nudges in the UI

### DIFF
--- a/static/app/views/settings/account/notifications/fields.tsx
+++ b/static/app/views/settings/account/notifications/fields.tsx
@@ -71,8 +71,8 @@ export const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {
     defaultFieldName: 'weeklyReports',
   },
   approval: {
-    title: t('Approvals'),
-    description: t('Notifications from teammates that require review or approval.'),
+    title: t('Nudges'),
+    description: t('Notifications that require review or approval.'),
     type: 'select',
     // No choices here because it's going to have dynamic content
     // Component will create choices,

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -59,7 +59,7 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, Field> = {
     },
   },
   approval: {
-    name: 'Nudges',
+    name: 'approval',
     type: 'select',
     label: t('Nudges'),
     choices: [

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -59,14 +59,14 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, Field> = {
     },
   },
   approval: {
-    name: 'approval',
+    name: 'Nudges',
     type: 'select',
-    label: t('Approvals'),
+    label: t('Nudges'),
     choices: [
       ['always', t('On')],
       ['never', t('Off')],
     ],
-    help: t('Notifications from teammates that require review or approval.'),
+    help: t('Notifications that require review or approval.'),
   },
   quota: {
     name: 'quota',


### PR DESCRIPTION
<img width="1240" alt="Screenshot 2023-09-19 at 14 09 58" src="https://github.com/getsentry/sentry/assets/70817427/3aacda47-069d-4bb0-9c41-6d0905eea6f2">
<img width="1236" alt="Screenshot 2023-09-19 at 14 09 40" src="https://github.com/getsentry/sentry/assets/70817427/a9ab4113-7822-409c-9f96-9bf9b186ebbb">

The url is still `/settings/account/notifications/approval/` though.