### PR TITLE
fix(crons): Enforce min value of `1` for missed_margin

### DIFF
--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -244,7 +244,7 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
             resp = self.client.post(path, {"status": "error"}, **self.token_auth_headers)
             assert resp.status_code == 404
 
-    def test_monitor_creation_and_update_via_checkin(self):
+    def test_monitor_upsert_via_checkin(self):
         for i, path_func in enumerate(self._get_path_functions()):
             slug = f"my-new-monitor-{i}"
             path = path_func(slug)
@@ -286,6 +286,31 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
 
             checkins = MonitorCheckIn.objects.filter(monitor=monitor)
             assert len(checkins) == 2
+
+    def test_monitor_upsert_checkin_margin_zero(self):
+        """
+        As part of GH-56526 we changed the minimum value allowed for the
+        checkin_margin to 1 from 0. Some monitors may still be upserting with a
+        0 set, we transform it to None in those cases.
+        """
+        for i, path_func in enumerate(self._get_path_functions()):
+            slug = f"my-new-monitor-{i}"
+            path = path_func(slug)
+
+            resp = self.client.post(
+                path,
+                {
+                    "status": "ok",
+                    "monitor_config": {
+                        "schedule_type": "crontab",
+                        "schedule": "5 * * * *",
+                        "checkin_margin": 0,
+                    },
+                },
+                **self.dsn_auth_headers,
+            )
+            assert resp.status_code == 201, resp.content
+            assert Monitor.objects.get(slug=slug).config["checkin_margin"] == 1
 
     def test_monitor_creation_invalid_slug(self):
         for i, path_func in enumerate(self._get_path_functions()):

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -279,3 +279,19 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         )
         assert rule is not None
         assert rule.environment_id == self.environment.id
+
+    def test_checkin_margin_zero(self):
+        # Invalid checkin margin
+        #
+        # XXX(epurkhiser): We currently transform 0 -> 1 for backwards
+        # compatability. If we remove the custom transformer in the config
+        # validator this test will chagne to a get_error_response test.
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "slug": "cron_job",
+            "type": "cron_job",
+            "config": {"schedule_type": "crontab", "schedule": "@daily", "checkin_margin": 0},
+        }
+        response = self.get_success_response(self.organization.slug, **data)
+        assert Monitor.objects.get(slug=response.data["slug"]).config["checkin_margin"] == 1

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -480,6 +480,25 @@ class MonitorConsumerTest(TestCase):
         monitor = Monitor.objects.get(slug="someslugwith-weirdstuff")
         assert monitor is not None
 
+    def test_monitor_upsert_checkin_margin_zero(self):
+        """
+        As part of GH-56526 we changed the minimum value allowed for the
+        checkin_margin to 1 from 0. Some monitors may still be upserting with a
+        0 set, we transform it to None in those cases.
+        """
+        self.send_checkin(
+            "invalid-monitor-checkin",
+            monitor_config={
+                "schedule": {"type": "crontab", "value": "13 * * * *"},
+                "checkin_margin": 0,
+            },
+            environment="my-environment",
+        )
+
+        monitor = Monitor.objects.filter(slug="invalid-monitor-checkin")
+        assert monitor.exists()
+        assert monitor[0].config["checkin_margin"] == 1
+
     def test_monitor_invalid_config(self):
         # 6 value schedule
         self.send_checkin(


### PR DESCRIPTION
Part of https://github.com/getsentry/sentry/issues/56526