### PR TITLE
chore(api): Cleanup unused params and clarify "Id" use

### DIFF
--- a/api-docs/paths/events/project-issues.json
+++ b/api-docs/paths/events/project-issues.json
@@ -139,7 +139,7 @@
   },
   "put": {
     "tags": ["Events"],
-    "description": "Bulk mutate various attributes on issues.  The list of issues to modify is given through the `id` query parameter.  It is repeated for each issue that should be modified.\n\n- For non-status updates, the `id` query parameter is required.\n- For status updates, the `id` query parameter may be omitted\nfor a batch \"update all\" query.\n- An optional `status` query parameter may be used to restrict\nmutations to only events with the given status.\n\nThe following attributes can be modified and are supplied as JSON object in the body:\n\nIf any ids are out of scope this operation will succeed without any data mutation.",
+    "description": "Bulk mutate various attributes on issues.  The list of issues to modify is given through the `id` query parameter.  It is repeated for each issue that should be modified.\n\n- For non-status updates, the `id` query parameter is required.\n- For status updates, the `id` query parameter may be omitted\nfor a batch \"update all\" query.\n- An optional `status` query parameter may be used to restrict\nmutations to only events with the given status.\n\nThe following attributes can be modified and are supplied as JSON object in the body:\n\nIf any IDs are out of scope this operation will succeed without any data mutation.",
     "operationId": "Bulk Mutate a List of Issues",
     "parameters": [
       {
@@ -163,7 +163,7 @@
       {
         "name": "id",
         "in": "query",
-        "description": "A list of Ids of the issues to be mutated. This parameter shall be repeated for each issue. It is optional only if a status is mutated in which case an implicit update all is assumed.",
+        "description": "A list of IDs of the issues to be mutated. This parameter shall be repeated for each issue. It is optional only if a status is mutated in which case an implicit update all is assumed.",
         "required": false,
         "schema": {
           "type": "integer"
@@ -233,7 +233,7 @@
               },
               "assignedTo": {
                 "type": "string",
-                "description": "The actor id (or username) of the user or team that should be assigned to this issue."
+                "description": "The actor ID (or username) of the user or team that should be assigned to this issue."
               },
               "hasSeen": {
                 "type": "boolean",
@@ -300,7 +300,7 @@
   },
   "delete": {
     "tags": ["Events"],
-    "description": "Permanently remove the given issues. The list of issues to modify is given through the `id` query parameter.  It is repeated for each issue that should be removed.\n\nOnly queries by 'id' are accepted.\n\nIf any ids are out of scope this operation will succeed without any data mutation.",
+    "description": "Permanently remove the given issues. The list of issues to modify is given through the `id` query parameter.  It is repeated for each issue that should be removed.\n\nOnly queries by 'id' are accepted.\n\nIf any IDs are out of scope this operation will succeed without any data mutation.",
     "operationId": "Bulk Remove a List of Issues",
     "parameters": [
       {
@@ -324,7 +324,7 @@
       {
         "name": "id",
         "in": "query",
-        "description": "A list of Ids of the issues to be removed. This parameter shall be repeated for each issue, e.g. `?id=1&id=2&id=3`. If this parameter is not provided, it will attempt to remove the first 1000 issues.",
+        "description": "A list of IDs of the issues to be removed. This parameter shall be repeated for each issue, e.g. `?id=1&id=2&id=3`. If this parameter is not provided, it will attempt to remove the first 1000 issues.",
         "schema": {
           "type": "integer"
         }

--- a/api-docs/paths/events/project-issues.json
+++ b/api-docs/paths/events/project-issues.json
@@ -163,7 +163,7 @@
       {
         "name": "id",
         "in": "query",
-        "description": "A list of IDs of the issues to be mutated. This parameter shall be repeated for each issue. It is optional only if a status is mutated in which case an implicit update all is assumed.",
+        "description": "A list of Ids of the issues to be mutated. This parameter shall be repeated for each issue. It is optional only if a status is mutated in which case an implicit update all is assumed.",
         "required": false,
         "schema": {
           "type": "integer"
@@ -324,7 +324,7 @@
       {
         "name": "id",
         "in": "query",
-        "description": "A list of IDs of the issues to be removed. This parameter shall be repeated for each issue, e.g. `?id=1&id=2&id=3`. If this parameter is not provided, it will attempt to remove the first 1000 issues.",
+        "description": "A list of Ids of the issues to be removed. This parameter shall be repeated for each issue, e.g. `?id=1&id=2&id=3`. If this parameter is not provided, it will attempt to remove the first 1000 issues.",
         "schema": {
           "type": "integer"
         }

--- a/api-docs/paths/integration-platform/sentry-app-external-issue-details.json
+++ b/api-docs/paths/integration-platform/sentry-app-external-issue-details.json
@@ -16,7 +16,7 @@
       {
         "name": "external_issue_id",
         "in": "path",
-        "description": "The Id of the external issue.",
+        "description": "The ID of the external issue.",
         "required": true,
         "schema": {
           "type": "string"

--- a/api-docs/paths/integration-platform/sentry-app-external-issue-details.json
+++ b/api-docs/paths/integration-platform/sentry-app-external-issue-details.json
@@ -16,7 +16,7 @@
       {
         "name": "external_issue_id",
         "in": "path",
-        "description": "The id of the external issue.",
+        "description": "The Id of the external issue.",
         "required": true,
         "schema": {
           "type": "string"

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -397,7 +397,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         If any ids are out of scope this operation will succeed without
         any data mutation.
 
-        :qparam int id: a list of IDs of the issues to be mutated.  This
+        :qparam int id: a list of Ids of the issues to be mutated.  This
                         parameter shall be repeated for each issue.  It
                         is optional only if a status is mutated in which
                         case an implicit `update all` is assumed.
@@ -478,7 +478,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         If any ids are out of scope this operation will succeed without
         any data mutation.
 
-        :qparam int id: a list of IDs of the issues to be removed.  This
+        :qparam int id: a list of Ids of the issues to be removed.  This
                         parameter shall be repeated for each issue, e.g.
                         `?id=1&id=2&id=3`. If this parameter is not provided,
                         it will attempt to remove the first 1000 issues.

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -397,7 +397,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         If any ids are out of scope this operation will succeed without
         any data mutation.
 
-        :qparam int id: a list of Ids of the issues to be mutated.  This
+        :qparam int id: a list of IDs of the issues to be mutated.  This
                         parameter shall be repeated for each issue.  It
                         is optional only if a status is mutated in which
                         case an implicit `update all` is assumed.
@@ -475,10 +475,10 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
         Only queries by 'id' are accepted.
 
-        If any ids are out of scope this operation will succeed without
+        If any IDs are out of scope this operation will succeed without
         any data mutation.
 
-        :qparam int id: a list of Ids of the issues to be removed.  This
+        :qparam int id: a list of IDs of the issues to be removed.  This
                         parameter shall be repeated for each issue, e.g.
                         `?id=1&id=2&id=3`. If this parameter is not provided,
                         it will attempt to remove the first 1000 issues.

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -135,7 +135,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         operation_id="Retrieve an Organization Member",
         parameters=[
             GlobalParams.ORG_SLUG,
-            GlobalParams.member_id("The Id of the member to delete."),
+            GlobalParams.member_id("The ID of the member to delete."),
         ],
         responses={
             200: OrganizationMemberWithRolesSerializer,  # The Sentry response serializer
@@ -168,7 +168,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         operation_id="Update an Organization Member's Roles",
         parameters=[
             GlobalParams.ORG_SLUG,
-            GlobalParams.member_id("The Id of the member to update."),
+            GlobalParams.member_id("The ID of the member to update."),
         ],
         request=inline_serializer(
             "UpdateOrgMemberRoles",
@@ -359,7 +359,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         operation_id="Delete an Organization Member",
         parameters=[
             GlobalParams.ORG_SLUG,
-            GlobalParams.member_id("The Id of the member to delete."),
+            GlobalParams.member_id("The ID of the member to delete."),
         ],
         responses={
             204: RESPONSE_NO_CONTENT,

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -25,7 +25,7 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
-from sentry.apidocs.parameters import GlobalParams, OrganizationParams
+from sentry.apidocs.parameters import GlobalParams
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
     InviteStatus,
@@ -135,7 +135,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         operation_id="Retrieve an Organization Member",
         parameters=[
             GlobalParams.ORG_SLUG,
-            OrganizationParams.MEMBER_ID,
+            GlobalParams.member_id("The Id of the member to delete."),
         ],
         responses={
             200: OrganizationMemberWithRolesSerializer,  # The Sentry response serializer
@@ -168,7 +168,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         operation_id="Update an Organization Member's Roles",
         parameters=[
             GlobalParams.ORG_SLUG,
-            OrganizationParams.MEMBER_ID,
+            GlobalParams.member_id("The Id of the member to update."),
         ],
         request=inline_serializer(
             "UpdateOrgMemberRoles",
@@ -359,7 +359,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         operation_id="Delete an Organization Member",
         parameters=[
             GlobalParams.ORG_SLUG,
-            OrganizationParams.MEMBER_ID,
+            GlobalParams.member_id("The Id of the member to delete."),
         ],
         responses={
             204: RESPONSE_NO_CONTENT,

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -203,7 +203,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         If any ids are out of scope this operation will succeed without
         any data mutation.
 
-        :qparam int id: a list of IDs of the issues to be mutated.  This
+        :qparam int id: a list of Ids of the issues to be mutated.  This
                         parameter shall be repeated for each issue.  It
                         is optional only if a status is mutated in which
                         case an implicit `update all` is assumed.
@@ -266,7 +266,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         If any ids are out of scope this operation will succeed without
         any data mutation.
 
-        :qparam int id: a list of IDs of the issues to be removed.  This
+        :qparam int id: a list of Ids of the issues to be removed.  This
                         parameter shall be repeated for each issue.
         :pparam string organization_slug: the slug of the organization the
                                           issues belong to.

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -200,10 +200,10 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         The following attributes can be modified and are supplied as
         JSON object in the body:
 
-        If any ids are out of scope this operation will succeed without
+        If any IDs are out of scope this operation will succeed without
         any data mutation.
 
-        :qparam int id: a list of Ids of the issues to be mutated.  This
+        :qparam int id: a list of IDs of the issues to be mutated.  This
                         parameter shall be repeated for each issue.  It
                         is optional only if a status is mutated in which
                         case an implicit `update all` is assumed.
@@ -263,10 +263,10 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         Only queries by 'id' are accepted.
 
-        If any ids are out of scope this operation will succeed without
+        If any IDs are out of scope this operation will succeed without
         any data mutation.
 
-        :qparam int id: a list of Ids of the issues to be removed.  This
+        :qparam int id: a list of IDs of the issues to be removed.  This
                         parameter shall be repeated for each issue.
         :pparam string organization_slug: the slug of the organization the
                                           issues belong to.

--- a/src/sentry/apidocs/api_ownership_stats_dont_modify.json
+++ b/src/sentry/apidocs/api_ownership_stats_dont_modify.json
@@ -710,6 +710,7 @@
         "public": [],
         "private": [],
         "experimental": [
+            "CustomRulesEndpoint::GET",
             "CustomRulesEndpoint::POST"
         ],
         "unknown": [
@@ -725,7 +726,7 @@
         ]
     },
     "team-starfish": {
-        "block_start": 727,
+        "block_start": 728,
         "public": [],
         "private": [],
         "experimental": [],
@@ -735,7 +736,7 @@
         ]
     },
     "growth": {
-        "block_start": 737,
+        "block_start": 738,
         "public": [],
         "private": [],
         "experimental": [],
@@ -744,18 +745,19 @@
         ]
     },
     "feedback-backend": {
-        "block_start": 746,
+        "block_start": 747,
         "public": [],
         "private": [],
         "experimental": [
             "FeedbackIngestEndpoint::POST",
             "OrganizationFeedbackIndexEndpoint::GET",
+            "ProjectFeedbackDetailsEndpoint::DELETE",
             "ProjectFeedbackDetailsEndpoint::GET"
         ],
         "unknown": []
     },
     "replay-backend": {
-        "block_start": 757,
+        "block_start": 759,
         "public": [],
         "private": [],
         "experimental": [],
@@ -764,7 +766,7 @@
         ]
     },
     "profiling": {
-        "block_start": 766,
+        "block_start": 768,
         "public": [],
         "private": [],
         "experimental": [],
@@ -780,7 +782,7 @@
         ]
     },
     "team-web-sdk-frontend": {
-        "block_start": 782,
+        "block_start": 784,
         "public": [],
         "private": [
             "SourceMapDebugBlueThunderEditionEndpoint::GET"
@@ -789,7 +791,7 @@
         "unknown": []
     },
     "hybrid-cloud": {
-        "block_start": 791,
+        "block_start": 793,
         "public": [],
         "private": [],
         "experimental": [],

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -89,41 +89,14 @@ For example `24h`, to mean query data starting from 24 hours ago to now.""",
             description=description,
         )
 
-    @staticmethod
-    def name(description: str, required: bool = False) -> OpenApiParameter:
-        return OpenApiParameter(
-            name="name",
-            location="query",
-            required=required,
-            type=str,
-            description=description,
-        )
-
-    @staticmethod
-    def slug(description: str, required: bool = False) -> OpenApiParameter:
-        return OpenApiParameter(
-            name="slug",
-            location="query",
-            required=required,
-            type=str,
-            description=description,
-        )
-
 
 class SCIMParams:
-    MEMBER_ID = OpenApiParameter(
-        name="member_id",
-        location="path",
-        required=True,
-        type=int,
-        description="The id of the member you'd like to query.",
-    )
     TEAM_ID = OpenApiParameter(
         name="team_id",
         location="path",
         required=True,
         type=int,
-        description="The id of the team you'd like to query / update.",
+        description="The Id of the team you'd like to query / update.",
     )
 
 
@@ -133,7 +106,7 @@ class IssueAlertParams:
         location="path",
         required=True,
         type=int,
-        description="The id of the rule you'd like to query.",
+        description="The Id of the rule you'd like to query.",
     )
 
 
@@ -202,7 +175,7 @@ class MonitorParams:
         location="path",
         required=True,
         type=OpenApiTypes.UUID,
-        description="The id of the check-in.",
+        description="The Id of the check-in.",
     )
 
 
@@ -212,7 +185,7 @@ class EventParams:
         location="path",
         required=True,
         type=OpenApiTypes.UUID,
-        description="The id of the event.",
+        description="The Id of the event.",
     )
 
     FRAME_IDX = OpenApiParameter(
@@ -229,16 +202,6 @@ class EventParams:
         required=True,
         type=int,
         description="Index of the exception that should be used for source map resolution.",
-    )
-
-
-class OrganizationParams:
-    MEMBER_ID = OpenApiParameter(
-        name="member_id",
-        location="path",
-        required=True,
-        type=str,
-        description="The member ID.",
     )
 
 
@@ -282,16 +245,6 @@ keys if not specified.
             description=description,
         )
 
-    @staticmethod
-    def platform(description: str) -> OpenApiParameter:
-        return OpenApiParameter(
-            name="platform",
-            location="query",
-            required=False,
-            type=str,
-            description=description,
-        )
-
 
 class TeamParams:
     DETAILED = OpenApiParameter(
@@ -311,5 +264,5 @@ class ReplayParams:
         location="path",
         required=True,
         type=OpenApiTypes.UUID,
-        description="""The id of the replay you'd like to retrieve.""",
+        description="""The Id of the replay you'd like to retrieve.""",
     )

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -68,7 +68,7 @@ For example `24h`, to mean query data starting from 24 hours ago to now.""",
         required=False,
         many=True,
         type=int,
-        description="The ids of projects to filter by. `-1` means all available projects. If this parameter is omitted, the request will default to using 'My Projects'.",
+        description="The IDs of projects to filter by. `-1` means all available projects. If this parameter is omitted, the request will default to using 'My Projects'.",
     )
     ENVIRONMENT = OpenApiParameter(
         name="environment",
@@ -96,7 +96,7 @@ class SCIMParams:
         location="path",
         required=True,
         type=int,
-        description="The Id of the team you'd like to query / update.",
+        description="The ID of the team you'd like to query / update.",
     )
 
 
@@ -106,7 +106,7 @@ class IssueAlertParams:
         location="path",
         required=True,
         type=int,
-        description="The Id of the rule you'd like to query.",
+        description="The ID of the rule you'd like to query.",
     )
 
 
@@ -175,7 +175,7 @@ class MonitorParams:
         location="path",
         required=True,
         type=OpenApiTypes.UUID,
-        description="The Id of the check-in.",
+        description="The ID of the check-in.",
     )
 
 
@@ -185,7 +185,7 @@ class EventParams:
         location="path",
         required=True,
         type=OpenApiTypes.UUID,
-        description="The Id of the event.",
+        description="The ID of the event.",
     )
 
     FRAME_IDX = OpenApiParameter(
@@ -264,5 +264,5 @@ class ReplayParams:
         location="path",
         required=True,
         type=OpenApiTypes.UUID,
-        description="""The Id of the replay you'd like to retrieve.""",
+        description="""The ID of the replay you'd like to retrieve.""",
     )

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -204,7 +204,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         operation_id="Query an Individual Organization Member",
         parameters=[
             GlobalParams.ORG_SLUG,
-            GlobalParams.member_id("The Id of the member to query."),
+            GlobalParams.member_id("The ID of the member to query."),
         ],
         request=None,
         responses={
@@ -231,7 +231,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         operation_id="Update an Organization Member's Attributes",
         parameters=[
             GlobalParams.ORG_SLUG,
-            GlobalParams.member_id("The Id of the member to update."),
+            GlobalParams.member_id("The ID of the member to update."),
         ],
         request=SCIMPatchRequestSerializer,
         responses={
@@ -277,7 +277,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         operation_id="Delete an Organization Member via SCIM",
         parameters=[
             GlobalParams.ORG_SLUG,
-            GlobalParams.member_id("The Id of the member to delete."),
+            GlobalParams.member_id("The ID of the member to delete."),
         ],
         request=None,
         responses={
@@ -299,7 +299,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         operation_id="Update an Organization Member's Attributes",
         parameters=[
             GlobalParams.ORG_SLUG,
-            GlobalParams.member_id("The Id of the member to update."),
+            GlobalParams.member_id("The ID of the member to update."),
         ],
         request=inline_serializer(
             "SCIMMemberProvision", fields={"sentryOrgRole": serializers.CharField()}

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -33,7 +33,7 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.examples.scim_examples import SCIMExamples
-from sentry.apidocs.parameters import GlobalParams, SCIMParams
+from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.providers.saml2.activedirectory.apps import ACTIVE_DIRECTORY_PROVIDER_NAME
 from sentry.models import InviteStatus, OrganizationMember
@@ -202,7 +202,10 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
 
     @extend_schema(
         operation_id="Query an Individual Organization Member",
-        parameters=[GlobalParams.ORG_SLUG, SCIMParams.MEMBER_ID],
+        parameters=[
+            GlobalParams.ORG_SLUG,
+            GlobalParams.member_id("The Id of the member to query."),
+        ],
         request=None,
         responses={
             200: OrganizationMemberSCIMSerializer,
@@ -226,7 +229,10 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
 
     @extend_schema(
         operation_id="Update an Organization Member's Attributes",
-        parameters=[GlobalParams.ORG_SLUG, SCIMParams.MEMBER_ID],
+        parameters=[
+            GlobalParams.ORG_SLUG,
+            GlobalParams.member_id("The Id of the member to update."),
+        ],
         request=SCIMPatchRequestSerializer,
         responses={
             204: RESPONSE_SUCCESS,
@@ -269,7 +275,10 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
 
     @extend_schema(
         operation_id="Delete an Organization Member via SCIM",
-        parameters=[GlobalParams.ORG_SLUG, SCIMParams.MEMBER_ID],
+        parameters=[
+            GlobalParams.ORG_SLUG,
+            GlobalParams.member_id("The Id of the member to delete."),
+        ],
         request=None,
         responses={
             204: RESPONSE_SUCCESS,
@@ -288,7 +297,10 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
 
     @extend_schema(
         operation_id="Update an Organization Member's Attributes",
-        parameters=[GlobalParams.ORG_SLUG, SCIMParams.MEMBER_ID],
+        parameters=[
+            GlobalParams.ORG_SLUG,
+            GlobalParams.member_id("The Id of the member to update."),
+        ],
         request=inline_serializer(
             "SCIMMemberProvision", fields={"sentryOrgRole": serializers.CharField()}
         ),


### PR DESCRIPTION
Delete all unused query params that have been switched to body params, and standardize `ID` capitalization