### PR TITLE
feat(ddm): Use metric saved searches

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -46,6 +46,7 @@ export enum SavedSearchType {
   EVENT = 1,
   SESSION = 2,
   REPLAY = 3,
+  METRIC = 4,
 }
 
 export enum IssueCategory {

--- a/static/app/views/ddm/metricsExplorer.tsx
+++ b/static/app/views/ddm/metricsExplorer.tsx
@@ -24,7 +24,7 @@ import Tag from 'sentry/components/tag';
 import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {MetricsTag, PageFilters, TagCollection} from 'sentry/types';
+import {MetricsTag, PageFilters, SavedSearchType, TagCollection} from 'sentry/types';
 import {
   defaultMetricDisplayType,
   formatMetricsUsingUnitAndOp,
@@ -247,6 +247,7 @@ function MetricSearchBar({tags, mri, disabled, onChange, query}: MetricSearchBar
       onSearch={handleChange}
       placeholder={t('Filter by tags')}
       defaultQuery={query}
+      savedSearchType={SavedSearchType.METRIC}
     />
   );
 }


### PR DESCRIPTION
Recent searches from other parts of the product are leaking into ddm search. This PR fixes that.

Requires https://github.com/getsentry/sentry/pull/57064
Closes https://github.com/getsentry/sentry/issues/57063