### PR TITLE
feat(trace-view-load-more): Fixed bug that loads an extra row of orphans.

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -965,7 +965,7 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
         # We are now left with orphan errors in the error_map,
         # that we need to serialize and return with our results.
         orphan_errors: List[TraceError] = []
-        if allow_orphan_errors and iteration <= limit:
+        if allow_orphan_errors and iteration < limit:
             for errors in error_map.values():
                 for error in errors:
                     orphan_errors.append(self.serialize_error(error))


### PR DESCRIPTION
This fixes the bug allowing an extra row of orphan to be loaded past the row count limit in the trace view:
<img width="1265" alt="Screenshot 2023-09-20 at 10 20 21 AM" src="https://github.com/getsentry/sentry/assets/60121741/a5a48f79-8551-447e-99f1-f353da5bca5d">
<img width="1276" alt="Screenshot 2023-09-20 at 10 20 36 AM" src="https://github.com/getsentry/sentry/assets/60121741/7b63ae3e-29a7-4ef4-ab6c-cde1c240e85d">
