### PR TITLE
fix(fly): return user with correct auth

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -197,13 +197,16 @@ class DatabaseBackedUserService(UserService):
                 if user_query.count() > 1:
                     logger.warning("Email has multiple users", extra={"email": email})
                     if ident:
-                        for candid_user in user_query:
-                            identity_query = AuthIdentity.objects.filter(
-                                user=candid_user, ident=ident
+                        identity_query = AuthIdentity.objects.filter(
+                            user__in=user_query, ident=ident
+                        )
+                        if identity_query.exists():
+                            user = identity_query[0].user
+                        if identity_query.count() > 1:
+                            logger.warning(
+                                "Email has two auth identity for the same ident",
+                                extra={"email": email},
                             )
-                            if identity_query.exists():
-                                user = candid_user
-                                break
 
             return serialize_rpc_user(user)
 

--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -21,6 +21,7 @@ from sentry.models import (
     OrganizationStatus,
     UserEmail,
 )
+from sentry.models.authidentity import AuthIdentity
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.auth import AuthenticationContext
 from sentry.services.hybrid_cloud.filter_query import (
@@ -37,6 +38,7 @@ from sentry.services.hybrid_cloud.user import (
 )
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
 from sentry.services.hybrid_cloud.user.service import UserService
+from sentry.signals import user_signup
 
 logger = logging.getLogger("user:provisioning")
 
@@ -172,7 +174,9 @@ class DatabaseBackedUserService(UserService):
             return None
         return serialize_rpc_user(user)
 
-    def get_or_create_user_by_email(self, *, email: str) -> RpcUser:
+    def get_or_create_user_by_email(
+        self, *, email: str, ident: Optional[str] = None, referrer: Optional[str] = None
+    ) -> RpcUser:
         with transaction.atomic(router.db_for_write(User)):
             user_query = User.objects.filter(email__iexact=email, is_active=True)
             # Create User if it doesn't exist
@@ -182,12 +186,25 @@ class DatabaseBackedUserService(UserService):
                     email=email,
                     name=email,
                 )
+                user_signup.send_robust(
+                    sender=self, user=user, source="api", referrer=referrer or "unknown"
+                )
             else:
                 # Users are not supposed to have the same email but right now our auth pipeline let this happen
-                # So let's not break the user experience
+                # So let's not break the user experience. Instead return the user with auth identity of ident or
+                # the first user if ident is None
+                user = user_query[0]
                 if user_query.count() > 1:
                     logger.warning("Email has multiple users", extra={"email": email})
-                user = user_query[0]
+                    if ident:
+                        for candid_user in user_query:
+                            identity_query = AuthIdentity.objects.filter(
+                                user=candid_user, ident=ident
+                            )
+                            if identity_query.exists():
+                                user = candid_user
+                                break
+
             return serialize_rpc_user(user)
 
     def verify_any_email(self, *, email: str) -> bool:

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -139,7 +139,9 @@ class UserService(RpcService):
 
     @rpc_method
     @abstractmethod
-    def get_or_create_user_by_email(self, *, email: str) -> RpcUser:
+    def get_or_create_user_by_email(
+        self, *, email: str, ident: Optional[str] = None, referrer: Optional[str] = None
+    ) -> RpcUser:
         pass
 
     @rpc_method

--- a/tests/sentry/services/hybrid_cloud/user/test_impl.py
+++ b/tests/sentry/services/hybrid_cloud/user/test_impl.py
@@ -1,3 +1,6 @@
+from sentry.auth.providers.fly.provider import FlyOAuth2Provider
+from sentry.models.authidentity import AuthIdentity
+from sentry.models.authprovider import AuthProvider
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
@@ -28,3 +31,19 @@ class DatabaseBackedUserService(TestCase):
         user = self.create_user(email="tESt@email.com")
         fetched_user = user_service.get_or_create_user_by_email(email="TesT@email.com")
         assert user.id == fetched_user.id
+
+    def test_get_user_with_ident(self):
+        user1 = self.create_user(email="test@email.com", username="1")
+        user2 = self.create_user(email="test@email.com", username="2")
+        org = self.create_organization(slug="test")
+        config_data = FlyOAuth2Provider.build_config(resource={"id": "x1234x"})
+        partner_user_id = "u4567u"
+        provider = AuthProvider.objects.create(
+            organization_id=org.id, provider="fly", config=config_data
+        )
+        AuthIdentity.objects.create(auth_provider=provider, user=user2, ident=partner_user_id)
+        fetched_user = user_service.get_or_create_user_by_email(
+            email="TesT@email.com", ident=partner_user_id
+        )
+        assert user2.id == fetched_user.id
+        assert user1.id != fetched_user.id


### PR DESCRIPTION
When we find 2 users for one email we return the first one so the user experience doesn't break. This is causing issue for fly because one of the users is the one that's setup with fly auth.

This fix returns the user who has the auth setup or the first user if ident is None
