### PR TITLE
ref(crons): Pass reference timestamp down to fan-out tasks

### DIFF
--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from typing import Optional
 
 import msgpack
 import sentry_sdk
@@ -202,7 +203,7 @@ def check_missing(current_datetime: datetime):
     max_retries=0,
     record_timing=True,
 )
-def mark_environment_missing(monitor_environment_id: int):
+def mark_environment_missing(monitor_environment_id: int, ts: Optional[datetime] = None):
     logger.info("monitor.missed-checkin", extra={"monitor_environment_id": monitor_environment_id})
 
     monitor_environment = MonitorEnvironment.objects.select_related("monitor").get(
@@ -282,7 +283,7 @@ def check_timeout(current_datetime: datetime):
     name="sentry.monitors.tasks.mark_checkin_timeout",
     max_retries=0,
 )
-def mark_checkin_timeout(checkin_id: int):
+def mark_checkin_timeout(checkin_id: int, ts: Optional[datetime] = None):
     logger.info("checkin.timeout", extra={"checkin_id": checkin_id})
 
     checkin = MonitorCheckIn.objects.select_related("monitor_environment").get(id=checkin_id)


### PR DESCRIPTION
We'll need the `ts` to compute check-in date_added's generated in the
tasks more accurately