### PR TITLE
ref(crons): Make platform logos larger

### DIFF
--- a/static/app/views/monitors/components/platformPickerPanel.tsx
+++ b/static/app/views/monitors/components/platformPickerPanel.tsx
@@ -90,9 +90,9 @@ const Actions = styled('div')`
 `;
 
 const PlatformButton = styled(Button)`
-  width: 64px;
-  height: 64px;
-  padding: ${space(1)};
+  width: 80px;
+  height: 80px;
+  padding: ${space(1.5)};
 `;
 
 const PlatformOption = styled('div')`


### PR DESCRIPTION
**Before ——**
<img width="503" alt="Screenshot 2023-09-20 at 4 46 48 PM" src="https://github.com/getsentry/sentry/assets/44172267/2d53de70-3019-4e96-97d8-27f18d97a05e">


**After ——**
<img width="503" alt="Screenshot 2023-09-20 at 4 46 27 PM" src="https://github.com/getsentry/sentry/assets/44172267/2c965c67-ca58-4018-a20d-24e237abc069">
