### PR TITLE
feat(perf): Allow more measurements on tags page

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -23,6 +23,10 @@ from sentry.utils.cursors import Cursor, CursorResult
 ALLOWED_AGGREGATE_COLUMNS = {
     "transaction.duration",
     "measurements.lcp",
+    "measurements.cls",
+    "measurements.fcp",
+    "measurements.fid",
+    "measurements.inp",
     "spans.browser",
     "spans.http",
     "spans.db",


### PR DESCRIPTION
This allows faceting by more measurements, since we need to find cls.source for cls measurements and fid.element (in the future) for fid elements.