### PR TITLE
ref(ButtonBar): Remove extra exports from ButtonBar

### DIFF
--- a/static/app/components/buttonBar.tsx
+++ b/static/app/components/buttonBar.tsx
@@ -128,5 +128,4 @@ const ButtonGrid = styled('div')<{gap: ValidSize; merged: boolean}>`
   ${p => p.merged && MergedStyles}
 `;
 
-export {ButtonGrid, MergedStyles};
 export default ButtonBar;

--- a/static/app/views/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.tsx
@@ -8,7 +8,7 @@ import * as qs from 'query-string';
 import {Client} from 'sentry/api';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {Button} from 'sentry/components/button';
-import ButtonBar, {ButtonGrid} from 'sentry/components/buttonBar';
+import ButtonBar from 'sentry/components/buttonBar';
 import GroupList from 'sentry/components/issues/groupList';
 import Pagination from 'sentry/components/pagination';
 import QueryCount from 'sentry/components/queryCount';
@@ -424,9 +424,6 @@ const ControlsWrapper = styled('div')`
   justify-content: space-between;
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     display: block;
-    ${ButtonGrid} {
-      overflow: auto;
-    }
   }
 `;
 


### PR DESCRIPTION
These two exports aren't needed. The one place that used ButtonGrid for some css seems to flow down into Pagination and the "Open In Issues" button, which doesn't need any kind of overflow set.

This is what pagination looks like when that media query has kicked in (per [release cf9f94e99f11](https://sentry.sentry.io/releases/frontend%40cf9f94e99f117153b87f4e8e31874e2d0f586225/?chart=crashFreeSessions&project=11276):
![SCR-20230919-ncrs](https://github.com/getsentry/sentry/assets/187460/625b1ea1-342b-456c-bdad-7a0677b30044)