### PR TITLE
ref(hc): Fix early return

### DIFF
--- a/src/sentry/tasks/deliver_from_outbox.py
+++ b/src/sentry/tasks/deliver_from_outbox.py
@@ -68,7 +68,7 @@ def schedule_batch(
             lo = outbox_model.objects.all().aggregate(Min("id"))["id__min"] or 0
             hi = outbox_model.objects.all().aggregate(Max("id"))["id__max"] or -1
             if hi < lo:
-                return
+                continue
 
             scheduled_count += hi - lo + 1
             batch_size = math.ceil((hi - lo + 1) / concurrency)


### PR DESCRIPTION
A simple, embarassing fix.

In getsentry we actually have 2 region outbox types.  If the usage outbox isn't processing (very low volume), the normal region outboxes are not processing thanks to this simple issue.