### PR TITLE
Remove requires_relay as it doesn't work in CI

### DIFF
--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -65,12 +65,6 @@ def _requires_snuba() -> None:
 
 
 @pytest.fixture(scope="session")
-def _requires_relay() -> None:
-    if not _service_available("127.0.0.1", settings.SENTRY_RELAY_PORT):
-        pytest.skip("requires relay server running")
-
-
-@pytest.fixture(scope="session")
 def _requires_kafka() -> None:
     kafka_conf = settings.SENTRY_DEVSERVICES["kafka"](settings, {})
     (port,) = kafka_conf["ports"].values()
@@ -89,6 +83,5 @@ def _requires_symbolicator() -> None:
 
 
 requires_snuba = pytest.mark.usefixtures("_requires_snuba")
-requires_relay = pytest.mark.usefixtures("_requires_relay")
 requires_symbolicator = pytest.mark.usefixtures("_requires_symbolicator")
 requires_kafka = pytest.mark.usefixtures("_requires_kafka")

--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -11,9 +11,9 @@ from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now, iso_format, timestamp_format
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_kafka, requires_relay
+from sentry.testutils.skips import requires_kafka
 
-pytestmark = [requires_kafka, requires_relay]
+pytestmark = [requires_kafka]
 
 
 class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):

--- a/tests/relay_integration/test_message_filters.py
+++ b/tests/relay_integration/test_message_filters.py
@@ -7,10 +7,10 @@ from sentry.ingest.inbound_filters import (
 from sentry.models import ProjectOption
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_kafka, requires_relay
+from sentry.testutils.skips import requires_kafka
 from sentry.utils.safe import set_path
 
-pytestmark = [requires_kafka, requires_relay]
+pytestmark = [requires_kafka]
 
 
 class FilterTests(RelayStoreHelper, TransactionTestCase):

--- a/tests/relay_integration/test_metrics_extraction.py
+++ b/tests/relay_integration/test_metrics_extraction.py
@@ -9,10 +9,10 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import Feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_kafka, requires_relay
+from sentry.testutils.skips import requires_kafka
 from sentry.utils import json
 
-pytestmark = [requires_kafka, requires_relay]
+pytestmark = [requires_kafka]
 
 
 class MetricsExtractionTest(RelayStoreHelper, TransactionTestCase):

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -12,10 +12,10 @@ from sentry.receivers import create_default_projects
 from sentry.testutils.asserts import assert_mock_called_once_with_partial
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.pytest.relay import adjust_settings_for_relay_tests
-from sentry.testutils.skips import requires_kafka, requires_relay
+from sentry.testutils.skips import requires_kafka
 from sentry.utils.sdk import bind_organization_context, configure_sdk
 
-pytestmark = [requires_kafka, requires_relay]
+pytestmark = [requires_kafka]
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Anthony pointed out that local and CI testing seem to differ and the requires_relay checks were skipping tests.