### PR TITLE
ref(crons): Use `rrule.after` over manual search

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -81,7 +81,7 @@ class MonitorEnvironmentValidationFailed(Exception):
     pass
 
 
-def get_next_schedule(reference_ts: datetime, schedule_type, schedule):
+def get_next_schedule(reference_ts: datetime, schedule_type: int, schedule):
     """
     Given the schedule type and schedule, determine the next timestamp for a
     schedule from the reference_ts
@@ -98,17 +98,16 @@ def get_next_schedule(reference_ts: datetime, schedule_type, schedule):
     >>> 07:35
     """
     if schedule_type == ScheduleType.CRONTAB:
-        itr = croniter(schedule, reference_ts)
-        next_schedule = itr.get_next(datetime)
+        next_schedule = croniter(schedule, reference_ts).get_next(datetime)
     elif schedule_type == ScheduleType.INTERVAL:
         interval, unit_name = schedule
         rule = rrule.rrule(
-            freq=SCHEDULE_INTERVAL_MAP[unit_name], interval=interval, dtstart=reference_ts, count=2
+            freq=SCHEDULE_INTERVAL_MAP[unit_name],
+            interval=interval,
+            dtstart=reference_ts,
+            count=2,
         )
-        if rule[0] > reference_ts:
-            next_schedule = rule[0]
-        else:
-            next_schedule = rule[1]
+        next_schedule = rule.after(reference_ts)
     else:
         raise NotImplementedError("unknown schedule_type")
 


### PR DESCRIPTION
This is basically the same implementation as what we had before (see rrule source [0]).

The advantage here is that the abstraction is more clear

[0]: https://github.com/dateutil/dateutil/blob/master/src/dateutil/rrule.py#L221-L227