### PR TITLE
feat(profiling): adds optional `fingerprint` query parameter to flamegraph endpoint.

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -18,6 +18,7 @@ from sentry.profiles.flamegraph import (
     get_profile_ids,
     get_profile_ids_for_span_op,
     get_profile_ids_with_spans,
+    get_profiles_with_function,
 )
 from sentry.profiles.utils import parse_profile_filters, proxy_profiling_service
 
@@ -96,7 +97,13 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
                 request.query_params.get("query", None),
             )
         else:
-            profile_ids = get_profile_ids(params, request.query_params.get("query", None))
+            if "fingerprint" in request.query_params:
+                function_fingerprint = request.query_params["fingerprint"]
+                profile_ids = get_profiles_with_function(
+                    organization.id, project_ids[0], function_fingerprint, params
+                )
+            else:
+                profile_ids = get_profile_ids(params, request.query_params.get("query", None))
 
         kwargs: Dict[str, Any] = {
             "method": "POST",

--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -96,14 +96,13 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
                 backend,
                 request.query_params.get("query", None),
             )
+        elif "fingerprint" in request.query_params:
+            function_fingerprint = int(request.query_params["fingerprint"])
+            profile_ids = get_profiles_with_function(
+                organization.id, project_ids[0], function_fingerprint, params
+            )
         else:
-            if "fingerprint" in request.query_params:
-                function_fingerprint = request.query_params["fingerprint"]
-                profile_ids = get_profiles_with_function(
-                    organization.id, project_ids[0], function_fingerprint, params
-                )
-            else:
-                profile_ids = get_profile_ids(params, request.query_params.get("query", None))
+            profile_ids = get_profile_ids(params, request.query_params.get("query", None))
 
         kwargs: Dict[str, Any] = {
             "method": "POST",

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -250,7 +250,7 @@ def get_profiles_with_function(
     query = Query(
         match=Entity(EntityKey.Functions.value),
         select=[
-            Function("groupUniqArrayMerge", [Column("examples")], "profile_ids"),
+            Function("groupUniqArrayMerge(100)", [Column("examples")], "profile_ids"),
         ],
         where=[
             Condition(Column("project_id"), Op.EQ, project_id),
@@ -273,4 +273,4 @@ def get_profiles_with_function(
         request,
         referrer=Referrer.API_PROFILING_FUNCTION_SCOPED_FLAMEGRAPH.value,
     )["data"]
-    return {"profile_ids": list(map(lambda x: x.replace("-", ""), data[0]["profile_ids"][:100]))}
+    return {"profile_ids": list(map(lambda x: x.replace("-", ""), data[0]["profile_ids"]))}

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -244,7 +244,7 @@ def get_profile_ids_for_span_op(
 def get_profiles_with_function(
     organization_id: int,
     project_id: int,
-    function_fingerprint: str,
+    function_fingerprint: int,
     params: ParamsType,
 ):
     query = Query(

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -34,3 +34,4 @@ class EntityKey(Enum):
     GenericMetricsCounters = "generic_metrics_counters"
     GenericOrgMetricsCounters = "generic_org_metrics_counters"
     IssuePlatform = "search_issues"
+    Functions = "functions"

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -333,6 +333,7 @@ class Referrer(Enum):
     API_PROFILING_PROFILE_SUMMARY_TABLE = "api.profiling.profile-summary-table"
     API_PROFILING_PROFILE_SUMMARY_FUNCTIONS_TABLE = "api.profiling.profile-summary-functions-table"
     API_PROFILING_PROFILE_FLAMEGRAPH = "api.profiling.profile-flamegraph"
+    API_PROFILING_FUNCTION_SCOPED_FLAMEGRAPH = "api.profiling.function-scoped-flamegraph"
     API_PROFILING_TRANSACTION_HOVERCARD_FUNCTIONS = "api.profiling.transaction-hovercard.functions"
     API_PROFILING_TRANSACTION_HOVERCARD_LATEST = "api.profiling.transaction-hovercard.latest"
     API_PROFILING_TRANSACTION_HOVERCARD_SLOWEST = "api.profiling.transaction-hovercard.slowest"


### PR DESCRIPTION
This let the endpoint user specify a function fingerprint so that the endpoint will return a flamegraph generated only with profiles that contain the function of interest.
