### PR TITLE
feat(rca): Add span diff to issue details

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
@@ -17,7 +17,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 
-type SpanDiff = {
+interface SpanDiff {
   duration_after: number;
   duration_before: number;
   duration_delta: number;
@@ -29,9 +29,9 @@ type SpanDiff = {
   span_description: string;
   span_group: string;
   span_op: string;
-};
+}
 
-type DiffRowProps = {
+interface DiffRowProps {
   after: number;
   before: number;
   delta: number;
@@ -42,15 +42,15 @@ type DiffRowProps = {
   projectId: string;
   start: string;
   transaction: string;
-};
+}
 
-type UseFetchAdvancedAnalysisProps = {
+interface UseFetchAdvancedAnalysisProps {
   breakpoint: string;
   end: string;
   projectId: string;
   start: string;
   transaction: string;
-};
+}
 
 function useFetchAdvancedAnalysis({
   transaction,
@@ -132,7 +132,7 @@ function DiffRow({
         </Tooltip>
       </Label>
       <Tooltip
-        title={tct(`from [beforeDuration] to [afterDuration]`, {
+        title={tct(`From [beforeDuration] to [afterDuration]`, {
           beforeDuration: getDuration(before / 1000, 2, undefined, true),
           afterDuration: getDuration(after / 1000, 2, undefined, true),
         })}
@@ -145,14 +145,14 @@ function DiffRow({
   );
 }
 
-function SpanDiffs({event, projectId}) {
+function AggregateSpanDiff({event, projectId}) {
   const {transaction, requestStart, requestEnd, breakpoint} =
     event?.occurrence?.evidenceData;
 
   const start = new Date(requestStart * 1000).toISOString();
   const end = new Date(requestEnd * 1000).toISOString();
   const breakpointTimestamp = new Date(breakpoint * 1000).toISOString();
-  const {data, isLoading} = useFetchAdvancedAnalysis({
+  const {data, isLoading, isError} = useFetchAdvancedAnalysis({
     transaction,
     start,
     end,
@@ -165,7 +165,13 @@ function SpanDiffs({event, projectId}) {
   }
 
   let content;
-  if (!defined(data) || data.length === 0) {
+  if (isError) {
+    content = (
+      <EmptyStateWarning>
+        <p>{t('Oops! Something went wrong fetching span diffs')}</p>
+      </EmptyStateWarning>
+    );
+  } else if (!defined(data) || data.length === 0) {
     content = (
       <EmptyStateWarning>
         <p>{t('Unable to find significant differences in spans')}</p>
@@ -201,7 +207,7 @@ function SpanDiffs({event, projectId}) {
   );
 }
 
-export default SpanDiffs;
+export default AggregateSpanDiff;
 
 const Label = styled('div')`
   flex: auto;

--- a/static/app/components/events/eventStatisticalDetector/spanDiff.tsx
+++ b/static/app/components/events/eventStatisticalDetector/spanDiff.tsx
@@ -1,0 +1,227 @@
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import {DataSection} from 'sentry/components/events/styles';
+import Link from 'sentry/components/links/link';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import TextOverflow from 'sentry/components/textOverflow';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconAdd, IconSubtract} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import {getDuration} from 'sentry/utils/formatters';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
+
+type SpanDiff = {
+  duration_after: number;
+  duration_before: number;
+  duration_delta: number;
+  freq_after: number;
+  freq_before: number;
+  freq_delta: number;
+  sample_event_id: string;
+  score_delta: number;
+  span_description: string;
+  span_group: string;
+  span_op: string;
+};
+
+type DiffRowProps = {
+  after: number;
+  before: number;
+  delta: number;
+  end: string;
+  group: string;
+  label: string;
+  op: string;
+  projectId: string;
+  start: string;
+  transaction: string;
+};
+
+type UseFetchAdvancedAnalysisProps = {
+  breakpoint: string;
+  end: string;
+  projectId: string;
+  start: string;
+  transaction: string;
+};
+
+function useFetchAdvancedAnalysis({
+  transaction,
+  start,
+  end,
+  breakpoint,
+  projectId,
+}: UseFetchAdvancedAnalysisProps) {
+  const organization = useOrganization();
+  return useApiQuery<SpanDiff[]>(
+    [
+      `/organizations/${organization.slug}/events-root-cause-analysis/`,
+      {
+        query: {
+          transaction,
+          project: projectId,
+          start,
+          end,
+          breakpoint,
+          per_page: 10,
+        },
+      },
+    ],
+    {
+      staleTime: 60000,
+      retry: false,
+    }
+  );
+}
+
+function DiffRow({
+  delta,
+  label,
+  before,
+  after,
+  op,
+  group,
+  projectId,
+  transaction,
+  start,
+  end,
+}: DiffRowProps) {
+  const theme = useTheme();
+  const organization = useOrganization();
+  const location = useLocation();
+
+  const {background, color} =
+    delta > 0
+      ? {background: theme.red100, color: theme.red300}
+      : {background: theme.green100, color: theme.green300};
+  const Icon = delta > 0 ? IconAdd : IconSubtract;
+  return (
+    <Row backgroundColor={background}>
+      <IconWrapper color={color}>
+        <Icon />
+        <span style={{paddingLeft: '8px'}}>{t('Span')}</span>
+      </IconWrapper>
+      <Label>
+        <Tooltip title={label} showOnlyOnOverflow>
+          <TextOverflow>
+            <Link
+              to={spanDetailsRouteWithQuery({
+                orgSlug: organization.slug,
+                spanSlug: {op, group},
+                transaction,
+                projectID: projectId,
+                query: {
+                  ...location.query,
+                  statsPeriod: undefined,
+                  query: undefined,
+                  start,
+                  end,
+                },
+              })}
+            >
+              {label}
+            </Link>
+          </TextOverflow>
+        </Tooltip>
+      </Label>
+      <Tooltip
+        title={tct(`from [beforeDuration] to [afterDuration]`, {
+          beforeDuration: getDuration(before / 1000, 2, undefined, true),
+          afterDuration: getDuration(after / 1000, 2, undefined, true),
+        })}
+        showUnderline
+      >
+        {delta > 0 ? '+' : ''}
+        {delta.toFixed(2)}%
+      </Tooltip>
+    </Row>
+  );
+}
+
+function SpanDiffs({event, projectId}) {
+  const {transaction, requestStart, requestEnd, breakpoint} =
+    event?.occurrence?.evidenceData;
+
+  const start = new Date(requestStart * 1000).toISOString();
+  const end = new Date(requestEnd * 1000).toISOString();
+  const breakpointTimestamp = new Date(breakpoint * 1000).toISOString();
+  const {data, isLoading} = useFetchAdvancedAnalysis({
+    transaction,
+    start,
+    end,
+    breakpoint: breakpointTimestamp,
+    projectId,
+  });
+
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
+
+  let content;
+  if (!defined(data) || data.length === 0) {
+    content = (
+      <EmptyStateWarning>
+        <p>{t('Unable to find significant differences in spans')}</p>
+      </EmptyStateWarning>
+    );
+  } else {
+    content = data.map(diff => (
+      <DiffRow
+        key={`${diff.span_op}:${diff.span_group}`}
+        delta={diff.duration_delta * 100}
+        before={diff.duration_before}
+        after={diff.duration_after}
+        label={
+          diff.span_description
+            ? `${diff.span_op}: ${diff.span_description}`
+            : diff.span_op
+        }
+        op={diff.span_op}
+        group={diff.span_group}
+        projectId={projectId}
+        transaction={transaction}
+        start={start}
+        end={end}
+      />
+    ));
+  }
+
+  return (
+    <DataSection>
+      <strong>{t('Frequent Diffs:')}</strong>
+      {content}
+    </DataSection>
+  );
+}
+
+export default SpanDiffs;
+
+const Label = styled('div')`
+  flex: auto;
+  margin: 0 ${space(2)};
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const IconWrapper = styled('div')<{color: string}>`
+  display: flex;
+  align-items: center;
+  color: ${p => p.color};
+`;
+
+const Row = styled('div')<{backgroundColor: string}>`
+  background: ${p => p.backgroundColor};
+  padding: ${space(2)};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -15,11 +15,11 @@ import {EventEvidence} from 'sentry/components/events/eventEvidence';
 import {EventExtraData} from 'sentry/components/events/eventExtraData';
 import EventReplay from 'sentry/components/events/eventReplay';
 import {EventSdk} from 'sentry/components/events/eventSdk';
+import AggregateSpanDiff from 'sentry/components/events/eventStatisticalDetector/aggregateSpanDiff';
 import EventSpanOpBreakdown from 'sentry/components/events/eventStatisticalDetector/aggregateSpanOps/spanOpBreakdown';
 import EventBreakpointChart from 'sentry/components/events/eventStatisticalDetector/breakpointChart';
 import EventComparison from 'sentry/components/events/eventStatisticalDetector/eventComparison';
 import RegressionMessage from 'sentry/components/events/eventStatisticalDetector/regressionMessage';
-import SpanDiff from 'sentry/components/events/eventStatisticalDetector/spanDiff';
 import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScreenshot';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
 import {EventGroupingInfo} from 'sentry/components/events/groupingInfo';
@@ -115,7 +115,7 @@ function GroupEventDetailsContent({
             <EventSpanOpBreakdown event={event} />
           </ErrorBoundary>
           <ErrorBoundary mini>
-            <SpanDiff event={event} projectId={project.id} />
+            <AggregateSpanDiff event={event} projectId={project.id} />
           </ErrorBoundary>
           <ErrorBoundary mini>
             <EventComparison event={event} group={group} project={project} />

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -19,6 +19,7 @@ import EventSpanOpBreakdown from 'sentry/components/events/eventStatisticalDetec
 import EventBreakpointChart from 'sentry/components/events/eventStatisticalDetector/breakpointChart';
 import EventComparison from 'sentry/components/events/eventStatisticalDetector/eventComparison';
 import RegressionMessage from 'sentry/components/events/eventStatisticalDetector/regressionMessage';
+import SpanDiff from 'sentry/components/events/eventStatisticalDetector/spanDiff';
 import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScreenshot';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
 import {EventGroupingInfo} from 'sentry/components/events/groupingInfo';
@@ -112,6 +113,9 @@ function GroupEventDetailsContent({
           </ErrorBoundary>
           <ErrorBoundary mini>
             <EventSpanOpBreakdown event={event} />
+          </ErrorBoundary>
+          <ErrorBoundary mini>
+            <SpanDiff event={event} projectId={project.id} />
           </ErrorBoundary>
           <ErrorBoundary mini>
             <EventComparison event={event} group={group} project={project} />


### PR DESCRIPTION
Add UI for span diff. Since not all spans get a description, I opted for showing the span op AND the span description if possible

<img width="1315" alt="Screenshot 2023-09-27 at 10 54 51 AM" src="https://github.com/getsentry/sentry/assets/22846452/b6aa6029-17bb-4866-9eb9-8ae5fbd3e291">
