### PR TITLE
chore(tests): Add requires snuba to tests/sentry_plugins/

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -921,6 +921,7 @@ class PermissionTestCase(TestCase):
         self.assert_cannot_access(user, path, **kwargs)
 
 
+@requires_snuba
 class PluginTestCase(TestCase):
     @property
     def plugin(self):


### PR DESCRIPTION
Ran this locally with and without snuba running, some tests still ran in both states, everything passed with snuba enabled and skipped without snuba running, so seems like a reasonable approach.