### PR TITLE
feat(CoGS): Add `use_case_id` to `tenant_ids` for Generic Metrics queries

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,7 +63,7 @@
       "source.organizeImports": true,
       "source.fixAll.eslint": false
     },
-    "editor.defaultFormatter": "ms-python.black-formatter"
+    "editor.defaultFormatter": "ms-python.autopep8"
   },
 
   "[html]": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,7 +63,7 @@
       "source.organizeImports": true,
       "source.fixAll.eslint": false
     },
-    "editor.defaultFormatter": "ms-python.autopep8"
+    "editor.defaultFormatter": "ms-python.black-formatter"
   },
 
   "[html]": {

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -231,7 +231,14 @@ class BaseQueryBuilder:
         org_id = self.organization_id or (
             self.params.organization.id if self.params.organization else None
         )
-        self.tenant_ids = {"organization_id": org_id} if org_id else None
+        self.tenant_ids = dict()
+        if org_id is not None:
+            self.tenant_ids["organization_id"] = org_id
+        use_case_id = params.get("use_case_id")
+        if use_case_id is not None:
+            self.tenant_ids["use_case_id"] = use_case_id
+        if not self.tenant_ids:
+            self.tenant_ids = None
 
         # Function is a subclass of CurriedFunction
         self.where: List[WhereType] = []

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -387,6 +387,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
 
         query = apply_dataset_query_conditions(self.query_type, query, None)
         params["project_id"] = project_ids
+        params["use_case_id"] = self._get_use_case_id().value
         qb = AlertMetricsQueryBuilder(
             dataset=Dataset(self.dataset.value),
             query=query,

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -725,7 +725,10 @@ def get_series(
     """Get time series for the given query"""
 
     organization_id = projects[0].organization_id if projects else None
-    tenant_ids = tenant_ids or {"organization_id": organization_id} if organization_id else None
+    tenant_ids = dict()
+    if organization_id is not None:
+        tenant_ids["organization_id"] = organization_id
+    tenant_ids["use_case_id"] = use_case_id.value
 
     if metrics_query.interval is not None:
         interval = metrics_query.interval

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -90,6 +90,7 @@ def _get_metrics_for_entity(
         referrer="snuba.metrics.get_metrics_names_for_entity",
         project_ids=project_ids,
         org_id=org_id,
+        use_case_id=use_case_id,
         start=start,
         end=end,
     )
@@ -380,6 +381,7 @@ def _fetch_tags_or_values_for_mri(
             referrer=referrer,
             project_ids=[p.id for p in projects],
             org_id=org_id,
+            use_case_id=use_case_id,
         )
 
         for row in rows:

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -124,6 +124,7 @@ def run_metrics_query(
     project_ids: Sequence[int],
     org_id: int,
     referrer: str,
+    use_case_id: UseCaseID,
     start: Optional[datetime] = None,
     end: Optional[datetime] = None,
 ) -> List[SnubaDataType]:
@@ -154,7 +155,7 @@ def run_metrics_query(
         dataset=Dataset.Metrics.value,
         app_id="metrics",
         query=query,
-        tenant_ids={"organization_id": org_id},
+        tenant_ids={"organization_id": org_id, "use_case_id": use_case_id.value},
     )
     result = raw_snql_query(request, referrer, use_cache=True)
     return result["data"]
@@ -231,6 +232,7 @@ def _get_entity_of_metric_mri(
             referrer=f"snuba.metrics.meta.get_entity_of_metric.{use_case_id.value}",
             project_ids=[p.id for p in projects],
             org_id=org_id,
+            use_case_id=use_case_id,
         )
         if data:
             return entity_key

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -422,13 +422,15 @@ def query_transactions(
     transactions_per_project: int,
 ) -> List[DetectorPayload]:
 
+    use_case_id = UseCaseID.TRANSACTIONS
+
     # both the metric and tag that we are using are hardcoded values in sentry_metrics.indexer.strings
     # so the org_id that we are using does not actually matter here, we only need to pass in an org_id
     duration_metric_id = indexer.resolve(
-        UseCaseID.TRANSACTIONS, org_ids[0], str(TransactionMRI.DURATION.value)
+        use_case_id, org_ids[0], str(TransactionMRI.DURATION.value)
     )
     transaction_name_metric_id = indexer.resolve(
-        UseCaseID.TRANSACTIONS,
+        use_case_id,
         org_ids[0],
         "transaction",
     )
@@ -504,6 +506,7 @@ def query_transactions(
             # As it is now (09-13-2023), this query will likely be throttled (i.e be slower) by the allocation
             # policy as soon as we start scanning more than just the sentry org
             "organization_id": -42069,
+            "use_case_id": use_case_id.value,
         },
     )
     data = raw_snql_query(


### PR DESCRIPTION
### Overview
- As part of analyzing cogs for the Generic Metrics dataset in Snuba, we need to see a split of the shared resource by use case (`use_case_id`)
- Currently, queries do not contain `use_case_id` so I'm starting to add a new Tenant ID for generic metrics queries for this
- This will eventually be a required Tenant ID for generic metrics queries

### Note
- If anyone notices more easy spots to add `use_case_id` to Snuba requests do let me know!