### PR TITLE
chore(api): Use body params for proj update + clarify slug usage

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from django.db import IntegrityError, router, transaction
 from django.utils import timezone
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -28,7 +28,7 @@ from sentry.api.serializers.rest_framework.list import EmptyListField, ListField
 from sentry.api.serializers.rest_framework.origin import OriginField
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NO_CONTENT, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.project_examples import ProjectExamples
-from sentry.apidocs.parameters import GlobalParams, ProjectParams
+from sentry.apidocs.parameters import GlobalParams
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import RESERVED_PROJECT_SLUGS, ObjectStatus
 from sentry.datascrubbing import validate_pii_config_update
@@ -68,6 +68,24 @@ from sentry.utils import json
 #: Relay compiles this list into a regex which cannot exceed a certain size.
 #: Limit determined experimentally here: https://github.com/getsentry/relay/blob/3105d8544daca3a102c74cefcd77db980306de71/relay-general/src/pii/convert.rs#L289
 MAX_SENSITIVE_FIELD_CHARS = 4000
+
+_options_description = """
+Configure various project filters:
+- `Hydration Errors`: Filter out react hydration errors that are often unactionable
+- `IP Addresses`: Filter events from these IP addresses separated with newlines.
+- `Releases`: Filter events from these releases separated with newlines. Allows [glob pattern matching](https://docs.sentry.io/product/data-management-settings/filtering/#glob-matching).
+- `Error Message`: Filter events by error messages separated with newlines. Allows [glob pattern matching](https://docs.sentry.io/product/data-management-settings/filtering/#glob-matching).
+```json
+{
+    options: {
+        filters:react-hydration-errors: true,
+        filters:blacklisted_ips: "127.0.0.1\\n192.168. 0.1"
+        filters:releases: "[!3]\\n4"
+        filters:error_messages: "TypeError*\\n*ConnectionError*"
+    }
+}
+```
+"""
 
 
 def clean_newline_inputs(value, case_insensitive=True):
@@ -457,13 +475,35 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         parameters=[
             GlobalParams.ORG_SLUG,
             GlobalParams.PROJECT_SLUG,
-            GlobalParams.name("The name for the project."),
-            GlobalParams.slug("The slug for the project."),
-            ProjectParams.platform("The platform for the project."),
-            ProjectParams.IS_BOOKMARKED,
-            ProjectParams.OPTIONS,
         ],
-        request=ProjectAdminSerializer,
+        request=inline_serializer(
+            "UpdateProject",
+            fields={
+                "slug": serializers.RegexField(
+                    DEFAULT_SLUG_PATTERN,
+                    help_text="Uniquely identifies a project and is used for the interface.",
+                    required=False,
+                    max_length=50,
+                    error_messages={"invalid": DEFAULT_SLUG_ERROR_MESSAGE},
+                ),
+                "name": serializers.CharField(
+                    help_text="The name for the project.",
+                    required=False,
+                    max_length=200,
+                ),
+                "platform": serializers.CharField(
+                    help_text="The platform for the project.",
+                    required=False,
+                    allow_null=True,
+                    allow_blank=True,
+                ),
+                "isBookmarked": serializers.BooleanField(
+                    help_text="Enables starring the project within the projects tab.",
+                    required=False,
+                ),
+                "options": serializers.DictField(help_text=_options_description, required=False),
+            },
+        ),
         responses={
             200: DetailedProjectSerializer,
             403: RESPONSE_FORBIDDEN,

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -367,46 +367,6 @@ Configures multiple options for the Javascript Loader Script.
         description="Activate or deactivate the client key.",
     )
 
-    IS_BOOKMARKED = OpenApiParameter(
-        name="isBookmarked",
-        location="query",
-        required=False,
-        type=bool,
-        description="Enables starring the project within the projects tab.",
-    )
-
-    OPTIONS = OpenApiParameter(
-        name="options",
-        location="query",
-        required=False,
-        type=inline_serializer(
-            name="ProjectOptionsSerializer",
-            fields={
-                "filters:react-hydration-errors": serializers.BooleanField(required=False),
-                "filters:blacklisted_ips": serializers.CharField(required=False),
-                "filters:releases": serializers.CharField(required=False),
-                "filters:error_messages": serializers.CharField(required=False),
-            },
-        ),
-        description="""
-Configure various project filters:
-- `Hydration Errors`: Filter out react hydration errors that are often unactionable
-- `IP Addresses`: Filter events from these IP addresses separated with newlines.
-- `Releases`: Filter events from these releases separated with newlines. Allows [glob pattern matching](https://docs.sentry.io/product/data-management-settings/filtering/#glob-matching).
-- `Error Message`: Filter events by error messages separated with newlines. Allows [glob pattern matching](https://docs.sentry.io/product/data-management-settings/filtering/#glob-matching).
-```json
-{
-    options: {
-        filters:react-hydration-errors: true,
-        filters:blacklisted_ips: "127.0.0.1\\n192.168. 0.1"
-        filters:releases: "[!3]\\n4"
-        filters:error_messages: "TypeError*\\n*ConnectionError*"
-    }
-}
-```
-""",
-    )
-
     RATE_LIMIT = OpenApiParameter(
         name="rateLimit",
         location="query",


### PR DESCRIPTION
The only params that have changed are `slug` and `name`. I swapped the ordering so people will hopefully use `slug`, and also clarified what `slug` is used for. 

In a future PR, I will mark `name` as deprecated like https://github.com/getsentry/sentry/pull/56458. Currently unable to do it now because we still require `name` when creating a project, and the UI still uses `name` (also sends response with `name` which then has `slug` autogenerated from it)
![Screenshot 2023-09-19 at 7 14 56 PM](https://github.com/getsentry/sentry/assets/67301797/d0f53331-2b3f-4d98-b60c-1ae4cc1cd7f1)

### Update Before + After
![Screenshot 2023-09-19 at 7 10 20 PM](https://github.com/getsentry/sentry/assets/67301797/6b93b613-ba95-45c7-a253-eef4beed736f)
![Screenshot 2023-09-19 at 7 10 11 PM](https://github.com/getsentry/sentry/assets/67301797/5c95009d-c333-420a-b473-05f16dc87297)
