### PR TITLE
ref(crons): Compute last_checkin from checkin.date_added in mark_failed

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -24,8 +24,17 @@ logger = logging.getLogger(__name__)
 
 def mark_failed(
     failed_checkin: MonitorCheckIn,
-    ts: datetime | None,
+    ts: datetime,
 ):
+    """
+    Given a failing check-in, mark the monitor environent as failed and trigger
+    side-effects for creating monitor incidents and issues.
+
+    The provided `ts` is the reference time for when the next checkin time is
+    calculated from. This typically would be the failed check-in's `date_added`
+    or completion time. Though for the missed and timedout tasks this may be
+    computed based on the tasks reference time.
+    """
     monitor_env = failed_checkin.monitor_environment
     failure_issue_threshold = monitor_env.monitor.config.get("failure_issue_threshold", 0)
 
@@ -37,23 +46,24 @@ def mark_failed(
 
 def mark_failed_threshold(
     failed_checkin: MonitorCheckIn,
-    ts: datetime | None,
+    ts: datetime,
     failure_issue_threshold: int,
 ):
     from sentry.signals import monitor_environment_failed
 
     monitor_env = failed_checkin.monitor_environment
 
-    # update monitor environment timestamps on every check-in
-    if ts is None:
-        next_checkin_base = timezone.now()
-        last_checkin = monitor_env.last_checkin or timezone.now()
-    else:
-        next_checkin_base = ts
-        last_checkin = ts
+    next_checkin = monitor_env.monitor.get_next_expected_checkin(ts)
+    next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(ts)
 
-    next_checkin = monitor_env.monitor.get_next_expected_checkin(next_checkin_base)
-    next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(next_checkin_base)
+    # Whe the failed check-in is a synthetic missed check-in we do not move the
+    # `last_checkin` timestamp forward.
+    if failed_checkin.status == CheckInStatus.MISSED:
+        # When a monitor is MISSED it MUST have already had a `last_checkin`. A
+        # monitor cannot be missed without having checked in.
+        last_checkin = monitor_env.last_checkin
+    else:
+        last_checkin = failed_checkin.date_added
 
     # update monitor environment timestamps without updating status
     # affected returns number of rows returned from the filter() call
@@ -65,6 +75,9 @@ def mark_failed_threshold(
         next_checkin_latest=next_checkin_latest,
         last_checkin=last_checkin,
     )
+
+    # If we did not update the monitor enviromnent it means there was a newer
+    # check-in. We have nothing to do in this case.
     if not affected:
         return False
 
@@ -127,18 +140,11 @@ def mark_failed_threshold(
 
 def mark_failed_no_threshold(
     failed_checkin: MonitorCheckIn,
-    ts: datetime | None,
+    ts: datetime,
 ):
     from sentry.signals import monitor_environment_failed
 
     monitor_env = failed_checkin.monitor_environment
-
-    if ts is None:
-        next_checkin_base = timezone.now()
-        last_checkin = monitor_env.last_checkin or timezone.now()
-    else:
-        next_checkin_base = ts
-        last_checkin = ts
 
     failed_status_map = {
         CheckInStatus.MISSED: MonitorStatus.MISSED_CHECKIN,
@@ -146,8 +152,17 @@ def mark_failed_no_threshold(
     }
     new_status = failed_status_map.get(failed_checkin.status, MonitorStatus.ERROR)
 
-    next_checkin = monitor_env.monitor.get_next_expected_checkin(next_checkin_base)
-    next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(next_checkin_base)
+    next_checkin = monitor_env.monitor.get_next_expected_checkin(ts)
+    next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(ts)
+
+    # Whe the failed check-in is a synthetic missed check-in we do not move the
+    # `last_checkin` timestamp forward.
+    if failed_checkin.status == CheckInStatus.MISSED:
+        # When a monitor is MISSED it MUST have already had a `last_checkin`. A
+        # monitor cannot be missed without having checked in.
+        last_checkin = monitor_env.last_checkin
+    else:
+        last_checkin = failed_checkin.date_added
 
     # affected returns number of rows returned from the filter() call
     # not the number of rows that actually modify their values via update()
@@ -159,6 +174,9 @@ def mark_failed_no_threshold(
         status=new_status,
         last_checkin=last_checkin,
     )
+
+    # If we did not update the monitor enviromnent it means there was a newer
+    # check-in. We have nothing to do in this case.
     if not affected:
         return False
 

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -222,10 +222,10 @@ def mark_environment_missing(monitor_environment_id: int, ts: Optional[datetime]
         expected_time=expected_time,
         monitor_config=monitor.get_validated_config(),
     )
-    # TODO(epurkhiser): To properly fix GH-55874 we need to actually
-    # pass a timestamp here. But I'm not 100% sure what that should
-    # look like yet.
-    mark_failed(checkin, ts=None)
+    # TODO(epurkhiser): To properly fix GH-55874 we should NOT pass
+    # timezone.now, we need to use the reference timestamp. But I'm not 100%
+    # sure what that should look like yet.
+    mark_failed(checkin, ts=timezone.now())
 
 
 @instrumented_task(
@@ -272,6 +272,6 @@ def mark_checkin_timeout(checkin_id: int, ts: Optional[datetime] = None):
         status__in=[CheckInStatus.OK, CheckInStatus.ERROR],
     ).exists()
     if not has_newer_result:
-        # TODO(epurkhiser): We also need a timestamp here, but not sure
-        # what we want it to be
-        mark_failed(checkin, ts=None)
+        # TODO(epurkhiser): We should not be using timezone.now here, but need
+        # to verify what actually makes sense.
+        mark_failed(checkin, ts=timezone.now())

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
@@ -192,7 +192,7 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
             assert monitor_environment.next_checkin > checkin.date_added
             assert monitor_environment.next_checkin_latest > checkin.date_added
             assert monitor_environment.status == MonitorStatus.ERROR
-            assert monitor_environment.last_checkin > checkin.date_added
+            assert monitor_environment.last_checkin == checkin.date_added
 
     def test_finished_values(self):
         monitor = self._create_monitor()

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import timedelta
 from itertools import cycle
 from unittest.mock import patch
 
@@ -133,16 +134,22 @@ class MarkFailedTestCase(TestCase):
     @with_feature({"organizations:issue-platform": False})
     @patch("sentry.coreapi.insert_data_to_database_legacy")
     def test_mark_failed_with_missed_reason_legacy(self, mock_insert_data_to_database_legacy):
+        last_checkin = timezone.now().replace(second=0, microsecond=0)
+        next_checkin = last_checkin + timedelta(hours=1)
+
         monitor = Monitor.objects.create(
             name="test monitor",
             organization_id=self.organization.id,
             project_id=self.project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+            config={"schedule": [1, "hour"], "schedule_type": ScheduleType.INTERVAL},
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
             environment=self.environment,
+            last_checkin=last_checkin,
+            next_checkin=next_checkin,
+            next_checkin_latest=next_checkin + timedelta(minutes=1),
             status=monitor.status,
         )
         checkin = MonitorCheckIn.objects.create(
@@ -172,7 +179,7 @@ class MarkFailedTestCase(TestCase):
                     "monitor": {
                         "status": "missed_checkin",
                         "type": "cron_job",
-                        "config": {"schedule_type": 2, "schedule": [1, "month"]},
+                        "config": {"schedule_type": 2, "schedule": [1, "hour"]},
                         "id": str(monitor.guid),
                         "name": monitor.name,
                         "slug": monitor.slug,
@@ -381,28 +388,32 @@ class MarkFailedTestCase(TestCase):
     @with_feature("organizations:issue-platform")
     @patch("sentry.issues.producer.produce_occurrence_to_kafka")
     def test_mark_failed_with_missed_reason_issue_platform(self, mock_produce_occurrence_to_kafka):
+        last_checkin = timezone.now().replace(second=0, microsecond=0)
+        next_checkin = last_checkin + timedelta(hours=1)
+
         monitor = Monitor.objects.create(
             name="test monitor",
             organization_id=self.organization.id,
             project_id=self.project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+            config={"schedule": [1, "hour"], "schedule_type": ScheduleType.INTERVAL},
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
             environment=self.environment,
+            last_checkin=last_checkin,
+            next_checkin=next_checkin,
+            next_checkin_latest=next_checkin + timedelta(minutes=1),
             status=monitor.status,
         )
-        last_checkin = timezone.now()
-        expected_time = monitor.get_next_expected_checkin(last_checkin)
 
         failed_checkin = MonitorCheckIn.objects.create(
             monitor=monitor,
             monitor_environment=monitor_environment,
             project_id=self.project.id,
             status=CheckInStatus.MISSED,
-            date_added=last_checkin,
-            expected_time=expected_time,
+            expected_time=next_checkin,
+            date_added=next_checkin + timedelta(minutes=1),
         )
         assert mark_failed(failed_checkin, ts=failed_checkin.date_added)
 
@@ -421,7 +432,7 @@ class MarkFailedTestCase(TestCase):
                 "project_id": self.project.id,
                 "fingerprint": [hash_from_values(["monitor", str(monitor.guid), "missed_checkin"])],
                 "issue_title": f"Monitor failure: {monitor.name}",
-                "subtitle": f"No check-in reported on {expected_time.strftime(SUBTITLE_DATETIME_FORMAT)}.",
+                "subtitle": f"No check-in reported on {next_checkin.strftime(SUBTITLE_DATETIME_FORMAT)}.",
                 "resource_id": None,
                 "evidence_data": {},
                 "evidence_display": [
@@ -450,7 +461,7 @@ class MarkFailedTestCase(TestCase):
                     "monitor": {
                         "status": "missed_checkin",
                         "type": "cron_job",
-                        "config": {"schedule_type": 2, "schedule": [1, "month"]},
+                        "config": {"schedule_type": 2, "schedule": [1, "hour"]},
                         "id": str(monitor.guid),
                         "name": monitor.name,
                         "slug": monitor.slug,

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -306,6 +306,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         failing_monitor_environment = MonitorEnvironment.objects.create(
             monitor=exception_monitor,
             environment=self.environment,
+            last_checkin=ts - timedelta(minutes=2),
             next_checkin=ts - timedelta(minutes=1),
             next_checkin_latest=ts,
             status=MonitorStatus.OK,
@@ -320,6 +321,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         successful_monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
             environment=self.environment,
+            last_checkin=ts - timedelta(minutes=2),
             next_checkin=ts - timedelta(minutes=1),
             next_checkin_latest=ts,
             status=MonitorStatus.OK,


### PR DESCRIPTION
This improvement helps to clarify the logic for computing the
next_checkin as well, since the ts is now required and can be considered
the reference timestamp used to compute the next-checkin

The implicit timezone.now usage has moved to the only usages in the
check_missing and check_timeout tasks. This will help to resolve
GH-55874.