### PR TITLE
feat(analytics): Track source map method

### DIFF
--- a/fixtures/js-stubs/event.ts
+++ b/fixtures/js-stubs/event.ts
@@ -23,6 +23,7 @@ export function Event(params = {}): TEvent {
     location: '',
     type: EventOrGroupType.ERROR,
     occurrence: null,
+    resolvedWith: [],
     contexts: {},
     ...params,
   };

--- a/fixtures/js-stubs/events.ts
+++ b/fixtures/js-stubs/events.ts
@@ -75,6 +75,7 @@ export function DetailedEvents(): Event[] {
       location: './app/utils/handleXhrErrorResponse.tsx',
       occurrence: null,
       projectID: '1',
+      resolvedWith: [],
     },
     {
       eventID: '807f0de4d8c246098f21f8e0f1684f3d',
@@ -139,6 +140,7 @@ export function DetailedEvents(): Event[] {
       location: './app/utils/handleXhrErrorResponse.tsx',
       occurrence: null,
       projectID: '1',
+      resolvedWith: [],
     },
   ];
 }

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -777,6 +777,7 @@ interface EventBase {
   previousEventID?: string | null;
   projectSlug?: string;
   release?: EventRelease | null;
+  resolvedWith?: string[];
   sdk?: {
     name: string;
     version: string;

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -33,6 +33,7 @@ export type BaseEventAnalyticsParams = {
   num_in_app_stack_frames: number;
   num_stack_frames: number;
   num_threads_with_names: number;
+  resolved_with: string[];
   error_has_replay?: boolean;
   error_has_user_feedback?: boolean;
   event_errors?: string;

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -455,6 +455,7 @@ export function getAnalyticsDataForEvent(event?: Event | null): BaseEventAnalyti
     sdk_name: event?.sdk?.name,
     sdk_version: event?.sdk?.version,
     release_user_agent: event?.release?.userAgent,
+    resolved_with: event?.resolvedWith ?? [],
     error_has_replay: Boolean(getReplayIdFromEvent(event)),
     error_has_user_feedback: defined(event?.userReport),
     has_otel: event?.contexts?.otel !== undefined,


### PR DESCRIPTION
Track source map method(`resolved_with`) when sending the `Issue Details: Viewed` event.

Closes https://github.com/getsentry/sentry/issues/54834