### PR TITLE
feat(feedback): Use Feedback widget modal for Crons

### DIFF
--- a/static/app/components/feedback/widget/feedbackForm.tsx
+++ b/static/app/components/feedback/widget/feedbackForm.tsx
@@ -4,6 +4,8 @@ import styled from '@emotion/styled';
 import {getCurrentHub} from '@sentry/react';
 
 interface FeedbackFormProps {
+  sendButtonText: string;
+  descriptionPlaceholder: string;
   onClose: () => void;
   onSubmit: (data: {comment: string; email: string; name: string}) => void;
 }
@@ -16,7 +18,7 @@ const retrieveStringValue = (formData: FormData, key: string) => {
   return '';
 };
 
-export function FeedbackForm({onClose, onSubmit}: FeedbackFormProps) {
+export function FeedbackForm({sendButtonText, onClose, onSubmit}: FeedbackFormProps) {
   const formRef = useRef<HTMLFormElement>(null);
   const [hasDescription, setHasDescription] = useState(false);
 
@@ -57,7 +59,7 @@ export function FeedbackForm({onClose, onSubmit}: FeedbackFormProps) {
           }}
           id="sentry-feedback-comment"
           name="comment"
-          placeholder="What's the bug? What did you expect?"
+          placeholder={descriptionPlaceholder}
         />
       </Label>
       <ButtonGroup>
@@ -66,7 +68,7 @@ export function FeedbackForm({onClose, onSubmit}: FeedbackFormProps) {
           disabled={!hasDescription}
           aria-disabled={!hasDescription}
         >
-          Send Bug Report
+          {sendButtonText}
         </SubmitButton>
         <CancelButton type="button" onClick={onClose}>
           Cancel

--- a/static/app/components/feedback/widget/feedbackForm.tsx
+++ b/static/app/components/feedback/widget/feedbackForm.tsx
@@ -4,10 +4,10 @@ import styled from '@emotion/styled';
 import {getCurrentHub} from '@sentry/react';
 
 interface FeedbackFormProps {
-  sendButtonText: string;
   descriptionPlaceholder: string;
   onClose: () => void;
   onSubmit: (data: {comment: string; email: string; name: string}) => void;
+  sendButtonText: string;
 }
 
 const retrieveStringValue = (formData: FormData, key: string) => {
@@ -18,7 +18,12 @@ const retrieveStringValue = (formData: FormData, key: string) => {
   return '';
 };
 
-export function FeedbackForm({sendButtonText, onClose, onSubmit}: FeedbackFormProps) {
+export function FeedbackForm({
+  descriptionPlaceholder,
+  sendButtonText,
+  onClose,
+  onSubmit,
+}: FeedbackFormProps) {
   const formRef = useRef<HTMLFormElement>(null);
   const [hasDescription, setHasDescription] = useState(false);
 

--- a/static/app/components/feedback/widget/feedbackModal.tsx
+++ b/static/app/components/feedback/widget/feedbackModal.tsx
@@ -215,8 +215,8 @@ const Content = styled('div')`
   transition: transform 0.2s ease-in-out;
   transform: translate(0, 0) scale(1);
   dialog:not([open]) & {
-  transform: translate(0, -16px) scale(0.98);
-}
+    transform: translate(0, -16px) scale(0.98);
+  }
 `;
 
 const Header = styled('h2')`

--- a/static/app/components/feedback/widget/feedbackModal.tsx
+++ b/static/app/components/feedback/widget/feedbackModal.tsx
@@ -29,6 +29,8 @@ interface FeedbackModalProps {
   children: FeedbackRenderFunction;
   title: string;
   className?: string;
+  descriptionPlaceholder?: string;
+  sendButtonText?: string;
   type?: string;
   widgetTheme?: 'dark' | 'light';
 }
@@ -67,10 +69,12 @@ function stopPropagation(e: React.MouseEvent) {
  */
 export function FeedbackModal({
   className,
+  descriptionPlaceholder = "What's the bug? What did you expect?",
+  sendButtonText = 'Send Bug Report',
+  widgetTheme = 'light',
   title,
   type,
   children,
-  widgetTheme = 'light',
 }: FeedbackModalProps) {
   const [open, setOpen] = useState(false);
   const [errorMessage, setError] = useState('');
@@ -139,7 +143,14 @@ export function FeedbackModal({
         <Content onClick={stopPropagation}>
           <Header>{title}</Header>
           {errorMessage ? <Error>{errorMessage}</Error> : null}
-          {open && <FeedbackForm onSubmit={handleSubmit} onClose={handleClose} />}
+          {open && (
+            <FeedbackForm
+              descriptionPlaceholder={descriptionPlaceholder}
+              sendButtonText={sendButtonText}
+              onSubmit={handleSubmit}
+              onClose={handleClose}
+            />
+          )}
         </Content>
       </Dialog>
       <FeedbackSuccessMessage show={showSuccessMessage} />
@@ -204,8 +215,8 @@ const Content = styled('div')`
   transition: transform 0.2s ease-in-out;
   transform: translate(0, 0) scale(1);
   dialog:not([open]) & {
-    transform: translate(0, -16px) scale(0.98);
-  }
+  transform: translate(0, -16px) scale(0.98);
+}
 `;
 
 const Header = styled('h2')`

--- a/static/app/views/monitors/components/cronsFeedbackButton.tsx
+++ b/static/app/views/monitors/components/cronsFeedbackButton.tsx
@@ -1,15 +1,14 @@
 import {Button} from 'sentry/components/button';
 import {FeedbackModal} from 'sentry/components/feedback/widget/feedbackModal';
 import {IconMegaphone} from 'sentry/icons/iconMegaphone';
-import {t} from 'sentry/locale';
 
 const CRONS_FEEDBACK_NAME = 'crons';
 
 function CronsFeedbackButton() {
-  const title = t('Give Feedback');
+  const title = 'Give Feedback';
 
   return (
-    <FeedbackModal title={title} type={CRONS_FEEDBACK_NAME}>
+    <FeedbackModal title={title} type={CRONS_FEEDBACK_NAME} sendButtonText="Send Feedback" descriptionPlaceholder="What did you expect?">
       {({showModal}) => (
         <Button size="sm" icon={<IconMegaphone />} onClick={showModal}>
           {title}

--- a/static/app/views/monitors/components/cronsFeedbackButton.tsx
+++ b/static/app/views/monitors/components/cronsFeedbackButton.tsx
@@ -1,9 +1,22 @@
-import {FeatureFeedback} from 'sentry/components/featureFeedback';
+import {Button} from 'sentry/components/button';
+import {FeedbackModal} from 'sentry/components/feedback/widget/feedbackModal';
+import {IconMegaphone} from 'sentry/icons/iconMegaphone';
+import {t} from 'sentry/locale';
 
 const CRONS_FEEDBACK_NAME = 'crons';
 
 function CronsFeedbackButton() {
-  return <FeatureFeedback featureName={CRONS_FEEDBACK_NAME} buttonProps={{size: 'sm'}} />;
+  const title = t('Give Feedback');
+
+  return (
+    <FeedbackModal title={title} type={CRONS_FEEDBACK_NAME}>
+      {({showModal}) => (
+        <Button size="sm" icon={<IconMegaphone />} onClick={showModal}>
+          {title}
+        </Button>
+      )}
+    </FeedbackModal>
+  );
 }
 
 export default CronsFeedbackButton;

--- a/static/app/views/monitors/components/cronsFeedbackButton.tsx
+++ b/static/app/views/monitors/components/cronsFeedbackButton.tsx
@@ -8,7 +8,12 @@ function CronsFeedbackButton() {
   const title = 'Give Feedback';
 
   return (
-    <FeedbackModal title={title} type={CRONS_FEEDBACK_NAME} sendButtonText="Send Feedback" descriptionPlaceholder="What did you expect?">
+    <FeedbackModal
+      title={title}
+      type={CRONS_FEEDBACK_NAME}
+      sendButtonText="Send Feedback"
+      descriptionPlaceholder="What did you expect?"
+    >
       {({showModal}) => (
         <Button size="sm" icon={<IconMegaphone />} onClick={showModal}>
           {title}


### PR DESCRIPTION
This replaces the use of `FeedbackFeature` with a temporary feedbackv2 widget in the Crons view.


<img width="437" alt="image" src="https://github.com/getsentry/sentry/assets/79684/8ab678a0-7564-4aa7-9704-3c449a35f812">

Closes https://github.com/getsentry/team-replay/issues/190
