### PR TITLE
chore(open-source): Fix product owner script

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -84,7 +84,6 @@ body:
         - 'Footer'
         - 'APIs'
         - 'Org Relocation'
-        - 'Unknown'
         - 'Other'
         # end product areas
     validations:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -68,7 +68,6 @@ body:
         - 'Footer'
         - 'APIs'
         - 'Org Relocation'
-        - 'Unknown'
         - 'Other'
         # end product areas
     validations:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -248,8 +248,6 @@
   color: '8D5494'
 - name: 'Product Area: Org Relocation'
   color: '8D5494'
-- name: 'Product Area: Unknown'
-  color: '8D5494'
 - name: 'Product Area: Other'
   color: '8D5494'
 

--- a/bin/react-to-product-owners-yml-changes.py
+++ b/bin/react-to-product-owners-yml-changes.py
@@ -50,11 +50,14 @@ def main():
         current.append(line)
 
     for area in areas:
-        if "'" in area:
-            area_lines.append(f'- name: "Product Area: {area}"\n')
-        else:
-            area_lines.append(f"- name: 'Product Area: {area}'\n")
-        area_lines.append("  color: '8D5494'\n")
+        # These are specifically placed at the front and end of the list of product areas.
+        # They will always exist, so ignore what is coming in from security-as-code as a workaround.
+        if area != "Other" and area != "Unknown":
+            if "'" in area:
+                area_lines.append(f'- name: "Product Area: {area}"\n')
+            else:
+                area_lines.append(f"- name: 'Product Area: {area}'\n")
+            area_lines.append("  color: '8D5494'\n")
 
     area_lines += ["- name: 'Product Area: Other'\n", "  color: '8D5494'\n"]
 
@@ -84,10 +87,11 @@ def main():
                 current.append(line)
 
         for area in areas:
-            if "'" in area:
-                area_lines.append(f'        - "{area}"\n')
-            else:
-                area_lines.append(f"        - '{area}'\n")
+            if area != "Other" and area != "Unknown":
+                if "'" in area:
+                    area_lines.append(f'        - "{area}"\n')
+                else:
+                    area_lines.append(f"        - '{area}'\n")
 
         area_lines += ["        - 'Other'\n", END]
 


### PR DESCRIPTION
Product Areas Unknown and Other need to be at the front and bottom of the product areas list respectively. They are now mapped to team-ospo in security-as-code, so let's not repeat those values here and preserve the order with this workaround.