### PR TITLE
ref(hc): Update User.get_orgs_require_2fa to use control models

### DIFF
--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -383,12 +383,14 @@ class User(BaseModel, AbstractBaseUser):
             request.session["_nonce"] = self.session_nonce
 
     def get_orgs_require_2fa(self):
-        from sentry.models import Organization, OrganizationStatus
+        from sentry.models import OrganizationMapping, OrganizationMemberMapping, OrganizationStatus
 
-        return Organization.objects.filter(
-            flags=models.F("flags").bitor(Organization.flags.require_2fa),
+        return OrganizationMapping.objects.filter(
+            require_2fa=True,
             status=OrganizationStatus.ACTIVE,
-            member_set__user_id=self.id,
+            organization_id__in=OrganizationMemberMapping.objects.filter(
+                user_id=self.id
+            ).values_list("organization_id", flat=True),
         )
 
     def clear_lost_passwords(self):

--- a/tests/sentry/api/endpoints/test_user_authenticator_details.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_details.py
@@ -188,7 +188,7 @@ class UserAuthenticatorDeviceDetailsTest(UserAuthenticatorDetailsTestBase):
         )
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class UserAuthenticatorDetailsTest(UserAuthenticatorDetailsTestBase):
     endpoint = "sentry-api-0-user-authenticator-details"
 


### PR DESCRIPTION
This is currently only used in UserAuthenticatorDetailsEndpoint. This updates the implementation to use control silo models now that the require_2fa flag is replicated.