### PR TITLE
feat(replays): new widgets with example replays

### DIFF
--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -1,89 +1,266 @@
-import {Fragment} from 'react';
+import {ComponentProps, Fragment, ReactNode, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
-import {IconCursorArrow} from 'sentry/icons';
+import {LinkButton} from 'sentry/components/button';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import TextOverflow from 'sentry/components/textOverflow';
+import {IconCursorArrow, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import EventView from 'sentry/utils/discover/eventView';
+import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import useDeadRageSelectors from 'sentry/utils/replays/hooks/useDeadRageSelectors';
+import useReplayList from 'sentry/utils/replays/hooks/useReplayList';
 import {useLocation} from 'sentry/utils/useLocation';
-import SelectorTable from 'sentry/views/replays/deadRageClick/selectorTable';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useRoutes} from 'sentry/utils/useRoutes';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import Accordion from 'sentry/views/performance/landing/widgets/components/accordion';
+import {RightAlignedCell} from 'sentry/views/performance/landing/widgets/components/selectableList';
+import {
+  ContentContainer,
+  HeaderContainer,
+  HeaderTitleLegend,
+  StatusContainer,
+  Subtitle,
+  WidgetContainer,
+} from 'sentry/views/profiling/landing/styles';
+import {ReplayCell} from 'sentry/views/replays/replayTable/tableCell';
+import {ReplayListLocationQuery} from 'sentry/views/replays/types';
+
+function transformSelectorQuery(selector: string) {
+  const escaped = selector.replace(/"/g, '\\"');
+  return escaped.replace(/aria=/g, 'aria-label=');
+}
+
+function UseExampleReplays(selector, location, clickType, deadOrRage) {
+  const organization = useOrganization();
+  const query = transformSelectorQuery(selector);
+  const {project, environment, start, statsPeriod, utc, end} = location.query;
+  const emptyLocation: Location<ReplayListLocationQuery> = useMemo(() => {
+    return {
+      pathname: '',
+      search: '',
+      hash: '',
+      state: '',
+      action: 'PUSH' as const,
+      key: '',
+      query: {project, environment, start, statsPeriod, utc, end},
+    };
+  }, [project, environment, start, statsPeriod, utc, end]);
+
+  const eventView = useMemo(
+    () =>
+      EventView.fromNewQueryWithLocation(
+        {
+          id: '',
+          name: '',
+          version: 2,
+          fields: [
+            'activity',
+            'duration',
+            'id',
+            'project_id',
+            'user',
+            'finished_at',
+            'is_archived',
+            'started_at',
+            'urls',
+          ],
+          projects: [],
+          query: `${deadOrRage}.selector:"${query}"`,
+          orderby: `-${clickType}`,
+        },
+        emptyLocation
+      ),
+    [emptyLocation, query, clickType, deadOrRage]
+  );
+
+  const {replays, isFetching, fetchError} = useReplayList({
+    eventView,
+    location: emptyLocation,
+    organization,
+    perPage: 3,
+  });
+
+  const routes = useRoutes();
+  const referrer = getRouteStringFromRoutes(routes);
+
+  return (
+    <Fragment>
+      {fetchError || (!isFetching && !replays?.length) ? (
+        <EmptyStateWarning withIcon={false} small>
+          {t('No replays found')}
+        </EmptyStateWarning>
+      ) : (
+        replays?.map(r => {
+          return (
+            <ReplayCell
+              key="session"
+              replay={r}
+              eventView={eventView}
+              organization={organization}
+              referrer={referrer}
+              showUrl={false}
+              referrer_table="main"
+            />
+          );
+        })
+      )}
+    </Fragment>
+  );
+}
 
 function DeadRageSelectorCards() {
   const location = useLocation();
 
   return (
     <SplitCardContainer>
-      <DeadClickTable location={location} />
-      <RageClickTable location={location} />
+      <AccordionWidget
+        clickType="count_dead_clicks"
+        widgetTitle={t('Most Dead Clicks')}
+        deadOrRage="dead"
+        location={location}
+      />
+      <AccordionWidget
+        clickType="count_rage_clicks"
+        widgetTitle={t('Most Rage Clicks')}
+        deadOrRage="rage"
+        location={location}
+      />
     </SplitCardContainer>
   );
 }
 
-function DeadClickTable({location}: {location: Location<any>}) {
+function AccordionWidget({
+  location,
+  clickType,
+  deadOrRage,
+  widgetTitle,
+}: {
+  clickType: 'count_dead_clicks' | 'count_rage_clicks';
+  deadOrRage: string;
+  location: Location<any>;
+  widgetTitle: string;
+}) {
+  const [selectedListIndex, setSelectListIndex] = useState(0);
   const {isLoading, isError, data} = useDeadRageSelectors({
-    per_page: 4,
-    sort: '-count_dead_clicks',
+    per_page: 3,
+    sort: `-${clickType}`,
     cursor: undefined,
     prefix: 'selector_',
     isWidgetData: true,
   });
 
+  const filteredData = data.filter(d => (d[clickType] ?? 0) > 0);
+
   return (
-    <SelectorTable
-      data={data.filter(d => (d.count_dead_clicks ?? 0) > 0)}
-      isError={isError}
-      isLoading={isLoading}
-      location={location}
-      clickCountColumns={[{key: 'count_dead_clicks', name: 'dead clicks'}]}
-      title={
-        <Fragment>
-          <IconContainer>
-            <IconCursorArrow size="xs" color="yellow300" />
-          </IconContainer>
-          {t('Most Dead Clicks')}
-        </Fragment>
-      }
-      customHandleResize={() => {}}
-      clickCountSortable={false}
-    />
+    <Fragment>
+      <WidgetContainer>
+        <StyledHeaderContainer>
+          <HeaderTitleLegend>{widgetTitle}</HeaderTitleLegend>
+          <Subtitle>{t('Suggested replays to watch')}</Subtitle>
+        </StyledHeaderContainer>
+        <StyledContainerContainer>
+          {isLoading && (
+            <StatusContainer>
+              <LoadingIndicator />
+            </StatusContainer>
+          )}
+          {isError && (
+            <StatusContainer>
+              <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
+            </StatusContainer>
+          )}
+          {!isLoading && filteredData.length === 0 ? (
+            <EmptyStateWarning>
+              <p>{t('No results found')}</p>
+            </EmptyStateWarning>
+          ) : (
+            <Accordion
+              expandedIndex={selectedListIndex}
+              setExpandedIndex={setSelectListIndex}
+              items={filteredData.map(d => {
+                return {
+                  header: () => (
+                    <Fragment>
+                      <StyledText>
+                        <code>{d.dom_element}</code>
+                      </StyledText>
+                      <RightAlignedCell>
+                        {clickType === 'count_dead_clicks' ? (
+                          <DeadClickCount>
+                            <IconContainer>
+                              <IconCursorArrow size="xs" />
+                            </IconContainer>
+                            {d[clickType]}
+                          </DeadClickCount>
+                        ) : (
+                          <RageClickCount>
+                            <IconContainer>
+                              <IconCursorArrow size="xs" />
+                            </IconContainer>
+                            {d[clickType]}
+                          </RageClickCount>
+                        )}
+                      </RightAlignedCell>
+                    </Fragment>
+                  ),
+                  content: () =>
+                    UseExampleReplays(d.dom_element, location, clickType, deadOrRage),
+                };
+              })}
+            />
+          )}
+        </StyledContainerContainer>
+        <SearchButton
+          label={t('See all selectors')}
+          path="selectors"
+          sort={`-${clickType}`}
+        />
+      </WidgetContainer>
+    </Fragment>
   );
 }
 
-function RageClickTable({location}: {location: Location<any>}) {
-  const {isLoading, isError, data} = useDeadRageSelectors({
-    per_page: 4,
-    sort: '-count_rage_clicks',
-    cursor: undefined,
-    prefix: 'selector_',
-    isWidgetData: true,
-  });
+function SearchButton({
+  label,
+  sort,
+  path,
+  ...props
+}: {
+  label: ReactNode;
+  path: string;
+  sort: string;
+} & Omit<ComponentProps<typeof LinkButton>, 'size' | 'to'>) {
+  const location = useLocation();
+  const organization = useOrganization();
 
   return (
-    <SelectorTable
-      data={data.filter(d => (d.count_rage_clicks ?? 0) > 0)}
-      isError={isError}
-      isLoading={isLoading}
-      location={location}
-      clickCountColumns={[{key: 'count_rage_clicks', name: 'rage clicks'}]}
-      title={
-        <Fragment>
-          <IconContainer>
-            <IconCursorArrow size="xs" color="red300" />
-          </IconContainer>
-          {t('Most Rage Clicks')}
-        </Fragment>
-      }
-      customHandleResize={() => {}}
-      clickCountSortable={false}
-    />
+    <StyledButton
+      {...props}
+      size="xs"
+      to={{
+        pathname: normalizeUrl(`/organizations/${organization.slug}/replays/${path}/`),
+        query: {
+          ...location.query,
+          sort,
+          query: undefined,
+          cursor: undefined,
+        },
+      }}
+    >
+      {label}
+    </StyledButton>
   );
 }
 
 const SplitCardContainer = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: max-content max-content;
+  grid-template-rows: max-content;
   grid-auto-flow: column;
   gap: 0 ${space(2)};
   align-items: stretch;
@@ -92,6 +269,36 @@ const SplitCardContainer = styled('div')`
 
 const IconContainer = styled('span')`
   margin-right: ${space(1)};
+`;
+
+const StyledText = styled('div')`
+  flex: 1;
+`;
+
+const DeadClickCount = styled(TextOverflow)`
+  color: ${p => p.theme.yellow300};
+`;
+
+const RageClickCount = styled(TextOverflow)`
+  color: ${p => p.theme.red300};
+`;
+
+const StyledHeaderContainer = styled(HeaderContainer)`
+  margin-bottom: ${space(1)};
+`;
+
+const StyledContainerContainer = styled(ContentContainer)`
+  justify-content: flex-start;
+`;
+
+const StyledButton = styled(LinkButton)`
+  width: 100%;
+  border-radius: ${p => p.theme.borderRadiusBottom};
+  padding: ${space(3)};
+  border-bottom: none;
+  border-left: none;
+  border-right: none;
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 export default DeadRageSelectorCards;

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -211,14 +211,16 @@ const DeadClickColor = styled(TextOverflow)`
   color: ${p => p.theme.yellow300};
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: ${space(0.75)};
+  gap: ${space(0.5)};
+  align-items: center;
 `;
 
 const RageClickColor = styled(TextOverflow)`
   color: ${p => p.theme.red300};
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: ${space(0.75)};
+  gap: ${space(0.5)};
+  align-items: center;
 `;
 
 const StyledHeaderContainer = styled(HeaderContainer)`

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -32,7 +32,7 @@ import {ReplayListLocationQuery} from 'sentry/views/replays/types';
 
 function transformSelectorQuery(selector: string) {
   return selector
-    .replaceAll('"', `\"`)
+    .replaceAll('"', `\\"`)
     .replaceAll('aria=', 'aria-label=')
     .replaceAll('testid=', 'data-test-id=');
 }

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 import {LinkButton} from 'sentry/components/button';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import TextOverflow from 'sentry/components/textOverflow';
 import {IconCursorArrow, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -35,12 +36,14 @@ function DeadRageSelectorCards() {
         widgetTitle={t('Most Dead Clicks')}
         deadOrRage="dead"
         location={location}
+        tooltip={t('The top selectors your users have dead clicked on.')}
       />
       <AccordionWidget
         clickType="count_rage_clicks"
         widgetTitle={t('Most Rage Clicks')}
         deadOrRage="rage"
         location={location}
+        tooltip={t('The top selectors your users have rage clicked on.')}
       />
     </SplitCardContainer>
   );
@@ -51,10 +54,12 @@ function AccordionWidget({
   clickType,
   deadOrRage,
   widgetTitle,
+  tooltip,
 }: {
   clickType: 'count_dead_clicks' | 'count_rage_clicks';
   deadOrRage: string;
   location: Location<any>;
+  tooltip: string;
   widgetTitle: string;
 }) {
   const [selectedListIndex, setSelectListIndex] = useState(0);
@@ -71,7 +76,11 @@ function AccordionWidget({
   return (
     <WidgetContainer>
       <StyledHeaderContainer>
-        <HeaderTitleLegend>{widgetTitle}</HeaderTitleLegend>
+        <StyledWidgetHeader>
+          {widgetTitle}
+          <StyledQuestionTooltip size="xs" position="top" title={tooltip} isHoverable />
+        </StyledWidgetHeader>
+
         <Subtitle>{t('Suggested replays to watch')}</Subtitle>
       </StyledHeaderContainer>
       {isLoading && (
@@ -222,6 +231,14 @@ const StyledAccordionHeader = styled('div')`
 `;
 const StyledEmptyState = styled(ContentContainer)`
   justify-content: center;
+`;
+
+const StyledWidgetHeader = styled(HeaderTitleLegend)`
+  display: block;
+`;
+
+const StyledQuestionTooltip = styled(QuestionTooltip)`
+  margin-left: ${space(1)};
 `;
 
 export default DeadRageSelectorCards;

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -31,8 +31,10 @@ import {ReplayCell} from 'sentry/views/replays/replayTable/tableCell';
 import {ReplayListLocationQuery} from 'sentry/views/replays/types';
 
 function transformSelectorQuery(selector: string) {
-  const escaped = selector.replace(/"/g, '\\"');
-  return escaped.replace(/aria=/g, 'aria-label=');
+  return selector
+    .replace(/"/g, '\\"')
+    .replace(/aria=/g, 'aria-label=')
+    .replace(/testid=/g, 'data-test-id=');
 }
 
 function UseExampleReplays(selector, location, clickType, deadOrRage) {

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -1,4 +1,4 @@
-import {ComponentProps, Fragment, ReactNode, useMemo, useState} from 'react';
+import {ComponentProps, ReactNode, useState} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
@@ -9,13 +9,9 @@ import TextOverflow from 'sentry/components/textOverflow';
 import {IconCursorArrow, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import EventView from 'sentry/utils/discover/eventView';
-import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import useDeadRageSelectors from 'sentry/utils/replays/hooks/useDeadRageSelectors';
-import useReplayList from 'sentry/utils/replays/hooks/useReplayList';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import Accordion from 'sentry/views/performance/landing/widgets/components/accordion';
 import {RightAlignedCell} from 'sentry/views/performance/landing/widgets/components/selectableList';
@@ -27,93 +23,7 @@ import {
   Subtitle,
   WidgetContainer,
 } from 'sentry/views/profiling/landing/styles';
-import {ReplayCell} from 'sentry/views/replays/replayTable/tableCell';
-import {ReplayListLocationQuery} from 'sentry/views/replays/types';
-
-function transformSelectorQuery(selector: string) {
-  return selector
-    .replaceAll('"', `\\"`)
-    .replaceAll('aria=', 'aria-label=')
-    .replaceAll('testid=', 'data-test-id=');
-}
-
-function UseExampleReplays(selector, location, clickType, deadOrRage) {
-  const organization = useOrganization();
-  const query = transformSelectorQuery(selector);
-  const {project, environment, start, statsPeriod, utc, end} = location.query;
-  const emptyLocation: Location<ReplayListLocationQuery> = useMemo(() => {
-    return {
-      pathname: '',
-      search: '',
-      hash: '',
-      state: '',
-      action: 'PUSH' as const,
-      key: '',
-      query: {project, environment, start, statsPeriod, utc, end},
-    };
-  }, [project, environment, start, statsPeriod, utc, end]);
-
-  const eventView = useMemo(
-    () =>
-      EventView.fromNewQueryWithLocation(
-        {
-          id: '',
-          name: '',
-          version: 2,
-          fields: [
-            'activity',
-            'duration',
-            'id',
-            'project_id',
-            'user',
-            'finished_at',
-            'is_archived',
-            'started_at',
-            'urls',
-          ],
-          projects: [],
-          query: `${deadOrRage}.selector:"${query}"`,
-          orderby: `-${clickType}`,
-        },
-        emptyLocation
-      ),
-    [emptyLocation, query, clickType, deadOrRage]
-  );
-
-  const {replays, isFetching, fetchError} = useReplayList({
-    eventView,
-    location: emptyLocation,
-    organization,
-    perPage: 3,
-  });
-
-  const routes = useRoutes();
-  const referrer = getRouteStringFromRoutes(routes);
-
-  return (
-    <Fragment>
-      {fetchError || (!isFetching && !replays?.length) ? (
-        <EmptyStateWarning withIcon={false} small>
-          {t('No replays found')}
-        </EmptyStateWarning>
-      ) : (
-        replays?.map(r => {
-          return (
-            <ReplayCell
-              key="session"
-              replay={r}
-              eventView={eventView}
-              organization={organization}
-              referrer={referrer}
-              showUrl={false}
-              referrer_table="main"
-            />
-          );
-        })
-      )}
-    </Fragment>
-  );
-}
+import ExampleReplaysList from 'sentry/views/replays/deadRageClick/exampleReplaysList';
 
 function DeadRageSelectorCards() {
   const location = useLocation();
@@ -159,73 +69,77 @@ function AccordionWidget({
   const filteredData = data.filter(d => (d[clickType] ?? 0) > 0);
 
   return (
-    <Fragment>
-      <WidgetContainer>
-        <StyledHeaderContainer>
-          <HeaderTitleLegend>{widgetTitle}</HeaderTitleLegend>
-          <Subtitle>{t('Suggested replays to watch')}</Subtitle>
-        </StyledHeaderContainer>
-        {isLoading && (
-          <StatusContainer>
-            <LoadingIndicator />
-          </StatusContainer>
-        )}
-        {isError && (
-          <StatusContainer>
-            <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
-          </StatusContainer>
-        )}
-        {!isLoading && filteredData.length === 0 ? (
-          <StyledEmptyState>
-            <EmptyStateWarning>
-              <p>{t('No results found')}</p>
-            </EmptyStateWarning>
-          </StyledEmptyState>
-        ) : (
-          <StyledContainerContainer>
-            <Accordion
-              expandedIndex={selectedListIndex}
-              setExpandedIndex={setSelectListIndex}
-              items={filteredData.map(d => {
-                return {
-                  header: () => (
-                    <StyledAccordionHeader>
-                      <TextOverflow>
-                        <code>{d.dom_element}</code>
-                      </TextOverflow>
-                      <RightAlignedCell>
-                        {clickType === 'count_dead_clicks' ? (
-                          <DeadClickCount>
-                            <IconContainer>
-                              <IconCursorArrow size="xs" />
-                            </IconContainer>
-                            {d[clickType]}
-                          </DeadClickCount>
-                        ) : (
-                          <RageClickCount>
-                            <IconContainer>
-                              <IconCursorArrow size="xs" />
-                            </IconContainer>
-                            {d[clickType]}
-                          </RageClickCount>
-                        )}
-                      </RightAlignedCell>
-                    </StyledAccordionHeader>
-                  ),
-                  content: () =>
-                    UseExampleReplays(d.dom_element, location, clickType, deadOrRage),
-                };
-              })}
-            />
-          </StyledContainerContainer>
-        )}
-        <SearchButton
-          label={t('See all selectors')}
-          path="selectors"
-          sort={`-${clickType}`}
-        />
-      </WidgetContainer>
-    </Fragment>
+    <WidgetContainer>
+      <StyledHeaderContainer>
+        <HeaderTitleLegend>{widgetTitle}</HeaderTitleLegend>
+        <Subtitle>{t('Suggested replays to watch')}</Subtitle>
+      </StyledHeaderContainer>
+      {isLoading && (
+        <StatusContainer>
+          <LoadingIndicator />
+        </StatusContainer>
+      )}
+      {isError && (
+        <StatusContainer>
+          <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
+        </StatusContainer>
+      )}
+      {!isLoading && filteredData.length === 0 ? (
+        <StyledEmptyState>
+          <EmptyStateWarning>
+            <p>{t('No results found')}</p>
+          </EmptyStateWarning>
+        </StyledEmptyState>
+      ) : (
+        <StyledContentContainer>
+          <Accordion
+            expandedIndex={selectedListIndex}
+            setExpandedIndex={setSelectListIndex}
+            items={filteredData.map(d => {
+              return {
+                header: () => (
+                  <StyledAccordionHeader>
+                    <TextOverflow>
+                      <code>{d.dom_element}</code>
+                    </TextOverflow>
+                    <RightAlignedCell>
+                      {clickType === 'count_dead_clicks' ? (
+                        <DeadClickCount>
+                          <IconContainer>
+                            <IconCursorArrow size="xs" />
+                          </IconContainer>
+                          {d[clickType]}
+                        </DeadClickCount>
+                      ) : (
+                        <RageClickCount>
+                          <IconContainer>
+                            <IconCursorArrow size="xs" />
+                          </IconContainer>
+                          {d[clickType]}
+                        </RageClickCount>
+                      )}
+                    </RightAlignedCell>
+                  </StyledAccordionHeader>
+                ),
+                content: () => (
+                  <ExampleReplaysList
+                    selector={d.dom_element}
+                    location={location}
+                    clickType={clickType}
+                    deadOrRage={deadOrRage}
+                  />
+                ),
+              };
+            })}
+          />
+        </StyledContentContainer>
+      )}
+      <SearchButton
+        label={t('See all selectors')}
+        path="selectors"
+        sort={`-${clickType}`}
+      />
+    </WidgetContainer>
   );
 }
 
@@ -287,7 +201,7 @@ const StyledHeaderContainer = styled(HeaderContainer)`
   margin-bottom: ${space(1)};
 `;
 
-const StyledContainerContainer = styled(ContentContainer)`
+const StyledContentContainer = styled(ContentContainer)`
   justify-content: flex-start;
 `;
 

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -187,10 +187,10 @@ function AccordionWidget({
               items={filteredData.map(d => {
                 return {
                   header: () => (
-                    <Fragment>
-                      <StyledText>
+                    <StyledAccordionHeader>
+                      <TextOverflow>
                         <code>{d.dom_element}</code>
-                      </StyledText>
+                      </TextOverflow>
                       <RightAlignedCell>
                         {clickType === 'count_dead_clicks' ? (
                           <DeadClickCount>
@@ -208,7 +208,7 @@ function AccordionWidget({
                           </RageClickCount>
                         )}
                       </RightAlignedCell>
-                    </Fragment>
+                    </StyledAccordionHeader>
                   ),
                   content: () =>
                     UseExampleReplays(d.dom_element, location, clickType, deadOrRage),
@@ -273,10 +273,6 @@ const IconContainer = styled('span')`
   margin-right: ${space(1)};
 `;
 
-const StyledText = styled('div')`
-  flex: 1;
-`;
-
 const DeadClickCount = styled(TextOverflow)`
   color: ${p => p.theme.yellow300};
 `;
@@ -301,6 +297,12 @@ const StyledButton = styled(LinkButton)`
   border-left: none;
   border-right: none;
   font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const StyledAccordionHeader = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  flex: 1;
 `;
 
 export default DeadRageSelectorCards;

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -165,22 +165,24 @@ function AccordionWidget({
           <HeaderTitleLegend>{widgetTitle}</HeaderTitleLegend>
           <Subtitle>{t('Suggested replays to watch')}</Subtitle>
         </StyledHeaderContainer>
-        <StyledContainerContainer>
-          {isLoading && (
-            <StatusContainer>
-              <LoadingIndicator />
-            </StatusContainer>
-          )}
-          {isError && (
-            <StatusContainer>
-              <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
-            </StatusContainer>
-          )}
-          {!isLoading && filteredData.length === 0 ? (
+        {isLoading && (
+          <StatusContainer>
+            <LoadingIndicator />
+          </StatusContainer>
+        )}
+        {isError && (
+          <StatusContainer>
+            <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
+          </StatusContainer>
+        )}
+        {!isLoading && filteredData.length === 0 ? (
+          <StyledEmptyState>
             <EmptyStateWarning>
               <p>{t('No results found')}</p>
             </EmptyStateWarning>
-          ) : (
+          </StyledEmptyState>
+        ) : (
+          <StyledContainerContainer>
             <Accordion
               expandedIndex={selectedListIndex}
               setExpandedIndex={setSelectListIndex}
@@ -215,8 +217,8 @@ function AccordionWidget({
                 };
               })}
             />
-          )}
-        </StyledContainerContainer>
+          </StyledContainerContainer>
+        )}
         <SearchButton
           label={t('See all selectors')}
           path="selectors"
@@ -303,6 +305,9 @@ const StyledAccordionHeader = styled('div')`
   display: grid;
   grid-template-columns: 1fr max-content;
   flex: 1;
+`;
+const StyledEmptyState = styled(ContentContainer)`
+  justify-content: center;
 `;
 
 export default DeadRageSelectorCards;

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -32,9 +32,9 @@ import {ReplayListLocationQuery} from 'sentry/views/replays/types';
 
 function transformSelectorQuery(selector: string) {
   return selector
-    .replace(/"/g, '\\"')
-    .replace(/aria=/g, 'aria-label=')
-    .replace(/testid=/g, 'data-test-id=');
+    .replaceAll('"', `\"`)
+    .replaceAll('aria=', 'aria-label=')
+    .replaceAll('testid=', 'data-test-id=');
 }
 
 function UseExampleReplays(selector, location, clickType, deadOrRage) {

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -145,16 +145,12 @@ function AccordionItemHeader({
   const clickCount =
     deadOrRage === 'dead' ? (
       <DeadClickColor>
-        <IconContainer>
-          <IconCursorArrow size="xs" />
-        </IconContainer>
+        <IconCursorArrow size="xs" />
         {count}
       </DeadClickColor>
     ) : (
       <RageClickColor>
-        <IconContainer>
-          <IconCursorArrow size="xs" />
-        </IconContainer>
+        <IconCursorArrow size="xs" />
         {count}
       </RageClickColor>
     );
@@ -211,16 +207,18 @@ const SplitCardContainer = styled('div')`
   padding-top: ${space(1)};
 `;
 
-const IconContainer = styled('span')`
-  margin-right: ${space(1)};
-`;
-
 const DeadClickColor = styled(TextOverflow)`
   color: ${p => p.theme.yellow300};
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: ${space(0.75)};
 `;
 
 const RageClickColor = styled(TextOverflow)`
   color: ${p => p.theme.red300};
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: ${space(0.75)};
 `;
 
 const StyledHeaderContainer = styled(HeaderContainer)`

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -81,7 +81,7 @@ function AccordionWidget({
         <div>
           <StyledWidgetHeader>
             {widgetTitle}
-            <StyledQuestionTooltip size="xs" position="top" title={tooltip} isHoverable />
+            <QuestionTooltip size="xs" position="top" title={tooltip} isHoverable />
           </StyledWidgetHeader>
           <Subtitle>{t('Suggested replays to watch')}</Subtitle>
         </div>
@@ -255,11 +255,10 @@ const StyledAccordionHeader = styled('div')`
 `;
 
 const StyledWidgetHeader = styled(HeaderTitleLegend)`
-  display: block;
-`;
-
-const StyledQuestionTooltip = styled(QuestionTooltip)`
-  margin-left: ${space(1)};
+  display: grid;
+  gap: ${space(1)};
+  justify-content: start;
+  align-items: center;
 `;
 
 export default DeadRageSelectorCards;

--- a/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
+++ b/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
@@ -12,26 +12,16 @@ import {useRoutes} from 'sentry/utils/useRoutes';
 import {StatusContainer} from 'sentry/views/profiling/landing/styles';
 import {ReplayCell} from 'sentry/views/replays/replayTable/tableCell';
 
-function transformSelectorQuery(selector: string) {
-  return selector
-    .replaceAll('"', `\\"`)
-    .replaceAll('aria=', 'aria-label=')
-    .replaceAll('testid=', 'data-test-id=');
-}
-
 export default function ExampleReplaysList({
-  selector,
   location,
   clickType,
-  deadOrRage,
+  query,
 }: {
   clickType: 'count_dead_clicks' | 'count_rage_clicks';
-  deadOrRage: 'dead' | 'rage';
   location: Location;
-  selector: string;
+  query: string;
 }) {
   const organization = useOrganization();
-  const query = transformSelectorQuery(selector);
   const {project, environment, start, statsPeriod, utc, end} = location.query;
   const emptyLocation: Location = useMemo(() => {
     return {
@@ -64,12 +54,12 @@ export default function ExampleReplaysList({
             'urls',
           ],
           projects: [],
-          query: `${deadOrRage}.selector:"${query}"`,
+          query,
           orderby: `-${clickType}`,
         },
         emptyLocation
       ),
-    [emptyLocation, query, clickType, deadOrRage]
+    [emptyLocation, query, clickType]
   );
 
   const {replays, isFetching, fetchError} = useReplayList({

--- a/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
+++ b/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
@@ -1,0 +1,106 @@
+import {Fragment, useMemo} from 'react';
+import {Location} from 'history';
+
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import {t} from 'sentry/locale';
+import EventView from 'sentry/utils/discover/eventView';
+import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
+import useReplayList from 'sentry/utils/replays/hooks/useReplayList';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useRoutes} from 'sentry/utils/useRoutes';
+import {ReplayCell} from 'sentry/views/replays/replayTable/tableCell';
+
+function transformSelectorQuery(selector: string) {
+  return selector
+    .replaceAll('"', `\\"`)
+    .replaceAll('aria=', 'aria-label=')
+    .replaceAll('testid=', 'data-test-id=');
+}
+
+export default function ExampleReplaysList({
+  selector,
+  location,
+  clickType,
+  deadOrRage,
+}: {
+  clickType: string;
+  deadOrRage: string;
+  location: Location;
+  selector: string;
+}) {
+  const organization = useOrganization();
+  const query = transformSelectorQuery(selector);
+  const {project, environment, start, statsPeriod, utc, end} = location.query;
+  const emptyLocation: Location = useMemo(() => {
+    return {
+      pathname: '',
+      search: '',
+      hash: '',
+      state: '',
+      action: 'PUSH' as const,
+      key: '',
+      query: {project, environment, start, statsPeriod, utc, end},
+    };
+  }, [project, environment, start, statsPeriod, utc, end]);
+
+  const eventView = useMemo(
+    () =>
+      EventView.fromNewQueryWithLocation(
+        {
+          id: '',
+          name: '',
+          version: 2,
+          fields: [
+            'activity',
+            'duration',
+            'id',
+            'project_id',
+            'user',
+            'finished_at',
+            'is_archived',
+            'started_at',
+            'urls',
+          ],
+          projects: [],
+          query: `${deadOrRage}.selector:"${query}"`,
+          orderby: `-${clickType}`,
+        },
+        emptyLocation
+      ),
+    [emptyLocation, query, clickType, deadOrRage]
+  );
+
+  const {replays, isFetching, fetchError} = useReplayList({
+    eventView,
+    location: emptyLocation,
+    organization,
+    perPage: 3,
+  });
+
+  const routes = useRoutes();
+  const referrer = getRouteStringFromRoutes(routes);
+
+  return (
+    <Fragment>
+      {fetchError || (!isFetching && !replays?.length) ? (
+        <EmptyStateWarning withIcon={false} small>
+          {t('No replays found')}
+        </EmptyStateWarning>
+      ) : (
+        replays?.map(r => {
+          return (
+            <ReplayCell
+              key="session"
+              replay={r}
+              eventView={eventView}
+              organization={organization}
+              referrer={referrer}
+              showUrl={false}
+              referrer_table="main"
+            />
+          );
+        })
+      )}
+    </Fragment>
+  );
+}

--- a/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
+++ b/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
@@ -2,12 +2,14 @@ import {Fragment, useMemo} from 'react';
 import {Location} from 'history';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import useReplayList from 'sentry/utils/replays/hooks/useReplayList';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useRoutes} from 'sentry/utils/useRoutes';
+import {StatusContainer} from 'sentry/views/profiling/landing/styles';
 import {ReplayCell} from 'sentry/views/replays/replayTable/tableCell';
 
 function transformSelectorQuery(selector: string) {
@@ -23,8 +25,8 @@ export default function ExampleReplaysList({
   clickType,
   deadOrRage,
 }: {
-  clickType: string;
-  deadOrRage: string;
+  clickType: 'count_dead_clicks' | 'count_rage_clicks';
+  deadOrRage: 'dead' | 'rage';
   location: Location;
   selector: string;
 }) {
@@ -82,6 +84,11 @@ export default function ExampleReplaysList({
 
   return (
     <Fragment>
+      {isFetching && (
+        <StatusContainer>
+          <LoadingIndicator />
+        </StatusContainer>
+      )}
       {fetchError || (!isFetching && !replays?.length) ? (
         <EmptyStateWarning withIcon={false} small>
           {t('No replays found')}

--- a/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
+++ b/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
@@ -103,7 +103,7 @@ export default function ExampleReplaysList({
               organization={organization}
               referrer={referrer}
               showUrl={false}
-              referrer_table="main"
+              referrer_table="selector-widget"
             />
           );
         })

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -48,7 +48,6 @@ interface Props {
   isError: boolean;
   isLoading: boolean;
   location: Location<any>;
-  customHandleResize?: () => void;
   title?: ReactNode;
 }
 
@@ -65,7 +64,6 @@ export default function SelectorTable({
   isLoading,
   location,
   title,
-  customHandleResize,
   clickCountSortable,
 }: Props) {
   const organization = useOrganization();
@@ -121,7 +119,7 @@ export default function SelectorTable({
       columnSortBy={[]}
       stickyHeader
       grid={{
-        onResizeColumn: customHandleResize ?? handleResizeColumn,
+        onResizeColumn: handleResizeColumn,
         renderHeadCell,
         renderBodyCell,
       }}

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -43,7 +43,12 @@ type Props = {
   showDropdownFilters?: boolean;
 };
 
-export type ReferrerTableType = 'main' | 'dead-table' | 'errors-table' | 'rage-table';
+export type ReferrerTableType =
+  | 'main'
+  | 'dead-table'
+  | 'errors-table'
+  | 'rage-table'
+  | 'selector-widget';
 
 type EditType = 'set' | 'remove';
 

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -334,8 +334,8 @@ export function ReplayCell({
       case 'errors-table':
         return replayDetailsErrorTab;
       case 'dead-table':
-        return replayDetailsDOMEventsTab;
       case 'rage-table':
+      case 'selector-widget':
         return replayDetailsDOMEventsTab;
       default:
         return replayDetails;


### PR DESCRIPTION
Closes  https://github.com/getsentry/team-replay/issues/187

Both tables with 3 rows: 
<img width="1185" alt="SCR-20230927-rmuv" src="https://github.com/getsentry/sentry/assets/56095982/74cd6ae4-963c-4c10-a68b-5ecb9a5857c7">

3 rows / < 3 rows:
<img width="1197" alt="SCR-20230927-rnzf" src="https://github.com/getsentry/sentry/assets/56095982/b14d9228-cef8-43c5-817a-e2a10c0d2db9">

3 rows / no rows:
<img width="1194" alt="SCR-20230927-rnsd" src="https://github.com/getsentry/sentry/assets/56095982/86c8422a-27ff-41e9-b7b1-f8240f3821a8">

Both no rows:
<img width="1190" alt="SCR-20230927-rnff" src="https://github.com/getsentry/sentry/assets/56095982/a8018f9c-a6fb-4609-ae29-b6f329d18389">





