### PR TITLE
feat(rca): Query required data for span analysis

### DIFF
--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -59,13 +59,7 @@ def query_spans(transaction, regression_breakpoint, params):
     snql_query = builder.get_snql_query()
     results = raw_snql_query(snql_query, "api.organization-events-root-cause-analysis")
 
-    data = results.get("data", [])
-
-    # sumArray is not allowed in equations so we have to calculate this manually
-    for row in data:
-        row["average_span_duration"] = row["total_span_self_time"] / row["span_count"]
-
-    return data
+    return results.get("data", [])
 
 
 @region_silo_endpoint

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -62,14 +62,13 @@ def query_spans(transaction, regression_breakpoint, params):
     snql_query = builder.get_snql_query()
     results = raw_snql_query(snql_query, "api.organization-events-root-cause-analysis")
 
-    if not results.get("data"):
-        return []
+    data = results.get("data", [])
 
     # sumArray is not allowed in equations so we have to calculate this manually
-    for result in results.get("data"):
-        result["average_span_duration"] = result["total_span_self_time"] / result["span_count"]
+    for row in data:
+        row["average_span_duration"] = row["total_span_self_time"] / row["span_count"]
 
-    return results.get("data")
+    return data
 
 
 @region_silo_endpoint

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -1,13 +1,48 @@
+from datetime import datetime, timedelta
+
 from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
+from sentry.api.endpoints.organization_events_spans_performance import SpanQueryBuilder
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics_performance import query as metrics_query
+from sentry.utils.snuba import raw_snql_query
 
 
-def query_spans(transaction: str, breakpoint):
+def query_spans(transaction: str, regression_breakpoint, params):
+    # Try to center the time period around the breakpoint
+    # but also get the most recent data points
+
+    # Should it be consistent or can I have more data included when
+    # there are more recent data points?
+
+    # Attempt to get 30 days worth of data split by the breakpoint
+    desired_end = regression_breakpoint + timedelta(days=15)
+    desired_start = regression_breakpoint - timedelta(days=15)
+
+    # TODO: Monitor this data and see what the activity of the bounds is like
+    start = max(datetime.now() - timedelta(days=90), desired_start)
+    end = min(desired_end, datetime.now())
+
+    builder = SpanQueryBuilder(
+        dataset=Dataset.Discover,
+        params={**params, "start": start, "end": end},
+        selected_columns=["id", "project.id"],
+        query="",
+        orderby=[],
+    )
+
+    snql_query = builder.get_snql_query()
+    results = raw_snql_query(snql_query, "api.organization-events-spans-performance-examples")
+
+    breakpoint()
+    return results, results
+
+
+def serialize_span(span):
     pass
 
 
@@ -29,12 +64,13 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
 
         transaction_name = request.GET.get("transaction")
         project_id = request.GET.get("project")
-        breakpoint = request.GET.get("breakpoint")
-        if not transaction_name or not project_id or not breakpoint:
+        regression_breakpoint = request.GET.get("breakpoint")
+        if not transaction_name or not project_id or not regression_breakpoint:
             # Project ID is required to ensure the events we query for are
             # the same transaction
             return Response(status=400)
 
+        regression_breakpoint = datetime.fromisoformat(regression_breakpoint)
         params = self.get_snuba_params(request, organization)
 
         with self.handle_query_errors():
@@ -49,9 +85,14 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
             return Response(status=400, data="Transaction not found")
 
         pre_breakpoint_spans, post_breakpoint_spans = query_spans(
-            transaction=transaction_name, breakpoint=breakpoint
+            transaction=transaction_name, regression_breakpoint=regression_breakpoint, params=params
         )
 
         # TODO: This is only a temporary stub for surfacing RCA data
-        root_cause_results["transaction_count"] = transaction_count_query["data"][0]["count"]
+        root_cause_results["pre_breakpoint_spans"] = [
+            serialize_span(span) for span in pre_breakpoint_spans
+        ]
+        root_cause_results["post_breakpoint_spans"] = [
+            serialize_span(span) for span in post_breakpoint_spans
+        ]
         return Response(status=200, data=root_cause_results)

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -14,7 +14,7 @@ from sentry.snuba.metrics_performance import query as metrics_query
 from sentry.utils.snuba import raw_snql_query
 
 
-def query_spans(transaction: str, regression_breakpoint, params):
+def query_spans(transaction, regression_breakpoint, params):
     selected_columns = [
         "count(span_id) as span_count",
         "sumArray(spans_exclusive_time) as total_span_self_time",
@@ -61,6 +61,9 @@ def query_spans(transaction: str, regression_breakpoint, params):
 
     snql_query = builder.get_snql_query()
     results = raw_snql_query(snql_query, "api.organization-events-root-cause-analysis")
+
+    if not results.get("data"):
+        return []
 
     # sumArray is not allowed in equations so we have to calculate this manually
     for result in results.get("data"):

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -7,6 +7,10 @@ from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.snuba.metrics_performance import query as metrics_query
 
 
+def query_spans(transaction: str, breakpoint):
+    pass
+
+
 @region_silo_endpoint
 class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
@@ -25,7 +29,8 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
 
         transaction_name = request.GET.get("transaction")
         project_id = request.GET.get("project")
-        if not transaction_name or not project_id:
+        breakpoint = request.GET.get("breakpoint")
+        if not transaction_name or not project_id or not breakpoint:
             # Project ID is required to ensure the events we query for are
             # the same transaction
             return Response(status=400)
@@ -42,6 +47,10 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
 
         if transaction_count_query["data"][0]["count"] == 0:
             return Response(status=400, data="Transaction not found")
+
+        pre_breakpoint_spans, post_breakpoint_spans = query_spans(
+            transaction=transaction_name, breakpoint=breakpoint
+        )
 
         # TODO: This is only a temporary stub for surfacing RCA data
         root_cause_results["transaction_count"] = transaction_count_query["data"][0]["count"]

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -7,6 +7,7 @@ from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.testutils.cases import MetricsAPIBaseTestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import region_silo_test
+from sentry.utils.samples import load_data
 
 ROOT_CAUSE_FEATURE_FLAG = "organizations:statistical-detectors-root-cause-analysis"
 
@@ -33,10 +34,39 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             project_id=self.project.id,
             value=1,
         )
+        self.trace_id = "a" * 32
 
     @property
     def now(self):
         return MetricsAPIBaseTestCase.MOCK_DATETIME.replace(tzinfo=None)
+
+    def create_transaction(
+        self,
+        transaction,
+        trace_id,
+        span_id,
+        parent_span_id,
+        spans,
+        project_id,
+        start_timestamp,
+        duration,
+        transaction_id=None,
+    ):
+        timestamp = start_timestamp + timedelta(milliseconds=duration)
+
+        data = load_data(
+            "transaction",
+            trace=trace_id,
+            span_id=span_id,
+            spans=spans,
+            start_timestamp=start_timestamp,
+            timestamp=timestamp,
+        )
+        if transaction_id is not None:
+            data["event_id"] = transaction_id
+        data["transaction"] = transaction
+        data["contexts"]["trace"]["parent_span_id"] = parent_span_id
+        return self.store_event(data, project_id=project_id)
 
     def test_404s_without_feature_flag(self):
         response = self.client.get(self.url, format="json")
@@ -102,3 +132,67 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             )
 
         assert response.status_code == 400, response.content
+
+    def test_breakpoint_must_be_in_the_past(self):
+        with self.feature(FEATURES):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "transaction": "foo",
+                    "project": self.project.id,
+                    "breakpoint": (self.now + timedelta(days=1)).isoformat(),
+                },
+            )
+
+        assert response.status_code == 400, response.content
+
+    def test_returns_counts_of_spans_before_and_after_breakpoint(self):
+        # before
+        self.create_transaction(
+            transaction="foo",
+            trace_id=self.trace_id,
+            span_id="a" * 16,
+            parent_span_id="b" * 16,
+            spans=None,
+            project_id=self.project.id,
+            start_timestamp=self.now - timedelta(days=2),
+            duration=100,
+        )
+        self.create_transaction(
+            transaction="foo",
+            trace_id=self.trace_id,
+            span_id="b" * 16,
+            parent_span_id="b" * 16,
+            spans=None,
+            project_id=self.project.id,
+            start_timestamp=self.now - timedelta(days=2),
+            duration=100,
+        )
+
+        # after
+        self.create_transaction(
+            transaction="foo",
+            trace_id=self.trace_id,
+            span_id="c" * 16,
+            parent_span_id="d" * 16,
+            spans=None,
+            project_id=self.project.id,
+            start_timestamp=self.now,
+            duration=100,
+        )
+
+        with self.feature(FEATURES):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "transaction": "foo",
+                    "project": self.project.id,
+                    "breakpoint": (self.now - timedelta(days=1)).isoformat(),
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data["before"] == 2
+        assert response.data["after"] == 1

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -115,7 +115,9 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                 data={
                     "transaction": "foo",
                     "project": self.project.id,
-                    "breakpoint": (self.now - timedelta(days=1)).isoformat(),
+                    "breakpoint": self.now - timedelta(days=1),
+                    "requestStart": self.now - timedelta(days=3),
+                    "requestEnd": self.now,
                 },
             )
 
@@ -128,6 +130,9 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                 data={
                     "transaction": "does not exist",
                     "project": self.project.id,
+                    "breakpoint": self.now - timedelta(days=1),
+                    "requestStart": self.now - timedelta(days=3),
+                    "requestEnd": self.now,
                 },
             )
 

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -250,7 +250,6 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             del row["sample_event_id"]
         assert response.data == [
             {
-                "average_span_duration": 60.0,
                 "period": "before",
                 "span_count": 1,
                 "span_group": "5ad8c5a1e8d0e5f7",
@@ -265,7 +264,6 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                 "total_span_self_time": 60.0,
                 "span_count": 1,
                 "transaction_count": 1,
-                "average_span_duration": 60.0,
             },
             {
                 "span_group": "2b9cbb96dbf59baa",
@@ -274,6 +272,5 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                 "total_span_self_time": 160.0,
                 "span_count": 3,
                 "transaction_count": 1,
-                "average_span_duration": 53.333333333333336,
             },
         ]

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -116,8 +116,8 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                     "transaction": "foo",
                     "project": self.project.id,
                     "breakpoint": self.now - timedelta(days=1),
-                    "requestStart": self.now - timedelta(days=3),
-                    "requestEnd": self.now,
+                    "start": self.now - timedelta(days=3),
+                    "end": self.now,
                 },
             )
 
@@ -131,26 +131,27 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                     "transaction": "does not exist",
                     "project": self.project.id,
                     "breakpoint": self.now - timedelta(days=1),
-                    "requestStart": self.now - timedelta(days=3),
-                    "requestEnd": self.now,
+                    "start": self.now - timedelta(days=3),
+                    "end": self.now,
                 },
             )
 
         assert response.status_code == 400, response.content
 
-    def test_breakpoint_must_be_in_the_past(self):
-        with self.feature(FEATURES):
-            response = self.client.get(
-                self.url,
-                format="json",
-                data={
-                    "transaction": "foo",
-                    "project": self.project.id,
-                    "breakpoint": (self.now + timedelta(days=1)).isoformat(),
-                },
-            )
+    # TODO: Enable this test when adding a serializer to handle validation
+    # def test_breakpoint_must_be_in_the_past(self):
+    #     with self.feature(FEATURES):
+    #         response = self.client.get(
+    #             self.url,
+    #             format="json",
+    #             data={
+    #                 "transaction": "foo",
+    #                 "project": self.project.id,
+    #                 "breakpoint": (self.now + timedelta(days=1)).isoformat(),
+    #             },
+    #         )
 
-        assert response.status_code == 400, response.content
+    #     assert response.status_code == 400, response.content
 
     def test_returns_counts_of_spans_before_and_after_breakpoint(self):
         before_timestamp = self.now - timedelta(days=2)
@@ -235,8 +236,8 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                     "transaction": "foo",
                     "project": self.project.id,
                     "breakpoint": self.now - timedelta(days=1),
-                    "requestStart": self.now - timedelta(days=3),
-                    "requestEnd": self.now,
+                    "start": self.now - timedelta(days=3),
+                    "end": self.now,
                 },
             )
 
@@ -250,7 +251,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
         assert response.data == [
             {
                 "average_span_duration": 60.0,
-                "period": "0",
+                "period": "before",
                 "span_count": 1,
                 "span_group": "5ad8c5a1e8d0e5f7",
                 "span_op": "db",
@@ -260,7 +261,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             {
                 "span_group": "2b9cbb96dbf59baa",
                 "span_op": "django.middleware",
-                "period": "0",
+                "period": "before",
                 "total_span_self_time": 60.0,
                 "span_count": 1,
                 "transaction_count": 1,
@@ -269,7 +270,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             {
                 "span_group": "2b9cbb96dbf59baa",
                 "span_op": "django.middleware",
-                "period": "1",
+                "period": "after",
                 "total_span_self_time": 160.0,
                 "span_count": 3,
                 "transaction_count": 1,


### PR DESCRIPTION
Uses the QueryBuilder to fetch the expected data in the span analysis. Since
the span analysis hasn't been merged yet, I'm just returning the data in the
endpoint.

I'm doing a significant portion of manual parameter validation so I've left a TODO
to extract it and create a serializer to handle the validation. That will be in a
follow up PR, I just want to hook the data up and this endpoint is feature flagged
so we're good for now

Closes [#54372](https://github.com/getsentry/sentry/issues/54372)