### PR TITLE
ref(hc): Outbox Backfill supports User model.

### DIFF
--- a/src/sentry/db/models/outboxes.py
+++ b/src/sentry/db/models/outboxes.py
@@ -10,6 +10,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Protocol,
     Tuple,
     Type,
     TypeVar,
@@ -418,6 +419,26 @@ class ReplicatedControlModel(ControlOutboxProducingModel):
         Also keep in mind that any errors or failures will force a retry of processing, so be certain all
         operations are idempotent!
         """
+        pass
+
+
+class HasControlReplicationHandlers(Protocol):
+    """
+    Helps cover the interface of ReplicatedControlModel and User (which cannot subclass) that allows them
+    to use OutboxCategory.connect_control_model_updates.
+    """
+
+    @classmethod
+    def handle_async_deletion(
+        cls,
+        identifier: int,
+        region_name: str,
+        shard_identifier: int,
+        payload: Mapping[str, Any] | None,
+    ) -> None:
+        pass
+
+    def handle_async_replication(self, region_name: str, shard_identifier: int) -> None:
         pass
 
 

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -44,7 +44,7 @@ from sentry.db.models import (
     region_silo_only_model,
     sane_repr,
 )
-from sentry.db.models.outboxes import ReplicatedControlModel, ReplicatedRegionModel
+from sentry.db.models.outboxes import HasControlReplicationHandlers, ReplicatedRegionModel
 from sentry.db.postgres.transactions import (
     django_test_transaction_water_mark,
     enforce_constraints,
@@ -128,7 +128,7 @@ class OutboxCategory(IntEnum):
 
         process_region_outbox.connect(receiver, weak=False, sender=self)
 
-    def connect_control_model_updates(self, model: Type[ReplicatedControlModel]) -> None:
+    def connect_control_model_updates(self, model: Type[HasControlReplicationHandlers]) -> None:
         def receiver(
             object_identifier: int,
             payload: Optional[Mapping[str, Any]],
@@ -139,7 +139,7 @@ class OutboxCategory(IntEnum):
         ):
             from sentry.receivers.outbox import maybe_process_tombstone
 
-            maybe_instance: ReplicatedControlModel | None = maybe_process_tombstone(
+            maybe_instance: HasControlReplicationHandlers | None = maybe_process_tombstone(
                 cast(Any, model), object_identifier, region_name=region_name
             )
             if maybe_instance is None:

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import logging
 import secrets
 import warnings
 from string import ascii_letters, digits
-from typing import List, Optional, Tuple
+from typing import Any, List, Mapping, Optional, Tuple, Type
 
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.models import UserManager as DjangoUserManager
@@ -10,6 +12,7 @@ from django.contrib.auth.signals import user_logged_out
 from django.db import IntegrityError, models, router, transaction
 from django.db.models import Count, Subquery
 from django.db.models.query import QuerySet
+from django.db.models.signals import class_prepared
 from django.dispatch import receiver
 from django.forms import model_to_dict
 from django.urls import reverse
@@ -33,8 +36,8 @@ from sentry.locks import locks
 from sentry.models.authenticator import Authenticator
 from sentry.models.avatars import UserAvatar
 from sentry.models.lostpasswordhash import LostPasswordHash
-from sentry.models.outbox import ControlOutbox, OutboxCategory, OutboxScope, outbox_context
-from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.models.outbox import ControlOutboxBase, OutboxCategory, outbox_context
+from sentry.services.hybrid_cloud.organization import RpcRegionUser, organization_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.types.region import find_regions_for_user
@@ -82,6 +85,7 @@ class UserManager(BaseManager, DjangoUserManager):
 @control_silo_only_model
 class User(BaseModel, AbstractBaseUser):
     __relocation_scope__ = RelocationScope.User
+    replication_version: int = 1
 
     id = BoundedBigAutoField(primary_key=True)
     username = models.CharField(_("username"), max_length=MAX_USERNAME_LENGTH, unique=True)
@@ -292,21 +296,16 @@ class User(BaseModel, AbstractBaseUser):
         for email in email_list:
             self.send_confirm_email_singular(email, is_new_user)
 
-    def outboxes_for_update(self) -> List[ControlOutbox]:
+    def outboxes_for_update(self) -> List[ControlOutboxBase]:
         return User.outboxes_for_user_update(self.id)
 
     @staticmethod
-    def outboxes_for_user_update(identifier: int) -> List[ControlOutbox]:
-        return [
-            ControlOutbox(
-                shard_scope=OutboxScope.USER_SCOPE,
-                shard_identifier=identifier,
-                object_identifier=identifier,
-                category=OutboxCategory.USER_UPDATE,
-                region_name=region_name,
-            )
-            for region_name in find_regions_for_user(identifier)
-        ]
+    def outboxes_for_user_update(identifier: int) -> List[ControlOutboxBase]:
+        return OutboxCategory.USER_UPDATE.as_control_outboxes(
+            region_names=find_regions_for_user(identifier),
+            object_identifier=identifier,
+            shard_identifier=identifier,
+        )
 
     def merge_to(from_user, to_user):
         # TODO: we could discover relations automatically and make this useful
@@ -477,6 +476,26 @@ class User(BaseModel, AbstractBaseUser):
             # Perform the remainder of the write while we're still holding the lock.
             return do_write()
 
+    @classmethod
+    def handle_async_deletion(
+        cls,
+        identifier: int,
+        region_name: str,
+        shard_identifier: int,
+        payload: Mapping[str, Any] | None,
+    ) -> None:
+        pass
+
+    def handle_async_replication(self, region_name: str, shard_identifier: int) -> None:
+        organization_service.update_region_user(
+            user=RpcRegionUser(
+                id=self.id,
+                is_active=self.is_active,
+                email=self.email,
+            ),
+            region_name=region_name,
+        )
+
 
 # HACK(dcramer): last_login needs nullable for Django 1.8
 User._meta.get_field("last_login").null = True
@@ -498,3 +517,8 @@ def refresh_api_user_nonce(sender, request, user, **kwargs):
         return
     user = User.objects.get(id=user.id)
     refresh_user_nonce(sender, request, user, **kwargs)
+
+
+@receiver(class_prepared, sender=User)
+def connect_control_model_updates(sender: Type[User], **kwargs: Any) -> None:
+    OutboxCategory.USER_UPDATE.connect_control_model_updates(sender)

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -4,7 +4,7 @@ import logging
 import secrets
 import warnings
 from string import ascii_letters, digits
-from typing import Any, List, Mapping, Optional, Tuple, Type
+from typing import Any, List, Mapping, Optional, Tuple
 
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.models import UserManager as DjangoUserManager
@@ -12,7 +12,6 @@ from django.contrib.auth.signals import user_logged_out
 from django.db import IntegrityError, models, router, transaction
 from django.db.models import Count, Subquery
 from django.db.models.query import QuerySet
-from django.db.models.signals import class_prepared
 from django.dispatch import receiver
 from django.forms import model_to_dict
 from django.urls import reverse
@@ -519,6 +518,4 @@ def refresh_api_user_nonce(sender, request, user, **kwargs):
     refresh_user_nonce(sender, request, user, **kwargs)
 
 
-@receiver(class_prepared, sender=User)
-def connect_control_model_updates(sender: Type[User], **kwargs: Any) -> None:
-    OutboxCategory.USER_UPDATE.connect_control_model_updates(sender)
+OutboxCategory.USER_UPDATE.connect_control_model_updates(User)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1624,3 +1624,10 @@ register(
     default=0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "outbox_replication.auth_user.replication_version",
+    type=Int,
+    default=0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -18,32 +18,13 @@ from sentry.models import (
     OrganizationIntegration,
     OutboxCategory,
     SentryAppInstallation,
-    User,
     process_control_outbox,
 )
 from sentry.receivers.outbox import maybe_process_tombstone
-from sentry.services.hybrid_cloud.organization import (
-    RpcOrganizationSignal,
-    RpcRegionUser,
-    organization_service,
-)
+from sentry.services.hybrid_cloud.organization import RpcOrganizationSignal, organization_service
 from sentry.silo.base import SiloMode
 
 logger = logging.getLogger(__name__)
-
-
-@receiver(process_control_outbox, sender=OutboxCategory.USER_UPDATE)
-def process_user_updates(object_identifier: int, region_name: str, **kwds: Any):
-    if (user := maybe_process_tombstone(User, object_identifier, region_name=region_name)) is None:
-        return
-    organization_service.update_region_user(
-        user=RpcRegionUser(
-            id=user.id,
-            is_active=user.is_active,
-            email=user.email,
-        ),
-        region_name=region_name,
-    )
 
 
 @receiver(process_control_outbox, sender=OutboxCategory.INTEGRATION_UPDATE)

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -10,14 +10,12 @@ from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.models.outbox import ControlOutbox, WebhookProviderIdentifier
-from sentry.models.user import User
 from sentry.receivers.outbox.control import (
     process_api_application_updates,
     process_async_webhooks,
     process_integration_updates,
     process_organization_integration_update,
     process_sentry_app_installation_updates,
-    process_user_updates,
 )
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.silo.base import SiloMode
@@ -31,12 +29,6 @@ _TEST_REGION = Region("eu", 1, "http://eu.testserver", RegionCategory.MULTI_TENA
 @control_silo_test(stable=True, regions=[_TEST_REGION])
 class ProcessControlOutboxTest(TestCase):
     identifier = 1
-
-    @patch("sentry.receivers.outbox.control.maybe_process_tombstone")
-    def test_process_user_updates(self, mock_maybe_process):
-        mock_maybe_process.return_value = User(id=1, is_active=True)
-        process_user_updates(object_identifier=self.identifier, region_name=_TEST_REGION.name)
-        mock_maybe_process.assert_called_with(User, self.identifier, region_name=_TEST_REGION.name)
 
     @patch("sentry.receivers.outbox.control.maybe_process_tombstone")
     def test_process_integration_updatess(self, mock_maybe_process):


### PR DESCRIPTION
In preparation for user level caching, enabling outbox backfill for User model.  Note -- due to the requirement of the `User` model to subclass `BaseModel` but not `Model`, it's not possible to directly use `ReplicatedControlModel`, hence a bit of special casing on this particular model.