### PR TITLE
Unify FileBlob locking

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -287,6 +287,9 @@ register("filestore.options", default={"location": "/tmp/sentry-files"}, flags=F
 register("filestore.control.backend", default="", flags=FLAG_NOSTORE)
 register("filestore.control.options", default={}, flags=FLAG_NOSTORE)
 
+# Whether to use a redis lock on fileblob uploads and deletes
+register("fileblob.upload.use_lock", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Symbol server
 register(
     "symbolserver.enabled",

--- a/src/sentry/tasks/files.py
+++ b/src/sentry/tasks/files.py
@@ -42,12 +42,10 @@ def delete_file_control(path, checksum, **kwargs):
 
 
 def delete_file(file_blob_model, path, checksum, **kwargs):
-    from sentry.locks import locks
-    from sentry.models.files import get_storage
-    from sentry.utils.retries import TimedRetryPolicy
+    from sentry.models.files.utils import get_storage, lock_blob
 
-    lock = locks.get(f"fileblob:upload:{checksum}", duration=60 * 10, name="fileblob_upload")
-    with TimedRetryPolicy(60)(lock.acquire):
+    lock = lock_blob(checksum, "fileblob_upload")
+    with lock:
         # check that the fileblob with *this* path exists, as its possible
         # that a concurrent re-upload added the same chunk once again, with a
         # different path that time


### PR DESCRIPTION
This moves all the FileBlob locking into one central function, and makes it configurable so we can turn it off completely.