### PR TITLE
fix(github-invite): use sql for missing members API to utilize db indices

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -44,7 +44,8 @@ def _get_missing_organization_members_query(
     shared_domain: str | None = None,
 ):
     date = timezone.now() - timedelta(days=30)
-    with connection.cursor() as cursor:
+    using = router.db_for_read(Commit)
+    with connections[using].cursor() as cursor:
         additional_query = ""
         for filtered_character in filtered_characters:
             additional_query += f"""and email not like '%{filtered_character}%' """

--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from datetime import timedelta
 from email.headerregistry import Address
 from functools import reduce
-from typing import Dict, List, Sequence
+from typing import Dict, Sequence
 
 from django.db import connection
 from django.db.models import Q
@@ -40,7 +40,7 @@ class MissingMembersPermission(OrganizationPermission):
 
 
 def _get_missing_organization_members_query(
-    integration_ids: List[int],
+    integration_ids: Sequence[int],
     shared_domain: str | None = None,
 ):
     date = timezone.now() - timedelta(days=30)

--- a/tests/sentry/api/endpoints/test_organization_missing_org_members.py
+++ b/tests/sentry/api/endpoints/test_organization_missing_org_members.py
@@ -163,8 +163,8 @@ class OrganizationMissingMembersTestCase(APITestCase):
         assert response.data[0]["integration"] == "github"
         assert response.data[0]["users"] == [
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
-            {"email": "d@example.com", "externalId": "d", "commitCount": 1},
             {"email": "a@exampletwo.com", "externalId": "not", "commitCount": 1},
+            {"email": "d@example.com", "externalId": "d", "commitCount": 1},
         ]
 
     def test_owners_invalid_domain_no_filter(self):
@@ -175,8 +175,8 @@ class OrganizationMissingMembersTestCase(APITestCase):
         response = self.get_success_response(self.organization.slug)
         assert response.data[0]["users"] == [
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
-            {"email": "d@example.com", "externalId": "d", "commitCount": 1},
             {"email": "a@exampletwo.com", "externalId": "not", "commitCount": 1},
+            {"email": "d@example.com", "externalId": "d", "commitCount": 1},
         ]
 
     def test_excludes_empty_owner_emails(self):
@@ -195,25 +195,6 @@ class OrganizationMissingMembersTestCase(APITestCase):
         assert response.data[0]["users"] == [
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
-        ]
-
-    def test_query_on_author_email_and_external_id(self):
-        # self.nonmember_commit_author1 matches on email
-        # the below matches on external id
-        nonmember_commit_author = self.create_commit_author(
-            project=self.project, email="c2@example.com"
-        )
-        nonmember_commit_author.external_id = "c@example.com"
-        nonmember_commit_author.save()
-
-        self.create_commit(repo=self.repo, author=nonmember_commit_author)
-
-        response = self.get_success_response(self.organization.slug, query="c@example.com")
-
-        assert response.data[0]["integration"] == "github"
-        assert response.data[0]["users"] == [
-            {"email": "c@example.com", "externalId": "c", "commitCount": 2},
-            {"email": "c2@example.com", "externalId": "c@example.com", "commitCount": 1},
         ]
 
     def test_no_github_integration(self):


### PR DESCRIPTION
Use SQL to better utilize db indices to improve the performance of the API. Attempts to fix [SENTRY-161D](https://sentry.sentry.io/issues/4492352871/?project=1).

Existing indices
- `Commit`: `("repository_id", "date_added")`

`CommitAuthor` doesn't have an index on external_id, but if we filter on it after using a subquery, it's already filtered.

Also removes querying for commit author `external_id` and/or `email` because we don't surface this anywhere on the FE.