### PR TITLE
feat(statistical-detectors): Add a new group type

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -318,10 +318,20 @@ class PerformanceHTTPOverheadGroupType(PerformanceGroupTypeDefaults, GroupType):
     category = GroupCategory.PERFORMANCE.value
 
 
+# experimental
 @dataclass(frozen=True)
 class PerformanceDurationRegressionGroupType(PerformanceGroupTypeDefaults, GroupType):
     type_id = 1017
     slug = "performance_duration_regression"
+    description = "Exp Duration Regression"
+    noise_config = NoiseConfig(ignore_limit=0)
+    category = GroupCategory.PERFORMANCE.value
+
+
+@dataclass(frozen=True)
+class PerformanceP95DurationRegressionGroupType(PerformanceGroupTypeDefaults, GroupType):
+    type_id = 1018
+    slug = "performance_p95_duration_regression"
     description = "Duration Regression"
     noise_config = NoiseConfig(ignore_limit=0)
     category = GroupCategory.PERFORMANCE.value

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1272,7 +1272,48 @@ register(
 register(
     "performance.issues.http_overhead.ga-rollout", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
-
+# Experimental issue
+register(
+    "performance.issues.duration_regression.problem-creation",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "performance.issues.duration_regression.la-rollout",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "performance.issues.duration_regression.ea-rollout",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "performance.issues.duration_regression.ga-rollout",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Actual duration regression issue
+register(
+    "performance.issues.p95_duration_regression.problem-creation",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "performance.issues.p95_duration_regression.la-rollout",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "performance.issues.p95_duration_regression.ea-rollout",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "performance.issues.p95_duration_regression.ga-rollout",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # System-wide options for default performance detection settings for any org opted into the performance-issues-ingest feature. Meant for rollout.
 register(

--- a/tests/sentry/api/endpoints/test_organization_events_trends_v2.py
+++ b/tests/sentry/api/endpoints/test_organization_events_trends_v2.py
@@ -522,7 +522,7 @@ class OrganizationEventsTrendsStatsV2EndpointTest(MetricsAPIBaseTestCase):
             occurrence,
             **{
                 "project_id": self.project.id,
-                "issue_title": "Duration Regression",
+                "issue_title": "Exp Duration Regression",
                 "subtitle": "Increased from 14.0ms to 28.0ms (P95)",
                 "resource_id": None,
                 "evidence_data": mock_trends_result[0],


### PR DESCRIPTION
Add a new group type. There's a lot of options logic that depends on the issue slug so it ended up being easier to create a new issue type instead of modifying the existing one.