### PR TITLE
feat(ui): Condensed feature badge in sidebar

### DIFF
--- a/static/app/components/featureBadge.stories.tsx
+++ b/static/app/components/featureBadge.stories.tsx
@@ -41,7 +41,7 @@ export default storyBook('FeatureBadge', story => {
           </span>
         )}
         propMatrix={{
-          variant: ['badge', 'indicator'],
+          variant: ['badge', 'indicator', 'short'],
           type: ['alpha', 'beta', 'new', 'experimental'],
         }}
         selectedProps={['type', 'variant']}

--- a/static/app/components/featureBadge.tsx
+++ b/static/app/components/featureBadge.tsx
@@ -22,7 +22,7 @@ type BadgeProps = {
 
 type Props = Omit<React.HTMLAttributes<HTMLDivElement>, keyof BadgeProps> & BadgeProps;
 
-const defaultTitles = {
+const defaultTitles: Record<BadgeType, string> = {
   alpha: t('This feature is internal and available for QA purposes'),
   beta: t('This feature is available for early adopters and may change'),
   new: t('This feature is new! Try it out and let us know what you think'),
@@ -31,7 +31,7 @@ const defaultTitles = {
   ),
 };
 
-const labels = {
+const labels: Record<BadgeType, string> = {
   alpha: t('alpha'),
   beta: t('beta'),
   new: t('new'),

--- a/static/app/components/featureBadge.tsx
+++ b/static/app/components/featureBadge.tsx
@@ -40,8 +40,8 @@ const labels: Record<BadgeType, string> = {
 };
 
 const shortLabels: Record<BadgeType, string> = {
-  alpha: 'a',
-  beta: 'b',
+  alpha: 'α',
+  beta: 'β',
   new: 'n',
   experimental: 'e',
 };

--- a/static/app/components/featureBadge.tsx
+++ b/static/app/components/featureBadge.tsx
@@ -14,10 +14,11 @@ export type BadgeType = 'alpha' | 'beta' | 'new' | 'experimental';
 
 type BadgeProps = {
   type: BadgeType;
+  condensed?: boolean;
   expiresAt?: Date;
   title?: string;
   tooltipProps?: Partial<TooltipProps>;
-  variant?: 'indicator' | 'badge';
+  variant?: 'badge' | 'indicator' | 'short';
 };
 
 type Props = Omit<React.HTMLAttributes<HTMLDivElement>, keyof BadgeProps> & BadgeProps;
@@ -36,6 +37,13 @@ const labels: Record<BadgeType, string> = {
   beta: t('beta'),
   new: t('new'),
   experimental: t('experimental'),
+};
+
+const shortLabels: Record<BadgeType, string> = {
+  alpha: 'a',
+  beta: 'b',
+  new: 'n',
+  experimental: 'e',
 };
 
 function BaseFeatureBadge({
@@ -65,6 +73,7 @@ function BaseFeatureBadge({
       <Tooltip title={title ?? defaultTitles[type]} position="right" {...tooltipProps}>
         <Fragment>
           {variant === 'badge' && <StyledBadge type={type} text={labels[type]} />}
+          {variant === 'short' && <StyledBadge type={type} text={shortLabels[type]} />}
           {variant === 'indicator' && (
             <CircleIndicator color={theme.badge[type].indicatorColor} size={8} />
           )}

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -160,9 +160,15 @@ function SidebarItem({
 
   const badges = (
     <Fragment>
-      {showIsNew && <FeatureBadge type="new" tooltipProps={{disabled: true}} />}
-      {isBeta && <FeatureBadge type="beta" tooltipProps={{disabled: true}} />}
-      {isAlpha && <FeatureBadge type="alpha" tooltipProps={{disabled: true}} />}
+      {showIsNew && (
+        <FeatureBadge type="new" variant="short" tooltipProps={{disabled: true}} />
+      )}
+      {isBeta && (
+        <FeatureBadge type="beta" variant="short" tooltipProps={{disabled: true}} />
+      )}
+      {isAlpha && (
+        <FeatureBadge type="alpha" variant="short" tooltipProps={{disabled: true}} />
+      )}
     </Fragment>
   );
 


### PR DESCRIPTION
Some sidebar items have long names and feature badges like "alpha" cause alignment problems. This PR adds a "short" variant, which only uses the first character of the badge type. All sidebar badges use this short version.

**e.g.,**
<img width="233" alt="Screenshot 2023-09-22 at 2 24 59 PM" src="https://github.com/getsentry/sentry/assets/989898/49433717-adb1-4b6c-a5a3-439ce262605c">


## Changes
- Enforce types on string enums
- Add short badge variant
- Use greek characters
- Use short badges in the sidebar
