### PR TITLE
fix(ui) Fix origin handling logic for CSRF tokens

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -90,7 +90,7 @@ function csrfSafeMethod(method?: string): boolean {
  * similar origins are those that share an ancestor. Example `sentry.sentry.io` and `us.sentry.io`
  * are similar origins, but sentry.sentry.io and sentry.example.io are not.
  */
-function isSimilarOrigin(target: string, origin: string): boolean {
+export function isSimilarOrigin(target: string, origin: string): boolean {
   const targetUrl = new URL(target, origin);
   const originUrl = new URL(origin);
   if (originUrl.hostname.endsWith(targetUrl.hostname)) {

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -80,9 +80,33 @@ export type ResponseMeta<R = any> = {
 /**
  * Check if the requested method does not require CSRF tokens
  */
-function csrfSafeMethod(method?: string) {
+function csrfSafeMethod(method?: string): boolean {
   // these HTTP methods do not require CSRF protection
   return /^(GET|HEAD|OPTIONS|TRACE)$/.test(method ?? '');
+}
+
+/**
+ * Check if we a request is going to the same or similar origin.
+ * similar origins are those that share an ancestor. Example `sentry.sentry.io` and `us.sentry.io`
+ * are similar origins, but sentry.sentry.io and sentry.example.io are not.
+ */
+function isSimilarOrigin(target: string, origin: string): boolean {
+  const targetUrl = new URL(target, origin);
+  const originUrl = new URL(origin);
+  if (originUrl.hostname.endsWith(targetUrl.hostname)) {
+    return true;
+  }
+  // Check if the target and origin are on sibiling subdomains.
+  const targetHost = targetUrl.hostname.split('.');
+  const originHost = originUrl.hostname.split('.');
+
+  // Remove the subdomains. If don't have at least 2 segments we aren't subdomains.
+  targetHost.shift();
+  originHost.shift();
+  if (targetHost.length < 2 || originHost.length < 2) {
+    return false;
+  }
+  return targetHost.join('.') === originHost.join('.');
 }
 
 // TODO: Need better way of identifying anonymous pages that don't trigger redirect
@@ -464,10 +488,7 @@ export class Client {
 
     // Do not set the X-CSRFToken header when making a request outside of the
     // current domain. Because we use subdomains we loosely compare origins
-    const absoluteUrl = new URL(fullUrl, window.location.origin);
-    const originUrl = new URL(window.location.origin);
-    const isSameOrigin = originUrl.hostname.endsWith(absoluteUrl.hostname);
-    if (!csrfSafeMethod(method) && isSameOrigin) {
+    if (!csrfSafeMethod(method) && isSimilarOrigin(fullUrl, window.location.origin)) {
       headers.set('X-CSRFToken', getCsrfToken());
     }
 


### PR DESCRIPTION
With the addition of region domains for API requests our existing cross-origin logic for CSRF tokens is not robust enough. We now need to send CSRF tokens when the origin is sentry.sentry.io and the request is going to one of `sentry.io`, `sentry.sentry.io` or `us.sentry.io`.