### PR TITLE
Fix(generic-metrics): Stop cache from being replenished when missed in `resolve`

### DIFF
--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -164,14 +164,19 @@ class CachingIndexer(StringIndexer):
         result = self.cache.get(key)
 
         if result and isinstance(result, int):
-            metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "true", "caller": "resolve"})
+            metrics.incr(
+                _INDEXER_CACHE_METRIC,
+                tags={"cache_hit": "true", "caller": "resolve", "use_case": use_case_id.value},
+            )
             return result
 
-        metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "false", "caller": "resolve"})
         id = self.indexer.resolve(use_case_id, org_id, string)
-
         if id is not None:
             self.cache.set(key, id)
+            metrics.incr(
+                _INDEXER_CACHE_METRIC,
+                tags={"cache_hit": "false", "caller": "resolve", "use_case": use_case_id.value},
+            )
 
         return id
 

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -13,6 +13,7 @@ from sentry.sentry_metrics.indexer.base import (
     metric_path_key_compatible_rev_resolve,
 )
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
+from sentry.utils import metrics
 
 # !!! DO NOT CHANGE THESE VALUES !!!
 #
@@ -238,6 +239,9 @@ class StaticStringIndexer(StringIndexer):
 
     @metric_path_key_compatible_resolve
     def resolve(self, use_case_id: UseCaseID, org_id: int, string: str) -> Optional[int]:
+        # TODO: remove this metric after investigation is over
+        if use_case_id is UseCaseID.ESCALATING_ISSUES:
+            metrics.incr("string_indexer_resolve_escalating_issues")
         if string in SHARED_STRINGS:
             return SHARED_STRINGS[string]
         return self.indexer.resolve(use_case_id, org_id, string)


### PR DESCRIPTION
### Overview

The last seen updater operates under the assumption that a (string → id) cache is only replenished via a `bulk_record` from a db read.
This pr removes code that puts values into cache in `resolve`. Also adds logging to determine the impact on use cases.