### PR TITLE
Allow caching of FileBlob checksum lookups

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -289,6 +289,8 @@ register("filestore.control.options", default={}, flags=FLAG_NOSTORE)
 
 # Whether to use a redis lock on fileblob uploads and deletes
 register("fileblob.upload.use_lock", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# Whether to use redis to cache `FileBlob.id` lookups
+register("fileblob.upload.use_blobid_cache", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Symbol server
 register(

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 
 from sentry.models import File, FileBlob, FileBlobIndex
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
 
 
@@ -53,12 +54,29 @@ class FileBlobTest(TestCase):
             mock_super.side_effect = DatabaseError("server closed connection")
             with self.tasks(), pytest.raises(DatabaseError):
                 blob.delete()
-        # Even those postgres failed we should stil queue
+        # Even though postgres failed we should still queue
         # a task to delete the filestore object.
         assert mock_delete_file_region.apply_async.call_count == 1
 
         # blob is still around.
         assert FileBlob.objects.get(id=blob.id)
+
+    @override_options(
+        {
+            "fileblob.upload.use_blobid_cache": True,
+            "fileblob.upload.use_lock": False,
+        }
+    )
+    def test_dedupe_works_with_cache(self):
+        contents = ContentFile(b"foo bar")
+
+        FileBlob.from_file(contents)
+        contents.seek(0)
+
+        file_1 = File.objects.create(name="foo")
+        file_1.putfile(contents)
+
+        assert FileBlob.objects.count() == 1
 
 
 class FileTest(TestCase):


### PR DESCRIPTION
We have seen that the `FileBlob` checksum lookups can be unreasonably slow in some circumstances, so introduce a hopefully quicker Redis-based cache in between.