### PR TITLE
feat(starfish): Fixes chart colors and adds project icons next to page score rows

### DIFF
--- a/static/app/views/performance/browser/webVitals/pagePerformanceTables.tsx
+++ b/static/app/views/performance/browser/webVitals/pagePerformanceTables.tsx
@@ -3,6 +3,7 @@ import {Link} from 'react-router';
 import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
+import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {
   COL_WIDTH_UNDEFINED,
   GridColumnHeader,
@@ -73,6 +74,15 @@ export function PagePerformanceTables() {
       })}`;
       return (
         <NoOverflow>
+          {project && (
+            <StyledProjectAvatar
+              project={project}
+              direction="left"
+              size={16}
+              hasTooltip
+              tooltip={project.slug}
+            />
+          )}
           <Link to={link}>{row.transaction}</Link>
         </NoOverflow>
       );
@@ -151,6 +161,7 @@ const GridContainer = styled('div')`
 const NoOverflow = styled('span')`
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const AlignRight = styled('span')<{color?: string}>`
@@ -197,4 +208,10 @@ const GridDescription = styled('div')`
 const GridDescriptionHeader = styled('div')`
   font-weight: bold;
   color: ${p => p.theme.textColor};
+`;
+
+const StyledProjectAvatar = styled(ProjectAvatar)`
+  top: ${space(0.25)};
+  position: relative;
+  padding-right: ${space(1)};
 `;

--- a/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
+++ b/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
@@ -102,7 +102,7 @@ export function PerformanceScoreChart({projectScore, webVital}: Props) {
         <PerformanceScoreSubtext>{performanceScoreSubtext}</PerformanceScoreSubtext>
         <Chart
           stacked
-          height={160}
+          height={180}
           data={[
             {
               data: data?.lcp.map(({name, value}) => ({
@@ -167,6 +167,7 @@ export function PerformanceScoreChart({projectScore, webVital}: Props) {
             bottom: 0,
           }}
           dataMax={100}
+          chartColors={segmentColors}
         />
       </ChartContainer>
     </Flex>
@@ -211,6 +212,7 @@ const PerformanceScoreSubtext = styled('div')`
   width: 100%;
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.gray300};
+  margin-bottom: ${space(1)};
 `;
 
 const ProgressRingContainer = styled('div')``;

--- a/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
@@ -120,7 +120,7 @@ export function WebVitalsDetailPanel({
     <PageErrorProvider>
       <DetailPanel detailKey={detailKey ?? undefined} onClose={onClose}>
         {project && (
-          <SpanSummaryProjectAvatar
+          <StyledProjectAvatar
             project={project}
             direction="left"
             size={40}
@@ -169,7 +169,7 @@ const mapWebVitalToColumn = (webVital?: WebVitals | null) => {
   }
 };
 
-const SpanSummaryProjectAvatar = styled(ProjectAvatar)`
+const StyledProjectAvatar = styled(ProjectAvatar)`
   padding-top: ${space(1)};
   padding-bottom: ${space(2)};
 `;


### PR DESCRIPTION
Fixes chart colors and adds project icons next to page score rows
<img width="106" alt="image" src="https://github.com/getsentry/sentry/assets/83961295/e57d2e42-e29f-4eea-80f5-47539bf34d86">
