### PR TITLE
Error Count release threshold status api

### DIFF
--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, DefaultDict
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List
 
 from django.db.models import F, Q
 from django.http import HttpResponse
@@ -16,6 +17,7 @@ from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.models import Release
+from sentry.models.release_threshold.constants import ReleaseThresholdType, TriggerType
 from sentry.services.hybrid_cloud.organization import RpcOrganization
 
 if TYPE_CHECKING:
@@ -62,25 +64,27 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
         """
         List all derived statuses of releases that fall within the provided start/end datetimes
 
-        Constructs a nested response key'd off release_id, project_id, and lists _all_ thresholds for specified project
-        Each returned threshold value will contain the full serialized release_threshold instance as well as it's derived health status
+        Constructs a response key'd off release_id, project_id, environment, and lists thresholds with their status for *specified* projects
+        Each returned enriched threshold will contain the full serialized release_threshold instance as well as it's derived health status
 
-        health = {
-            release_id: {
-                project_id: [
-                    {
-                        threshold_id,
-                        project,
-                        ...,
-                        is_healthy: True/False
-                    },
-                    {...},
-                ],
-                project2_id: [],
-                ...
-            },
-            ...
+        {
+            {release}-{proj}-{env}: [
+                {
+                    project_id,
+                    environment,
+                    ...,
+                    key: {release}-{proj}-{env},
+                    release_version: '',
+                    is_healthy: True/False,
+                    start: datetime,
+                    end: datetime,
+                },
+                {...},
+                {...}
+            ],
+            {release}-{proj}-{env}: [...],
         }
+
         ``````````````````
 
         :param start: timestamp of the beginning of the specified date range
@@ -89,6 +93,9 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
         TODO:
         - should we limit/paginate results? (this could get really bulky)
         """
+        # ========================================================================
+        # STEP 1: Validate request data
+        # ========================================================================
         data = request.data if len(request.GET) == 0 and hasattr(request, "data") else request.GET
         start, end = get_date_range_from_params(params=data)
 
@@ -102,8 +109,11 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
         project_ids_list = serializer.validated_data.get("project")
         release_ids_list = serializer.validated_data.get("release_id")
 
+        # ========================================================================
+        # Step 2: Fetch releases, prefetch projects & release_thresholds
         # NOTE: we're only filtering on date ADDED
         # This is not synonymous with a deploy... which may be what we actually want.
+        # ========================================================================
         release_query = Q(organization=organization, date_added__gte=start, date_added__lte=end)
         if environments_list:
             release_query &= Q(
@@ -126,22 +136,27 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
             .order_by("-date")
             .distinct()
         )
-        queryset.prefetch_related("projects__release_thresholds")
+        queryset.prefetch_related(
+            "projects__release_thresholds"
+        )  # maybe prefetch "deploy_set" as well?
 
         # ========================================================================
-        # TODO:
-        # Fetch relevant snuba/sessions data
-        # Determine which thresholds have succeeded/failed
-
-        release_threshold_health: DefaultDict[int, Any] = defaultdict()
+        # Step 3: flatten thresholds and compile projects/releases/thresholds by type
+        # ========================================================================
+        thresholds_by_type: DefaultDict[int, dict[str, list]] = {
+            "projects": [],
+            "releases": [],
+            "thresholds": [],
+        }
         for release in queryset:
-            release_project = defaultdict(list)
+            # TODO:
+            # We should update release model to preserve threshold states.
+            # if release.failed_thresholds/passed_thresholds exists - then skip calculating and just return thresholds
             if project_ids_list:
                 project_list = release.projects.filter(id__in=project_ids_list)
             else:
                 project_list = release.projects.all()
             for project in project_list:
-                project_threshold_statuses = []
                 if environments_list:
                     thresholds_list = project.release_thresholds.filter(
                         environment__name__in=environments_list
@@ -149,38 +164,173 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
                 else:
                     thresholds_list = project.release_thresholds.all()
                 for threshold in thresholds_list:
-                    is_healthy = self.is_threshold_healthy(threshold)
-                    project_threshold_statuses.append(
-                        {
-                            **serialize(threshold),
-                            "is_healthy": is_healthy,
-                        }
+                    thresholds_by_type[threshold.threshold_type]["projects"].append(project.id)
+                    thresholds_by_type[threshold.threshold_type]["release_id"].append(
+                        release.version
                     )
-                release_project[project.id] = project_threshold_statuses
-            release_threshold_health[release.id] = release_project
+                    enriched_threshold = {
+                        **serialize(threshold),
+                        "key": self.construct_threshold_key(
+                            release=release, project=project, threshold=threshold
+                        ),
+                        "start": release.date,  # deploy.date_finished _would_ be more accurate, but is not keyed on project so cannot be used
+                        "end": release.date
+                        + timedelta(threshold.window_in_seconds),  # start + threshold.window
+                        "release": release.version,
+                        "project_id": project.id,
+                        "is_healthy": False,
+                    }
+                    thresholds_by_type[threshold.threshold_type]["thresholds"].append(
+                        enriched_threshold
+                    )
+
+        # ========================================================================
+        # Step 4: Determine threshold status per threshold type and return results
+        # ========================================================================
+        release_threshold_health = defaultdict(list)
+        for threshold_type, filter_list in enumerate(thresholds_by_type.items()):
+            project_id_list = [proj_id for proj_id in filter_list["projects"]]
+            release_value_list = [release_version for release_version in filter_list["releases"]]
+            category_thresholds = filter_list["thresholds"]
+            if threshold_type == ReleaseThresholdType.TOTAL_ERROR_COUNT:
+                """
+                Fetch errors timeseries for all projects with an error_count threshold in desired releases
+                Iterate through timeseries given threshold window and determine health status
+
+                TODO: determine whether results have been truncated or not
+                - this will determine whether we can give an accurate status report or not
+                """
+                error_counts = get_errors_timeseries_counts_by_project_and_release(
+                    start=start,
+                    end=end,
+                    project_id_list=project_id_list,
+                    release_value_list=release_value_list,
+                    organization_id=organization.id,
+                )
+                for ethreshold in category_thresholds:
+                    is_healthy = is_error_count_healthy(ethreshold, error_counts)
+                    ethreshold["is_healthy"] = is_healthy
+                    release_threshold_health[ethreshold["key"]].append(
+                        ethreshold
+                    )  # so we can fill all thresholds under the same key
+            elif threshold_type == ReleaseThresholdType.NEW_ISSUE_COUNT:
+                for ethreshold in category_thresholds:
+                    release_threshold_health[ethreshold["key"]].append(
+                        ethreshold
+                    )  # so we can fill all thresholds under the same key
+            elif threshold_type == ReleaseThresholdType.UNHANDLED_ISSUE_COUNT:
+                for ethreshold in category_thresholds:
+                    release_threshold_health[ethreshold["key"]].append(
+                        ethreshold
+                    )  # so we can fill all thresholds under the same key
+            elif threshold_type == ReleaseThresholdType.REGRESSED_ISSUE_COUNT:
+                for ethreshold in category_thresholds:
+                    release_threshold_health[ethreshold["key"]].append(
+                        ethreshold
+                    )  # so we can fill all thresholds under the same key
+            elif threshold_type == ReleaseThresholdType.FAILURE_RATE:
+                for ethreshold in category_thresholds:
+                    release_threshold_health[ethreshold["key"]].append(
+                        ethreshold
+                    )  # so we can fill all thresholds under the same key
+            elif threshold_type == ReleaseThresholdType.CRASH_FREE_SESSION_RATE:
+                for ethreshold in category_thresholds:
+                    release_threshold_health[ethreshold["key"]].append(
+                        ethreshold
+                    )  # so we can fill all thresholds under the same key
+            elif threshold_type == ReleaseThresholdType.CRASH_FREE_USER_RATE:
+                for ethreshold in category_thresholds:
+                    release_threshold_health[ethreshold["key"]].append(
+                        ethreshold
+                    )  # so we can fill all thresholds under the same key
 
         return Response(release_threshold_health, status=200)
 
-    def is_threshold_healthy(self, threshold) -> bool:
+    def construct_threshold_key(self, project, release, threshold) -> str:
         """
-        Determines whether a projects threshold has been breached or not
-        True - healthy
-        False - unhealthy
+        Consistent key helps to determine which thresholds can be grouped together.
         """
-        # TODO:
-        # for each threshold type - determine how to properly pull the data?
-        # threshold_type = threshold.threshold_type
-        # trigger_type = threshold.trigger_type
-        # value = threshold.value
-        # window = threshold.window_in_seconds
-        # project = threshold.project
-        # environment = threshold.environment
+        return f"{project.id}-{release.version}-{threshold.environment}"
 
-        """
-        Does each threshold type turn into a query string?
-        DD - has query formula that is run
 
-        Dig to see where we fetch this data today
-        """
+def is_error_count_healthy(ethreshold: Dict[str, Any], timeseries: List[Dict[str, Any]]) -> bool:
+    """
+    Iterate through timeseries given threshold window and determine health status
+    enriched threshold (ethreshold) includes `start`, `end`, and a constructed `key` identifier
+    """
+    total_count = 0
+    for i in timeseries:
+        if i.time > ethreshold.end:
+            # timeseries are ordered chronologically
+            # So if we're past our threshold.end, we can skip the rest
+            break
+        if (
+            i.time <= ethreshold.start
+            or i.time > ethreshold.end
+            or i.release != ethreshold.release
+            or i.project_id != ethreshold.project_id
+        ):
+            # IF timesefries is chronological, once we pass threshold end, we can break :shrug:
+            continue
+        # else ethreshold.start < i.time <= ethreshold.end
+        total_count += i["count()"]
 
-        return True
+    if ethreshold.trigger_type == TriggerType.OVER:
+        return total_count > ethreshold.value
+
+    # else if ethreshold.trigger_type == TriggerType.UNDER:
+    return total_count < ethreshold.value
+
+
+from snuba_sdk import Request as SnubaRequest
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import Condition, Op
+from snuba_sdk.entity import Entity
+from snuba_sdk.expressions import Granularity
+from snuba_sdk.function import Function
+from snuba_sdk.orderby import Direction, OrderBy
+from snuba_sdk.query import Query
+
+from sentry.snuba.dataset import Dataset
+from sentry.utils import snuba
+
+
+def get_errors_timeseries_counts_by_project_and_release(
+    start,
+    end,
+    project_id_list,
+    release_value_list,
+    organization_id,
+) -> [dict]:
+    query = Query(
+        match=Entity("events"),  # synonymous w/ discover dataset
+        select=[Function("count", [])],
+        groupby=[
+            Column("release"),
+            Column("project_id"),
+            Column("environment"),
+            Column("time"),  # groupby 'time' gives us a timeseries
+        ],
+        orderby=[
+            OrderBy(Column("time"), Direction.DESC),
+        ],
+        granularity=Granularity(60),
+        where=[
+            Condition(Column("type"), Op.EQ, "error"),
+            Condition(Column("timestamp"), Op.GTE, start),
+            Condition(Column("timestamp"), Op.LT, end),
+            Condition(Column("project_id"), Op.IN, project_id_list),
+            Condition(Column("release"), Op.IN, release_value_list),
+        ],
+    )
+    request = SnubaRequest(
+        dataset=Dataset.Events.value,
+        app_id="default",
+        query=query,
+        tenant_ids={"organization_id": organization_id},
+    )
+    data = snuba.raw_snql_query(
+        request=request, referrer="snuba.sessions.check_releases_have_health_data"
+    )["data"]
+
+    return data

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -317,8 +317,8 @@ def is_error_count_healthy(ethreshold: EnrichedThreshold, timeseries: List[Dict[
         total_count += i["count()"]
 
     if ethreshold["trigger_type"] == TriggerType.OVER:
-        # If total is under the threshold value, then it is healthy
-        return total_count < ethreshold["value"]
+        # If total is under/equal the threshold value, then it is healthy
+        return total_count <= ethreshold["value"]
 
-    # Else, if total is over the threshold value, then it is healthy
-    return total_count > ethreshold["value"]
+    # Else, if total is over/equal the threshold value, then it is healthy
+    return total_count >= ethreshold["value"]

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -16,7 +16,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.endpoints.release_thresholds.utils import (
-    get_errors_timeseries_counts_by_project_and_release,
+    get_errors_counts_timeseries_by_project_and_release,
 )
 from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
@@ -223,7 +223,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
                 TODO: determine whether results have been truncated or not
                 - this will determine whether we can give an accurate status report or not
                 """
-                error_counts = get_errors_timeseries_counts_by_project_and_release(
+                error_counts = get_errors_counts_timeseries_by_project_and_release(
                     end=end,
                     environments_list=environments_list,
                     organization_id=organization.id,

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -204,13 +204,15 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
                 - this will determine whether we can give an accurate status report or not
                 """
                 error_counts = get_errors_timeseries_counts_by_project_and_release(
-                    start=start,
                     end=end,
+                    environments_list=environments_list,
+                    organization_id=organization.id,
                     project_id_list=project_id_list,
                     release_value_list=release_value_list,
-                    organization_id=organization.id,
+                    start=start,
                 )
                 for ethreshold in category_thresholds:
+                    # TODO: filter by environment as well?
                     is_healthy = is_error_count_healthy(ethreshold, error_counts)
                     ethreshold["is_healthy"] = is_healthy
                     release_threshold_health[ethreshold["key"]].append(
@@ -276,8 +278,8 @@ def is_error_count_healthy(ethreshold: Dict[str, Any], timeseries: List[Dict[str
             or i.time > ethreshold["end"]
             or i.release != ethreshold["release"]
             or i.project_id != ethreshold["project_id"]
+            or i.environment != ethreshold["environment"]
         ):
-            # IF timesefries is chronological, once we pass threshold end, we can break :shrug:
             continue
         # else ethreshold.start < i.time <= ethreshold.end
         total_count += i["count()"]

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 class EnrichedThreshold(TypedDict):
     date: datetime
     end: datetime
-    environment: Environment
+    environment: Environment | None
     is_healthy: bool
     key: str
     project: Project

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -143,12 +143,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
         # ========================================================================
         # Step 3: flatten thresholds and compile projects/releases/thresholds by type
         # ========================================================================
-        tracker = {
-            "projects": [],
-            "releases": [],
-            "thresholds": [],
-        }
-        thresholds_by_type: DefaultDict[int, dict[str, list]] = defaultdict(lambda: tracker)
+        thresholds_by_type: DefaultDict[int, dict[str, list]] = defaultdict()
         for release in queryset:
             # TODO:
             # We should update release model to preserve threshold states.
@@ -165,6 +160,12 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
                 else:
                     thresholds_list = project.release_thresholds.all()
                 for threshold in thresholds_list:
+                    if threshold.threshold_type not in thresholds_by_type:
+                        thresholds_by_type[threshold.threshold_type] = {
+                            "projects": [],
+                            "releases": [],
+                            "thresholds": [],
+                        }
                     thresholds_by_type[threshold.threshold_type]["projects"].append(project.id)
                     thresholds_by_type[threshold.threshold_type]["releases"].append(release.version)
                     enriched_threshold = {

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -304,7 +304,10 @@ def is_error_count_healthy(ethreshold: EnrichedThreshold, timeseries: List[Dict[
             or parser.parse(i["time"]) > ethreshold["end"]  # ts is after our threshold ned
             or i["release"] != ethreshold["release"]  # ts is not our the right release
             or i["project_id"] != ethreshold["project_id"]  # ts is not the right project
-            or i["environment"] != ethreshold["environment"]  # ts is not the right environment
+            or i["environment"]
+            != (
+                ethreshold["environment"].name if ethreshold["environment"] else None
+            )  # ts is not the right environment
         ):
             continue
         # else ethreshold.start < i.time <= ethreshold.end

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -14,6 +14,9 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
+from sentry.api.endpoints.release_thresholds.utils import (
+    get_errors_timeseries_counts_by_project_and_release,
+)
 from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.models import Release
@@ -284,57 +287,3 @@ def is_error_count_healthy(ethreshold: Dict[str, Any], timeseries: List[Dict[str
 
     # else if ethreshold.trigger_type == TriggerType.UNDER:
     return total_count < ethreshold["value"]
-
-
-from snuba_sdk import Request as SnubaRequest
-from snuba_sdk.column import Column
-from snuba_sdk.conditions import Condition, Op
-from snuba_sdk.entity import Entity
-from snuba_sdk.expressions import Granularity
-from snuba_sdk.function import Function
-from snuba_sdk.orderby import Direction, OrderBy
-from snuba_sdk.query import Query
-
-from sentry.snuba.dataset import Dataset
-from sentry.utils import snuba
-
-
-def get_errors_timeseries_counts_by_project_and_release(
-    start,
-    end,
-    project_id_list,
-    release_value_list,
-    organization_id,
-) -> [dict]:
-    query = Query(
-        match=Entity("events"),  # synonymous w/ discover dataset
-        select=[Function("count", [])],
-        groupby=[
-            Column("release"),
-            Column("project_id"),
-            Column("environment"),
-            Column("time"),  # groupby 'time' gives us a timeseries
-        ],
-        orderby=[
-            OrderBy(Column("time"), Direction.DESC),
-        ],
-        granularity=Granularity(60),
-        where=[
-            Condition(Column("type"), Op.EQ, "error"),
-            Condition(Column("timestamp"), Op.GTE, start),
-            Condition(Column("timestamp"), Op.LT, end),
-            Condition(Column("project_id"), Op.IN, project_id_list),
-            Condition(Column("release"), Op.IN, release_value_list),
-        ],
-    )
-    request = SnubaRequest(
-        dataset=Dataset.Events.value,
-        app_id="default",
-        query=query,
-        tenant_ids={"organization_id": organization_id},
-    )
-    data = snuba.raw_snql_query(
-        request=request, referrer="snuba.sessions.check_releases_have_health_data"
-    )["data"]
-
-    return data

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -227,12 +227,12 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
                 - this will determine whether we can give an accurate status report or not
                 """
                 error_counts = get_errors_counts_timeseries_by_project_and_release(
-                    end=int(end.timestamp()),
+                    end=end,
                     environments_list=environments_list,
                     organization_id=organization.id,
                     project_id_list=project_id_list,
                     release_value_list=release_value_list,
-                    start=int(start.timestamp()),
+                    start=start,
                 )
                 for ethreshold in category_thresholds:
                     # TODO: filter by environment as well?

--- a/src/sentry/api/endpoints/release_thresholds/utils.py
+++ b/src/sentry/api/endpoints/release_thresholds/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Dict, List
 
 from snuba_sdk import Request as SnubaRequest
@@ -16,11 +17,11 @@ from sentry.utils import snuba
 
 
 def get_errors_counts_timeseries_by_project_and_release(
-    end: int,
+    end: datetime,
     organization_id: int,
     project_id_list: List[int],
     release_value_list: List[str],
-    start: int,
+    start: datetime,
     environments_list: List[str] | None = None,
 ) -> List[Dict[str, Any]]:
     additional_conditions = []

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -386,8 +386,8 @@ class ErrorCountThresholdCheckTest(TestCase):
             },
         ]
 
-        # base threshold within series
-        threshold_healthy: EnrichedThreshold = {
+        # current threshold within series
+        current_threshold_healthy: EnrichedThreshold = {
             "date": now,
             "start": now - timedelta(minutes=1),
             "end": now,
@@ -399,10 +399,28 @@ class ErrorCountThresholdCheckTest(TestCase):
             "release": self.release1.version,
             "threshold_type": ReleaseThresholdType.TOTAL_ERROR_COUNT,
             "trigger_type": TriggerType.OVER,
-            "value": 2,
-            "window_in_seconds": 60,
+            "value": 4,  # error counts _not_ be over threshold value
+            "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
         }
-        assert is_error_count_healthy(ethreshold=threshold_healthy, timeseries=timeseries)
+        assert is_error_count_healthy(ethreshold=current_threshold_healthy, timeseries=timeseries)
+
+        # threshold equal to count
+        threshold_at_limit_healthy: EnrichedThreshold = {
+            "date": now,
+            "start": now - timedelta(minutes=1),
+            "end": now,
+            "environment": None,
+            "is_healthy": False,
+            "key": "",
+            "project": self.project1,
+            "project_id": self.project1.id,
+            "release": self.release1.version,
+            "threshold_type": ReleaseThresholdType.TOTAL_ERROR_COUNT,
+            "trigger_type": TriggerType.OVER,
+            "value": 1,  # error counts equal to threshold limit value
+            "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
+        }
+        assert is_error_count_healthy(ethreshold=threshold_at_limit_healthy, timeseries=timeseries)
 
         # past healthy threshold within series
         past_threshold_healthy: EnrichedThreshold = {
@@ -418,12 +436,12 @@ class ErrorCountThresholdCheckTest(TestCase):
             "threshold_type": ReleaseThresholdType.TOTAL_ERROR_COUNT,
             "trigger_type": TriggerType.OVER,
             "value": 2,
-            "window_in_seconds": 60,
+            "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
         }
         assert is_error_count_healthy(ethreshold=past_threshold_healthy, timeseries=timeseries)
 
         # threshold within series but trigger is under
-        threshold_unhealthy: EnrichedThreshold = {
+        threshold_under_unhealthy: EnrichedThreshold = {
             "date": now,
             "start": now - timedelta(minutes=1),
             "end": now,
@@ -435,10 +453,12 @@ class ErrorCountThresholdCheckTest(TestCase):
             "release": self.release1.version,
             "threshold_type": ReleaseThresholdType.TOTAL_ERROR_COUNT,
             "trigger_type": TriggerType.UNDER,
-            "value": 2,
-            "window_in_seconds": 60,
+            "value": 4,
+            "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
         }
-        assert not is_error_count_healthy(ethreshold=threshold_unhealthy, timeseries=timeseries)
+        assert not is_error_count_healthy(
+            ethreshold=threshold_under_unhealthy, timeseries=timeseries
+        )
 
         # threshold within series but end is in future
         threshold_unfinished: EnrichedThreshold = {
@@ -453,8 +473,8 @@ class ErrorCountThresholdCheckTest(TestCase):
             "release": self.release1.version,
             "threshold_type": ReleaseThresholdType.TOTAL_ERROR_COUNT,
             "trigger_type": TriggerType.OVER,
-            "value": 2,
-            "window_in_seconds": 60,
+            "value": 4,
+            "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
         }
         assert is_error_count_healthy(ethreshold=threshold_unfinished, timeseries=timeseries)
 
@@ -532,8 +552,8 @@ class ErrorCountThresholdCheckTest(TestCase):
             "release": self.release1.version,
             "threshold_type": ReleaseThresholdType.TOTAL_ERROR_COUNT,
             "trigger_type": TriggerType.OVER,
-            "value": 2,
-            "window_in_seconds": 60,
+            "value": 4,
+            "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
         }
         assert is_error_count_healthy(ethreshold=threshold_healthy, timeseries=timeseries)
 
@@ -550,8 +570,8 @@ class ErrorCountThresholdCheckTest(TestCase):
             "release": self.release2.version,
             "threshold_type": ReleaseThresholdType.TOTAL_ERROR_COUNT,
             "trigger_type": TriggerType.OVER,
-            "value": 2,
-            "window_in_seconds": 60,
+            "value": 1,
+            "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
         }
         assert not is_error_count_healthy(ethreshold=threshold_unhealthy, timeseries=timeseries)
 
@@ -629,8 +649,8 @@ class ErrorCountThresholdCheckTest(TestCase):
             "release": self.release1.version,
             "threshold_type": ReleaseThresholdType.TOTAL_ERROR_COUNT,
             "trigger_type": TriggerType.OVER,
-            "value": 2,
-            "window_in_seconds": 60,
+            "value": 4,
+            "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
         }
         assert is_error_count_healthy(ethreshold=threshold_healthy, timeseries=timeseries)
 
@@ -647,8 +667,8 @@ class ErrorCountThresholdCheckTest(TestCase):
             "release": self.release1.version,
             "threshold_type": ReleaseThresholdType.TOTAL_ERROR_COUNT,
             "trigger_type": TriggerType.OVER,
-            "value": 2,
-            "window_in_seconds": 60,
+            "value": 1,
+            "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
         }
         assert not is_error_count_healthy(ethreshold=threshold_unhealthy, timeseries=timeseries)
 
@@ -727,7 +747,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "threshold_type": ReleaseThresholdType.TOTAL_ERROR_COUNT,
             "trigger_type": TriggerType.OVER,
             "value": 2,
-            "window_in_seconds": 60,
+            "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
         }
         assert is_error_count_healthy(ethreshold=threshold_healthy, timeseries=timeseries)
 
@@ -744,7 +764,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "release": self.release1.version,
             "threshold_type": ReleaseThresholdType.TOTAL_ERROR_COUNT,
             "trigger_type": TriggerType.OVER,
-            "value": 2,
-            "window_in_seconds": 60,
+            "value": 1,
+            "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
         }
         assert not is_error_count_healthy(ethreshold=threshold_unhealthy, timeseries=timeseries)

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -2,7 +2,9 @@ from datetime import datetime, timedelta
 
 from sentry.models import Environment, Release, ReleaseEnvironment, ReleaseProjectEnvironment
 from sentry.models.release_threshold.constants import ReleaseThresholdType
-from sentry.models.release_threshold.release_threshold import ReleaseThreshold
+from sentry.models.release_threshold.release_threshold import (  # is_error_count_healthy,
+    ReleaseThreshold,
+)
 from sentry.testutils.cases import APITestCase
 
 
@@ -319,3 +321,17 @@ class ReleaseThresholdStatusTest(APITestCase):
         # release2
         r2_keys = [k for k, v in data.items() if k.split("-")[2] == self.release2.version]
         assert len(r2_keys) == 0
+
+
+class TestErrorCountThresholdCheck:
+    def setup(self):
+        pass
+
+    def test_threshold_within_timeseries(self):
+        pass
+
+    def test_threshold_time_subset_within_timeseries(self):
+        pass
+
+    def test_multiple_releases_projects_and_envs_within_timeseries(self):
+        pass

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -669,7 +669,7 @@ class ErrorCountThresholdCheckTest(APITestCase):
                 "release": self.release1.version,
                 "project_id": self.project1.id,
                 "time": (now - timedelta(minutes=3)).isoformat(),
-                "environment": "foo",
+                "environment": "canary",
                 "count()": 2,
             },
             {
@@ -683,7 +683,7 @@ class ErrorCountThresholdCheckTest(APITestCase):
                 "release": self.release1.version,
                 "project_id": self.project1.id,
                 "time": (now - timedelta(minutes=2)).isoformat(),
-                "environment": "foo",
+                "environment": "canary",
                 "count()": 2,
             },
             {
@@ -697,7 +697,7 @@ class ErrorCountThresholdCheckTest(APITestCase):
                 "release": self.release1.version,
                 "project_id": self.project1.id,
                 "time": (now - timedelta(minutes=1)).isoformat(),
-                "environment": "foo",
+                "environment": "canary",
                 "count()": 2,
             },
             {
@@ -711,7 +711,7 @@ class ErrorCountThresholdCheckTest(APITestCase):
                 "release": self.release1.version,
                 "project_id": self.project1.id,
                 "time": now.isoformat(),
-                "environment": "foo",
+                "environment": "canary",
                 "count()": 2,
             },
         ]

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -325,19 +325,14 @@ class ReleaseThresholdStatusTest(APITestCase):
         assert len(r2_keys) == 0
 
 
-class TestErrorCountThresholdCheck(APITestCase):
+class ErrorCountThresholdCheckTest(APITestCase):
     def setUp(self):
         # 3 projects
         self.project1 = self.create_project(name="foo", organization=self.organization)
         self.project2 = self.create_project(name="bar", organization=self.organization)
-        self.project3 = self.create_project(name="biz", organization=self.organization)
 
-        # 2 environments
         self.canary_environment = Environment.objects.create(
             organization_id=self.organization.id, name="canary"
-        )
-        self.production_environment = Environment.objects.create(
-            organization_id=self.organization.id, name="production"
         )
 
         # release created for proj1, and proj2
@@ -346,15 +341,10 @@ class TestErrorCountThresholdCheck(APITestCase):
         self.release1.add_project(self.project1)
         self.release1.add_project(self.project2)
 
-        # release created for proj1, and proj2
+        # release created for proj1
         self.release2 = Release.objects.create(version="v2", organization=self.organization)
         # add_project get_or_creates a ReleaseProject
         self.release2.add_project(self.project1)
-
-        # # release created for proj1, and proj2
-        # self.release3 = Release.objects.create(version="v3", organization=self.organization)
-        # # add_project get_or_creates a ReleaseProject
-        # self.release3.add_project(self.project1)
 
     def test_threshold_within_timeseries(self):
         """
@@ -749,7 +739,7 @@ class TestErrorCountThresholdCheck(APITestCase):
             "date": now,
             "start": now - timedelta(minutes=1),
             "end": now,
-            "environment": "foo",
+            "environment": self.canary_environment,
             "is_healthy": False,
             "key": "",
             "project": self.project1,

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -7,7 +7,7 @@ from sentry.api.endpoints.release_thresholds.release_threshold_status_index impo
 from sentry.models import Environment, Release, ReleaseEnvironment, ReleaseProjectEnvironment
 from sentry.models.release_threshold.constants import ReleaseThresholdType, TriggerType
 from sentry.models.release_threshold.release_threshold import ReleaseThreshold
-from sentry.testutils.cases import APITestCase
+from sentry.testutils.cases import APITestCase, TestCase
 
 
 class ReleaseThresholdStatusTest(APITestCase):
@@ -325,7 +325,7 @@ class ReleaseThresholdStatusTest(APITestCase):
         assert len(r2_keys) == 0
 
 
-class ErrorCountThresholdCheckTest(APITestCase):
+class ErrorCountThresholdCheckTest(TestCase):
     def setUp(self):
         # 3 projects
         self.project1 = self.create_project(name="foo", organization=self.organization)
@@ -457,9 +457,6 @@ class ErrorCountThresholdCheckTest(APITestCase):
             "window_in_seconds": 60,
         }
         assert is_error_count_healthy(ethreshold=threshold_unfinished, timeseries=timeseries)
-
-    def test_threshold_time_subset_within_timeseries(self):
-        pass
 
     def test_multiple_releases_within_timeseries(self):
         now = datetime.utcnow()

--- a/tests/sentry/api/endpoints/release_thresholds/test_utils.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest import mock
 
 from snuba_sdk.column import Column
@@ -17,25 +18,27 @@ class GetErrorCountTimeseriesTest(TestCase):
 
     @mock.patch("sentry.api.endpoints.release_thresholds.utils.snuba.raw_snql_query")
     def test_errors_timeseries_snuba_fetch(self, mock_snql_query):
+        now = datetime.utcnow()
         get_errors_counts_timeseries_by_project_and_release(
-            end=0,
+            end=now,
             organization_id=self.org.id,
             project_id_list=[],
             release_value_list=[],
-            start=0,
+            start=now,
         )
 
         assert mock_snql_query.call_count == 1
 
     @mock.patch("sentry.api.endpoints.release_thresholds.utils.snuba.raw_snql_query")
     def test_errors_timeseries_snuba_fetch_called_with_env(self, mock_snql_query):
+        now = datetime.utcnow()
         env_list = ["foo"]
         get_errors_counts_timeseries_by_project_and_release(
-            end=0,
+            end=now,
             organization_id=self.org.id,
             project_id_list=[],
             release_value_list=[],
-            start=0,
+            start=now,
             environments_list=env_list,
         )
 


### PR DESCRIPTION
implement error events timeseries snuba fetch + threshold status response

This logic is complicated

Currently we have no easy way to fetch for error counts for a given period.
The Organization Event Stats implementation is very tightly coupled to their frontend UI, and seems pretty over engineered.

Here i've implemented a much simpler snuba query

Once we've fetched the error event counts, we can use the time series to determine whether our threshold has been breached or not.

TODO:
- Can probably break the `construct_key` method out into a separate helper too

RELATED:
- https://github.com/getsentry/sentry/pull/57175