### PR TITLE
fix(source-map-debugger): Access SDK name in a more defensive way

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData.tsx
@@ -35,7 +35,7 @@ interface SourceMapDebugBlueThunderResponse {
 
 export function useSourceMapDebuggerData(event: Event, projectSlug: string) {
   const isSdkThatShouldShowSourceMapsDebugger =
-    !!event.sdk?.name.startsWith('sentry.javascript.');
+    !!event.sdk?.name?.startsWith('sentry.javascript.');
   const organization = useOrganization({allowNull: true});
   const {data: sourceMapDebuggerData} = useApiQuery<SourceMapDebugBlueThunderResponse>(
     [


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/56853