### PR TITLE
fix(jira server): Always try again if issuetypes fails

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -705,10 +705,9 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
         project_id = params.get("project", defaults.get("project"))
         jira_projects = self.get_projects()
 
-        try_other_projects = False
+        try_other_projects = True
         if not project_id:
             project_id = jira_projects[0]["id"]
-            try_other_projects = True
 
         logger.info(
             "get_create_issue_config.start",


### PR DESCRIPTION
For customers who do have a default Jira project, we're currently not falling into the block where we try again with another project from the list of project if getting the issue types fails. This changes that so we always attempt again. 