### PR TITLE
Refresh chunk timestamps on assemble poll

### DIFF
--- a/src/sentry/debug_files/upload.py
+++ b/src/sentry/debug_files/upload.py
@@ -1,10 +1,16 @@
 from typing import Sequence
 
-from sentry.models.files.fileblobowner import FileBlobOwner
+from django.utils import timezone
+
+from sentry.models.files import FileBlob, FileBlobOwner
 
 
 def find_missing_chunks(organization_id: int, chunks: Sequence[str]):
     """Returns a list of chunks which are missing for an org."""
+    # refresh the timestamp of all files we are interested in,
+    # so they don't disappear from under us
+    FileBlob.objects.filter(checksum__in=chunks).update(timestamp=timezone.now())
+
     owned = set(
         FileBlobOwner.objects.filter(
             blob__checksum__in=chunks, organization_id=organization_id


### PR DESCRIPTION
This will also refresh any chunks of a to-be-uploaded file when checking for which chunks to upload. That way, those chunks won't be reclaimed, racing with the upload itself.