### PR TITLE
ref(ui): Refine featureDisabled prop type

### DIFF
--- a/static/app/components/acl/featureDisabled.tsx
+++ b/static/app/components/acl/featureDisabled.tsx
@@ -1,7 +1,7 @@
-import {Fragment, useState} from 'react';
+import React, {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Alert} from 'sentry/components/alert';
+import {Alert, AlertProps} from 'sentry/components/alert';
 import {Button, ButtonLabel} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {CONFIG_DOCS_URL} from 'sentry/constants';
@@ -34,7 +34,7 @@ type Props = {
    * Attaches additional styles to the FeatureDisabled component to make it
    * look consistent within the Alert.
    */
-  alert?: boolean | React.ElementType;
+  alert?: boolean | React.ComponentType<AlertProps>;
   /**
    * Do not show the help toggle. The description will always be rendered.
    */

--- a/static/app/components/acl/featureDisabled.tsx
+++ b/static/app/components/acl/featureDisabled.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useState} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert, AlertProps} from 'sentry/components/alert';


### PR DESCRIPTION
later int the file typescript compares `Alert` and `React.ElementType` and this was slow. We can refine the props we expect the component to have

before
<img width="716" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/6305dcf0-68e0-442e-9ab3-c22c39c15f37">

after
<img width="710" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/3b4b723d-4fef-4ee3-b69d-3200c40042b2">
