### PR TITLE
fix(platforms): Streamline php-symfony platform name

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -119,7 +119,6 @@ export const platformProductAvailability = {
   'node-koa': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   php: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'php-laravel': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
-  // TODO(arthur): cleanup naming missmatch between php-symfony and php-symfony2
   ['php-symfony']: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   python: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'python-aiohttp': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -120,10 +120,7 @@ export const platformProductAvailability = {
   php: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'php-laravel': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   // TODO(arthur): cleanup naming missmatch between php-symfony and php-symfony2
-  ['php-symfony' as 'php-symfony2']: [
-    ProductSolution.PERFORMANCE_MONITORING,
-    ProductSolution.PROFILING,
-  ],
+  ['php-symfony']: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   python: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'python-aiohttp': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'python-awslambda': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -86,16 +86,6 @@ class PlatformPicker extends Component<PlatformPickerProps, State> {
         return true;
       }
 
-      // Symfony was no appering under the server category
-      // because the php-symfony entry in src/sentry/integration-docs/_platforms.json
-      // does not contain the suffix 2.
-      // This is a temporary fix until we can update that file or completly remove the php-symfony2 occurrences
-      if (
-        (platform.id as any) === 'php-symfony' &&
-        (currentCategory?.platforms as undefined | string[])?.includes('php-symfony2')
-      ) {
-        return true;
-      }
       return (currentCategory?.platforms as undefined | string[])?.includes(platform.id);
     };
 

--- a/static/app/components/profiling/ProfilingOnboarding/util.ts
+++ b/static/app/components/profiling/ProfilingOnboarding/util.ts
@@ -71,7 +71,7 @@ export const supportedPlatformExpectedDocKeys: Record<
   ],
 };
 
-function makeDocKey(platformId: PlatformKey, key: string) {
+function makeDocKey(platformId: SupportedProfilingPlatformSDK, key: string) {
   if (platformId === 'javascript-nextjs') {
     return `node-javascript-nextjs-profiling-onboarding-${key}`;
   }
@@ -84,7 +84,10 @@ function makeDocKey(platformId: PlatformKey, key: string) {
   return `${platformId}-profiling-onboarding-${key}`;
 }
 
-type DocKeyMap = Record<(typeof profilingOnboardingDocKeys)[number], string>;
+type DocKeyMap = Record<
+  (ProfilingOnboardingDocKeys | BrowserProfilingOnboardingDocKeys)[number],
+  string
+>;
 export function makeDocKeyMap(platformId: PlatformKey | undefined) {
   const docsPlatform = getDocsPlatformSDKForPlatform(platformId);
 
@@ -92,8 +95,10 @@ export function makeDocKeyMap(platformId: PlatformKey | undefined) {
     return null;
   }
 
-  const expectedDocKeys: ProfilingOnboardingDocKeys[] =
-    supportedPlatformExpectedDocKeys[docsPlatform];
+  const expectedDocKeys: (
+    | ProfilingOnboardingDocKeys
+    | BrowserProfilingOnboardingDocKeys
+  )[] = supportedPlatformExpectedDocKeys[docsPlatform];
 
   if (!expectedDocKeys) {
     return null;

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -104,7 +104,7 @@ export const backend = [
   'php',
   'php-laravel',
   'php-monolog',
-  'php-symfony2',
+  'php-symfony',
   'python',
   'python-django',
   'python-flask',
@@ -274,7 +274,7 @@ export const profiling: PlatformKey[] = [
   // php
   'php',
   'php-laravel',
-  'php-symfony2',
+  'php-symfony',
   // ruby
   'ruby',
   'ruby-rails',

--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -104,7 +104,6 @@ const platformToIcon = {
   php: 'php',
   'php-laravel': 'laravel',
   'php-monolog': 'php',
-  'php-symfony2': 'symfony',
   'php-symfony': 'symfony',
   python: 'python',
   'python-aiohttp': 'aiohttp',

--- a/static/app/utils/profiling/platforms.tsx
+++ b/static/app/utils/profiling/platforms.tsx
@@ -1,8 +1,6 @@
-import {profiling} from 'sentry/data/platformCategories';
 import {Project} from 'sentry/types/project';
 
-export const supportedProfilingPlatforms = profiling;
-export const supportedProfilingPlatformSDKs = [
+const supportedProfilingPlatformSDKs = [
   'android',
   'apple-ios',
   'go',
@@ -20,7 +18,7 @@ export const supportedProfilingPlatformSDKs = [
   'javascript-react',
   'react-native',
 ] as const;
-export type SupportedProfilingPlatform = (typeof supportedProfilingPlatforms)[number];
+export type SupportedProfilingPlatform = (typeof supportedProfilingPlatformSDKs)[number];
 export type SupportedProfilingPlatformSDK =
   (typeof supportedProfilingPlatformSDKs)[number];
 
@@ -75,6 +73,8 @@ export function getDocsPlatformSDKForPlatform(
     return 'php-laravel';
   }
   if (platform === 'php-symfony') {
+    // TODD(aknaus): simplify once we migrate the docs to the sentry repo
+    // php-symfony2 is the name for php-symfony in the docs
     return 'php-symfony2';
   }
   if (platform.startsWith('php')) {

--- a/static/app/views/monitors/components/monitorQuickStartGuide.tsx
+++ b/static/app/views/monitors/components/monitorQuickStartGuide.tsx
@@ -66,7 +66,7 @@ const onboardingGuides: Record<string, OnboardingGuide> = {
   php: {
     label: 'PHP',
     Guide: PHPCronQuickStart,
-    platforms: new Set(['php', 'php-monolog', 'php-symfony2']),
+    platforms: new Set(['php', 'php-monolog', 'php-symfony']),
   },
   phpLaravel: {
     label: 'Laravel',


### PR DESCRIPTION
* Streamline naming / types to use `php-symfony` where possible
* This fixes a bug where the wrong (generic) cron onboarding was shown for symfony.


Closes https://github.com/getsentry/sentry/issues/55974