### PR TITLE
feat(COGS): Add `tenant_ids` to new subscriptions created

### DIFF
--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -241,6 +241,7 @@ def _create_snql_in_snuba(subscription, snuba_query, snql_query, entity_subscrip
         "query": str(snql_query.query),
         "time_window": snuba_query.time_window,
         "resolution": snuba_query.resolution,
+        "tenant_ids": {"organization_id": subscription.project.organization_id},
         **entity_subscription.get_entity_extra_params(),
     }
 


### PR DESCRIPTION
### Overview
- As part of figuring out what % of generic metrics subscriptions queries originate from which use case IDs, we need to add extra data to the create subscription request
- For now this just means trying to update the subscriptions creation path with `tenant_ids`
- Eventually, there would be some sort of `use_case_id` passed along in the subscription creation flow which gets sent along in `tenant_ids`

### Notes
- At some point, we'll need to do some sort of backfilling of all existing Subscriptions to now add this field as well
- Maybe using this?
    - https://github.com/getsentry/getsentry/blob/master/bin/subscription-migrate.py