### PR TITLE
chore(tests): Increase pytest verbosity to 2 in debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,7 +55,7 @@
       "type": "python",
       "request": "launch",
       "module": "pytest",
-      "args": ["--verbose", "${file}"],
+      "args": ["--verbosity", "2", "${file}"],
       "django": true,
       "env": {
         "SENTRY_MODEL_MANIFEST_FILE_PATH": "./model-manifest.json"


### PR DESCRIPTION
This increases the [verbosity](https://docs.pytest.org/en/7.1.x/how-to/output.html#verbosity) of pytest, when it's being run in the VSCode debugger, from 1 to 2, so that its output when a test fails shows the full difference between what was received and what was expected.