### PR TITLE
fix(starfish): Don't query for span.domain field for spans table

### DIFF
--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -72,7 +72,6 @@ function SpanSummaryPage({params}: Props) {
       SpanMetricsField.SPAN_OP,
       SpanMetricsField.SPAN_DESCRIPTION,
       SpanMetricsField.SPAN_ACTION,
-      SpanMetricsField.SPAN_DOMAIN,
       SpanMetricsField.SPAN_DOMAIN_ARRAY,
       'count()',
       `${SpanFunction.SPM}()`,
@@ -91,7 +90,7 @@ function SpanSummaryPage({params}: Props) {
     [SpanMetricsField.SPAN_OP]: string;
     [SpanMetricsField.SPAN_DESCRIPTION]: string;
     [SpanMetricsField.SPAN_ACTION]: string;
-    [SpanMetricsField.SPAN_DOMAIN]: string;
+    [SpanMetricsField.SPAN_DOMAIN_ARRAY]: string[];
     [SpanMetricsField.SPAN_GROUP]: string;
   };
 

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -15,7 +15,6 @@ const {
   SPAN_DESCRIPTION,
   SPAN_GROUP,
   SPAN_OP,
-  SPAN_DOMAIN,
   SPAN_DOMAIN_ARRAY,
   PROJECT_ID,
 } = SpanMetricsField;
@@ -25,7 +24,6 @@ export type SpanMetrics = {
   'http_error_count()': number;
   'project.id': number;
   'span.description': string;
-  'span.domain': string;
   'span.domain_array': Array<string>;
   'span.group': string;
   'span.op': string;
@@ -91,7 +89,6 @@ function getEventView(
     SPAN_OP,
     SPAN_GROUP,
     SPAN_DESCRIPTION,
-    SPAN_DOMAIN,
     SPAN_DOMAIN_ARRAY,
     'spm()',
     `sum(${SPAN_SELF_TIME})`,

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -37,9 +37,10 @@ export type SpanStringFields =
   | 'span.module'
   | 'span.action'
   | 'span.domain'
-  | 'span.domain_array'
   | 'span.group'
   | 'project.id';
+
+export type SpanArrayFields = 'span.domain_array';
 
 export type SpanFunctions =
   | 'sps'
@@ -56,6 +57,8 @@ export type MetricsResponse = {
   [Property in SpanFunctions as `${Property}()`]: number;
 } & {
   [Property in SpanStringFields as `${Property}`]: string;
+} & {
+  [Property in SpanArrayFields as `${Property}`]: string[];
 } & {
   'time_spent_percentage(local)': number;
 };
@@ -93,6 +96,7 @@ export type SpanIndexedFieldTypes = {
   [SpanIndexedField.TRANSACTION_METHOD]: string;
   [SpanIndexedField.TRANSACTION_OP]: string;
   [SpanIndexedField.SPAN_DOMAIN]: string;
+  [SpanIndexedField.SPAN_DOMAIN_ARRAY]: string[];
   [SpanIndexedField.TIMESTAMP]: string;
   [SpanIndexedField.PROJECT]: string;
 };

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
@@ -14,7 +14,7 @@ interface Props {
     [SpanMetricsField.SPAN_DESCRIPTION]?: string;
     [SpanMetricsField.SPAN_ACTION]?: string;
     [SpanMetricsField.SPAN_DOMAIN]?: string;
-    [SpanMetricsField.SPAN_DOMAIN_ARRAY]?: string;
+    [SpanMetricsField.SPAN_DOMAIN_ARRAY]?: string[];
     [SpanMetricsField.SPAN_GROUP]?: string;
   };
 }

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -74,7 +74,7 @@ export function SpanSummaryView({groupId}: Props) {
     [SpanMetricsField.SPAN_DESCRIPTION]: string;
     [SpanMetricsField.SPAN_ACTION]: string;
     [SpanMetricsField.SPAN_DOMAIN]: string;
-    [SpanMetricsField.SPAN_DOMAIN_ARRAY]: string;
+    [SpanMetricsField.SPAN_DOMAIN_ARRAY]: string[];
     [SpanMetricsField.SPAN_GROUP]: string;
   };
 

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -27,7 +27,6 @@ type Row = {
   'avg(span.self_time)': number;
   'http_error_count()': number;
   'span.description': string;
-  'span.domain': string;
   'span.domain_array': Array<string>;
   'span.group': string;
   'span.op': string;
@@ -48,7 +47,7 @@ type Props = {
   spanCategory?: string;
 };
 
-const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_DOMAIN, SPAN_GROUP, SPAN_OP, PROJECT_ID} =
+const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, PROJECT_ID} =
   SpanMetricsField;
 
 export default function SpansTable({
@@ -169,15 +168,6 @@ function renderBodyCell(
   return rendered;
 }
 
-function getDomainHeader(moduleName: ModuleName) {
-  if (moduleName === ModuleName.HTTP) {
-    return 'Host';
-  }
-  if (moduleName === ModuleName.DB) {
-    return 'Table';
-  }
-  return 'Domain';
-}
 function getDescriptionHeader(moduleName: ModuleName, spanCategory?: string) {
   if (moduleName === ModuleName.HTTP) {
     return 'URL Request';
@@ -210,8 +200,6 @@ function getColumns(
 ): Column[] {
   const description = getDescriptionHeader(moduleName, spanCategory);
 
-  const domain = getDomainHeader(moduleName);
-
   const order = [
     // We don't show the operation selector in specific modules, so there's no
     // point having that column
@@ -227,15 +215,6 @@ function getColumns(
       name: description,
       width: COL_WIDTH_UNDEFINED,
     },
-    ...(moduleName !== ModuleName.ALL && moduleName !== ModuleName.DB
-      ? [
-          {
-            key: SPAN_DOMAIN,
-            name: domain,
-            width: COL_WIDTH_UNDEFINED,
-          } as Column,
-        ]
-      : []),
     {
       key: 'spm()',
       name: getThroughputTitle(moduleName),


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/56494 we stopped using `span.domain`, so let's stop querying for it to render the spans table.

Once https://github.com/getsentry/sentry/pull/57028 merges in, we'll revert all of these changes and go back to relying on `span.domain`.

Endpoint details page breaks, but we'll be fixing this right afterwards.