### PR TITLE
docs(api): Sort path+body+body params by required

### DIFF
--- a/src/sentry/apidocs/api_ownership_stats_dont_modify.json
+++ b/src/sentry/apidocs/api_ownership_stats_dont_modify.json
@@ -231,12 +231,6 @@
             "MetricRuleSnoozeEndpoint::DELETE",
             "MetricRuleSnoozeEndpoint::POST",
             "MsTeamsWebhookEndpoint::POST",
-            "NotificationActionsAvailableEndpoint::GET",
-            "NotificationActionsDetailsEndpoint::DELETE",
-            "NotificationActionsDetailsEndpoint::GET",
-            "NotificationActionsDetailsEndpoint::PUT",
-            "NotificationActionsIndexEndpoint::GET",
-            "NotificationActionsIndexEndpoint::POST",
             "OAuthUserInfoEndpoint::GET",
             "OrganizationAccessRequestDetailsEndpoint::GET",
             "OrganizationAccessRequestDetailsEndpoint::PUT",
@@ -301,7 +295,6 @@
             "OrganizationMemberTeamDetailsEndpoint::GET",
             "OrganizationMemberTeamDetailsEndpoint::PUT",
             "OrganizationMemberUnreleasedCommitsEndpoint::GET",
-            "OrganizationMissingMembersEndpoint::GET",
             "OrganizationMonitorIndexStatsEndpoint::GET",
             "OrganizationMonitorStatsEndpoint::GET",
             "OrganizationOnboardingTaskEndpoint::POST",
@@ -560,7 +553,7 @@
         ]
     },
     "owners-native": {
-        "block_start": 562,
+        "block_start": 555,
         "public": [],
         "private": [],
         "experimental": [],
@@ -575,7 +568,7 @@
         ]
     },
     "performance": {
-        "block_start": 577,
+        "block_start": 570,
         "public": [
             "OrganizationEventsEndpoint::GET"
         ],
@@ -630,7 +623,7 @@
         ]
     },
     "discover-n-dashboards": {
-        "block_start": 632,
+        "block_start": 625,
         "public": [],
         "private": [],
         "experimental": [],
@@ -645,7 +638,7 @@
         ]
     },
     "enterprise": {
-        "block_start": 647,
+        "block_start": 640,
         "public": [
             "OrganizationSCIMMemberDetails::DELETE",
             "OrganizationSCIMMemberDetails::GET",
@@ -664,7 +657,18 @@
             "ReleaseThresholdEndpoint::GET",
             "ReleaseThresholdEndpoint::POST"
         ],
-        "experimental": [],
+        "experimental": [
+            "NotificationActionsAvailableEndpoint::GET",
+            "NotificationActionsDetailsEndpoint::DELETE",
+            "NotificationActionsDetailsEndpoint::GET",
+            "NotificationActionsDetailsEndpoint::PUT",
+            "NotificationActionsIndexEndpoint::GET",
+            "NotificationActionsIndexEndpoint::POST",
+            "OrganizationAuditLogsEndpoint::GET",
+            "OrganizationMissingMembersEndpoint::GET",
+            "OrganizationSCIMMemberDetails::PUT",
+            "OrganizationSCIMTeamDetails::PUT"
+        ],
         "unknown": [
             "ApiAuthorizationsEndpoint::DELETE",
             "ApiAuthorizationsEndpoint::GET",
@@ -680,15 +684,12 @@
             "OrgAuthTokenDetailsEndpoint::PUT",
             "OrgAuthTokensEndpoint::GET",
             "OrgAuthTokensEndpoint::POST",
-            "OrganizationAuditLogsEndpoint::GET",
             "OrganizationAuthProviderDetailsEndpoint::GET",
             "OrganizationAuthProviderSendRemindersEndpoint::POST",
             "OrganizationAuthProvidersEndpoint::GET",
             "OrganizationIntegrationMigrateOpsgenieEndpoint::PUT",
             "OrganizationProjectsExperimentEndpoint::POST",
-            "OrganizationSCIMMemberDetails::PUT",
             "OrganizationSCIMSchemaIndex::GET",
-            "OrganizationSCIMTeamDetails::PUT",
             "OrganizationStatsEndpoint::GET",
             "UserAuthenticatorDetailsEndpoint::DELETE",
             "UserAuthenticatorDetailsEndpoint::GET",
@@ -704,10 +705,12 @@
         ]
     },
     "telemetry-experience": {
-        "block_start": 706,
+        "block_start": 707,
         "public": [],
         "private": [],
-        "experimental": [],
+        "experimental": [
+            "CustomRulesEndpoint::POST"
+        ],
         "unknown": [
             "OrganizationMetricDetailsEndpoint::GET",
             "OrganizationMetricsDataEndpoint::GET",
@@ -721,7 +724,7 @@
         ]
     },
     "team-starfish": {
-        "block_start": 723,
+        "block_start": 726,
         "public": [],
         "private": [],
         "experimental": [],
@@ -731,7 +734,7 @@
         ]
     },
     "growth": {
-        "block_start": 733,
+        "block_start": 736,
         "public": [],
         "private": [],
         "experimental": [],
@@ -740,7 +743,7 @@
         ]
     },
     "feedback-backend": {
-        "block_start": 742,
+        "block_start": 745,
         "public": [],
         "private": [],
         "experimental": [
@@ -751,7 +754,7 @@
         "unknown": []
     },
     "replay-backend": {
-        "block_start": 753,
+        "block_start": 756,
         "public": [],
         "private": [],
         "experimental": [],
@@ -760,7 +763,7 @@
         ]
     },
     "profiling": {
-        "block_start": 762,
+        "block_start": 765,
         "public": [],
         "private": [],
         "experimental": [],
@@ -776,7 +779,7 @@
         ]
     },
     "team-web-sdk-frontend": {
-        "block_start": 778,
+        "block_start": 781,
         "public": [],
         "private": [
             "SourceMapDebugBlueThunderEditionEndpoint::GET"
@@ -785,7 +788,7 @@
         "unknown": []
     },
     "hybrid-cloud": {
-        "block_start": 787,
+        "block_start": 790,
         "public": [],
         "private": [],
         "experimental": [],

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -236,7 +236,6 @@ def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> An
                     raise SentryApiBuildError(
                         f"Unable to parse body parameters due to KeyError {e} for endpoint {endpoint_name}. Please reach out to Enterprise team to fix."
                     )
-
     return result
 
 

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -234,7 +234,7 @@ def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> An
                         )
                 except KeyError as e:
                     raise SentryApiBuildError(
-                        f"Unable to parse body parameters due to KeyError {e} for endpoint {endpoint_name}. Please reach out to Enterprise team to fix."
+                        f"Unable to parse body parameters due to KeyError {e} for endpoint {endpoint_name}. Please post in #discuss-apis to fix."
                     )
     return result
 

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -1,5 +1,6 @@
 import json  # noqa: S003
 import os
+from collections import OrderedDict
 from typing import Any, Dict, List, Literal, Mapping, Set, Tuple, TypedDict
 
 from sentry.api.api_owners import ApiOwner
@@ -197,16 +198,43 @@ def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> An
     for path, endpoints in result["paths"].items():
         for method_info in endpoints.values():
             _check_tag(path, method_info)
+            endpoint_name = f"'{method_info['operationId']}'"
 
             if method_info.get("description") is None:
                 raise SentryApiBuildError(
-                    "Please add a description to your endpoint method via a docstring"
+                    f"Please add a description via docstring to your endpoint {endpoint_name}"
                 )
-            # ensure path parameters have a description
+
             for param in method_info.get("parameters", []):
+                # Ensure path parameters have a description
                 if param["in"] == "path" and param.get("description") is None:
                     raise SentryApiBuildError(
-                        f"Please add a description to your path parameter '{param['name']}'"
+                        f"Please add a description to your path parameter '{param['name']}' for endpoint {endpoint_name}"
+                    )
+
+            # Ensure body parameters are sorted by placing required parameters first
+            if "requestBody" in method_info:
+                try:
+                    content = method_info["requestBody"]["content"]
+                    # media type can either "multipart/form-data" or "application/json"
+                    if "multipart/form-data" in content:
+                        schema = content["multipart/form-data"]["schema"]
+                    else:
+                        schema = content["application/json"]["schema"]
+
+                    # Required params are stored in a list and not in the param itself
+                    required = set(schema.get("required", []))
+                    if required:
+                        # Explicitly sort body params by converting the dict to an ordered dict
+                        schema["properties"] = OrderedDict(
+                            sorted(
+                                schema["properties"].items(),
+                                key=lambda param: 0 if param[0] in required else 1,
+                            )
+                        )
+                except KeyError as e:
+                    raise SentryApiBuildError(
+                        f"Unable to parse body parameters due to KeyError {e} for endpoint {endpoint_name}. Please reach out to Enterprise team to fix."
                     )
 
     return result

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1319,7 +1319,7 @@ REST_FRAMEWORK = {
 }
 
 
-def custom_parameter_sort(parameter: dict) -> tuple(str, str):
+def custom_parameter_sort(parameter: dict) -> tuple[str, int]:
     """
     Sort parameters by type then if the parameter is required or not.
     It should group path parameters first, then query parameters.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1319,6 +1319,17 @@ REST_FRAMEWORK = {
 }
 
 
+def custom_parameter_sort(parameter: dict) -> tuple(str, str):
+    """
+    Sort parameters by type then if the parameter is required or not.
+    It should group path parameters first, then query parameters.
+    In each group, required parameters should come before optional parameters.
+    """
+    param_type = parameter["in"]
+    required = parameter.get("required", False)
+    return (param_type, 0 if required else 1)
+
+
 if os.environ.get("OPENAPIGENERATE", False):
     OLD_OPENAPI_JSON_PATH = "tests/apidocs/openapi-deprecated.json"
     from sentry.apidocs.build import OPENAPI_TAGS, get_old_json_components, get_old_json_paths
@@ -1341,7 +1352,7 @@ if os.environ.get("OPENAPIGENERATE", False):
         "PARSER_WHITELIST": ["rest_framework.parsers.JSONParser"],
         "APPEND_PATHS": get_old_json_paths(OLD_OPENAPI_JSON_PATH),
         "APPEND_COMPONENTS": get_old_json_components(OLD_OPENAPI_JSON_PATH),
-        "SORT_OPERATION_PARAMETERS": False,
+        "SORT_OPERATION_PARAMETERS": custom_parameter_sort,
     }
 
 CRISPY_TEMPLATE_PACK = "bootstrap3"


### PR DESCRIPTION
## Summary
Before we allowed parameters to come in any order, but we now order them by placing required params first. We can easily due this with `path`+`query` params using drf-spec, but `body` params are stored as a dictionary with implicit ordering due to python dicts now having ordering in 3.6+. 

To get around this, we parse the `body` params in the postprocess hook and explicitly order by converting it to an OrderedDict, placing required params at the front.

Note that other than required parameters, the ordering remains the same as specified in `@extend_schema` decorator. For `path`+`query` params, this the order of the `parameters` list kwarg. For `body` params, this is the order of the serializer fields that are specified in the serializer that is passed to the `request` kwarg

## Body Params
Nothing is modified by the `body` params change

## Path+Query Params
The endpoints that are modified by sorting `path`+`query` params are:
1. [Retrieve Event Counts for an Organization (v2)](https://docs.sentry.io/api/organizations/retrieve-event-counts-for-an-organization-v2/) - `groupBy` & `field` are required
### Before
<img width="422" alt="Screenshot 2023-09-21 at 12 46 34 AM" src="https://github.com/getsentry/sentry/assets/67301797/c7c5fca4-4304-4f18-8c12-2440fdd685aa">

### After
<img width="430" alt="Screenshot 2023-09-21 at 12 53 23 AM" src="https://github.com/getsentry/sentry/assets/67301797/d8892698-df6e-4da8-9ee6-45b519e81ac3">

3. [Query Discover Events in Table Format](https://docs.sentry.io/api/discover/query-discover-events-in-table-format/) - `field` is required
### Before
<img width="431" alt="Screenshot 2023-09-21 at 12 47 01 AM" src="https://github.com/getsentry/sentry/assets/67301797/5090276c-f637-4891-9aa7-0f7754595960">

### After
<img width="429" alt="Screenshot 2023-09-21 at 12 52 34 AM" src="https://github.com/getsentry/sentry/assets/67301797/dba3e0e7-7794-4fc0-9aea-43e5d3829b12">