### PR TITLE
security: reduce validity time of lost password hashes 

### DIFF
--- a/src/sentry/models/lostpasswordhash.py
+++ b/src/sentry/models/lostpasswordhash.py
@@ -38,7 +38,7 @@ class LostPasswordHash(Model):
         self.hash = get_secure_token()
 
     def is_valid(self) -> bool:
-        return self.date_added > timezone.now() - timedelta(hours=48)
+        return self.date_added > timezone.now() - timedelta(hours=1)
 
     @classmethod
     def send_email(cls, user, hash, request, mode="recover") -> None:

--- a/src/sentry/templates/sentry/emails/recover_account.html
+++ b/src/sentry/templates/sentry/emails/recover_account.html
@@ -5,7 +5,7 @@
 {% block main %}
     <h3>Reset Password</h3>
     <p>A password reset was requested for your account ({{ user.username|safe }}) on Sentry ({{ domain }}). If you did not authorize this, you may simply ignore this email.</p>
-    <p>To continue with your password reset, simply click the button below, and you will be able to change your password. This link will expire in 48 hours.</p>
+    <p>To continue with your password reset, simply click the button below, and you will be able to change your password. This link will expire in 1 hour.</p>
 
     <p><a href="{{ url|safe }}" class="btn">Reset Password</a></p>
 


### PR DESCRIPTION
This fixes a medium finding on a security code audit where lost password hashes were too long-lived. [OWASP recommends one hour for most scenarios.](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities#:~:text=Does%20the%20link%20expire,more%20than%20an%20hour.)
