### PR TITLE
ref(ingest): Small `_process_existing_aggregate` refactor

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2018,6 +2018,10 @@ def _process_existing_aggregate(
         updated_group_values["level"] = incoming_group_values["level"]
     if group.culprit != incoming_group_values["culprit"]:
         updated_group_values["culprit"] = incoming_group_values["culprit"]
+
+    # If the new event has a timestamp earlier than our current `fist_seen` value (which can happen,
+    # for example because of misaligned internal clocks on two different host machines or because of
+    # race conditions) then we want to use the current event's time
     if group.first_seen > event.datetime:
         updated_group_values["first_seen"] = event.datetime
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1733,7 +1733,10 @@ def _save_aggregate(
         ).update(group=group)
 
     is_regression = _process_existing_aggregate(
-        group=group, event=event, new_group_data=kwargs, release=release
+        group=group,
+        event=event,
+        incoming_group_values=kwargs,
+        release=release,
     )
 
     return GroupInfo(group, is_new, is_regression)
@@ -2001,20 +2004,20 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
 
 
 def _process_existing_aggregate(
-    group: Group, event: Event, new_group_data: Mapping[str, Any], release: Optional[Release]
+    group: Group, event: Event, incoming_group_values: Mapping[str, Any], release: Optional[Release]
 ) -> bool:
     last_seen = max(event.datetime, group.last_seen)
-    extra = {"last_seen": last_seen, "data": new_group_data["data"]}
+    extra = {"last_seen": last_seen, "data": incoming_group_values["data"]}
     if (
         event.search_message
         and event.search_message != group.message
         and event.get_event_type() != TransactionEvent.key
     ):
         extra["message"] = event.search_message
-    if group.level != new_group_data["level"]:
-        extra["level"] = new_group_data["level"]
-    if group.culprit != new_group_data["culprit"]:
-        extra["culprit"] = new_group_data["culprit"]
+    if group.level != incoming_group_values["level"]:
+        extra["level"] = incoming_group_values["level"]
+    if group.culprit != incoming_group_values["culprit"]:
+        extra["culprit"] = incoming_group_values["culprit"]
     if group.first_seen > event.datetime:
         extra["first_seen"] = event.datetime
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2007,27 +2007,27 @@ def _process_existing_aggregate(
     group: Group, event: Event, incoming_group_values: Mapping[str, Any], release: Optional[Release]
 ) -> bool:
     last_seen = max(event.datetime, group.last_seen)
-    extra = {"last_seen": last_seen, "data": incoming_group_values["data"]}
+    updated_group_values = {"last_seen": last_seen, "data": incoming_group_values["data"]}
     if (
         event.search_message
         and event.search_message != group.message
         and event.get_event_type() != TransactionEvent.key
     ):
-        extra["message"] = event.search_message
+        updated_group_values["message"] = event.search_message
     if group.level != incoming_group_values["level"]:
-        extra["level"] = incoming_group_values["level"]
+        updated_group_values["level"] = incoming_group_values["level"]
     if group.culprit != incoming_group_values["culprit"]:
-        extra["culprit"] = incoming_group_values["culprit"]
+        updated_group_values["culprit"] = incoming_group_values["culprit"]
     if group.first_seen > event.datetime:
-        extra["first_seen"] = event.datetime
+        updated_group_values["first_seen"] = event.datetime
 
     is_regression = _handle_regression(group, event, release)
 
-    group.last_seen = extra["last_seen"]
+    group.last_seen = updated_group_values["last_seen"]
 
     update_kwargs = {"times_seen": 1}
 
-    buffer_incr(Group, update_kwargs, {"id": group.id}, extra)
+    buffer_incr(Group, update_kwargs, {"id": group.id}, updated_group_values)
 
     return bool(is_regression)
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2008,6 +2008,10 @@ def _process_existing_aggregate(
 ) -> bool:
     last_seen = max(event.datetime, group.last_seen)
     updated_group_values = {"last_seen": last_seen, "data": incoming_group_values["data"]}
+    # Unclear why this is necessary, given that it's also in `updated_group_values`, but removing
+    # it causes unrelated tests to fail. Hard to say if that's the tests or the removal, though.
+    group.last_seen = updated_group_values["last_seen"]
+
     if (
         event.search_message
         and event.search_message != group.message
@@ -2026,8 +2030,6 @@ def _process_existing_aggregate(
         updated_group_values["first_seen"] = event.datetime
 
     is_regression = _handle_regression(group, event, release)
-
-    group.last_seen = updated_group_values["last_seen"]
 
     update_kwargs = {"times_seen": 1}
 


### PR DESCRIPTION
This is a small refactor to `_process_existing_aggregate` to:

- Rename `new_group_data` to `incoming_group_values`, since the former could be misunderstood to be referencing a new group rather than new data and since the value of `new_group_data` contains a `data` property but is more than just that property, leading to more possible confusion.
- Rename `extra` to `updated_group_values` because, well, that actually tells you what it does.
- Move all of the code dealing with `last_seen` into one spot.
- Add a few comments.

No behavior changes.