### PR TITLE
fix(hybridcloud) Use org scoped URLs for more endpoints

### DIFF
--- a/static/app/components/events/groupingInfo/groupingConfigSelect.tsx
+++ b/static/app/components/events/groupingInfo/groupingConfigSelect.tsx
@@ -13,6 +13,7 @@ type Props = DeprecatedAsyncComponent['props'] & {
   configId: string;
   eventConfigId: string;
   onSelect: (selection: any) => void;
+  organizationSlug: string;
 };
 
 type State = DeprecatedAsyncComponent['state'] & {
@@ -28,7 +29,8 @@ class GroupingConfigSelect extends DeprecatedAsyncComponent<Props, State> {
   }
 
   getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
-    return [['configs', '/grouping-configs/']];
+    const {organizationSlug} = this.props;
+    return [['configs', `/organizations/${organizationSlug}/grouping-configs/`]];
   }
 
   renderLoading() {

--- a/static/app/components/events/groupingInfo/index.tsx
+++ b/static/app/components/events/groupingInfo/index.tsx
@@ -129,7 +129,7 @@ class GroupingInfo extends DeprecatedAsyncComponent<Props, State> {
 
   renderGroupConfigSelect() {
     const {configOverride} = this.state;
-    const {event} = this.props;
+    const {event, organization} = this.props;
 
     if (!event.groupingConfig) {
       return null;
@@ -139,6 +139,7 @@ class GroupingInfo extends DeprecatedAsyncComponent<Props, State> {
 
     return (
       <GroupingConfigSelect
+        organizationSlug={organization.slug}
         eventConfigId={event.groupingConfig.id}
         configId={configId}
         onSelect={this.handleConfigSelect}

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
@@ -18,7 +18,7 @@ describe('Debug Meta - Image Details', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: `/builtin-symbol-sources/`,
+      url: `/organizations/${organization.slug}/builtin-symbol-sources/`,
       method: 'GET',
       body: [],
     });

--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -64,7 +64,11 @@ class ProjectDebugSymbols extends DeprecatedAsyncView<Props, State> {
     ];
 
     if (!builtinSymbolSources && organization.features.includes('symbol-sources')) {
-      endpoints.push(['builtinSymbolSources', '/builtin-symbol-sources/', {}]);
+      endpoints.push([
+        'builtinSymbolSources',
+        `/organizations/${organization.slug}/builtin-symbol-sources/`,
+        {},
+      ]);
     }
 
     return endpoints;

--- a/static/app/views/settings/projectGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.spec.tsx
@@ -62,7 +62,7 @@ describe('projectGeneralSettings', function () {
 
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: '/grouping-configs/',
+      url: `/organizations/${org.slug}/grouping-configs/`,
       method: 'GET',
       body: groupingConfigs,
     });


### PR DESCRIPTION
Use the newly deployed org scoped URLs so that control-silo proxying can be effective in the future.

Fixes HC-908