### PR TITLE
chore(open-source): Use getsentry-bot instead of getsantry app for script

### DIFF
--- a/.github/workflows/react-to-product-owners-yml-changes.yml
+++ b/.github/workflows/react-to-product-owners-yml-changes.yml
@@ -15,15 +15,10 @@ jobs:
         with:
           python-version: 3.11.3
 
-      - name: Get an auth token
-        id: token
-        uses: getsentry/action-github-app-token@v2.0.0
-        with:
-          app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
-          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
-
       - name: React to product-owners.yml changes
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.BUMP_SENTRY_TOKEN }}
+          COMMITTER_NAME: getsentry-bot
+          COMMITTER_EMAIL: bot@sentry.io
         run: ./bin/react-to-product-owners-yml-changes.sh


### PR DESCRIPTION
The user is a part of the sentry org, so it won't require getsentry tests and /gcbrun
