### PR TITLE
chore(statistical-detectors): Update function regression issue descri…

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -411,7 +411,7 @@ class ProfileFrameDropType(GroupType):
 class ProfileFunctionRegressionExperimentalType(GroupType):
     type_id = 2010
     slug = "profile_function_regression_exp"
-    description = "Frame Regression"
+    description = "Function Duration Regression"
     category = GroupCategory.PERFORMANCE.value
 
 


### PR DESCRIPTION
…ption

The word frame is overloaded, so use the word function for this use case and leave frame for use cases like frame drops.