### PR TITLE
feat(tasks): Create new queue for auto-resolve-issues tasks

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -895,6 +895,7 @@ CELERY_QUEUES_REGION = [
     Queue("profiling.statistical_detector", routing_key="profiling.statistical_detector"),
     CELERY_ISSUE_STATES_QUEUE,
     Queue("nudge.invite_missing_org_members", routing_key="invite_missing_org_members"),
+    Queue("auto_resolve_issues", routing_key="auto_resolve_issues"),
 ]
 
 from celery.schedules import crontab


### PR DESCRIPTION
## Objective:

Currently all auto-resolve-issues and auto-transition-issue-states tasks are in the same queue. However, they have different message rates and different worker auto-scaling needs. 

This is the first PR to migrate the auto-resolve-issues tasks to a separate queue. This PR create the queue.