### PR TITLE
feat(stat-detectors): Convert RCA feature flag in endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -76,7 +76,7 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
 
     def get(self, request, organization):
         if not features.has(
-            "organizations:statistical-detectors-root-cause-analysis",
+            "organizations:performance-duration-regression-visible",
             organization,
             actor=request.user,
         ):

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1638,8 +1638,6 @@ SENTRY_FEATURES = {
     "organizations:performance-tracing-without-performance": False,
     # Enable database view powered by span metrics
     "organizations:performance-database-view": False,
-    # Enable root cause analysis for statistical detector perf issues
-    "organizations:statistical-detectors-root-cause-analysis": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,
     # Enable usage of external relays, for use with Relay. See

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -160,7 +160,6 @@ default_manager.add("organizations:performance-metrics-backed-transaction-summar
 default_manager.add("organizations:performance-slow-db-issue", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-tracing-without-performance", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-database-view", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:statistical-detectors-root-cause-analysis", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:profiling-view", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:profiling-ui-frames", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -9,9 +9,7 @@ from sentry.testutils.helpers.datetime import freeze_time, iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.samples import load_data
 
-ROOT_CAUSE_FEATURE_FLAG = "organizations:statistical-detectors-root-cause-analysis"
-
-FEATURES = [ROOT_CAUSE_FEATURE_FLAG]
+FEATURES = ["organizations:performance-duration-regression-visible"]
 
 pytestmark = [pytest.mark.sentry_metrics]
 


### PR DESCRIPTION
The root cause feature flag was added before issue creation. I'm swapping over to the statistical detector feature flag to ensure access is kept in sync