### PR TITLE
ref(replay): Refactor ReplayPreview to accept button/analytics params and debug log them in dev-ui

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -221,7 +221,8 @@ function BaseButton({
 
   const useButtonTrackingLogger = () => {
     const hasAnalyticsDebug = window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
-    if (!analyticsEventName || !hasAnalyticsDebug) {
+    const hasEventName = analyticsEventName || analyticsEventKey;
+    if (!hasEventName || !hasAnalyticsDebug) {
       return () => {};
     }
 

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -219,8 +219,27 @@ function BaseButton({
   const accessibleLabel =
     ariaLabel ?? (typeof children === 'string' ? children : undefined);
 
-  const useButtonTracking = HookStore.get('react-hook:use-button-tracking')[0];
-  const buttonTracking = useButtonTracking?.({
+  const useButtonTrackingLogger = () => {
+    const hasAnalyticsDebug = window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
+    if (!analyticsEventName || !hasAnalyticsDebug) {
+      return () => {};
+    }
+
+    return () => {
+      // eslint-disable-next-line no-console
+      console.log('buttonAnalyticsEvent', {
+        eventKey: analyticsEventKey,
+        eventName: analyticsEventName,
+        priority,
+        href,
+        ...analyticsParams,
+      });
+    };
+  };
+
+  const useButtonTracking =
+    HookStore.get('react-hook:use-button-tracking')[0] ?? useButtonTrackingLogger;
+  const buttonTracking = useButtonTracking({
     analyticsEventName,
     analyticsEventKey,
     analyticsParams: {
@@ -240,7 +259,7 @@ function BaseButton({
         return;
       }
 
-      buttonTracking?.();
+      buttonTracking();
       onClick?.(e);
     },
     [disabled, busy, onClick, buttonTracking]

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -221,7 +221,7 @@ function BaseButton({
 
   const useButtonTrackingLogger = () => {
     const hasAnalyticsDebug = window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
-    const hasEventName = analyticsEventName || analyticsEventKey;
+    const hasEventName = analyticsEventName || analyticsEventKey || analyticsParams;
     if (!hasEventName || !hasAnalyticsDebug) {
       return () => {};
     }

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -221,8 +221,8 @@ function BaseButton({
 
   const useButtonTrackingLogger = () => {
     const hasAnalyticsDebug = window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
-    const hasEventName = analyticsEventName || analyticsEventKey || analyticsParams;
-    if (!hasEventName || !hasAnalyticsDebug) {
+    const hasCustomAnalytics = analyticsEventName || analyticsEventKey || analyticsParams;
+    if (!hasCustomAnalytics || !hasAnalyticsDebug) {
       return () => {};
     }
 

--- a/static/app/components/events/eventReplay/replayPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.spec.tsx
@@ -17,10 +17,11 @@ const mockOrgSlug = 'sentry-emerging-tech';
 const mockReplaySlug = 'replays:761104e184c64d439ee1014b72b4d83b';
 const mockReplayId = '761104e184c64d439ee1014b72b4d83b';
 
-const mockEvent = {
-  ...TestStubs.Event(),
-  dateCreated: '2022-09-22T16:59:41.596000Z',
-};
+// const mockEvent = {
+//   ...TestStubs.Event(),
+//   dateCreated: '2022-09-22T16:59:41.596000Z',
+// };
+const mockEventCreatedDate = new Date('2022-09-22T16:59:41.596000Z');
 
 const mockButtonHref = `/organizations/${mockOrgSlug}/replays/761104e184c64d439ee1014b72b4d83b/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&t=62&t_main=console`;
 
@@ -115,7 +116,7 @@ describe('ReplayPreview', () => {
       <ReplayPreview
         orgSlug={mockOrgSlug}
         replaySlug={mockReplaySlug}
-        event={mockEvent}
+        eventTimestampMs={mockEventCreatedDate.getTime()}
       />
     );
 
@@ -142,7 +143,7 @@ describe('ReplayPreview', () => {
       <ReplayPreview
         orgSlug={mockOrgSlug}
         replaySlug={mockReplaySlug}
-        event={mockEvent}
+        eventTimestampMs={mockEventCreatedDate.getTime()}
       />
     );
 
@@ -154,7 +155,7 @@ describe('ReplayPreview', () => {
       <ReplayPreview
         orgSlug={mockOrgSlug}
         replaySlug={mockReplaySlug}
-        event={mockEvent}
+        eventTimestampMs={mockEventCreatedDate.getTime()}
       />
     );
 
@@ -167,7 +168,7 @@ describe('ReplayPreview', () => {
       <ReplayPreview
         orgSlug={mockOrgSlug}
         replaySlug={mockReplaySlug}
-        event={mockEvent}
+        eventTimestampMs={mockEventCreatedDate.getTime()}
       />
     );
 

--- a/static/app/components/events/eventReplay/replayPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.spec.tsx
@@ -17,11 +17,7 @@ const mockOrgSlug = 'sentry-emerging-tech';
 const mockReplaySlug = 'replays:761104e184c64d439ee1014b72b4d83b';
 const mockReplayId = '761104e184c64d439ee1014b72b4d83b';
 
-// const mockEvent = {
-//   ...TestStubs.Event(),
-//   dateCreated: '2022-09-22T16:59:41.596000Z',
-// };
-const mockEventCreatedDate = new Date('2022-09-22T16:59:41.596000Z');
+const mockEventTimestampMs = new Date('2022-09-22T16:59:41Z').getTime();
 
 const mockButtonHref = `/organizations/${mockOrgSlug}/replays/761104e184c64d439ee1014b72b4d83b/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&t=62&t_main=console`;
 
@@ -116,7 +112,7 @@ describe('ReplayPreview', () => {
       <ReplayPreview
         orgSlug={mockOrgSlug}
         replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventCreatedDate.getTime()}
+        eventTimestampMs={mockEventTimestampMs}
       />
     );
 
@@ -143,7 +139,7 @@ describe('ReplayPreview', () => {
       <ReplayPreview
         orgSlug={mockOrgSlug}
         replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventCreatedDate.getTime()}
+        eventTimestampMs={mockEventTimestampMs}
       />
     );
 
@@ -155,7 +151,7 @@ describe('ReplayPreview', () => {
       <ReplayPreview
         orgSlug={mockOrgSlug}
         replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventCreatedDate.getTime()}
+        eventTimestampMs={mockEventTimestampMs}
       />
     );
 
@@ -168,7 +164,7 @@ describe('ReplayPreview', () => {
       <ReplayPreview
         orgSlug={mockOrgSlug}
         replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventCreatedDate.getTime()}
+        eventTimestampMs={mockEventTimestampMs}
       />
     );
 

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -1,8 +1,8 @@
-import {useMemo} from 'react';
+import {ComponentProps, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/alert';
-import {Button} from 'sentry/components/button';
+import {LinkButton} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
@@ -12,7 +12,6 @@ import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import {IconPlay} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Event} from 'sentry/types/event';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import {useRoutes} from 'sentry/utils/useRoutes';
@@ -20,26 +19,20 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 
 type Props = {
-  event: Event;
+  eventTimestampMs: number;
   orgSlug: string;
   replaySlug: string;
-  onClickOpenReplay?: () => void;
+  buttonProps?: Partial<ComponentProps<typeof LinkButton>>;
 };
 
-function ReplayPreview({orgSlug, replaySlug, event, onClickOpenReplay}: Props) {
+function ReplayPreview({orgSlug, replaySlug, eventTimestampMs, buttonProps}: Props) {
   const routes = useRoutes();
   const {fetching, replay, replayRecord, fetchError, replayId} = useReplayReader({
     orgSlug,
     replaySlug,
   });
 
-  const timeOfEvent = event.dateCreated ?? event.dateReceived;
-  const eventTimestampMs = timeOfEvent
-    ? Math.floor(new Date(timeOfEvent).getTime() / 1000) * 1000
-    : 0;
-
   const startTimestampMs = replayRecord?.started_at.getTime() ?? 0;
-
   const initialTimeOffsetMs = useMemo(() => {
     if (eventTimestampMs && startTimestampMs) {
       return Math.abs(eventTimestampMs - startTimestampMs);
@@ -66,13 +59,13 @@ function ReplayPreview({orgSlug, replaySlug, event, onClickOpenReplay}: Props) {
         showIcon
         data-test-id="replay-error"
         trailingItems={
-          <Button
+          <LinkButton
             external
             href="https://docs.sentry.io/platforms/javascript/session-replay/#error-linking"
             size="xs"
           >
             {t('Read Docs')}
-          </Button>
+          </LinkButton>
         }
       >
         <p>
@@ -119,14 +112,14 @@ function ReplayPreview({orgSlug, replaySlug, event, onClickOpenReplay}: Props) {
           <ReplayPlayer isPreview />
         </StaticPanel>
         <CTAOverlay>
-          <Button
-            onClick={onClickOpenReplay}
+          <LinkButton
+            {...buttonProps}
             icon={<IconPlay />}
             priority="primary"
             to={fullReplayUrl}
           >
             {t('Open Replay')}
-          </Button>
+          </LinkButton>
         </CTAOverlay>
         <BadgeContainer>
           <FeatureText>{t('Replays')}</FeatureText>
@@ -138,7 +131,6 @@ function ReplayPreview({orgSlug, replaySlug, event, onClickOpenReplay}: Props) {
 
 const PlayerContainer = styled(FluidHeight)`
   position: relative;
-  margin-bottom: ${space(2)};
   background: ${p => p.theme.background};
   gap: ${space(1)};
   max-height: 448px;

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -79,7 +79,6 @@ export type IssueEventParameters = {
   'issue_details.external_issue_modal_opened': ExternalIssueParams;
   'issue_details.header_view_replay_clicked': GroupEventParams;
   'issue_details.issue_status_docs_clicked': {};
-  'issue_details.open_replay_details_clicked': GroupEventParams;
   'issue_details.performance.autogrouped_siblings_toggle': {};
   'issue_details.performance.hidden_spans_expanded': {};
   'issue_details.sourcemap_wizard_copy': SourceMapWizardParam;
@@ -311,6 +310,4 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_details.sourcemap_wizard_copy': 'Issue Details: Sourcemap Wizard Copy',
   'issue_details.sourcemap_wizard_learn_more':
     'Issue Details: Sourcemap Wizard Learn More',
-  'issue_details.open_replay_details_clicked':
-    'Issue Details: Open Replay Details Clicked',
 };


### PR DESCRIPTION
This changes up the props for ReplayPreview so it no longer accepts a callback, instead it's just taking any button props, including `analyticsEventKey` and the like. To help test this I created a logger-fallback for the analytics hook. So when using `yarn dev-ui` we can see button clicks with the same `DEBUG_ANALYTICS` param as usual.

Also, the component doesn't need a while `event`, it can be decoupled and accept the timestamp from an event instead.
