### PR TITLE
feat(starfish): Switch back to using `span.domain`

### DIFF
--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -75,7 +75,7 @@ function DatabaseLandingPage() {
 
             <DomainSelector
               moduleName={moduleName}
-              value={moduleFilters[SpanMetricsField.SPAN_DOMAIN_ARRAY] || ''}
+              value={moduleFilters[SpanMetricsField.SPAN_DOMAIN] || ''}
             />
           </FilterOptionsContainer>
 

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -72,7 +72,7 @@ function SpanSummaryPage({params}: Props) {
       SpanMetricsField.SPAN_OP,
       SpanMetricsField.SPAN_DESCRIPTION,
       SpanMetricsField.SPAN_ACTION,
-      SpanMetricsField.SPAN_DOMAIN_ARRAY,
+      SpanMetricsField.SPAN_DOMAIN,
       'count()',
       `${SpanFunction.SPM}()`,
       `sum(${SpanMetricsField.SPAN_SELF_TIME})`,
@@ -90,7 +90,7 @@ function SpanSummaryPage({params}: Props) {
     [SpanMetricsField.SPAN_OP]: string;
     [SpanMetricsField.SPAN_DESCRIPTION]: string;
     [SpanMetricsField.SPAN_ACTION]: string;
-    [SpanMetricsField.SPAN_DOMAIN_ARRAY]: string[];
+    [SpanMetricsField.SPAN_DOMAIN]: string[];
     [SpanMetricsField.SPAN_GROUP]: string;
   };
 

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -10,21 +10,15 @@ import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
-const {
-  SPAN_SELF_TIME,
-  SPAN_DESCRIPTION,
-  SPAN_GROUP,
-  SPAN_OP,
-  SPAN_DOMAIN_ARRAY,
-  PROJECT_ID,
-} = SpanMetricsField;
+const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, SPAN_DOMAIN, PROJECT_ID} =
+  SpanMetricsField;
 
 export type SpanMetrics = {
   'avg(span.self_time)': number;
   'http_error_count()': number;
   'project.id': number;
   'span.description': string;
-  'span.domain_array': Array<string>;
+  'span.domain': Array<string>;
   'span.group': string;
   'span.op': string;
   'spm()': number;
@@ -89,7 +83,7 @@ function getEventView(
     SPAN_OP,
     SPAN_GROUP,
     SPAN_DESCRIPTION,
-    SPAN_DOMAIN_ARRAY,
+    SPAN_DOMAIN,
     'spm()',
     `sum(${SPAN_SELF_TIME})`,
     `avg(${SPAN_SELF_TIME})`,

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -22,7 +22,6 @@ export enum SpanMetricsField {
   SPAN_MODULE = 'span.module',
   SPAN_ACTION = 'span.action',
   SPAN_DOMAIN = 'span.domain',
-  SPAN_DOMAIN_ARRAY = 'span.domain_array',
   SPAN_GROUP = 'span.group',
   SPAN_DURATION = 'span.duration',
   SPAN_SELF_TIME = 'span.self_time',
@@ -36,11 +35,10 @@ export type SpanStringFields =
   | 'span.description'
   | 'span.module'
   | 'span.action'
-  | 'span.domain'
   | 'span.group'
   | 'project.id';
 
-export type SpanArrayFields = 'span.domain_array';
+export type SpanStringArrayFields = 'span.domain';
 
 export type SpanFunctions =
   | 'sps'
@@ -58,7 +56,7 @@ export type MetricsResponse = {
 } & {
   [Property in SpanStringFields as `${Property}`]: string;
 } & {
-  [Property in SpanArrayFields as `${Property}`]: string[];
+  [Property in SpanStringArrayFields as `${Property}`]: string[];
 } & {
   'time_spent_percentage(local)': number;
 };
@@ -78,7 +76,6 @@ export enum SpanIndexedField {
   TRANSACTION_METHOD = 'transaction.method',
   TRANSACTION_OP = 'transaction.op',
   SPAN_DOMAIN = 'span.domain',
-  SPAN_DOMAIN_ARRAY = 'span.domain_array',
   TIMESTAMP = 'timestamp',
   PROJECT = 'project',
 }
@@ -95,8 +92,7 @@ export type SpanIndexedFieldTypes = {
   [SpanIndexedField.TRANSACTION_ID]: string;
   [SpanIndexedField.TRANSACTION_METHOD]: string;
   [SpanIndexedField.TRANSACTION_OP]: string;
-  [SpanIndexedField.SPAN_DOMAIN]: string;
-  [SpanIndexedField.SPAN_DOMAIN_ARRAY]: string[];
+  [SpanIndexedField.SPAN_DOMAIN]: string[];
   [SpanIndexedField.TIMESTAMP]: string;
   [SpanIndexedField.PROJECT]: string;
 };

--- a/static/app/views/starfish/utils/buildEventViewQuery.tsx
+++ b/static/app/views/starfish/utils/buildEventViewQuery.tsx
@@ -5,19 +5,12 @@ import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 import {NULL_SPAN_CATEGORY} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
-const {
-  SPAN_DESCRIPTION,
-  SPAN_OP,
-  SPAN_DOMAIN,
-  SPAN_ACTION,
-  SPAN_MODULE,
-  SPAN_DOMAIN_ARRAY,
-} = SpanMetricsField;
+const {SPAN_DESCRIPTION, SPAN_OP, SPAN_DOMAIN, SPAN_ACTION, SPAN_MODULE} =
+  SpanMetricsField;
 
 const SPAN_FILTER_KEYS = [
   SPAN_OP,
   SPAN_DOMAIN,
-  SPAN_DOMAIN_ARRAY,
   SPAN_ACTION,
   `!${SPAN_MODULE}`,
   '!span.category',

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
@@ -13,8 +13,7 @@ interface Props {
     [SpanMetricsField.SPAN_OP]?: string;
     [SpanMetricsField.SPAN_DESCRIPTION]?: string;
     [SpanMetricsField.SPAN_ACTION]?: string;
-    [SpanMetricsField.SPAN_DOMAIN]?: string;
-    [SpanMetricsField.SPAN_DOMAIN_ARRAY]?: string[];
+    [SpanMetricsField.SPAN_DOMAIN]?: string[];
     [SpanMetricsField.SPAN_GROUP]?: string;
   };
 }

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -55,7 +55,6 @@ export function SpanSummaryView({groupId}: Props) {
       SpanMetricsField.SPAN_DESCRIPTION,
       SpanMetricsField.SPAN_ACTION,
       SpanMetricsField.SPAN_DOMAIN,
-      SpanMetricsField.SPAN_DOMAIN_ARRAY,
       'count()',
       `${SpanFunction.SPM}()`,
       `sum(${SpanMetricsField.SPAN_SELF_TIME})`,
@@ -73,8 +72,7 @@ export function SpanSummaryView({groupId}: Props) {
     [SpanMetricsField.SPAN_OP]: string;
     [SpanMetricsField.SPAN_DESCRIPTION]: string;
     [SpanMetricsField.SPAN_ACTION]: string;
-    [SpanMetricsField.SPAN_DOMAIN]: string;
-    [SpanMetricsField.SPAN_DOMAIN_ARRAY]: string[];
+    [SpanMetricsField.SPAN_DOMAIN]: string[];
     [SpanMetricsField.SPAN_GROUP]: string;
   };
 

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -45,7 +45,7 @@ export function DomainSelector({
   const eventView = getEventView(location, moduleName, spanCategory, state.search);
 
   const {data: domains, isLoading} = useSpansQuery<
-    Array<{[SpanMetricsField.SPAN_DOMAIN_ARRAY]: Array<string>}>
+    Array<{[SpanMetricsField.SPAN_DOMAIN]: Array<string>}>
   >({
     eventView,
     initialData: [],
@@ -55,7 +55,7 @@ export function DomainSelector({
 
   const transformedDomains = Array.from(
     domains?.reduce((acc, curr) => {
-      const spanDomainArray = curr[SpanMetricsField.SPAN_DOMAIN_ARRAY];
+      const spanDomainArray = curr[SpanMetricsField.SPAN_DOMAIN];
       if (spanDomainArray) {
         spanDomainArray.forEach(name => acc.add(name));
       }
@@ -128,7 +128,7 @@ export function DomainSelector({
           ...location,
           query: {
             ...location.query,
-            [SpanMetricsField.SPAN_DOMAIN_ARRAY]: newValue.value,
+            [SpanMetricsField.SPAN_DOMAIN]: newValue.value,
           },
         });
       }}
@@ -155,18 +155,18 @@ function getEventView(
       moduleName,
       location: {
         ...location,
-        query: omit(location.query, SpanMetricsField.SPAN_DOMAIN_ARRAY),
+        query: omit(location.query, SpanMetricsField.SPAN_DOMAIN),
       },
       spanCategory,
     }),
     ...(search && search.length > 0
-      ? [`${SpanMetricsField.SPAN_DOMAIN_ARRAY}:*${[search]}*`]
+      ? [`${SpanMetricsField.SPAN_DOMAIN}:*${[search]}*`]
       : []),
   ].join(' ');
   return EventView.fromNewQueryWithLocation(
     {
       name: '',
-      fields: [SpanMetricsField.SPAN_DOMAIN_ARRAY, 'count()'],
+      fields: [SpanMetricsField.SPAN_DOMAIN, 'count()'],
       orderby: '-count',
       query,
       dataset: DiscoverDatasets.SPANS_METRICS,

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -27,7 +27,7 @@ type Row = {
   'avg(span.self_time)': number;
   'http_error_count()': number;
   'span.description': string;
-  'span.domain_array': Array<string>;
+  'span.domain': Array<string>;
   'span.group': string;
   'span.op': string;
   'spm()': number;
@@ -47,7 +47,7 @@ type Props = {
   spanCategory?: string;
 };
 
-const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, PROJECT_ID} =
+const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, PROJECT_ID, SPAN_DOMAIN} =
   SpanMetricsField;
 
 export default function SpansTable({
@@ -168,6 +168,16 @@ function renderBodyCell(
   return rendered;
 }
 
+function getDomainHeader(moduleName: ModuleName) {
+  if (moduleName === ModuleName.HTTP) {
+    return 'Host';
+  }
+  if (moduleName === ModuleName.DB) {
+    return 'Table';
+  }
+  return 'Domain';
+}
+
 function getDescriptionHeader(moduleName: ModuleName, spanCategory?: string) {
   if (moduleName === ModuleName.HTTP) {
     return 'URL Request';
@@ -199,6 +209,7 @@ function getColumns(
   transaction?: string
 ): Column[] {
   const description = getDescriptionHeader(moduleName, spanCategory);
+  const domain = getDomainHeader(moduleName);
 
   const order = [
     // We don't show the operation selector in specific modules, so there's no
@@ -215,6 +226,15 @@ function getColumns(
       name: description,
       width: COL_WIDTH_UNDEFINED,
     },
+    ...(moduleName !== ModuleName.ALL && moduleName !== ModuleName.DB
+      ? [
+          {
+            key: SPAN_DOMAIN,
+            name: domain,
+            width: COL_WIDTH_UNDEFINED,
+          } as Column,
+        ]
+      : []),
     {
       key: 'spm()',
       name: getThroughputTitle(moduleName),

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -13,7 +13,7 @@ import {useModuleSort} from 'sentry/views/starfish/views/spans/useModuleSort';
 
 import SpansTable from './spansTable';
 
-const {SPAN_ACTION, SPAN_DOMAIN_ARRAY, SPAN_OP} = SpanMetricsField;
+const {SPAN_ACTION, SPAN_DOMAIN, SPAN_OP} = SpanMetricsField;
 
 const LIMIT: number = 25;
 
@@ -56,7 +56,7 @@ export default function SpansView(props: Props) {
 
         <DomainSelector
           moduleName={moduleName}
-          value={moduleFilters[SPAN_DOMAIN_ARRAY] || ''}
+          value={moduleFilters[SPAN_DOMAIN] || ''}
           spanCategory={props.spanCategory}
         />
       </FilterOptionsContainer>

--- a/static/app/views/starfish/views/spans/useModuleFilters.ts
+++ b/static/app/views/starfish/views/spans/useModuleFilters.ts
@@ -6,7 +6,6 @@ import {SpanMetricsField} from 'sentry/views/starfish/types';
 export type ModuleFilters = {
   [SpanMetricsField.SPAN_ACTION]?: string;
   [SpanMetricsField.SPAN_DOMAIN]?: string;
-  [SpanMetricsField.SPAN_DOMAIN_ARRAY]?: string;
   [SpanMetricsField.SPAN_GROUP]?: string;
   [SpanMetricsField.SPAN_OP]?: string;
 };
@@ -17,7 +16,6 @@ export const useModuleFilters = () => {
   return pick(location.query, [
     SpanMetricsField.SPAN_ACTION,
     SpanMetricsField.SPAN_DOMAIN,
-    SpanMetricsField.SPAN_DOMAIN_ARRAY,
     SpanMetricsField.SPAN_OP,
     SpanMetricsField.SPAN_GROUP,
   ]);


### PR DESCRIPTION
Now that https://github.com/getsentry/sentry/pull/57028 has merged in, we can soft-revert the changes in https://github.com/getsentry/sentry/pull/56494 and https://github.com/getsentry/sentry/pull/57031 to use the arrayifyed `span.domain` everywhere.