### PR TITLE
fix(github-invite): temp disable hitting missing members api

### DIFF
--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -42,12 +42,12 @@ const roles = [
   },
 ];
 
-const missingMembers = [
-  {
-    integration: 'github',
-    users: TestStubs.MissingMembers(),
-  },
-];
+// const missingMembers = [
+//   {
+//     integration: 'github',
+//     users: TestStubs.MissingMembers(),
+//   },
+// ];
 
 describe('OrganizationMembersList', function () {
   const members = TestStubs.Members();
@@ -587,52 +587,54 @@ describe('OrganizationMembersList', function () {
     });
   });
 
-  describe('inviteBanner', function () {
-    it('invites member from banner', async function () {
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/missing-members/',
-        method: 'GET',
-        body: missingMembers,
-      });
+  // TODO(cathy): uncomment
 
-      const newMember = TestStubs.Member({
-        id: '6',
-        email: 'hello@sentry.io',
-        teams: [],
-        teamRoles: [],
-        flags: {
-          'sso:linked': true,
-          'idp:provisioned': false,
-        },
-      });
+  // describe('inviteBanner', function () {
+  //   it('invites member from banner', async function () {
+  //     MockApiClient.addMockResponse({
+  //       url: '/organizations/org-slug/missing-members/',
+  //       method: 'GET',
+  //       body: missingMembers,
+  //     });
 
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/members/?referrer=github_nudge_invite',
-        method: 'POST',
-        body: newMember,
-      });
+  //     const newMember = TestStubs.Member({
+  //       id: '6',
+  //       email: 'hello@sentry.io',
+  //       teams: [],
+  //       teamRoles: [],
+  //       flags: {
+  //         'sso:linked': true,
+  //         'idp:provisioned': false,
+  //       },
+  //     });
 
-      const org = TestStubs.Organization({
-        features: ['integrations-gh-invite'],
-        githubNudgeInvite: true,
-      });
+  //     MockApiClient.addMockResponse({
+  //       url: '/organizations/org-slug/members/?referrer=github_nudge_invite',
+  //       method: 'POST',
+  //       body: newMember,
+  //     });
 
-      render(<OrganizationMembersList {...defaultProps} organization={org} />, {
-        context: TestStubs.routerContext([{organization: org}]),
-      });
+  //     const org = TestStubs.Organization({
+  //       features: ['integrations-gh-invite'],
+  //       githubNudgeInvite: true,
+  //     });
 
-      expect(
-        await screen.findByRole('heading', {
-          name: 'Bring your full GitHub team on board in Sentry',
-        })
-      ).toBeInTheDocument();
-      expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);
-      expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
+  //     render(<OrganizationMembersList {...defaultProps} organization={org} />, {
+  //       context: TestStubs.routerContext([{organization: org}]),
+  //     });
 
-      const inviteButton = screen.queryAllByTestId('invite-missing-member')[0];
-      await userEvent.click(inviteButton);
-      expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(4);
-      expect(screen.getByText('See all 4 missing members')).toBeInTheDocument();
-    });
-  });
+  //     expect(
+  //       await screen.findByRole('heading', {
+  //         name: 'Bring your full GitHub team on board in Sentry',
+  //       })
+  //     ).toBeInTheDocument();
+  //     expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(5);
+  //     expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
+
+  //     const inviteButton = screen.queryAllByTestId('invite-missing-member')[0];
+  //     await userEvent.click(inviteButton);
+  //     expect(screen.queryAllByTestId('invite-missing-member')).toHaveLength(4);
+  //     expect(screen.getByText('See all 4 missing members')).toBeInTheDocument();
+  //   });
+  // });
 });

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -96,12 +96,12 @@ class OrganizationMembersList extends DeprecatedAsyncView<Props, State> {
       ],
 
       ['inviteRequests', `/organizations/${organization.slug}/invite-requests/`],
-      [
-        'missingMembers',
-        `/organizations/${organization.slug}/missing-members/`,
-        {},
-        {allowError: error => error.status === 403},
-      ],
+      // [
+      //   'missingMembers',
+      //   `/organizations/${organization.slug}/missing-members/`,
+      //   {},
+      //   {allowError: error => error.status === 403},
+      // ],
     ];
   }
 


### PR DESCRIPTION
The query is not efficient for large orgs at the moment. Temporarily removing the API call so orgs' members list pages can load.