### PR TITLE
chore(hybridcloud) Improve grouping and context for outbox failures

### DIFF
--- a/src/sentry/tasks/deliver_from_outbox.py
+++ b/src/sentry/tasks/deliver_from_outbox.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import math
 from typing import Any, Type
 
+import sentry_sdk
 from celery import Task
 from django.conf import settings
 from django.db.models import Max, Min
-from sentry_sdk.api import capture_exception
 
-from sentry.models import ControlOutboxBase, OutboxBase, RegionOutboxBase
+from sentry.models.outbox import ControlOutboxBase, OutboxBase, OutboxFlushError, RegionOutboxBase
 from sentry.silo.base import SiloMode
 from sentry.tasks.backfill_outboxes import backfill_outboxes_for
 from sentry.tasks.base import instrumented_task
@@ -91,7 +91,7 @@ def schedule_batch(
         if process_outbox_backfills:
             backfill_outboxes_for(silo_mode, scheduled_count)
     except Exception:
-        capture_exception()
+        sentry_sdk.capture_exception()
         raise
 
 
@@ -125,7 +125,7 @@ def drain_outbox_shards(
 
         process_outbox_batch(outbox_identifier_hi, outbox_identifier_low, outbox_model)
     except Exception:
-        capture_exception()
+        sentry_sdk.capture_exception()
         raise
 
 
@@ -144,7 +144,7 @@ def drain_outbox_shards_control(
 
         process_outbox_batch(outbox_identifier_hi, outbox_identifier_low, outbox_model)
     except Exception:
-        capture_exception()
+        sentry_sdk.capture_exception()
         raise
 
 
@@ -163,10 +163,22 @@ def process_outbox_batch(
         try:
             processed_count += 1
             shard_outbox.drain_shard(flush_all=True)
-        except Exception:
-            capture_exception()
-            # In production, it's ok to just continue processing forward, but in tests we aim to surface
-            # problems aggressively.
-            if in_test_environment():
-                raise
+        except Exception as e:
+            with sentry_sdk.push_scope() as scope:
+                if isinstance(e, OutboxFlushError):
+                    scope.set_tag("outbox.category", e.outbox.category)
+                    scope.set_tag("outbox.shard_scope", e.outbox.shard_scope)
+                    scope.set_context(
+                        "outbox",
+                        {
+                            "shard_identifier": e.outbox.shard_identifier,
+                            "object_identifier": e.outbox.object_identifier,
+                            "payload": e.outbox.payload,
+                        },
+                    )
+                sentry_sdk.capture_exception(e)
+                # In production, it's ok to just continue processing forward, but in tests we aim to surface
+                # problems aggressively.
+                if in_test_environment():
+                    raise
     return processed_count


### PR DESCRIPTION
Currently we don't get great grouping on outbox delivery failures. By reducing the variance we have in the message string, and having adding tags/context I hope to be able to better understand which kinds of outboxes are failing to deliver. The addition context should let us see which messages are failing without having to scan through the repr output.