### PR TITLE
feat(ddm): summary table

### DIFF
--- a/static/app/views/ddm/metricsExplorer.tsx
+++ b/static/app/views/ddm/metricsExplorer.tsx
@@ -336,7 +336,7 @@ function MetricsExplorerDisplay({displayType, ...metricsDataProps}: DisplayProps
 
   // TODO(ddm): we should move this into the useMetricsData hook
   const sorted = sortData(data);
-  const unit = getUnitFromMRI(Object.keys(data.groups[0].series)[0]); // this assumes that all series have the same unit
+  const unit = getUnitFromMRI(Object.keys(data.groups[0]?.series ?? {})[0]); // this assumes that all series have the same unit
 
   const series = sorted.groups.map(g => {
     return {

--- a/static/app/views/ddm/metricsExplorer.tsx
+++ b/static/app/views/ddm/metricsExplorer.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useCallback, useEffect, useMemo, useReducer, useState} from 'react';
-import {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import moment from 'moment';
 
@@ -7,7 +6,6 @@ import Alert from 'sentry/components/alert';
 import {AreaChart} from 'sentry/components/charts/areaChart';
 import {BarChart} from 'sentry/components/charts/barChart';
 import ChartZoom from 'sentry/components/charts/chartZoom';
-import Legend from 'sentry/components/charts/components/legend';
 import {LineChart} from 'sentry/components/charts/lineChart';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import EmptyMessage from 'sentry/components/emptyMessage';
@@ -17,7 +15,6 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
-import PanelTable from 'sentry/components/panels/panelTable';
 import Tag from 'sentry/components/tag';
 import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -44,6 +41,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
+import {SummaryTable} from 'sentry/views/ddm/summaryTable';
 
 const useProjectSelectionSlugs = () => {
   const {selection} = usePageFilters();
@@ -316,6 +314,16 @@ function MetricsExplorerDisplayOuter(props?: DisplayProps) {
 
 function MetricsExplorerDisplay({displayType, ...metricsDataProps}: DisplayProps) {
   const {data, isLoading, isError} = useMetricsData(metricsDataProps);
+  // TODO(ddm): maybe it is nicer to use a set here, or to keep state of shown series instead
+  const [hiddenSeries, setHiddenSeries] = useState<string[]>([]);
+
+  const toggleSeriesVisibility = (seriesName: string) => {
+    if (hiddenSeries.includes(seriesName)) {
+      setHiddenSeries(hiddenSeries.filter(s => s !== seriesName));
+    } else {
+      setHiddenSeries([...hiddenSeries, seriesName]);
+    }
+  };
 
   if (!data) {
     return (
@@ -326,15 +334,38 @@ function MetricsExplorerDisplay({displayType, ...metricsDataProps}: DisplayProps
     );
   }
 
+  // TODO(ddm): we should move this into the useMetricsData hook
   const sorted = sortData(data);
+  const unit = getUnitFromMRI(Object.keys(data.groups[0].series)[0]); // this assumes that all series have the same unit
+
+  const series = sorted.groups.map(g => {
+    return {
+      values: Object.values(g.series)[0],
+      name: getSeriesName(g, data.groups.length === 1),
+    };
+  });
+
+  const colors = theme.charts.getColorPalette(series.length);
+
+  const chartSeries = series.map((item, i) => ({
+    seriesName: item.name,
+    unit,
+    color: colors[i],
+    hidden: hiddenSeries.includes(item.name),
+    data: item.values.map((value, index) => ({
+      name: sorted.intervals[index],
+      value,
+    })),
+  }));
 
   return (
     <DisplayWrapper>
-      {displayType === MetricDisplayType.TABLE ? (
-        <Table data={sorted} />
-      ) : (
-        <Chart data={sorted} displayType={displayType} />
-      )}
+      <Chart
+        series={chartSeries}
+        displayType={displayType}
+        {...normalizeChartTimeParams(sorted)}
+      />
+      <SummaryTable series={chartSeries} onClick={toggleSeriesVisibility} />
     </DisplayWrapper>
   );
 }
@@ -399,38 +430,34 @@ function normalizeChartTimeParams(data: MetricsData) {
   };
 }
 
-function Chart({data, displayType}: {data: MetricsData; displayType: MetricDisplayType}) {
-  const {start, end, period, utc} = normalizeChartTimeParams(data);
+export type Series = {
+  color: string;
+  data: {name: string; value: number}[];
+  seriesName: string;
+  unit: string;
+  hidden?: boolean;
+};
 
-  const unit = getUnitFromMRI(Object.keys(data.groups[0].series)[0]); // this assumes that all series have the same unit
+type ChartProps = {
+  displayType: MetricDisplayType;
+  series: Series[];
+  end?: string;
+  period?: string;
+  start?: string;
+  utc?: boolean;
+};
 
-  const series = data.groups.map(g => {
-    return {
-      values: Object.values(g.series)[0],
-      name: getSeriesName(g, data.groups.length === 1),
-    };
-  });
+function Chart({series, displayType, start, end, period, utc}: ChartProps) {
+  const unit = series[0].unit;
 
-  const chartSeries = series.map(item => ({
-    seriesName: item.name,
-    data: item.values.map((value, index) => ({
-      name: data.intervals[index],
-      value,
-    })),
-  }));
+  const seriesToShow = series.filter(s => !s.hidden);
 
   const chartProps = {
     isGroupedByDate: true,
-    series: chartSeries,
+    series: seriesToShow,
     height: 300,
-    legend: Legend({
-      itemGap: 20,
-      bottom: 20,
-      data: chartSeries.map(s => s.seriesName),
-      theme: theme as Theme,
-      formatter: mri => getNameFromMRI(mri),
-    }),
-    grid: {top: 30, bottom: 40, left: 20, right: 20},
+    colors: seriesToShow.map(s => s.color),
+    grid: {top: 20, bottom: 20, left: 20, right: 20},
     tooltip: {
       valueFormatter: (value: number) => tooltipFormatterUsingUnit(value, unit),
       nameFormatter: mri => getNameFromMRI(mri),
@@ -443,59 +470,21 @@ function Chart({data, displayType}: {data: MetricsData; displayType: MetricDispl
   };
 
   return (
-    <ChartZoom period={period} start={start} end={end} utc={utc}>
-      {zoomRenderProps =>
-        displayType === MetricDisplayType.LINE ? (
-          <LineChart {...chartProps} {...zoomRenderProps} />
-        ) : displayType === MetricDisplayType.AREA ? (
-          <AreaChart {...chartProps} {...zoomRenderProps} />
-        ) : (
-          <BarChart stacked {...chartProps} {...zoomRenderProps} />
-        )
-      }
-    </ChartZoom>
+    <Fragment>
+      <ChartZoom period={period} start={start} end={end} utc={utc}>
+        {zoomRenderProps =>
+          displayType === MetricDisplayType.LINE ? (
+            <LineChart {...chartProps} {...zoomRenderProps} />
+          ) : displayType === MetricDisplayType.AREA ? (
+            <AreaChart {...chartProps} {...zoomRenderProps} />
+          ) : (
+            <BarChart stacked {...chartProps} {...zoomRenderProps} />
+          )
+        }
+      </ChartZoom>
+    </Fragment>
   );
 }
-
-function Table({data}: {data: MetricsData}) {
-  const rows = data.intervals.map((interval, index) => {
-    const row = {
-      id: moment(interval).utc().format(),
-    };
-
-    data.groups.forEach(group => {
-      const seriesName = getSeriesName(group, data.groups.length === 1);
-      Object.values(group.series).forEach(values => {
-        row[seriesName] = values[index];
-      });
-    });
-    return row;
-  });
-
-  return (
-    <SeriesTable headers={Object.keys(rows[0])}>
-      {rows.map(row => (
-        <Fragment key={row.id}>
-          {Object.values(row).map((value, idx) => (
-            <Cell key={`${row.id}-${idx}`}>{value}</Cell>
-          ))}
-        </Fragment>
-      ))}
-    </SeriesTable>
-  );
-}
-
-const SeriesTable = styled(PanelTable)`
-  max-height: 290px;
-  margin-bottom: 0;
-  border: none;
-  border-radius: 0;
-  border-bottom: 1px;
-`;
-
-const Cell = styled('div')`
-  padding: ${space(0.5)} 0 ${space(0.5)} ${space(1)};
-`;
 
 const MetricsExplorerPanel = styled(Panel)`
   padding-bottom: 0;
@@ -503,7 +492,6 @@ const MetricsExplorerPanel = styled(Panel)`
 
 const DisplayWrapper = styled('div')`
   padding: ${space(1)};
-  height: 300px;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/static/app/views/ddm/summaryTable.tsx
+++ b/static/app/views/ddm/summaryTable.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {formatMetricsUsingUnitAndOp, getNameFromMRI} from 'sentry/utils/metrics';
 import {Series} from 'sentry/views/ddm/metricsExplorer';
@@ -17,11 +18,11 @@ export function SummaryTable({
   return (
     <SummaryTableWrapper>
       <HeaderCell />
-      <HeaderCell>Name</HeaderCell>
-      <HeaderCell>Avg</HeaderCell>
-      <HeaderCell>Min</HeaderCell>
-      <HeaderCell>Max</HeaderCell>
-      <HeaderCell>Sum</HeaderCell>
+      <HeaderCell>{t('Name')}</HeaderCell>
+      <HeaderCell>{t('Avg')}</HeaderCell>
+      <HeaderCell>{t('Min')}</HeaderCell>
+      <HeaderCell>{t('Max')}</HeaderCell>
+      <HeaderCell>{t('Sum')}</HeaderCell>
 
       {series.map(({seriesName, color, hidden, unit, data}) => {
         const {avg, min, max, sum} = getValues(data);

--- a/static/app/views/ddm/summaryTable.tsx
+++ b/static/app/views/ddm/summaryTable.tsx
@@ -1,0 +1,110 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+import {getNameFromMRI, tooltipFormatterUsingUnit} from 'sentry/utils/metrics';
+import {Series} from 'sentry/views/ddm/metricsExplorer';
+
+export function SummaryTable({
+  series,
+  onClick,
+}: {
+  onClick: (seriesName: string) => void;
+  series: Series[];
+}) {
+  return (
+    <SummaryTableWrapper>
+      <HeaderCell />
+      <HeaderCell>Name</HeaderCell>
+      <HeaderCell>Avg</HeaderCell>
+      <HeaderCell>Min</HeaderCell>
+      <HeaderCell>Max</HeaderCell>
+      <HeaderCell>Sum</HeaderCell>
+
+      {series.map(({seriesName, color, hidden, unit, data}) => {
+        const {avg, min, max, sum} = getValues(data);
+
+        return (
+          <Fragment key={seriesName}>
+            <FlexCell onClick={() => onClick(seriesName)} hidden={hidden}>
+              <ColorDot color={color} />
+            </FlexCell>
+            <Cell onClick={() => onClick(seriesName)}>{getNameFromMRI(seriesName)}</Cell>
+            {/* TODO(ddm): Add a tooltip with the full value, don't add on click in case users want to copy the value */}
+            <Cell>{tooltipFormatterUsingUnit(avg, unit)}</Cell>
+            <Cell>{tooltipFormatterUsingUnit(min, unit)}</Cell>
+            <Cell>{tooltipFormatterUsingUnit(max, unit)}</Cell>
+            <Cell>{tooltipFormatterUsingUnit(sum, unit)}</Cell>
+          </Fragment>
+        );
+      })}
+    </SummaryTableWrapper>
+  );
+}
+
+function getValues(seriesData: Series['data']) {
+  if (!seriesData) {
+    return {min: null, max: null, avg: null, sum: null};
+  }
+
+  const res = seriesData.reduce(
+    (acc, {value}) => {
+      if (value === null) {
+        return acc;
+      }
+
+      acc.min = Math.min(acc.min, value);
+      acc.max = Math.max(acc.max, value);
+      acc.sum += value;
+
+      return acc;
+    },
+    {min: Infinity, max: -Infinity, sum: 0}
+  );
+
+  return {...res, avg: res.sum / seriesData.length};
+}
+
+// TODO(ddm): PanelTable component proved to be a bit too opinionated for this use case,
+// so we're using a custom styled component instead. Figure out what we want to do here
+const SummaryTableWrapper = styled(`div`)`
+  display: grid;
+  grid-template-columns: 0.5fr 8fr 1fr 1fr 1fr 1fr;
+`;
+
+// TODO(ddm): This is a copy of PanelTableHeader, try to figure out how to reuse it
+const HeaderCell = styled('div')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: 600;
+  text-transform: uppercase;
+  border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
+  line-height: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  padding: ${space(0.5)};
+`;
+
+const Cell = styled('div')`
+  padding: ${space(0.25)};
+
+  :hover {
+    cursor: ${p => (p.onClick ? 'pointer' : 'default')};
+  }
+`;
+
+const FlexCell = styled(Cell)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: ${p => (p.hidden ? 0.5 : 1)};
+`;
+
+const ColorDot = styled(`div`)`
+  background-color: ${p => p.color};
+  border-radius: 50%;
+  width: ${space(1)};
+  height: ${space(1)};
+`;


### PR DESCRIPTION
Adds a summary table underneath the chart. Closes #55653
![image](https://github.com/getsentry/sentry/assets/86684834/59e6ac10-f3e7-411c-9589-0f1622bdad9a)
