### PR TITLE
ref(replays): add coloring and icons to rage/dead click cells

### DIFF
--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -115,7 +115,7 @@ type GridEditableProps<DataRow, ColumnKey> = {
    * - `columnSortBy` is not used at the moment, however it might be better to
    *   move sorting into Grid for performance
    */
-  title?: string | ReactNode;
+  title?: ReactNode;
 };
 
 type GridEditableState = {

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -1,4 +1,4 @@
-import {Component, createRef, Fragment, Profiler} from 'react';
+import {Component, createRef, Fragment, Profiler, ReactNode} from 'react';
 import {Location} from 'history';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -115,7 +115,7 @@ type GridEditableProps<DataRow, ColumnKey> = {
    * - `columnSortBy` is not used at the moment, however it might be better to
    *   move sorting into Grid for performance
    */
-  title?: string;
+  title?: string | ReactNode;
 };
 
 type GridEditableState = {

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps, Fragment, ReactNode} from 'react';
+import {ComponentProps, Fragment, ReactNode} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -43,7 +43,7 @@ function DeadClickTable({location}: {location: Location<any>}) {
       title={
         <React.Fragment>
           <IconContainer>
-            <IconCursorArrow size="sm" color="yellow300" />
+            <IconCursorArrow size="xs" color="yellow300" />
           </IconContainer>
           {t('Most Dead Clicks')}
         </React.Fragment>
@@ -79,7 +79,7 @@ function RageClickTable({location}: {location: Location<any>}) {
       title={
         <React.Fragment>
           <IconContainer>
-            <IconCursorArrow size="sm" color="red300" />
+            <IconCursorArrow size="xs" color="red300" />
           </IconContainer>
           {t('Most Rage Clicks')}
         </React.Fragment>
@@ -112,7 +112,7 @@ function SearchButton({
   return (
     <LinkButton
       {...props}
-      size="sm"
+      size="xs"
       to={{
         pathname: normalizeUrl(`/organizations/${organization.slug}/replays/${path}/`),
         query: {

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps, ReactNode} from 'react';
+import React, {ComponentProps, Fragment, ReactNode} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
@@ -41,12 +41,12 @@ function DeadClickTable({location}: {location: Location<any>}) {
       clickCountColumn={{key: 'count_dead_clicks', name: 'dead clicks'}}
       clickCountSortable={false}
       title={
-        <React.Fragment>
+        <Fragment>
           <IconContainer>
             <IconCursorArrow size="xs" color="yellow300" />
           </IconContainer>
           {t('Most Dead Clicks')}
-        </React.Fragment>
+        </Fragment>
       }
       headerButtons={
         <SearchButton

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -77,12 +77,12 @@ function RageClickTable({location}: {location: Location<any>}) {
       clickCountColumn={{key: 'count_rage_clicks', name: 'rage clicks'}}
       clickCountSortable={false}
       title={
-        <React.Fragment>
+        <Fragment>
           <IconContainer>
             <IconCursorArrow size="xs" color="red300" />
           </IconContainer>
           {t('Most Rage Clicks')}
-        </React.Fragment>
+        </Fragment>
       }
       headerButtons={
         <SearchButton

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -1,10 +1,10 @@
-import {ComponentProps, ReactNode} from 'react';
+import React, {ComponentProps, ReactNode} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {LinkButton} from 'sentry/components/button';
 import {hydratedSelectorData} from 'sentry/components/replays/utils';
-import {IconShow} from 'sentry/icons';
+import {IconCursorArrow, IconShow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useDeadRageSelectors from 'sentry/utils/replays/hooks/useDeadRageSelectors';
@@ -40,7 +40,14 @@ function DeadClickTable({location}: {location: Location<any>}) {
       location={location}
       clickCountColumn={{key: 'count_dead_clicks', name: 'dead clicks'}}
       clickCountSortable={false}
-      title={t('Most Dead Clicks')}
+      title={
+        <React.Fragment>
+          <IconContainer>
+            <IconCursorArrow size="sm" color="yellow300" />
+          </IconContainer>
+          {t('Most Dead Clicks')}
+        </React.Fragment>
+      }
       headerButtons={
         <SearchButton
           label={t('Show all')}
@@ -69,7 +76,14 @@ function RageClickTable({location}: {location: Location<any>}) {
       location={location}
       clickCountColumn={{key: 'count_rage_clicks', name: 'rage clicks'}}
       clickCountSortable={false}
-      title={t('Most Rage Clicks')}
+      title={
+        <React.Fragment>
+          <IconContainer>
+            <IconCursorArrow size="sm" color="red300" />
+          </IconContainer>
+          {t('Most Rage Clicks')}
+        </React.Fragment>
+      }
       headerButtons={
         <SearchButton
           label={t('Show all')}
@@ -123,6 +137,10 @@ const SplitCardContainer = styled('div')`
   gap: 0 ${space(2)};
   align-items: stretch;
   padding-top: ${space(1)};
+`;
+
+const IconContainer = styled('span')`
+  margin-right: ${space(1)};
 `;
 
 export default DeadRageSelectorCards;

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -26,7 +26,7 @@ interface Props {
   location: Location<any>;
   customHandleResize?: () => void;
   headerButtons?: ReactNode;
-  title?: string | ReactNode;
+  title?: ReactNode;
 }
 
 const BASE_COLUMNS: GridColumnOrder<string>[] = [

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -1,4 +1,5 @@
 import {Fragment, ReactNode, useCallback, useMemo} from 'react';
+import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import renderSortableHeaderCell from 'sentry/components/feedback/table/renderSortableHeaderCell';
@@ -25,7 +26,7 @@ interface Props {
   location: Location<any>;
   customHandleResize?: () => void;
   headerButtons?: ReactNode;
-  title?: string;
+  title?: string | ReactNode;
 }
 
 const BASE_COLUMNS: GridColumnOrder<string>[] = [
@@ -130,5 +131,23 @@ function SelectorLink({
 }
 
 function renderSimpleBodyCell<T>(column: GridColumnOrder<string>, dataRow: T) {
+  if (column.key === 'count_dead_clicks') {
+    return <DeadClickCount>{dataRow[column.key]}</DeadClickCount>;
+  }
+  if (column.key === 'count_rage_clicks') {
+    return <RageClickCount>{dataRow[column.key]}</RageClickCount>;
+  }
   return <TextOverflow>{dataRow[column.key]}</TextOverflow>;
 }
+
+const DeadClickCount = styled(TextOverflow)<{
+  clickType?: string;
+}>`
+  color: ${p => p.theme.yellow300};
+`;
+
+const RageClickCount = styled(TextOverflow)<{
+  clickType?: string;
+}>`
+  color: ${p => p.theme.red300};
+`;

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -140,14 +140,10 @@ function renderSimpleBodyCell<T>(column: GridColumnOrder<string>, dataRow: T) {
   return <TextOverflow>{dataRow[column.key]}</TextOverflow>;
 }
 
-const DeadClickCount = styled(TextOverflow)<{
-  clickType?: string;
-}>`
+const DeadClickCount = styled(TextOverflow)`
   color: ${p => p.theme.yellow300};
 `;
 
-const RageClickCount = styled(TextOverflow)<{
-  clickType?: string;
-}>`
+const RageClickCount = styled(TextOverflow)`
   color: ${p => p.theme.red300};
 `;

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -15,7 +15,13 @@ import ScoreBar from 'sentry/components/scoreBar';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
-import {IconCalendar, IconDelete, IconEllipsis, IconFire} from 'sentry/icons';
+import {
+  IconCalendar,
+  IconCursorArrow,
+  IconDelete,
+  IconEllipsis,
+  IconFire,
+} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space, ValidSize} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types';
@@ -528,7 +534,10 @@ export function RageClickCountCell({replay, showDropdownFilters}: Props) {
     <Item data-test-id="replay-table-count-rage-clicks">
       <Container>
         {replay.count_rage_clicks ? (
-          <DeadRageCount>{replay.count_rage_clicks}</DeadRageCount>
+          <RageClickCount>
+            <IconCursorArrow size="sm" />
+            {replay.count_rage_clicks}
+          </RageClickCount>
         ) : (
           <Count>0</Count>
         )}
@@ -551,7 +560,10 @@ export function DeadClickCountCell({replay, showDropdownFilters}: Props) {
     <Item data-test-id="replay-table-count-dead-clicks">
       <Container>
         {replay.count_dead_clicks ? (
-          <DeadRageCount>{replay.count_dead_clicks}</DeadRageCount>
+          <DeadClickCount>
+            <IconCursorArrow size="sm" />
+            {replay.count_dead_clicks}
+          </DeadClickCount>
         ) : (
           <Count>0</Count>
         )}
@@ -627,9 +639,18 @@ const Count = styled('span')`
   font-variant-numeric: tabular-nums;
 `;
 
-const DeadRageCount = styled(Count)`
+const DeadClickCount = styled(Count)`
   display: flex;
   width: 40px;
+  gap: ${space(0.5)};
+  color: ${p => p.theme.yellow300};
+`;
+
+const RageClickCount = styled(Count)`
+  display: flex;
+  width: 40px;
+  gap: ${space(0.5)};
+  color: ${p => p.theme.red300};
 `;
 
 const ErrorCount = styled(Count)`


### PR DESCRIPTION

<img width="1190" alt="SCR-20230920-lyka" src="https://github.com/getsentry/sentry/assets/56095982/a6f146a5-3a9b-4cca-9e1a-e5280c20bd56">

per this design: https://www.figma.com/file/yS1d4Q0m8bziJ15esyAUXB/Exploration%3A-Index-v6?type=design&node-id=737-3696&mode=design&t=lL11NyBCTs321GxC-0

closes https://github.com/getsentry/team-replay/issues/189