### PR TITLE
fix(alerts): Set create and edit alerts to the same width

### DIFF
--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -1,6 +1,5 @@
 import {Component, Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
-import styled from '@emotion/styled';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -135,7 +134,7 @@ class Create extends Component<Props, State> {
             </Layout.Title>
           </Layout.HeaderContent>
         </Layout.Header>
-        <Body>
+        <Layout.Body>
           <Teams provideUserTeams>
             {({teams, initiallyLoaded}) =>
               initiallyLoaded ? (
@@ -176,22 +175,10 @@ class Create extends Component<Props, State> {
               )
             }
           </Teams>
-        </Body>
+        </Layout.Body>
       </Fragment>
     );
   }
 }
-
-const Body = styled(Layout.Body)`
-  && {
-    padding: 0;
-    gap: 0;
-  }
-  grid-template-rows: 1fr;
-
-  @media (min-width: ${p => p.theme.breakpoints.large}) {
-    grid-template-columns: minmax(100px, auto) 400px;
-  }
-`;
 
 export default withRouteAnalytics(Create);

--- a/static/app/views/alerts/edit.tsx
+++ b/static/app/views/alerts/edit.tsx
@@ -1,6 +1,5 @@
 import {Component, Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
-import styled from '@emotion/styled';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -80,7 +79,7 @@ class ProjectAlertsEditor extends Component<Props, State> {
             <Layout.Title>{this.getTitle()}</Layout.Title>
           </Layout.HeaderContent>
         </Layout.Header>
-        <EditConditionsBody>
+        <Layout.Body>
           <Teams provideUserTeams>
             {({teams, initiallyLoaded}) =>
               initiallyLoaded ? (
@@ -108,16 +107,10 @@ class ProjectAlertsEditor extends Component<Props, State> {
               )
             }
           </Teams>
-        </EditConditionsBody>
+        </Layout.Body>
       </Fragment>
     );
   }
 }
-
-const EditConditionsBody = styled(Layout.Body)`
-  *:not(img) {
-    max-width: 1000px;
-  }
-`;
 
 export default ProjectAlertsEditor;

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1289,7 +1289,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
     // the form with a loading mask on top of it, but force a re-render by using
     // a different key when we have fetched the rule so that form inputs are filled in
     return (
-      <Main>
+      <Main fullWidth>
         <PermissionAlert access={['alerts:write']} project={project} />
 
         <StyledForm
@@ -1691,6 +1691,10 @@ export const findIncompatibleRules = (
   return {conditionIndices: null, filterIndices: null};
 };
 
+const Main = styled(Layout.Main)`
+  max-width: 1000px;
+`;
+
 // TODO(ts): Understand why styled is not correctly inheriting props here
 const StyledForm = styled(Form)<FormProps>`
   position: relative;
@@ -1831,10 +1835,6 @@ const ContentIndent = styled('div')`
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     margin-left: ${space(4)};
   }
-`;
-
-const Main = styled(Layout.Main)`
-  padding: ${space(2)} ${space(4)};
 `;
 
 const AcknowledgeLabel = styled('label')`

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1034,7 +1034,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
 }
 
 const Main = styled(Layout.Main)`
-  padding: ${space(2)} ${space(4)};
+  max-width: 1000px;
 `;
 
 const StyledListItem = styled(ListItem)`


### PR DESCRIPTION
For some reason they had different widths and padding, now they are all the same max 1000px


some pages had extra padding - everything shouild be left aligned
![image](https://github.com/getsentry/sentry/assets/1400464/3044904f-efd8-435c-86df-649bf0a6c419)
