### PR TITLE
fix(severity): Calculate severity for all `default`-type events

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2061,9 +2061,12 @@ def _get_severity_score(event: Event) -> float | None:
     # message data elsewhere in the event.)
     title = event.title
     event_type = get_event_type(event.data)
+
+    # If the event hasn't yet been given a helpful title, attempt to calculate one
     if title in NON_TITLE_EVENT_TITLES:
         title = event_type.get_title(event_type.get_metadata(event.data))
 
+    # If there's still nothing helpful to be had, bail
     if title in NON_TITLE_EVENT_TITLES:
         logger_data.update(
             {"event_type": event_type.key, "event_title": event.title, "computed_title": title}


### PR DESCRIPTION
This fixes a potential bug in `_get_severity_score` wherein events without an `exception` property (like those captured using `capture_message`) could get ignored if they came into the function with certain titles. (If the event has a title like `<untitled>`, `_get_severity_score` will currently attempt to compute a new title using the `ErrorEvent.compute_title` method, but that doesn't work for `capture_message`-type events, because they're actually of `DefaultEvent` type. This switches from specifically using `ErrorEvent` to using whichever `EventType` class is appropriate for the given event.)