### PR TITLE
fix(perf): Improve contrast on span sample chart markline

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -107,9 +107,11 @@ function DurationChart({
       },
       emphasis: {disabled: true},
       label: {
-        fontSize: 11,
         position: 'insideEndBottom',
         formatter: () => 'Average',
+        fontSize: 14,
+        color: theme.chartLabel,
+        backgroundColor: theme.chartOther,
       },
     },
   };


### PR DESCRIPTION
Similar to #50658. Improves contrast/readability on the span sample chart.

- Increase font size
- Change colour and background

**Before:**
<img width="602" alt="Screenshot 2023-09-27 at 10 47 55 AM" src="https://github.com/getsentry/sentry/assets/989898/8c0a5e37-735d-45cc-ba75-70eb852046df">
<img width="605" alt="Screenshot 2023-09-27 at 10 49 55 AM" src="https://github.com/getsentry/sentry/assets/989898/4fa6209c-44c9-4a78-b4d9-c56d89e7d2c1">

**After:**
<img width="602" alt="Screenshot 2023-09-27 at 10 47 40 AM" src="https://github.com/getsentry/sentry/assets/989898/751bd2b6-688e-4acd-9ea8-a795aac09300">
<img width="606" alt="Screenshot 2023-09-27 at 10 48 13 AM" src="https://github.com/getsentry/sentry/assets/989898/3ba60256-4dc7-40fb-b4a6-c1433ec89ba3">
