### PR TITLE
ref: add autouse fixture to catch leaked file descriptors

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -124,6 +124,7 @@ pre-commit==3.3.2
 progressbar2==3.41.0
 proto-plus==1.22.1
 protobuf==4.21.6
+psutil==5.9.2
 psycopg2-binary==2.8.6
 pyasn1==0.4.5
 pyasn1-modules==0.2.4
@@ -199,6 +200,7 @@ types-oauthlib==3.2.0.8
 types-parsimonious==0.10.0.8
 types-pillow==9.5.0.4
 types-protobuf==4.23.0.1
+types-psutil==5.9.5.16
 types-psycopg2==2.9.21
 types-python-dateutil==2.8.19
 types-pytz==2022.1.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ docker>=3.7.0,<3.8.0
 time-machine>=2.13.0
 honcho>=1.1.0
 openapi-core>=0.14.2
+psutil
 pytest>=7.2.1
 pytest-cov>=4.0.0
 pytest-django>=4.4.0
@@ -43,6 +44,7 @@ types-oauthlib
 types-parsimonious
 types-pillow
 types-protobuf
+types-psutil
 types-psycopg2
 types-python-dateutil
 types-pytz

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 from typing import MutableMapping
 
+import psutil
 import pytest
 import responses
 from django.db import connections
@@ -21,6 +22,13 @@ pytest_plugins = ["sentry.testutils.pytest"]
 #
 # Inspired by:
 # https://github.com/pytest-dev/pytest/blob/master/src/_pytest/terminal.py
+
+
+@pytest.fixture(autouse=True)
+def unclosed_files():
+    fds = frozenset(psutil.Process().open_files())
+    yield
+    assert frozenset(psutil.Process().open_files()) == fds
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)


### PR DESCRIPTION
this adds a little overhead to tests -- but should prevent flakes from people abusing `mkstemp` or other file io without proper context managers

<!-- Describe your PR here. -->