### PR TITLE
ref: delete backend-typing make target

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -290,7 +290,7 @@ jobs:
           SENTRY_LIGHT_BUILD=1 pip install --no-deps -e .
           sentry init
 
-      - run: make backend-typing
+      - run: mypy
         id: run
 
       - uses: getsentry/action-github-app-token@97c9e23528286821f97fba885c1b1123284b29cc # v2.0.0
@@ -300,7 +300,7 @@ jobs:
           app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
-      # only if `backend-typing` succeeds should we try and trim the blocklist
+      # only if `mypy` succeeds should we try and trim the blocklist
       - run: |
           python3 -m tools.mypy_helpers.make_module_ignores
           git diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -162,11 +162,6 @@ test-tools:
 	pytest -c /dev/null --confcutdir tests/tools tests/tools -vv --cov=tools --cov=tests/tools --cov-report="xml:.artifacts/tools.coverage.xml"
 	@echo ""
 
-backend-typing:
-	@echo "--> Running Python typing checks"
-	mypy
-	@echo ""
-
 # JavaScript relay tests are meant to be run within Symbolicator test suite, as they are parametrized to verify both processing pipelines during migration process.
 # Running Locally: Run `sentry devservices up kafka zookeeper` before starting these tests
 test-symbolicator: create-db


### PR DESCRIPTION
it is less typing to run mypy directly -- and faster


there's some misconception that this target needs to run all the time -- but `mypy filename` is a better workflow