### PR TITLE
ref(crons): Remove temp dual read logic in consumer

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -68,7 +68,6 @@ LOCK_EXP_BASE = 2.0
 def _ensure_monitor_with_config(
     project: Project,
     monitor_slug: str,
-    monitor_slug_from_param: str,
     config: Optional[Dict],
 ):
     try:
@@ -79,21 +78,6 @@ def _ensure_monitor_with_config(
         )
     except Monitor.DoesNotExist:
         monitor = None
-
-    # XXX(epurkhiser): Temporary dual-read logic to handle some monitors
-    # that were created before we correctly slugified slugs on upsert in
-    # this consumer.
-    #
-    # Once all slugs are correctly slugified we can remove this.
-    if not monitor:
-        try:
-            monitor = Monitor.objects.get(
-                slug=monitor_slug_from_param,
-                project_id=project.id,
-                organization_id=project.organization_id,
-            )
-        except Monitor.DoesNotExist:
-            pass
 
     if not config:
         return monitor
@@ -391,7 +375,6 @@ def _process_checkin(
         monitor = _ensure_monitor_with_config(
             project,
             monitor_slug,
-            params["monitor_slug"],
             monitor_config,
         )
     except MonitorLimitsExceeded:

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -480,18 +480,6 @@ class MonitorConsumerTest(TestCase):
         monitor = Monitor.objects.get(slug="someslugwith-weirdstuff")
         assert monitor is not None
 
-    def test_monitor_upsert_temp_dual_read_invalid_slug(self):
-        monitor = self._create_monitor(slug="my/monitor/invalid-slug")
-
-        self.send_checkin(
-            "my/monitor/invalid-slug",
-            monitor_config={"schedule": {"type": "crontab", "value": "0 * * * *"}},
-        )
-
-        checkin = MonitorCheckIn.objects.get(guid=self.guid)
-        assert checkin.status == CheckInStatus.OK
-        assert checkin.monitor_id == monitor.id
-
     def test_monitor_invalid_config(self):
         # 6 value schedule
         self.send_checkin(


### PR DESCRIPTION
This is a follow up after the cleanup done for https://github.com/getsentry/team-crons/issues/77

Validated that all monitor slugs in the database currently match the `slugify` output.