### PR TITLE
fix(CoGS): Use Case ID not being propagated in Metrics Query Builder

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -853,6 +853,9 @@ class MetricsQueryBuilder(QueryBuilder):
                 )
             }
 
+        self.tenant_ids = self.tenant_ids or dict()
+        self.tenant_ids["use_case_id"] = self.use_case_id
+
         if self.builder_config.use_metrics_layer or self._on_demand_metric_spec:
             from sentry.snuba.metrics.datasource import get_series
             from sentry.snuba.metrics.mqb_query_transformer import (

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -854,7 +854,7 @@ class MetricsQueryBuilder(QueryBuilder):
             }
 
         self.tenant_ids = self.tenant_ids or dict()
-        self.tenant_ids["use_case_id"] = self.use_case_id
+        self.tenant_ids["use_case_id"] = self.use_case_id.value
 
         if self.builder_config.use_metrics_layer or self._on_demand_metric_spec:
             from sentry.snuba.metrics.datasource import get_series


### PR DESCRIPTION
### Overview
- #56694
- This PR added a bunch of `use_case_id` tenant IDs but they're not showing up, likely because of the way params are populated