### PR TITLE
feat(starfish): Use span domain array for domain selector

### DIFF
--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -71,7 +71,7 @@ function DatabaseLandingPage() {
 
             <DomainSelector
               moduleName={moduleName}
-              value={moduleFilters[SpanMetricsField.SPAN_DOMAIN] || ''}
+              value={moduleFilters[SpanMetricsField.SPAN_DOMAIN_ARRAY] || ''}
             />
           </FilterOptionsContainer>
 

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -73,6 +73,7 @@ function SpanSummaryPage({params}: Props) {
       SpanMetricsField.SPAN_DESCRIPTION,
       SpanMetricsField.SPAN_ACTION,
       SpanMetricsField.SPAN_DOMAIN,
+      SpanMetricsField.SPAN_DOMAIN_ARRAY,
       'count()',
       `${SpanFunction.SPM}()`,
       `sum(${SpanMetricsField.SPAN_SELF_TIME})`,

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -10,8 +10,15 @@ import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
-const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, SPAN_DOMAIN, PROJECT_ID} =
-  SpanMetricsField;
+const {
+  SPAN_SELF_TIME,
+  SPAN_DESCRIPTION,
+  SPAN_GROUP,
+  SPAN_OP,
+  SPAN_DOMAIN,
+  SPAN_DOMAIN_ARRAY,
+  PROJECT_ID,
+} = SpanMetricsField;
 
 export type SpanMetrics = {
   'avg(span.self_time)': number;
@@ -19,6 +26,7 @@ export type SpanMetrics = {
   'project.id': number;
   'span.description': string;
   'span.domain': string;
+  'span.domain_array': Array<string>;
   'span.group': string;
   'span.op': string;
   'spm()': number;
@@ -84,6 +92,7 @@ function getEventView(
     SPAN_GROUP,
     SPAN_DESCRIPTION,
     SPAN_DOMAIN,
+    SPAN_DOMAIN_ARRAY,
     'spm()',
     `sum(${SPAN_SELF_TIME})`,
     `avg(${SPAN_SELF_TIME})`,

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -22,6 +22,7 @@ export enum SpanMetricsField {
   SPAN_MODULE = 'span.module',
   SPAN_ACTION = 'span.action',
   SPAN_DOMAIN = 'span.domain',
+  SPAN_DOMAIN_ARRAY = 'span.domain_array',
   SPAN_GROUP = 'span.group',
   SPAN_DURATION = 'span.duration',
   SPAN_SELF_TIME = 'span.self_time',
@@ -36,6 +37,7 @@ export type SpanStringFields =
   | 'span.module'
   | 'span.action'
   | 'span.domain'
+  | 'span.domain_array'
   | 'span.group'
   | 'project.id';
 
@@ -73,6 +75,7 @@ export enum SpanIndexedField {
   TRANSACTION_METHOD = 'transaction.method',
   TRANSACTION_OP = 'transaction.op',
   SPAN_DOMAIN = 'span.domain',
+  SPAN_DOMAIN_ARRAY = 'span.domain_array',
   TIMESTAMP = 'timestamp',
   PROJECT = 'project',
 }

--- a/static/app/views/starfish/utils/buildEventViewQuery.tsx
+++ b/static/app/views/starfish/utils/buildEventViewQuery.tsx
@@ -5,12 +5,19 @@ import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 import {NULL_SPAN_CATEGORY} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
-const {SPAN_DESCRIPTION, SPAN_OP, SPAN_DOMAIN, SPAN_ACTION, SPAN_MODULE} =
-  SpanMetricsField;
+const {
+  SPAN_DESCRIPTION,
+  SPAN_OP,
+  SPAN_DOMAIN,
+  SPAN_ACTION,
+  SPAN_MODULE,
+  SPAN_DOMAIN_ARRAY,
+} = SpanMetricsField;
 
 const SPAN_FILTER_KEYS = [
   SPAN_OP,
   SPAN_DOMAIN,
+  SPAN_DOMAIN_ARRAY,
   SPAN_ACTION,
   `!${SPAN_MODULE}`,
   '!span.category',

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
@@ -14,6 +14,7 @@ interface Props {
     [SpanMetricsField.SPAN_DESCRIPTION]?: string;
     [SpanMetricsField.SPAN_ACTION]?: string;
     [SpanMetricsField.SPAN_DOMAIN]?: string;
+    [SpanMetricsField.SPAN_DOMAIN_ARRAY]?: string;
     [SpanMetricsField.SPAN_GROUP]?: string;
   };
 }

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -55,6 +55,7 @@ export function SpanSummaryView({groupId}: Props) {
       SpanMetricsField.SPAN_DESCRIPTION,
       SpanMetricsField.SPAN_ACTION,
       SpanMetricsField.SPAN_DOMAIN,
+      SpanMetricsField.SPAN_DOMAIN_ARRAY,
       'count()',
       `${SpanFunction.SPM}()`,
       `sum(${SpanMetricsField.SPAN_SELF_TIME})`,
@@ -73,6 +74,7 @@ export function SpanSummaryView({groupId}: Props) {
     [SpanMetricsField.SPAN_DESCRIPTION]: string;
     [SpanMetricsField.SPAN_ACTION]: string;
     [SpanMetricsField.SPAN_DOMAIN]: string;
+    [SpanMetricsField.SPAN_DOMAIN_ARRAY]: string;
     [SpanMetricsField.SPAN_GROUP]: string;
   };
 

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -17,8 +17,6 @@ import {
   EmptyContainer,
 } from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
-const {SPAN_DOMAIN} = SpanMetricsField;
-
 type Props = {
   moduleName?: ModuleName;
   spanCategory?: string;
@@ -46,15 +44,31 @@ export function DomainSelector({
   const location = useLocation();
   const eventView = getEventView(location, moduleName, spanCategory, state.search);
 
-  const {data: domains, isLoading} = useSpansQuery<{'span.domain': string}[]>({
+  const {data: domains, isLoading} = useSpansQuery<
+    Array<{[SpanMetricsField.SPAN_DOMAIN_ARRAY]: Array<string>}>
+  >({
     eventView,
     initialData: [],
     limit: LIMIT,
     referrer: 'api.starfish.get-span-domains',
   });
 
+  const transformedDomains = Array.from(
+    domains?.reduce((acc, curr) => {
+      const spanDomainArray = curr[SpanMetricsField.SPAN_DOMAIN_ARRAY];
+      if (spanDomainArray) {
+        spanDomainArray.forEach(name => acc.add(name));
+      }
+      return acc;
+    }, new Set<string>()) || []
+  );
+
   // If the maximum number of domains is returned, we need to requery on input change to get full results
-  if (!state.shouldRequeryOnInputChange && domains && domains.length >= LIMIT) {
+  if (
+    !state.shouldRequeryOnInputChange &&
+    transformedDomains &&
+    transformedDomains.length >= LIMIT
+  ) {
     setState({...state, shouldRequeryOnInputChange: true});
   }
 
@@ -71,12 +85,11 @@ export function DomainSelector({
   const options = optionsReady
     ? [
         {value: '', label: 'All'},
-        ...(domains ?? [])
-          .filter(datum => Boolean(datum[SPAN_DOMAIN]))
+        ...transformedDomains
           .map(datum => {
             return {
-              value: datum[SPAN_DOMAIN],
-              label: datum[SPAN_DOMAIN],
+              value: datum,
+              label: datum,
             };
           })
           .sort((a, b) => a.value.localeCompare(b.value)),
@@ -115,7 +128,7 @@ export function DomainSelector({
           ...location,
           query: {
             ...location.query,
-            [SPAN_DOMAIN]: newValue.value,
+            [SpanMetricsField.SPAN_DOMAIN_ARRAY]: newValue.value,
           },
         });
       }}
@@ -140,15 +153,20 @@ function getEventView(
   const query = [
     ...buildEventViewQuery({
       moduleName,
-      location: {...location, query: omit(location.query, SPAN_DOMAIN)},
+      location: {
+        ...location,
+        query: omit(location.query, SpanMetricsField.SPAN_DOMAIN_ARRAY),
+      },
       spanCategory,
     }),
-    ...(search && search.length > 0 ? [`span.domain:*${search}*`] : []),
+    ...(search && search.length > 0
+      ? [`${SpanMetricsField.SPAN_DOMAIN_ARRAY}:*${[search]}*`]
+      : []),
   ].join(' ');
   return EventView.fromNewQueryWithLocation(
     {
       name: '',
-      fields: ['span.domain', 'count()'],
+      fields: [SpanMetricsField.SPAN_DOMAIN_ARRAY, 'count()'],
       orderby: '-count',
       query,
       dataset: DiscoverDatasets.SPANS_METRICS,

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -28,6 +28,7 @@ type Row = {
   'http_error_count()': number;
   'span.description': string;
   'span.domain': string;
+  'span.domain_array': Array<string>;
   'span.group': string;
   'span.op': string;
   'spm()': number;

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -13,7 +13,7 @@ import {useModuleSort} from 'sentry/views/starfish/views/spans/useModuleSort';
 
 import SpansTable from './spansTable';
 
-const {SPAN_ACTION, SPAN_DOMAIN, SPAN_OP} = SpanMetricsField;
+const {SPAN_ACTION, SPAN_DOMAIN_ARRAY, SPAN_OP} = SpanMetricsField;
 
 const LIMIT: number = 25;
 
@@ -56,7 +56,7 @@ export default function SpansView(props: Props) {
 
         <DomainSelector
           moduleName={moduleName}
-          value={moduleFilters[SPAN_DOMAIN] || ''}
+          value={moduleFilters[SPAN_DOMAIN_ARRAY] || ''}
           spanCategory={props.spanCategory}
         />
       </FilterOptionsContainer>

--- a/static/app/views/starfish/views/spans/useModuleFilters.ts
+++ b/static/app/views/starfish/views/spans/useModuleFilters.ts
@@ -6,6 +6,7 @@ import {SpanMetricsField} from 'sentry/views/starfish/types';
 export type ModuleFilters = {
   [SpanMetricsField.SPAN_ACTION]?: string;
   [SpanMetricsField.SPAN_DOMAIN]?: string;
+  [SpanMetricsField.SPAN_DOMAIN_ARRAY]?: string;
   [SpanMetricsField.SPAN_GROUP]?: string;
   [SpanMetricsField.SPAN_OP]?: string;
 };
@@ -16,6 +17,7 @@ export const useModuleFilters = () => {
   return pick(location.query, [
     SpanMetricsField.SPAN_ACTION,
     SpanMetricsField.SPAN_DOMAIN,
+    SpanMetricsField.SPAN_DOMAIN_ARRAY,
     SpanMetricsField.SPAN_OP,
     SpanMetricsField.SPAN_GROUP,
   ]);


### PR DESCRIPTION
Temporarily swapping to `span.domain_array` as `span.domain` is now going to be emitted as an array.

<img width="1267" alt="image" src="https://github.com/getsentry/sentry/assets/18689448/4e9bf9ad-08d5-428c-aa59-41bba0f99264">

After this gets merged in and deployed, we can swap out the backend to change the typing of `span.domain`, and then re-adjust the frontend again.