### PR TITLE
chore: Make sure all statistical detector tasks are disabled with option

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -149,6 +149,9 @@ def detect_transaction_trends(
 def detect_transaction_change_points(
     transactions: List[Tuple[int, str | int]], start: datetime, *args, **kwargs
 ) -> None:
+    if not options.get("statistical_detectors.enable"):
+        return
+
     for project_id, transaction in transactions:
         with sentry_sdk.push_scope() as scope:
             scope.set_tag("regressed_project_id", project_id)
@@ -265,6 +268,9 @@ def detect_function_trends(project_ids: List[int], start: datetime, *args, **kwa
 def detect_function_change_points(
     functions_list: List[Tuple[int, int]], start: datetime, *args, **kwargs
 ) -> None:
+    if not options.get("statistical_detectors.enable"):
+        return
+
     breakpoint_count = 0
     emitted_count = 0
 

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -341,7 +341,8 @@ def test_detect_function_change_points(
         ]
     }
 
-    detect_function_change_points([(project.id, fingerprint)], timestamp)
+    with override_options({"statistical_detectors.enable": True}):
+        detect_function_change_points([(project.id, fingerprint)], timestamp)
     assert mock_emit_function_regression_issue.called
 
 


### PR DESCRIPTION
This was missed in a few of the tasks but make sure when the option is disabled, every related task will be disabled.
