### PR TITLE
chore(hybrid-cloud): Check 2FA in control silo

### DIFF
--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -13,6 +13,7 @@ from sentry.api.serializers import serialize
 from sentry.auth.authenticators.u2f import decode_credential_id
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import Authenticator
+from sentry.models.user import User
 from sentry.security import capture_security_activity
 
 
@@ -125,7 +126,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
             return self._regenerate_recovery_code(authenticator, request, user)
 
     @sudo_required
-    def delete(self, request: Request, user, auth_id, interface_device_id=None) -> Response:
+    def delete(self, request: Request, user: User, auth_id, interface_device_id=None) -> Response:
         """
         Remove authenticator
         ````````````````````
@@ -167,7 +168,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
                 user, ignore_backup=True
             )
             last_2fa_method = len(enrolled_methods) == 1
-            require_2fa = user.get_orgs_require_2fa().exists()
+            require_2fa = user.has_org_requiring_2fa()
 
             if require_2fa and last_2fa_method:
                 return Response(

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -724,7 +724,7 @@ class DeleteOrganizationMemberTest(OrganizationMemberTestBase):
         ).exists()
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class ResetOrganizationMember2faTest(APITestCase):
     def setUp(self):
         self.owner = self.create_user()


### PR DESCRIPTION
Org owners can reset a member's 2FA. But this flow checks if the user belongs to an organization that requires 2FA. 

This validation should only run exclusively in the control silo.