### PR TITLE
ref(alerts): Add rule disable audit log entry

### DIFF
--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -200,6 +200,14 @@ default_manager.add(
         event_id=83, name="RULE_SNOOZE", api_name="rule.mute", template='muted rule "{label}"'
     )
 )
+default_manager.add(
+    AuditLogEvent(
+        event_id=83,
+        name="RULE_DISABLE",
+        api_name="rule.disable",
+        template='disabled rule "{label}"',
+    )
+)
 default_manager.add(events.ServiceHookAddAuditLogEvent())
 default_manager.add(events.ServiceHookEditAuditLogEvent())
 default_manager.add(events.ServiceHookRemoveAuditLogEvent())

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -202,7 +202,7 @@ default_manager.add(
 )
 default_manager.add(
     AuditLogEvent(
-        event_id=83,
+        event_id=84,
         name="RULE_DISABLE",
         api_name="rule.disable",
         template='disabled rule "{label}"',

--- a/tests/sentry/audit_log/test_register.py
+++ b/tests/sentry/audit_log/test_register.py
@@ -48,6 +48,7 @@ class AuditLogEventRegisterTest(TestCase):
             "rule.edit",
             "rule.remove",
             "rule.mute",
+            "rule.disable",
             "servicehook.create",
             "servicehook.edit",
             "servicehook.remove",


### PR DESCRIPTION
Add an audit log entry for disabling a rule so that when we run the task that disables rules, customers can check there. 