### PR TITLE
ref(rules): Add sent_initial_email_date to filter

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -233,7 +233,10 @@ class RuleSerializer(Serializer):
 
         try:
             neglected_rule = NeglectedRule.objects.get(
-                rule=obj, organization=obj.project.organization_id, opted_out=False
+                rule=obj,
+                organization=obj.project.organization_id,
+                opted_out=False,
+                sent_initial_email_date__isnull=False,
             )
             d["disableReason"] = "noisy"
             d["disableDate"] = neglected_rule.disable_date

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -174,6 +174,7 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
             rule=self.rule,
             organization=self.organization,
             opted_out=False,
+            sent_initial_email_date=now,
             disable_date=now + timedelta(days=14),
         )
         response = self.get_success_response(


### PR DESCRIPTION
Add `sent_initial_email_date` to the filter so that if/when we do a dry run for the tasks that send the emails we aren't showing a banner on the rule details pages about the migration before we've notified users.