### PR TITLE
feat(metrics): Add data dog metric to estimate the quality of results from metrics estimation endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
@@ -105,8 +105,7 @@ class OrganizationMetricsEstimationStatsEndpoint(OrganizationEventsV2EndpointBas
                         stats_quality = StatsQualityEstimation.NO_DATA
 
                     metrics.incr(
-                        "sentry-api-0-organization-metrics-estimation-stats"
-                        "metrics_estimation_stats",
+                        "metrics_estimation_stats.data_quality",
                         sample_rate=1.0,
                         tags={"data_quality": stats_quality.value},
                     )

--- a/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import Enum
 from types import ModuleType
 from typing import Dict, List, Optional, Sequence, TypedDict, Union, cast
 
@@ -15,6 +16,7 @@ from sentry.search.events import fields
 from sentry.snuba import discover, metrics_performance
 from sentry.snuba.metrics.extraction import to_standard_metrics_query
 from sentry.snuba.referrer import Referrer
+from sentry.utils import metrics
 from sentry.utils.snuba import SnubaTSResult
 
 
@@ -25,6 +27,25 @@ class CountResult(TypedDict):
 # Type returned by get_events_stats_data is actually a [int, List[CountResult]] where the first
 # param is the timestamp
 MetricVolumeRow = List[Union[int, List[CountResult]]]
+
+
+class StatsQualityEstimation(Enum):
+    """
+    Enum to represent the quality of the stats estimation
+    """
+
+    NO_DATA = "no-data"  # no data available (not even metrics)
+    NO_INDEXED_DATA = "no-indexed-data"  # no indexed data available
+    POOR_INDEXED_DATA = (
+        "poor-indexed-data"  # indexed data available but missing more than 40% intervals
+    )
+    ACCEPTABLE_INDEXED_DATA = (
+        "acceptable-indexed-data"  # indexed data available and missing between 20% and 60%
+    )
+    # intervals
+    GOOD_INDEXED_DATA = (
+        "good-indexed-data"  # indexed data available and missing less than 20% intervals
+    )
 
 
 @region_silo_endpoint
@@ -53,9 +74,8 @@ class OrganizationMetricsEstimationStatsEndpoint(OrganizationEventsV2EndpointBas
                     organization,
                     get_stats_generator(use_discover=True, remove_on_demand=False),
                 )
-
+                stats_quality = estimate_stats_quality(discover_stats["data"])
                 if _should_scale(measurement):
-
                     # we scale the indexed data with the ratio between indexed counts and metrics counts
                     # in order to get an estimate of the true volume of transactions
 
@@ -77,12 +97,58 @@ class OrganizationMetricsEstimationStatsEndpoint(OrganizationEventsV2EndpointBas
                     )
                     discover_stats["data"] = estimated_volume
 
+                    # we can't find any data (not even in metrics))
+                    if (
+                        stats_quality == StatsQualityEstimation.NO_INDEXED_DATA
+                        and _count_non_zero_intervals(base_discover["data"]) == 0
+                    ):
+                        stats_quality = StatsQualityEstimation.NO_DATA
+
+                    metrics.incr(
+                        "sentry-api-0-organization-metrics-estimation-stats"
+                        "metrics_estimation_stats",
+                        sample_rate=1.0,
+                        tags={"data_quality": stats_quality.value},
+                    )
+
             except ValidationError:
                 return Response(
                     {"detail": "Comparison period is outside retention window"}, status=400
                 )
 
         return Response(discover_stats, status=200)
+
+
+def _count_non_zero_intervals(stats: List[MetricVolumeRow]) -> int:
+    """
+    Counts the number of intervals with non-zero values
+    """
+    non_zero_intervals = 0
+    for idx in range(len(stats)):
+        if _get_value(stats[idx]) != 0:
+            non_zero_intervals += 1
+    return non_zero_intervals
+
+
+def estimate_stats_quality(stats: List[MetricVolumeRow]) -> StatsQualityEstimation:
+    """
+    Estimates the quality of the stats estimation based on the number of intervals with no data
+    """
+    if len(stats) == 0:
+        return StatsQualityEstimation.NO_DATA
+
+    data_intervals = _count_non_zero_intervals(stats)
+
+    data_ratio = data_intervals / len(stats)
+
+    if data_ratio >= 0.8:
+        return StatsQualityEstimation.GOOD_INDEXED_DATA
+    elif data_ratio > 0.4:
+        return StatsQualityEstimation.ACCEPTABLE_INDEXED_DATA
+    elif data_intervals > 0:
+        return StatsQualityEstimation.POOR_INDEXED_DATA
+    else:
+        return StatsQualityEstimation.NO_INDEXED_DATA
 
 
 def get_stats_generator(use_discover: bool, remove_on_demand: bool):

--- a/tests/sentry/api/endpoints/test_organization_metrics_estimation_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_estimation_stats.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from sentry.api.endpoints.organization_metrics_estimation_stats import (
     CountResult,
+    MetricVolumeRow,
     StatsQualityEstimation,
     _count_non_zero_intervals,
     _should_scale,
@@ -261,9 +262,11 @@ def test_estimate_stats_quality(zero_samples, expected_result):
     one: CountResult = {"count": 1}
     zero: CountResult = {"count": 0}
 
-    data = [[start_timestamp + idx * 100, [zero]] for idx in range(zero_samples)] + [
-        [start_timestamp + idx * 100, [one]] for idx in range(zero_samples, num_samples)
-    ]
+    data = cast(
+        List[MetricVolumeRow],
+        [[start_timestamp + idx * 100, [zero]] for idx in range(zero_samples)]
+        + [[start_timestamp + idx * 100, [one]] for idx in range(zero_samples, num_samples)],
+    )
 
     assert estimate_stats_quality(data) == expected_result
 
@@ -277,8 +280,10 @@ def test_count_non_zero_intervals(zero_samples):
     one: CountResult = {"count": 1}
     zero: CountResult = {"count": 0}
 
-    data = [[start_timestamp + idx * 100, [zero]] for idx in range(zero_samples)] + [
-        [start_timestamp + idx * 100, [one]] for idx in range(zero_samples, num_samples)
-    ]
+    data = cast(
+        List[MetricVolumeRow],
+        [[start_timestamp + idx * 100, [zero]] for idx in range(zero_samples)]
+        + [[start_timestamp + idx * 100, [one]] for idx in range(zero_samples, num_samples)],
+    )
 
     assert _count_non_zero_intervals(data) == num_samples - zero_samples

--- a/tests/sentry/api/endpoints/test_organization_metrics_estimation_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_estimation_stats.py
@@ -7,7 +7,10 @@ from django.utils import timezone
 
 from sentry.api.endpoints.organization_metrics_estimation_stats import (
     CountResult,
+    StatsQualityEstimation,
+    _count_non_zero_intervals,
     _should_scale,
+    estimate_stats_quality,
     estimate_volume,
 )
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
@@ -239,3 +242,43 @@ def test_should_scale(metric: str, should_scale: bool):
     Tests the _should_scale function
     """
     assert _should_scale(metric) == should_scale
+
+
+@pytest.mark.parametrize(
+    "zero_samples, expected_result",
+    [
+        (10, StatsQualityEstimation.GOOD_INDEXED_DATA),
+        (50, StatsQualityEstimation.ACCEPTABLE_INDEXED_DATA),
+        (70, StatsQualityEstimation.POOR_INDEXED_DATA),
+        (100, StatsQualityEstimation.NO_INDEXED_DATA),
+    ],
+)
+def test_estimate_stats_quality(zero_samples, expected_result):
+    num_samples = 100
+
+    start_timestamp = 1_500_000_000
+
+    one: CountResult = {"count": 1}
+    zero: CountResult = {"count": 0}
+
+    data = [[start_timestamp + idx * 100, [zero]] for idx in range(zero_samples)] + [
+        [start_timestamp + idx * 100, [one]] for idx in range(zero_samples, num_samples)
+    ]
+
+    assert estimate_stats_quality(data) == expected_result
+
+
+@pytest.mark.parametrize("zero_samples", [0, 1, 5, 9, 10])
+def test_count_non_zero_intervals(zero_samples):
+    num_samples = 10
+
+    start_timestamp = 1_500_000_000
+
+    one: CountResult = {"count": 1}
+    zero: CountResult = {"count": 0}
+
+    data = [[start_timestamp + idx * 100, [zero]] for idx in range(zero_samples)] + [
+        [start_timestamp + idx * 100, [one]] for idx in range(zero_samples, num_samples)
+    ]
+
+    assert _count_non_zero_intervals(data) == num_samples - zero_samples


### PR DESCRIPTION
This PR adds a data dog counter that keeps track of the relative quality of the estimation.
Estimation quality is based on the relative number of non 0 results in the indexed data:

We tag the counter with the following values:
`no-data` : no data available (either indexed of metrics)
`no-indexed-data`: no indexed data available, all data points 0 ( will force all estimated points to be 0 )
`poor-indexed-data`: more than 60% points with 0 in the indexed data
`acceptable-indexed-data`: between 60% and 20% with 0 in the indexed data:
`good-indexed-data`: less that 20% intervals with 0 in the indexed data

Resolves: https://github.com/getsentry/sentry/issues/55976

