### PR TITLE
feat(escalating-issues): Create Generics Metrics Backend queries

### DIFF
--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -23,7 +23,9 @@ from snuba_sdk import (
     Query,
     Request,
 )
+from snuba_sdk.expressions import Granularity
 
+from sentry import features
 from sentry.eventstore.models import GroupEvent
 from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
 from sentry.issues.escalating_issues_alg import GroupCount
@@ -35,11 +37,16 @@ from sentry.models import (
     GroupHistoryStatus,
     GroupInboxReason,
     GroupStatus,
+    Organization,
+    Project,
     add_group_to_inbox,
     record_group_history,
 )
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.signals import issue_escalating
 from sentry.snuba.dataset import Dataset, EntityKey
+from sentry.snuba.metrics import MetricField, MetricGroupByField, MetricsQuery, get_series
+from sentry.snuba.metrics.naming_layer.mri import ErrorsMRI
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 from sentry.utils.cache import cache
@@ -56,6 +63,7 @@ BUCKETS_PER_GROUP = 7 * 24
 ONE_WEEK_DURATION = 7
 IS_ESCALATING_REFERRER = "sentry.issues.escalating.is_escalating"
 GROUP_HOURLY_COUNT_TTL = 60
+HOUR = 3600  # 3600 seconds
 
 GroupsCountResponse = TypedDict(
     "GroupsCountResponse",
@@ -159,14 +167,22 @@ def _query_with_pagination(
     all_results = []
     offset = 0
     while True:
-        query = _generate_query(project_ids, group_ids, offset, start_date, end_date, category)
-        request = Request(
-            dataset=_issue_category_dataset(category),
-            app_id=REFERRER,
-            query=query,
-            tenant_ids={"referrer": REFERRER, "organization_id": organization_id},
+        query = _generate_query(
+            organization_id, project_ids, group_ids, offset, start_date, end_date, category
         )
-        results = raw_snql_query(request, referrer=REFERRER)["data"]
+        if isinstance(query, MetricsQuery):
+            projects = Project.objects.filter(id_in=project_ids)
+            results = get_series(
+                projects=projects, metrics_query=query, use_case_id=UseCaseID.ESCALATING_ISSUES
+            )
+        else:
+            request = Request(
+                dataset=_issue_category_dataset(category),
+                app_id=REFERRER,
+                query=query,
+                tenant_ids={"referrer": REFERRER, "organization_id": organization_id},
+            )
+            results = raw_snql_query(request, referrer=REFERRER)["data"]
         all_results += results
         offset += ELEMENTS_PER_SNUBA_PAGE
         if not results or len(results) < ELEMENTS_PER_SNUBA_PAGE:
@@ -176,6 +192,7 @@ def _query_with_pagination(
 
 
 def _generate_query(
+    organization_id: int,
     project_ids: Sequence[int],
     group_ids: Sequence[int],
     offset: int,
@@ -186,6 +203,30 @@ def _generate_query(
     """This simply generates a query based on the passed parameters"""
     group_id_col = Column("group_id")
     proj_id_col = Column("project_id")
+    organization = Organization.objects.get(id=organization_id)
+    if features.has("organizations:escalating-issues-v2", organization):
+        select = [
+            MetricField(metric_mri=ErrorsMRI.EVENT_INGESTED.value, alias="event_ingested", op=None),
+        ]
+
+        groupby = [MetricGroupByField(field="project_id"), Column(name="tags[group_id]")]
+
+        where = Condition(
+            lhs=Column(name="tags[group_id]"),
+            op=Op.IN,
+            rhs=[str(group_id) for group_id in group_ids],
+        )
+        return MetricsQuery(
+            org_id=organization_id,
+            project_ids=project_ids,
+            select=select,
+            start=start_date,
+            end=end_date,
+            where=where,
+            granularity=Granularity(HOUR),
+            groupby=groupby,
+        )
+
     return Query(
         match=Entity(_issue_category_entity(category)),
         select=[

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -234,11 +234,13 @@ def _generate_generic_metrics_backend_query(
 
     groupby = [MetricGroupByField(field="project_id"), Column(name="tags[group_id]")]
 
-    where = Condition(
-        lhs=Column(name="tags[group_id]"),
-        op=Op.IN,
-        rhs=[str(group_id) for group_id in group_ids],
-    )
+    where = [
+        Condition(
+            lhs=Column(name="tags[group_id]"),
+            op=Op.IN,
+            rhs=[str(group_id) for group_id in group_ids],
+        )
+    ]
     return MetricsQuery(
         org_id=organization_id,
         project_ids=project_ids,

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -193,7 +193,7 @@ def _query_with_pagination(
         metrics_query = _generate_generic_metrics_backend_query(
             organization_id, project_ids, group_ids, start_date, end_date, category
         )
-        projects = Project.objects.filter(id_in=project_ids)
+        projects = Project.objects.filter(id__in=project_ids)
         metrics_results = get_series(
             projects=projects, metrics_query=metrics_query, use_case_id=UseCaseID.ESCALATING_ISSUES
         )
@@ -232,7 +232,7 @@ def _generate_generic_metrics_backend_query(
         MetricField(metric_mri=ErrorsMRI.EVENT_INGESTED.value, alias="event_ingested", op=None),
     ]
 
-    groupby = [MetricGroupByField(field="project_id"), Column(name="tags[group_id]")]
+    groupby = [MetricGroupByField(field="project_id"), MetricGroupByField(field="tags[group_id]")]
 
     where = [
         Condition(

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -229,14 +229,14 @@ def _generate_generic_metrics_backend_query(
         raise Exception("Invalid category.")
 
     select = [
-        MetricField(metric_mri=ErrorsMRI.EVENT_INGESTED.value, alias="event_ingested", op=None),
+        MetricField(metric_mri=ErrorsMRI.EVENT_INGESTED.value, alias="event_ingested", op="count"),
     ]
 
-    groupby = [MetricGroupByField(field="project_id"), MetricGroupByField(field="tags[group_id]")]
+    groupby = [MetricGroupByField(field="project_id"), MetricGroupByField(field="tags[group]")]
 
     where = [
         Condition(
-            lhs=Column(name="tags[group_id]"),
+            lhs=Column(name="tags[group]"),
             op=Op.IN,
             rhs=[str(group_id) for group_id in group_ids],
         )

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -257,6 +257,8 @@ def _query_metrics_with_pagination(
                 extra={"metrics_results": metrics_results, "dataset_results": all_results},
             )
 
+    return
+
 
 def transform_to_groups_count_response(data: dict) -> List[GroupsCountResponse]:
     """

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -206,7 +206,7 @@ def _query_metrics_with_pagination(
     end_date: datetime,
     all_results: List[GroupsCountResponse],
     category: GroupCategory | None = None,
-) -> List[GroupsCountResponse]:
+):
     """
     Paginates Snuba metric queries for event counts for the
     given list of project ids and groups ids in a time range.
@@ -256,8 +256,6 @@ def _query_metrics_with_pagination(
                 "Generics Metrics Backend query results not the same as Errors dataset query.",
                 extra={"metrics_results": metrics_results, "dataset_results": all_results},
             )
-
-    return
 
 
 def transform_to_groups_count_response(data: dict) -> List[GroupsCountResponse]:

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -262,7 +262,7 @@ def transform_to_groups_count_response(data: dict) -> List[GroupsCountResponse]:
     """
     Transforms results from `get_series` metrics query to List[GroupsCountResponse]
     """
-    result = []
+    result: List[GroupsCountResponse] = []
 
     for group in data["groups"]:
         project_id = group["by"]["project_id"]

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -193,7 +193,7 @@ def _query_with_pagination(
             break
 
     _query_metrics_with_pagination(
-        organization_id, project_ids, group_ids, start_date, end_date, category, all_results
+        organization_id, project_ids, group_ids, start_date, end_date, all_results, category
     )
     return all_results
 
@@ -204,8 +204,8 @@ def _query_metrics_with_pagination(
     group_ids: Sequence[int],
     start_date: datetime,
     end_date: datetime,
-    category: Optional[GroupCategory],
     all_results: List[GroupsCountResponse],
+    category: GroupCategory | None = None,
 ) -> List[GroupsCountResponse]:
     """
     Paginates Snuba metric queries for event counts for the
@@ -298,7 +298,7 @@ def _generate_generic_metrics_backend_query(
     start_date: datetime,
     end_date: datetime,
     offset: int,
-    category: Optional[GroupCategory],
+    category: GroupCategory | None = None,
 ):
     """
     This function generates a query to fetch the hourly events

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -222,6 +222,14 @@ def _get_entity_of_metric_mri(
         entity_keys_set = frozenset(
             {EntityKey.MetricsCounters, EntityKey.MetricsSets, EntityKey.MetricsDistributions}
         )
+    elif use_case_id is UseCaseID.ESCALATING_ISSUES:
+        entity_keys_set = frozenset(
+            {
+                EntityKey.GenericMetricsCounters,
+                EntityKey.GenericMetricsSets,
+                EntityKey.GenericMetricsDistributions,
+            }
+        )
     else:
         raise InvalidParams
 

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -438,7 +438,7 @@ class RawOp(MetricOperation):
         org_id: int,
         params: Optional[MetricOperationParams] = None,
     ) -> Function:
-        if use_case_id in [UseCaseID.TRANSACTIONS, UseCaseID.CUSTOM]:
+        if use_case_id in [UseCaseID.TRANSACTIONS, UseCaseID.CUSTOM, UseCaseID.ESCALATING_ISSUES]:
             snuba_function = GENERIC_OP_TO_SNUBA_FUNCTION[entity][self.op]
         else:
             snuba_function = OP_TO_SNUBA_FUNCTION[entity][self.op]

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -223,13 +223,7 @@ def _get_entity_of_metric_mri(
             {EntityKey.MetricsCounters, EntityKey.MetricsSets, EntityKey.MetricsDistributions}
         )
     elif use_case_id is UseCaseID.ESCALATING_ISSUES:
-        entity_keys_set = frozenset(
-            {
-                EntityKey.GenericMetricsCounters,
-                EntityKey.GenericMetricsSets,
-                EntityKey.GenericMetricsDistributions,
-            }
-        )
+        entity_keys_set = frozenset({EntityKey.GenericMetricsCounters})
     else:
         raise InvalidParams
 

--- a/src/sentry/snuba/metrics/naming_layer/mapping.py
+++ b/src/sentry/snuba/metrics/naming_layer/mapping.py
@@ -13,11 +13,13 @@ from sentry.api.utils import InvalidParams
 from sentry.snuba.metrics.naming_layer.mri import (
     MRI_EXPRESSION_REGEX,
     MRI_SCHEMA_REGEX,
+    ErrorsMRI,
     SessionMRI,
     SpanMRI,
     TransactionMRI,
 )
 from sentry.snuba.metrics.naming_layer.public import (
+    ErrorsMetricKey,
     SessionMetricKey,
     SpanMetricKey,
     TransactionMetricKey,
@@ -41,6 +43,7 @@ def create_name_mapping_layers() -> None:
         (SessionMetricKey, SessionMRI),
         (TransactionMetricKey, TransactionMRI),
         (SpanMetricKey, SpanMRI),
+        (ErrorsMetricKey, ErrorsMRI),
     ):
         # Adds new names at the end, so that when the reverse mapping is created
         for metric_key in MetricKey:

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -22,6 +22,7 @@ __all__ = (
     "SpanMRI",
     "MRI_SCHEMA_REGEX",
     "MRI_EXPRESSION_REGEX",
+    "ErrorsMRI",
     "parse_mri",
     "get_available_operations",
 )
@@ -33,7 +34,7 @@ from typing import List, Optional
 
 from sentry.snuba.metrics.utils import AVAILABLE_GENERIC_OPERATIONS, AVAILABLE_OPERATIONS, OP_REGEX
 
-NAMESPACE_REGEX = r"(transactions|errors|issues|sessions|alerts|custom|spans)"
+NAMESPACE_REGEX = r"(transactions|errors|issues|sessions|alerts|custom|spans|escalating_issues)"
 ENTITY_TYPE_REGEX = r"(c|s|d|g|e)"
 # This regex allows for a string of words composed of small letters alphabet characters with
 # allowed the underscore character, optionally separated by a single dot
@@ -162,7 +163,7 @@ class SpanMRI(Enum):
 
 
 class ErrorsMRI(Enum):
-    EVENT_INGESTED = "c:errors/event_ingested@none"
+    EVENT_INGESTED = "c:escalating_issues/event_ingested@none"
 
 
 @dataclass

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -161,6 +161,10 @@ class SpanMRI(Enum):
     HTTP_ERROR_RATE_LIGHT = "e:spans/http_error_rate_light@ratio"
 
 
+class ErrorsMRI(Enum):
+    EVENT_INGESTED = "c:errors/event_ingested@none"
+
+
 @dataclass
 class ParsedMRI:
     entity: str

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -124,6 +124,10 @@ class SpanMetricKey(Enum):
     HTTP_ERROR_RATE_LIGHT = "span.http_error_rate_light"
 
 
+class ErrorsMetricKey(Enum):
+    EVENT_INGESTED = "errors.event_ingested"
+
+
 class SpanTagsKey(Enum):
     HTTP_STATUS_CODE = "span.status_code"
 

--- a/tests/sentry/issues/test_escalating.py
+++ b/tests/sentry/issues/test_escalating.py
@@ -164,11 +164,7 @@ class HistoricGroupCounts(
     @with_feature("organizations:escalating-issues-v2")
     @mock.patch("sentry.issues.escalating.logger")
     def test_pagination(self, mock_logger) -> None:
-        group1_events = []
-        for i in range(10):
-            event = self._create_events_for_group(count=2, hours_ago=10 - i, group="group-1")
-            group1_events.append(event)
-
+        group1_bucket1_event = self._create_events_for_group(count=2, hours_ago=2, group="group-1")
         group2_bucket1_event = self._create_events_for_group(count=1, hours_ago=2, group="group-2")
         group2_bucket2_event = self._create_events_for_group(count=2, hours_ago=1, group="group-2")
         group3_bucket1_event = self._create_events_for_group(count=2, hours_ago=1, group="group-3")
@@ -176,11 +172,10 @@ class HistoricGroupCounts(
         # This forces to test the iteration over the Snuba data
         with patch("sentry.issues.escalating.ELEMENTS_PER_SNUBA_PAGE", new=2):
             assert query_groups_past_counts(Group.objects.all()) == [
-                self._create_hourly_bucket(2, event) for event in group1_events
-            ] + [
+                self._create_hourly_bucket(2, group1_bucket1_event),
                 self._create_hourly_bucket(1, group2_bucket1_event),
                 self._create_hourly_bucket(2, group2_bucket2_event),
-                self._create_hourly_bucket(1, group3_bucket1_event),
+                self._create_hourly_bucket(2, group3_bucket1_event),
             ]
 
         assert mock_logger.info.call_count == 0

--- a/tests/sentry/issues/test_escalating.py
+++ b/tests/sentry/issues/test_escalating.py
@@ -162,21 +162,19 @@ class HistoricGroupCounts(
         assert mock_logger.info.call_count == 0
 
     @with_feature("organizations:escalating-issues-v2")
+    # This forces to test the iteration over the Snuba data
+    @mock.patch("sentry.issues.escalating.ELEMENTS_PER_SNUBA_METRICS_QUERY", new=4)
+    @mock.patch("sentry.issues.escalating.ELEMENTS_PER_SNUBA_PAGE", new=4)
     @mock.patch("sentry.issues.escalating.logger")
     def test_pagination(self, mock_logger) -> None:
-        group1_bucket1_event = self._create_events_for_group(count=2, hours_ago=2, group="group-1")
-        group2_bucket1_event = self._create_events_for_group(count=1, hours_ago=2, group="group-2")
-        group2_bucket2_event = self._create_events_for_group(count=2, hours_ago=1, group="group-2")
-        group3_bucket1_event = self._create_events_for_group(count=2, hours_ago=1, group="group-3")
+        events = []
+        for i in range(20):
+            event = self._create_events_for_group(count=1, hours_ago=2, group=f"group-{i}")
+            events.append(event)
 
-        # This forces to test the iteration over the Snuba data
-        with patch("sentry.issues.escalating.ELEMENTS_PER_SNUBA_PAGE", new=2):
-            assert query_groups_past_counts(Group.objects.all()) == [
-                self._create_hourly_bucket(2, group1_bucket1_event),
-                self._create_hourly_bucket(1, group2_bucket1_event),
-                self._create_hourly_bucket(2, group2_bucket2_event),
-                self._create_hourly_bucket(2, group3_bucket1_event),
-            ]
+        assert query_groups_past_counts(Group.objects.all()) == [
+            self._create_hourly_bucket(1, event) for event in events
+        ]
 
         assert mock_logger.info.call_count == 0
 


### PR DESCRIPTION
## Objective:

We want to start making queries to the Generic Metrics backend for our Escalating Forecasts. However, I want to check if the results from the queries are equivalent to the results from the Dataset queries. So we will still rely on the Dataset queries to make the Forecasts and if the values are not equal, we will log an exception in Sentry for visibility.