### PR TITLE
chore(github-growth): track programming languages per repo

### DIFF
--- a/fixtures/github.py
+++ b/fixtures/github.py
@@ -33,7 +33,7 @@ PUSH_EVENT_EXAMPLE_INSTALLATION = r"""{
 
       ],
       "removed": [
-
+        "setup.jsx"
       ],
       "modified": [
         "hello.py"
@@ -57,7 +57,7 @@ PUSH_EVENT_EXAMPLE_INSTALLATION = r"""{
         "username": "baxterthehacker"
       },
       "added": [
-
+        "setup.jsx"
       ],
       "removed": [
 

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -47,7 +47,7 @@ def get_github_external_id(event: Mapping[str, Any], host: str | None = None) ->
     return f"{host}:{external_id}" if host else external_id
 
 
-def get_file_language(filename: str):
+def get_file_language(filename: str) -> str | None:
     extension = filename.split(".")[-1]
     language = None
     if extension != filename:

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -17,7 +17,7 @@ from rest_framework.request import Request
 from sentry import analytics, options
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
-from sentry.constants import ObjectStatus
+from sentry.constants import EXTENSION_LANGUAGE_MAP, ObjectStatus
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.models import Commit, CommitAuthor, Organization, PullRequest, Repository
 from sentry.models.commitfilechange import CommitFileChange
@@ -45,6 +45,18 @@ logger = logging.getLogger("sentry.webhooks")
 def get_github_external_id(event: Mapping[str, Any], host: str | None = None) -> str | None:
     external_id: str | None = event.get("installation", {}).get("id")
     return f"{host}:{external_id}" if host else external_id
+
+
+def get_file_language(filename: str):
+    extension = filename.split(".")[-1]
+    language = None
+    if extension != filename:
+        language = EXTENSION_LANGUAGE_MAP.get(extension)
+
+        if language is None:
+            logger.info("github.unaccounted_file_lang", extra={"extension": extension})
+
+    return language
 
 
 class Webhook:
@@ -346,6 +358,7 @@ class PushEventWebhook(Webhook):
             if author:
                 author.preload_users()
             try:
+                languages = set()
                 with transaction.atomic(router.db_for_write(Commit)):
                     c = Commit.objects.create(
                         repository_id=repo.id,
@@ -356,6 +369,7 @@ class PushEventWebhook(Webhook):
                         date_added=parse_date(commit["timestamp"]).astimezone(timezone.utc),
                     )
                     for fname in commit["added"]:
+                        languages.add(get_file_language(fname))
                         CommitFileChange.objects.create(
                             organization_id=organization.id,
                             commit=c,
@@ -363,6 +377,7 @@ class PushEventWebhook(Webhook):
                             type="A",
                         )
                     for fname in commit["removed"]:
+                        languages.add(get_file_language(fname))
                         CommitFileChange.objects.create(
                             organization_id=organization.id,
                             commit=c,
@@ -370,12 +385,20 @@ class PushEventWebhook(Webhook):
                             type="D",
                         )
                     for fname in commit["modified"]:
+                        languages.add(get_file_language(fname))
                         CommitFileChange.objects.create(
                             organization_id=organization.id,
                             commit=c,
                             filename=fname,
                             type="M",
                         )
+
+                    languages.discard(None)
+                    repo_languages = set(repo.languages)
+                    repo_languages.update(languages)
+                    repo.languages = list(repo_languages)
+                    repo.save()
+
             except IntegrityError:
                 pass
 

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -37,7 +37,7 @@ class WebhookTest(APITestCase):
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="UnregisteredEvent",
-            HTTP_X_HUB_SIGNATURE="sha1=f834c327e17e6ef77f7882f948022747b379a1e3",
+            HTTP_X_HUB_SIGNATURE="sha1=2b116e7c1f7510b62727673b0f9acc0db951263a",
             HTTP_X_GITHUB_DELIVERY=str(uuid4()),
         )
 
@@ -81,7 +81,7 @@ class PushEventWebhookTest(APITestCase):
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="push",
-            HTTP_X_HUB_SIGNATURE="sha1=f834c327e17e6ef77f7882f948022747b379a1e3",
+            HTTP_X_HUB_SIGNATURE="sha1=2b116e7c1f7510b62727673b0f9acc0db951263a",
             HTTP_X_GITHUB_DELIVERY=str(uuid4()),
         )
 
@@ -128,10 +128,10 @@ class PushEventWebhookTest(APITestCase):
         assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
 
         commit_filechanges = CommitFileChange.objects.all()
-        assert len(commit_filechanges) == 2
+        assert len(commit_filechanges) == 4
 
         repo.refresh_from_db()
-        assert repo.languages == ["python"]
+        assert set(repo.languages) == {"python", "javascript"}
 
     @patch("sentry.integrations.github.webhook.metrics")
     def test_creates_missing_repo(self, mock_metrics):
@@ -210,10 +210,10 @@ class PushEventWebhookTest(APITestCase):
         assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
 
         commit_filechanges = CommitFileChange.objects.all()
-        assert len(commit_filechanges) == 2
+        assert len(commit_filechanges) == 4
 
         repo.refresh_from_db()
-        assert repo.languages == ["python"]
+        assert set(repo.languages) == {"python", "javascript"}
 
     def test_multiple_orgs(self):
         project = self.project  # force creation
@@ -259,7 +259,7 @@ class PushEventWebhookTest(APITestCase):
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="push",
-            HTTP_X_HUB_SIGNATURE="sha1=f834c327e17e6ef77f7882f948022747b379a1e3",
+            HTTP_X_HUB_SIGNATURE="sha1=2b116e7c1f7510b62727673b0f9acc0db951263a",
             HTTP_X_GITHUB_DELIVERY=str(uuid4()),
         )
 
@@ -302,7 +302,7 @@ class PushEventWebhookTest(APITestCase):
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="push",
-            HTTP_X_HUB_SIGNATURE="sha1=f834c327e17e6ef77f7882f948022747b379a1e3",
+            HTTP_X_HUB_SIGNATURE="sha1=2b116e7c1f7510b62727673b0f9acc0db951263a",
             HTTP_X_GITHUB_DELIVERY=str(uuid4()),
         )
 
@@ -349,7 +349,7 @@ class PushEventWebhookTest(APITestCase):
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="push",
-            HTTP_X_HUB_SIGNATURE="sha1=f834c327e17e6ef77f7882f948022747b379a1e3",
+            HTTP_X_HUB_SIGNATURE="sha1=2b116e7c1f7510b62727673b0f9acc0db951263a",
             HTTP_X_GITHUB_DELIVERY=str(uuid4()),
         )
 

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -90,7 +90,7 @@ class PushEventWebhookTest(APITestCase):
     def test_simple(self):
         project = self.project  # force creation
 
-        Repository.objects.create(
+        repo = Repository.objects.create(
             organization_id=project.organization.id,
             external_id="35129377",
             provider="integrations:github",
@@ -130,6 +130,9 @@ class PushEventWebhookTest(APITestCase):
         commit_filechanges = CommitFileChange.objects.all()
         assert len(commit_filechanges) == 2
 
+        repo.refresh_from_db()
+        assert repo.languages == ["python"]
+
     @patch("sentry.integrations.github.webhook.metrics")
     def test_creates_missing_repo(self, mock_metrics):
         project = self.project  # force creation
@@ -165,7 +168,7 @@ class PushEventWebhookTest(APITestCase):
     def test_anonymous_lookup(self):
         project = self.project  # force creation
 
-        Repository.objects.create(
+        repo = Repository.objects.create(
             organization_id=project.organization.id,
             external_id="35129377",
             provider="integrations:github",
@@ -208,6 +211,9 @@ class PushEventWebhookTest(APITestCase):
 
         commit_filechanges = CommitFileChange.objects.all()
         assert len(commit_filechanges) == 2
+
+        repo.refresh_from_db()
+        assert repo.languages == ["python"]
 
     def test_multiple_orgs(self):
         project = self.project  # force creation
@@ -302,7 +308,7 @@ class PushEventWebhookTest(APITestCase):
 
         assert response.status_code == 204
 
-        repos = Repository.objects.all()
+        repos = Repository.objects.all().order_by("date_added")
         assert len(repos) == 2
 
         assert repos[0].organization_id == project.organization.id


### PR DESCRIPTION
Populate the languages column in the Repository model (as introduced in #56751) when we consume Github commit push webhooks.