### PR TITLE
fix(on-demand): Fix measurements field name mapping

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -889,7 +889,7 @@ def _map_field_name(search_key: str) -> str:
 
     # Measurements support generic access.
     if search_key.startswith("measurements."):
-        return f"event.{search_key}"
+        return f"event.{search_key}.value"
 
     # Run a schema-aware check for tags. Always use the resolver output,
     # since it accounts for passing `tags[foo]` as key.

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -1033,9 +1033,11 @@ class SearchQueryConverter:
                 "value": [value],
             }
         else:
-            # Special case: `x != ""` is the result of a `has:x` query, which
-            # needs to be translated as `not(x == null)`.
-            if token.operator == "!=" and value == "":
+            # Special case for the `has` and `!has` operators which are parsed as follows:
+            # - `has:x` -> `x != ""`
+            # - `!has:x` -> `x = ""`
+            # They both need to be translated to `x not eq null` and `x eq null`.
+            if token.operator in ("!=", "=") and value == "":
                 value = None
 
             if isinstance(value, str):

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -2599,7 +2599,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query_hash_index = indexer.resolve(UseCaseID.TRANSACTIONS, None, QUERY_HASH_KEY)
 
         query_hash_clause = Condition(
-            lhs=Column(name=f"tags_raw[{query_hash_index}]"), op=Op.EQ, rhs="3b902501"
+            lhs=Column(name=f"tags_raw[{query_hash_index}]"), op=Op.EQ, rhs="62b395db"
         )
 
         assert query_hash_clause in snql_query.where

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -269,6 +269,26 @@ def test_spec_with_custom_measurement():
     }
 
 
+def test_spec_with_has():
+    spec = OnDemandMetricSpec(
+        "avg(measurements.lcp)", "has:measurements.lcp AND !has:measurements.memoryUsage"
+    )
+
+    assert spec._metric_type == "d"
+    assert spec.field_to_extract == "event.measurements.lcp.value"
+    assert spec.op == "avg"
+    assert spec.condition == {
+        "inner": [
+            {
+                "inner": {"name": "event.measurements.lcp.value", "op": "eq", "value": None},
+                "op": "not",
+            },
+            {"name": "event.measurements.memoryUsage.value", "op": "eq", "value": None},
+        ],
+        "op": "and",
+    }
+
+
 def test_spec_ignore_fields():
     with_ignored_field = OnDemandMetricSpec("count()", "transaction.duration:>=1 project:sentry")
     without_ignored_field = OnDemandMetricSpec("count()", "transaction.duration:>=1")

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -256,7 +256,7 @@ def test_spec_in_operator():
     }
 
 
-def test_spec_with_custom_measurements():
+def test_spec_with_custom_measurement():
     spec = OnDemandMetricSpec("avg(measurements.memoryUsed)", "measurements.memoryUsed:>100")
 
     assert spec._metric_type == "d"

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -137,7 +137,7 @@ def test_spec_simple_query_distribution():
     spec = OnDemandMetricSpec("p75(measurements.fp)", "transaction.duration:>1s")
 
     assert spec._metric_type == "d"
-    assert spec.field_to_extract == "event.measurements.fp"
+    assert spec.field_to_extract == "event.measurements.fp.value"
     assert spec.op == "p75"
     assert spec.condition == {"name": "event.duration", "op": "gt", "value": 1000.0}
 
@@ -253,6 +253,19 @@ def test_spec_in_operator():
     assert not_in_spec.condition == {
         "inner": {"name": "event.duration", "op": "eq", "value": [1.0, 2.0, 3.0]},
         "op": "not",
+    }
+
+
+def test_spec_with_custom_measurements():
+    spec = OnDemandMetricSpec("avg(measurements.memoryUsed)", "measurements.memoryUsed:>100")
+
+    assert spec._metric_type == "d"
+    assert spec.field_to_extract == "event.measurements.memoryUsed.value"
+    assert spec.op == "avg"
+    assert spec.condition == {
+        "name": "event.measurements.memoryUsed.value",
+        "op": "gt",
+        "value": 100.0,
     }
 
 


### PR DESCRIPTION
This PR fixes an issue with on demand metrics and custom measurements, in which the spec was emitted lacking the `.value` suffix, which is required by Relay when trying to extract measurements from events.

It also fixes a problem in which the `!has` operator was not properly implemented.

Closes https://github.com/getsentry/sentry/issues/56837