### PR TITLE
ref(github-invite): remove querying and evaluate commit id set in missing members API

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_missing_org_members.py
+++ b/tests/sentry/api/endpoints/test_organization_missing_org_members.py
@@ -197,25 +197,6 @@ class OrganizationMissingMembersTestCase(APITestCase):
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
         ]
 
-    def test_query_on_author_email_and_external_id(self):
-        # self.nonmember_commit_author1 matches on email
-        # the below matches on external id
-        nonmember_commit_author = self.create_commit_author(
-            project=self.project, email="c2@example.com"
-        )
-        nonmember_commit_author.external_id = "c@example.com"
-        nonmember_commit_author.save()
-
-        self.create_commit(repo=self.repo, author=nonmember_commit_author)
-
-        response = self.get_success_response(self.organization.slug, query="c@example.com")
-
-        assert response.data[0]["integration"] == "github"
-        assert response.data[0]["users"] == [
-            {"email": "c@example.com", "externalId": "c", "commitCount": 2},
-            {"email": "c2@example.com", "externalId": "c@example.com", "commitCount": 1},
-        ]
-
     def test_no_github_integration(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.delete()


### PR DESCRIPTION
The request is still taking too long at the old `if queryset.exists()` ([SENTRY-15P3](https://sentry.sentry.io/issues/4474247346/?project=1)).

From Django docs https://docs.djangoproject.com/en/4.2/ref/models/querysets/#django.db.models.query.QuerySet.exists

> To find whether a queryset contains any items:
> 
> ```
> if some_queryset.exists():
>     print("There is at least one object in some_queryset")
> ```
> 
> Which will be faster than:
> 
> ```
> if some_queryset:
>     print("There is at least one object in some_queryset")
> ```
> 
> … but not by a large degree (hence needing a large queryset for efficiency gains).
> 
> **Additionally, if a some_queryset has not yet been evaluated, but you know that it will be at some point, then using some_queryset.exists() will do more overall work (one query for the existence check plus an extra one to later retrieve the results) than using bool(some_queryset), which retrieves the results and then checks if any were returned.**

The last point is what I think is happening.

I also removed querying because we do not utilize it on the frontend.