### PR TITLE
feat(ddm): Add METRIC as a search type

### DIFF
--- a/src/sentry/models/search_common.py
+++ b/src/sentry/models/search_common.py
@@ -6,3 +6,4 @@ class SearchType(IntEnum):
     EVENT = 1
     SESSION = 2
     REPLAY = 3
+    METRIC = 4

--- a/tests/sentry/api/endpoints/test_organization_recent_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_recent_searches.py
@@ -62,6 +62,14 @@ class RecentSearchesListTest(APITestCase):
             last_seen=timezone.now(),
             date_added=timezone.now(),
         )
+        metric_recent_search = RecentSearch.objects.create(
+            organization=self.organization,
+            user_id=self.user.id,
+            type=SearchType.METRIC.value,
+            query="some test",
+            last_seen=timezone.now(),
+            date_added=timezone.now(),
+        )
         issue_recent_searches = [
             RecentSearch.objects.create(
                 organization=self.organization,
@@ -91,6 +99,7 @@ class RecentSearchesListTest(APITestCase):
         self.check_results(issue_recent_searches, search_type=SearchType.ISSUE)
         self.check_results([event_recent_search], search_type=SearchType.EVENT)
         self.check_results([session_recent_search], search_type=SearchType.SESSION)
+        self.check_results([metric_recent_search], search_type=SearchType.METRIC)
 
     def test_param_validation(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
Since ddm is introducing a new metrics search bar, we'd like to show recent searches pertaining to metrics. 
Hence adding a new saved search type.

Relates to https://github.com/getsentry/sentry/issues/57063