### PR TITLE
fix(perf): Fix incorrect units in TPM table field

### DIFF
--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -214,8 +214,13 @@ class _Table extends Component<Props, State> {
     const tableMeta = tableData.meta;
 
     const field = String(column.key);
+
     const fieldRenderer = getFieldRenderer(field, tableMeta, false);
-    const rendered = fieldRenderer(dataRow, {organization, location});
+    const rendered = fieldRenderer(dataRow, {
+      organization,
+      location,
+      unit: tableMeta.units?.[column.key],
+    });
 
     const allowActions = [
       Actions.ADD,


### PR DESCRIPTION
We need to make sure to pass the field unit to the renderer. Without the unit, depending on the field type, it might assume an incorrect unit. For example, `"rate"` fields will assume the rate is per second, even though it might actually be per minute.

The Performance landing page table wasn't passing the unit, so it was incorrectly showing rates as "/s" even though they're "/min".

**Before:**
<img width="80" alt="Screenshot 2023-09-27 at 10 10 52 AM" src="https://github.com/getsentry/sentry/assets/989898/688c130b-f83a-4152-a0a3-21d371187641">

**After:**
<img width="94" alt="Screenshot 2023-09-27 at 10 10 57 AM" src="https://github.com/getsentry/sentry/assets/989898/6387b216-d4bc-4b9b-9f96-0770f1ef8624">

There's also a question of whether the field should have a more generic name like "Throughput", and/or a unitless value, but we can do that separately, we need to fix the incorrect unit at a minimum.