### PR TITLE
fix(span-clusterer): Fetch empty databag when None

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -203,7 +203,7 @@ def record_span_descriptions(
 def _get_span_description_to_store(span: Mapping[str, Any]) -> Optional[str]:
     if not span.get("op", "").startswith("http"):
         return None
-    data = span.get("data", {})
+    data = span.get("data") or {}
     return data.get("description.scrubbed") or span.get("description")
 
 
@@ -225,7 +225,7 @@ def _update_span_description_rule_lifetime(project: Project, event_data: Mapping
 
     spans = event_data.get("_meta", {}).get("spans", {})
     for span in spans.values():
-        data = span.get("data", {})
+        data = span.get("data") or {}
         applied_rule = data.get("description.scrubbed", {}).get("", {}).get("rem", [[]])[0]
         if not applied_rule:
             continue

--- a/tests/sentry/ingest/test_span_desc_clusterer.py
+++ b/tests/sentry/ingest/test_span_desc_clusterer.py
@@ -499,6 +499,26 @@ def test_dont_store_inexisting_rules(_, default_organization):
 
 
 @django_db_all
+def test_record_span_descriptions_no_databag(default_organization):
+    """Verify a `None` databag doesn't break the span description clusterer."""
+    with Feature("projects:span-metrics-extraction"), override_options(
+        {"span_descs.bump-lifetime-sample-rate": 1.0}
+    ):
+        payload = {
+            "spans": [
+                {
+                    "description": "GET a",
+                    "op": "http.client",
+                    "data": None,
+                }
+            ],
+        }
+
+        project = Project(id=123, name="project", organization_id=default_organization.id)
+        record_span_descriptions(project, payload)
+
+
+@django_db_all
 def test_stale_rules_arent_saved(default_project):
     assert len(get_sorted_rules(ClustererNamespace.SPANS, default_project)) == 0
 


### PR DESCRIPTION
Fixes https://sentry.sentry.io/issues/4478126940/?project=1&referrer=alerts-related-issues-issue-stream

This PR fixes an issue when a span's databag is explicitly `None`, and assumes an empty databag in these cases. The issue and the fix is the same as the example `b` below:

```shell
>>> d = {'a': 1, 'b': None}
>>> d
{'a': 1, 'b': None}
>>> d.get('a', 'default')
1
>>> d.get('c', 'default')
'default'
>>> d.get('b', 'default')
>>> d.get('b') or 'default'
'default'
```
