### PR TITLE
feat(hc): Add RegionSiloUserEndpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,6 @@ module = [
     "sentry.api.bases.rule",
     "sentry.api.bases.sentryapps",
     "sentry.api.bases.team",
-    "sentry.api.bases.user",
     "sentry.api.endpoints.accept_organization_invite",
     "sentry.api.endpoints.artifact_lookup",
     "sentry.api.endpoints.auth_config",

--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from rest_framework.request import Request
+from typing_extensions import override
 
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -10,13 +11,12 @@ from sentry.auth.system import is_system_auth
 from sentry.models import OrganizationMapping, OrganizationMemberMapping, OrganizationStatus, User
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.services.hybrid_cloud.user import RpcUser
+from sentry.services.hybrid_cloud.user.service import user_service
 
 
 class UserPermission(SentryPermission):
     def has_object_permission(self, request: Request, view, user: User | RpcUser | None = None):
-        if user is None:
-            user = request.user
-        if request.user.id == user.id:
+        if user is None or request.user.id == user.id:
             return True
         if is_system_auth(request.auth):
             return True
@@ -43,8 +43,11 @@ class OrganizationUserPermission(UserPermission):
         organization = organization_service.get_organization_by_id(
             id=organization_id, user_id=request.user.id
         )
+        if not organization:
+            return False
 
         self.determine_access(request, organization)
+        assert request.method is not None
         allowed_scopes = set(self.scope_map.get(request.method, []))
         return any(request.access.has_scope(s) for s in allowed_scopes)
 
@@ -81,15 +84,48 @@ class UserEndpoint(Endpoint):
 
     permission_classes = (UserPermission,)
 
-    def convert_args(self, request: Request, user_id, *args, **kwargs):
+    @override
+    def convert_args(self, request: Request, user_id: str | None = None, *args, **kwargs):
         if user_id == "me":
             if not request.user.is_authenticated:
                 raise ResourceDoesNotExist
             user_id = request.user.id
 
+        if user_id is None:
+            raise ResourceDoesNotExist
+
         try:
             user = User.objects.get(id=user_id)
         except (User.DoesNotExist, ValueError):
+            raise ResourceDoesNotExist
+
+        self.check_object_permissions(request, user)
+
+        kwargs["user"] = user
+        return args, kwargs
+
+
+class RegionSiloUserEndpoint(Endpoint):
+    """
+    The base endpoint for APIs that deal with Users but live in the region silo.
+    Inherit from this class to get permission checks and to automatically
+    convert user ID "me" to the currently logged in user's ID.
+    """
+
+    permission_classes = (UserPermission,)
+
+    @override
+    def convert_args(self, request: Request, user_id: str | None = None, *args, **kwargs):
+        user: RpcUser | User | None = None
+
+        if user_id == "me":
+            if not request.user.is_authenticated:
+                raise ResourceDoesNotExist
+            user = request.user
+        elif user_id is not None:
+            user = user_service.get_user(user_id=int(user_id))
+
+        if not user:
             raise ResourceDoesNotExist
 
         self.check_object_permissions(request, user)

--- a/src/sentry/api/endpoints/user_organizations.py
+++ b/src/sentry/api/endpoints/user_organizations.py
@@ -3,44 +3,21 @@ from __future__ import annotations
 from django.db.models import Q
 from rest_framework.request import Request
 from rest_framework.response import Response
-from typing_extensions import override
 
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, region_silo_endpoint
-from sentry.api.bases.user import UserPermission
-from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.user import RegionSiloUserEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import Organization, User
+from sentry.models import Organization
 from sentry.services.hybrid_cloud.user import RpcUser
-from sentry.services.hybrid_cloud.user.service import user_service
 
 
 @region_silo_endpoint
-class UserOrganizationsEndpoint(Endpoint):
+class UserOrganizationsEndpoint(RegionSiloUserEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
-    permission_classes = (UserPermission,)
-
-    @override
-    def convert_args(self, request: Request, user_id: str | None = None, *args, **kwargs):
-        user: RpcUser | User | None = None
-
-        if user_id == "me":
-            if not request.user.is_authenticated:
-                raise ResourceDoesNotExist
-            user = request.user
-        elif user_id is not None:
-            user = user_service.get_user(user_id=int(user_id))
-
-        if not user:
-            raise ResourceDoesNotExist
-
-        self.check_object_permissions(request, user)
-
-        kwargs["user"] = user
-        return args, kwargs
 
     def get(self, request: Request, user: RpcUser) -> Response:
         queryset = Organization.objects.get_for_user_ids({user.id})

--- a/tests/sentry/api/bases/test_user.py
+++ b/tests/sentry/api/bases/test_user.py
@@ -1,0 +1,80 @@
+import pytest
+from rest_framework.request import Request
+
+from sentry.api.bases.user import RegionSiloUserEndpoint, UserEndpoint, UserPermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import all_silo_test, control_silo_test, region_silo_test
+
+
+@all_silo_test(stable=True)
+class UserPermissionTest(TestCase):
+    user_permission = UserPermission()
+
+    def test_anonymous_no_user(self):
+        request = Request(self.make_request(method="GET"))
+        assert self.user_permission.has_object_permission(request, None, None)
+
+    def test_request_user(self):
+        user = self.create_user()
+        request = Request(self.make_request(method="GET"))
+        request.user = user
+        assert self.user_permission.has_object_permission(request, None, user)
+
+    def test_anonymous(self):
+        user = self.create_user()
+        request = Request(self.make_request(method="GET"))
+        assert not self.user_permission.has_object_permission(request, None, user)
+
+    def test_other(self):
+        request = Request(self.make_request(method="GET"))
+        request.user = self.create_user()
+        assert not self.user_permission.has_object_permission(request, None, self.create_user())
+
+
+@control_silo_test(stable=True)
+class UserEndpointTest(TestCase):
+    endpoint = UserEndpoint()
+
+    def test_retrieves_me_anonymous(self):
+        request = Request(self.make_request(method="GET"))
+        with pytest.raises(ResourceDoesNotExist):
+            self.endpoint.convert_args(request, user_id="me")
+
+    def test_retrieves_me(self):
+        user = self.create_user()
+        request = Request(self.make_request(method="GET"))
+        request.user = user
+        args, kwargs = self.endpoint.convert_args(request, user_id="me")
+        assert kwargs["user"].id == user.id
+
+    def test_retrieves_user_id(self):
+        user = self.create_user()
+        request = Request(self.make_request(method="GET"))
+        request.user = user
+        args, kwargs = self.endpoint.convert_args(request, user_id=user.id)
+        assert kwargs["user"].id == user.id
+
+
+@region_silo_test(stable=True)
+class RegionSiloUserEndpointTest(TestCase):
+    endpoint = RegionSiloUserEndpoint()
+
+    def test_retrieves_me_anonymous(self):
+        request = Request(self.make_request(method="GET"))
+        with pytest.raises(ResourceDoesNotExist):
+            self.endpoint.convert_args(request, user_id="me")
+
+    def test_retrieves_me(self):
+        user = self.create_user()
+        request = Request(self.make_request(method="GET"))
+        request.user = user
+        args, kwargs = self.endpoint.convert_args(request, user_id="me")
+        assert kwargs["user"].id == user.id
+
+    def test_retrieves_user_id(self):
+        user = self.create_user()
+        request = Request(self.make_request(method="GET"))
+        request.user = user
+        args, kwargs = self.endpoint.convert_args(request, user_id=user.id)
+        assert kwargs["user"].id == user.id

--- a/tests/sentry/api/bases/test_user.py
+++ b/tests/sentry/api/bases/test_user.py
@@ -1,80 +1,69 @@
+from __future__ import annotations
+
 import pytest
+from django.http import HttpRequest
 from rest_framework.request import Request
 
 from sentry.api.bases.user import RegionSiloUserEndpoint, UserEndpoint, UserPermission
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.models.user import User
 from sentry.testutils.cases import TestCase
+from sentry.testutils.factories import Factories
 from sentry.testutils.silo import all_silo_test, control_silo_test, region_silo_test
+
+
+def get_request(user: User | None = None) -> Request:
+    request = Request(HttpRequest())
+    request.method = "GET"
+    request.session = Factories.create_session()
+    if user is not None:
+        request.user = user
+    return request
 
 
 @all_silo_test(stable=True)
 class UserPermissionTest(TestCase):
     user_permission = UserPermission()
 
-    def test_anonymous_no_user(self):
-        request = Request(self.make_request(method="GET"))
-        assert self.user_permission.has_object_permission(request, None, None)
+    def test_allows_none_user_as_anonymous(self):
+        assert self.user_permission.has_object_permission(get_request(), None, None)
 
-    def test_request_user(self):
-        user = self.create_user()
-        request = Request(self.make_request(method="GET"))
-        request.user = user
-        assert self.user_permission.has_object_permission(request, None, user)
+    def test_allows_current_user(self):
+        user = Factories.create_user()
+        assert self.user_permission.has_object_permission(get_request(user), None, user)
 
-    def test_anonymous(self):
-        user = self.create_user()
-        request = Request(self.make_request(method="GET"))
-        assert not self.user_permission.has_object_permission(request, None, user)
+    def test_rejects_user_as_anonymous(self):
+        user = Factories.create_user()
+        assert not self.user_permission.has_object_permission(get_request(), None, user)
 
-    def test_other(self):
-        request = Request(self.make_request(method="GET"))
-        request.user = self.create_user()
-        assert not self.user_permission.has_object_permission(request, None, self.create_user())
+    def test_rejects_other_user(self):
+        user, other = Factories.create_user(), Factories.create_user()
+        assert not self.user_permission.has_object_permission(get_request(user), None, other)
+
+
+class BaseUserEndpointTest:
+    endpoint: RegionSiloUserEndpoint | UserEndpoint = UserEndpoint()
+
+    def test_retrieves_me_anonymous(self):
+        with pytest.raises(ResourceDoesNotExist):
+            self.endpoint.convert_args(get_request(), user_id="me")
+
+    def test_retrieves_me(self):
+        user = Factories.create_user()
+        args, kwargs = self.endpoint.convert_args(get_request(user), user_id="me")
+        assert kwargs["user"].id == user.id
+
+    def test_retrieves_user_id(self):
+        user = Factories.create_user()
+        args, kwargs = self.endpoint.convert_args(get_request(user), user_id=user.id)
+        assert kwargs["user"].id == user.id
 
 
 @control_silo_test(stable=True)
-class UserEndpointTest(TestCase):
+class UserEndpointTest(BaseUserEndpointTest, TestCase):
     endpoint = UserEndpoint()
-
-    def test_retrieves_me_anonymous(self):
-        request = Request(self.make_request(method="GET"))
-        with pytest.raises(ResourceDoesNotExist):
-            self.endpoint.convert_args(request, user_id="me")
-
-    def test_retrieves_me(self):
-        user = self.create_user()
-        request = Request(self.make_request(method="GET"))
-        request.user = user
-        args, kwargs = self.endpoint.convert_args(request, user_id="me")
-        assert kwargs["user"].id == user.id
-
-    def test_retrieves_user_id(self):
-        user = self.create_user()
-        request = Request(self.make_request(method="GET"))
-        request.user = user
-        args, kwargs = self.endpoint.convert_args(request, user_id=user.id)
-        assert kwargs["user"].id == user.id
 
 
 @region_silo_test(stable=True)
-class RegionSiloUserEndpointTest(TestCase):
+class RegionSiloUserEndpointTest(BaseUserEndpointTest, TestCase):
     endpoint = RegionSiloUserEndpoint()
-
-    def test_retrieves_me_anonymous(self):
-        request = Request(self.make_request(method="GET"))
-        with pytest.raises(ResourceDoesNotExist):
-            self.endpoint.convert_args(request, user_id="me")
-
-    def test_retrieves_me(self):
-        user = self.create_user()
-        request = Request(self.make_request(method="GET"))
-        request.user = user
-        args, kwargs = self.endpoint.convert_args(request, user_id="me")
-        assert kwargs["user"].id == user.id
-
-    def test_retrieves_user_id(self):
-        user = self.create_user()
-        request = Request(self.make_request(method="GET"))
-        request.user = user
-        args, kwargs = self.endpoint.convert_args(request, user_id=user.id)
-        assert kwargs["user"].id == user.id


### PR DESCRIPTION
This extracts the existing `convert_args` definition from `src/sentry/api/endpoints/user_organizations.py` and moves it to a new base endpoint, the region-silo version of UserEndpoint, for endpoints which handle users but are located in the region silo. This ends up being pretty similar to OrganizationEndpoint/ControlSiloOrganizationEndpoint.

This should probably converge with UserEndpoint long-term (using user_service) but I was concerned about the downstream affects of making such a large change.

This will also be used in getsentry/getsentry#11741