### PR TITLE
ref(crons): Use checkin.date_added for last_checkin on OK checkins

### DIFF
--- a/src/sentry/monitors/logic/mark_ok.py
+++ b/src/sentry/monitors/logic/mark_ok.py
@@ -23,7 +23,7 @@ def mark_ok(checkin: MonitorCheckIn, ts: datetime):
     next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(ts)
 
     params = {
-        "last_checkin": ts,
+        "last_checkin": checkin.date_added,
         "next_checkin": next_checkin,
         "next_checkin_latest": next_checkin_latest,
     }

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
@@ -91,6 +91,7 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
                 monitor_environment=monitor_environment,
                 project_id=self.project.id,
                 date_added=monitor.date_added,
+                status=CheckInStatus.IN_PROGRESS,
             )
 
             path = path_func(monitor.guid, checkin.guid)
@@ -114,7 +115,7 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
             assert monitor_environment.next_checkin > checkin.date_added
             assert monitor_environment.next_checkin_latest > checkin.date_added
             assert monitor_environment.status == MonitorStatus.OK
-            assert monitor_environment.last_checkin > checkin.date_added
+            assert monitor_environment.last_checkin == checkin.date_added
 
     def test_passing_with_config(self):
         monitor = self._create_monitor()
@@ -149,7 +150,7 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
             assert monitor_environment.next_checkin > checkin.date_added
             assert monitor_environment.next_checkin_latest > checkin.date_added
             assert monitor_environment.status == MonitorStatus.OK
-            assert monitor_environment.last_checkin > checkin.date_added
+            assert monitor_environment.last_checkin == checkin.date_added
 
     def test_passing_with_slug(self):
         monitor = self._create_monitor()
@@ -179,6 +180,7 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
                 monitor_environment=monitor_environment,
                 project_id=self.project.id,
                 date_added=monitor.date_added,
+                status=CheckInStatus.IN_PROGRESS,
             )
 
             path = path_func(monitor.guid, checkin.guid)
@@ -302,11 +304,14 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
             checkin3 = MonitorCheckIn.objects.get(id=checkin3.id)
             assert checkin3.status == CheckInStatus.OK
 
+            checkin4 = MonitorCheckIn.objects.get(guid=resp.data["id"])
+            assert checkin4.status == CheckInStatus.OK
+
             monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
             assert monitor_environment.next_checkin > checkin2.date_added
             assert monitor_environment.next_checkin_latest > checkin2.date_added
             assert monitor_environment.status == MonitorStatus.OK
-            assert monitor_environment.last_checkin > checkin2.date_added
+            assert monitor_environment.last_checkin == checkin4.date_added
 
     def test_latest_with_no_unfinished_checkin(self):
         monitor = self._create_monitor()


### PR DESCRIPTION
This is a follow up to GH-57107 in which `mark_failed` now uses the failed_checkin.date_added for the last_checkin timestamp.

We want to do the same thing here for consistency.

This change is saying we want the actual check-in represented in the timeline to be the "last" time a check-in happened, NOT the last time a check-in was updated.