### PR TITLE
Pass down the Scraping Config to all symbolication requests

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -1,13 +1,12 @@
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from sentry.debug_files.artifact_bundles import maybe_renew_artifact_bundles_from_processing
 from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import Symbolicator
-from sentry.models import EventError, Project
+from sentry.models import EventError
 from sentry.stacktraces.processing import find_stacktraces_in_data
 from sentry.utils import metrics
-from sentry.utils.http import get_origins
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)
@@ -199,28 +198,6 @@ def _normalize_nonhandled_frame(frame, data):
     return frame
 
 
-def generate_scraping_config(project: Project) -> Dict[str, Any]:
-    allow_scraping_org_level = project.organization.get_option("sentry:scrape_javascript", True)
-    allow_scraping_project_level = project.get_option("sentry:scrape_javascript", True)
-    allow_scraping = allow_scraping_org_level and allow_scraping_project_level
-
-    allowed_origins = []
-    scraping_headers = {}
-    if allow_scraping:
-        allowed_origins = list(get_origins(project))
-
-        token = project.get_option("sentry:token")
-        if token:
-            token_header = project.get_option("sentry:token_header") or "X-Sentry-Token"
-            scraping_headers[token_header] = token
-
-    return {
-        "enabled": allow_scraping,
-        "headers": scraping_headers,
-        "allowed_origins": allowed_origins,
-    }
-
-
 def _normalize_frame(frame: Any) -> dict:
     frame = dict(frame)
 
@@ -231,9 +208,6 @@ def _normalize_frame(frame: Any) -> dict:
 
 
 def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
-    project = symbolicator.project
-    scraping_config = generate_scraping_config(project)
-
     modules = sourcemap_images_from_data(data)
 
     stacktrace_infos = find_stacktraces_in_data(data)
@@ -259,7 +233,6 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
         modules=modules,
         release=data.get("release"),
         dist=data.get("dist"),
-        scraping_config=scraping_config,
     )
 
     if not _handle_response_status(data, response):
@@ -267,7 +240,7 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
 
     used_artifact_bundles = response.get("used_artifact_bundles", [])
     if used_artifact_bundles:
-        maybe_renew_artifact_bundles_from_processing(project.id, used_artifact_bundles)
+        maybe_renew_artifact_bundles_from_processing(symbolicator.project.id, used_artifact_bundles)
 
     processing_errors = response.get("errors", [])
     if len(processing_errors) > 0:

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -6,7 +6,7 @@ import random
 import sys
 from copy import deepcopy
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import jsonschema
 import sentry_sdk
@@ -19,6 +19,7 @@ from sentry.debug_files.artifact_bundle_indexing import FlatFileIdentifier, Flat
 from sentry.models.artifactbundle import NULL_STRING
 from sentry.models.project import Project
 from sentry.utils import json, redis, safe
+from sentry.utils.http import get_origins
 
 logger = logging.getLogger(__name__)
 
@@ -241,6 +242,28 @@ def get_bundle_index_urls(
         debug_id_index = make_download_url(debug_id_meta)
 
     return debug_id_index, url_index
+
+
+def get_scraping_config(project: Project) -> Dict[str, Any]:
+    allow_scraping_org_level = project.organization.get_option("sentry:scrape_javascript", True)
+    allow_scraping_project_level = project.get_option("sentry:scrape_javascript", True)
+    allow_scraping = allow_scraping_org_level and allow_scraping_project_level
+
+    allowed_origins = []
+    scraping_headers = {}
+    if allow_scraping:
+        allowed_origins = list(get_origins(project))
+
+        token = project.get_option("sentry:token")
+        if token:
+            token_header = project.get_option("sentry:token_header") or "X-Sentry-Token"
+            scraping_headers[token_header] = token
+
+    return {
+        "enabled": allow_scraping,
+        "headers": scraping_headers,
+        "allowed_origins": allowed_origins,
+    }
 
 
 def get_internal_artifact_lookup_source(project: Project):

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -18,6 +18,7 @@ from sentry import options
 from sentry.lang.native.sources import (
     get_bundle_index_urls,
     get_internal_artifact_lookup_source,
+    get_scraping_config,
     sources_for_symbolication,
 )
 from sentry.models import Project
@@ -143,8 +144,10 @@ class Symbolicator:
 
     def process_minidump(self, minidump):
         (sources, process_response) = sources_for_symbolication(self.project)
+        scraping_config = get_scraping_config(self.project)
         data = {
             "sources": json.dumps(sources),
+            "scraping": json.dumps(scraping_config),
             "options": '{"dif_candidates": true}',
         }
 
@@ -155,8 +158,10 @@ class Symbolicator:
 
     def process_applecrashreport(self, report):
         (sources, process_response) = sources_for_symbolication(self.project)
+        scraping_config = get_scraping_config(self.project)
         data = {
             "sources": json.dumps(sources),
+            "scraping": json.dumps(scraping_config),
             "options": '{"dif_candidates": true}',
         }
 
@@ -170,11 +175,13 @@ class Symbolicator:
 
     def process_payload(self, stacktraces, modules, signal=None, apply_source_context=True):
         (sources, process_response) = sources_for_symbolication(self.project)
+        scraping_config = get_scraping_config(self.project)
         json = {
             "sources": sources,
             "options": {"dif_candidates": True, "apply_source_context": apply_source_context},
             "stacktraces": stacktraces,
             "modules": modules,
+            "scraping": scraping_config,
         }
 
         if signal:
@@ -183,16 +190,16 @@ class Symbolicator:
         res = self._process("symbolicate_stacktraces", "symbolicate", json=json)
         return process_response(res)
 
-    def process_js(
-        self, stacktraces, modules, release, dist, scraping_config=None, apply_source_context=True
-    ):
+    def process_js(self, stacktraces, modules, release, dist, apply_source_context=True):
         source = get_internal_artifact_lookup_source(self.project)
+        scraping_config = get_scraping_config(self.project)
 
         json = {
             "source": source,
             "stacktraces": stacktraces,
             "modules": modules,
             "options": {"apply_source_context": apply_source_context},
+            "scraping": scraping_config,
         }
 
         try:
@@ -208,8 +215,6 @@ class Symbolicator:
             json["release"] = release
         if dist is not None:
             json["dist"] = dist
-        if scraping_config is not None:
-            json["scraping"] = scraping_config
 
         return self._process("symbolicate_js_stacktraces", "symbolicate-js", json=json)
 

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -13,7 +13,6 @@ from symbolic.proguard import ProguardMapper
 from sentry import quotas
 from sentry.constants import DataCategory
 from sentry.lang.javascript.processing import _handles_frame as is_valid_javascript_frame
-from sentry.lang.javascript.processing import generate_scraping_config
 from sentry.lang.native.symbolicator import Symbolicator, SymbolicatorTaskKind
 from sentry.models import EventError, Organization, Project, ProjectDebugFile
 from sentry.profiles.device import classify_device
@@ -758,12 +757,10 @@ def process_js_stacktraces(
     stacktraces: List[Any],
     apply_source_context: bool = False,
 ) -> Any:
-    project = symbolicator.project
     return symbolicator.process_js(
         stacktraces=stacktraces,
         modules=modules,
         release=profile.get("release"),
         dist=profile.get("dist"),
-        scraping_config=generate_scraping_config(project),
         apply_source_context=apply_source_context,
     )


### PR DESCRIPTION
In particular, this will allow using the existing scraping config header to define credentials that are being passed along sourcelink requests in native symbolication.