### PR TITLE
feat(ddm): Add url filter persisting

### DIFF
--- a/static/app/utils/metrics.tsx
+++ b/static/app/utils/metrics.tsx
@@ -1,4 +1,5 @@
 import {useMemo} from 'react';
+import {InjectedRouter} from 'react-router';
 import moment from 'moment';
 
 import {getInterval} from 'sentry/components/charts/utils';
@@ -272,4 +273,14 @@ export function formatMetricsUsingUnitAndOp(
 
 export function isAllowedOp(op: string) {
   return !['max_timestamp', 'min_timestamp', 'histogram'].includes(op);
+}
+
+export function updateQuery(router: InjectedRouter, partialQuery: Record<string, any>) {
+  router.push({
+    ...router.location,
+    query: {
+      ...router.location.query,
+      ...partialQuery,
+    },
+  });
 }

--- a/static/app/views/ddm/metricsExplorer.tsx
+++ b/static/app/views/ddm/metricsExplorer.tsx
@@ -173,6 +173,7 @@ function QueryBuilder({metricsQuery}: QueryBuilderProps) {
           mri={metricsQuery.mri}
           disabled={!metricsQuery.mri}
           onChange={query => updateQuery(router, {query})}
+          query={metricsQuery.query}
         />
       </QueryBuilderRow>
     </QueryBuilderWrapper>
@@ -184,9 +185,10 @@ type MetricSearchBarProps = {
   onChange: (value: string) => void;
   tags: MetricsTag[];
   disabled?: boolean;
+  query?: string;
 };
 
-function MetricSearchBar({tags, mri, disabled, onChange}: MetricSearchBarProps) {
+function MetricSearchBar({tags, mri, disabled, onChange, query}: MetricSearchBarProps) {
   const org = useOrganization();
   const api = useApi();
 
@@ -227,6 +229,7 @@ function MetricSearchBar({tags, mri, disabled, onChange}: MetricSearchBarProps) 
       onClose={handleChange}
       onSearch={handleChange}
       placeholder={t('Filter by tags')}
+      defaultQuery={query}
     />
   );
 }

--- a/static/app/views/ddm/metricsExplorer.tsx
+++ b/static/app/views/ddm/metricsExplorer.tsx
@@ -32,6 +32,7 @@ import {
   MetricsData,
   MetricsDataProps,
   MetricsQuery,
+  updateQuery,
   useMetricsData,
   useMetricsMeta,
   useMetricsTags,
@@ -126,14 +127,10 @@ function QueryBuilder({metricsQuery}: QueryBuilderProps) {
               const selectedOp = availableOps.includes(metricsQuery.op ?? '')
                 ? metricsQuery.op
                 : availableOps[0];
-              router.push({
-                ...router.location,
-                query: {
-                  ...router.location.query,
-                  mri: option.value,
-                  op: selectedOp,
-                  groupBy: undefined,
-                },
+              updateQuery(router, {
+                mri: option.value,
+                op: selectedOp,
+                groupBy: undefined,
               });
             }}
           />
@@ -147,15 +144,11 @@ function QueryBuilder({metricsQuery}: QueryBuilderProps) {
             }
             disabled={!metricsQuery.mri}
             value={metricsQuery.op}
-            onChange={option => {
-              router.push({
-                ...router.location,
-                query: {
-                  ...router.location.query,
-                  op: option.value,
-                },
-              });
-            }}
+            onChange={option =>
+              updateQuery(router, {
+                op: option.value,
+              })
+            }
           />
           <CompactSelect
             multiple
@@ -166,15 +159,11 @@ function QueryBuilder({metricsQuery}: QueryBuilderProps) {
             }))}
             disabled={!metricsQuery.mri}
             value={metricsQuery.groupBy}
-            onChange={options => {
-              router.push({
-                ...router.location,
-                query: {
-                  ...router.location.query,
-                  groupBy: options.map(o => o.value),
-                },
-              });
-            }}
+            onChange={options =>
+              updateQuery(router, {
+                groupBy: options.map(o => o.value),
+              })
+            }
           />
         </PageFilterBar>
       </QueryBuilderRow>
@@ -183,15 +172,7 @@ function QueryBuilder({metricsQuery}: QueryBuilderProps) {
           tags={tags}
           mri={metricsQuery.mri}
           disabled={!metricsQuery.mri}
-          onChange={query => {
-            router.push({
-              ...router.location,
-              query: {
-                ...router.location.query,
-                query,
-              },
-            });
-          }}
+          onChange={query => updateQuery(router, {query})}
         />
       </QueryBuilderRow>
     </QueryBuilderWrapper>

--- a/static/app/views/ddm/summaryTable.tsx
+++ b/static/app/views/ddm/summaryTable.tsx
@@ -24,23 +24,27 @@ export function SummaryTable({
       <HeaderCell>{t('Max')}</HeaderCell>
       <HeaderCell>{t('Sum')}</HeaderCell>
 
-      {series.map(({seriesName, color, hidden, unit, data}) => {
-        const {avg, min, max, sum} = getValues(data);
+      {series
+        .sort((a, b) => a.seriesName.localeCompare(b.seriesName))
+        .map(({seriesName, color, hidden, unit, data}) => {
+          const {avg, min, max, sum} = getValues(data);
 
-        return (
-          <Fragment key={seriesName}>
-            <FlexCell onClick={() => onClick(seriesName)} hidden={hidden}>
-              <ColorDot color={color} />
-            </FlexCell>
-            <Cell onClick={() => onClick(seriesName)}>{getNameFromMRI(seriesName)}</Cell>
-            {/* TODO(ddm): Add a tooltip with the full value, don't add on click in case users want to copy the value */}
-            <Cell>{formatMetricsUsingUnitAndOp(avg, unit, operation)}</Cell>
-            <Cell>{formatMetricsUsingUnitAndOp(min, unit, operation)}</Cell>
-            <Cell>{formatMetricsUsingUnitAndOp(max, unit, operation)}</Cell>
-            <Cell>{formatMetricsUsingUnitAndOp(sum, unit, operation)}</Cell>
-          </Fragment>
-        );
-      })}
+          return (
+            <Fragment key={seriesName}>
+              <FlexCell onClick={() => onClick(seriesName)} hidden={hidden}>
+                <ColorDot color={color} />
+              </FlexCell>
+              <Cell onClick={() => onClick(seriesName)}>
+                {getNameFromMRI(seriesName)}
+              </Cell>
+              {/* TODO(ddm): Add a tooltip with the full value, don't add on click in case users want to copy the value */}
+              <Cell>{formatMetricsUsingUnitAndOp(avg, unit, operation)}</Cell>
+              <Cell>{formatMetricsUsingUnitAndOp(min, unit, operation)}</Cell>
+              <Cell>{formatMetricsUsingUnitAndOp(max, unit, operation)}</Cell>
+              <Cell>{formatMetricsUsingUnitAndOp(sum, unit, operation)}</Cell>
+            </Fragment>
+          );
+        })}
     </SummaryTableWrapper>
   );
 }


### PR DESCRIPTION
This PR adds a URL filter persisting. It means that mri, op, groupBy, query, and hiddenSeries are no longer stored in the local state but in the URL. This will enable persisting the view after a full page refresh and everything will be share-able just by copy-pasting the link.

Closes https://github.com/getsentry/sentry/issues/56712