### PR TITLE
fix(apitoken): Get correct organization ID from internal integration tokens

### DIFF
--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -93,10 +93,10 @@ class ApiToken(Model, HasApiScopes):
         try:
             installation = SentryAppInstallation.objects.get_by_api_token(self.id).get()
         except SentryAppInstallation.DoesNotExist:
-            return None
+            installation = None
 
         # TODO(nisanthan): Right now, Internal Integrations can have multiple ApiToken, so we use the join table `SentryAppInstallationToken` to map the one to many relationship. However, for Public Integrations, we can only have 1 ApiToken per installation. So we currently don't use the join table for Public Integrations. We should update to make records in the join table for Public Integrations so that we can have a common abstraction for finding an installation by ApiToken.
-        if installation.sentry_app.status == SentryAppStatus.INTERNAL:
+        if not installation or installation.sentry_app.status == SentryAppStatus.INTERNAL:
             try:
                 install_token = SentryAppInstallationToken.objects.select_related(
                     "sentry_app_installation"

--- a/tests/sentry/models/test_apitoken.py
+++ b/tests/sentry/models/test_apitoken.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.utils import timezone
 
 from sentry.models import ApiToken
+from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -28,3 +29,24 @@ class ApiTokenTest(TestCase):
 
         token = ApiToken(scope_list=["project:read"])
         assert token.get_scopes() == ["project:read"]
+
+
+class ApiTokenInternalIntegrationTest(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.proxy = self.create_user()
+        self.org = self.create_organization()
+        self.internal_app = self.create_internal_integration(
+            name="Internal App",
+            organization=self.org,
+        )
+        self.install = SentryAppInstallation.objects.get(sentry_app=self.internal_app)
+
+    def test_multiple_tokens_have_correct_organization_id(self):
+        # First token is created automatically with the application
+        token_1 = self.internal_app.installations.first().api_token
+        # Second token is created manually and isn't directly linked from the SentryAppInstallation model
+        token_2 = self.create_internal_integration_token(install=self.install, user=self.user)
+
+        assert token_1.organization_id == self.org.id
+        assert token_2.organization_id == self.org.id


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/56618

## Problem

Requests to fetch issues using internal integration tokens work inconsistently. The first token created when the app is created will work as intended, but subsequent tokens created in that app will have different behavior. For example, issues returned from the API will have a correct `permalink` property for the first token, but it will be null when fetched by subsequent tokens. 

## Why is this happening?

In the Group model, we can see that `authorized` is being marked as False, which causes the null value:

https://github.com/getsentry/sentry/blob/17d7b08c837ab0ba02a707e7d76a4bebc42ff497/src/sentry/api/serializers/models/group.py#L735-L740

Looking at the logic where `authorized` is determined, `token_has_org_access` must be returning False for the subsequent internal integration tokens.

https://github.com/getsentry/sentry/blob/435fbde1b43d09e9e2e62f95316048ce5686dc97/src/sentry/api/serializers/models/group.py#L754-L755

`AuthenticatedToken` simply checks if `organization_id` matches:

https://github.com/getsentry/sentry/blob/435fbde1b43d09e9e2e62f95316048ce5686dc97/src/sentry/services/hybrid_cloud/auth/model.py#L203-L204

Which comes from the computed property on the ApiToken model:

https://github.com/getsentry/sentry/blob/435fbde1b43d09e9e2e62f95316048ce5686dc97/src/sentry/models/apitoken.py#L90-L108

So it appears that the `SentryAppInstallation.objects.get_by_api_token(self.id)` doesn't work correctly for subsequent internal integration tokens, since they are not linked directly to the SentryAppInstallation model. The relationship for them is defined in the SentryAppInstallationToken model, the logic for which already exists below but isn't hit due to the early return statement.

I believe this most likely regressed in https://github.com/getsentry/sentry/pull/53237