### PR TITLE
ref(backup): Enable multi-DB support

### DIFF
--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from enum import Enum, auto, unique
 from functools import lru_cache
-from typing import NamedTuple, Tuple, Type
+from typing import NamedTuple, Optional, Tuple, Type
 
 from django.db import models
 from django.db.models.fields.related import ForeignKey, OneToOneField
@@ -62,6 +62,16 @@ class ModelRelations(NamedTuple):
 
 def normalize_model_name(model: Type[models.base.Model]):
     return f"{model._meta.app_label}.{model._meta.object_name}"
+
+
+def get_model(model_name: str) -> Optional[Type[models.base.Model]]:
+    """
+    Given a standardized model name string, retrieve the matching Sentry model.
+    """
+    for model in sorted_dependencies():
+        if f"sentry.{str(model.__name__).lower()}" == model_name.lower():
+            return model
+    return None
 
 
 class DependenciesJSONEncoder(json.JSONEncoder):

--- a/src/sentry/models/orgauthtoken.py
+++ b/src/sentry/models/orgauthtoken.py
@@ -21,7 +21,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
-from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.orgauthtoken import orgauthtoken_service
 
 MAX_NAME_LENGTH = 255
@@ -96,11 +96,13 @@ class OrgAuthToken(Model):
             token_hashed=self.token_hashed
         ).first()
         if (not self.token_hashed) or matching_token_hashed:
-            org_context = organization_service.get_organization_by_id(id=self.organization_id)
-            if org_context is None:
+            org_mapping = OrganizationMapping.objects.filter(
+                organization_id=self.organization_id
+            ).first()
+            if org_mapping is None:
                 return None
 
-            token_str = generate_token(org_context.organization.slug, generate_region_url())
+            token_str = generate_token(org_mapping.slug, generate_region_url())
             self.token_hashed = hash_token(token_str)
             self.token_last_characters = token_str[-4:]
 

--- a/tests/sentry/backup/__init__.py
+++ b/tests/sentry/backup/__init__.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Type
+from typing import Type
 
-import pytest
 from django.db import models
 
 from sentry.backup.exports import DatetimeSafeDjangoJSONEncoder
-from sentry.testutils.hybrid_cloud import use_split_dbs
 
 
 def targets(expected_models: list[Type]):
@@ -95,19 +93,3 @@ def targets(expected_models: list[Type]):
         return wrapped
 
     return decorator
-
-
-def run_backup_tests_only_on_single_db(test_case: Type | Callable[..., Any]):
-    """Skip tests on backup functionality if testing on a split DB.
-
-    The backup commands currently are implemented only for a monolithic database.
-    When backup eventually supports importing and exporting JSON for databases in
-    individual Hybrid Cloud silos, update the affected tests and remove all instances
-    of this decorator.
-    """
-    # TODO(getsentry/team-ospo#185)
-
-    delegate = pytest.mark.skipif(
-        use_split_dbs(), reason="backup is currently supported only for single DB"
-    )
-    return delegate(test_case)

--- a/tests/sentry/backup/test_exhaustive.py
+++ b/tests/sentry/backup/test_exhaustive.py
@@ -13,7 +13,7 @@ from sentry.testutils.helpers.backups import (
     clear_database,
     export_to_file,
 )
-from tests.sentry.backup import run_backup_tests_only_on_single_db, targets
+from tests.sentry.backup import targets
 
 EXHAUSTIVELY_TESTED_MODELS = set()
 
@@ -35,7 +35,6 @@ def mark(*marking: Type | Literal["__all__"]):
     return marking
 
 
-@run_backup_tests_only_on_single_db
 class ExhaustiveTests(BackupTestCase):
     """Ensure that a database with all exportable models filled out still works."""
 
@@ -50,7 +49,6 @@ class ExhaustiveTests(BackupTestCase):
         return self.import_export_then_validate(self._testMethodName, reset_pks=False)
 
 
-@run_backup_tests_only_on_single_db
 class UniquenessTests(BackupTestCase):
     """Ensure that required uniqueness (ie, model fields marked `unique=True`) is honored."""
 

--- a/tests/sentry/backup/test_exports.py
+++ b/tests/sentry/backup/test_exports.py
@@ -16,7 +16,6 @@ from sentry.models.useremail import UserEmail
 from sentry.models.userip import UserIP
 from sentry.testutils.helpers.backups import BackupTestCase, export_to_file
 from sentry.utils.json import JSONData
-from tests.sentry.backup import run_backup_tests_only_on_single_db
 
 
 class ExportTestCase(BackupTestCase):
@@ -25,7 +24,6 @@ class ExportTestCase(BackupTestCase):
         return export_to_file(tmp_path, **kwargs)
 
 
-@run_backup_tests_only_on_single_db
 class ScopingTests(ExportTestCase):
     """
     Ensures that only models with the allowed relocation scopes are actually exported.
@@ -66,7 +64,6 @@ class ScopingTests(ExportTestCase):
                     )
 
 
-@run_backup_tests_only_on_single_db
 class FilteringTests(ExportTestCase):
     """
     Ensures that filtering operations include the correct models.

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -45,7 +45,6 @@ from sentry.testutils.helpers.backups import (
     export_to_file,
 )
 from sentry.utils import json
-from tests.sentry.backup import run_backup_tests_only_on_single_db
 
 
 class ImportTestCase(BackupTestCase):
@@ -56,7 +55,6 @@ class ImportTestCase(BackupTestCase):
         return tmp_path
 
 
-@run_backup_tests_only_on_single_db
 class SanitizationTests(ImportTestCase):
     """
     Ensure that potentially damaging data is properly scrubbed at import time.
@@ -366,7 +364,6 @@ class SanitizationTests(ImportTestCase):
                     import_in_user_scope(tmp_file, printer=NOOP_PRINTER)
 
 
-@run_backup_tests_only_on_single_db
 class SignalingTests(ImportTestCase):
     """
     Some models are automatically created via signals and similar automagic from related models. We
@@ -427,7 +424,6 @@ class SignalingTests(ImportTestCase):
         assert ProjectOption.objects.filter(key="sentry:option-epoch").exists()
 
 
-@run_backup_tests_only_on_single_db
 class ScopingTests(ImportTestCase):
     """
     Ensures that only models with the allowed relocation scopes are actually imported.
@@ -461,7 +457,6 @@ class ScopingTests(ImportTestCase):
                         assert model.objects.count() == 0
 
 
-@run_backup_tests_only_on_single_db
 class FilterTests(ImportTestCase):
     """
     Ensures that filtering operations include the correct models.
@@ -622,7 +617,6 @@ class FilterTests(ImportTestCase):
         assert Email.objects.count() == 0
 
 
-@run_backup_tests_only_on_single_db
 class CollisionTests(ImportTestCase):
     """
     Ensure that collisions are properly handled in different flag modes.

--- a/tests/sentry/backup/test_models.py
+++ b/tests/sentry/backup/test_models.py
@@ -85,7 +85,7 @@ from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventTy
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers.backups import import_export_then_validate
 from sentry.utils.json import JSONData
-from tests.sentry.backup import run_backup_tests_only_on_single_db, targets
+from tests.sentry.backup import targets
 
 UNIT_TESTED_MODELS = set()
 
@@ -109,7 +109,6 @@ def mark(*marking: Type | Literal["__all__"]):
     return marking
 
 
-@run_backup_tests_only_on_single_db
 class ModelBackupTests(TransactionTestCase):
     """
     Test the JSON-ification of models marked `__relocation_scope__ != RelocationScope.Excluded`.
@@ -540,7 +539,6 @@ class ModelBackupTests(TransactionTestCase):
         return self.import_export_then_validate()
 
 
-@run_backup_tests_only_on_single_db
 class DynamicRelocationScopeTests(TransactionTestCase):
     """
     For models that support different relocation scopes depending on properties of the model instance itself (ie, they have a set for their `__relocation_scope__`, rather than a single value), make sure that this dynamic deduction works correctly.

--- a/tests/sentry/backup/test_roundtrip.py
+++ b/tests/sentry/backup/test_roundtrip.py
@@ -8,10 +8,8 @@ from sentry.testutils.helpers.backups import (
     import_export_from_fixture_then_validate,
 )
 from sentry.testutils.pytest.fixtures import django_db_all
-from tests.sentry.backup import run_backup_tests_only_on_single_db
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True, reset_sequences=True)
 def test_good_fresh_install(tmp_path):
     import_export_from_fixture_then_validate(
@@ -19,7 +17,6 @@ def test_good_fresh_install(tmp_path):
     )
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True, reset_sequences=True)
 def test_bad_unequal_json(tmp_path):
     # Without calling `get_default_comparators()` as the third argument to
@@ -36,13 +33,11 @@ def test_bad_unequal_json(tmp_path):
     assert findings[2].kind == ComparatorFindingKind.UnequalJSON
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True, reset_sequences=True)
 def test_date_updated_with_zeroed_milliseconds(tmp_path):
     import_export_from_fixture_then_validate(tmp_path, "datetime-with-zeroed-millis.json")
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True, reset_sequences=True)
 def test_date_updated_with_unzeroed_milliseconds(tmp_path):
     with pytest.raises(ValidationError) as execinfo:
@@ -57,7 +52,6 @@ def test_date_updated_with_unzeroed_milliseconds(tmp_path):
     assert """+  "last_updated": "2023-06-22T00:00:00.000Z",""" in findings[0].reason
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True, reset_sequences=True)
 def test_good_continuing_sequences(tmp_path):
     # Populate once to set the sequences.
@@ -76,7 +70,6 @@ def test_good_continuing_sequences(tmp_path):
 
 
 # User models are unique and important enough that we target them with a specific test case.
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_user_pk_mapping(tmp_path):
     import_export_from_fixture_then_validate(
@@ -86,7 +79,6 @@ def test_user_pk_mapping(tmp_path):
 
 # The import should be robust to usernames and organization slugs that have had random suffixes
 # added on due to conflicts in the existing database.
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_auto_suffix_username_and_organization_slug(tmp_path):
     import_export_from_fixture_then_validate(

--- a/tests/sentry/runner/commands/test_backup.py
+++ b/tests/sentry/runner/commands/test_backup.py
@@ -7,10 +7,8 @@ from click.testing import CliRunner
 from django.db import IntegrityError
 
 from sentry.runner.commands.backup import export, import_
-from sentry.silo import unguarded_write
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.pytest.fixtures import django_db_all
-from tests.sentry.backup import run_backup_tests_only_on_single_db
 
 GOOD_FILE_PATH = get_fixture_path("backup", "fresh-install.json")
 BAD_FILE_PATH = get_fixture_path("backup", "corrupted-users.json")
@@ -20,93 +18,77 @@ NONEXISTENT_FILE_PATH = get_fixture_path("backup", "does-not-exist.json")
 def cli_import_then_export(
     scope: str, *, import_args: list[str] | None = None, export_args: list[str] | None = None
 ):
-    # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
-    with unguarded_write(using="default"):
+    rv = CliRunner().invoke(
+        import_, [scope, GOOD_FILE_PATH] + ([] if import_args is None else import_args)
+    )
+    assert rv.exit_code == 0, rv.output
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir).joinpath("good.json")
         rv = CliRunner().invoke(
-            import_, [scope, GOOD_FILE_PATH] + ([] if import_args is None else import_args)
+            export, [scope, str(tmp_path)] + ([] if export_args is None else export_args)
         )
         assert rv.exit_code == 0, rv.output
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir).joinpath("good.json")
-            rv = CliRunner().invoke(
-                export, [scope, str(tmp_path)] + ([] if export_args is None else export_args)
-            )
-            assert rv.exit_code == 0, rv.output
 
-
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_global_scope():
     cli_import_then_export("global")
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_global_scope_import_overwrite_configs():
     cli_import_then_export("global", import_args=["--overwrite_configs"])
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_organization_scope_import_filter_org_slugs():
     cli_import_then_export("organizations", import_args=["--filter_org_slugs", "testing"])
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_organization_scope_export_filter_org_slugs():
     cli_import_then_export("organizations", export_args=["--filter_org_slugs", "testing"])
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_user_scope():
     cli_import_then_export("users")
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_user_scope_export_merge_users():
     cli_import_then_export("users", import_args=["--merge_users"])
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_user_scope_import_filter_usernames():
     cli_import_then_export("users", import_args=["--filter_usernames", "testing@example.com"])
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_user_scope_export_filter_usernames():
     cli_import_then_export("users", export_args=["--filter_usernames", "testing@example.com"])
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_import_integrity_error_exit_code():
-    # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
-    with unguarded_write(using="default"):
-        # First import should succeed.
-        rv = CliRunner().invoke(import_, ["global", GOOD_FILE_PATH] + [])
-        assert rv.exit_code == 0, rv.output
+    # First import should succeed.
+    rv = CliRunner().invoke(import_, ["global", GOOD_FILE_PATH] + [])
+    assert rv.exit_code == 0, rv.output
 
-        # Global imports assume an empty DB, so this should fail with an `IntegrityError`.
-        rv = CliRunner().invoke(import_, ["global", GOOD_FILE_PATH])
-        assert (
-            ">> Are you restoring from a backup of the same version of Sentry?\n>> Are you restoring onto a clean database?\n>> If so then this IntegrityError might be our fault, you can open an issue here:\n>> https://github.com/getsentry/sentry/issues/new/choose\n"
-            in rv.output
-        )
-        assert isinstance(rv.exception, IntegrityError)
-        assert rv.exit_code == 1, rv.output
+    # Global imports assume an empty DB, so this should fail with an `IntegrityError`.
+    rv = CliRunner().invoke(import_, ["global", GOOD_FILE_PATH])
+    assert (
+        ">> Are you restoring from a backup of the same version of Sentry?\n>> Are you restoring onto a clean database?\n>> If so then this IntegrityError might be our fault, you can open an issue here:\n>> https://github.com/getsentry/sentry/issues/new/choose\n"
+        in rv.output
+    )
+    assert isinstance(rv.exception, IntegrityError)
+    assert rv.exit_code == 1, rv.output
 
 
-@run_backup_tests_only_on_single_db
 @django_db_all(transaction=True)
 def test_import_file_read_error_exit_code():
-    # TODO(Hybrid-Cloud): Review whether this is the correct route to apply in this case.
-    with unguarded_write(using="default"):
-        rv = CliRunner().invoke(import_, ["global", NONEXISTENT_FILE_PATH])
-        assert not isinstance(rv.exception, IntegrityError)
-        assert rv.exit_code == 2, rv.output
+    rv = CliRunner().invoke(import_, ["global", NONEXISTENT_FILE_PATH])
+    assert not isinstance(rv.exception, IntegrityError)
+    assert rv.exit_code == 2, rv.output


### PR DESCRIPTION
The upshot is that we now test all of our import/export code in multi-database mode, but, until we add support for testing in single DB mode, THAT CODEPATH IS UNTESTED. This is quite bad, since this is the exact codepath that self-hosted users use, so we should prioritize fixing this ASAP, lest we release broken code to that repo.

This change switches the backup feature from assuming a single atomic transaction on a single DB, to one that checks the number of DBs and proceeds based on that information: if there is one DB, we proceed as before in a single atomic transaction, while if there are multiple, we do atomic transactions pure model kind.

There are a number of other changes here as well:
- The DB clearing algorithm has been updated to account for the pecularities of the actor refactor that is under way.
- We now update the table sequences for every model after we write, than in one huge `sqlsequencereset` call at the end of the import, to account for the per-model atomicity mentioned above.
- We've removed the `@run_backup_tests_only_on_single_db` decorator, as we now run only on multiple DBs instead.
- All of the `unguarded_write("default")` and `transaction.atomic("default")` related to the backup feature have been removed as well.

Issue: getsentry/team-ospo#185
Issue: getsentry/team-ospo#196