### PR TITLE
chore(ui) Cleanup oxfordize util

### DIFF
--- a/static/app/utils/oxfordizeArray.spec.tsx
+++ b/static/app/utils/oxfordizeArray.spec.tsx
@@ -37,17 +37,10 @@ describe('Oxfordize', function () {
   });
 
   it('correctly formats two elements', function () {
-    const items = ['one', 'two'];
+    const items = ['one', <i key="2">two</i>];
     render(<Oxfordize>{items}</Oxfordize>);
 
-    expect(screen.getByText('one and two')).toBeInTheDocument();
-  });
-
-  it('correctly formats mixed lists of nodes', function () {
-    const items = [<i key="1">one</i>, 'two'];
-    render(<Oxfordize>{items}</Oxfordize>);
-
-    expect(screen.getByText('one')).toBeInTheDocument();
-    expect(screen.getByText(/and two/)).toBeInTheDocument();
+    expect(screen.getByText(/one and/)).toBeInTheDocument();
+    expect(screen.getByText(/two/)).toBeInTheDocument();
   });
 });

--- a/static/app/utils/oxfordizeArray.tsx
+++ b/static/app/utils/oxfordizeArray.tsx
@@ -11,30 +11,6 @@ const oxfordizeArray = (strings: string[]) =>
     ? strings.join(' and ')
     : [strings.slice(0, -1).join(', '), strings.slice(-1)[0]].join(', and ');
 
-export const oxfordizeElements = (elements: JSX.Element[]): JSX.Element => {
-  if (elements.length === 0) {
-    return <span />;
-  }
-  if (elements.length === 1) {
-    return elements[0];
-  }
-  if (elements.length === 2) {
-    return (
-      <span>
-        {elements[0]} and {elements[1]}
-      </span>
-    );
-  }
-  const joinedElements: JSX.Element[] = [];
-  for (const [i, element] of elements.slice(0, -1).entries()) {
-    joinedElements.push(<Fragment key={i}>{element}, </Fragment>);
-  }
-  joinedElements.push(
-    <Fragment key={elements.length - 1}>and {elements[elements.length - 1]}</Fragment>
-  );
-  return <span>{joinedElements}</span>;
-};
-
 type Props = {
   children: React.ReactNode;
 };


### PR DESCRIPTION
When I started to update getsentry to use this module, I realized that `oxfordizeElements` could be removed, and that the tests could be simpler.
