### PR TITLE
fix(backup): Fix backup tests for CustomDynamicSamplingRule

### DIFF
--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -46,6 +46,7 @@ from sentry.models.dashboard_widget import (
     DashboardWidgetQuery,
     DashboardWidgetTypes,
 )
+from sentry.models.dynamicsampling import CustomDynamicSamplingRule
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.integrations.project_integration import ProjectIntegration
@@ -323,6 +324,15 @@ class BackupTestCase(TransactionTestCase):
             disable_date=datetime.now(),
             sent_initial_email_date=datetime.now(),
             sent_final_email_date=datetime.now(),
+        )
+        CustomDynamicSamplingRule.update_or_create(
+            condition={"op": "equals", "name": "environment", "value": "prod"},
+            start=timezone.now(),
+            end=timezone.now() + timedelta(hours=1),
+            project_ids=[project.id],
+            organization_id=org.id,
+            num_samples=100,
+            sample_rate=0.5,
         )
 
         # Environment*

--- a/tests/sentry/backup/test_models.py
+++ b/tests/sentry/backup/test_models.py
@@ -228,6 +228,19 @@ class ModelBackupTests(TransactionTestCase):
         Counter.increment(project, 1)
         return self.import_export_then_validate()
 
+    @targets(mark(CustomDynamicSamplingRule, CustomDynamicSamplingRuleProject))
+    def test_custom_dynamic_sampling(self):
+        CustomDynamicSamplingRule.update_or_create(
+            condition={"op": "equals", "name": "environment", "value": "prod"},
+            start=timezone.now(),
+            end=timezone.now() + timedelta(hours=1),
+            project_ids=[self.project.id],
+            organization_id=self.organization.id,
+            num_samples=100,
+            sample_rate=0.5,
+        )
+        return self.import_export_then_validate()
+
     @targets(mark(Dashboard))
     def test_dashboard(self):
         self.create_dashboard()
@@ -524,25 +537,6 @@ class ModelBackupTests(TransactionTestCase):
         user = self.create_user()
         role = UserRole.objects.create(name="test-role")
         UserRoleUser.objects.create(user=user, role=role)
-        return self.import_export_then_validate()
-
-    @targets(mark(CustomDynamicSamplingRule, CustomDynamicSamplingRuleProject))
-    def test_custom_dynamic_sampling_rule(self):
-        condition = {"op": "equals", "name": "environment", "value": "prod"}
-
-        rule = CustomDynamicSamplingRule.update_or_create(
-            condition=condition,
-            start=timezone.now(),
-            end=timezone.now() + timedelta(hours=1),
-            project_ids=[self.project.id],
-            organization_id=self.organization.id,
-            num_samples=100,
-            sample_rate=0.5,
-        )
-
-        CustomDynamicSamplingRuleProject.objects.create(
-            rule=rule, project=self.project, organization=self.organization
-        )
         return self.import_export_then_validate()
 
 


### PR DESCRIPTION
This model erroring out in backup tests was not caught because backup tests are currently disabled in CI.
