### PR TITLE
ref(hc): Make check auth operations less aggressive

### DIFF
--- a/src/sentry/models/authidentity.py
+++ b/src/sentry/models/authidentity.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from typing import Collection
 
 from django.conf import settings
@@ -52,20 +51,6 @@ class AuthIdentity(ReplicatedControlModel):
 
     def get_audit_log_data(self):
         return {"user_id": self.user_id, "data": self.data}
-
-    # TODO(dcramer): we'd like to abstract this so there's a central Role object
-    # and it doesnt require two composite db objects to talk to each other
-    def is_valid(self, member):
-        if getattr(member.flags, "sso:invalid"):
-            return False
-        if not getattr(member.flags, "sso:linked"):
-            return False
-
-        if not self.last_verified:
-            return False
-        if self.last_verified < timezone.now() - timedelta(hours=24):
-            return False
-        return True
 
     def get_display_name(self):
         return self.user.get_display_name()

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from collections import defaultdict
 from itertools import chain
 from typing import TYPE_CHECKING, Collection, Iterable, Mapping
@@ -378,30 +377,6 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
     def get_members_as_rpc_users(self) -> Iterable[RpcUser]:
         member_ids = self.member_set.values_list("user_id", flat=True)
         return user_service.get_many(filter=dict(user_ids=list(member_ids)))
-
-    def has_access(self, user, access=None):
-        from sentry.models import AuthIdentity, OrganizationMember
-
-        warnings.warn("Project.has_access is deprecated.", DeprecationWarning)
-
-        queryset = self.member_set.filter(user_id=user.id)
-
-        if access is not None:
-            queryset = queryset.filter(type__lte=access)
-
-        try:
-            member = queryset.get()
-        except OrganizationMember.DoesNotExist:
-            return False
-
-        try:
-            auth_identity = AuthIdentity.objects.get(
-                auth_provider__organization=self.organization_id, user=member.user_id
-            )
-        except AuthIdentity.DoesNotExist:
-            return True
-
-        return auth_identity.is_valid(member)
 
     def get_audit_log_data(self):
         return {

--- a/src/sentry/services/hybrid_cloud/access/service.py
+++ b/src/sentry/services/hybrid_cloud/access/service.py
@@ -48,7 +48,7 @@ class AccessService(abc.ABC):
 
         if not auth_identity.last_verified:
             return False
-        if auth_identity.last_verified < timezone.now() - timedelta(hours=24):
+        if auth_identity.last_verified < timezone.now() - timedelta(hours=24 * 7):
             return False
         return True
 

--- a/src/sentry/tasks/check_auth.py
+++ b/src/sentry/tasks/check_auth.py
@@ -14,7 +14,7 @@ from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.auth")
 
-AUTH_CHECK_INTERVAL = 3600
+AUTH_CHECK_INTERVAL = 3600 * 24
 
 
 @instrumented_task(name="sentry.tasks.check_auth", queue="auth.control", silo_mode=SiloMode.CONTROL)


### PR DESCRIPTION
1.  Any auth identity that has `refresh_identity` success in the last 24 hours, we don't process it until 24 hours (instead of every single hour!)
2.  If auth identity has not been validated for 7 days, we don't consider it valid (instead of 24 hours).

Greatly reduces huge amount of unnecessary processing and replication.

Notably, if a auth provider decomissions a user, we already remove their `AuthIdentity` by other means -- this job is purely an 'edge case' handler.