### PR TITLE
feat(rules): Add analytics when a rule is re-enabled

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -61,6 +61,7 @@ from .release_get_previous_commits import *  # noqa: F401,F403
 from .release_set_commits import *  # noqa: F401,F403
 from .repo_linked import *  # noqa: F401,F403
 from .rule_disable_opt_out import *  # noqa: F401,F403
+from .rule_reenable import *  # noqa: F401,F403
 from .rule_snooze import *  # noqa: F401,F403
 from .search_saved import *  # noqa: F401,F403
 from .second_platform_added import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/rule_reenable.py
+++ b/src/sentry/analytics/events/rule_reenable.py
@@ -1,0 +1,15 @@
+from sentry import analytics
+
+
+class RuleReenable(analytics.Event):
+    """Re-enable a rule that was disabled"""
+
+    type = "rule.reenable"
+    attributes = (
+        analytics.Attribute("rule_id"),
+        analytics.Attribute("user_id"),
+        analytics.Attribute("organization_id"),
+    )
+
+
+analytics.register(RuleReenable)

--- a/src/sentry/api/endpoints/project_rule_enable.py
+++ b/src/sentry/api/endpoints/project_rule_enable.py
@@ -2,7 +2,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import audit_log
+from sentry import analytics, audit_log
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -60,5 +60,11 @@ class ProjectRuleEnableEndpoint(ProjectEndpoint):
             target_object=rule.id,
             event=audit_log.get_event_id("RULE_EDIT"),
             data=rule.get_audit_log_data(),
+        )
+        analytics.record(
+            "rule.reenable",
+            rule_id=rule.id,
+            user_id=request.user.id,
+            organization_id=project.organization.id,
         )
         return Response(status=202)


### PR DESCRIPTION
When a user re-enables a rule that was disabled, add an analytics event.

Closes #56198 (I added the opt out ones in another PR)