### PR TITLE
feat(CoGS): Dynamic Sampling Use Case IDs

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -56,6 +56,7 @@ from sentry.dynamic_sampling.tasks.utils import (
 )
 from sentry.models import Organization, Project
 from sentry.sentry_metrics import indexer
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.silo import SiloMode
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
@@ -184,7 +185,10 @@ def fetch_projects_with_total_root_transaction_count_and_rates(
                 .set_offset(offset)
             )
             request = Request(
-                dataset=Dataset.PerformanceMetrics.value, app_id="dynamic_sampling", query=query
+                dataset=Dataset.PerformanceMetrics.value,
+                app_id="dynamic_sampling",
+                query=query,
+                tenant_ids={"use_case_id": UseCaseID.TRANSACTIONS.value},
             )
             data = raw_snql_query(
                 request,

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -48,6 +48,7 @@ from sentry.dynamic_sampling.tasks.utils import (
 )
 from sentry.models import Organization
 from sentry.sentry_metrics import indexer
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.silo import SiloMode
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
@@ -311,7 +312,10 @@ class FetchProjectTransactionTotals:
                 .set_offset(self.offset)
             )
             request = Request(
-                dataset=Dataset.PerformanceMetrics.value, app_id="dynamic_sampling", query=query
+                dataset=Dataset.PerformanceMetrics.value,
+                app_id="dynamic_sampling",
+                query=query,
+                tenant_ids={"use_case_id": UseCaseID.TRANSACTIONS.value},
             )
             data = raw_snql_query(
                 request,
@@ -487,7 +491,10 @@ class FetchProjectTransactionVolumes:
                 .set_offset(self.offset)
             )
             request = Request(
-                dataset=Dataset.PerformanceMetrics.value, app_id="dynamic_sampling", query=query
+                dataset=Dataset.PerformanceMetrics.value,
+                app_id="dynamic_sampling",
+                query=query,
+                tenant_ids={"use_case_id": UseCaseID.TRANSACTIONS.value},
             )
             data = raw_snql_query(
                 request,

--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -31,6 +31,7 @@ from sentry.dynamic_sampling.tasks.helpers.sliding_window import extrapolate_mon
 from sentry.dynamic_sampling.tasks.logging import log_extrapolated_monthly_volume, log_query_timeout
 from sentry.dynamic_sampling.tasks.task_context import DynamicSamplingLogState, TaskContext
 from sentry.sentry_metrics import indexer
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.snuba.referrer import Referrer
@@ -236,7 +237,10 @@ class GetActiveOrgs:
                 .set_offset(self.offset)
             )
             request = Request(
-                dataset=Dataset.PerformanceMetrics.value, app_id="dynamic_sampling", query=query
+                dataset=Dataset.PerformanceMetrics.value,
+                app_id="dynamic_sampling",
+                query=query,
+                tenant_ids={"use_case_id": UseCaseID.TRANSACTIONS.value},
             )
             self.log_state.num_db_calls += 1
             data = raw_snql_query(
@@ -420,7 +424,10 @@ class GetActiveOrgsVolumes:
                 .set_offset(self.offset)
             )
             request = Request(
-                dataset=Dataset.PerformanceMetrics.value, app_id="dynamic_sampling", query=query
+                dataset=Dataset.PerformanceMetrics.value,
+                app_id="dynamic_sampling",
+                query=query,
+                tenant_ids={"use_case_id": UseCaseID.TRANSACTIONS.value},
             )
             self.log_state.num_db_calls += 1
             data = raw_snql_query(

--- a/src/sentry/dynamic_sampling/tasks/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window.py
@@ -41,6 +41,7 @@ from sentry.dynamic_sampling.tasks.logging import log_query_timeout
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task_with_context
 from sentry.sentry_metrics import indexer
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.silo import SiloMode
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
@@ -217,7 +218,10 @@ def fetch_projects_with_total_root_transactions_count(
         )
 
         request = Request(
-            dataset=Dataset.PerformanceMetrics.value, app_id="dynamic_sampling", query=query
+            dataset=Dataset.PerformanceMetrics.value,
+            app_id="dynamic_sampling",
+            query=query,
+            tenant_ids={"use_case_id": UseCaseID.TRANSACTIONS.value},
         )
 
         data = raw_snql_query(


### PR DESCRIPTION
### Overview
- Adding `use_case_id` Tenant ID to all `generic_metrics` Snuba queries
- Dynamic sampling queries are all Transactions use case
- Previous CoGS labelling PRs for context [here](https://github.com/getsentry/sentry/pulls?q=is%3Apr+author%3Arahul-kumar-saini+CoGS)