### PR TITLE
ref(github-invite): exclude some email domains in missing members API

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -31,6 +31,15 @@ if TYPE_CHECKING:
     from django_stubs_ext import WithAnnotations
 
 
+filtered_email_domains = {
+    "gmail.com",
+    "icloud.com",
+    "hotmail.com",
+    "outlook.com",
+    "noreply.github.com",
+}
+
+
 class MissingOrgMemberSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
         return {"email": obj.email, "externalId": obj.external_id, "commitCount": obj.commit__count}
@@ -136,6 +145,9 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
 
             if shared_domain:
                 queryset = queryset.filter(email__endswith=shared_domain)
+            else:
+                for filtered_email in filtered_email_domains:
+                    queryset = queryset.exclude(email__endswith=filtered_email)
 
             if queryset.exists():
                 query = request.GET.get("query")

--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -39,6 +39,8 @@ filtered_email_domains = {
     "noreply.github.com",
 }
 
+filtered_characters = {"+"}
+
 
 class MissingOrgMemberSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
@@ -148,6 +150,9 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
             else:
                 for filtered_email in filtered_email_domains:
                     queryset = queryset.exclude(email__endswith=filtered_email)
+
+            for filtered_character in filtered_characters:
+                queryset = queryset.exclude(email__icontains=filtered_character)
 
             if queryset.exists():
                 query = request.GET.get("query")

--- a/tests/sentry/api/endpoints/test_organization_missing_org_members.py
+++ b/tests/sentry/api/endpoints/test_organization_missing_org_members.py
@@ -141,6 +141,17 @@ class OrganizationMissingMembersTestCase(APITestCase):
             role="owner",
         )
 
+        # this user has an email domain that is filtered
+        noreply_email_author = self.create_commit_author(
+            project=self.project, email="hi@noreply.github.com"
+        )
+        noreply_email_author.external_id = "hi"
+        noreply_email_author.save()
+        self.create_commit(
+            repo=self.repo,
+            author=noreply_email_author,
+        )
+
         response = self.get_success_response(self.organization.slug)
 
         assert response.data[0]["integration"] == "github"

--- a/tests/sentry/api/endpoints/test_organization_missing_org_members.py
+++ b/tests/sentry/api/endpoints/test_organization_missing_org_members.py
@@ -41,6 +41,12 @@ class OrganizationMissingMembersTestCase(APITestCase):
         self.nonmember_commit_author2.external_id = "d"
         self.nonmember_commit_author2.save()
 
+        nonmember_commit_author_invalid_char = self.create_commit_author(
+            project=self.project, email="hi+1@example.com"
+        )
+        nonmember_commit_author_invalid_char.external_id = "hi+1"
+        nonmember_commit_author_invalid_char.save()
+
         self.integration = self.create_integration(
             organization=self.organization, provider="github", name="Github", external_id="github:1"
         )


### PR DESCRIPTION
When not all of the owners have the same email domain, also filter out email domains that are generally not associated with a company when fetching commit authors that are not members of an organization.

This list includes
```
{
    "gmail.com",
    "icloud.com",
    "hotmail.com",
    "outlook.com",
    "noreply.github.com"
}
```