### PR TITLE
fix(ddm): Reset focus when series change

### DIFF
--- a/static/app/views/ddm/metricsExplorer.tsx
+++ b/static/app/views/ddm/metricsExplorer.tsx
@@ -138,6 +138,7 @@ function QueryBuilder({metricsQuery}: QueryBuilderProps) {
                 mri: option.value,
                 op: selectedOp,
                 groupBy: undefined,
+                focusedSeries: undefined,
               });
             }}
           />
@@ -169,6 +170,7 @@ function QueryBuilder({metricsQuery}: QueryBuilderProps) {
             onChange={options =>
               updateQuery(router, {
                 groupBy: options.map(o => o.value),
+                focusedSeries: undefined,
               })
             }
           />


### PR DESCRIPTION
We do not want to keep the old series line focused when it might not even be there anymore (because of changed MRI / groupBy).