### PR TITLE
feat(metrics): Convert gauges to counters in the indexer consumer

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    List,
     Mapping,
     MutableMapping,
     MutableSequence,
@@ -15,7 +16,7 @@ from typing import (
     Set,
     Tuple,
     Union,
-    cast, List,
+    cast,
 )
 
 import rapidjson
@@ -46,7 +47,9 @@ MAX_NAME_LENGTH = MAX_INDEXED_COLUMN_LENGTH
 
 ACCEPTED_METRIC_TYPES = {"s", "c", "d"}  # set, counter, distribution
 MRI_RE_PATTERN = re.compile(r"^([c|s|d|g|e]):([a-zA-Z0-9_]+)/.*$")
-FULL_MRI_RE_PATTERN = re.compile(r"^([c|s|d|g|e]):([a-zA-Z0-9_]+)/([a-z_]+(?:\.[a-z_]+)*)(?:@([a-z]+))?$")
+FULL_MRI_RE_PATTERN = re.compile(
+    r"^([c|s|d|g|e]):([a-zA-Z0-9_]+)/([a-z_]+(?:\.[a-z_]+)*)(?:@([a-z]+))?$"
+)
 
 OrgId = int
 Headers = MutableSequence[Tuple[str, bytes]]
@@ -82,6 +85,7 @@ def extract_use_case_id(mri: str) -> UseCaseID:
             return UseCaseID(use_case_str)
     raise ValidationError(f"Invalid mri: {mri}")
 
+
 def _convert_gauge_to_counters(message: ParsedMessage) -> List[ParsedMessage]:
     if message["type"] == "g":
         metric_name = message["name"]
@@ -104,6 +108,7 @@ def _convert_gauge_to_counters(message: ParsedMessage) -> List[ParsedMessage]:
             return converted_messages
 
     return [message]
+
 
 class IndexerBatch:
     def __init__(

--- a/tests/sentry/sentry_metrics/test_batch.py
+++ b/tests/sentry/sentry_metrics/test_batch.py
@@ -2014,6 +2014,7 @@ def test_cardinality_limiter(caplog, settings):
         )
     ]
 
+
 @pytest.mark.django_db
 @patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
 def test_cardinality_limiter(caplog, settings):
@@ -2035,10 +2036,7 @@ def test_cardinality_limiter(caplog, settings):
     gauge_headers = [("namespace", b"sessions")]
 
     outer_message = _construct_outer_message(
-        [
-            (counter_payload, counter_headers),
-            (gauge_payload, gauge_headers)
-        ]
+        [(counter_payload, counter_headers), (gauge_payload, gauge_headers)]
     )
 
     batch = IndexerBatch(
@@ -2052,15 +2050,15 @@ def test_cardinality_limiter(caplog, settings):
     assert batch.extract_strings() == {
         MockUseCaseID.SESSIONS: {
             1: {
-                'c:sessions/session@none',
+                "c:sessions/session@none",
                 "environment",
                 "production",
                 "session.status",
-                'init',
+                "init",
                 "release",
                 "1.0",
                 "http.status_code",
-                "200"
+                "200",
             },
         }
     }
@@ -2089,4 +2087,3 @@ def test_cardinality_limiter(caplog, settings):
             }
         },
     )
-


### PR DESCRIPTION
This PR implements the gauges to counters conversion in the metrics indexer consumer, in order to have a way to approximately estimate cost of gauges without having to implement them into the storage layer (which will be done at a later step).

Closes https://github.com/getsentry/sentry/issues/56482