### PR TITLE
feat(statistical-detectors): Fetch function name for regression issue

### DIFF
--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -163,3 +163,30 @@ def parse_profile_filters(query: str) -> Dict[str, str]:
         profile_filters[term.key.name] = term.value.value
 
     return profile_filters
+
+
+def make_join_with_separator_formatter(separator: str):
+    def join_with_separator_formatter(package: str, function: str) -> str:
+        if not package:
+            return function
+        return f"{package}{separator}{function}"
+
+    return join_with_separator_formatter
+
+
+def default_formatter(package: str, function: str) -> str:
+    return function
+
+
+FUNCTION_FORMATTERS = {
+    "android": default_formatter,
+    "cocoa": default_formatter,
+    "node": make_join_with_separator_formatter("."),
+    "php": default_formatter,
+    "python": make_join_with_separator_formatter("."),
+}
+
+
+def format_profile_function(platform: str, package: str, function: str) -> str:
+    formatter = FUNCTION_FORMATTERS.get(platform, default_formatter)
+    return formatter(package, function)

--- a/src/sentry/statistical_detectors/detector.py
+++ b/src/sentry/statistical_detectors/detector.py
@@ -20,6 +20,7 @@ class DetectorPayload:
     count: float
     value: float
     timestamp: datetime
+    description: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/tests/sentry/profiles/test_utils.py
+++ b/tests/sentry/profiles/test_utils.py
@@ -1,0 +1,47 @@
+import pytest
+
+from sentry.profiles.utils import format_profile_function
+
+
+@pytest.mark.parametrize(
+    ["platform", "package", "function", "expected"],
+    [
+        pytest.param(
+            "python",
+            "sentry.nodestore.base",
+            "NodeStorage._set_cache_item",
+            "sentry.nodestore.base.NodeStorage._set_cache_item",
+            id="python",
+        ),
+        pytest.param(
+            "node",
+            "node:async_hooks",
+            "run",
+            "node:async_hooks.run",
+            id="node with package",
+        ),
+        pytest.param(
+            "node",
+            "",
+            "run",
+            "run",
+            id="node without package",
+        ),
+        pytest.param(
+            "android",
+            "io.sentry.samples.android.databinding",
+            "io.sentry.samples.android.databinding.ActivityMainBinding.inflate(android.view.LayoutInflater, android.view.ViewGroup, boolean): io.sentry.samples.android.databinding.ActivityMainBinding",
+            "io.sentry.samples.android.databinding.ActivityMainBinding.inflate(android.view.LayoutInflater, android.view.ViewGroup, boolean): io.sentry.samples.android.databinding.ActivityMainBinding",
+            id="android",
+        ),
+        pytest.param(
+            "cocoa",
+            "iOS-Swift",
+            "PerformanceViewController.doRandomWork()",
+            "PerformanceViewController.doRandomWork()",
+            id="cocoa",
+        ),
+    ],
+)
+def test_format_profile_function(platform, package, function, expected):
+    assert format_profile_function(platform, package, function) == expected

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -362,6 +362,7 @@ class FunctionsTasksTest(ProfilesSnubaTestCase):
                 count=100,
                 value=pytest.approx(100),  # type: ignore[arg-type]
                 timestamp=self.hour_ago,
+                description="foo",
             )
             for project in self.projects
         ]


### PR DESCRIPTION
To create the regression issue, we'd like to be able to surface the culprit. For functions, it'd be the function path. So make sure to fetch it so it can be used to create the issue.