### PR TITLE
fix(issues): Hide setup release CTA in issue list for multi select

### DIFF
--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -184,4 +184,23 @@ describe('ResolveActions', function () {
     await userEvent.click(screen.getByLabelText('More resolve options'));
     expect(screen.getByText('Resolving is better with Releases')).toBeInTheDocument();
   });
+
+  it('does not prompt to setup releases when multiple projects are selected', async function () {
+    render(
+      <ResolveActions
+        onUpdate={spy}
+        hasRelease={false}
+        projectSlug="proj-1"
+        multipleProjectsSelected
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('More resolve options'));
+    expect(
+      screen.getByRole('menuitemradio', {name: 'The current release'})
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Resolving is better with Releases')
+    ).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -59,6 +59,7 @@ export interface ResolveActionsProps {
   isAutoResolved?: boolean;
   isResolved?: boolean;
   latestRelease?: Project['latestRelease'];
+  multipleProjectsSelected?: boolean;
   priority?: 'primary';
   projectFetchError?: boolean;
   projectSlug?: string;
@@ -80,6 +81,7 @@ function ResolveActions({
   disableDropdown,
   priority,
   projectFetchError,
+  multipleProjectsSelected,
   onUpdate,
 }: ResolveActionsProps) {
   const organization = useOrganization();
@@ -171,7 +173,8 @@ function ResolveActions({
       return renderResolved();
     }
 
-    const actionTitle = !hasRelease
+    const shouldDisplayCta = !hasRelease && !multipleProjectsSelected;
+    const actionTitle = shouldDisplayCta
       ? t('Set up release tracking in order to use this feature.')
       : '';
 
@@ -220,7 +223,7 @@ function ResolveActions({
 
     return (
       <StyledDropdownMenu
-        itemsHidden={!hasRelease}
+        itemsHidden={shouldDisplayCta}
         items={items}
         trigger={triggerProps => (
           <DropdownTrigger
@@ -233,11 +236,13 @@ function ResolveActions({
           />
         )}
         disabledKeys={
-          disabled || !hasRelease
+          multipleProjectsSelected
+            ? ['next-release', 'current-release', 'another-release', 'a-commit']
+            : disabled || !hasRelease
             ? ['next-release', 'current-release', 'another-release']
             : []
         }
-        menuTitle={hasRelease ? t('Resolved In') : <SetupReleasesPrompt />}
+        menuTitle={shouldDisplayCta ? <SetupReleasesPrompt /> : t('Resolved In')}
         isDisabled={isDisabled}
       />
     );

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -252,6 +252,8 @@ function ActionSet({
           anySelected={anySelected}
           params={{
             hasRelease: false,
+            multipleProjectsSelected: true,
+            disabled: true,
             confirm,
             label,
           }}

--- a/static/app/views/issueList/actions/resolveActions.tsx
+++ b/static/app/views/issueList/actions/resolveActions.tsx
@@ -8,7 +8,12 @@ type Props = {
   onUpdate: (data?: any) => void;
   params: Pick<
     ResolveActionsProps,
-    'disabled' | 'hasRelease' | 'latestRelease' | 'projectSlug' | 'projectFetchError'
+    | 'disabled'
+    | 'hasRelease'
+    | 'latestRelease'
+    | 'projectSlug'
+    | 'projectFetchError'
+    | 'multipleProjectsSelected'
   > & {
     confirm: ReturnType<typeof getConfirm>;
     label: ReturnType<typeof getLabel>;
@@ -24,6 +29,7 @@ function ResolveActionsContainer({
 }: Props) {
   const {
     hasRelease,
+    multipleProjectsSelected,
     latestRelease,
     projectSlug,
     confirm,
@@ -42,6 +48,7 @@ function ResolveActionsContainer({
   return (
     <ResolveActions
       hasRelease={hasRelease}
+      multipleProjectsSelected={multipleProjectsSelected}
       latestRelease={latestRelease}
       projectSlug={projectSlug}
       onUpdate={onUpdate}


### PR DESCRIPTION
We don't allow resolving in releases across multiple projects in the issues list. We should not show the CTA to setup releases

fixes #56565