### PR TITLE
feat(onboarding): Bring back platform other

### DIFF
--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -5,6 +5,7 @@ import {PlatformIcon} from 'platformicons';
 
 import {Button} from 'sentry/components/button';
 import EmptyMessage from 'sentry/components/emptyMessage';
+import ExternalLink from 'sentry/components/links/externalLink';
 import ListLink from 'sentry/components/links/listLink';
 import NavTabs from 'sentry/components/navTabs';
 import SearchBar from 'sentry/components/searchBar';
@@ -14,9 +15,9 @@ import categoryList, {
   filterAliases,
   PlatformKey,
 } from 'sentry/data/platformCategories';
-import platforms from 'sentry/data/platforms';
+import platforms, {otherPlatform} from 'sentry/data/platforms';
 import {IconClose, IconProject} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization, PlatformIntegration} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -181,9 +182,24 @@ class PlatformPicker extends Component<PlatformPickerProps, State> {
             icon={<IconProject size="xl" />}
             title={t("We don't have an SDK for that yet!")}
           >
-            {t(
-              "Make sure you've typed the platform correctly. If that doesn't help, we have several SDKs that are still useful if you use a lesser-known platform. For example, Browser JavaScript, Python, Node, .NET & Java."
-            )}
+            <p>
+              {tct(
+                `Sure you haven't misspelled? You can still create a project, but looks like we don't have an official SDK for your platform yet. However, there's a rich ecosystem of community supported SDKs (including NestJS, Nuxt2, Perl, CFML and Clojure).`,
+                {
+                  search: (
+                    <ExternalLink href="https://github.com/search?q=-org%3Agetsentry+topic%3Asentry&type=Repositories" />
+                  ),
+                }
+              )}
+            </p>
+            <Button
+              onClick={() => {
+                this.setState({filter: otherPlatform.name});
+                setPlatform({...otherPlatform, category});
+              }}
+            >
+              {t('Continue without a specialized platform')}
+            </Button>
           </EmptyMessage>
         )}
       </Fragment>

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -5,7 +5,6 @@ import {PlatformIcon} from 'platformicons';
 
 import {Button} from 'sentry/components/button';
 import EmptyMessage from 'sentry/components/emptyMessage';
-import ExternalLink from 'sentry/components/links/externalLink';
 import ListLink from 'sentry/components/links/listLink';
 import NavTabs from 'sentry/components/navTabs';
 import SearchBar from 'sentry/components/searchBar';
@@ -182,24 +181,21 @@ class PlatformPicker extends Component<PlatformPickerProps, State> {
             icon={<IconProject size="xl" />}
             title={t("We don't have an SDK for that yet!")}
           >
-            <p>
-              {tct(
-                `Sure you haven't misspelled? You can still create a project, but looks like we don't have an official SDK for your platform yet. However, there's a rich ecosystem of community supported SDKs (including NestJS, Nuxt2, Perl, CFML and Clojure).`,
-                {
-                  search: (
-                    <ExternalLink href="https://github.com/search?q=-org%3Agetsentry+topic%3Asentry&type=Repositories" />
-                  ),
-                }
-              )}
-            </p>
-            <Button
-              onClick={() => {
-                this.setState({filter: otherPlatform.name});
-                setPlatform({...otherPlatform, category});
-              }}
-            >
-              {t('Continue without a specialized platform')}
-            </Button>
+            {tct(
+              `Sure you haven't misspelled? If you're using a lesser-known platform, consider choosing a more generic SDK like Browser JavaScript, Python, Node, .NET & Java or create a generic project, by selecting [linkOther:“Other”].`,
+              {
+                linkOther: (
+                  <Button
+                    aria-label={t("Select 'Other'")}
+                    priority="link"
+                    onClick={() => {
+                      this.setState({filter: otherPlatform.name});
+                      setPlatform({...otherPlatform, category});
+                    }}
+                  />
+                ),
+              }
+            )}
           </EmptyMessage>
         )}
       </Fragment>

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -3,6 +3,7 @@ import sortBy from 'lodash/sortBy';
 import {t} from 'sentry/locale';
 import type {PlatformIntegration} from 'sentry/types';
 
+// TODO(arthur): clean up and use PlatformIntegration type here
 type Platform = {
   id: string;
   language: string;
@@ -566,7 +567,7 @@ const nativePlatforms: Platform[] = [
   },
 ];
 
-const otherPlatforms: Platform[] = [
+const miscPlatforms: Platform[] = [
   {
     id: 'android',
     name: 'Android',
@@ -667,6 +668,14 @@ const otherPlatforms: Platform[] = [
   },
 ];
 
+export const otherPlatform: PlatformIntegration = {
+  id: 'other',
+  name: 'Other',
+  type: 'language',
+  language: 'other',
+  link: 'https://docs.sentry.io/platforms/',
+};
+
 // If you update items of this list, please remember to update the "GETTING_STARTED_DOCS_PLATFORMS" list
 // in the 'src/sentry/models/project.py' file. This way, they'll work together correctly.
 // Otherwise, creating a project will cause an error in the backend, saying "Invalid platform".
@@ -681,7 +690,8 @@ const allPlatforms = [
   ...goPlatforms,
   ...rubyPlatforms,
   ...nativePlatforms,
-  ...otherPlatforms,
+  ...miscPlatforms,
+  otherPlatform,
 ];
 
 const platforms = sortBy(allPlatforms, 'id') as PlatformIntegration[];

--- a/static/app/views/projectInstall/otherPlatformsInfo.tsx
+++ b/static/app/views/projectInstall/otherPlatformsInfo.tsx
@@ -78,17 +78,17 @@ export function OtherPlatformsInfo({
             </ExternalLink>
           </ListItem>
         </List>
-        <p>
-          {tct(
-            "Also there's a rich ecosystem of [link:community supported SDKs] (including NestJS, Nuxt2, Perl, CFML and Clojure).",
-            {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/#community-supported" />
-              ),
-            }
-          )}
-        </p>
       </Suggestion>
+      <div>
+        {tct(
+          "Also there's a rich ecosystem of [link:community sudivported SDKs] (including NestJS, Nuxt2, Perl, CFML and Clojure).",
+          {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/#community-supported" />
+            ),
+          }
+        )}
+      </div>
     </Wrapper>
   );
 }

--- a/static/app/views/projectInstall/otherPlatformsInfo.tsx
+++ b/static/app/views/projectInstall/otherPlatformsInfo.tsx
@@ -6,7 +6,7 @@ import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project, ProjectKey} from 'sentry/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -44,7 +44,7 @@ export function OtherPlatformsInfo({
         "We cannot provide instructions for '%s' projects. However, please find below the DSN key for this project, which is required to instrument Sentry.",
         platform
       )}
-      <CodeSnippet dark language="bash">
+      <CodeSnippet dark language="properties">
         {t('dsn: %s', data[0].dsn.public)}
       </CodeSnippet>
       <Suggestion>
@@ -78,6 +78,16 @@ export function OtherPlatformsInfo({
             </ExternalLink>
           </ListItem>
         </List>
+        <p>
+          {tct(
+            "Also there's a rich ecosystem of [link:community supported SDKs] (including NestJS, Nuxt2, Perl, CFML and Clojure).",
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/#community-supported" />
+              ),
+            }
+          )}
+        </p>
       </Suggestion>
     </Wrapper>
   );

--- a/static/app/views/projectInstall/otherPlatformsInfo.tsx
+++ b/static/app/views/projectInstall/otherPlatformsInfo.tsx
@@ -81,7 +81,7 @@ export function OtherPlatformsInfo({
       </Suggestion>
       <div>
         {tct(
-          "Also there's a rich ecosystem of [link:community sudivported SDKs] (including NestJS, Nuxt2, Perl, CFML and Clojure).",
+          "Also there's a rich ecosystem of [link:community suported SDKs] (including NestJS, Nuxt2, Perl, CFML and Clojure).",
           {
             link: (
               <ExternalLink href="https://docs.sentry.io/platforms/#community-supported" />


### PR DESCRIPTION
* Re-activate `other` as a choosable platform
* Improve docs content for `other`

Closes https://github.com/getsentry/sentry/issues/56155