### PR TITLE
fix(ddm): Fix count formatting and unit access

### DIFF
--- a/static/app/utils/metrics.tsx
+++ b/static/app/utils/metrics.tsx
@@ -78,7 +78,6 @@ export function useMetricsTagValues(mri: string, tag: string) {
   );
 }
 
-// TODO(ddm): reuse from types/metrics.tsx
 export type MetricsDataProps = {
   datetime: PageFilters['datetime'];
   mri: string;
@@ -205,7 +204,7 @@ export function getNameFromMRI(mri: string) {
   return mri.match(/^[a-z]:\w+\/(.+)(?:@\w+)$/)?.[1] ?? mri;
 }
 
-export function tooltipFormatterUsingUnit(value: number | null, unit: string) {
+export function formatMetricUsingUnit(value: number | null, unit: string) {
   if (!defined(value)) {
     return '\u2014';
   }

--- a/static/app/views/ddm/metricsExplorer.tsx
+++ b/static/app/views/ddm/metricsExplorer.tsx
@@ -442,7 +442,7 @@ function Chart({
     tooltip: {
       valueFormatter: (value: number) => {
         if (operation === 'count') {
-          // if the operation is count, we want to ignore the unit and alwats format the value as a number
+          // if the operation is count, we want to ignore the unit and always format the value as a number
           return value.toLocaleString();
         }
         return formatMetricUsingUnit(value, unit);
@@ -453,7 +453,7 @@ function Chart({
       axisLabel: {
         formatter: (value: number) => {
           if (operation === 'count') {
-            // if the operation is count, we want to ignore the unit and alwats format the value as a number
+            // if the operation is count, we want to ignore the unit and always format the value as a number
             return value.toLocaleString();
           }
           return formatMetricUsingUnit(value, unit);


### PR DESCRIPTION
When operation count is selected, we should not take the unit into account when formatting the value - instead, we should treat it like a number.

This also fixes an issue with accessing the unit when changing filters.

Closes https://github.com/getsentry/sentry/issues/56732