### PR TITLE
feat(ui): Dedupe requests in team avatar

### DIFF
--- a/static/app/components/avatar/actorAvatar.spec.tsx
+++ b/static/app/components/avatar/actorAvatar.spec.tsx
@@ -1,20 +1,24 @@
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import MemberListStore from 'sentry/stores/memberListStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import TeamStore from 'sentry/stores/teamStore';
-import {Team, User} from 'sentry/types';
+import type {Team as TeamType, User as UserType} from 'sentry/types';
 
 describe('ActorAvatar', function () {
-  const user: User = {
-    ...TestStubs.User(),
+  const user: UserType = {
+    ...User(),
     id: '1',
     name: 'JanActore Bloggs',
     email: 'janebloggs@example.com',
   };
-  const team1: Team = {
-    ...TestStubs.Team(),
+  const team1: TeamType = {
+    ...Team(),
     id: '3',
     slug: 'cool-team',
     name: 'COOL TEAM',
@@ -25,74 +29,71 @@ describe('ActorAvatar', function () {
     TeamStore.loadInitialData([team1]);
   });
 
-  describe('render()', function () {
-    it('should show a gravatar when actor type is a user', function () {
-      render(
-        <ActorAvatar
-          actor={{
-            id: '1',
-            name: 'Jane Bloggs',
-            type: 'user',
-          }}
-        />
-      );
+  it('should show a gravatar when actor type is a user', function () {
+    render(
+      <ActorAvatar
+        actor={{
+          id: '1',
+          name: 'Jane Bloggs',
+          type: 'user',
+        }}
+      />
+    );
+  });
+
+  it('should not show a gravatar when actor type is a team', function () {
+    render(
+      <ActorAvatar
+        actor={{
+          id: '3',
+          name: 'COOL TEAM',
+          type: 'team',
+        }}
+      />
+    );
+
+    expect(screen.getByText('CT')).toBeInTheDocument();
+  });
+
+  it('should return null when actor type is a unknown', function () {
+    render(
+      <ActorAvatar
+        actor={{
+          id: '3',
+          name: 'COOL TEAM',
+          // @ts-expect-error (type shall be incorrect here)
+          type: 'teapot',
+        }}
+      />
+    );
+
+    expect(screen.queryByText('CT')).not.toBeInTheDocument();
+  });
+
+  it('should fetch a team not in the store', async function () {
+    const organization = Organization();
+
+    OrganizationStore.onUpdate(organization, {replace: true});
+
+    const team2 = Team({id: '2', name: 'COOL TEAM', slug: 'cool-team'});
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      method: 'GET',
+      body: [team2],
     });
 
-    it('should not show a gravatar when actor type is a team', function () {
-      render(
-        <ActorAvatar
-          actor={{
-            id: '3',
-            name: 'COOL TEAM',
-            type: 'team',
-          }}
-        />
-      );
+    render(
+      <ActorAvatar
+        actor={{
+          id: team2.id,
+          name: team2.name,
+          type: 'team',
+        }}
+      />
+    );
 
-      expect(screen.getByText('CT')).toBeInTheDocument();
-    });
-
-    it('should return null when actor type is a unknown', function () {
-      render(
-        <ActorAvatar
-          actor={{
-            id: '3',
-            name: 'COOL TEAM',
-            // @ts-expect-error (type shall be incorrect here)
-            type: 'teapot',
-          }}
-        />
-      );
-
-      expect(screen.queryByText('CT')).not.toBeInTheDocument();
-    });
-
-    it('should fetch a team not in the store', async function () {
-      const organization = TestStubs.Organization();
-
-      OrganizationStore.onUpdate(organization, {replace: true});
-
-      const team2 = TestStubs.Team({id: '2', name: 'COOL TEAM', slug: 'cool-team'});
-
-      const mockRequest = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/teams/`,
-        method: 'GET',
-        body: [team2],
-      });
-
-      render(
-        <ActorAvatar
-          actor={{
-            id: team2.id,
-            name: team2.name,
-            type: 'team',
-          }}
-        />
-      );
-
-      await waitFor(() => expect(mockRequest).toHaveBeenCalled());
-
-      expect(screen.getByText('CT')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('CT')).toBeInTheDocument();
+    expect(mockRequest).toHaveBeenCalled();
   });
 });

--- a/static/app/components/avatar/actorAvatar.tsx
+++ b/static/app/components/avatar/actorAvatar.tsx
@@ -3,12 +3,12 @@ import * as Sentry from '@sentry/react';
 import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import UserAvatar from 'sentry/components/avatar/userAvatar';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {TooltipProps} from 'sentry/components/tooltip';
+import type {TooltipProps} from 'sentry/components/tooltip';
 import MemberListStore from 'sentry/stores/memberListStore';
-import {Actor} from 'sentry/types';
-import Teams from 'sentry/utils/teams';
+import type {Actor} from 'sentry/types';
+import {useTeamsById} from 'sentry/utils/useTeamsById';
 
-type Props = {
+interface ActorAvatarProps {
   actor: Actor;
   className?: string;
   default?: string;
@@ -21,9 +21,26 @@ type Props = {
   title?: string;
   tooltip?: React.ReactNode;
   tooltipOptions?: Omit<TooltipProps, 'children' | 'title'>;
-};
+}
 
-function ActorAvatar({size = 24, hasTooltip = true, actor, ...props}: Props) {
+/**
+ * Wrapper to assist loading the team from api or store
+ */
+function LoadTeamAvatar({
+  teamId,
+  ...props
+}: {teamId: string} & Omit<React.ComponentProps<typeof TeamAvatar>, 'team'>) {
+  const {teams, isLoading} = useTeamsById({ids: [teamId]});
+  const team = teams.find(t => t.id === teamId);
+
+  if (isLoading || !team) {
+    return <LoadingIndicator mini />;
+  }
+
+  return <TeamAvatar team={team} {...props} />;
+}
+
+function ActorAvatar({size = 24, hasTooltip = true, actor, ...props}: ActorAvatarProps) {
   const otherProps = {
     size,
     hasTooltip,
@@ -36,17 +53,7 @@ function ActorAvatar({size = 24, hasTooltip = true, actor, ...props}: Props) {
   }
 
   if (actor.type === 'team') {
-    return (
-      <Teams ids={[actor.id]}>
-        {({initiallyLoaded, teams}) =>
-          initiallyLoaded ? (
-            <TeamAvatar team={teams[0]} {...otherProps} />
-          ) : (
-            <LoadingIndicator mini />
-          )
-        }
-      </Teams>
-    );
+    return <LoadTeamAvatar teamId={actor.id} {...otherProps} />;
   }
 
   Sentry.withScope(scope => {

--- a/static/app/components/avatar/teamAvatar.tsx
+++ b/static/app/components/avatar/teamAvatar.tsx
@@ -1,12 +1,12 @@
 import BaseAvatar from 'sentry/components/avatar/baseAvatar';
-import {Team} from 'sentry/types';
+import type {Team} from 'sentry/types';
 import {explodeSlug} from 'sentry/utils';
 
-type Props = {
+interface TeamAvatarProps extends Omit<BaseAvatar['props'], 'uploadPath' | 'uploadId'> {
   team: Team | null;
-} & Omit<BaseAvatar['props'], 'uploadPath' | 'uploadId'>;
+}
 
-function TeamAvatar({team, tooltip: tooltipProp, ...props}: Props) {
+function TeamAvatar({team, tooltip: tooltipProp, ...props}: TeamAvatarProps) {
   if (!team) {
     return null;
   }


### PR DESCRIPTION
Use the new `useTeamsById` to dedupe requests to fetch teams that are not in the TeamStore. It might also make no requests since it now waits for the store to have loaded.

This is most prominent on the issue list in large orgs (> 100 teams) where we might make a request for a team for every issue in a list.

[example profile](https://sentry.sentry.io/performance/javascript:137c12420ac647a1b3eb6893676f86b2/)
![Screenshot 2023-09-27 at 2 56 55 PM Redacted](https://github.com/getsentry/sentry/assets/1400464/fed75a89-afce-4650-b906-67d495091f6f)
