### PR TITLE
feat(am2): Add bun as am2 compat SDK

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -59,6 +59,7 @@ GETTING_STARTD_DOCS_PLATFORMS = [
     "apple",
     "apple-ios",
     "apple-macos",
+    "bun",
     "capacitor",
     "cordova",
     "dart",

--- a/src/sentry/tasks/check_am2_compatibility.py
+++ b/src/sentry/tasks/check_am2_compatibility.py
@@ -53,6 +53,7 @@ SUPPORTED_SDK_VERSIONS = {
     "sentry.javascript.node": "7.6.0",
     "sentry.javascript.angular-ivy": "7.6.0",
     "sentry.javascript.sveltekit": "7.6.0",
+    "sentry.javascript.bun": "7.70.0",
     # Apple
     "sentry-cocoa": "7.23.0",
     "sentry-objc": "7.23.0",
@@ -211,6 +212,7 @@ SDKS_SUPPORTING_PERFORMANCE = {
     "sentry-laravel",
     "sentry.php.laravel",
     "sentry.javascript.node",
+    "sentry.javascript.bun",
     "sentry-php",
     "sentry.php",
     "sentry-python",


### PR DESCRIPTION
ref https://github.com/getsentry/sentry/issues/56856

See https://github.com/getsentry/sentry-javascript/issues/9042 and https://docs.sentry.io/platforms/javascript/guides/bun/

Bun inherits directly from our Node SDK, so is good to go for am2 :)