### PR TITLE
fix(alerts): Fix comparison of env data from db

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -193,7 +193,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 "actions": data["actions"],
                 "frequency": data.get("frequency"),
             }
-            duplicate_rule = find_duplicate_rule(kwargs, project, rule.id)
+            duplicate_rule = find_duplicate_rule(project=project, rule_data=kwargs, rule_id=rule.id)
             if duplicate_rule:
                 return Response(
                     {

--- a/src/sentry/api/endpoints/project_rule_enable.py
+++ b/src/sentry/api/endpoints/project_rule_enable.py
@@ -43,7 +43,7 @@ class ProjectRuleEnableEndpoint(ProjectEndpoint):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        duplicate_rule = find_duplicate_rule(rule.data, project, rule_id)
+        duplicate_rule = find_duplicate_rule(project=project, rule_id=rule_id, rule=rule)
         if duplicate_rule:
             return Response(
                 {

--- a/tests/sentry/api/endpoints/test_project_rule_enable.py
+++ b/tests/sentry/api/endpoints/test_project_rule_enable.py
@@ -92,6 +92,53 @@ class ProjectRuleEnableTestCase(APITestCase):
             == f"This rule is an exact duplicate of '{rule.label}' in this project and may not be enabled unless it's edited."
         )
 
+    def test_duplicate_rule_diff_env(self):
+        """Test that we do allow enabling a rule that's the exact duplicate of another
+        rule in the same project EXCEPT that the environment is different"""
+        conditions = [
+            {
+                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+            }
+        ]
+        actions = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+            }
+        ]
+        dev_env = self.create_environment(self.project, name="dev", organization=self.organization)
+        prod_env = self.create_environment(
+            self.project, name="prod", organization=self.organization
+        )
+        rule = self.create_project_rule(
+            project=self.project,
+            action_match=actions,
+            condition_match=conditions,
+            environment_id=dev_env.id,
+        )
+
+        rule2 = self.create_project_rule(
+            project=self.project,
+            action_match=actions,
+            condition_match=conditions,
+            environment_id=prod_env.id,
+        )
+        rule2.status = ObjectStatus.DISABLED
+        rule2.save()
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            rule2.id,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+        assert (
+            response.data["detail"]
+            == f"This rule is an exact duplicate of '{rule.label}' in this project and may not be enabled unless it's edited."
+        )
+
     def test_no_action_rule(self):
         """Test that we do not allow enabling a rule that has no action(s)"""
         conditions = [


### PR DESCRIPTION
Same issue as described in https://github.com/getsentry/sentry/pull/56778 

This updates the `find_duplicate_rule` function to accept either a `rule_data` object when we are creating or updating a rule in the app/api, and a `rule` object for when we we re-enabling a rule and are therefore accessing the environment data via the `environment_id` column rather than inside the `rule_data` object.