### PR TITLE
feat(discord): Add serializers and trigger actions for Discord metric alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -483,7 +483,6 @@ module = [
     "sentry.integrations.slack.client",
     "sentry.integrations.slack.integration",
     "sentry.integrations.slack.message_builder.issues",
-    "sentry.integrations.slack.message_builder.metric_alerts",
     "sentry.integrations.slack.message_builder.notifications.digest",
     "sentry.integrations.slack.message_builder.notifications.issues",
     "sentry.integrations.slack.notifications",

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -22,6 +22,8 @@ class AlertRuleTriggerActionSerializer(Serializer):
             return "Send a notification via " + action.target_display
         elif action.type == action.Type.OPSGENIE.value:
             return "Send an Opsgenie notification to " + action.target_display
+        elif action.type == action.Type.DISCORD.value:
+            return "Send a Discord notification to " + action.target_display
 
     def get_identifier_from_action(self, action):
         if action.type in [

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -259,6 +259,32 @@ class MsTeamsActionHandler(DefaultActionHandler):
 
 
 @AlertRuleTriggerAction.register_type(
+    "discord",
+    AlertRuleTriggerAction.Type.DISCORD,
+    [AlertRuleTriggerAction.TargetType.SPECIFIC],
+    integration_provider="discord",
+)
+class DiscordActionHandler(DefaultActionHandler):
+    provider = "discord"
+
+    def send_alert(
+        self,
+        metric_value: int | float,
+        new_status: IncidentStatus,
+        notification_uuid: str | None = None,
+    ):
+        from sentry.integrations.discord.actions.metric_alert import (
+            send_incident_alert_notification,
+        )
+
+        success = send_incident_alert_notification(
+            self.action, self.incident, metric_value, new_status, notification_uuid
+        )
+        if success:
+            self.record_alert_sent_analytics(self.action.target_identifier, notification_uuid)
+
+
+@AlertRuleTriggerAction.register_type(
     "pagerduty",
     AlertRuleTriggerAction.Type.PAGERDUTY,
     [AlertRuleTriggerAction.TargetType.SPECIFIC],

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -116,6 +116,11 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                 raise serializers.ValidationError(
                     {"integration": "Integration must be provided for slack"}
                 )
+        elif attrs.get("type") == AlertRuleTriggerAction.Type.DISCORD:
+            if not attrs.get("integration_id"):
+                raise serializers.ValidationError(
+                    {"integration": "Integration must be provided for discord"}
+                )
 
         elif attrs.get("type") == AlertRuleTriggerAction.Type.SENTRY_APP:
             sentry_app_installation_uuid = attrs.get("sentry_app_installation_uuid")

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sentry_sdk
+
+from sentry import features
+from sentry.incidents.charts import build_metric_alert_chart
+from sentry.incidents.models import AlertRuleTriggerAction, Incident, IncidentStatus
+from sentry.integrations.discord.client import DiscordClient
+from sentry.integrations.discord.message_builder.metric_alerts import (
+    DiscordMetricAlertMessageBuilder,
+)
+from sentry.shared_integrations.exceptions.base import ApiError
+
+from ..utils import logger
+
+
+def send_incident_alert_notification(
+    action: AlertRuleTriggerAction,
+    incident: Incident,
+    metric_value: int,
+    new_status: IncidentStatus,
+    notification_uuid: str | None = None,
+) -> None:
+    chart_url = None
+    if features.has("organizations:metric-alert-chartcuterie", incident.organization):
+        try:
+            chart_url = build_metric_alert_chart(
+                organization=incident.organization,
+                alert_rule=incident.alert_rule,
+                selected_incident=incident,
+            )
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+
+    channel = action.target_identifier
+
+    if not channel:
+        # We can't send a message if we don't know the channel
+        logger.warning(
+            "discord.metric_alert.no_channel",
+            extra={"guild_id": incident.identifier},
+        )
+        return
+
+    message = DiscordMetricAlertMessageBuilder(
+        incident.alert_rule, incident, new_status, metric_value, chart_url, notification_uuid
+    )
+
+    client = DiscordClient(integration_id=incident.identifier)
+    try:
+        client.send_message(channel, message)
+    except ApiError as error:
+        logger.warning(
+            "discord.metric_alert.messsage_send_failure",
+            extra={"error": error, "guild_id": incident.identifier, "channel_id": channel},
+        )

--- a/src/sentry/integrations/discord/message_builder/base/embed/__init__.py
+++ b/src/sentry/integrations/discord/message_builder/base/embed/__init__.py
@@ -1,3 +1,4 @@
 from .base import *  # noqa: F401,F403
 from .field import *  # noqa: F401,F403
 from .footer import *  # noqa: F401,F403
+from .image import *  # noqa: F401,F403

--- a/src/sentry/integrations/discord/message_builder/base/embed/base.py
+++ b/src/sentry/integrations/discord/message_builder/base/embed/base.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from sentry.integrations.discord.message_builder.base.embed.field import DiscordMessageEmbedField
 from sentry.integrations.discord.message_builder.base.embed.footer import DiscordMessageEmbedFooter
+from sentry.integrations.discord.message_builder.base.embed.image import DiscordMessageEmbedImage
 
 
 class DiscordMessageEmbed:
@@ -25,6 +26,7 @@ class DiscordMessageEmbed:
         footer: DiscordMessageEmbedFooter | None = None,
         fields: Iterable[DiscordMessageEmbedField] | None = None,
         timestamp: datetime | None = None,
+        image: DiscordMessageEmbedImage | None = None,
     ) -> None:
         self.title = title
         self.description = description
@@ -33,6 +35,7 @@ class DiscordMessageEmbed:
         self.footer = footer
         self.fields = fields
         self.timestamp = timestamp
+        self.image = image
 
     def build(self) -> dict[str, object]:
         attributes = vars(self).items()
@@ -46,5 +49,8 @@ class DiscordMessageEmbed:
 
         if self.timestamp is not None:
             embed["timestamp"] = self.timestamp.isoformat()
+
+        if self.image is not None:
+            embed["image"] = self.image.build()
 
         return embed

--- a/src/sentry/integrations/discord/message_builder/base/embed/image.py
+++ b/src/sentry/integrations/discord/message_builder/base/embed/image.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+class DiscordMessageEmbedImage:
+    def __init__(
+        self,
+        url: str,
+        proxy_url: str | None = None,
+        height: int | None = None,
+        width: int | None = None,
+    ) -> None:
+        self.url = url
+        self.proxy_url = proxy_url
+        self.height = height
+        self.width = width
+
+    def build(self) -> dict[str, str]:
+        attributes = vars(self).items()
+        return {k: v for k, v in attributes if v}

--- a/src/sentry/integrations/discord/message_builder/metric_alerts.py
+++ b/src/sentry/integrations/discord/message_builder/metric_alerts.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import time
+from datetime import datetime
+from typing import Optional
+
+from sentry.incidents.models import AlertRule, Incident, IncidentStatus
+from sentry.integrations.discord.message_builder import INCIDENT_COLOR_MAPPING, LEVEL_TO_COLOR
+from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
+from sentry.integrations.discord.message_builder.base.embed.base import DiscordMessageEmbed
+from sentry.integrations.discord.message_builder.base.embed.image import DiscordMessageEmbedImage
+from sentry.integrations.metric_alerts import metric_alert_attachment_info
+from sentry.integrations.slack.utils.escape import escape_slack_text
+
+
+class DiscordMetricAlertMessageBuilder(DiscordMessageBuilder):
+    def __init__(
+        self,
+        alert_rule: AlertRule,
+        incident: Optional[Incident] = None,
+        new_status: Optional[IncidentStatus] = None,
+        metric_value: Optional[int] = None,
+        chart_url: Optional[str] = None,
+        notification_uuid: str | None = None,
+    ) -> None:
+        self.alert_rule = alert_rule
+        self.incident = incident
+        self.metric_value = metric_value
+        self.new_status = new_status
+        self.chart_url = chart_url
+        self.notification_uuid = notification_uuid
+
+    def build(self, notification_uuid: str | None = None) -> dict[str, object]:
+        data = metric_alert_attachment_info(
+            self.alert_rule, self.incident, self.new_status, self.metric_value
+        )
+
+        embeds = [
+            DiscordMessageEmbed(
+                title=data["title"],
+                url=f"{data['title_link']}&referrer=discord",
+                description=f"<{data['title_link']}|*{escape_slack_text(data['title'])}*>  \n{data['text']}",
+                color=LEVEL_TO_COLOR[INCIDENT_COLOR_MAPPING.get(data["status"], "")],
+                image=DiscordMessageEmbedImage(self.chart_url) if self.chart_url else None,
+            )
+        ]
+
+        return self._build(embeds=embeds)
+
+
+def get_started_at(timestamp: datetime) -> str:
+    unix_timestamp = int(time.mktime(timestamp.timetuple()))
+    return f"Started <t:{unix_timestamp}:R>"

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -149,7 +149,7 @@ def metric_alert_attachment_info(
     alert_rule: AlertRule,
     selected_incident: Optional[Incident] = None,
     new_status: Optional[IncidentStatus] = None,
-    metric_value: Optional[str] = None,
+    metric_value: Optional[int] = None,
 ):
     latest_incident = None
     if selected_incident is None:

--- a/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
@@ -1,7 +1,10 @@
+import responses
+
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import create_alert_rule_trigger, create_alert_rule_trigger_action
 from sentry.incidents.models import AlertRuleTriggerAction
 from sentry.incidents.serializers import ACTION_TARGET_TYPE_TO_STRING
+from sentry.models.integrations.integration import Integration
 from sentry.testutils.cases import TestCase
 
 
@@ -34,3 +37,40 @@ class AlertRuleTriggerActionSerializerTest(TestCase):
         )
         result = serialize(action)
         self.assert_action_serialized(action, result)
+        assert result["desc"] == action.target_display
+
+    @responses.activate
+    def test_discord(self):
+        base_url: str = "https://discord.com/api/v10"
+        responses.add(
+            method=responses.GET,
+            url=f"{base_url}/channels/channel-id",
+            json={
+                "guild_id": "guild_id",
+                "name": "guild_id",
+            },
+        )
+
+        alert_rule = self.create_alert_rule()
+        integration = Integration.objects.create(
+            provider="discord",
+            name="Example Discord",
+            external_id="guild_id",
+            metadata={
+                "guild_id": "guild_id",
+                "name": "guild_name",
+            },
+        )
+        trigger = create_alert_rule_trigger(alert_rule, "hi", 1000)
+        with self.feature("organizations:integrations-discord-metric-alerts"):
+            action = create_alert_rule_trigger_action(
+                trigger,
+                AlertRuleTriggerAction.Type.DISCORD,
+                AlertRuleTriggerAction.TargetType.SPECIFIC,
+                target_identifier="channel-id",
+                integration_id=integration.id,
+            )
+
+        result = serialize(action)
+        self.assert_action_serialized(action, result)
+        assert str(action.target_display) in result["desc"]

--- a/tests/sentry/integrations/discord/test_message_builder.py
+++ b/tests/sentry/integrations/discord/test_message_builder.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from django.urls import reverse
+
+from sentry.eventstore.models import Event
+from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
+from sentry.incidents.models import IncidentStatus
+from sentry.integrations.discord.message_builder import LEVEL_TO_COLOR
+from sentry.integrations.discord.message_builder.metric_alerts import (
+    DiscordMetricAlertMessageBuilder,
+)
+from sentry.models import Group, Team, User
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+from sentry.utils.dates import to_timestamp
+from sentry.utils.http import absolute_uri
+
+
+def build_test_message(
+    teams: set[Team],
+    users: set[User],
+    timestamp: datetime,
+    group: Group,
+    event: Event | None = None,
+    link_to_event: bool = False,
+) -> dict[str, Any]:
+    project = group.project
+
+    title = group.title
+    title_link = f"http://testserver/organizations/{project.organization.slug}/issues/{group.id}"
+    if event:
+        title = event.title
+        if link_to_event:
+            title_link += f"/events/{event.event_id}"
+    title_link += "/?referrer=discord"
+
+    return {
+        "text": "",
+        "color": "#E03E2F",  # red for error level
+        "actions": [
+            {"name": "status", "text": "Resolve", "type": "button", "value": "resolved"},
+            {"name": "status", "text": "Ignore", "type": "button", "value": "ignored:forever"},
+            {
+                "option_groups": [
+                    {
+                        "text": "Teams",
+                        "options": [
+                            {"text": f"#{team.slug}", "value": f"team:{team.id}"} for team in teams
+                        ],
+                    },
+                    {
+                        "text": "People",
+                        "options": [
+                            {
+                                "text": user.email,
+                                "value": f"user:{user.id}",
+                            }
+                            for user in users
+                        ],
+                    },
+                ],
+                "text": "Select Assignee...",
+                "selected_options": [],
+                "type": "select",
+                "name": "assign",
+            },
+        ],
+        "mrkdwn_in": ["text"],
+        "title": title,
+        "fields": [],
+        "footer": f"{project.slug.upper()}-1",
+        "ts": to_timestamp(timestamp),
+        "title_link": title_link,
+        "callback_id": '{"issue":' + str(group.id) + "}",
+        "fallback": f"[{project.slug}] {title}",
+        "footer_icon": "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
+    }
+
+
+@region_silo_test(stable=True)
+class BuildMetricAlertAttachmentTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.alert_rule = self.create_alert_rule()
+
+    def test_metric_alert_without_incidents(self):
+        title = f"Resolved: {self.alert_rule.name}"
+        link = absolute_uri(
+            reverse(
+                "sentry-metric-alert-details",
+                kwargs={
+                    "organization_slug": self.alert_rule.organization.slug,
+                    "alert_rule_id": self.alert_rule.id,
+                },
+            )
+        )
+        assert DiscordMetricAlertMessageBuilder(self.alert_rule).build() == {
+            "content": "",
+            "embeds": [
+                {
+                    "title": title,
+                    "description": f"<{link}|*{title}*>  \n",
+                    "url": f"{link}&referrer=discord",
+                    "color": LEVEL_TO_COLOR["_incident_resolved"],
+                }
+            ],
+            "components": [],
+        }
+
+    def test_metric_alert_with_selected_incident(self):
+        new_status = IncidentStatus.CLOSED.value
+        incident = self.create_incident(alert_rule=self.alert_rule, status=new_status)
+        trigger = self.create_alert_rule_trigger(self.alert_rule, CRITICAL_TRIGGER_LABEL, 100)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+        title = f"Resolved: {self.alert_rule.name}"
+        link = (
+            absolute_uri(
+                reverse(
+                    "sentry-metric-alert-details",
+                    kwargs={
+                        "organization_slug": self.alert_rule.organization.slug,
+                        "alert_rule_id": self.alert_rule.id,
+                    },
+                )
+            )
+            + f"?alert={incident.identifier}"
+        )
+
+        assert DiscordMetricAlertMessageBuilder(self.alert_rule, incident).build() == {
+            "content": "",
+            "embeds": [
+                {
+                    "title": title,
+                    "description": f"<{link}|*{title}*>  \n",
+                    "url": f"{link}&referrer=discord",
+                    "color": LEVEL_TO_COLOR["_incident_resolved"],
+                }
+            ],
+            "components": [],
+        }
+
+    def test_metric_alert_with_active_incident(self):
+        incident = self.create_incident(
+            alert_rule=self.alert_rule, status=IncidentStatus.CRITICAL.value
+        )
+        trigger = self.create_alert_rule_trigger(self.alert_rule, CRITICAL_TRIGGER_LABEL, 100)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+        title = f"Critical: {self.alert_rule.name}"
+        link = absolute_uri(
+            reverse(
+                "sentry-metric-alert-details",
+                kwargs={
+                    "organization_slug": self.alert_rule.organization.slug,
+                    "alert_rule_id": self.alert_rule.id,
+                },
+            )
+        )
+
+        assert DiscordMetricAlertMessageBuilder(self.alert_rule).build() == {
+            "content": "",
+            "embeds": [
+                {
+                    "color": LEVEL_TO_COLOR["fatal"],
+                    "title": title,
+                    "description": f"<{link}|*{title}*>  \n0 events in the last 10 minutes",
+                    "url": f"{link}&referrer=discord",
+                }
+            ],
+            "components": [],
+        }
+
+    def test_metric_value(self):
+        incident = self.create_incident(
+            alert_rule=self.alert_rule, status=IncidentStatus.CLOSED.value
+        )
+
+        # This test will use the action/method and not the incident to build status
+        title = f"Critical: {self.alert_rule.name}"
+        metric_value = 5000
+        trigger = self.create_alert_rule_trigger(self.alert_rule, CRITICAL_TRIGGER_LABEL, 100)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+        link = absolute_uri(
+            reverse(
+                "sentry-metric-alert-details",
+                kwargs={
+                    "organization_slug": self.alert_rule.organization.slug,
+                    "alert_rule_id": self.alert_rule.id,
+                },
+            )
+        )
+        assert DiscordMetricAlertMessageBuilder(
+            self.alert_rule, incident, IncidentStatus.CRITICAL, metric_value=metric_value
+        ).build() == {
+            "content": "",
+            "embeds": [
+                {
+                    "title": title,
+                    "color": LEVEL_TO_COLOR["fatal"],
+                    "description": f"<{link}?alert={incident.identifier}|*{title}*>  \n"
+                    f"{metric_value} events in the last 10 minutes",
+                    "url": f"{link}?alert={incident.identifier}&referrer=discord",
+                }
+            ],
+            "components": [],
+        }
+
+    def test_metric_alert_chart(self):
+        title = f"Resolved: {self.alert_rule.name}"
+        link = absolute_uri(
+            reverse(
+                "sentry-metric-alert-details",
+                kwargs={
+                    "organization_slug": self.alert_rule.organization.slug,
+                    "alert_rule_id": self.alert_rule.id,
+                },
+            )
+        )
+        incident = self.create_incident(
+            alert_rule=self.alert_rule, status=IncidentStatus.OPEN.value
+        )
+        new_status = IncidentStatus.CLOSED
+        assert DiscordMetricAlertMessageBuilder(
+            self.alert_rule, incident, new_status, chart_url="chart_url"
+        ).build() == {
+            "content": "",
+            "embeds": [
+                {
+                    "title": title,
+                    "description": f"<{link}?alert={incident.identifier}|*{title}*>  \n",
+                    "url": f"{link}?alert={incident.identifier}&referrer=discord",
+                    "color": 5097329,
+                    "image": {"url": "chart_url"},
+                }
+            ],
+            "components": [],
+        }


### PR DESCRIPTION
Split from https://github.com/getsentry/sentry/pull/55928

The overall feature has been tested and approved.