### PR TITLE
fix(ddm): Fix route redirects

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -742,6 +742,12 @@ urlpatterns += [
         react_page_view,
         name="discover",
     ),
+    # DDM
+    re_path(
+        r"^ddm/",
+        react_page_view,
+        name="ddm",
+    ),
     # Request to join an organization
     re_path(
         r"^join-request/",


### PR DESCRIPTION
If you load the DDM page today (hard refresh, not react routing) it will get redirected to the Issues page.
This PR aims to solve that.