### PR TITLE
ref(crons): Slugfiy provided slug in API ingestion

### DIFF
--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from django.utils.text import slugify
 from rest_framework.request import Request
 
 from sentry.api.authentication import (
@@ -16,7 +17,7 @@ from sentry.api.bases.project import ProjectPermission
 from sentry.api.exceptions import ParameterValidationError, ResourceDoesNotExist
 from sentry.constants import ObjectStatus
 from sentry.models import Organization, Project, ProjectKey
-from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn
+from sentry.monitors.models import MAX_SLUG_LENGTH, CheckInStatus, Monitor, MonitorCheckIn
 from sentry.utils.sdk import bind_organization_context, configure_scope
 
 
@@ -138,6 +139,7 @@ class MonitorIngestEndpoint(Endpoint):
         *args,
         **kwargs,
     ):
+        monitor_slug = slugify(monitor_slug)[:MAX_SLUG_LENGTH].strip("-")
         monitor = None
 
         # Include monitor_slug in kwargs when upsert is enabled

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -462,6 +462,15 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
 
         assert resp.status_code == 404
 
+    def test_invalid_slug_transform(self):
+        monitor = self._create_monitor()
+
+        # Add trailing `_` to the slug, making the slug invalid. We expect the
+        # slug to be trimmed, whcih is the same behavior the consumer has.
+        path = reverse(self.endpoint_with_org, args=[self.organization.slug, f"{monitor.slug}_"])
+        resp = self.client.post(path, {"status": "ok"}, **self.token_auth_headers)
+        assert resp.status_code == 201
+
     def test_with_dsn_and_missing_monitor_without_create(self):
         path = reverse(self.endpoint, args=["my-missing-monitor"])
         resp = self.client.post(path, {"status": "ok"}, **self.dsn_auth_headers)


### PR DESCRIPTION
Previously the API would validate slugs and require them to be correct.
With this change we're bringing the API inline with the monitor consumer
where check-in slugs are automatically slugified.