### PR TITLE
feat(ddm): Send mri to tag values endpoint

### DIFF
--- a/static/app/utils/metrics.tsx
+++ b/static/app/utils/metrics.tsx
@@ -181,10 +181,10 @@ function getDateTimeParams({start, end, period}: PageFilters['datetime']) {
 type UseCase = 'sessions' | 'transactions' | 'custom';
 
 export function getUseCaseFromMri(mri?: string): UseCase {
-  if (mri?.includes('custom')) {
+  if (mri?.includes('custom/')) {
     return 'custom';
   }
-  if (mri?.includes('transactions')) {
+  if (mri?.includes('transactions/')) {
     return 'transactions';
   }
   return 'sessions';

--- a/static/app/views/ddm/metricsExplorer.tsx
+++ b/static/app/views/ddm/metricsExplorer.tsx
@@ -214,15 +214,14 @@ function MetricSearchBar({tags, mri, disabled, onChange, query}: MetricSearchBar
         `/organizations/${org.slug}/metrics/tags/${tag.key}/`,
         {
           query: {
-            // TODO(ddm): OrganizationMetricsTagDetailsEndpoint does not return values when metric is specified
-            // metric: mri,
+            metric: mri,
             useCase: getUseCaseFromMri(mri),
             project: selection.projects,
           },
         }
       );
 
-      return tagsValues.map(tv => tv.value);
+      return tagsValues.filter(tv => tv.value !== '').map(tv => tv.value);
     },
     [api, mri, org.slug, selection.projects]
   );


### PR DESCRIPTION
This PR makes it so that tag values autosuggestions are scoped to the MRI.
It also filters out empty strings.

Relates to https://github.com/getsentry/sentry/issues/56918