### PR TITLE
feat(starfish): Add unique span domain column

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -45,6 +45,7 @@ TOTAL_SPAN_DURATION_ALIAS = "total.span_duration"
 SPAN_MODULE_ALIAS = "span.module"
 SPAN_DOMAIN_ALIAS = "span.domain_array"
 SPAN_DOMAIN_SEPARATOR = ","
+UNIQUE_SPAN_DOMAIN_ALIAS = "unique_span_domains"
 
 
 class ThresholdDict(TypedDict):

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -45,7 +45,7 @@ TOTAL_SPAN_DURATION_ALIAS = "total.span_duration"
 SPAN_MODULE_ALIAS = "span.module"
 SPAN_DOMAIN_ALIAS = "span.domain_array"
 SPAN_DOMAIN_SEPARATOR = ","
-UNIQUE_SPAN_DOMAIN_ALIAS = "unique_span_domains"
+UNIQUE_SPAN_DOMAIN_ALIAS = "unique.span_domains"
 
 
 class ThresholdDict(TypedDict):

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -35,6 +35,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         return {
             constants.SPAN_MODULE_ALIAS: self._resolve_span_module,
             constants.SPAN_DOMAIN_ALIAS: self._resolve_span_domain,
+            constants.UNIQUE_SPAN_DOMAIN_ALIAS: self._resolve_unique_span_domains,
         }
 
     def resolve_metric(self, value: str) -> int:
@@ -394,6 +395,12 @@ class SpansMetricsDatasetConfig(DatasetConfig):
             ],
             alias,
         )
+
+    def _resolve_unique_span_domains(
+        self,
+        alias: Optional[str] = None,
+    ) -> SelectType:
+        return Function("arrayJoin", [self._resolve_span_domain()], alias)
 
     # Query Functions
     def _resolve_count_if(

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -758,9 +758,9 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         )
         response = self.do_request(
             {
-                "field": ["unique_span_domains", "count()"],
+                "field": ["unique.span_domains", "count()"],
                 "query": "",
-                "orderby": "unique_span_domains",
+                "orderby": "unique.span_domains",
                 "project": self.project.id,
                 "dataset": "spansMetrics",
             }
@@ -769,10 +769,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 3
-        assert data[0]["unique_span_domains"] == "sentry_table1"
-        assert data[1]["unique_span_domains"] == "sentry_table2"
-        assert data[2]["unique_span_domains"] == "sentry_table3"
-        assert meta["fields"]["unique_span_domains"] == "string"
+        assert data[0]["unique.span_domains"] == "sentry_table1"
+        assert data[1]["unique.span_domains"] == "sentry_table2"
+        assert data[2]["unique.span_domains"] == "sentry_table3"
+        assert meta["fields"]["unique.span_domains"] == "string"
 
     def test_unique_values_span_domain_with_filter(self):
         self.store_span_metric(
@@ -789,9 +789,9 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         )
         response = self.do_request(
             {
-                "field": ["unique_span_domains", "count()"],
+                "field": ["unique.span_domains", "count()"],
                 "query": "span.domain_array:sentry_tab*",
-                "orderby": "unique_span_domains",
+                "orderby": "unique.span_domains",
                 "project": self.project.id,
                 "dataset": "spansMetrics",
             }
@@ -800,9 +800,9 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 2
-        assert data[0]["unique_span_domains"] == "sentry_table2"
-        assert data[1]["unique_span_domains"] == "sentry_table3"
-        assert meta["fields"]["unique_span_domains"] == "string"
+        assert data[0]["unique.span_domains"] == "sentry_table2"
+        assert data[1]["unique.span_domains"] == "sentry_table3"
+        assert meta["fields"]["unique.span_domains"] == "string"
 
 
 @region_silo_test


### PR DESCRIPTION
- This needs to be a new field alias since we need to group on it
- While this column will return all the possible span domain values, it must be filtered with the span.domain_array (which will become the span.domain) field instead