### PR TITLE
fix(rule): Update rule disable link and fix text

### DIFF
--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -342,7 +342,7 @@ function AlertRuleDetails({params, location, router}: AlertRuleDetailsProps) {
       return (
         <Alert type="warning" showIcon>
           {tct(
-            'This alert is scheduled to be disabled in [date] due to lack of activity. Please [keepAlive] to keep this alert active. [docs:Learn more]',
+            'This alert is scheduled to be disabled [date] due to lack of activity. Please [keepAlive] to keep this alert active. [docs:Learn more]',
             {
               date: <TimeSince date={rule.disableDate} />,
               keepAlive: (
@@ -350,7 +350,9 @@ function AlertRuleDetails({params, location, router}: AlertRuleDetailsProps) {
                   {t('click here')}
                 </BoldButton>
               ),
-              docs: <ExternalLink href="https://docs.sentry.io/product/alerts/" />,
+              docs: (
+                <ExternalLink href="https://docs.sentry.io/product/alerts/#disabled-alerts" />
+              ),
             }
           )}
         </Alert>


### PR DESCRIPTION
The text said "in in" and the anchor tag for disabled alerts didn't exist yet - this fixes the text and links to the new section. 

**Before**
<img width="1093" alt="Screenshot 2023-09-22 at 2 08 18 PM" src="https://github.com/getsentry/sentry/assets/29959063/25170419-592f-416b-ad8e-2bda8cbcafba">

**After**
<img width="1097" alt="Screenshot 2023-09-22 at 2 07 31 PM" src="https://github.com/getsentry/sentry/assets/29959063/cfbdd34b-0cae-474e-86d8-b2c224f1a459">


