### PR TITLE
feat(notifications): enable double writes if user has no orgs

### DIFF
--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -708,6 +708,9 @@ def is_double_write_enabled(
             OrganizationMapping.objects.filter(organization_id__in=list(org_ids)),
         )
     )
+    # if no orgs, then automatically enable the feature
+    if not orgs:
+        return True
     return any(features.has("organizations:notifications-double-write", org) for org in orgs)
 
 

--- a/tests/sentry/api/endpoints/test_user_notification_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_details.py
@@ -2,6 +2,7 @@ from sentry.models import (
     NotificationSetting,
     NotificationSettingOption,
     NotificationSettingProvider,
+    OrganizationMemberMapping,
 )
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils.cases import APITestCase
@@ -90,6 +91,11 @@ class UserNotificationDetailsPutTest(UserNotificationDetailsTestBase):
             "personalActivityNotifications": True,
             "selfAssignOnResolve": True,
         }
+        # make an org mapping for the user
+        OrganizationMemberMapping.objects.create(
+            organization_id=self.organization.id, user_id=self.user.id
+        )
+
         response = self.get_success_response("me", **data)
 
         assert response.data.get("deployNotifications") == 2

--- a/tests/sentry/notifications/test_helpers.py
+++ b/tests/sentry/notifications/test_helpers.py
@@ -103,6 +103,13 @@ class DoubleWriteTests(TestCase):
         with pytest.raises(ValueError):
             is_double_write_enabled()
 
+    @mock.patch("sentry.notifications.helpers.features.has", return_value=False)
+    def test_no_orgs(self, mock_has):
+        user1 = self.create_user()
+
+        assert is_double_write_enabled(user_id=user1.id)
+        mock_has.assert_not_called()
+
 
 class NotificationHelpersTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
We need to start enabling the feature flag for everyone in Flagr but for users that have no org, we have to do this instead.