### PR TITLE
ref(sessions): Rename sessions to raw_sessions

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -352,7 +352,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         def _count_users(total: bool, referrer: str) -> Dict[Any, int]:
             select = [
-                MetricField(metric_mri=SessionMRI.USER.value, alias="value", op="count_unique")
+                MetricField(metric_mri=SessionMRI.RAW_USER.value, alias="value", op="count_unique")
             ]
             query = MetricsQuery(
                 org_id=org_id,
@@ -812,7 +812,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             MetricField(metric_mri=SessionMRI.CRASHED.value, alias="crashed", op=None),
             MetricField(metric_mri=SessionMRI.ALL.value, alias="init", op=None),
             MetricField(
-                metric_mri=SessionMRI.ERRORED_PREAGGREGATED.value, alias="errored_preaggr", op=None
+                metric_mri=SessionMRI.ERRORED_PREAGGREGATED.value,
+                alias="errored_preaggr",
+                op=None,
             ),
         ]
 

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -460,10 +460,14 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         select = [
             MetricField(
-                metric_mri=SessionMRI.SESSION.value, alias="min_counter_date", op="min_timestamp"
+                metric_mri=SessionMRI.RAW_SESSION.value,
+                alias="min_counter_date",
+                op="min_timestamp",
             ),
             MetricField(
-                metric_mri=SessionMRI.SESSION.value, alias="max_counter_date", op="max_timestamp"
+                metric_mri=SessionMRI.RAW_SESSION.value,
+                alias="max_counter_date",
+                op="max_timestamp",
             ),
             MetricField(
                 metric_mri=SessionMRI.RAW_DURATION.value, alias="min_dist_date", op="min_timestamp"
@@ -580,7 +584,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         projects, org_id = self._get_projects_and_org_id(project_ids)
 
-        select = [MetricField(metric_mri=SessionMRI.SESSION.value, alias="value", op="sum")]
+        select = [MetricField(metric_mri=SessionMRI.RAW_SESSION.value, alias="value", op="sum")]
 
         where_clause = []
         groupby = [
@@ -636,7 +640,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         projects, org_id = self._get_projects_and_org_id(project_ids)
 
-        select = [MetricField(metric_mri=SessionMRI.SESSION.value, alias="value", op="sum")]
+        select = [MetricField(metric_mri=SessionMRI.RAW_SESSION.value, alias="value", op="sum")]
         groupby = [MetricGroupByField(field="release")]
         where_clause = [
             Condition(
@@ -1300,7 +1304,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             MetricGroupByField(field="project_id"),
         ]
         select = [
-            MetricField(metric_mri=SessionMRI.SESSION.value, alias="oldest", op="min_timestamp"),
+            MetricField(
+                metric_mri=SessionMRI.RAW_SESSION.value, alias="oldest", op="min_timestamp"
+            ),
         ]
 
         query = MetricsQuery(

--- a/src/sentry/release_health/release_monitor/metrics.py
+++ b/src/sentry/release_health/release_monitor/metrics.py
@@ -55,7 +55,7 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
                             Condition(
                                 Column("metric_id"),
                                 Op.EQ,
-                                SESSION_METRIC_NAMES[SessionMRI.SESSION.value],
+                                SESSION_METRIC_NAMES[SessionMRI.RAW_SESSION.value],
                             ),
                         ],
                         granularity=Granularity(3600),
@@ -133,7 +133,7 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
                                 Column("metric_id"),
                                 Op.EQ,
                                 indexer.resolve(
-                                    UseCaseID.SESSIONS, org_id, SessionMRI.SESSION.value
+                                    UseCaseID.SESSIONS, org_id, SessionMRI.RAW_SESSION.value
                                 ),
                             ),
                         ],

--- a/src/sentry/search/events/datasets/metrics_layer.py
+++ b/src/sentry/search/events/datasets/metrics_layer.py
@@ -266,7 +266,7 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
                         "sum_if_column",
                         # We use the metric mri specified in
                         # sentry.snuba.entity_subscription.MetricsCountersEntitySubscription.metric_key.
-                        [Column(SessionMRI.SESSION.value), args["if_col"], args["if_val"]],
+                        [Column(SessionMRI.RAW_SESSION.value), args["if_col"], args["if_val"]],
                         alias,
                     ),
                     default_result_type="integer",

--- a/src/sentry/search/events/datasets/metrics_layer.py
+++ b/src/sentry/search/events/datasets/metrics_layer.py
@@ -314,7 +314,7 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
                         # We use the metric mri specified in
                         # sentry.snuba.entity_subscription.MetricsSetsEntitySubscription.metric_key.
                         [
-                            Column(SessionMRI.USER.value),
+                            Column(SessionMRI.RAW_USER.value),
                         ],
                         alias,
                     ),
@@ -331,7 +331,7 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
                         "uniq_if_column",
                         # We use the metric mri specified in
                         # sentry.snuba.entity_subscription.MetricsSetsEntitySubscription.metric_key.
-                        [Column(SessionMRI.USER.value), args["if_col"], args["if_val"]],
+                        [Column(SessionMRI.RAW_USER.value), args["if_col"], args["if_val"]],
                         alias,
                     ),
                     default_result_type="integer",

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -568,7 +568,7 @@ class BaseCrashRateMetricsEntitySubscription(BaseMetricsEntitySubscription):
 
 
 class MetricsCountersEntitySubscription(BaseCrashRateMetricsEntitySubscription):
-    metric_key: SessionMRI = SessionMRI.SESSION
+    metric_key: SessionMRI = SessionMRI.RAW_SESSION
 
     def get_snql_aggregations(self) -> List[str]:
         return [

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -593,7 +593,7 @@ class MetricsCountersEntitySubscription(BaseCrashRateMetricsEntitySubscription):
 
 
 class MetricsSetsEntitySubscription(BaseCrashRateMetricsEntitySubscription):
-    metric_key: SessionMRI = SessionMRI.USER
+    metric_key: SessionMRI = SessionMRI.RAW_USER
 
     def get_snql_aggregations(self) -> List[str]:
         return [

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -1300,7 +1300,7 @@ DERIVED_METRICS = {
     for derived_metric in [
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.ALL.value,
-            metrics=[SessionMRI.SESSION.value],
+            metrics=[SessionMRI.RAW_SESSION.value],
             unit="sessions",
             snql=lambda project_ids, org_id, metric_ids, alias=None: all_sessions(
                 org_id, metric_ids, alias=alias
@@ -1316,7 +1316,7 @@ DERIVED_METRICS = {
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.ABNORMAL.value,
-            metrics=[SessionMRI.SESSION.value],
+            metrics=[SessionMRI.RAW_SESSION.value],
             unit="sessions",
             snql=lambda project_ids, org_id, metric_ids, alias=None: abnormal_sessions(
                 org_id, metric_ids, alias=alias
@@ -1332,7 +1332,7 @@ DERIVED_METRICS = {
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.CRASHED.value,
-            metrics=[SessionMRI.SESSION.value],
+            metrics=[SessionMRI.RAW_SESSION.value],
             unit="sessions",
             snql=lambda project_ids, org_id, metric_ids, alias=None: crashed_sessions(
                 org_id, metric_ids, alias=alias
@@ -1440,7 +1440,7 @@ DERIVED_METRICS = {
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.ERRORED_PREAGGREGATED.value,
-            metrics=[SessionMRI.SESSION.value],
+            metrics=[SessionMRI.RAW_SESSION.value],
             unit="sessions",
             snql=lambda project_ids, org_id, metric_ids, alias=None: errored_preaggr_sessions(
                 org_id, metric_ids, alias=alias

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -1308,7 +1308,7 @@ DERIVED_METRICS = {
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.ALL_USER.value,
-            metrics=[SessionMRI.USER.value],
+            metrics=[SessionMRI.RAW_USER.value],
             unit="users",
             snql=lambda project_ids, org_id, metric_ids, alias=None: all_users(
                 org_id, metric_ids, alias=alias
@@ -1324,7 +1324,7 @@ DERIVED_METRICS = {
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.ABNORMAL_USER.value,
-            metrics=[SessionMRI.USER.value],
+            metrics=[SessionMRI.RAW_USER.value],
             unit="users",
             snql=lambda project_ids, org_id, metric_ids, alias=None: abnormal_users(
                 org_id, metric_ids, alias=alias
@@ -1340,7 +1340,7 @@ DERIVED_METRICS = {
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.CRASHED_USER.value,
-            metrics=[SessionMRI.USER.value],
+            metrics=[SessionMRI.RAW_USER.value],
             unit="users",
             snql=lambda project_ids, org_id, metric_ids, alias=None: crashed_users(
                 org_id, metric_ids, alias=alias
@@ -1348,7 +1348,7 @@ DERIVED_METRICS = {
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.ANR_USER.value,
-            metrics=[SessionMRI.USER.value],
+            metrics=[SessionMRI.RAW_USER.value],
             unit="users",
             snql=lambda project_ids, org_id, metric_ids, alias=None: anr_users(
                 org_id, metric_ids, alias=alias
@@ -1356,7 +1356,7 @@ DERIVED_METRICS = {
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.FOREGROUND_ANR_USER.value,
-            metrics=[SessionMRI.USER.value],
+            metrics=[SessionMRI.RAW_USER.value],
             unit="users",
             snql=lambda project_ids, org_id, metric_ids, alias=None: foreground_anr_users(
                 org_id, metric_ids, alias=alias
@@ -1448,7 +1448,7 @@ DERIVED_METRICS = {
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.ERRORED_SET.value,
-            metrics=[SessionMRI.ERROR.value],
+            metrics=[SessionMRI.RAW_ERROR.value],
             unit="sessions",
             snql=lambda project_ids, org_id, metric_ids, alias=None: uniq_aggregation_on_metric(
                 metric_ids, alias=alias
@@ -1487,7 +1487,7 @@ DERIVED_METRICS = {
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.ERRORED_USER_ALL.value,
-            metrics=[SessionMRI.USER.value],
+            metrics=[SessionMRI.RAW_USER.value],
             unit="users",
             snql=lambda project_ids, org_id, metric_ids, alias=None: errored_all_users(
                 org_id, metric_ids, alias=alias

--- a/src/sentry/snuba/metrics/naming_layer/mapping.py
+++ b/src/sentry/snuba/metrics/naming_layer/mapping.py
@@ -31,9 +31,9 @@ def create_name_mapping_layers() -> None:
         {
             # Session
             "sentry.sessions.session": SessionMRI.RAW_SESSION,
-            "sentry.sessions.user": SessionMRI.USER,
+            "sentry.sessions.user": SessionMRI.RAW_USER,
             "sentry.sessions.session.duration": SessionMRI.RAW_DURATION,
-            "sentry.sessions.session.error": SessionMRI.ERROR,
+            "sentry.sessions.session.error": SessionMRI.RAW_ERROR,
         }
     )
 

--- a/src/sentry/snuba/metrics/naming_layer/mapping.py
+++ b/src/sentry/snuba/metrics/naming_layer/mapping.py
@@ -30,7 +30,7 @@ def create_name_mapping_layers() -> None:
     NAME_TO_MRI.update(
         {
             # Session
-            "sentry.sessions.session": SessionMRI.SESSION,
+            "sentry.sessions.session": SessionMRI.RAW_SESSION,
             "sentry.sessions.user": SessionMRI.USER,
             "sentry.sessions.session.duration": SessionMRI.RAW_DURATION,
             "sentry.sessions.session.error": SessionMRI.ERROR,

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -46,9 +46,12 @@ MRI_EXPRESSION_REGEX = re.compile(rf"^{OP_REGEX}\(({MRI_SCHEMA_REGEX_STRING})\)$
 
 class SessionMRI(Enum):
     # Ingested
-    SESSION = "c:sessions/session@none"
-    ERROR = "s:sessions/error@none"
-    USER = "s:sessions/user@none"
+    # Do *not* use these metrics in product queries. Use the derived metrics below instead.
+    # The raw metrics do not necessarily add up in intuitive ways. For example, `RAW_SESSION`
+    # double-counts crashed sessions.
+    RAW_SESSION = "c:sessions/session@none"
+    RAW_ERROR = "s:sessions/error@none"
+    RAW_USER = "s:sessions/user@none"
     RAW_DURATION = "d:sessions/duration@second"
 
     # Derived

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1363,16 +1363,16 @@ class BaseMetricsTestCase(SnubaTestCase):
 
         # Mark the session as errored, which includes fatal sessions.
         if session.get("errors", 0) > 0 or status not in ("ok", "exited"):
-            push("set", SessionMRI.ERROR.value, {}, session["session_id"])
+            push("set", SessionMRI.RAW_ERROR.value, {}, session["session_id"])
             if not user_is_nil:
-                push("set", SessionMRI.USER.value, {"session.status": "errored"}, user)
+                push("set", SessionMRI.RAW_USER.value, {"session.status": "errored"}, user)
         elif not user_is_nil:
-            push("set", SessionMRI.USER.value, {}, user)
+            push("set", SessionMRI.RAW_USER.value, {}, user)
 
         if status in ("abnormal", "crashed"):  # fatal
             push("counter", SessionMRI.RAW_SESSION.value, {"session.status": status}, +1)
             if not user_is_nil:
-                push("set", SessionMRI.USER.value, {"session.status": status}, user)
+                push("set", SessionMRI.RAW_USER.value, {"session.status": status}, user)
 
         if status == "exited":
             if session["duration"] is not None:

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1357,7 +1357,7 @@ class BaseMetricsTestCase(SnubaTestCase):
         # seq=0 is equivalent to relay's session.init, init=True is transformed
         # to seq=0 in Relay.
         if session["seq"] == 0:  # init
-            push("counter", SessionMRI.SESSION.value, {"session.status": "init"}, +1)
+            push("counter", SessionMRI.RAW_SESSION.value, {"session.status": "init"}, +1)
 
         status = session["status"]
 
@@ -1370,7 +1370,7 @@ class BaseMetricsTestCase(SnubaTestCase):
             push("set", SessionMRI.USER.value, {}, user)
 
         if status in ("abnormal", "crashed"):  # fatal
-            push("counter", SessionMRI.SESSION.value, {"session.status": status}, +1)
+            push("counter", SessionMRI.RAW_SESSION.value, {"session.status": status}, +1)
             if not user_is_nil:
                 push("set", SessionMRI.USER.value, {"session.status": status}, user)
 

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -51,7 +51,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             self.project.organization.id, TransactionMRI.MEASUREMENTS_LCP.value
         )
         org_id = self.organization.id
-        self.session_metric = rh_indexer_record(org_id, SessionMRI.SESSION.value)
+        self.session_metric = rh_indexer_record(org_id, SessionMRI.RAW_SESSION.value)
         self.session_duration = rh_indexer_record(org_id, SessionMRI.DURATION.value)
         self.session_error_metric = rh_indexer_record(org_id, SessionMRI.ERROR.value)
 
@@ -1205,7 +1205,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         within the limit, and that are also with complete data from across the entities
         """
         self.store_release_health_metric(
-            name=SessionMRI.SESSION.value,
+            name=SessionMRI.RAW_SESSION.value,
             tags={"tag3": "value1"},
             value=10,
         )
@@ -1249,7 +1249,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         """
         for tag, tag_value in (("tag1", "group1"), ("tag1", "group2")):
             self.store_release_health_metric(
-                name=SessionMRI.SESSION.value,
+                name=SessionMRI.RAW_SESSION.value,
                 tags={tag: tag_value},
                 value=10,
             )
@@ -1304,7 +1304,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             ("tag2", "C1"),
         ):
             self.store_release_health_metric(
-                name=SessionMRI.SESSION.value,
+                name=SessionMRI.RAW_SESSION.value,
                 tags={tag: tag_value},
                 value=10,
                 minutes_before_now=4,
@@ -1505,7 +1505,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         self.login_as(user=self.user)
         org_id = self.organization.id
         self.session_duration_metric = rh_indexer_record(org_id, SessionMRI.RAW_DURATION.value)
-        self.session_metric = rh_indexer_record(org_id, SessionMRI.SESSION.value)
+        self.session_metric = rh_indexer_record(org_id, SessionMRI.RAW_SESSION.value)
         self.session_user_metric = rh_indexer_record(org_id, SessionMRI.USER.value)
         self.session_error_metric = rh_indexer_record(org_id, SessionMRI.ERROR.value)
         self.session_status_tag = rh_indexer_record(org_id, "session.status")
@@ -1686,7 +1686,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
             ("init", 15),
         ):
             self.store_release_health_metric(
-                name=SessionMRI.SESSION.value,
+                name=SessionMRI.RAW_SESSION.value,
                 tags={"session.status": tag_value},
                 value=value,
                 minutes_before_now=4,
@@ -1734,7 +1734,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
             ("bar", 3, 2),
         ):
             self.store_release_health_metric(
-                name=SessionMRI.SESSION.value,
+                name=SessionMRI.RAW_SESSION.value,
                 tags={"session.status": "abnormal", "release": tag_value},
                 value=value,
                 minutes_before_now=minutes,
@@ -1883,7 +1883,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
             ("crashed", "foobar@2.0", 3, 2),
         ):
             self.store_release_health_metric(
-                name=SessionMRI.SESSION.value,
+                name=SessionMRI.RAW_SESSION.value,
                 tags={"session.status": tag_value, "release": release_tag_value},
                 value=value,
             )
@@ -1921,7 +1921,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
             ({"session.status": "init", "release": "foo"}, 10),
         ):
             self.store_release_health_metric(
-                name=SessionMRI.SESSION.value,
+                name=SessionMRI.RAW_SESSION.value,
                 tags=tags,
                 value=value,
             )
@@ -1950,7 +1950,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
             ("init", 10),
         ):
             self.store_release_health_metric(
-                name=SessionMRI.SESSION.value,
+                name=SessionMRI.RAW_SESSION.value,
                 tags={"session.status": tag_value, "release": "foo"},
                 value=value,
             )

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -53,7 +53,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         org_id = self.organization.id
         self.session_metric = rh_indexer_record(org_id, SessionMRI.RAW_SESSION.value)
         self.session_duration = rh_indexer_record(org_id, SessionMRI.DURATION.value)
-        self.session_error_metric = rh_indexer_record(org_id, SessionMRI.ERROR.value)
+        self.session_error_metric = rh_indexer_record(org_id, SessionMRI.RAW_ERROR.value)
 
     @property
     def now(self):
@@ -1260,7 +1260,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         ):
             for value in numbers:
                 self.store_release_health_metric(
-                    name=SessionMRI.ERROR.value,
+                    name=SessionMRI.RAW_ERROR.value,
                     tags={tag: tag_value},
                     value=value,
                 )
@@ -1318,7 +1318,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         ):
             for value in numbers:
                 self.store_release_health_metric(
-                    name=SessionMRI.ERROR.value,
+                    name=SessionMRI.RAW_ERROR.value,
                     tags={tag: tag_value},
                     value=value,
                 )
@@ -1506,8 +1506,8 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         org_id = self.organization.id
         self.session_duration_metric = rh_indexer_record(org_id, SessionMRI.RAW_DURATION.value)
         self.session_metric = rh_indexer_record(org_id, SessionMRI.RAW_SESSION.value)
-        self.session_user_metric = rh_indexer_record(org_id, SessionMRI.USER.value)
-        self.session_error_metric = rh_indexer_record(org_id, SessionMRI.ERROR.value)
+        self.session_user_metric = rh_indexer_record(org_id, SessionMRI.RAW_USER.value)
+        self.session_error_metric = rh_indexer_record(org_id, SessionMRI.RAW_ERROR.value)
         self.session_status_tag = rh_indexer_record(org_id, "session.status")
         self.release_tag = rh_indexer_record(self.organization.id, "release")
         self.tx_metric = perf_indexer_record(org_id, TransactionMRI.DURATION.value)
@@ -1693,7 +1693,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
             )
         for value in range(3):
             self.store_release_health_metric(
-                name=SessionMRI.ERROR.value,
+                name=SessionMRI.RAW_ERROR.value,
                 tags={"release": "foo"},
                 value=value,
             )
@@ -1763,7 +1763,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         ):
             for value in values:
                 self.store_release_health_metric(
-                    name=SessionMRI.USER.value,
+                    name=SessionMRI.RAW_USER.value,
                     tags={"session.status": "crashed", "release": tag_value},
                     value=value,
                 )
@@ -1787,7 +1787,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
     def test_all_user_sessions(self):
         for value in [1, 2, 4]:
             self.store_release_health_metric(
-                name=SessionMRI.USER.value,
+                name=SessionMRI.RAW_USER.value,
                 tags={},
                 value=value,
             )
@@ -1810,7 +1810,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         for tags, values in cases:
             for value in values:
                 self.store_release_health_metric(
-                    name=SessionMRI.USER.value,
+                    name=SessionMRI.RAW_USER.value,
                     tags=tags,
                     value=value,
                 )
@@ -1833,7 +1833,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         ):
             for value in values:
                 self.store_release_health_metric(
-                    name=SessionMRI.USER.value,
+                    name=SessionMRI.RAW_USER.value,
                     tags=tags,
                     value=value,
                 )
@@ -1867,7 +1867,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         ):
             for value in values:
                 self.store_release_health_metric(
-                    name=SessionMRI.USER.value,
+                    name=SessionMRI.RAW_USER.value,
                     tags=tags,
                     value=value,
                 )
@@ -1928,7 +1928,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
 
         for value in range(3):
             self.store_release_health_metric(
-                name=SessionMRI.ERROR.value,
+                name=SessionMRI.RAW_ERROR.value,
                 tags={"release": "foo"},
                 value=value,
             )
@@ -1982,7 +1982,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         ):
             for value in values:
                 self.store_release_health_metric(
-                    name=SessionMRI.USER.value,
+                    name=SessionMRI.RAW_USER.value,
                     tags={"session.status": tag_value},
                     value=value,
                 )
@@ -2003,7 +2003,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         # Errored = -3
         for value in [1, 2, 4]:
             self.store_release_health_metric(
-                name=SessionMRI.USER.value,
+                name=SessionMRI.RAW_USER.value,
                 tags={"session.status": "crashed"},
                 value=value,
             )
@@ -2027,7 +2027,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         for tags, values in cases:
             for value in values:
                 self.store_release_health_metric(
-                    name=SessionMRI.USER.value,
+                    name=SessionMRI.RAW_USER.value,
                     tags=tags,
                     value=value,
                 )
@@ -2046,7 +2046,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         # init = 0
         # errored_all = 1
         self.store_release_health_metric(
-            name=SessionMRI.USER.value,
+            name=SessionMRI.RAW_USER.value,
             tags={"session.status": "errored"},
             value=1,
         )

--- a/tests/sentry/api/endpoints/test_organization_metric_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_details.py
@@ -125,7 +125,7 @@ class OrganizationMetricDetailsIntegrationTest(OrganizationMetricMetaIntegration
         )
         assert response.status_code == 404
 
-        _indexer_record(self.organization.id, SessionMRI.SESSION.value)
+        _indexer_record(self.organization.id, SessionMRI.RAW_SESSION.value)
         response = self.get_response(
             self.organization.slug,
             SessionMetricKey.CRASH_FREE_RATE.value,

--- a/tests/sentry/api/endpoints/test_organization_metric_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tags.py
@@ -139,7 +139,7 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
         indexer.record(
             use_case_id=UseCaseID.SESSIONS,
             org_id=self.organization.id,
-            string=SessionMRI.SESSION.value,
+            string=SessionMRI.RAW_SESSION.value,
         )
         assert (
             self.get_response(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -859,7 +859,7 @@ class MetricsCrashRateAlertCreationTest(AlertRuleCreateEndpointTestCrashRateAler
         self.valid_alert_rule["dataset"] = Dataset.Metrics.value
         for tag in [
             SessionMRI.RAW_SESSION.value,
-            SessionMRI.USER.value,
+            SessionMRI.RAW_USER.value,
             "session.status",
             "init",
             "crashed",

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -858,7 +858,7 @@ class MetricsCrashRateAlertCreationTest(AlertRuleCreateEndpointTestCrashRateAler
         super().setUp()
         self.valid_alert_rule["dataset"] = Dataset.Metrics.value
         for tag in [
-            SessionMRI.SESSION.value,
+            SessionMRI.RAW_SESSION.value,
             SessionMRI.USER.value,
             "session.status",
             "init",

--- a/tests/sentry/sentry_metrics/test_batch.py
+++ b/tests/sentry/sentry_metrics/test_batch.py
@@ -60,7 +60,7 @@ distribution_payload = {
 distribution_headers = [("namespace", b"sessions")]
 
 set_payload = {
-    "name": SessionMRI.ERROR.value,
+    "name": SessionMRI.RAW_ERROR.value,
     "tags": {
         "environment": "production",
         "session.status": "errored",

--- a/tests/sentry/sentry_metrics/test_batch.py
+++ b/tests/sentry/sentry_metrics/test_batch.py
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.sentry_metrics
 BROKER_TIMESTAMP = datetime.now(tz=timezone.utc)
 ts = int(datetime.now(tz=timezone.utc).timestamp())
 counter_payload = {
-    "name": SessionMRI.SESSION.value,
+    "name": SessionMRI.RAW_SESSION.value,
     "tags": {
         "environment": "production",
         "session.status": "init",

--- a/tests/sentry/sentry_metrics/test_indexer.py
+++ b/tests/sentry/sentry_metrics/test_indexer.py
@@ -9,17 +9,17 @@ INDEXER = MockIndexer()
 def test_resolve():
     assert INDEXER.resolve(UseCaseID.SESSIONS, 1, "what") is None
     assert (
-        INDEXER.resolve(UseCaseID.SESSIONS, 1, SessionMRI.USER.value)
-        == SHARED_STRINGS[SessionMRI.USER.value]
+        INDEXER.resolve(UseCaseID.SESSIONS, 1, SessionMRI.RAW_USER.value)
+        == SHARED_STRINGS[SessionMRI.RAW_USER.value]
     )
     # hardcoded values don't depend on org_id
     assert (
-        INDEXER.resolve(UseCaseID.SESSIONS, 0, SessionMRI.USER.value)
-        == SHARED_STRINGS[SessionMRI.USER.value]
+        INDEXER.resolve(UseCaseID.SESSIONS, 0, SessionMRI.RAW_USER.value)
+        == SHARED_STRINGS[SessionMRI.RAW_USER.value]
     )
 
 
 def test_reverse_resolve():
     assert INDEXER.reverse_resolve(UseCaseID.SESSIONS, 1, 666) is None
-    id = SHARED_STRINGS[SessionMRI.USER.value]
-    assert INDEXER.reverse_resolve(UseCaseID.SESSIONS, 1, id) == SessionMRI.USER.value
+    id = SHARED_STRINGS[SessionMRI.RAW_USER.value]
+    assert INDEXER.reverse_resolve(UseCaseID.SESSIONS, 1, id) == SessionMRI.RAW_USER.value

--- a/tests/sentry/sentry_metrics/test_parallel_indexer.py
+++ b/tests/sentry/sentry_metrics/test_parallel_indexer.py
@@ -11,7 +11,7 @@ from sentry.utils import json
 
 ts = int(datetime.now(tz=timezone.utc).timestamp())
 counter_payload = {
-    "name": SessionMRI.SESSION.value,
+    "name": SessionMRI.RAW_SESSION.value,
     "tags": {
         "environment": "production",
         "session.status": "init",

--- a/tests/sentry/sentry_metrics/test_rh_metrics_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_rh_metrics_multiprocess_steps.py
@@ -253,7 +253,7 @@ distribution_payload: dict[str, Any] = {
 }
 
 set_payload: dict[str, Any] = {
-    "name": SessionMRI.ERROR.value,
+    "name": SessionMRI.RAW_ERROR.value,
     "tags": {
         "environment": "production",
         "session.status": "errored",
@@ -341,7 +341,7 @@ def test_process_messages() -> None:
 invalid_payloads = [
     (
         {
-            "name": SessionMRI.ERROR.value,
+            "name": SessionMRI.RAW_ERROR.value,
             "tags": {
                 "environment": "production" * 21,
                 "session.status": "errored",
@@ -358,7 +358,7 @@ invalid_payloads = [
     ),
     (
         {
-            "name": SessionMRI.ERROR.value * 21,
+            "name": SessionMRI.RAW_ERROR.value * 21,
             "tags": {
                 "environment": "production",
                 "session.status": "errored",

--- a/tests/sentry/sentry_metrics/test_rh_metrics_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_rh_metrics_multiprocess_steps.py
@@ -226,7 +226,7 @@ def test_metrics_batch_builder():
 
 ts = int(datetime.now(tz=timezone.utc).timestamp())
 counter_payload: dict[str, Any] = {
-    "name": SessionMRI.SESSION.value,
+    "name": SessionMRI.RAW_SESSION.value,
     "tags": {
         "environment": "production",
         "session.status": "init",

--- a/tests/sentry/snuba/metrics/fields/test_base.py
+++ b/tests/sentry/snuba/metrics/fields/test_base.py
@@ -60,7 +60,7 @@ rh_indexer_record = partial(indexer_record, UseCaseID.SESSIONS)
 
 def get_entity_of_metric_mocked(_, metric_mri, use_case_id):
     return {
-        SessionMRI.SESSION.value: EntityKey.MetricsCounters,
+        SessionMRI.RAW_SESSION.value: EntityKey.MetricsCounters,
         SessionMRI.USER.value: EntityKey.MetricsSets,
         SessionMRI.ERROR.value: EntityKey.MetricsSets,
         TransactionMRI.DURATION.value: EntityKey.MetricsDistributions,
@@ -159,7 +159,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         use_case_id = UseCaseID.SESSIONS
         for status in ("init", "abnormal", "crashed", "errored"):
             rh_indexer_record(org_id, status)
-        session_ids = [rh_indexer_record(org_id, SessionMRI.SESSION.value)]
+        session_ids = [rh_indexer_record(org_id, SessionMRI.RAW_SESSION.value)]
         session_user_ids = [rh_indexer_record(org_id, SessionMRI.USER.value)]
 
         derived_name_snql = {
@@ -292,7 +292,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
     @mock.patch("sentry.snuba.metrics.fields.base.org_id_from_projects", lambda _: 0)
     def test_generate_metric_ids(self):
         org_id = self.project.organization_id
-        session_metric_id = rh_indexer_record(org_id, SessionMRI.SESSION.value)
+        session_metric_id = rh_indexer_record(org_id, SessionMRI.RAW_SESSION.value)
         session_error_metric_id = rh_indexer_record(org_id, SessionMRI.ERROR.value)
         session_user_id = rh_indexer_record(org_id, SessionMRI.USER.value)
         use_case_id = UseCaseID.SESSIONS

--- a/tests/sentry/snuba/metrics/fields/test_base.py
+++ b/tests/sentry/snuba/metrics/fields/test_base.py
@@ -61,8 +61,8 @@ rh_indexer_record = partial(indexer_record, UseCaseID.SESSIONS)
 def get_entity_of_metric_mocked(_, metric_mri, use_case_id):
     return {
         SessionMRI.RAW_SESSION.value: EntityKey.MetricsCounters,
-        SessionMRI.USER.value: EntityKey.MetricsSets,
-        SessionMRI.ERROR.value: EntityKey.MetricsSets,
+        SessionMRI.RAW_USER.value: EntityKey.MetricsSets,
+        SessionMRI.RAW_ERROR.value: EntityKey.MetricsSets,
         TransactionMRI.DURATION.value: EntityKey.MetricsDistributions,
         TransactionMRI.USER.value: EntityKey.MetricsSets,
         TransactionMRI.MEASUREMENTS_LCP.value: EntityKey.MetricsDistributions,
@@ -160,7 +160,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         for status in ("init", "abnormal", "crashed", "errored"):
             rh_indexer_record(org_id, status)
         session_ids = [rh_indexer_record(org_id, SessionMRI.RAW_SESSION.value)]
-        session_user_ids = [rh_indexer_record(org_id, SessionMRI.USER.value)]
+        session_user_ids = [rh_indexer_record(org_id, SessionMRI.RAW_USER.value)]
 
         derived_name_snql = {
             SessionMRI.ALL.value: (all_sessions, session_ids),
@@ -185,7 +185,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
                 ),
             ]
 
-        session_error_metric_ids = [rh_indexer_record(org_id, SessionMRI.ERROR.value)]
+        session_error_metric_ids = [rh_indexer_record(org_id, SessionMRI.RAW_ERROR.value)]
         assert DERIVED_METRICS[SessionMRI.ERRORED_SET.value].generate_select_statements(
             [self.project],
             use_case_id=use_case_id,
@@ -293,8 +293,8 @@ class SingleEntityDerivedMetricTestCase(TestCase):
     def test_generate_metric_ids(self):
         org_id = self.project.organization_id
         session_metric_id = rh_indexer_record(org_id, SessionMRI.RAW_SESSION.value)
-        session_error_metric_id = rh_indexer_record(org_id, SessionMRI.ERROR.value)
-        session_user_id = rh_indexer_record(org_id, SessionMRI.USER.value)
+        session_error_metric_id = rh_indexer_record(org_id, SessionMRI.RAW_ERROR.value)
+        session_user_id = rh_indexer_record(org_id, SessionMRI.RAW_USER.value)
         use_case_id = UseCaseID.SESSIONS
 
         for derived_metric_mri in [
@@ -394,7 +394,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         with pytest.raises(DerivedMetricParseException):
             SingularEntityDerivedMetric(
                 metric_mri=SessionMRI.ERRORED_SET.value,
-                metrics=[SessionMRI.ERROR.value],
+                metrics=[SessionMRI.RAW_ERROR.value],
                 unit="sessions",
                 snql=None,
             )

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
@@ -103,7 +103,7 @@ class ReleaseHealthMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
             )
         for value in range(3):
             self.store_release_health_metric(
-                name=SessionMRI.ERROR.value,
+                name=SessionMRI.RAW_ERROR.value,
                 tags={"release": "foo"},
                 value=value,
             )
@@ -228,7 +228,7 @@ class ReleaseHealthMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
                 tags.update({"abnormal_mechanism": anr_mechanism})
 
             self.store_release_health_metric(
-                name=SessionMRI.USER.value,
+                name=SessionMRI.RAW_USER.value,
                 tags=tags,
                 value=count_value,
                 minutes_before_now=4,

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
@@ -96,7 +96,7 @@ class ReleaseHealthMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
             ("init", 15),
         ):
             self.store_release_health_metric(
-                name=SessionMRI.SESSION.value,
+                name=SessionMRI.RAW_SESSION.value,
                 tags={"session.status": tag_value},
                 value=count_value,
                 minutes_before_now=4,

--- a/tests/sentry/snuba/metrics/test_query.py
+++ b/tests/sentry/snuba/metrics/test_query.py
@@ -391,7 +391,7 @@ def test_validate_many_order_by_fields_are_in_select():
     # This example should pass because both session crash free rate
     # and sum(session) both go to the entity counters
     metric_field_1 = MetricField(op=None, metric_mri=SessionMRI.CRASH_FREE_RATE.value)
-    metric_field_2 = MetricField(op="sum", metric_mri=SessionMRI.SESSION.value)
+    metric_field_2 = MetricField(op="sum", metric_mri=SessionMRI.RAW_SESSION.value)
     metrics_query_dict = (
         MetricsQueryBuilder()
         .with_select([metric_field_1, metric_field_2])

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -96,7 +96,7 @@ USE_CASE_ID = UseCaseID.SESSIONS
 def get_entity_of_metric_mocked(_, metric_name, use_case_id):
     return {
         "sentry.sessions.session": EntityKey.MetricsCounters,
-        SessionMRI.SESSION.value: EntityKey.MetricsCounters,
+        SessionMRI.RAW_SESSION.value: EntityKey.MetricsCounters,
         "sentry.sessions.session.error": EntityKey.MetricsSets,
         SessionMRI.ERROR.value: EntityKey.MetricsSets,
     }[metric_name]
@@ -356,7 +356,7 @@ def test_build_snuba_query(mock_now, mock_now2):
         org_id=1,
         project_ids=[1],
         select=[
-            MetricField("sum", SessionMRI.SESSION.value),
+            MetricField("sum", SessionMRI.RAW_SESSION.value),
             MetricField("count_unique", SessionMRI.USER.value),
             MetricField("p95", SessionMRI.RAW_DURATION.value),
         ],
@@ -509,7 +509,7 @@ def test_build_snuba_query_mri(mock_now, mock_now2):
 
     assert fields_in_entities == {
         "metrics_counters": [
-            ("sum", SessionMRI.SESSION.value, SessionMRI.SESSION.value),
+            ("sum", SessionMRI.RAW_SESSION.value, SessionMRI.RAW_SESSION.value),
         ]
     }
 
@@ -549,7 +549,7 @@ def test_build_snuba_query_mri(mock_now, mock_now2):
                 Condition(
                     Column("metric_id"),
                     Op.IN,
-                    [resolve_weak(use_case_id, org_id, SessionMRI.SESSION.value)],
+                    [resolve_weak(use_case_id, org_id, SessionMRI.RAW_SESSION.value)],
                 ),
             ],
             having=[],
@@ -622,21 +622,23 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2):
                 select=[
                     errored_preaggr_sessions(
                         org_id,
-                        metric_ids=[resolve_weak(use_case_id, org_id, SessionMRI.SESSION.value)],
+                        metric_ids=[
+                            resolve_weak(use_case_id, org_id, SessionMRI.RAW_SESSION.value)
+                        ],
                         alias=f"{SessionMRI.ERRORED_PREAGGREGATED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}",
                     ),
                     addition(
                         crashed_sessions(
                             org_id,
                             metric_ids=[
-                                resolve_weak(use_case_id, org_id, SessionMRI.SESSION.value)
+                                resolve_weak(use_case_id, org_id, SessionMRI.RAW_SESSION.value)
                             ],
                             alias=SessionMRI.CRASHED.value,
                         ),
                         abnormal_sessions(
                             org_id,
                             metric_ids=[
-                                resolve_weak(use_case_id, org_id, SessionMRI.SESSION.value)
+                                resolve_weak(use_case_id, org_id, SessionMRI.RAW_SESSION.value)
                             ],
                             alias=SessionMRI.ABNORMAL.value,
                         ),
@@ -647,14 +649,14 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2):
                             crashed_sessions(
                                 org_id,
                                 metric_ids=[
-                                    resolve_weak(use_case_id, org_id, SessionMRI.SESSION.value)
+                                    resolve_weak(use_case_id, org_id, SessionMRI.RAW_SESSION.value)
                                 ],
                                 alias=SessionMRI.CRASHED.value,
                             ),
                             all_sessions(
                                 org_id,
                                 metric_ids=[
-                                    resolve_weak(use_case_id, org_id, SessionMRI.SESSION.value)
+                                    resolve_weak(use_case_id, org_id, SessionMRI.RAW_SESSION.value)
                                 ],
                                 alias=SessionMRI.ALL.value,
                             ),
@@ -664,7 +666,9 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2):
                     ),
                     all_sessions(
                         org_id,
-                        metric_ids=[resolve_weak(use_case_id, org_id, SessionMRI.SESSION.value)],
+                        metric_ids=[
+                            resolve_weak(use_case_id, org_id, SessionMRI.RAW_SESSION.value)
+                        ],
                         alias=SessionMetricKey.ALL.value,
                     ),
                 ],
@@ -681,7 +685,7 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2):
                     Condition(
                         Column("metric_id"),
                         Op.IN,
-                        [resolve_weak(use_case_id, org_id, SessionMRI.SESSION.value)],
+                        [resolve_weak(use_case_id, org_id, SessionMRI.RAW_SESSION.value)],
                     ),
                 ],
                 having=[],
@@ -1086,7 +1090,7 @@ def test_translate_results_missing_slots(_1, _2):
     query_definition = QueryDefinition([PseudoProject(1, 1)], query_params)
     fields_in_entities = {
         "metrics_counters": [
-            ("sum", SessionMRI.SESSION.value, "sum(sentry.sessions.session)"),
+            ("sum", SessionMRI.RAW_SESSION.value, "sum(sentry.sessions.session)"),
         ],
     }
 
@@ -1095,7 +1099,7 @@ def test_translate_results_missing_slots(_1, _2):
             "totals": {
                 "data": [
                     {
-                        "metric_id": resolve(use_case_id, org_id, SessionMRI.SESSION.value),
+                        "metric_id": resolve(use_case_id, org_id, SessionMRI.RAW_SESSION.value),
                         "sum(sentry.sessions.session)": 400,
                     },
                 ],
@@ -1103,13 +1107,13 @@ def test_translate_results_missing_slots(_1, _2):
             "series": {
                 "data": [
                     {
-                        "metric_id": resolve(use_case_id, org_id, SessionMRI.SESSION.value),
+                        "metric_id": resolve(use_case_id, org_id, SessionMRI.RAW_SESSION.value),
                         "bucketed_time": "2021-08-23T00:00Z",
                         "sum(sentry.sessions.session)": 100,
                     },
                     # no data for 2021-08-24
                     {
-                        "metric_id": resolve(use_case_id, org_id, SessionMRI.SESSION.value),
+                        "metric_id": resolve(use_case_id, org_id, SessionMRI.RAW_SESSION.value),
                         "bucketed_time": "2021-08-25T00:00Z",
                         "sum(sentry.sessions.session)": 300,
                     },
@@ -1304,12 +1308,12 @@ def test_translate_meta_result_type_composite_entity_derived_metric(_):
     [
         pytest.param(
             [
-                MetricField("sum", SessionMRI.SESSION.value),
+                MetricField("sum", SessionMRI.RAW_SESSION.value),
                 MetricField("count_unique", SessionMRI.USER.value),
                 MetricField("p95", SessionMRI.RAW_DURATION.value),
             ],
             [
-                MetricGroupByField(MetricField("sum", SessionMRI.SESSION.value)),
+                MetricGroupByField(MetricField("sum", SessionMRI.RAW_SESSION.value)),
             ],
             UseCaseID.SESSIONS,
             re.escape("Cannot group by metrics expression sum(sentry.sessions.session)"),
@@ -1399,12 +1403,12 @@ def test_only_can_groupby_operations_can_be_added_to_groupby(
     [
         pytest.param(
             [
-                MetricField("sum", SessionMRI.SESSION.value),
+                MetricField("sum", SessionMRI.RAW_SESSION.value),
                 MetricField("count_unique", SessionMRI.USER.value),
                 MetricField("p95", SessionMRI.RAW_DURATION.value),
             ],
             [
-                MetricConditionField(MetricField("sum", SessionMRI.SESSION.value), Op.GTE, 10),
+                MetricConditionField(MetricField("sum", SessionMRI.RAW_SESSION.value), Op.GTE, 10),
             ],
             UseCaseID.SESSIONS,
             re.escape("Cannot filter by metrics expression sum(sentry.sessions.session)"),
@@ -1962,7 +1966,7 @@ def test_timestamp_operators(op: MetricOperationType, clickhouse_op: str):
         org_id=org_id,
         project_ids=[1],
         select=[
-            MetricField(op=op, metric_mri=SessionMRI.SESSION.value, alias="ts"),
+            MetricField(op=op, metric_mri=SessionMRI.RAW_SESSION.value, alias="ts"),
         ],
         start=MOCK_NOW - timedelta(days=90),
         end=MOCK_NOW,
@@ -1986,7 +1990,7 @@ def test_timestamp_operators(op: MetricOperationType, clickhouse_op: str):
                 "equals",
                 [
                     Column("metric_id"),
-                    resolve_weak(UseCaseID.SESSIONS, org_id, SessionMRI.SESSION.value),
+                    resolve_weak(UseCaseID.SESSIONS, org_id, SessionMRI.RAW_SESSION.value),
                 ],
             ),
         ],
@@ -2014,7 +2018,7 @@ def test_having_clause(include_totals, include_series):
         org_id=1,
         project_ids=[1],
         select=[
-            MetricField("sum", SessionMRI.SESSION.value, alias="sum"),
+            MetricField("sum", SessionMRI.RAW_SESSION.value, alias="sum"),
         ],
         start=MOCK_NOW - timedelta(days=90),
         end=MOCK_NOW,

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -98,7 +98,7 @@ def get_entity_of_metric_mocked(_, metric_name, use_case_id):
         "sentry.sessions.session": EntityKey.MetricsCounters,
         SessionMRI.RAW_SESSION.value: EntityKey.MetricsCounters,
         "sentry.sessions.session.error": EntityKey.MetricsSets,
-        SessionMRI.ERROR.value: EntityKey.MetricsSets,
+        SessionMRI.RAW_ERROR.value: EntityKey.MetricsSets,
     }[metric_name]
 
 
@@ -357,7 +357,7 @@ def test_build_snuba_query(mock_now, mock_now2):
         project_ids=[1],
         select=[
             MetricField("sum", SessionMRI.RAW_SESSION.value),
-            MetricField("count_unique", SessionMRI.USER.value),
+            MetricField("count_unique", SessionMRI.RAW_USER.value),
             MetricField("p95", SessionMRI.RAW_DURATION.value),
         ],
         start=MOCK_NOW - timedelta(days=90),
@@ -699,7 +699,7 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2):
                 match=Entity("metrics_sets"),
                 select=[
                     uniq_aggregation_on_metric(
-                        metric_ids=[resolve_weak(use_case_id, org_id, SessionMRI.ERROR.value)],
+                        metric_ids=[resolve_weak(use_case_id, org_id, SessionMRI.RAW_ERROR.value)],
                         alias=f"{SessionMRI.ERRORED_SET.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}",
                     ),
                 ],
@@ -716,7 +716,7 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2):
                     Condition(
                         Column("metric_id"),
                         Op.IN,
-                        [resolve_weak(use_case_id, org_id, SessionMRI.ERROR.value)],
+                        [resolve_weak(use_case_id, org_id, SessionMRI.RAW_ERROR.value)],
                     ),
                 ],
                 having=[],
@@ -1309,7 +1309,7 @@ def test_translate_meta_result_type_composite_entity_derived_metric(_):
         pytest.param(
             [
                 MetricField("sum", SessionMRI.RAW_SESSION.value),
-                MetricField("count_unique", SessionMRI.USER.value),
+                MetricField("count_unique", SessionMRI.RAW_USER.value),
                 MetricField("p95", SessionMRI.RAW_DURATION.value),
             ],
             [
@@ -1404,7 +1404,7 @@ def test_only_can_groupby_operations_can_be_added_to_groupby(
         pytest.param(
             [
                 MetricField("sum", SessionMRI.RAW_SESSION.value),
-                MetricField("count_unique", SessionMRI.USER.value),
+                MetricField("count_unique", SessionMRI.RAW_USER.value),
                 MetricField("p95", SessionMRI.RAW_DURATION.value),
             ],
             [

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -39,7 +39,7 @@ class EntitySubscriptionTestCase(TestCase):
     def setUp(self) -> None:
         super().setUp()
         for tag in [
-            SessionMRI.SESSION.value,
+            SessionMRI.RAW_SESSION.value,
             SessionMRI.USER.value,
             "session.status",
             "init",

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -40,7 +40,7 @@ class EntitySubscriptionTestCase(TestCase):
         super().setUp()
         for tag in [
             SessionMRI.RAW_SESSION.value,
-            SessionMRI.USER.value,
+            SessionMRI.RAW_USER.value,
             "session.status",
             "init",
             "crashed",

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -187,7 +187,7 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest, TestCase):
 
     @responses.activate
     def test_granularity_on_metrics_crash_rate_alerts(self):
-        for tag in [SessionMRI.SESSION.value, SessionMRI.USER.value, "session.status"]:
+        for tag in [SessionMRI.RAW_SESSION.value, SessionMRI.USER.value, "session.status"]:
             rh_indexer_record(self.organization.id, tag)
         for (time_window, expected_granularity) in [
             (30, 10),
@@ -969,7 +969,7 @@ class BuildSnqlQueryTest(TestCase):
     def test_simple_sessions_for_metrics(self):
         with Feature("organizations:use-metrics-layer"):
             org_id = self.organization.id
-            for tag in [SessionMRI.SESSION.value, "session.status", "crashed", "init"]:
+            for tag in [SessionMRI.RAW_SESSION.value, "session.status", "crashed", "init"]:
                 rh_indexer_record(org_id, tag)
             expected_conditions = [
                 Condition(Column(name="org_id"), Op.EQ, self.organization.id),
@@ -995,7 +995,7 @@ class BuildSnqlQueryTest(TestCase):
                         resolve(
                             UseCaseKey.RELEASE_HEALTH,
                             self.organization.id,
-                            SessionMRI.SESSION.value,
+                            SessionMRI.RAW_SESSION.value,
                         )
                     ],
                 ),
@@ -1009,7 +1009,7 @@ class BuildSnqlQueryTest(TestCase):
                 entity_extra_fields={"org_id": self.organization.id},
                 granularity=10,
                 use_none_clauses=True,
-                aggregate_kwargs={"metric_mri": SessionMRI.SESSION.value},
+                aggregate_kwargs={"metric_mri": SessionMRI.RAW_SESSION.value},
             )
 
     def test_simple_users_for_metrics(self):
@@ -1048,7 +1048,7 @@ class BuildSnqlQueryTest(TestCase):
             env = self.create_environment(self.project, name="development")
             org_id = self.organization.id
             for tag in [
-                SessionMRI.SESSION.value,
+                SessionMRI.RAW_SESSION.value,
                 "session.status",
                 "environment",
                 "development",
@@ -1103,7 +1103,7 @@ class BuildSnqlQueryTest(TestCase):
                         resolve(
                             UseCaseKey.RELEASE_HEALTH,
                             self.organization.id,
-                            SessionMRI.SESSION.value,
+                            SessionMRI.RAW_SESSION.value,
                         )
                     ],
                 ),
@@ -1119,7 +1119,7 @@ class BuildSnqlQueryTest(TestCase):
                 granularity=10,
                 use_none_clauses=True,
                 aggregate_kwargs={
-                    "metric_mri": SessionMRI.SESSION.value,
+                    "metric_mri": SessionMRI.RAW_SESSION.value,
                 },
             )
 

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -187,7 +187,7 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest, TestCase):
 
     @responses.activate
     def test_granularity_on_metrics_crash_rate_alerts(self):
-        for tag in [SessionMRI.RAW_SESSION.value, SessionMRI.USER.value, "session.status"]:
+        for tag in [SessionMRI.RAW_SESSION.value, SessionMRI.RAW_USER.value, "session.status"]:
             rh_indexer_record(self.organization.id, tag)
         for (time_window, expected_granularity) in [
             (30, 10),
@@ -1015,7 +1015,7 @@ class BuildSnqlQueryTest(TestCase):
     def test_simple_users_for_metrics(self):
         with Feature("organizations:use-metrics-layer"):
             org_id = self.organization.id
-            for tag in [SessionMRI.USER.value, "session.status", "crashed"]:
+            for tag in [SessionMRI.RAW_USER.value, "session.status", "crashed"]:
                 rh_indexer_record(org_id, tag)
 
             expected_conditions = [
@@ -1026,7 +1026,9 @@ class BuildSnqlQueryTest(TestCase):
                     Op.IN,
                     [
                         resolve(
-                            UseCaseKey.RELEASE_HEALTH, self.organization.id, SessionMRI.USER.value
+                            UseCaseKey.RELEASE_HEALTH,
+                            self.organization.id,
+                            SessionMRI.RAW_USER.value,
                         )
                     ],
                 ),
@@ -1040,7 +1042,7 @@ class BuildSnqlQueryTest(TestCase):
                 entity_extra_fields={"org_id": self.organization.id},
                 granularity=10,
                 use_none_clauses=True,
-                aggregate_kwargs={"metric_mri": SessionMRI.USER.value},
+                aggregate_kwargs={"metric_mri": SessionMRI.RAW_USER.value},
             )
 
     def test_query_and_environment_sessions_metrics(self):
@@ -1128,7 +1130,7 @@ class BuildSnqlQueryTest(TestCase):
             env = self.create_environment(self.project, name="development")
             org_id = self.organization.id
             for tag in [
-                SessionMRI.USER.value,
+                SessionMRI.RAW_USER.value,
                 "session.status",
                 "environment",
                 "development",
@@ -1167,7 +1169,9 @@ class BuildSnqlQueryTest(TestCase):
                     Op.IN,
                     [
                         resolve(
-                            UseCaseKey.RELEASE_HEALTH, self.organization.id, SessionMRI.USER.value
+                            UseCaseKey.RELEASE_HEALTH,
+                            self.organization.id,
+                            SessionMRI.RAW_USER.value,
                         )
                     ],
                 ),
@@ -1185,7 +1189,7 @@ class BuildSnqlQueryTest(TestCase):
                 granularity=10,
                 use_none_clauses=True,
                 aggregate_kwargs={
-                    "metric_mri": SessionMRI.USER.value,
+                    "metric_mri": SessionMRI.RAW_USER.value,
                 },
             )
 


### PR DESCRIPTION
The metric `c:sessions/session@none` has the quirk that its `sum()` over a time range (without filtering down to tags) does not represent the total number of sessions in that time range. It double-counts `crashed` and `abnormal` sessions, because for those sessions relay increments the counter metric twice: once with tag `status=init`, and once with `status=crashed` (or `abnormal`).

To get the total session count, the derived metric should be used:

https://github.com/getsentry/sentry/blob/7331498fb5de13778da47ea4835d8eb31d19f4aa/src/sentry/snuba/metrics/naming_layer/mri.py#L58

In order to clarify that `SessionMRI.SESSION` is for internal use only, rename it to `SessionMRI.RAW_SESSION`.

This PR does not change any product logic, but it should make it easier to spot in what places the raw metric is used by accident.