### PR TITLE
feat(adv-analysis): Use span analysis util in endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -15,9 +15,10 @@ from sentry.snuba.metrics_performance import query as metrics_query
 from sentry.utils.snuba import raw_snql_query
 
 DEFAULT_LIMIT = 50
+SNUBA_QUERY_LIMIT = 10000
 
 
-def query_spans(transaction, regression_breakpoint, params, limit):
+def query_spans(transaction, regression_breakpoint, params):
     selected_columns = [
         "count(span_id) as span_count",
         "sumArray(spans_exclusive_time) as total_span_self_time",
@@ -34,7 +35,7 @@ def query_spans(transaction, regression_breakpoint, params, limit):
         equations=[],
         query=f"transaction:{transaction}",
         orderby=["span_op", "span_group", "total_span_self_time"],
-        limit=limit,
+        limit=SNUBA_QUERY_LIMIT,
         config=QueryBuilderConfig(
             auto_aggregations=True,
             use_aggregate_conditions=True,
@@ -59,7 +60,7 @@ def query_spans(transaction, regression_breakpoint, params, limit):
     )
     builder.columns.append(Function("countDistinct", [Column("event_id")], "transaction_count"))
     builder.groupby.append(Column("period"))
-    builder.limitby = LimitBy([Column("period")], limit // 2)
+    builder.limitby = LimitBy([Column("period")], SNUBA_QUERY_LIMIT // 2)
 
     snql_query = builder.get_snql_query()
     results = raw_snql_query(snql_query, "api.organization-events-root-cause-analysis")
@@ -109,7 +110,6 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
             transaction=transaction_name,
             regression_breakpoint=regression_breakpoint,
             params=params,
-            limit=int(request.GET.get("per_page", DEFAULT_LIMIT)),
         )
 
         span_analysis_results = span_analysis(span_data)
@@ -121,4 +121,5 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
                 result["span_group"],
             )
 
-        return Response(span_analysis_results, status=200)
+        limit = int(request.GET.get("per_page", DEFAULT_LIMIT))
+        return Response(span_analysis_results[:limit], status=200)

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -266,7 +266,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             }
         ]
 
-    def test_results_per_period_are_limited(self):
+    def test_results_are_limited(self):
         # Before
         self.create_transaction(
             transaction="foo",
@@ -330,9 +330,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                     "breakpoint": self.now - timedelta(days=1),
                     "start": self.now - timedelta(days=3),
                     "end": self.now,
-                    # Force a small page size and verify the 2 spans from After
-                    # don't dominate the results
-                    "per_page": 2,
+                    "per_page": 1,
                 },
             )
 
@@ -341,21 +339,18 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
         for row in response.data:
             del row["sample_event_id"]
 
+        assert len(response.data) == 1
         assert response.data == [
             {
-                "period": "after",
-                "span_count": 1,
-                "span_group": "d77d5e503ad1439f",
-                "span_op": "db",
-                "total_span_self_time": 100.0,
-                "transaction_count": 1,
-            },
-            {
-                "span_group": "2b9cbb96dbf59baa",
                 "span_op": "django.middleware",
-                "period": "before",
-                "total_span_self_time": 60.0,
-                "span_count": 1,
-                "transaction_count": 1,
-            },
+                "span_group": "2b9cbb96dbf59baa",
+                "score_delta": 0.6666666666666666,
+                "freq_before": 1.0,
+                "freq_after": 1.0,
+                "freq_delta": 0.0,
+                "duration_delta": 0.6666666666666666,
+                "duration_before": 60.0,
+                "duration_after": 100.0,
+                "span_description": "middleware span",
+            }
         ]

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -153,7 +153,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
 
     #     assert response.status_code == 400, response.content
 
-    def test_returns_counts_of_spans_before_and_after_breakpoint(self):
+    def test_returns_change_data_for_regressed_spans(self):
         before_timestamp = self.now - timedelta(days=2)
         before_span = {
             "parent_span_id": "a" * 16,
@@ -211,7 +211,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                     "timestamp": iso_format(after_timestamp),
                     "op": "django.middleware",
                     "description": "middleware span",
-                    "exclusive_time": 60.0,
+                    "exclusive_time": 600.0,
                 },
                 {
                     "parent_span_id": "1" * 16,
@@ -222,10 +222,13 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                     "description": "middleware span",
                     "exclusive_time": 60.0,
                 },
+                # This db span shouldn't appear in the results
+                # since there are no changes
+                {**before_span, "span_id": "5" * 16, "op": "db", "description": "db span"},
             ],
             project_id=self.project.id,
             start_timestamp=after_timestamp,
-            duration=100,
+            duration=600,
         )
 
         with self.feature(FEATURES):
@@ -250,29 +253,17 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             del row["sample_event_id"]
         assert response.data == [
             {
-                "period": "before",
-                "span_count": 1,
-                "span_group": "5ad8c5a1e8d0e5f7",
-                "span_op": "db",
-                "total_span_self_time": 60.0,
-                "transaction_count": 1,
-            },
-            {
-                "span_group": "2b9cbb96dbf59baa",
                 "span_op": "django.middleware",
-                "period": "before",
-                "total_span_self_time": 60.0,
-                "span_count": 1,
-                "transaction_count": 1,
-            },
-            {
                 "span_group": "2b9cbb96dbf59baa",
-                "span_op": "django.middleware",
-                "period": "after",
-                "total_span_self_time": 160.0,
-                "span_count": 3,
-                "transaction_count": 1,
-            },
+                "span_description": "middleware span",
+                "score_delta": 10.666666666666666,
+                "freq_before": 1.0,
+                "freq_after": 3.0,
+                "freq_delta": 2.0,
+                "duration_delta": 2.888888888888889,
+                "duration_before": 60.0,
+                "duration_after": 233.33333333333334,
+            }
         ]
 
     def test_results_per_period_are_limited(self):


### PR DESCRIPTION
Uses the span analysis util function in the endpoint. I tweaked the function to exclude results if they didn't increase the duration (i.e. no change or negative change in score). After we get the results we also want to iterate over them and get the span descriptions which are stored on the nodestore events. I import a util from a performance endpoint to do this.

I also replaced the limit in the query to allow for as much span data as we can, but limit the response size. This fixes issues where, due to the sorting on the span op and span group, we could have different results in the before/after group if there are spans in one side but not the other. If we get as much data as we can and truncate on the response then we can still run an accurate analysis.