### PR TITLE
fix(crons): Use `lte` when filtering late monitors

### DIFF
--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -6,6 +6,7 @@ import sentry_sdk
 from arroyo import Topic
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from django.conf import settings
+from django.db.models import F, Q
 from django.utils import timezone
 
 from sentry.constants import ObjectStatus
@@ -171,21 +172,27 @@ def check_missing(current_datetime: datetime):
     current_datetime = current_datetime.replace(second=0, microsecond=0)
 
     qs = (
+        # Monitors that have reached the latest checkin time
         MonitorEnvironment.objects.filter(
             monitor__type__in=[MonitorType.CRON_JOB],
-            # [!!]: Note that we use `lt` here to give a whole minute buffer
-            # for a check-in to be sent.
+            next_checkin_latest__lte=current_datetime,
+        )
+        # TODO(epurkhiser): Exclusion to be removed after GH-56526 is complete.
+        .exclude(
+            # As a temporary stop-gap while we fix GH-56526 we are skipping
+            # monitors which have a next_checkin_latest equal to their
+            # next_checkin
             #
-            # As an example, if our next_checkin_latest for a monitor was
-            # 11:00:00, and our task runs at 11:00:05, the time is clamped down
-            # to 11:00:00, and then compared:
-            #
-            #  next_checkin_latest < 11:00:00
-            #
-            # Since they are equal this does not match. When the task is run a
-            # minute later if the check-in still hasn't been sent we will THEN
-            # mark it as missed.
-            next_checkin_latest__lt=current_datetime,
+            # This is due to the fact that the default value of the
+            # `checkin_margin` was 0. With it set to a minimum and default of `1`
+            # future computed `next_checkin_latest`'s will ALWAYS have a minimum of
+            # one minute apart.
+            Q(next_checkin=F("next_checkin_latest"))
+            # Make sure to run these at the next tick though, which is what the
+            # previous behavior was. If the next_checkin{,_latest} values
+            # are equal ONLY exclude them when next_checkin_latest is the
+            # current time.
+            & Q(next_checkin_latest=current_datetime)
         )
         .exclude(
             status__in=[
@@ -202,6 +209,7 @@ def check_missing(current_datetime: datetime):
             ]
         )[:MONITOR_LIMIT]
     )
+
     metrics.gauge("sentry.monitors.tasks.check_missing.count", qs.count(), sample_rate=1.0)
     for monitor_environment in qs:
         mark_environment_missing.delay(monitor_environment.id)

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -40,7 +40,11 @@ def make_ref_time():
     #
     # This is testing that the task correctly clamps its reference time
     # down to the minute.
-    task_run_ts = ts.replace(second=12, microsecond=0)
+    #
+    # NOTE: We also remove the timezone info from the task run timestamp, since
+    # it recieves a date time object from the kafka producer. This helps test
+    # for bad timezone
+    task_run_ts = ts.replace(second=12, microsecond=0, tzinfo=None)
 
     # We truncate down to the minute when we mark the next_checkin, do the
     # same here.
@@ -75,7 +79,7 @@ class MonitorTaskCheckMissingTest(TestCase):
             environment=self.environment,
             last_checkin=ts - timedelta(minutes=2),
             next_checkin=ts - timedelta(minutes=1),
-            next_checkin_latest=ts - timedelta(minutes=1),
+            next_checkin_latest=ts,
             status=MonitorStatus.OK,
         )
 
@@ -108,6 +112,49 @@ class MonitorTaskCheckMissingTest(TestCase):
             monitor_environment.last_checkin + timedelta(minutes=1)
         ).replace(second=0, microsecond=0)
         assert missed_checkin.monitor_config == monitor.config
+
+    @mock.patch("sentry.monitors.tasks.mark_environment_missing")
+    def test_temp_ingore_next_checkin_equal_latest(self, mark_environment_missing_mock):
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+
+        task_run_ts, ts = make_ref_time()
+
+        monitor = Monitor.objects.create(
+            organization_id=org.id,
+            project_id=project.id,
+            type=MonitorType.CRON_JOB,
+            config={
+                "schedule": "* * * * *",
+                "schedule_type": ScheduleType.CRONTAB,
+                "max_runtime": None,
+                "checkin_margin": None,
+            },
+        )
+
+        # This monitor will be ignored, the next_checkin and
+        # next_checkin_latest are equal. In the future this should never happen
+        # since the `checkin_margin` will have a minimum of `1`.
+        monitor_environment = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment=self.environment,
+            last_checkin=ts - timedelta(minutes=1),
+            next_checkin=ts,
+            next_checkin_latest=ts,
+            status=MonitorStatus.OK,
+        )
+
+        # The task to mark the monitor as missed is not called
+        check_missing(task_run_ts)
+        assert mark_environment_missing_mock.delay.call_count == 0
+
+        # A minute later it now correctly is
+        check_missing(task_run_ts + timedelta(minutes=1))
+
+        assert mark_environment_missing_mock.delay.call_count == 1
+        assert mark_environment_missing_mock.delay.mock_calls[0] == mock.call(
+            monitor_environment.id
+        )
 
     @mock.patch("sentry.monitors.tasks.mark_environment_missing")
     def test_missing_checkin_with_margin(self, mark_environment_missing_mock):
@@ -216,7 +263,7 @@ class MonitorTaskCheckMissingTest(TestCase):
             monitor=monitor,
             environment=self.environment,
             next_checkin=ts - timedelta(minutes=1),
-            next_checkin_latest=ts - timedelta(minutes=1),
+            next_checkin_latest=ts,
             status=MonitorStatus.ACTIVE,
         )
 
@@ -252,7 +299,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         project = self.create_project(organization=org)
 
         task_run_ts, ts = make_ref_time()
-        last_checkin_ts = ts - timedelta(minutes=1)
+        last_checkin_ts = ts - timedelta(minutes=2)
 
         monitor = Monitor.objects.create(
             organization_id=org.id,
@@ -265,7 +312,7 @@ class MonitorTaskCheckMissingTest(TestCase):
             monitor=monitor,
             environment=self.environment,
             last_checkin=last_checkin_ts,
-            next_checkin=ts,
+            next_checkin=ts - timedelta(minutes=1),
             next_checkin_latest=ts,
             status=MonitorStatus.OK,
         )
@@ -314,7 +361,7 @@ class MonitorTaskCheckMissingTest(TestCase):
             monitor=exception_monitor,
             environment=self.environment,
             next_checkin=ts - timedelta(minutes=1),
-            next_checkin_latest=ts - timedelta(minutes=1),
+            next_checkin_latest=ts,
             status=MonitorStatus.OK,
         )
 
@@ -328,7 +375,7 @@ class MonitorTaskCheckMissingTest(TestCase):
             monitor=monitor,
             environment=self.environment,
             next_checkin=ts - timedelta(minutes=1),
-            next_checkin_latest=ts - timedelta(minutes=1),
+            next_checkin_latest=ts,
             status=MonitorStatus.OK,
         )
 
@@ -374,7 +421,7 @@ class MonitorTaskCheckTimemoutTest(TestCase):
             environment=self.environment,
             last_checkin=check_in_24hr_ago - timedelta(hours=24),
             next_checkin=check_in_24hr_ago,
-            next_checkin_latest=check_in_24hr_ago,
+            next_checkin_latest=check_in_24hr_ago + timedelta(minutes=1),
             status=MonitorStatus.OK,
         )
         # In progress started 24hr ago
@@ -439,7 +486,7 @@ class MonitorTaskCheckTimemoutTest(TestCase):
             # Next checkin is in the future, we just completed our last checkin
             last_checkin=ts,
             next_checkin=ts + timedelta(hours=24),
-            next_checkin_latest=ts + timedelta(hours=24),
+            next_checkin_latest=ts + timedelta(hours=24, minutes=1),
             status=MonitorStatus.OK,
         )
         # Checkin 24hr ago
@@ -496,7 +543,7 @@ class MonitorTaskCheckTimemoutTest(TestCase):
             environment=self.environment,
             last_checkin=check_in_24hr_ago,
             next_checkin=ts,
-            next_checkin_latest=ts,
+            next_checkin_latest=ts + timedelta(minutes=1),
             status=MonitorStatus.OK,
         )
         checkin = MonitorCheckIn.objects.create(
@@ -550,7 +597,7 @@ class MonitorTaskCheckTimemoutTest(TestCase):
             environment=self.environment,
             last_checkin=ts,
             next_checkin=ts + timedelta(hours=24),
-            next_checkin_latest=ts + timedelta(hours=24),
+            next_checkin_latest=ts + timedelta(hours=24, minutes=1),
             status=MonitorStatus.OK,
         )
         MonitorCheckIn.objects.create(
@@ -576,7 +623,7 @@ class MonitorTaskCheckTimemoutTest(TestCase):
             environment=self.environment,
             last_checkin=ts,
             next_checkin=ts + timedelta(hours=24),
-            next_checkin_latest=ts + timedelta(hours=24),
+            next_checkin_latest=ts + timedelta(hours=24, minutes=1),
             status=MonitorStatus.OK,
         )
         checkin1 = MonitorCheckIn.objects.create(


### PR DESCRIPTION
This is part of GH-56526

(This is take 2 after 89e5507720, which had a very subtle timestamp bug)

Previously we allowed the `next_checkin_latest` to be equal to
`next_checkin`. This doesn't make sense since we want the default to be
`1` for the missed margin, as well as for it to have a minimum of `1`.

This change updates the query to be `__lte`. This looks like this:

Imagine this scenario

    missed_margin = 1
    next_checkin = 11:00:00
    next_checkin_latest = 11:01:00

When we run at `11:00:00`

    next_checkin_latest <= 11:00:00  # False

This will return false, we haven't passed the window yet.

    next_checkin_latest <= 11:01:00  # True

This will return true, we have reached the

---

A side effect of this change is now that **All monitors that were not
using the default value of `0` are now getting ONE LESS MINUTE to
complete their check-in.**

Previously if a monitor had a missed_margin of `1` it looked like this

    missed_margin = 1
    next_checkin = 11:00:00
    next_checkin_latest = 11:01:00

    next_checkin_latest < 11:01:00 # False
    next_checkin_latest < 11:02:00 # False

As you can see here, we actually waited until 11:02:00 to mark their
monitor as missed. **This behavior is changing**