### PR TITLE
feat(hybridcloud) Enable org-less endpoints to be proxied to a fixed region

### DIFF
--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -1,31 +1,56 @@
 from __future__ import annotations
 
+from typing import Any, Callable
+
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
 
-from sentry.api_gateway.proxy import proxy_request
+from sentry.api_gateway.proxy import proxy_region_request, proxy_request
 from sentry.silo import SiloMode
+from sentry.silo.base import SiloLimit
+from sentry.types.region import find_all_multitenant_region_names, get_region_by_name
+
+REGION_PINNED_URLS = (
+    "/api/0/builtin-symbol-sources/",
+    "/api/0/grouping-configs/",
+)
 
 
-def _request_should_be_proxied(request: Request, view_func, view_kwargs) -> bool:
+def _get_view_silo_mode(view_func: Callable[..., HttpResponseBase]) -> frozenset[SiloMode] | None:
     view_class = getattr(view_func, "view_class", None)
+    if not view_class:
+        return None
+    if not hasattr(view_class, "silo_limit"):
+        return None
+    endpoint_silo_limit: SiloLimit = view_class.silo_limit
+    return endpoint_silo_limit.modes
+
+
+def proxy_request_if_needed(
+    request: Request, view_func: Callable[..., HttpResponseBase], view_kwargs: dict[str, Any]
+) -> HttpResponseBase | None:
+    """
+    Main execution flow for the API Gateway.
+    returns None if proxying is not required, or a response if the proxy was successful.
+    """
     current_silo_mode = SiloMode.get_current_mode()
-    if current_silo_mode == SiloMode.CONTROL and view_class is not None:
-        endpoint_silo_limit = getattr(view_class, "silo_limit", None)
-        if endpoint_silo_limit is not None:
-            endpoint_silo_set = endpoint_silo_limit.modes
-            return current_silo_mode not in endpoint_silo_set and "organization_slug" in view_kwargs
-    return False
-
-
-def proxy_request_if_needed(request: Request, view_func, view_kwargs) -> HttpResponseBase | None:
-    """
-    Main execution flow for the API Gateway
-    returns None if proxying is not required
-    """
-    if not _request_should_be_proxied(request, view_func, view_kwargs):
+    if current_silo_mode != SiloMode.CONTROL:
         return None
 
-    # Request should be proxied at this point
-    org_slug = view_kwargs.get("organization_slug")
-    return proxy_request(request, org_slug)
+    silo_modes = _get_view_silo_mode(view_func)
+    if silo_modes and current_silo_mode in silo_modes:
+        return None
+
+    if "organization_slug" in view_kwargs:
+        org_slug = view_kwargs["organization_slug"]
+        return proxy_request(request, org_slug)
+
+    if request.path in REGION_PINNED_URLS:
+        # TODO(hybridcloud) This assumption may be unstable. We would need more metadata in regions
+        # to make this consistent and predictable.
+        regions = find_all_multitenant_region_names()
+        region = get_region_by_name(regions[0])
+
+        return proxy_region_request(request, region)
+
+    return None

--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -39,7 +39,7 @@ def proxy_request_if_needed(
         return None
 
     silo_modes = _get_view_silo_mode(view_func)
-    if silo_modes and current_silo_mode in silo_modes:
+    if not silo_modes or current_silo_mode in silo_modes:
         return None
 
     if "organization_slug" in view_kwargs:

--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from django.conf import settings
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
 
 from sentry.api_gateway.proxy import proxy_region_request, proxy_request
 from sentry.silo import SiloMode
 from sentry.silo.base import SiloLimit
-from sentry.types.region import find_all_multitenant_region_names, get_region_by_name
+from sentry.types.region import get_region_by_name
 
 REGION_PINNED_URLS = (
     "/api/0/builtin-symbol-sources/",
@@ -46,10 +47,7 @@ def proxy_request_if_needed(
         return proxy_request(request, org_slug)
 
     if request.path in REGION_PINNED_URLS:
-        # TODO(hybridcloud) This assumption may be unstable. We would need more metadata in regions
-        # to make this consistent and predictable.
-        regions = find_all_multitenant_region_names()
-        region = get_region_by_name(regions[0])
+        region = get_region_by_name(settings.SENTRY_MONOLITH_REGION)
 
         return proxy_region_request(request, region)
 

--- a/src/sentry/api_gateway/proxy.py
+++ b/src/sentry/api_gateway/proxy.py
@@ -18,7 +18,7 @@ from sentry.silo.util import (
     clean_outbound_headers,
     clean_proxy_headers,
 )
-from sentry.types.region import RegionResolutionError, get_region_for_organization
+from sentry.types.region import Region, RegionResolutionError, get_region_for_organization
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,11 @@ def proxy_request(request: HttpRequest, org_slug: str) -> StreamingHttpResponse:
         logger.info("region_resolution_error", extra={"org_slug": org_slug})
         raise NotFound from e
 
+    return proxy_region_request(request, region)
+
+
+def proxy_region_request(request: HttpRequest, region: Region) -> StreamingHttpResponse:
+    """Take a django request object and proxy it to a region silo"""
     target_url = urljoin(region.address, request.path)
     header_dict = clean_proxy_headers(request.headers)
     # TODO: use requests session for connection pooling capabilities

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -655,6 +655,8 @@ RPC_SHARED_SECRET = None
 SENTRY_CONTROL_ADDRESS = os.environ.get("SENTRY_CONTROL_ADDRESS", None)
 
 # Fallback region name for monolith deployments
+# This region name is also used by the ApiGateway to proxy org-less region
+# requests.
 SENTRY_MONOLITH_REGION: str = "--monolith--"
 
 # The key used for generating or verifying the HMAC signature for Integration Proxy Endpoint requests.

--- a/src/sentry/middleware/api_gateway.py
+++ b/src/sentry/middleware/api_gateway.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable
 
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
@@ -18,7 +18,11 @@ class ApiGatewayMiddleware:
         return self.get_response(request)
 
     def process_view(
-        self, request: Request, view_func, view_args, view_kwargs
+        self,
+        request: Request,
+        view_func: Callable[..., HttpResponseBase],
+        view_args: tuple[str],
+        view_kwargs: dict[str, Any],
     ) -> HttpResponseBase | None:
         proxy_response = proxy_request_if_needed(request, view_func, view_kwargs)
         if proxy_response is not None:

--- a/src/sentry/testutils/helpers/api_gateway.py
+++ b/src/sentry/testutils/helpers/api_gateway.py
@@ -129,9 +129,9 @@ def provision_middleware():
 @override_settings(ROOT_URLCONF=__name__)
 class ApiGatewayTestCase(APITestCase):
     _REGION = Region(
-        name="region",
+        name="us",
         snowflake_id=1,
-        address="http://region.internal.sentry.io",
+        address="http://us.internal.sentry.io",
         category=RegionCategory.MULTI_TENANT,
     )
 

--- a/src/sentry/testutils/helpers/api_gateway.py
+++ b/src/sentry/testutils/helpers/api_gateway.py
@@ -10,7 +10,7 @@ from django.urls import re_path
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
-from sentry.api.base import control_silo_endpoint, region_silo_endpoint
+from sentry.api.base import Endpoint, control_silo_endpoint, region_silo_endpoint
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrganizationEndpoint
 from sentry.api.endpoints.rpc import RpcServiceEndpoint
 from sentry.testutils.cases import APITestCase
@@ -35,6 +35,14 @@ class RegionEndpoint(OrganizationEndpoint):
         return Response({"proxy": False})
 
 
+@region_silo_endpoint
+class NoOrgRegionEndpoint(Endpoint):
+    permission_classes = (AllowAny,)
+
+    def get(self, request):
+        return Response({"proxy": False})
+
+
 urlpatterns = [
     re_path(
         r"^organizations/(?P<organization_slug>[^\/]+)/control/$",
@@ -45,6 +53,11 @@ urlpatterns = [
         r"^organizations/(?P<organization_slug>[^\/]+)/region/$",
         RegionEndpoint.as_view(),
         name="region-endpoint",
+    ),
+    re_path(
+        r"^api/0/builtin-symbol-sources/$",
+        NoOrgRegionEndpoint.as_view(),
+        name="no-org-region-endpoint",
     ),
     re_path(
         r"^rpc/(?P<service_name>\w+)/(?P<method_name>\w+)/$",

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -291,7 +291,7 @@ def find_all_region_names() -> Iterable[str]:
     return load_global_regions().by_name.keys()
 
 
-def find_all_multitenant_region_names() -> Iterable[str]:
+def find_all_multitenant_region_names() -> List[str]:
     return [
         region.name
         for region in load_global_regions().regions

--- a/tests/sentry/api_gateway/test_proxy.py
+++ b/tests/sentry/api_gateway/test_proxy.py
@@ -29,7 +29,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp.has_header("test")
         assert resp["test"] == "header"
         assert resp.has_header(PROXY_DIRECT_LOCATION_HEADER)
-        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region.internal.sentry.io/get"
+        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://us.internal.sentry.io/get"
 
         request = RequestFactory().get("http://sentry.io/error")
         resp = proxy_request(request, self.organization.slug)
@@ -39,7 +39,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp.has_header("test")
         assert resp["test"] == "header"
         assert resp.has_header(PROXY_DIRECT_LOCATION_HEADER)
-        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region.internal.sentry.io/error"
+        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://us.internal.sentry.io/error"
 
     @responses.activate
     def test_query_params(self):
@@ -67,7 +67,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         request_body = {"foo": "bar", "nested": {"int_list": [1, 2, 3]}}
         responses.add_callback(
             responses.POST,
-            "http://region.internal.sentry.io/post",
+            "http://us.internal.sentry.io/post",
             verify_request_body(request_body, {"test": "header"}),
         )
 
@@ -80,14 +80,14 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp.status_code == 200
         assert resp_json["proxy"]
         assert resp.has_header(PROXY_DIRECT_LOCATION_HEADER)
-        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region.internal.sentry.io/post"
+        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://us.internal.sentry.io/post"
 
     @responses.activate
     def test_put(self):
         request_body = {"foo": "bar", "nested": {"int_list": [1, 2, 3]}}
         responses.add_callback(
             responses.PUT,
-            "http://region.internal.sentry.io/put",
+            "http://us.internal.sentry.io/put",
             verify_request_body(request_body, {"test": "header"}),
         )
 
@@ -100,14 +100,14 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp.status_code == 200
         assert resp_json["proxy"]
         assert resp.has_header(PROXY_DIRECT_LOCATION_HEADER)
-        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region.internal.sentry.io/put"
+        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://us.internal.sentry.io/put"
 
     @responses.activate
     def test_patch(self):
         request_body = {"foo": "bar", "nested": {"int_list": [1, 2, 3]}}
         responses.add_callback(
             responses.PATCH,
-            "http://region.internal.sentry.io/patch",
+            "http://us.internal.sentry.io/patch",
             verify_request_body(request_body, {"test": "header"}),
         )
 
@@ -120,14 +120,14 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp.status_code == 200
         assert resp_json["proxy"]
         assert resp.has_header(PROXY_DIRECT_LOCATION_HEADER)
-        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region.internal.sentry.io/patch"
+        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://us.internal.sentry.io/patch"
 
     @responses.activate
     def test_head(self):
         request_body = {"foo": "bar", "nested": {"int_list": [1, 2, 3]}}
         responses.add_callback(
             responses.HEAD,
-            "http://region.internal.sentry.io/head",
+            "http://us.internal.sentry.io/head",
             verify_request_headers({"test": "header"}),
         )
 
@@ -140,14 +140,14 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp.status_code == 200
         assert resp_json["proxy"]
         assert resp.has_header(PROXY_DIRECT_LOCATION_HEADER)
-        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region.internal.sentry.io/head"
+        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://us.internal.sentry.io/head"
 
     @responses.activate
     def test_delete(self):
         request_body = {"foo": "bar", "nested": {"int_list": [1, 2, 3]}}
         responses.add_callback(
             responses.DELETE,
-            "http://region.internal.sentry.io/delete",
+            "http://us.internal.sentry.io/delete",
             verify_request_body(request_body, {"test": "header"}),
         )
 
@@ -160,7 +160,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp.status_code == 200
         assert resp_json["proxy"]
         assert resp.has_header(PROXY_DIRECT_LOCATION_HEADER)
-        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://region.internal.sentry.io/delete"
+        assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://us.internal.sentry.io/delete"
 
     @responses.activate
     def test_file_upload(self):
@@ -173,7 +173,7 @@ class ProxyTestCase(ApiGatewayTestCase):
 
         responses.add_callback(
             responses.POST,
-            "http://region.internal.sentry.io/post",
+            "http://us.internal.sentry.io/post",
             verify_file_body(contents, {"test": "header"}),
         )
         request = RequestFactory().post(
@@ -193,7 +193,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         request_body = contents
         responses.add_callback(
             responses.POST,
-            "http://region.internal.sentry.io/post",
+            "http://us.internal.sentry.io/post",
             verify_request_body(contents, {"test": "header"}),
         )
         request = RequestFactory().post(
@@ -212,7 +212,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         request_body = {"foo": "bar", "nested": {"int_list": [1, 2, 3]}}
         responses.add_callback(
             responses.POST,
-            "http://region.internal.sentry.io/post",
+            "http://us.internal.sentry.io/post",
             verify_request_body(request_body, {"test": "header"}),
         )
 


### PR DESCRIPTION
We have a non-zero amount of endpoints in sentry and getsentry that lack organization slugs. While we can fix some of these endpoints going forward we also need a way to preserve backwards compatiblity for existing customers while they update their usage.

Enable control silo proxy middleware to forward requests to region silo endpoints to a fixed region (the us) when no slug is used. I went with a path based solution so that incorporating the getsentry endpoints that region pinning to be included.