### PR TITLE
ref(hybrid-cloud): Adds new organization provisioning service, splits slug logic into separate service call

### DIFF
--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -18,12 +18,12 @@ from sentry.db.models.query import in_iexact
 from sentry.models import Organization, OrganizationMember, OrganizationStatus, ProjectPlatform
 from sentry.search.utils import tokenize_query
 from sentry.services.hybrid_cloud import IDEMPOTENCY_KEY_LENGTH
-from sentry.services.hybrid_cloud.organization_provisioning import (
+from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.services.organization import (
     OrganizationOptions,
     OrganizationProvisioningOptions,
     PostProvisionOptions,
 )
-from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.services.organization.provisioning import organization_provisioning_service
 from sentry.signals import org_setup_complete, terms_accepted
 

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -22,9 +22,9 @@ from sentry.services.hybrid_cloud.organization_provisioning import (
     OrganizationOptions,
     OrganizationProvisioningOptions,
     PostProvisionOptions,
-    organization_provisioning_service,
 )
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.services.organization.provisioning import organization_provisioning_service
 from sentry.signals import org_setup_complete, terms_accepted
 
 
@@ -229,9 +229,9 @@ class OrganizationIndexEndpoint(Endpoint):
                     ),
                 )
 
-                rpc_org = organization_provisioning_service.provision_organization(
+                rpc_org = organization_provisioning_service.provision_organization_in_region(
                     region_name=settings.SENTRY_MONOLITH_REGION,
-                    org_provision_args=provision_args,
+                    provisioning_options=provision_args,
                 )
                 org = Organization.objects.get(id=rpc_org.id)
 

--- a/src/sentry/services/hybrid_cloud/organization_provisioning/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_provisioning/impl.py
@@ -17,10 +17,8 @@ from sentry.services.hybrid_cloud.organization.serial import serialize_rpc_organ
 from sentry.services.hybrid_cloud.organization_actions.impl import (
     create_organization_and_member_for_monolith,
 )
-from sentry.services.organization import (
-    OrganizationProvisioningOptions,
-    OrganizationProvisioningService,
-)
+from sentry.services.hybrid_cloud.organization_provisioning import OrganizationProvisioningService
+from sentry.services.organization import OrganizationProvisioningOptions
 
 
 class SlugMismatchException(Exception):

--- a/src/sentry/services/hybrid_cloud/organization_provisioning/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_provisioning/impl.py
@@ -17,7 +17,7 @@ from sentry.services.hybrid_cloud.organization.serial import serialize_rpc_organ
 from sentry.services.hybrid_cloud.organization_actions.impl import (
     create_organization_and_member_for_monolith,
 )
-from sentry.services.hybrid_cloud.organization_provisioning import (
+from sentry.services.organization import (
     OrganizationProvisioningOptions,
     OrganizationProvisioningService,
 )

--- a/src/sentry/services/hybrid_cloud/organization_provisioning/model.py
+++ b/src/sentry/services/hybrid_cloud/organization_provisioning/model.py
@@ -1,12 +1,11 @@
 import pydantic
 
+# TODO(Gabe): Remove this once GetSentry has been updated to use new model file in org provisioning
 from sentry.services.organization.model import (  # noqa
     OrganizationOptions,
     OrganizationProvisioningOptions,
     PostProvisionOptions,
 )
-
-# TODO(Gabe): Remove this once GetSentry has been updated to use new model file in org provisioning
 
 
 class RpcOrganizationSlugReservation(pydantic.BaseModel):

--- a/src/sentry/services/hybrid_cloud/organization_provisioning/model.py
+++ b/src/sentry/services/hybrid_cloud/organization_provisioning/model.py
@@ -1,24 +1,12 @@
-from typing import Any, Union
-
 import pydantic
 
+from sentry.services.organization.model import (  # noqa
+    OrganizationOptions,
+    OrganizationProvisioningOptions,
+    PostProvisionOptions,
+)
 
-class OrganizationOptions(pydantic.BaseModel):
-    name: str
-    slug: str
-    owning_user_id: int
-    create_default_team: bool = True
-    is_test = False
-
-
-class PostProvisionOptions(pydantic.BaseModel):
-    sentry_options: Union[Any, None]  # Placeholder for any sentry post-provisioning data
-    getsentry_options: Union[Any, None]  # Reserved for getsentry post-provisioning data
-
-
-class OrganizationProvisioningOptions(pydantic.BaseModel):
-    provision_options: OrganizationOptions
-    post_provision_options: PostProvisionOptions
+# TODO(Gabe): Remove this once GetSentry has been updated to use new model file in org provisioning
 
 
 class RpcOrganizationSlugReservation(pydantic.BaseModel):

--- a/src/sentry/services/hybrid_cloud/organization_provisioning/service.py
+++ b/src/sentry/services/hybrid_cloud/organization_provisioning/service.py
@@ -6,9 +6,9 @@ from abc import abstractmethod
 from typing import Optional, cast
 
 from sentry.services.hybrid_cloud.organization import RpcOrganization
-from sentry.services.hybrid_cloud.organization_provisioning import OrganizationProvisioningOptions
 from sentry.services.hybrid_cloud.region import ByRegionName
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method
+from sentry.services.organization.model import OrganizationProvisioningOptions
 from sentry.silo import SiloMode
 
 

--- a/src/sentry/services/organization/__init__.py
+++ b/src/sentry/services/organization/__init__.py
@@ -1,2 +1,2 @@
-from model import *  # noqa
-from provisioning import *  # noqa
+from .model import *  # noqa
+from .provisioning import *  # noqa

--- a/src/sentry/services/organization/__init__.py
+++ b/src/sentry/services/organization/__init__.py
@@ -1,0 +1,2 @@
+from model import *  # noqa
+from provisioning import *  # noqa

--- a/src/sentry/services/organization/model.py
+++ b/src/sentry/services/organization/model.py
@@ -1,0 +1,21 @@
+from typing import Any, Union
+
+import pydantic
+
+
+class OrganizationOptions(pydantic.BaseModel):
+    name: str
+    slug: str
+    owning_user_id: int
+    create_default_team: bool = True
+    is_test = False
+
+
+class PostProvisionOptions(pydantic.BaseModel):
+    sentry_options: Union[Any, None]  # Placeholder for any sentry post-provisioning data
+    getsentry_options: Union[Any, None]  # Reserved for getsentry post-provisioning data
+
+
+class OrganizationProvisioningOptions(pydantic.BaseModel):
+    provision_options: OrganizationOptions
+    post_provision_options: PostProvisionOptions

--- a/src/sentry/services/organization/provisioning.py
+++ b/src/sentry/services/organization/provisioning.py
@@ -4,10 +4,10 @@ from django.conf import settings
 from django.db import IntegrityError, router, transaction
 
 from sentry.models import Organization
-from sentry.services.hybrid_cloud.organization_provisioning import OrganizationProvisioningOptions
 from sentry.services.hybrid_cloud.organization_provisioning import (
     organization_provisioning_service as rpc_org_provisioning_service,
 )
+from sentry.services.organization.model import OrganizationProvisioningOptions
 
 
 class OrganizationSlugCollisionException(Exception):

--- a/src/sentry/services/organization/provisioning.py
+++ b/src/sentry/services/organization/provisioning.py
@@ -40,6 +40,11 @@ class OrganizationProvisioningService:
 
         return rpc_org
 
+    def idempotent_provision_organization_in_region(
+        self, provisioning_options: OrganizationProvisioningOptions, region_name: Optional[str]
+    ):
+        raise NotImplementedError()
+
     def modify_organization_slug(self, organization_id: int, slug: str):
         """
         Updates an organization with the given slug if available.

--- a/src/sentry/services/organization/provisioning.py
+++ b/src/sentry/services/organization/provisioning.py
@@ -1,0 +1,62 @@
+from typing import Optional
+
+from django.conf import settings
+from django.db import IntegrityError, router, transaction
+
+from sentry.models import Organization
+from sentry.services.hybrid_cloud.organization_provisioning import OrganizationProvisioningOptions
+from sentry.services.hybrid_cloud.organization_provisioning import (
+    organization_provisioning_service as rpc_org_provisioning_service,
+)
+
+
+class OrganizationSlugCollisionException(Exception):
+    pass
+
+
+class OrganizationProvisioningService:
+    def provision_organization_in_region(
+        self, provisioning_options: OrganizationProvisioningOptions, region_name: Optional[str]
+    ):
+        """
+        Provisions an organization in the provided region. If no region is
+        provided, the default monolith region is assumed.
+
+        This method is fairly slim at the moment, solely because it's acting
+        as a proxy for the underlying RPC service. There will be more
+        provisioning logic added when this is made multi-region safe.
+
+        :param provisioning_options: The organization provisioning and post-
+        provisioning options
+        :param region_name: The region name to provision the organization in.
+        :return: RPCOrganization
+        """
+        if region_name is None:
+            region_name = settings.SENTRY_MONOLITH_REGION
+
+        rpc_org = rpc_org_provisioning_service.provision_organization(
+            region_name=region_name, org_provision_args=provisioning_options
+        )
+
+        return rpc_org
+
+    def modify_organization_slug(self, organization_id: int, slug: str):
+        """
+        Updates an organization with the given slug if available.
+
+         This is currently database backed, but will be switched to be
+         RPC based in the near future.
+        :param organization_id:
+        :param slug:
+        :return:
+        """
+        try:
+            with transaction.atomic(using=router.db_for_write(Organization)):
+                organization = Organization.objects.get(id=organization_id)
+                organization.slug = slug
+                organization.save()
+        except IntegrityError:
+            raise OrganizationSlugCollisionException()
+
+
+organization_provisioning_service = OrganizationProvisioningService()

--- a/src/sentry/services/organization/provisioning.py
+++ b/src/sentry/services/organization/provisioning.py
@@ -3,10 +3,6 @@ from typing import Optional
 from django.conf import settings
 from django.db import IntegrityError, router, transaction
 
-from sentry.models import Organization
-from sentry.services.hybrid_cloud.organization_provisioning import (
-    organization_provisioning_service as rpc_org_provisioning_service,
-)
 from sentry.services.organization.model import OrganizationProvisioningOptions
 
 
@@ -34,6 +30,10 @@ class OrganizationProvisioningService:
         if region_name is None:
             region_name = settings.SENTRY_MONOLITH_REGION
 
+        from sentry.services.hybrid_cloud.organization_provisioning import (
+            organization_provisioning_service as rpc_org_provisioning_service,
+        )
+
         rpc_org = rpc_org_provisioning_service.provision_organization(
             region_name=region_name, org_provision_args=provisioning_options
         )
@@ -55,6 +55,9 @@ class OrganizationProvisioningService:
         :param slug:
         :return:
         """
+
+        from sentry.models import Organization
+
         try:
             with transaction.atomic(using=router.db_for_write(Organization)):
                 organization = Organization.objects.get(id=organization_id)

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -29,10 +29,8 @@ from sentry.models import (
     OrganizationAvatar,
     OrganizationOption,
     OrganizationStatus,
-    OutboxFlushError,
     RegionScheduledDeletion,
     User,
-    outbox_context,
 )
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.signals import project_created
@@ -852,48 +850,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         self.organization.refresh_from_db()
         assert self.organization.slug == desired_slug
 
-        organization_mapping.refresh_from_db()
-        assert organization_mapping.slug == desired_slug
-
-    def test_update_slug_with_temporary_rename_collision(self):
-        desired_slug = "taken"
-        previous_slug = self.organization.slug
-        org_with_colliding_slug = self.create_organization(
-            slug=desired_slug, name="collision-imminent"
-        )
-
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            colliding_org_mapping = OrganizationMapping.objects.get(
-                organization_id=org_with_colliding_slug.id
-            )
-        assert colliding_org_mapping.slug == desired_slug
-
-        # Queue a slug update but don't drain the shard yet to ensure a temporary collision happens
-        org_with_colliding_slug.slug = "unique-slug"
-        with outbox_context(flush=False):
-            org_with_colliding_slug.save()
-
-        self.get_success_response(self.organization.slug, slug=desired_slug)
-        self.organization.refresh_from_db()
-        assert self.organization.slug == desired_slug
-
-        # Ensure that the organization update has been flushed, but it collides when attempting an upsert
-        with pytest.raises(OutboxFlushError):
-            self.organization.outbox_for_update().drain_shard()
-
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            organization_mapping = OrganizationMapping.objects.get(
-                organization_id=self.organization.id
-            )
-        assert organization_mapping.slug == previous_slug
-
-        # Flush the colliding org slug change
-        org_with_colliding_slug.outbox_for_update().drain_shard()
-        colliding_org_mapping.refresh_from_db()
-        assert colliding_org_mapping.slug == "unique-slug"
-
-        # Flush the desired slug change and assert the correct slug was resolved
-        self.organization.outbox_for_update().drain_shard()
         organization_mapping.refresh_from_db()
         assert organization_mapping.slug == desired_slug
 

--- a/tests/sentry/hybrid_cloud/test_organization_provisioning.py
+++ b/tests/sentry/hybrid_cloud/test_organization_provisioning.py
@@ -11,11 +11,11 @@ from sentry.models import (
     outbox_context,
 )
 from sentry.services.hybrid_cloud.organization import RpcOrganization
-from sentry.services.hybrid_cloud.organization_provisioning import (
+from sentry.services.hybrid_cloud.organization_provisioning import organization_provisioning_service
+from sentry.services.organization import (
     OrganizationOptions,
     OrganizationProvisioningOptions,
     PostProvisionOptions,
-    organization_provisioning_service,
 )
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase


### PR DESCRIPTION
The motivation behind this change is to provide an obvious organization service to use for creating an organization and editing its slug. As we're making Control Silo the source of truth for both of these operations via the `OrganizationSlugReservation` model, this service is acting as a temporary proxy which will eventually house more complex, region-safe provisioning and slug update logic.

