### PR TITLE
feat: Improve `/stories` helper components

### DIFF
--- a/static/app/components/button.stories.tsx
+++ b/static/app/components/button.stories.tsx
@@ -5,7 +5,7 @@ import Matrix from 'sentry/components/stories/matrix';
 import {IconDelete} from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook('Button', story => {
+export default storyBook(Button, story => {
   const sizes = ['md' as const, 'sm' as const, 'xs' as const, 'zero' as const];
   const priorities = [
     'default' as const,
@@ -40,23 +40,23 @@ export default storyBook('Button', story => {
   };
   story('Props', () => (
     <div>
-      <Matrix
-        component={Button}
+      <Matrix<typeof Button>
+        render={Button}
         propMatrix={propMatrix}
         selectedProps={['priority', 'size']}
       />
-      <Matrix
-        component={Button}
+      <Matrix<typeof Button>
+        render={Button}
         propMatrix={propMatrix}
         selectedProps={['children', 'icon']}
       />
-      <Matrix
-        component={Button}
+      <Matrix<typeof Button>
+        render={Button}
         propMatrix={propMatrix}
         selectedProps={['borderless', 'translucentBorder']}
       />
-      <Matrix
-        component={Button}
+      <Matrix<typeof Button>
+        render={Button}
         propMatrix={propMatrix}
         selectedProps={['disabled', 'busy']}
       />

--- a/static/app/components/button.stories.tsx
+++ b/static/app/components/button.stories.tsx
@@ -1,19 +1,11 @@
 import {Fragment, useState} from 'react';
 
 import {Button} from 'sentry/components/button';
-import Matrix from 'sentry/components/stories/matrix';
+import Matrix, {PropMatrix} from 'sentry/components/stories/matrix';
 import {IconDelete} from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 
 export default storyBook(Button, story => {
-  const sizes = ['md' as const, 'sm' as const, 'xs' as const, 'zero' as const];
-  const priorities = [
-    'default' as const,
-    'primary' as const,
-    'danger' as const,
-    'link' as const,
-  ];
-
   story('Default', () => <Button>Default Button</Button>);
 
   story('onClick', () => {
@@ -26,18 +18,19 @@ export default storyBook(Button, story => {
     );
   });
 
-  const propMatrix = {
+  const propMatrix: PropMatrix<typeof Button> = {
     borderless: [false, true],
     busy: [false, true],
     children: ['Save', undefined],
     icon: [undefined, <IconDelete key="" />],
-    priority: priorities,
-    size: sizes,
+    priority: ['default', 'primary', 'danger', 'link'],
+    size: ['md', 'sm', 'xs', 'zero'],
     disabled: [false, true],
     external: [false, true],
     title: [undefined, 'Save Now'],
     translucentBorder: [false, true],
   };
+
   story('Props', () => (
     <div>
       <Matrix<typeof Button>

--- a/static/app/components/featureBadge.stories.tsx
+++ b/static/app/components/featureBadge.stories.tsx
@@ -33,8 +33,8 @@ export default storyBook(FeatureBadge, story => {
         When using an indicator you might want to position it manually using{' '}
         <kbd>styled(FeatureBadge)</kbd>.
       </p>
-      <Matrix
-        component={props => (
+      <Matrix<typeof FeatureBadge>
+        render={props => (
           <span>
             Feature X
             <FeatureBadge {...props} />

--- a/static/app/components/stories/jsxNode.tsx
+++ b/static/app/components/stories/jsxNode.tsx
@@ -1,0 +1,55 @@
+import {Fragment, ReactNode} from 'react';
+import styled from '@emotion/styled';
+
+import JSXProperty from 'sentry/components/stories/jsxProperty';
+import {space} from 'sentry/styles/space';
+
+interface Props {
+  name: string;
+  children?: ReactNode;
+  props?: Record<string, unknown>;
+}
+
+export default function JSXNode({name, props = {}, children}: Props) {
+  if (children) {
+    return (
+      <Code data-node>
+        {`<${name}`}
+        {Object.entries(props).map(([propName, value]) => (
+          <Fragment key={propName}>
+            {' '}
+            <JSXProperty name={propName} value={value} />
+          </Fragment>
+        ))}
+        {`>`}
+        <br />
+        {children}
+        <br />
+        {`</${name}>`}
+      </Code>
+    );
+  }
+  return (
+    <Code data-node>
+      {`<${name} `}
+      {Object.entries(props).map(([propName, value]) => (
+        <Fragment key={propName}>
+          <JSXProperty name={propName} value={value} />{' '}
+        </Fragment>
+      ))}
+      {`/>`}
+    </Code>
+  );
+}
+
+const Code = styled('code')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  padding-inline: 0;
+  & > [data-property] {
+    font-size: ${p => p.theme.fontSizeMedium};
+    padding-inline: 0;
+  }
+  & > [data-node] {
+    padding-left: ${space(2)};
+  }
+`;

--- a/static/app/components/stories/jsxProperty.tsx
+++ b/static/app/components/stories/jsxProperty.tsx
@@ -1,0 +1,37 @@
+import {isValidElement} from 'react';
+
+interface Props {
+  name: string;
+  value: unknown;
+}
+
+export default function JSXProperty({name, value}: Props) {
+  if (value === null || value === undefined) {
+    return <code data-property="nullish">{`${name}={${value}}`}</code>;
+  }
+  if (value === true) {
+    return <code data-property="boolean">{name}</code>;
+  }
+  if (value === false) {
+    return <code data-property="boolean">{`${name}={${value}}`}</code>;
+  }
+  if (value === Number || value === Boolean || value === Function) {
+    // @ts-expect-error
+    return <code data-property="constructor">{`${name}={${value.name}}`}</code>;
+  }
+  if (typeof value === 'string') {
+    return <code data-property="string">{`${name}=${JSON.stringify(value)}`}</code>;
+  }
+  if (typeof value === 'number') {
+    return <code data-property="number">{`${name}={${value}}`}</code>;
+  }
+  if (typeof value === 'function') {
+    return (
+      <code data-property="function">{`${name}={${value.name || 'Function'}}`}</code>
+    );
+  }
+  if (isValidElement(value)) {
+    return <code data-property="element">{`${name}=${value}`}</code>;
+  }
+  return <code data-property="object">{`${name}={${JSON.stringify(value)}}`}</code>;
+}

--- a/static/app/components/stories/matrix.tsx
+++ b/static/app/components/stories/matrix.tsx
@@ -6,13 +6,12 @@ import JSXProperty from 'sentry/components/stories/jsxProperty';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import {space} from 'sentry/styles/space';
 
+export type PropMatrix<E extends ElementType> = Partial<{
+  [Prop in keyof ComponentProps<E>]: Array<ComponentProps<E>[Prop]>;
+}>;
+
 interface Props<E extends ElementType> {
-  propMatrix: Partial<
-    Record<
-      keyof ComponentProps<E>,
-      keyof ComponentProps<E> extends string ? unknown[] : never
-    >
-  >;
+  propMatrix: PropMatrix<E>;
   render: ElementType<ComponentProps<E>>;
   selectedProps: [keyof ComponentProps<E>, keyof ComponentProps<E>];
   sizingWindowProps?: Partial<ComponentProps<typeof SizingWindow>>;

--- a/static/app/components/stories/matrix.tsx
+++ b/static/app/components/stories/matrix.tsx
@@ -1,38 +1,54 @@
-import {type ElementType} from 'react';
-import {isValidElement} from 'react';
+import {ComponentProps, type ElementType} from 'react';
 import styled from '@emotion/styled';
+import first from 'lodash/first';
 
+import JSXProperty from 'sentry/components/stories/jsxProperty';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import {space} from 'sentry/styles/space';
 
-interface Props {
-  component: ElementType;
-  propMatrix: Record<string, unknown[]>;
-  selectedProps: [string, string];
+interface Props<E extends ElementType> {
+  propMatrix: Partial<
+    Record<
+      keyof ComponentProps<E>,
+      keyof ComponentProps<E> extends string ? unknown[] : never
+    >
+  >;
+  render: ElementType<ComponentProps<E>>;
+  selectedProps: [keyof ComponentProps<E>, keyof ComponentProps<E>];
+  sizingWindowProps?: Partial<ComponentProps<typeof SizingWindow>>;
 }
 
-export default function Matrix({component, propMatrix, selectedProps}: Props) {
+export default function Matrix<E extends ElementType>({
+  propMatrix,
+  render,
+  selectedProps,
+  sizingWindowProps,
+}: Props<E>) {
   const defaultValues = Object.fromEntries(
     Object.entries(propMatrix).map(([key, values]) => {
-      return [key, values[0]];
+      return [key, first(values)];
     })
   );
 
-  const values1 = propMatrix[selectedProps[0]];
-  const values2 = propMatrix[selectedProps[1]];
+  const values1 = propMatrix[selectedProps[0]] ?? [];
+  const values2 = propMatrix[selectedProps[1]] ?? [];
 
   const items = values1.flatMap(value1 => {
     const label = (
       <div>
-        <samp>{selectedProps[0]}</samp>=<PropValue value={value1} />
+        <JSXProperty name={String(selectedProps[0])} value={value1} />
       </div>
     );
     const content = values2.map(value2 => {
-      return item(component, {
-        ...defaultValues,
-        [selectedProps[0]]: value1,
-        [selectedProps[1]]: value2,
-      });
+      return item(
+        render,
+        {
+          ...defaultValues,
+          [selectedProps[0]]: value1,
+          [selectedProps[1]]: value2,
+        },
+        sizingWindowProps
+      );
     });
     return [label, ...content];
   });
@@ -50,7 +66,7 @@ export default function Matrix({component, propMatrix, selectedProps}: Props) {
         <div key="space-head" />
         {values2.map(value2 => (
           <div key={`title-2-${value2}`}>
-            <samp>{selectedProps[1]}</samp>=<PropValue value={value2} />
+            <JSXProperty name={String(selectedProps[1])} value={value2} />
           </div>
         ))}
         {items}
@@ -59,31 +75,18 @@ export default function Matrix({component, propMatrix, selectedProps}: Props) {
   );
 }
 
-function item(Component, props) {
+function item(Component, props, sizingWindowProps) {
   const hasChildren = 'children' in props;
 
   return hasChildren ? (
-    <SizingWindow key={JSON.stringify(props)}>
+    <SizingWindow key={JSON.stringify(props)} {...sizingWindowProps}>
       <Component {...props}>{props.children}</Component>
     </SizingWindow>
   ) : (
-    <SizingWindow key={JSON.stringify(props)}>
+    <SizingWindow key={JSON.stringify(props)} {...sizingWindowProps}>
       <Component {...props} />
     </SizingWindow>
   );
-}
-
-function PropValue({value}: {value: unknown}) {
-  if (['string', 'boolean', 'number'].includes(typeof value)) {
-    return <kbd>{String(value)}</kbd>;
-  }
-  if (value === null || value === undefined) {
-    return <var>{String(value)}</var>;
-  }
-  if (isValidElement(value)) {
-    return value;
-  }
-  return <var>{JSON.stringify(value)}</var>;
 }
 
 const Grid = styled('section')`

--- a/static/app/components/stories/sizingWindow.tsx
+++ b/static/app/components/stories/sizingWindow.tsx
@@ -3,12 +3,23 @@ import styled from '@emotion/styled';
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
 import {space} from 'sentry/styles/space';
 
-const SizingWindow = styled(NegativeSpaceContainer)`
+const SizingWindow = styled(NegativeSpaceContainer)<{display?: 'block' | 'flex'}>`
   border: 1px solid ${p => p.theme.yellow400};
   border-radius: ${p => p.theme.borderRadius};
 
   resize: both;
   padding: ${space(2)};
+
+  ${p =>
+    p.display === 'block'
+      ? `
+        display: block;
+        overflow: auto;
+      `
+      : `
+        display: flex;
+        overflow: hidden;
+      `}
 `;
 
 export default SizingWindow;

--- a/static/app/components/tabs/index.stories.tsx
+++ b/static/app/components/tabs/index.stories.tsx
@@ -51,17 +51,14 @@ export default storyBook(Tabs, story => {
     return (
       <Fragment>
         <p>When there are many items, they will overflow into a dropdown menu.</p>
-        <SizingWindow style={{height: '210px', width: '400px'}}>
-          {/* The inner <div> is needed because SizingWindow has overflow:hidden */}
-          <div style={{height: '100%', width: '100%'}}>
-            <Tabs defaultValue="two">
-              <TabList>
-                {tabs.map(tab => (
-                  <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
-                ))}
-              </TabList>
-            </Tabs>
-          </div>
+        <SizingWindow display="block" style={{height: '210px', width: '400px'}}>
+          <Tabs defaultValue="two">
+            <TabList>
+              {tabs.map(tab => (
+                <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+              ))}
+            </TabList>
+          </Tabs>
         </SizingWindow>
       </Fragment>
     );
@@ -122,8 +119,8 @@ export default storyBook(Tabs, story => {
   });
 
   story('Rendering', () => (
-    <Matrix
-      component={props => (
+    <Matrix<typeof Tabs & typeof TabList>
+      render={props => (
         <Tabs orientation={props.orientation}>
           <TabList hideBorder={props.hideBorder}>
             {TABS.map(tab => (

--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -4,6 +4,7 @@ import {PlatformIcon} from 'platformicons';
 
 import Input from 'sentry/components/input';
 import {Sticky} from 'sentry/components/sticky';
+import JSXNode from 'sentry/components/stories/jsxNode';
 import {Tooltip} from 'sentry/components/tooltip';
 import * as Icons from 'sentry/icons';
 import {space} from 'sentry/styles/space';
@@ -1368,7 +1369,7 @@ function Section({section}: {section: TSection}) {
           return (
             <Tooltip
               key={icon.id}
-              title={formatObjAsReactStatement(name, props)}
+              title={<JSXNode name={name} props={props} />}
               isHoverable
             >
               <Cell>
@@ -1400,7 +1401,7 @@ function PlatformIconsSection({searchTerm}: {searchTerm: string}) {
         {platforms.map(platform => (
           <Tooltip
             key={platform}
-            title={formatObjAsReactStatement('PlatformIcon', {platform})}
+            title={<JSXNode name="PlatformIcon" props={{platform}} />}
             isHoverable
           >
             <Cell>
@@ -1411,13 +1412,6 @@ function PlatformIconsSection({searchTerm}: {searchTerm: string}) {
       </Grid>
     </section>
   );
-}
-
-function formatObjAsReactStatement(name, props: Record<string, unknown>) {
-  const keyValues = Object.entries(props)
-    .map(([prop, val]) => (val === true ? prop : `${prop}=${JSON.stringify(val)}`))
-    .join(' ');
-  return `<${name} ${keyValues} />`;
 }
 
 const StyledSticky = styled(Sticky)`

--- a/static/app/views/stories/storyTree.tsx
+++ b/static/app/views/stories/storyTree.tsx
@@ -107,7 +107,7 @@ const Folder = styled('details')`
   &:before {
     content: '⏵';
     position: absolute;
-    left: 0;
+    left: 2px;
     top: 0;
   }
   &[open]:before {
@@ -137,6 +137,7 @@ const FolderName = styled('summary')`
 const FolderLink = styled(Link)`
   display: block;
   padding: ${space(0.25)};
+  padding-left: 14px;
 
   color: inherit;
   &:hover {


### PR DESCRIPTION
Some css updates to make things look better, and better type safety for property names (not really the values) passed into `<Matrix>` since we're editing that heavily anyway.

- File Tree has more indentation, and the toggle triangles line up a bit better.
- Matrix and Icons are using new helpers to print component & property names in a consistent and more copy+paste friendly way.
- SizingWindow is easier to use when content is not flex-aware (ie: it should have flex-grow or flex-shrink as appropriate), but flex-aware stuff is better imo, so the default remains the same.

| Before | After |
| --- | --- |
| <img width="257" alt="file tree before" src="https://github.com/getsentry/sentry/assets/187460/7f61e468-cf66-49c4-91b1-ede92e1a10d5"> | <img width="249" alt="file tree after" src="https://github.com/getsentry/sentry/assets/187460/ff3aa7a3-dbd1-43e9-a382-9c855b9ab3ac"> |
| <img width="594" alt="matrix before" src="https://github.com/getsentry/sentry/assets/187460/8b3888e0-13ac-446e-8465-2b2ce959d4ff"> | <img width="605" alt="matrix after" src="https://github.com/getsentry/sentry/assets/187460/20c87d26-4dc9-4891-8f5a-285a54d59d74"> |
