### PR TITLE
deps(ui): Bump eslint rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "benchmark": "^2.1.4",
     "eslint": "8.49.0",
-    "eslint-config-sentry-app": "1.124.0",
+    "eslint-config-sentry-app": "1.125.0",
     "html-webpack-plugin": "^5.5.0",
     "jest": "29.6.2",
     "jest-canvas-mock": "^2.5.2",

--- a/static/app/utils/highlightFuseMatches.spec.tsx
+++ b/static/app/utils/highlightFuseMatches.spec.tsx
@@ -51,12 +51,10 @@ describe('highlightFuseMatches', function () {
   });
 
   it('renders a highlighted string', function () {
-    // eslint-disable-next-line sentry/no-to-match-snapshot
     expect(highlightFuseMatches(matchObj)).toMatchSnapshot();
   });
 
   it('matches whole word', function () {
-    // eslint-disable-next-line sentry/no-to-match-snapshot
     expect(highlightFuseMatches({value: 'foo', indices: [[0, 2]]})).toMatchSnapshot();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5625,17 +5625,17 @@ eslint-config-prettier@^9.0.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz#eb25485946dd0c66cd216a46232dc05451518d1f"
   integrity sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==
 
-eslint-config-sentry-app@1.124.0:
-  version "1.124.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-1.124.0.tgz#3158f07d7cd7e323ad387a69805715b4762edd5e"
-  integrity sha512-zdfAgC25hoBF9kUArUb2SqOdEiTpwi0zQDoM9dPU0/e7lcmAcIVRB4uC+UE3qdPZNkeGe6jg5ibCRLuN6qhWpw==
+eslint-config-sentry-app@1.125.0:
+  version "1.125.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-1.125.0.tgz#8e06b1af03b05eee57a845e515af991d16773578"
+  integrity sha512-p4rALvCO0atcckSIWme/r8tpZO5g4MMFRJ8B+Xk5ry5juijb9j23XwReoUSNrpsbsDFZ1IahF5W9U2Ktyham7g==
   dependencies:
     "@emotion/eslint-plugin" "^11.11.0"
     "@typescript-eslint/eslint-plugin" "^6.7.0"
     "@typescript-eslint/parser" "^6.7.0"
     eslint-config-prettier "^9.0.0"
-    eslint-config-sentry "^1.124.0"
-    eslint-config-sentry-react "^1.124.0"
+    eslint-config-sentry "^1.125.0"
+    eslint-config-sentry-react "^1.125.0"
     eslint-import-resolver-typescript "^2.7.1"
     eslint-import-resolver-webpack "^0.13.7"
     eslint-plugin-import "^2.28.1"
@@ -5643,24 +5643,24 @@ eslint-config-sentry-app@1.124.0:
     eslint-plugin-no-lookahead-lookbehind-regexp "0.1.0"
     eslint-plugin-prettier "^5.0.0"
     eslint-plugin-react "^7.33.2"
-    eslint-plugin-sentry "^1.124.0"
+    eslint-plugin-sentry "^1.125.0"
     eslint-plugin-simple-import-sort "^10.0.0"
 
-eslint-config-sentry-react@^1.124.0:
-  version "1.124.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.124.0.tgz#d47fc987d1ec3b05938b2ba9e7ff123dc6c308ce"
-  integrity sha512-uLSwq1CAPms6/Z44dOzZoJYSgQo29qAW96zSwGHZzm5nkYPV0fTuSEYigQnNrnCt+hZ2FJm/3nyXddIZeJ1uXw==
+eslint-config-sentry-react@^1.125.0:
+  version "1.125.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.125.0.tgz#f64832efa75dfc2ea4c1f0ff4458b3e9b8c093b0"
+  integrity sha512-Cm+U1LYK/pBiF6i61XS15Pxb57JMLX7A9PZaB9iNHJjseOF33SznTOojkbflffZDOfC3olZ3vZLrJD8EdXypvQ==
   dependencies:
-    eslint-config-sentry "^1.124.0"
+    eslint-config-sentry "^1.125.0"
     eslint-plugin-jest-dom "^5.1.0"
     eslint-plugin-react-hooks "^4.6.0"
     eslint-plugin-testing-library "^6.0.1"
     eslint-plugin-typescript-sort-keys "^3.0.0"
 
-eslint-config-sentry@^1.124.0:
-  version "1.124.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.124.0.tgz#8024d37ff31469e4a412beda4493f1ee3cc736e1"
-  integrity sha512-FrqibjQki+Ag/wJd4mgmcoB0TCJzASvwz8sj0Rn1Vi/3wXwdQ2Lsqh+8yAr2vB0PGdJOYnXBb3xAoRUKhHAnbg==
+eslint-config-sentry@^1.125.0:
+  version "1.125.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.125.0.tgz#1f1058cb9ad20cce36f5d09d14c4fc1028579678"
+  integrity sha512-kH0oJ411Q9QUwXrQDwGoD9ogrDXahmW/znSIrbGOHi4AcW4C36wu3Yj/TmjgG59dnrGkqdzGejvYcgGZOfldEA==
 
 eslint-import-resolver-node@^0.3.7:
   version "0.3.7"
@@ -5787,10 +5787,10 @@ eslint-plugin-react@^7.33.2:
     semver "^6.3.1"
     string.prototype.matchall "^4.0.8"
 
-eslint-plugin-sentry@^1.124.0:
-  version "1.124.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-1.124.0.tgz#60174df3d7cbbee6d2500fd76016211d6ffd190e"
-  integrity sha512-b+RvkVRSi/43Mpq9SRNG0RZhx+IGkTJJBuMXFcrSlkHSyRM0j/ZOz86uvJf/ND37c/8BYIfHIHrJTrDBk2fSuA==
+eslint-plugin-sentry@^1.125.0:
+  version "1.125.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-1.125.0.tgz#ba938804718dbaf908215a920f0c6213616642a7"
+  integrity sha512-e+NPGsJ3Ml0rkhAkbQexBwtCho97MMJmafgvrjEeb5fws1OCgNB7YEC3ahcidPDGnpik+KRUiZG2P5MgC3Oavg==
   dependencies:
     requireindex "~1.2.0"
 


### PR DESCRIPTION
removes the toSnapshot lint rule see https://github.com/getsentry/eslint-config-sentry/pull/189
