### PR TITLE
chore(profiling): Track accepted profile outcomes

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -117,7 +117,8 @@ def process_profile_task(
     if not _push_profile_to_vroom(profile, project):
         return
 
-    _track_outcome(profile=profile, project=project, outcome=Outcome.ACCEPTED)
+    with metrics.timer("process_profile.track_outcome.accepted"):
+        _track_outcome(profile=profile, project=project, outcome=Outcome.ACCEPTED)
 
 
 JS_PLATFORMS = ["javascript", "node"]


### PR DESCRIPTION
We're tracking less accepted outcomes than we're inserting to vroom. This validates that we're losing profiles when sending to vroom and it's not an issue with the accepted outcome count.