### PR TITLE
ref(severity): Add `handled`, `has_stacktrace`, and `level` to severity inputs

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -132,7 +132,7 @@ from sentry.utils import json, metrics
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.canonical import CanonicalKeyDict
 from sentry.utils.dates import to_datetime, to_timestamp
-from sentry.utils.event import has_event_minified_stack_trace
+from sentry.utils.event import has_event_minified_stack_trace, has_stacktrace, is_handled
 from sentry.utils.metrics import MutableTags
 from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.performance_issues.performance_detection import detect_performance_problems
@@ -2079,6 +2079,11 @@ def _get_severity_score(event: Event) -> float | None:
 
     payload = {
         "message": title,
+        "has_stacktrace": int(has_stacktrace(event.data)),
+        "log_level": event.data.get("level"),
+        # TODO: For now we're counting not having a `handled` value as being handled, but
+        # we should update the model to account for three values: True, False, and None
+        "handled": 0 if is_handled(event.data) is False else 1,
     }
     logger_data["payload"] = payload
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2077,7 +2077,10 @@ def _get_severity_score(event: Event) -> float | None:
         )
         return None
 
-    logger_data["event_message"] = title
+    payload = {
+        "message": title,
+    }
+    logger_data["payload"] = payload
 
     with metrics.timer(op):
         with sentry_sdk.start_span(op=op):
@@ -2085,7 +2088,7 @@ def _get_severity_score(event: Event) -> float | None:
                 response = severity_connection_pool.urlopen(
                     "POST",
                     "/issues/severity-score",
-                    body=json.dumps({"message": title}),
+                    body=json.dumps(payload),
                     headers={"content-type": "application/json;charset=utf-8"},
                 )
                 severity = json.loads(response.data).get("severity")

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2522,10 +2522,17 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
         severity = _get_severity_score(event)
 
+        payload = {
+            "message": "NopeError: Nopey McNopeface",
+            "has_stacktrace": 0,
+            "log_level": "error",
+            "handled": 1,
+        }
+
         mock_urlopen.assert_called_with(
             "POST",
             "/issues/severity-score",
-            body='{"message":"NopeError: Nopey McNopeface"}',
+            body=json.dumps(payload),
             headers={"content-type": "application/json;charset=utf-8"},
         )
         mock_logger_info.assert_called_with(
@@ -2533,7 +2540,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             extra={
                 "event_id": event.event_id,
                 "op": "event_manager._get_severity_score",
-                "event_message": "NopeError: Nopey McNopeface",
+                "payload": payload,
             },
         )
         assert severity == 0.1231
@@ -2554,15 +2561,22 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             {"logentry": {"message": "Dogs are great!"}},
         ]
         for case in cases:
-            manager = EventManager(make_event(**case))
+            manager = EventManager(make_event(level="info", **case))
             event = manager.save(self.project.id)
 
             severity = _get_severity_score(event)
 
+            payload = {
+                "message": "Dogs are great!",
+                "has_stacktrace": 0,
+                "log_level": "info",
+                "handled": 1,
+            }
+
             mock_urlopen.assert_called_with(
                 "POST",
                 "/issues/severity-score",
-                body='{"message":"Dogs are great!"}',
+                body=json.dumps(payload),
                 headers={"content-type": "application/json;charset=utf-8"},
             )
             mock_logger_info.assert_called_with(
@@ -2570,7 +2584,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
                 extra={
                     "event_id": event.event_id,
                     "op": "event_manager._get_severity_score",
-                    "event_message": "Dogs are great!",
+                    "payload": payload,
                 },
             )
             assert severity == 0.1231
@@ -2595,7 +2609,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
         _get_severity_score(event)
 
-        assert mock_urlopen.call_args.kwargs["body"] == '{"message":"Dogs are great!"}'
+        assert json.loads(mock_urlopen.call_args.kwargs["body"])["message"] == "Dogs are great!"
 
     @patch(
         "sentry.event_manager.severity_connection_pool.urlopen",
@@ -2653,7 +2667,12 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             extra={
                 "event_id": event.event_id,
                 "op": "event_manager._get_severity_score",
-                "event_message": "NopeError: Nopey McNopeface",
+                "payload": {
+                    "message": "NopeError: Nopey McNopeface",
+                    "has_stacktrace": 0,
+                    "log_level": "error",
+                    "handled": 1,
+                },
             },
         )
         assert severity is None
@@ -2680,7 +2699,12 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             extra={
                 "event_id": event.event_id,
                 "op": "event_manager._get_severity_score",
-                "event_message": "NopeError: Nopey McNopeface",
+                "payload": {
+                    "message": "NopeError: Nopey McNopeface",
+                    "has_stacktrace": 0,
+                    "log_level": "error",
+                    "handled": 1,
+                },
             },
         )
         assert severity is None

--- a/tests/sentry/utils/test_event.py
+++ b/tests/sentry/utils/test_event.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+from sentry.utils.event import has_stacktrace
+
+
+@region_silo_test(stable=True)
+class HasStacktraceTest(TestCase):
+    def test_top_level_stacktrace_detected(self):
+        event_data = {
+            "stacktrace": {
+                "frames": [
+                    {
+                        "function": "fetchBall",
+                        "abs_path": "webpack:///./app/dogpark/fetch.ts",
+                        "lineno": 1231,
+                        "colno": 1121,
+                    }
+                ]
+            },
+        }
+        assert has_stacktrace(event_data) is True
+
+    def test_exception_or_threads_stacktrace_detected(self):
+        for container in ["exception", "threads"]:
+            event_data = {
+                container: {
+                    "values": [
+                        {
+                            "type": "MissingBallError",
+                            "value": "Ball went over a fence",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "function": "fetchBall",
+                                        "abs_path": "webpack:///./app/dogpark/fetch.ts",
+                                        "lineno": 1231,
+                                        "colno": 1121,
+                                    }
+                                ]
+                            },
+                        },
+                    ],
+                },
+            }
+            assert has_stacktrace(event_data) is True, f"Couldn't find stacktrace in `{container}`"
+
+    def test_top_level_empty_stacktrace_ignored(self):
+        event_data: dict[str, Any] = {
+            "stacktrace": {},
+        }
+        assert has_stacktrace(event_data) is False
+
+    def test_top_level_empty_frames_ignored(self):
+        event_data: dict[str, Any] = {
+            "stacktrace": {
+                "frames": [],
+            },
+        }
+        assert has_stacktrace(event_data) is False
+
+    def test_exception_or_threads_empty_stacktrace_ignored(self):
+        for container in ["exception", "threads"]:
+            event_data = {
+                container: {
+                    "values": [
+                        {
+                            "type": "MissingBallError",
+                            "value": "Ball went over a fence",
+                            "stacktrace": {},
+                        },
+                    ],
+                },
+            }
+            assert (
+                has_stacktrace(event_data) is False
+            ), f"Mistakenly detected stacktrace in `{container}`"
+
+    def test_exception_or_threads_empty_frames_ignored(self):
+        for container in ["exception", "threads"]:
+            event_data = {
+                container: {
+                    "values": [
+                        {
+                            "type": "MissingBallError",
+                            "value": "Ball went over a fence",
+                            "stacktrace": {
+                                "frames": [],
+                            },
+                        },
+                    ],
+                },
+            }
+            assert (
+                has_stacktrace(event_data) is False
+            ), f"Mistakenly detected stacktrace in `{container}`"
+
+    def test_exception_or_threads_no_stacktrace(self):
+        for container in ["exception", "threads"]:
+            event_data = {
+                container: {
+                    "values": [
+                        {
+                            "type": "MissingBallError",
+                            "value": "Ball went over a fence",
+                        },
+                    ],
+                },
+            }
+            assert (
+                has_stacktrace(event_data) is False
+            ), f"Mistakenly detected stacktrace in `{container}`"
+
+    def test_no_stacktrace_anywhere(self):
+        event_data = {"event_id": 11212012123120120415201309082013}
+        assert has_stacktrace(event_data) is False


### PR DESCRIPTION
This adds three new values to the payload sent to the severity microservice:

- `handled`: `1` if the event has no `handled` value, or if all `handled` values are `True`. `0` otherwise. (In future, we should handle lack of a `handled` value separately, but for now, we're giving events the benefit of the doubt.)
- `has_stacktrace`: `1` if there's a non-empty stacktrace with non-empty frames at the top level of the event, in `exception.values`, or in `threads.values`. `0` otherwise.
- `level` - The event's `level` value.

In order to do this, it also introduces two new utility functions, `has_stacktrace` and `is_handled`, to search through event data for the relevant information.