### PR TITLE
Handle FileBlob creation races

### DIFF
--- a/src/sentry/models/files/abstractfileblob.py
+++ b/src/sentry/models/files/abstractfileblob.py
@@ -109,6 +109,8 @@ class AbstractFileBlob(Model):
                 # with this checksum. we will fetch the other blob that was
                 # saved, and delete our backing storage to not leave orphaned
                 # chunks behind.
+                # we also won't have to worry about concurrent deletes, as deletions
+                # are only happening for blobs older than 24h.
                 metrics.incr("filestore.upload_race", sample_rate=1.0)
                 saved_path = blob.path
                 blob = cls.objects.get(checksum=blob.checksum)

--- a/src/sentry/models/files/abstractfileblob.py
+++ b/src/sentry/models/files/abstractfileblob.py
@@ -210,7 +210,7 @@ class AbstractFileBlob(Model):
                 # see `_save_blob` above
                 metrics.incr("filestore.upload_race", sample_rate=1.0)
                 saved_path = blob.path
-                blob = cls.objects.get(checksum=checksum)
+                blob = cls.objects.get(checksum=checksum)  # type:ignore
                 storage.delete(saved_path)
 
         metrics.timing("filestore.blob-size", size)

--- a/src/sentry/models/files/abstractfileblob.py
+++ b/src/sentry/models/files/abstractfileblob.py
@@ -102,7 +102,19 @@ class AbstractFileBlob(Model):
 
         def _save_blob(blob):
             logger.debug("FileBlob.from_files._save_blob.start", extra={"path": blob.path})
-            blob.save()
+            try:
+                blob.save()
+            except IntegrityError:
+                # this means that there was a race inserting a blob
+                # with this checksum. we will fetch the other blob that was
+                # saved, and delete our backing storage to not leave orphaned
+                # chunks behind.
+                metrics.incr("filestore.upload_race", sample_rate=1.0)
+                saved_path = blob.path
+                blob = cls.objects.get(checksum=blob.checksum)
+                storage = get_storage(cls._storage_config())
+                storage.delete(saved_path)
+
             _ensure_blob_owned(blob)
             logger.debug("FileBlob.from_files._save_blob.end", extra={"path": blob.path})
 
@@ -192,7 +204,14 @@ class AbstractFileBlob(Model):
             blob.path = cls.generate_unique_path()
             storage = get_storage(cls._storage_config())
             storage.save(blob.path, fileobj)
-            blob.save()
+            try:
+                blob.save()
+            except IntegrityError:
+                # see `_save_blob` above
+                metrics.incr("filestore.upload_race", sample_rate=1.0)
+                saved_path = blob.path
+                blob = cls.objects.get(checksum=checksum)
+                storage.delete(saved_path)
 
         metrics.timing("filestore.blob-size", size)
         logger.debug("FileBlob.from_file.end")


### PR DESCRIPTION
Currently we have a very heavy lock around file uploads, and the idea is to make file creation itself more resilient to races to potentially avoid that lock.