### PR TITLE
fix(perf): Rename "Query Insights" in sidebar

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -234,9 +234,7 @@ function Sidebar({location, organization}: Props) {
                 isBeta={RELEASE_LEVEL === 'beta'}
                 isNew={RELEASE_LEVEL === 'new'}
                 label={
-                  <GuideAnchor target="performance-database">
-                    {t('Query Insights')}
-                  </GuideAnchor>
+                  <GuideAnchor target="performance-database">{t('Queries')}</GuideAnchor>
                 }
                 to={`/organizations/${organization.slug}/performance/database/`}
                 id="performance-database"

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -144,9 +144,9 @@ function SidebarItem({
 
   const badges = (
     <Fragment>
-      {showIsNew && <FeatureBadge type="new" variant="short" />}
-      {isBeta && <FeatureBadge type="beta" variant="short" />}
-      {isAlpha && <FeatureBadge type="alpha" variant="short" />}
+      {showIsNew && <FeatureBadge type="new" />}
+      {isBeta && <FeatureBadge type="beta" />}
+      {isAlpha && <FeatureBadge type="alpha" />}
     </Fragment>
   );
 


### PR DESCRIPTION
- Rename Query Insights to Queries, it's clearer
- Use full badges, since now there's plenty of room

**e.g.,**
<img width="224" alt="Screenshot 2023-09-27 at 11 56 33 AM" src="https://github.com/getsentry/sentry/assets/989898/e79ae8e5-d364-448d-ab42-a94dfb32e0fa">
