### PR TITLE
fix(killswitch): Remove store.save-event-highcpu-platforms killswitch

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -130,12 +130,6 @@ ALL_KILLSWITCH_OPTIONS = {
             "platform": "The event platform as defined in the event payload's platform field, or 'none'",
         },
     ),
-    "store.save-event-highcpu-platforms": KillswitchInfo(
-        description="Send highcpu platform events to save_event highcpu queue",
-        fields={
-            "platform": "The event platform as defined in the event payload's platform field, or 'none'",
-        },
-    ),
     "store.symbolicate-event-lpq-never": KillswitchInfo(
         description="""
         Never allow a project's symbolication events to be demoted to symbolicator's low priority queue.


### PR DESCRIPTION
We're not using this option as killswitch by calling `killswitch_matches_context`. The current value is causing issues for `sentry killswitches list`

In fact, what we're doing here is more like a regular option. See https://github.com/getsentry/sentry/pull/54674 

Thus, let's remove this from killswitches. 