### PR TITLE
ref(crons): Set 1.0 sample rate for mark_environment_missing

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -128,6 +128,7 @@ SAMPLED_TASKS = {
     "sentry.tasks.derive_code_mappings.process_organizations": settings.SAMPLED_DEFAULT_RATE,
     "sentry.tasks.derive_code_mappings.derive_code_mappings": settings.SAMPLED_DEFAULT_RATE,
     "sentry.monitors.tasks.check_missing": 1.0,
+    "sentry.monitors.tasks.mark_environment_missing": 1.0,
     "sentry.monitors.tasks.check_timeout": 1.0,
     "sentry.monitors.tasks.clock_pulse": 1.0,
     "sentry.tasks.auto_enable_codecov": settings.SAMPLED_DEFAULT_RATE,


### PR DESCRIPTION
Not sure if we want to do this, this might actually be a little TOO MUCH stuff