### PR TITLE
ref(txcluster): Emit good clustering metric

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -88,11 +88,19 @@ def cluster_projects(projects: Sequence[Project]) -> None:
                 redis.clear_samples(ClustererNamespace.TRANSACTIONS, project)
             num_clustered += 1
     finally:
-        metrics.incr("txcluster.cluster_projects.clustered", amount=num_clustered, sample_rate=1.0)
+        metrics.incr(
+            "txcluster.cluster_projects",
+            amount=num_clustered,
+            tags={"clustered": True},
+            sample_rate=1.0,
+        )
         unclustered = len(projects) - num_clustered
         if unclustered > 0:
             metrics.incr(
-                "txcluster.cluster_projects.unclustered", amount=unclustered, sample_rate=1.0
+                "txcluster.cluster_projects",
+                amount=unclustered,
+                tags={"clustered": False},
+                sample_rate=1.0,
             )
 
 

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -88,6 +88,7 @@ def cluster_projects(projects: Sequence[Project]) -> None:
                 redis.clear_samples(ClustererNamespace.TRANSACTIONS, project)
             num_clustered += 1
     finally:
+        metrics.incr("txcluster.cluster_projects.clustered", amount=num_clustered, sample_rate=1.0)
         unclustered = len(projects) - num_clustered
         if unclustered > 0:
             metrics.incr(


### PR DESCRIPTION
Creating an SLO without a monitor (and its alerting) requires a good and bad metric. This PR sets a common metric for the good and bad outcomes, and sets the tag in each case.