### PR TITLE
fix: Issue scroll to see replay should not scroll too far

### DIFF
--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -351,7 +351,7 @@ export function GroupEventActions({event, group, projectSlug}: GroupEventActions
             label: t('View Replay'),
             hidden: !hasReplay || !isReplayEnabled,
             onAction: () => {
-              const breadcrumbsHeader = document.getElementById('breadcrumbs');
+              const breadcrumbsHeader = document.getElementById('replay');
               if (breadcrumbsHeader) {
                 breadcrumbsHeader.scrollIntoView({behavior: 'smooth'});
               }


### PR DESCRIPTION
Scroll to the replay section, not breadcrumbs which are further down.

Problem: https://jam.dev/c/b100dcf2-a69d-462f-97aa-a1eac584209e

Relates to: https://github.com/getsentry/sentry/pull/53120

