### PR TITLE
feat(metrics): Investigation rule exists endpoint (second attempt)

### DIFF
--- a/src/sentry/api/endpoints/custom_rules.py
+++ b/src/sentry/api/endpoints/custom_rules.py
@@ -51,10 +51,10 @@ class CustomRulesInputSerializer(serializers.Serializer):
         # check that the project exists
         invalid_projects = []
 
-        for project_id in data["projects"]:
-            try:
-                Project.objects.get_from_cache(id=project_id)
-            except Project.DoesNotExist:
+        requested_projects = data["projects"]
+        available_projects = {p.id for p in Project.objects.get_many_from_cache(data["projects"])}
+        for project_id in requested_projects:
+            if project_id not in available_projects:
                 invalid_projects.append(f"invalid project id: {project_id}")
 
         if invalid_projects:
@@ -82,6 +82,7 @@ class CustomRulesEndpoint(OrganizationEndpoint):
 
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.EXPERIMENTAL,
     }
 
     def post(self, request: Request, organization: Organization) -> Response:
@@ -122,18 +123,7 @@ class CustomRulesEndpoint(OrganizationEndpoint):
                 sample_rate=1.0,
             )
 
-            response_data = {
-                "ruleId": rule.external_rule_id,
-                "condition": json.loads(rule.condition),
-                "startDate": rule.start_date.strftime(CUSTOM_RULE_DATE_FORMAT),
-                "endDate": rule.end_date.strftime(CUSTOM_RULE_DATE_FORMAT),
-                "numSamples": rule.num_samples,
-                "sampleRate": rule.sample_rate,
-                "dateAdded": rule.date_added.strftime(CUSTOM_RULE_DATE_FORMAT),
-                "projects": [project.id for project in rule.projects.all()],
-                "orgId": rule.organization_id,
-            }
-            return Response(response_data, status=200)
+            return _rule_to_response(rule)
 
         except DatabaseError:
             return Response(
@@ -151,3 +141,78 @@ class CustomRulesEndpoint(OrganizationEndpoint):
             )
         except ValueError as e:
             return Response({"query": ["Could not convert to rule", str(e)]}, status=400)
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        requested_projects = request.GET.getlist("project")
+        query = request.GET.get("query")
+
+        try:
+            requested_projects_ids = [int(project_id) for project_id in requested_projects]
+        except ValueError:
+            return Response({"projects": ["Invalid project id"]}, status=400)
+
+        if requested_projects_ids:
+            org_rule = False
+            invalid_projects = []
+            available_projects = {
+                p.id for p in Project.objects.get_many_from_cache(requested_projects_ids)
+            }
+            for project_id in requested_projects_ids:
+                if project_id not in available_projects:
+                    invalid_projects.append(f"invalid project id: {project_id}")
+
+            if invalid_projects:
+                raise serializers.ValidationError({"projects": invalid_projects})
+        else:
+            # no project specified (it is an org rule)
+            org_rule = True
+
+        try:
+            tokens = parse_search_query(query)
+        except InvalidSearchQuery as e:
+            return Response({"query": [str(e)]}, status=400)
+
+        try:
+            converter = SearchQueryConverter(tokens)
+            condition = converter.convert()
+        except ValueError as e:
+            return Response({"query": ["Could not convert to rule", str(e)]}, status=400)
+
+        rule = CustomDynamicSamplingRule.get_rule_for_org(condition, organization.id)
+
+        if rule is None:
+            return Response(status=204)  # no rule found, nothing to reutrn
+
+        # we have a rule, check to see if the projects match
+
+        if rule.is_org_level:
+            # a rule org covers all projects
+            return _rule_to_response(rule)
+
+        if not rule.is_org_level and org_rule:
+            # we need an org rule and we have a simple rule return not found
+            return Response(status=204)
+
+        # project rule request and project rule found # see if we have all projects
+        available_projects = {p.id for p in rule.projects.all()}
+        for project_id in requested_projects_ids:
+            if project_id not in available_projects:
+                return Response(status=204)
+
+        # the rule covers all projects
+        return _rule_to_response(rule)
+
+
+def _rule_to_response(rule: CustomDynamicSamplingRule) -> Response:
+    response_data = {
+        "ruleId": rule.external_rule_id,
+        "condition": json.loads(rule.condition),
+        "startDate": rule.start_date.strftime(CUSTOM_RULE_DATE_FORMAT),
+        "endDate": rule.end_date.strftime(CUSTOM_RULE_DATE_FORMAT),
+        "numSamples": rule.num_samples,
+        "sampleRate": rule.sample_rate,
+        "dateAdded": rule.date_added.strftime(CUSTOM_RULE_DATE_FORMAT),
+        "projects": [project.id for project in rule.projects.all()],
+        "orgId": rule.organization.id,
+    }
+    return Response(response_data, status=200)

--- a/tests/sentry/api/endpoints/test_custom_rules.py
+++ b/tests/sentry/api/endpoints/test_custom_rules.py
@@ -1,16 +1,159 @@
 from datetime import datetime, timedelta
 
 import pytest
+from django.utils import timezone
 
 from sentry.api.endpoints.custom_rules import (
     DEFAULT_PERIOD_STRING,
     MAX_RULE_PERIOD_STRING,
     CustomRulesInputSerializer,
 )
-from sentry.models.dynamicsampling import CUSTOM_RULE_DATE_FORMAT
+from sentry.models.dynamicsampling import CUSTOM_RULE_DATE_FORMAT, CustomDynamicSamplingRule
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test(stable=True)
+class CustomRulesGetEndpoint(APITestCase):
+    """
+    Tests the GET endpoint
+    """
+
+    endpoint = "sentry-api-0-organization-dynamic_sampling-custom_rules"
+    method = "get"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        second_project = self.create_project(organization=self.organization)
+        third_project = self.create_project(organization=self.organization)
+        fourth_project = self.create_project(organization=self.organization)
+        self.known_projects = [self.project, second_project, third_project, fourth_project]
+
+        # create a project rule for second and third project
+        now = timezone.now()
+        self.proj_condition = {"op": "eq", "name": "event.environment", "value": "prod"}
+        start = now - timedelta(hours=2)
+        end = now + timedelta(hours=2)
+        projects = self.known_projects[1:3]
+        CustomDynamicSamplingRule.update_or_create(
+            condition=self.proj_condition,
+            start=start,
+            end=end,
+            project_ids=projects,
+            organization_id=self.organization.id,
+            num_samples=100,
+            sample_rate=1.0,
+        )
+
+        # create an org rule
+        now = timezone.now()
+        self.org_condition = {"op": "eq", "name": "event.environment", "value": "dev"}
+        start = now - timedelta(hours=2)
+        end = now + timedelta(hours=2)
+        CustomDynamicSamplingRule.update_or_create(
+            condition=self.org_condition,
+            start=start,
+            end=end,
+            project_ids=[],
+            organization_id=self.organization.id,
+            num_samples=100,
+            sample_rate=1.0,
+        )
+
+    def test_finds_project_rule(self):
+        """
+        Tests that the endpoint finds the rule when the query matches and
+        the existing rule contains all the requested projects
+
+        test with the original test being a project level rule
+        """
+
+        # call the endpoint
+        with Feature({"organizations:investigation-bias": True}):
+            resp = self.get_response(
+                self.organization.slug,
+                qs_params={
+                    "query": "environment:prod",
+                    "project": [self.known_projects[1].id],
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.data
+        assert data["condition"] == self.proj_condition
+        assert len(data["projects"]) == 2
+        assert self.known_projects[1].id in data["projects"]
+        assert self.known_projects[2].id in data["projects"]
+        # {'ruleId': 3001, 'condition': {'op': 'eq', 'name': 'event.environment', 'value': 'prod'}, 'startDate': '2023-09-22T12:23:35.984264Z', 'endDate': '2023-09-22T16:23:35.984264Z', 'numSamples': 100, 'sampleRate': 1.0, 'dateAdded': '2023-09-22T14:23:37.880615Z', 'projects': [4552672605044753, 4552672605044754], 'orgId': 4552672604913680}
+
+    def test_finds_org_condition(self):
+        """
+        A request for either any project of org will find an org rule ( if condition matches)
+        """
+
+        # finds projects in the org rule
+        with Feature({"organizations:investigation-bias": True}):
+            resp = self.get_response(
+                self.organization.slug,
+                qs_params={
+                    "query": "environment:dev",
+                    "project": [self.known_projects[1].id],
+                },
+            )
+        assert resp.status_code == 200
+
+        # finds org rule (with org request)
+        with Feature({"organizations:investigation-bias": True}):
+            resp = self.get_response(
+                self.organization.slug,
+                qs_params={
+                    "query": "environment:dev",
+                    "project": [],
+                },
+            )
+        assert resp.status_code == 200
+
+    def test_does_not_find_rule_when_condition_doesnt_match(self):
+        """
+        Querying for a condition that doesn't match any rule returns 204
+        """
+        with Feature({"organizations:investigation-bias": True}):
+            resp = self.get_response(
+                self.organization.slug,
+                qs_params={
+                    "query": "environment:integration",
+                    "project": [self.known_projects[1].id],
+                },
+            )
+        assert resp.status_code == 204
+
+    def test_does_not_find_rule_when_project_doesnt_match(self):
+        """
+        Querying for a condition that doesn't match any rule returns 204
+        """
+
+        # it finds it when the project matches
+        with Feature({"organizations:investigation-bias": True}):
+            resp = self.get_response(
+                self.organization.slug,
+                qs_params={
+                    "query": "environment:prod",
+                    "project": [self.known_projects[1].id],
+                },
+            )
+        assert resp.status_code == 200
+        # but it doesn't when the project doesn't match
+        with Feature({"organizations:investigation-bias": True}):
+            resp = self.get_response(
+                self.organization.slug,
+                qs_params={
+                    "query": "environment:prod",
+                    "project": [self.known_projects[0].id],
+                },
+            )
+        assert resp.status_code == 204
 
 
 @region_silo_test(stable=True)


### PR DESCRIPTION
## What  
  
This is an endpoint that will return information on whether a rule exists for a particular condition and set of projects.  
  
## Why  
  
We need so that the UI knows to either ask the user to create an investigation rule or tell him that there is already an investigation rule in progress when the user query returns few/no results.  

**NOTE:** this is the second attempt to create this PR (the first PR is in a weird loop where santry boot continuously adds commits to it every few minutes) 

Resolves: https://github.com/getsentry/sentry/issues/55680

