### PR TITLE
chore(hybrid-cloud): crossdomain.xml should not be accessible via control silo

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -4,6 +4,7 @@ from django.views.generic.base import View as BaseView
 from rest_framework.request import Request
 
 from sentry.models import Project
+from sentry.silo.base import SiloMode
 from sentry.utils import json
 from sentry.utils.http import get_origins
 from sentry.web.client_config import get_client_config
@@ -22,7 +23,7 @@ def robots_txt(request):
 
 @cache_control(max_age=60)
 def crossdomain_xml(request, project_id):
-    if not project_id.isdigit():
+    if SiloMode.get_current_mode() == SiloMode.CONTROL or (not project_id.isdigit()):
         return HttpResponse(status=404)
 
     try:

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from sentry.auth import superuser
 from sentry.models import ApiToken, Organization, OrganizationMember, OrganizationStatus
 from sentry.models.scheduledeletion import RegionScheduledDeletion
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.scheduled import run_deletion
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
@@ -19,6 +20,11 @@ class CrossDomainXmlTest(TestCase):
     @cached_property
     def path(self):
         return reverse("sentry-api-crossdomain-xml", kwargs={"project_id": self.project.id})
+
+    def test_inaccessible_in_control_silo(self):
+        with override_settings(SILO_MODE=SiloMode.CONTROL):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 404
 
     @mock.patch("sentry.web.api.get_origins")
     def test_output_with_global(self, get_origins):


### PR DESCRIPTION
We will use nginx to proxy `https://sentry.io/api/<project_id>/crossdomain.xml` to US region `https://us.sentry.io/api/<project_id>/crossdomain.xml` for backwards compatibility. 

This pull request ensures that `https://sentry.io/api/<project_id>/crossdomain.xml` is inaccessible in the control silo; since we cannot query `Project` in the control silo.