### PR TITLE
ref(stats-detectors): Make sending occurrences to platform more reusable

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -387,7 +387,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                     )
 
                     regression: BreakpointData = {
-                        **qualifying_trend,
+                        **qualifying_trend,  # type: ignore
                         "project": project_id,
                     }
 

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -375,16 +375,13 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             if len(qualifying_trends) > 0:
                 regressions_to_send = []
                 for qualifying_trend in qualifying_trends:
-                    project_id = (
-                        next(
+                    project_id = qualifying_trend["project"]
+                    if not experiment_use_project_id:
+                        project_id = next(
                             transaction["project_id"]
                             for transaction in top_trending_transactions["data"]
                             if transaction["transaction"] == qualifying_trend["transaction"]
-                            and transaction["project"] == qualifying_trend["project"]
                         )
-                        if not experiment_use_project_id
-                        else qualifying_trend["project"]
-                    )
 
                     regression: BreakpointData = {
                         **qualifying_trend,  # type: ignore

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -367,7 +367,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                     )
 
                     regressions_to_send.append(
-                        Regression(**qualifying_trend, project_id=project_id)
+                        dict(Regression(**qualifying_trend, project_id=project_id))
                     )
 
                 send_regressions_to_plaform(regressions_to_send, False)

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -366,9 +366,12 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                         and transaction["project"] == qualifying_trend["project"]
                     )
 
-                    regressions_to_send.append(
-                        dict(Regression(**qualifying_trend, project_id=project_id))
-                    )
+                    regression: Regression = {
+                        **qualifying_trend,  # type: ignore
+                        "project_id": project_id,
+                    }
+
+                    regressions_to_send.append(regression)
 
                 send_regressions_to_plaform(regressions_to_send, False)
 

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -15,15 +15,12 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.search.events.constants import METRICS_GRANULARITIES
-from sentry.seer.utils import detect_breakpoints
+from sentry.seer.utils import BreakpointData, detect_breakpoints
 from sentry.snuba import metrics_performance
 from sentry.snuba.discover import create_result_key, zerofill
 from sentry.snuba.metrics_performance import query as metrics_query
 from sentry.snuba.referrer import Referrer
-from sentry.statistical_detectors.issue_platform_adapter import (
-    Regression,
-    send_regressions_to_plaform,
-)
+from sentry.statistical_detectors.issue_platform_adapter import send_regressions_to_plaform
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.snuba import SnubaTSResult
 
@@ -95,6 +92,12 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
 
         top_trending_transactions = {}
 
+        experiment_use_project_id = features.has(
+            "organizations:performance-trendsv2-dev-only",
+            organization,
+            actor=request.user,
+        )
+
         def get_top_events(user_query, params, event_limit, referrer):
             top_event_columns = cast(List[str], selected_columns[:])
             top_event_columns.append("count()")
@@ -136,7 +139,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             timeseries_columns.append(trend_function)
 
             # When all projects or my projects options selected,
-            # keep only projects that had top events to reduce query cardinality
+            # keep only projects that top events belong to to reduce query cardinality
             used_project_ids = list({event["project"] for event in data})
 
             request.GET.projectSlugs = used_project_ids  # type: ignore
@@ -161,11 +164,18 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             formatted_results = {}
             for index, item in enumerate(top_events["data"]):
                 result_key = create_result_key(item, translated_groupby, {})
-                results[result_key] = {
-                    "order": index,
-                    "data": [],
-                    "project": item["project"],
-                }
+                if experiment_use_project_id:
+                    results[result_key] = {
+                        "order": index,
+                        "data": [],
+                        "project_id": item["project_id"],
+                    }
+                else:
+                    results[result_key] = {
+                        "order": index,
+                        "data": [],
+                        "project": item["project"],
+                    }
             for row in result.get("data", []):  # type: ignore
                 result_key = create_result_key(row, translated_groupby, {})
                 if result_key in results:
@@ -180,7 +190,11 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                         },
                     )
             for key, item in results.items():
-                key = f'{item["project"]},{key}'
+                key = (
+                    f'{item["project_id"]},{key}'
+                    if experiment_use_project_id
+                    else f'{item["project"]},{key}'
+                )
                 formatted_results[key] = SnubaTSResult(
                     {
                         "data": zerofill(
@@ -192,7 +206,9 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                         )
                         if zerofill_results
                         else item["data"],
-                        "project": item["project"],
+                        "project": item["project_id"]
+                        if experiment_use_project_id
+                        else item["project"],
                         "isMetricsData": True,
                         "order": item["order"],
                     },
@@ -307,7 +323,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 for t in results["data"]:
                     transaction_name = t["transaction"]
                     project = t["project"]
-                    t_p_key = project + "," + transaction_name
+                    t_p_key = f"{project},{transaction_name}"
                     if t_p_key in stats_data:
                         selected_stats_data = stats_data[t_p_key]
                         idx = next(
@@ -359,16 +375,20 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             if len(qualifying_trends) > 0:
                 regressions_to_send = []
                 for qualifying_trend in qualifying_trends:
-                    project_id = next(
-                        transaction["project_id"]
-                        for transaction in top_trending_transactions["data"]
-                        if transaction["transaction"] == qualifying_trend["transaction"]
-                        and transaction["project"] == qualifying_trend["project"]
+                    project_id = (
+                        next(
+                            transaction["project_id"]
+                            for transaction in top_trending_transactions["data"]
+                            if transaction["transaction"] == qualifying_trend["transaction"]
+                            and transaction["project"] == qualifying_trend["project"]
+                        )
+                        if not experiment_use_project_id
+                        else qualifying_trend["project"]
                     )
 
-                    regression: Regression = {
-                        **qualifying_trend,  # type: ignore
-                        "project_id": project_id,
+                    regression: BreakpointData = {
+                        **qualifying_trend,
+                        "project": project_id,
                     }
 
                     regressions_to_send.append(regression)

--- a/src/sentry/statistical_detectors/issue_platform_adapter.py
+++ b/src/sentry/statistical_detectors/issue_platform_adapter.py
@@ -1,0 +1,74 @@
+import hashlib
+import uuid
+from datetime import datetime, timezone
+from typing import List
+
+from sentry.issues.grouptype import PerformanceDurationRegressionGroupType
+from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
+from sentry.issues.producer import produce_occurrence_to_kafka
+from sentry.seer.utils import BreakpointData
+from sentry.utils import metrics
+
+
+def fingerprint_regression(transaction, automatic_detection=True):
+    prehashed_fingerprint = (
+        f"p95_transaction_duration_regression-{transaction}"
+        if automatic_detection
+        else f"p95_transaction_duration_regression-{transaction}-experiment"
+    )
+    return hashlib.sha1((prehashed_fingerprint).encode()).hexdigest()
+
+
+class Regression(BreakpointData):
+    project_id: int
+
+
+# automatic_detection is True for regressions found while running an hourly cron job
+# while automatic_detection is False for regressions found via calling trends v2 endpoint
+def send_regressions_to_plaform(regressions: List[Regression], automatic_detection=True):
+    current_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc)
+    for regression in regressions:
+        displayed_old_baseline = round(float(regression["aggregate_range_1"]), 2)
+        displayed_new_baseline = round(float(regression["aggregate_range_2"]), 2)
+
+        occurrence = IssueOccurrence(
+            id=uuid.uuid4().hex,
+            resource_id=None,
+            project_id=regression["project_id"],
+            event_id=uuid.uuid4().hex,
+            fingerprint=[fingerprint_regression(regression, automatic_detection)],
+            type=PerformanceDurationRegressionGroupType,
+            issue_title=PerformanceDurationRegressionGroupType.description,
+            subtitle=f"Increased from {displayed_old_baseline}ms to {displayed_new_baseline}ms (P95)",
+            culprit=regression["transaction"],
+            evidence_data=regression,
+            evidence_display=[
+                IssueEvidence(
+                    name="Regression",
+                    value=f"Increased from {displayed_old_baseline}ms to {displayed_new_baseline}ms (P95)",
+                    important=True,
+                ),
+                IssueEvidence(
+                    name="Transaction",
+                    value=regression["transaction"],
+                    important=True,
+                ),
+            ],
+            detection_time=current_timestamp,
+            level="info",
+        )
+
+        event_data = {
+            "timestamp": current_timestamp,
+            "project_id": regression["project_id"],
+            "transaction": regression["transaction"],
+            "event_id": occurrence.event_id,
+            "platform": "python",
+            "received": current_timestamp.isoformat(),
+            "tags": {},
+        }
+
+        metrics.incr(
+            "performance.trends.sent_occurrence", tags={"automatic_detection": automatic_detection}
+        )
+        produce_occurrence_to_kafka(occurrence, event_data)

--- a/src/sentry/statistical_detectors/issue_platform_adapter.py
+++ b/src/sentry/statistical_detectors/issue_platform_adapter.py
@@ -1,7 +1,7 @@
 import hashlib
 import uuid
 from datetime import datetime, timezone
-from typing import List
+from typing import List, cast
 
 from sentry.issues.grouptype import PerformanceDurationRegressionGroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
@@ -27,10 +27,14 @@ def send_regressions_to_plaform(regressions: List[BreakpointData], automatic_det
         displayed_old_baseline = round(float(regression["aggregate_range_1"]), 2)
         displayed_new_baseline = round(float(regression["aggregate_range_2"]), 2)
 
+        # For legacy reasons, we're passing project id as project
+        # TODO fix this in the breakpoint microservice and in tre
+        project_id = cast(int, regression["project"])
+
         occurrence = IssueOccurrence(
             id=uuid.uuid4().hex,
             resource_id=None,
-            project_id=regression["project"],
+            project_id=project_id,
             event_id=uuid.uuid4().hex,
             fingerprint=[fingerprint_regression(regression, automatic_detection)],
             type=PerformanceDurationRegressionGroupType,

--- a/src/sentry/statistical_detectors/issue_platform_adapter.py
+++ b/src/sentry/statistical_detectors/issue_platform_adapter.py
@@ -19,13 +19,9 @@ def fingerprint_regression(transaction, automatic_detection=True):
     return hashlib.sha1((prehashed_fingerprint).encode()).hexdigest()
 
 
-class Regression(BreakpointData):
-    project_id: int
-
-
 # automatic_detection is True for regressions found while running an hourly cron job
 # while automatic_detection is False for regressions found via calling trends v2 endpoint
-def send_regressions_to_plaform(regressions: List[Regression], automatic_detection=True):
+def send_regressions_to_plaform(regressions: List[BreakpointData], automatic_detection=True):
     current_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc)
     for regression in regressions:
         displayed_old_baseline = round(float(regression["aggregate_range_1"]), 2)
@@ -34,7 +30,7 @@ def send_regressions_to_plaform(regressions: List[Regression], automatic_detecti
         occurrence = IssueOccurrence(
             id=uuid.uuid4().hex,
             resource_id=None,
-            project_id=regression["project_id"],
+            project_id=regression["project"],
             event_id=uuid.uuid4().hex,
             fingerprint=[fingerprint_regression(regression, automatic_detection)],
             type=PerformanceDurationRegressionGroupType,
@@ -60,7 +56,7 @@ def send_regressions_to_plaform(regressions: List[Regression], automatic_detecti
 
         event_data = {
             "timestamp": current_timestamp,
-            "project_id": regression["project_id"],
+            "project_id": regression["project"],
             "transaction": regression["transaction"],
             "event_id": occurrence.event_id,
             "platform": "python",

--- a/src/sentry/statistical_detectors/issue_platform_adapter.py
+++ b/src/sentry/statistical_detectors/issue_platform_adapter.py
@@ -1,7 +1,7 @@
 import hashlib
 import uuid
 from datetime import datetime, timezone
-from typing import List, cast
+from typing import List
 
 from sentry.issues.grouptype import PerformanceDurationRegressionGroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
@@ -29,7 +29,7 @@ def send_regressions_to_plaform(regressions: List[BreakpointData], automatic_det
 
         # For legacy reasons, we're passing project id as project
         # TODO fix this in the breakpoint microservice and in trends v2
-        project_id = cast(int, regression["project"])
+        project_id = int(regression["project"])
 
         occurrence = IssueOccurrence(
             id=uuid.uuid4().hex,
@@ -60,7 +60,7 @@ def send_regressions_to_plaform(regressions: List[BreakpointData], automatic_det
 
         event_data = {
             "timestamp": current_timestamp,
-            "project_id": regression["project"],
+            "project_id": project_id,
             "transaction": regression["transaction"],
             "event_id": occurrence.event_id,
             "platform": "python",

--- a/src/sentry/statistical_detectors/issue_platform_adapter.py
+++ b/src/sentry/statistical_detectors/issue_platform_adapter.py
@@ -28,7 +28,7 @@ def send_regressions_to_plaform(regressions: List[BreakpointData], automatic_det
         displayed_new_baseline = round(float(regression["aggregate_range_2"]), 2)
 
         # For legacy reasons, we're passing project id as project
-        # TODO fix this in the breakpoint microservice and in tre
+        # TODO fix this in the breakpoint microservice and in trends v2
         project_id = cast(int, regression["project"])
 
         occurrence = IssueOccurrence(

--- a/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
+++ b/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
@@ -8,7 +8,7 @@ from sentry.statistical_detectors.issue_platform_adapter import send_regressions
 
 @mock.patch("sentry.statistical_detectors.issue_platform_adapter.produce_occurrence_to_kafka")
 def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
-    project_id = "123"
+    project_id = 123
 
     mock_regressions: List[BreakpointData] = [
         {

--- a/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
+++ b/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
@@ -8,7 +8,7 @@ from sentry.statistical_detectors.issue_platform_adapter import send_regressions
 
 @mock.patch("sentry.statistical_detectors.issue_platform_adapter.produce_occurrence_to_kafka")
 def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
-    project_id = 123
+    project_id = "123"
 
     mock_regressions: List[BreakpointData] = [
         {
@@ -35,7 +35,7 @@ def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
     assert dict(
         occurrence,
         **{
-            "project_id": project_id,
+            "project_id": 123,
             "issue_title": "Exp Duration Regression",
             "subtitle": "Increased from 14.0ms to 28.0ms (P95)",
             "resource_id": None,
@@ -57,7 +57,7 @@ def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
     assert dict(
         event,
         **{
-            "project_id": project_id,
+            "project_id": 123,
             "transaction": "foo",
             "event_id": occurrence["event_id"],
             "platform": "python",

--- a/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
+++ b/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import List
 from unittest import mock
 
 from sentry.issues.grouptype import PerformanceDurationRegressionGroupType
@@ -10,18 +10,22 @@ from sentry.statistical_detectors.issue_platform_adapter import send_regressions
 def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
     project_id = "123"
 
-    mock_regressions = [
+    mock_regressions: List[BreakpointData] = [
         {
             "project": project_id,
             "transaction": "foo",
-            "change": "regression",
             "trend_percentage": 2.0,
             "aggregate_range_1": 14,
             "aggregate_range_2": 28,
+            "unweighted_t_value": 1,
+            "unweighted_p_value": 2,
+            "absolute_percentage_change": 1.96,
+            "trend_difference": 16.6,
+            "breakpoint": 1691366400,
         }
     ]
 
-    mock_regressions = cast(BreakpointData, mock_regressions)
+    # mock_regressions = cast(List[BreakpointData], mock_regressions)
 
     send_regressions_to_plaform(mock_regressions)
 

--- a/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
+++ b/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
@@ -1,7 +1,11 @@
+from typing import List, cast
 from unittest import mock
 
 from sentry.issues.grouptype import PerformanceDurationRegressionGroupType
-from sentry.statistical_detectors.issue_platform_adapter import send_regressions_to_plaform
+from sentry.statistical_detectors.issue_platform_adapter import (
+    Regression,
+    send_regressions_to_plaform,
+)
 
 
 @mock.patch("sentry.statistical_detectors.issue_platform_adapter.produce_occurrence_to_kafka")
@@ -9,7 +13,7 @@ def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
     project_slug = "test"
     project_id = 123
 
-    mock_regression = [
+    mock_data = [
         {
             "project": project_slug,
             "project_id": project_id,
@@ -20,6 +24,8 @@ def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
             "aggregate_range_2": 28,
         }
     ]
+
+    mock_regression = cast(List[Regression], mock_data)
 
     send_regressions_to_plaform(mock_regression)
 

--- a/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
+++ b/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
@@ -6,7 +6,7 @@ from sentry.statistical_detectors.issue_platform_adapter import send_regressions
 
 @mock.patch("sentry.statistical_detectors.issue_platform_adapter.produce_occurrence_to_kafka")
 def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
-    project_id = "123"
+    project_id = 123
 
     mock_regressions = [
         {

--- a/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
+++ b/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
@@ -1,22 +1,16 @@
-from typing import List, cast
 from unittest import mock
 
 from sentry.issues.grouptype import PerformanceDurationRegressionGroupType
-from sentry.statistical_detectors.issue_platform_adapter import (
-    Regression,
-    send_regressions_to_plaform,
-)
+from sentry.statistical_detectors.issue_platform_adapter import send_regressions_to_plaform
 
 
 @mock.patch("sentry.statistical_detectors.issue_platform_adapter.produce_occurrence_to_kafka")
 def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
-    project_slug = "test"
-    project_id = 123
+    project_id = "123"
 
-    mock_data = [
+    mock_regressions = [
         {
-            "project": project_slug,
-            "project_id": project_id,
+            "project": project_id,
             "transaction": "foo",
             "change": "regression",
             "trend_percentage": 2.0,
@@ -25,9 +19,7 @@ def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
         }
     ]
 
-    mock_regression = cast(List[Regression], mock_data)
-
-    send_regressions_to_plaform(mock_regression)
+    send_regressions_to_plaform(mock_regressions)
 
     assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1
 
@@ -41,7 +33,7 @@ def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
             "issue_title": "Exp Duration Regression",
             "subtitle": "Increased from 14.0ms to 28.0ms (P95)",
             "resource_id": None,
-            "evidence_data": mock_regression[0],
+            "evidence_data": mock_regressions[0],
             "evidence_display": [
                 {
                     "name": "Regression",

--- a/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
+++ b/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
@@ -1,0 +1,62 @@
+from unittest import mock
+
+from sentry.issues.grouptype import PerformanceDurationRegressionGroupType
+from sentry.statistical_detectors.issue_platform_adapter import send_regressions_to_plaform
+
+
+@mock.patch("sentry.statistical_detectors.issue_platform_adapter.produce_occurrence_to_kafka")
+def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
+    project_slug = "test"
+    project_id = 123
+
+    mock_regression = [
+        {
+            "project": project_slug,
+            "project_id": project_id,
+            "transaction": "foo",
+            "change": "regression",
+            "trend_percentage": 2.0,
+            "aggregate_range_1": 14,
+            "aggregate_range_2": 28,
+        }
+    ]
+
+    send_regressions_to_plaform(mock_regression)
+
+    assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1
+
+    occurrence, event = mock_produce_occurrence_to_kafka.mock_calls[0].args
+    occurrence = occurrence.to_dict()
+
+    assert dict(
+        occurrence,
+        **{
+            "project_id": project_id,
+            "issue_title": "Exp Duration Regression",
+            "subtitle": "Increased from 14.0ms to 28.0ms (P95)",
+            "resource_id": None,
+            "evidence_data": mock_regression[0],
+            "evidence_display": [
+                {
+                    "name": "Regression",
+                    "value": "Increased from 14.0ms to 28.0ms (P95)",
+                    "important": True,
+                },
+                {"name": "Transaction", "value": "foo", "important": True},
+            ],
+            "type": PerformanceDurationRegressionGroupType.type_id,
+            "level": "info",
+            "culprit": "foo",
+        },
+    ) == dict(occurrence)
+
+    assert dict(
+        event,
+        **{
+            "project_id": project_id,
+            "transaction": "foo",
+            "event_id": occurrence["event_id"],
+            "platform": "python",
+            "tags": {},
+        },
+    ) == dict(event)

--- a/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
+++ b/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
@@ -1,12 +1,14 @@
+from typing import cast
 from unittest import mock
 
 from sentry.issues.grouptype import PerformanceDurationRegressionGroupType
+from sentry.seer.utils import BreakpointData
 from sentry.statistical_detectors.issue_platform_adapter import send_regressions_to_plaform
 
 
 @mock.patch("sentry.statistical_detectors.issue_platform_adapter.produce_occurrence_to_kafka")
 def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
-    project_id = 123
+    project_id = "123"
 
     mock_regressions = [
         {
@@ -18,6 +20,8 @@ def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
             "aggregate_range_2": 28,
         }
     ]
+
+    mock_regressions = cast(BreakpointData, mock_regressions)
 
     send_regressions_to_plaform(mock_regressions)
 

--- a/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
+++ b/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
@@ -25,8 +25,6 @@ def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
         }
     ]
 
-    # mock_regressions = cast(List[BreakpointData], mock_regressions)
-
     send_regressions_to_plaform(mock_regressions)
 
     assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1


### PR DESCRIPTION
Move occurrence creation and sending to the platform into a separate file under `statistical_detectors`

Fixes https://github.com/getsentry/sentry/issues/56571