### PR TITLE
fix(platformicons): Change `react` to `javascript-react` to get correct platform icon

### DIFF
--- a/static/app/utils/fileExtension.tsx
+++ b/static/app/utils/fileExtension.tsx
@@ -1,6 +1,6 @@
 const FILE_EXTENSION_TO_PLATFORM = {
-  jsx: 'react',
-  tsx: 'react',
+  jsx: 'javascript-react',
+  tsx: 'javascript-react',
   js: 'javascript',
   ts: 'javascript',
   php: 'php',


### PR DESCRIPTION
Looks like our platform icons mapping had the incorrect name. `react` should be `javascript-react`: https://github.com/getsentry/platformicons/blob/7b8260f3e07f817d5cc696c6fe5ebeafd66334c7/src/platformIcon.tsx#L60

See this as an example issue with the wrong icon: https://sentry.sentry.io/issues/4460538059

The way we determine the icon for a stacktrace still isn't great. Most of the time in our org you'll see the JS icon instead of the react icon, unless every stack frame has the same file extension (.tsx). See https://github.com/getsentry/sentry/issues/53132

Before:

<img width="295" alt="CleanShot 2023-09-21 at 16 01 42@2x" src="https://github.com/getsentry/sentry/assets/10888943/71fb07bd-71cd-42a7-8f83-71850b6636aa">

After:

<img width="256" alt="CleanShot 2023-09-21 at 16 01 51@2x" src="https://github.com/getsentry/sentry/assets/10888943/956153b0-9e8f-41d7-9c9f-50b5f0334ced">
