### PR TITLE
ref(alerts): Add better rule re-enable analytics

### DIFF
--- a/src/sentry/analytics/events/rule_reenable.py
+++ b/src/sentry/analytics/events/rule_reenable.py
@@ -1,10 +1,11 @@
+import abc
+
 from sentry import analytics
 
 
-class RuleReenable(analytics.Event):
+class RuleReenable(analytics.Event, abc.ABC):
     """Re-enable a rule that was disabled"""
 
-    type = "rule.reenable"
     attributes = (
         analytics.Attribute("rule_id"),
         analytics.Attribute("user_id"),
@@ -12,4 +13,13 @@ class RuleReenable(analytics.Event):
     )
 
 
-analytics.register(RuleReenable)
+class RuleReenableExplicit(RuleReenable):
+    type = "rule_reenable.explicit"
+
+
+class RuleReenableEdit(RuleReenable):
+    type = "rule_reenable.edit"
+
+
+analytics.register(RuleReenableExplicit)
+analytics.register(RuleReenableEdit)

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -218,6 +218,12 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             if rule.status == ObjectStatus.DISABLED:
                 rule.status = ObjectStatus.ACTIVE
                 rule.save()
+                analytics.record(
+                    "rule_reenable.edit",
+                    rule_id=rule.id,
+                    user_id=request.user.id,
+                    organization_id=project.organization.id,
+                )
 
             if data.get("pending_save"):
                 client = RedisRuleStatus()

--- a/src/sentry/api/endpoints/project_rule_enable.py
+++ b/src/sentry/api/endpoints/project_rule_enable.py
@@ -62,7 +62,7 @@ class ProjectRuleEnableEndpoint(ProjectEndpoint):
             data=rule.get_audit_log_data(),
         )
         analytics.record(
-            "rule.reenable",
+            "rule_reenable.explicit",
             rule_id=rule.id,
             user_id=request.user.id,
             organization_id=project.organization.id,

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -663,7 +663,8 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
         )
 
-    def test_reenable_disabled_rule(self):
+    @patch("sentry.analytics.record")
+    def test_reenable_disabled_rule(self, record_analytics):
         """Test that when you edit and save a rule that was disabled, it's re-enabled as long as it passes the checks"""
         rule = Rule.objects.create(
             label="hello world",
@@ -691,6 +692,14 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         # re-fetch rule after update
         rule = Rule.objects.get(id=rule.id)
         assert rule.status == ObjectStatus.ACTIVE
+
+        assert self.analytics_called_with_args(
+            record_analytics,
+            "rule_reenable.edit",
+            rule_id=rule.id,
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+        )
 
     @patch("sentry.analytics.record")
     def test_rule_disable_opt_out_explicit(self, record_analytics):

--- a/tests/sentry/api/endpoints/test_project_rule_enable.py
+++ b/tests/sentry/api/endpoints/test_project_rule_enable.py
@@ -40,7 +40,7 @@ class ProjectRuleEnableTestCase(APITestCase):
             ).exists()
         assert self.analytics_called_with_args(
             record_analytics,
-            "rule.reenable",
+            "rule_reenable.explicit",
             rule_id=self.rule.id,
             user_id=self.user.id,
             organization_id=self.organization.id,


### PR DESCRIPTION
Add analytics such that we can track when a rule was re-enabled explicitly or due to editing the rule.