### PR TITLE
nit(api): Allow build-list type to be any 

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from drf_spectacular.plumbing import build_array_type, build_basic_type
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
@@ -8,7 +10,7 @@ from rest_framework import serializers
 
 # drf-spectacular doesn't support a list type in it's OpenApiTypes, so we manually build
 # a typed list using this workaround
-def build_typed_list(type: OpenApiTypes):
+def build_typed_list(type: Any):
     return build_array_type(build_basic_type(type))
 
 


### PR DESCRIPTION
`build_basic_type` can take in native python types too so I shouldn't restrict it to OpenApiTypes only