### PR TITLE
fix(dashboards): Use loading indicator to avoid multiple requests

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -692,7 +692,6 @@ class DashboardDetail extends Component<Props, State> {
                 organization={organization}
                 eventView={EventView.fromLocation(location)}
                 location={location}
-                hideLoadingIndicator
               >
                 {metricsDataSide => (
                   <MEPSettingProvider
@@ -826,7 +825,6 @@ class DashboardDetail extends Component<Props, State> {
                       organization={organization}
                       eventView={eventView}
                       location={location}
-                      hideLoadingIndicator
                     >
                       {metricsDataSide => (
                         <MEPSettingProvider


### PR DESCRIPTION
Dashboard widgets were doing 2x the requests when there should only be one. This causes the occurrence of 429s to increase when opening a dashboard and is a poor user experience. The issue was hiding the loading in the metrics compatibility check. If we don't use the loader then the children (i.e. the widgets) will attempt to render, triggering a bunch of requests to our dashboard endpoints, and when the check is complete then we'll re-render and re-fetch metrics enhanced data.

I'm re-enabling the loading state because this is a big issue and it doesn't look out of place when the dashboard is loading up either.