### PR TITLE
feat(alerts): Add analytics to msteams issue alert action

### DIFF
--- a/src/sentry/integrations/msteams/actions/notification.py
+++ b/src/sentry/integrations/msteams/actions/notification.py
@@ -53,6 +53,8 @@ class MsTeamsNotifyServiceAction(IntegrationEventAction):
 
             client = MsTeamsClient(integration)
             client.send_card(channel, card)
+            rule = rules[0] if rules else None
+            self.record_notification_sent(event, channel, rule, notification_uuid)
 
         key = f"msteams:{integration.id}:{channel}"
 

--- a/src/sentry/integrations/msteams/analytics.py
+++ b/src/sentry/integrations/msteams/analytics.py
@@ -8,7 +8,7 @@ class MSTeamsIntegrationNotificationSent(analytics.Event):
         analytics.Attribute("organization_id"),
         analytics.Attribute("project_id", required=False),
         analytics.Attribute("category"),
-        analytics.Attribute("actor_id"),
+        analytics.Attribute("actor_id", required=False),
         analytics.Attribute("user_id", required=False),
         analytics.Attribute("notification_uuid"),
         analytics.Attribute("alert_id", required=False),

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
@@ -278,6 +278,7 @@ describe('AlertRuleDetails', () => {
     expect(
       screen.queryByText(/This alert was disabled due to lack of activity/)
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(/This alert is disabled/)).not.toBeInTheDocument();
   });
 
   it('renders the mute button and can mute/unmute alerts', async () => {

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
@@ -278,7 +278,6 @@ describe('AlertRuleDetails', () => {
     expect(
       screen.queryByText(/This alert was disabled due to lack of activity/)
     ).not.toBeInTheDocument();
-    expect(screen.queryByText(/This alert is disabled/)).not.toBeInTheDocument();
   });
 
   it('renders the mute button and can mute/unmute alerts', async () => {

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -38,14 +38,18 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         assert form.cleaned_data["channel"] == expected_channel
 
     @responses.activate
-    def test_applies_correctly(self):
+    @mock.patch("sentry.analytics.record")
+    def test_applies_correctly(self, mock_record):
         event = self.get_event()
 
         rule = self.get_rule(
             data={"team": self.integration.id, "channel": "Naboo", "channel_id": "nb"}
         )
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        notification_uuid = "123e4567-e89b-12d3-a456-426614174000"
+        results = list(
+            rule.after(event=event, state=self.get_state(), notification_uuid=notification_uuid)
+        )
         assert len(results) == 1
 
         responses.add(
@@ -68,6 +72,25 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         title_card = attachments[0]["content"]["body"][0]
         title_pattern = r"\[%s\](.*)" % event.title
         assert re.match(title_pattern, title_card["text"])
+        mock_record.assert_called_with(
+            "alert.sent",
+            provider="msteams",
+            alert_id="",
+            alert_type="issue_alert",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            external_id="nb",
+            notification_uuid=notification_uuid,
+        )
+        mock_record.assert_any_call(
+            "integrations.msteams.notification_sent",
+            category="issue_alert",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            group_id=event.group_id,
+            notification_uuid=notification_uuid,
+            alert_id=None,
+        )
 
     @responses.activate
     @mock.patch(


### PR DESCRIPTION
we have analytics for all notifications, but if they setup to send to a specific msteams channel it doesn't send as a notification. this adds analytics for the integration action