### PR TITLE
feat(starfish): Update offset logic, null group fallback logic

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -158,9 +158,11 @@ class AggregateSpans:
                 count,
                 start_ms - parent_timestamp,
             )
-            # Calculates the absolute offset by the average offset of parent and average relative offset of current span from parent
-            # so we can more accurately represent parent/child relationships in the span waterfall. ie, does a better job of ensuring
-            # that child spans don't start before parent span at the aggregate level.
+            # Calculates the absolute offset by the average offset of parent and average
+            # relative offset of current span from parent so we can more accurately
+            # represent parent/child relationships in the span waterfall. ie, does
+            # a better job of ensuring that child spans don't start before parent
+            # span at the aggregate level.
             node["avg(absolute_offset)"] = (
                 parent_node["avg(absolute_offset)"] + node["avg(relative_offset)"]
                 if parent_node

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -1,6 +1,6 @@
 import hashlib
 from collections import defaultdict, namedtuple
-from typing import Dict, List, TypedDict
+from typing import Any, Dict, List, Mapping, TypedDict
 
 from rest_framework import status
 from rest_framework.request import Request
@@ -26,6 +26,7 @@ EventSpan = namedtuple(
         "group",
         "group_raw",
         "description",
+        "op",
         "start_ms",
         "duration",
         "exclusive_time",
@@ -45,11 +46,13 @@ AggregateSpanRow = TypedDict(
         "parent_node_fingerprint": str,
         "group": str,
         "description": str,
+        "op": str,
         "start_ms": int,
         "avg(exclusive_time)": float,
         "avg(duration)": float,
         "is_segment": int,
-        "avg(offset)": float,
+        "avg(absolute_offset)": float,
+        "avg(relative_offset)": float,
         "count()": int,
     },
 )
@@ -57,13 +60,156 @@ AggregateSpanRow = TypedDict(
 NULL_GROUP = "00"
 
 
+class AggregateSpans:
+    def __init__(self) -> None:
+        self.aggregated_tree: Dict[str, AggregateSpanRow] = {}
+
+    def build_aggregate_span_tree(self, results: Mapping[str, Any]):
+        for event in results["data"]:
+            span_tree = {}
+            root_span_id = None
+            spans = event["spans"]
+
+            for span_ in spans:
+                span = EventSpan(*span_)
+                span_id = getattr(span, "span_id")
+                is_root = getattr(span, "is_segment")
+                if is_root:
+                    root_span_id = span_id
+                if span_id not in span_tree:
+                    spans_dict = span._asdict()
+                    # Fallback to group_raw if group doesn't exist for now
+                    spans_dict["key"] = (
+                        spans_dict["op"]
+                        if spans_dict["group"] == NULL_GROUP
+                        else spans_dict["group"]
+                    )
+                    span_tree[span_id] = spans_dict
+                    span_tree[span_id]["children"] = []
+
+            for span_ in span_tree.values():
+                parent_id = span_["parent_span_id"]
+                if parent_id in span_tree:
+                    parent_span = span_tree[parent_id]
+                    children = parent_span["children"]
+                    children.append(span_)
+
+            if root_span_id in span_tree:
+                root_span = span_tree[root_span_id]
+                self.fingerprint_nodes(root_span, root_span["start_ms"])
+
+        return self.aggregated_tree
+
+    def fingerprint_nodes(
+        self,
+        span_tree,
+        parent_timestamp,
+        root_prefix=None,
+        parent_node_fingerprint=None,
+        nth_span=0,
+    ):
+        """
+        Build a fingerprint using current span group and span groups of all the spans in the path before it.
+        Example 1:
+            A
+            |--B
+            |--C
+               |--D
+
+            In this example, given A, B, C, D are span groups, the fingerprint of span D would be
+            the md5 hash of the value A-C-D.
+
+        Example 2:
+            A
+            |--B
+            |--C
+            |  |--D
+            |
+            |--C
+               |--E
+
+            In this example, given A, B, C, D are span groups, the fingerprint of span D would be
+            the md5 hash of the value A-C-D and for span E would be md5 hash of the value A-C1-E.
+        """
+        key = span_tree["key"]
+        description = span_tree["description"]
+        start_ms = span_tree["start_ms"]
+        if root_prefix is None:
+            prefix = key
+        else:
+            if nth_span == 1:
+                prefix = f"{root_prefix}-{key}"
+            else:
+                prefix = f"{root_prefix}-{key}{nth_span}"
+        node_fingerprint = hashlib.md5(prefix.encode()).hexdigest()[:16]
+        parent_node = self.aggregated_tree.get(parent_node_fingerprint, None)
+
+        if node_fingerprint in self.aggregated_tree:
+            node = self.aggregated_tree[node_fingerprint]
+            count = node["count()"]
+            node["avg(exclusive_time)"] = incremental_average(
+                node["avg(exclusive_time)"], count, span_tree["exclusive_time"]
+            )
+            node["avg(duration)"] = incremental_average(
+                node["avg(duration)"], count, span_tree["duration"]
+            )
+            node["avg(relative_offset)"] = incremental_average(
+                node["avg(relative_offset)"],
+                count,
+                start_ms - parent_timestamp,
+            )
+            # Calculates the absolute offset by the average offset of parent and average relative offset of current span from parent
+            # so we can more accurately represent parent/child relationships in the span waterfall. ie, does a better job of ensuring
+            # that child spans don't start before parent span at the aggregate level.
+            node["avg(absolute_offset)"] = (
+                parent_node["avg(absolute_offset)"] + node["avg(relative_offset)"]
+                if parent_node
+                else node["avg(relative_offset)"]
+            )
+            node["count()"] += 1
+        else:
+            self.aggregated_tree[node_fingerprint] = {
+                "node_fingerprint": node_fingerprint,
+                "parent_node_fingerprint": parent_node_fingerprint,
+                "group": span_tree["group"],
+                "op": span_tree["op"],
+                "description": f"<<unparametrized>> {description}"
+                if span_tree["group"] == NULL_GROUP
+                else description,
+                "start_ms": start_ms,
+                "avg(exclusive_time)": span_tree["exclusive_time"],
+                "avg(duration)": span_tree["duration"],
+                "is_segment": span_tree["is_segment"],
+                "avg(relative_offset)": start_ms - parent_timestamp,
+                "avg(absolute_offset)": parent_node["avg(absolute_offset)"]
+                + start_ms
+                - parent_timestamp
+                if parent_node
+                else start_ms - parent_timestamp,
+                "count()": 1,
+            }
+
+        # Handles sibling spans that have the same group
+        span_tree["children"].sort(key=lambda s: s["start_ms"])
+        span_hash_seen: Dict[str, int] = defaultdict(lambda: 0)
+
+        for child in span_tree["children"]:
+            child_span_hash = child["key"]
+            span_hash_seen[child_span_hash] += 1
+            self.fingerprint_nodes(
+                child,
+                span_tree["start_ms"],
+                prefix,
+                node_fingerprint,
+                span_hash_seen[child_span_hash],
+            )
+
+
 @region_silo_endpoint
 class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
-
-    aggregated_tree: Dict[str, AggregateSpanRow] = {}
 
     def get(self, request: Request, organization: Organization) -> Response:
         if not features.has("organizations:starfish-view", organization, actor=request.user):
@@ -100,6 +246,7 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
                             Column("group"),
                             Column("group_raw"),
                             Column("description"),
+                            Column("op"),
                             Column("start_ms"),
                             Column("duration"),
                             Column("exclusive_time"),
@@ -112,128 +259,9 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
         snql_query = builder.get_snql_query()
         snql_query.tenant_ids = {"organization_id": organization.id}
         results = raw_snql_query(snql_query, Referrer.API_ORGANIZATION_SPANS_AGGREGATION.value)
-        for event in results["data"]:
-            span_tree = {}
-            root_span_id = None
-            spans = event["spans"]
+        aggregated_tree = AggregateSpans().build_aggregate_span_tree(results)
 
-            for span_ in spans:
-                span = EventSpan(*span_)
-                span_id = getattr(span, "span_id")
-                is_root = getattr(span, "is_segment")
-                if is_root:
-                    root_span_id = span_id
-                if span_id not in span_tree:
-                    spans_dict = span._asdict()
-                    # Fallback to group_raw if group doesn't exist for now
-                    spans_dict["coalesced_group"] = (
-                        spans_dict["group_raw"]
-                        if spans_dict["group"] == NULL_GROUP
-                        else spans_dict["group"]
-                    )
-                    span_tree[span_id] = spans_dict
-                    span_tree[span_id]["children"] = []
-
-            for span_ in span_tree.values():
-                parent_id = span_["parent_span_id"]
-                if parent_id in span_tree:
-                    parent_span = span_tree[parent_id]
-                    children = parent_span["children"]
-                    children.append(span_)
-
-            if root_span_id in span_tree:
-                root_span = span_tree[root_span_id]
-                self.fingerprint_nodes(root_span, root_span["start_ms"])
-
-        return Response(data=self.aggregated_tree)
-
-    def fingerprint_nodes(
-        self,
-        span_tree,
-        root_start_timestamp,
-        root_prefix=None,
-        parent_node_fingerprint=None,
-        nth_span=0,
-    ):
-        """
-        Build a fingerprint using current span group and span groups of all the spans in the path before it.
-        Example 1:
-            A
-            |--B
-            |--C
-               |--D
-
-            In this example, given A, B, C, D are span groups, the fingerprint of span D would be
-            the md5 hash of the value A-C-D.
-
-        Example 2:
-            A
-            |--B
-            |--C
-            |  |--D
-            |
-            |--C
-               |--E
-
-            In this example, given A, B, C, D are span groups, the fingerprint of span D would be
-            the md5 hash of the value A-C-D and for span E would be md5 hash of the value A-C1-E.
-        """
-        coalesced_group = span_tree["coalesced_group"]
-        description = span_tree["description"]
-        start_ms = span_tree["start_ms"]
-        if root_prefix is None:
-            prefix = coalesced_group
-        else:
-            if nth_span == 1:
-                prefix = f"{root_prefix}-{coalesced_group}"
-            else:
-                prefix = f"{root_prefix}-{coalesced_group}{nth_span}"
-        node_fingerprint = hashlib.md5(prefix.encode()).hexdigest()[:16]
-
-        if node_fingerprint in self.aggregated_tree:
-            node = self.aggregated_tree[node_fingerprint]
-            count = node["count()"]
-            node["avg(exclusive_time)"] = incremental_average(
-                node["avg(exclusive_time)"], count, span_tree["exclusive_time"]
-            )
-            node["avg(duration)"] = incremental_average(
-                node["avg(duration)"], count, span_tree["duration"]
-            )
-            node["avg(offset)"] = incremental_average(
-                node["avg(offset)"],
-                count,
-                start_ms - root_start_timestamp,
-            )
-            node["count()"] += 1
-        else:
-            self.aggregated_tree[node_fingerprint] = {
-                "node_fingerprint": node_fingerprint,
-                "parent_node_fingerprint": parent_node_fingerprint,
-                "group": span_tree["group"],
-                "description": description,
-                "start_ms": start_ms,
-                "avg(exclusive_time)": span_tree["exclusive_time"],
-                "avg(duration)": span_tree["duration"],
-                "is_segment": span_tree["is_segment"],
-                "avg(offset)": start_ms
-                - root_start_timestamp,  # offset of the span relative to the start timestamp of the root span
-                "count()": 1,
-            }
-
-        # Handles sibling spans that have the same group
-        span_tree["children"].sort(key=lambda s: s["start_ms"])
-        span_hash_seen: Dict[str, int] = defaultdict(lambda: 0)
-
-        for child in span_tree["children"]:
-            child_span_hash = child["coalesced_group"]
-            span_hash_seen[child_span_hash] += 1
-            self.fingerprint_nodes(
-                child,
-                root_start_timestamp,
-                prefix,
-                node_fingerprint,
-                span_hash_seen[child_span_hash],
-            )
+        return Response(data=aggregated_tree)
 
 
 def incremental_average(average, count, value):

--- a/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
+++ b/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
@@ -3,7 +3,91 @@ from unittest import mock
 
 from django.urls import reverse
 
+from sentry.api.endpoints.organization_spans_aggregation import NULL_GROUP
 from sentry.testutils.cases import APITestCase, SnubaTestCase
+
+MOCK_SNUBA_RESPONSE = {
+    "data": [
+        {
+            "transaction_id": "80fe542aea4945ffbe612646987ee449",
+            "count": 71,
+            "spans": [
+                [
+                    "root_1",
+                    1,
+                    "parent_1",
+                    "A",
+                    "A",
+                    "bind_organization_context",
+                    "other",
+                    100,
+                    0,
+                    0.0,
+                ],
+                ["B1", 0, "root_1", "B", "B", "connect", "db", 150, 50, 50.0],
+                [
+                    "C1",
+                    0,
+                    "root_1",
+                    "C",
+                    "C",
+                    "resolve_conditions",
+                    "discover.endpoint",
+                    155,
+                    0,
+                    10.0,
+                ],
+                ["D1", 0, "C1", "D", "D", "resolve_orderby", "discover.snql", 157, 0, 20.0],
+                ["E1", 0, "C1", NULL_GROUP, "E", "resolve_columns", "discover.snql", 157, 0, 20.0],
+            ],
+        },
+        {
+            "transaction_id": "86b21833d1854d9b811000b91e7fccfa",
+            "count": 71,
+            "spans": [
+                [
+                    "root_2",
+                    1,
+                    "parent_2",
+                    "A",
+                    "A",
+                    "bind_organization_context",
+                    "other",
+                    100,
+                    0,
+                    0.0,
+                ],
+                ["B2", 0, "root_2", "B", "B", "connect", "db", 110, 10, 30.0],
+                [
+                    "C2",
+                    0,
+                    "root_2",
+                    "C",
+                    "C",
+                    "resolve_conditions",
+                    "discover.endpoint",
+                    115,
+                    0,
+                    40.0,
+                ],
+                ["D2", 0, "C2", "D", "D", "resolve_orderby", "discover.snql", 150, 0, 10.0],
+                [
+                    "D2-duplicate",
+                    0,
+                    "C2",
+                    "D",
+                    "D",
+                    "resolve_orderby",
+                    "discover.snql",
+                    155,
+                    0,
+                    20.0,
+                ],
+                ["E2", 0, "C2", NULL_GROUP, "E", "resolve_columns", "discover.snql", 157, 0, 20.0],
+            ],
+        },
+    ]
+}
 
 
 class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
@@ -24,53 +108,7 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
 
     @mock.patch("sentry.api.endpoints.organization_spans_aggregation.raw_snql_query")
     def test_simple(self, mock_query):
-        mock_query.side_effect = [
-            {
-                "data": [
-                    {
-                        "transaction_id": "80fe542aea4945ffbe612646987ee449",
-                        "count": 71,
-                        "spans": [
-                            [
-                                "root_1",
-                                1,
-                                "parent_1",
-                                "A",
-                                "A",
-                                "bind_organization_context",
-                                422,
-                                0,
-                                0.0,
-                            ],
-                            ["B1", 0, "root_1", "B", "B", "connect", 158, 50, 50.0],
-                            ["C1", 0, "root_1", "C", "C", "resolve_conditions", 448, 0, 10.0],
-                            ["D1", 0, "C1", "D", "D", "resolve_orderby", 429, 0, 20.0],
-                        ],
-                    },
-                    {
-                        "transaction_id": "86b21833d1854d9b811000b91e7fccfa",
-                        "count": 71,
-                        "spans": [
-                            [
-                                "root_2",
-                                1,
-                                "parent_2",
-                                "A",
-                                "A",
-                                "bind_organization_context",
-                                422,
-                                0,
-                                0.0,
-                            ],
-                            ["B2", 0, "root_2", "B", "B", "connect", 158, 10, 30.0],
-                            ["C2", 0, "root_2", "C", "C", "resolve_conditions", 448, 0, 40.0],
-                            ["D2", 0, "C2", "D", "D", "resolve_orderby", 429, 0, 10.0],
-                            ["D2-duplicate", 0, "C2", "D", "D", "resolve_orderby", 430, 0, 20.0],
-                        ],
-                    },
-                ]
-            }
-        ]
+        mock_query.side_effect = [MOCK_SNUBA_RESPONSE]
         with self.feature(self.FEATURES):
             response = self.client.get(
                 self.url,
@@ -98,3 +136,48 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
             assert data[fingerprint]["description"] == "resolve_orderby"
             assert data[fingerprint]["avg(exclusive_time)"] == 20.0
             assert data[fingerprint]["count()"] == 1
+
+    @mock.patch("sentry.api.endpoints.organization_spans_aggregation.raw_snql_query")
+    def test_offset_logic(self, mock_query):
+        mock_query.side_effect = [MOCK_SNUBA_RESPONSE]
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={"transaction": "foo"},
+                format="json",
+            )
+
+            assert response.data
+            data = response.data
+            root_fingerprint = hashlib.md5(b"A").hexdigest()[:16]
+            assert root_fingerprint in data
+            assert data[root_fingerprint]["avg(absolute_offset)"] == 0.0
+
+            fingerprint = hashlib.md5(b"A-B").hexdigest()[:16]
+            assert data[fingerprint]["avg(absolute_offset)"] == 30.0
+
+            fingerprint = hashlib.md5(b"A-C").hexdigest()[:16]
+            assert data[fingerprint]["avg(absolute_offset)"] == 35.0
+
+            fingerprint = hashlib.md5(b"A-C-D").hexdigest()[:16]
+            assert data[fingerprint]["avg(absolute_offset)"] == 53.5
+
+            fingerprint = hashlib.md5(b"A-C-D2").hexdigest()[:16]
+            assert data[fingerprint]["avg(absolute_offset)"] == 75.0
+
+    @mock.patch("sentry.api.endpoints.organization_spans_aggregation.raw_snql_query")
+    def test_null_group_falls_back_to_span_op(self, mock_query):
+        mock_query.side_effect = [MOCK_SNUBA_RESPONSE]
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={"transaction": "foo"},
+                format="json",
+            )
+
+            assert response.data
+            data = response.data
+            root_fingerprint = hashlib.md5(b"A-C-discover.snql").hexdigest()[:16]
+            assert root_fingerprint in data
+            assert data[root_fingerprint]["description"] == "<<unparametrized>> resolve_columns"
+            assert data[root_fingerprint]["count()"] == 2


### PR DESCRIPTION
1. Update offset logic
             calculates the absolute offset by the average offset of parent and average
            relative offset of current span from parent so we can more accurately
            represent parent/child relationships in the span waterfall. ie, does
            a better job of ensuring that child spans don't start before parent
            span at the aggregate level.
2. Returns span op in the response
3. Falls back to span op instead of span description in hopes of reducing code paths we show in the ui
4. Sorry sorry, small refactor that moves all the span tree building logic into its own class.