### PR TITLE
feat(replays): add link to stats page from replay not found box

### DIFF
--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Alert} from 'sentry/components/alert';
 import {LinkButton} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
+import Link from 'sentry/components/links/link';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import Placeholder from 'sentry/components/placeholder';
@@ -43,7 +44,12 @@ function ReplayPreview({orgSlug, replaySlug, eventTimestampMs, buttonProps}: Pro
 
   if (fetchError) {
     const reasons = [
-      t('The replay was rate-limited and could not be accepted.'),
+      tct(
+        'The replay was rate-limited and could not be accepted. [link:View the stats page] for more information.',
+        {
+          link: <Link to={`/organizations/${orgSlug}/stats/?dataCategory=replays`} />,
+        }
+      ),
       t('The replay has been deleted by a member in your organization.'),
       t('There were network errors and the replay was not saved.'),
       tct('[link:Read the docs] to understand why.', {


### PR DESCRIPTION
related: https://github.com/getsentry/team-replay/issues/50 https://github.com/getsentry/sentry/issues/53082

<img width="1122" alt="Screenshot 2023-09-26 at 5 55 36 PM" src="https://github.com/getsentry/sentry/assets/1976777/31911208-6b19-4ad7-8284-bdc72dc7602f">
