### PR TITLE
feat(replay): Link page breadcrumb on Replay Details to the list page, filtered by project

### DIFF
--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -40,13 +40,16 @@ function DetailsPageBreadcrumbs({orgSlug, replayRecord}: Props) {
           label: t('Session Replay'),
         },
         {
-          label: (
-            <Fragment>
-              {project ? (
-                <ProjectBadge disableLink project={project} avatarSize={16} />
-              ) : null}
-            </Fragment>
-          ),
+          to: {
+            pathname: normalizeUrl(`/organizations/${orgSlug}/replays/`),
+            query: {
+              ...eventView.generateQueryStringObject(),
+              project: replayRecord?.project_id,
+            },
+          },
+          label: project ? (
+            <ProjectBadge disableLink project={project} avatarSize={16} />
+          ) : null,
         },
         {
           label: labelTitle,


### PR DESCRIPTION

<img width="686" alt="SCR-20230920-iogf" src="https://github.com/getsentry/sentry/assets/187460/fbacc94a-0d14-4b44-84ed-901abd76654e">



Fixes https://github.com/getsentry/sentry/issues/56566