### PR TITLE
feat(sourcemaps): Add sourcemap reference in the endpoint response

### DIFF
--- a/src/sentry/api/serializers/models/artifactbundle.py
+++ b/src/sentry/api/serializers/models/artifactbundle.py
@@ -69,6 +69,7 @@ class ArtifactBundleFilesSerializer(Serializer):
 
         headers = self.archive.normalize_headers(info.get("headers", {}))
         debug_id = self.archive.normalize_debug_id(headers.get("debug-id"))
+        sourcemap = headers.get("sourcemap")
 
         return {
             "file_type": SourceFileType.from_lowercase_key(info.get("type")),
@@ -76,6 +77,7 @@ class ArtifactBundleFilesSerializer(Serializer):
             "file_url": self.archive.get_file_url_by_file_path(file_path),
             "file_info": self.archive.get_file_info(file_path),
             "debug_id": debug_id,
+            "sourcemap": sourcemap,
         }
 
     def serialize(self, obj, attrs, user):
@@ -91,4 +93,5 @@ class ArtifactBundleFilesSerializer(Serializer):
             "filePath": attrs["file_url"],
             "fileSize": attrs["file_info"].file_size if attrs["file_info"] is not None else None,
             "debugId": attrs["debug_id"],
+            "sourcemap": attrs["sourcemap"],
         }

--- a/tests/sentry/api/endpoints/test_project_artifact_bundle_files.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_bundle_files.py
@@ -60,6 +60,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEuanM=",
                     "fileSize": 71,
                     "fileType": 0,
+                    "sourcemap": None,
                 },
                 {
                     "debugId": None,
@@ -67,6 +68,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEubWluLmpz",
                     "fileSize": 63,
                     "fileType": 2,
+                    "sourcemap": "bundle1.js.map",
                 },
                 {
                     "debugId": None,
@@ -74,6 +76,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "fileSize": 139,
                     "fileType": 0,
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEubWluLmpzLm1hcA==",
+                    "sourcemap": None,
                 },
                 {
                     "debugId": None,
@@ -81,6 +84,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2luZGV4Lmpz",
                     "fileSize": 3706,
                     "fileType": 1,
+                    "sourcemap": None,
                 },
                 {
                     "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
@@ -88,6 +92,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2luZGV4LmpzLm1hcA==",
                     "fileSize": 1804,
                     "fileType": 3,
+                    "sourcemap": None,
                 },
                 {
                     "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
@@ -95,6 +100,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2luZGV4Lm1pbi5qcw==",
                     "fileSize": 1676,
                     "fileType": 2,
+                    "sourcemap": "index.js.map",
                 },
             ],
         }
@@ -136,6 +142,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                         "id": "ZmlsZXMvXy9fL2J1bmRsZTEuanM=",
                         "fileSize": 71,
                         "fileType": 0,
+                        "sourcemap": None,
                     },
                     {
                         "debugId": None,
@@ -143,6 +150,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                         "id": "ZmlsZXMvXy9fL2J1bmRsZTEubWluLmpz",
                         "fileSize": 63,
                         "fileType": 2,
+                        "sourcemap": "bundle1.js.map",
                     },
                 ],
             },
@@ -156,6 +164,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                         "fileSize": 139,
                         "fileType": 0,
                         "id": "ZmlsZXMvXy9fL2J1bmRsZTEubWluLmpzLm1hcA==",
+                        "sourcemap": None,
                     },
                     {
                         "debugId": None,
@@ -163,6 +172,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                         "id": "ZmlsZXMvXy9fL2luZGV4Lmpz",
                         "fileSize": 3706,
                         "fileType": 1,
+                        "sourcemap": None,
                     },
                 ],
             },
@@ -176,6 +186,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                         "id": "ZmlsZXMvXy9fL2luZGV4LmpzLm1hcA==",
                         "fileSize": 1804,
                         "fileType": 3,
+                        "sourcemap": None,
                     },
                     {
                         "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
@@ -183,6 +194,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                         "id": "ZmlsZXMvXy9fL2luZGV4Lm1pbi5qcw==",
                         "fileSize": 1676,
                         "fileType": 2,
+                        "sourcemap": "index.js.map",
                     },
                 ],
             },
@@ -232,6 +244,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEuanM=",
                     "fileSize": 71,
                     "fileType": 0,
+                    "sourcemap": None,
                 },
             ],
         }
@@ -250,6 +263,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEuanM=",
                     "fileSize": 71,
                     "fileType": 0,
+                    "sourcemap": None,
                 },
                 {
                     "debugId": None,
@@ -257,6 +271,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEubWluLmpz",
                     "fileSize": 63,
                     "fileType": 2,
+                    "sourcemap": "bundle1.js.map",
                 },
                 {
                     "debugId": None,
@@ -264,6 +279,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "fileSize": 139,
                     "fileType": 0,
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEubWluLmpzLm1hcA==",
+                    "sourcemap": None,
                 },
             ],
         }
@@ -282,6 +298,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2luZGV4LmpzLm1hcA==",
                     "fileSize": 1804,
                     "fileType": 3,
+                    "sourcemap": None,
                 },
                 {
                     "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
@@ -289,6 +306,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2luZGV4Lm1pbi5qcw==",
                     "fileSize": 1676,
                     "fileType": 2,
+                    "sourcemap": "index.js.map",
                 },
             ],
         }
@@ -306,6 +324,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2luZGV4LmpzLm1hcA==",
                     "fileSize": 1804,
                     "fileType": 3,
+                    "sourcemap": None,
                 },
                 {
                     "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
@@ -313,6 +332,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2luZGV4Lm1pbi5qcw==",
                     "fileSize": 1676,
                     "fileType": 2,
+                    "sourcemap": "index.js.map",
                 },
             ],
         }
@@ -330,6 +350,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2luZGV4LmpzLm1hcA==",
                     "fileSize": 1804,
                     "fileType": 3,
+                    "sourcemap": None,
                 },
                 {
                     "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
@@ -337,6 +358,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                     "id": "ZmlsZXMvXy9fL2luZGV4Lm1pbi5qcw==",
                     "fileSize": 1676,
                     "fileType": 2,
+                    "sourcemap": "index.js.map",
                 },
             ],
         }


### PR DESCRIPTION
This PR adds the `sourcemap` reference in the API response for artifact bundle files. The `sourcemap` field will be set to `None` in case a file is not minified or if the sourcemap was not bound by Sentry CLI.

Closes https://github.com/getsentry/sentry/issues/56833