### PR TITLE
feat(backup): Add dangling reference info to `dependencies()`

### DIFF
--- a/bin/model-dependency-graphviz
+++ b/bin/model-dependency-graphviz
@@ -30,23 +30,36 @@ digraph Models {
         node [shape="plaintext",style="none"]
         key1 [label=<<table border="0" cellpadding="2" cellspacing="0" cellborder="0">
             <tr><td align="right" port="i1">HybridCloudForeignKey</td></tr>
-            <tr><td align="right" port="i2">Explicit ForeignKey</td></tr>
-            <tr><td align="right" port="i3">Implicit ForeignKey</td></tr>
-            <tr><td align="right" port="i4">Control Silo Model</td></tr>
-            <tr><td align="right" port="i5">Region Silo Model</td></tr>
-            <tr><td align="right" port="i6">Unexported Model</td></tr>
+            <tr><td align="right" port="i2">HybridCloudForeignKey (nullable)</td></tr>
+            <tr><td align="right" port="i3">Explicit ForeignKey</td></tr>
+            <tr><td align="right" port="i4">Explicit ForeignKey (nullable)</td></tr>
+            <tr><td align="right" port="i5">Implicit ForeignKey</td></tr>
+            <tr><td align="right" port="i6">Implicit ForeignKey (nullable)</td></tr>
+            <tr><td align="right" port="i7">Control Silo Model</td></tr>
+            <tr><td align="right" port="i8">Control Silo Model (dangling)</td></tr>
+            <tr><td align="right" port="i9">Region Silo Model</td></tr>
+            <tr><td align="right" port="i10">Region Silo Model (dangling)</td></tr>
+            <tr><td align="right" port="i11">Unexported Model</td></tr>
         </table>>]
         key2 [label=<<table border="0" cellpadding="2" cellspacing="0" cellborder="0">
             <tr><td port="i1">&nbsp;</td></tr>
             <tr><td port="i2">&nbsp;</td></tr>
             <tr><td port="i3">&nbsp;</td></tr>
-            <tr><td port="i4" bgcolor="lightcoral">&nbsp;</td></tr>
-            <tr><td port="i5" bgcolor="lightblue">&nbsp;</td></tr>
-            <tr><td port="i6" bgcolor="grey">&nbsp;</td></tr>
+            <tr><td port="i4">&nbsp;</td></tr>
+            <tr><td port="i5">&nbsp;</td></tr>
+            <tr><td port="i6">&nbsp;</td></tr>
+            <tr><td port="i7" bgcolor="#ffb6c1ff">&nbsp;</td></tr>
+            <tr><td port="i8" bgcolor="#ffb6c166">&nbsp;</td></tr>
+            <tr><td port="i9" bgcolor="#add8e6ff">&nbsp;</td></tr>
+            <tr><td port="i10" bgcolor="#add8e666">&nbsp;</td></tr>
+            <tr><td port="i11" bgcolor="#c0c0c0ff">&nbsp;</td></tr>
         </table>>]
-        key1:i1:e -> key2:i1:w [color=green]
-        key1:i2:e -> key2:i2:w [color=blue]
-        key1:i3:e -> key2:i3:w [color=red]
+        key1:i1:e -> key2:i1:w [color="#008b00ff",style=solid]
+        key1:i2:e -> key2:i2:w [color="#008b0066",style=dashed]
+        key1:i3:e -> key2:i3:w [color="#0000eeff",style=solid]
+        key1:i4:e -> key2:i4:w [color="#0000ee66",style=dashed]
+        key1:i5:e -> key2:i5:w [color="#cd0000ff",style=solid]
+        key1:i6:e -> key2:i6:w [color="#cd000066",style=dashed]
     }
 
     $clusters
@@ -63,7 +76,7 @@ cluster = Template(
         shape="rectangle"
         fillcolor="$fill"
         fontsize="40"
-        color="grey"
+        color="#c0c0c0"
 
         $nodes
     }
@@ -73,28 +86,30 @@ cluster = Template(
 
 @unique
 class ClusterColor(Enum):
-    Purple = "lavenderblush"
-    Yellow = "khaki"
-    Green = "honeydew"
-    Blue = "lightsteelblue1"
+    Purple = "#fff0f5"  # lavenderblush
+    Yellow = "#f0e68c"  # khaki
+    Green = "#f0fff0"  # honeydew
+    Blue = "#cae1ff"  # lightsteelblue1
 
 
 @unique
 class NodeColor(Enum):
-    Red = "lightpink"
-    Blue = "lightblue"
+    Red = "#ffb6c1"  # lightpink
+    Blue = "#add8e6"  # lightblue
 
 
 @unique
 class EdgeColor(Enum):
-    Hybrid = "color=green"
-    Explicit = "color=blue"
-    Implicit = "color=red"
+    Hybrid = "#008b00"  # green4
+    Explicit = "#0000ee"  # blue2
+    Implicit = "#cd0000"  # red3
 
 
-def print_model_node(model: models.base.ModelBase, silo: SiloMode) -> str:
+def print_model_node(mr: ModelRelations, silo: SiloMode) -> str:
+    id = mr.model.__name__
     color = NodeColor.Red if silo == SiloMode.CONTROL else NodeColor.Blue
-    return f""""{model.__name__}" [fillcolor="{color.value}"];"""
+    opacity = "66" if mr.dangling else "ff"
+    return f""""{id}" [fillcolor="{color.value}{opacity}",color="#000000{opacity}"];"""
 
 
 def print_rel_scope_subgraph(
@@ -104,7 +119,7 @@ def print_rel_scope_subgraph(
         num=num,
         name=name,
         fill=color.value,
-        nodes="\n        ".join([print_model_node(mr.model, mr.silos[0]) for mr in rels]),
+        nodes="\n        ".join([print_model_node(mr, mr.silos[0]) for mr in rels]),
     )
 
 
@@ -123,7 +138,7 @@ def print_edge(src: models.base.ModelBase, dest: models.base.ModelBase, field: F
     elif field.kind == ForeignFieldKind.ImplicitForeignKey:
         color = EdgeColor.Implicit
     style = "dashed" if field.nullable else "solid"
-    return f""""{src.__name__}":e -> "{dest.__name__}":w [{color.value},style={style}];"""
+    return f""""{src.__name__}":e -> "{dest.__name__}":w [color="{color.value}",style={style}];"""
 
 
 def get_most_permissive_relocation_scope(mr: ModelRelations) -> RelocationScope:

--- a/fixtures/backup/model_dependencies/detailed.json
+++ b/fixtures/backup/model_dependencies/detailed.json
@@ -1,5 +1,6 @@
 {
   "feedback.feedback": {
+    "dangling": false,
     "foreign_keys": {
       "environment": {
         "kind": "FlexibleForeignKey",
@@ -33,6 +34,7 @@
     ]
   },
   "hybridcloud.apikeyreplica": {
+    "dangling": false,
     "foreign_keys": {
       "apikey_id": {
         "kind": "HybridCloudForeignKey",
@@ -58,6 +60,7 @@
     ]
   },
   "hybridcloud.organizationslugreservationreplica": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "ImplicitForeignKey",
@@ -98,6 +101,7 @@
     ]
   },
   "hybridcloud.regioncacheversion": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "hybridcloud.regioncacheversion",
     "relocation_scope": "Excluded",
@@ -115,6 +119,7 @@
     ]
   },
   "nodestore.node": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "nodestore.node",
     "relocation_scope": "Excluded",
@@ -129,6 +134,7 @@
     ]
   },
   "replays.replayrecordingsegment": {
+    "dangling": false,
     "foreign_keys": {
       "file_id": {
         "kind": "ImplicitForeignKey",
@@ -164,6 +170,7 @@
     ]
   },
   "sentry.activity": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -194,6 +201,7 @@
     ]
   },
   "sentry.actor": {
+    "dangling": true,
     "foreign_keys": {
       "user_id": {
         "kind": "HybridCloudForeignKey",
@@ -220,6 +228,7 @@
     ]
   },
   "sentry.alertrule": {
+    "dangling": true,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -253,6 +262,7 @@
     ]
   },
   "sentry.alertruleactivity": {
+    "dangling": true,
     "foreign_keys": {
       "alert_rule": {
         "kind": "FlexibleForeignKey",
@@ -283,6 +293,7 @@
     ]
   },
   "sentry.alertruleexcludedprojects": {
+    "dangling": false,
     "foreign_keys": {
       "alert_rule": {
         "kind": "FlexibleForeignKey",
@@ -312,6 +323,7 @@
     ]
   },
   "sentry.alertruletrigger": {
+    "dangling": true,
     "foreign_keys": {
       "alert_rule": {
         "kind": "FlexibleForeignKey",
@@ -336,6 +348,7 @@
     ]
   },
   "sentry.alertruletriggeraction": {
+    "dangling": true,
     "foreign_keys": {
       "alert_rule_trigger": {
         "kind": "FlexibleForeignKey",
@@ -366,6 +379,7 @@
     ]
   },
   "sentry.alertruletriggerexclusion": {
+    "dangling": false,
     "foreign_keys": {
       "alert_rule_trigger": {
         "kind": "FlexibleForeignKey",
@@ -395,6 +409,7 @@
     ]
   },
   "sentry.apiapplication": {
+    "dangling": false,
     "foreign_keys": {
       "owner": {
         "kind": "FlexibleForeignKey",
@@ -418,6 +433,7 @@
     ]
   },
   "sentry.apiauthorization": {
+    "dangling": false,
     "foreign_keys": {
       "application": {
         "kind": "FlexibleForeignKey",
@@ -450,6 +466,7 @@
     ]
   },
   "sentry.apigrant": {
+    "dangling": false,
     "foreign_keys": {
       "application": {
         "kind": "FlexibleForeignKey",
@@ -475,6 +492,7 @@
     ]
   },
   "sentry.apikey": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "HybridCloudForeignKey",
@@ -498,6 +516,7 @@
     ]
   },
   "sentry.apitoken": {
+    "dangling": false,
     "foreign_keys": {
       "application": {
         "kind": "FlexibleForeignKey",
@@ -532,6 +551,7 @@
     ]
   },
   "sentry.appconnectbuild": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -552,6 +572,7 @@
     ]
   },
   "sentry.artifactbundle": {
+    "dangling": false,
     "foreign_keys": {
       "file": {
         "kind": "FlexibleForeignKey",
@@ -577,6 +598,7 @@
     ]
   },
   "sentry.artifactbundleflatfileindex": {
+    "dangling": false,
     "foreign_keys": {
       "project_id": {
         "kind": "ImplicitForeignKey",
@@ -602,6 +624,7 @@
     ]
   },
   "sentry.artifactbundleindex": {
+    "dangling": false,
     "foreign_keys": {
       "artifact_bundle": {
         "kind": "FlexibleForeignKey",
@@ -627,6 +650,7 @@
     ]
   },
   "sentry.assistantactivity": {
+    "dangling": false,
     "foreign_keys": {
       "user": {
         "kind": "FlexibleForeignKey",
@@ -651,6 +675,7 @@
     ]
   },
   "sentry.auditlogentry": {
+    "dangling": false,
     "foreign_keys": {
       "actor": {
         "kind": "FlexibleForeignKey",
@@ -686,6 +711,7 @@
     ]
   },
   "sentry.authenticator": {
+    "dangling": false,
     "foreign_keys": {
       "user": {
         "kind": "FlexibleForeignKey",
@@ -710,6 +736,7 @@
     ]
   },
   "sentry.authidentity": {
+    "dangling": false,
     "foreign_keys": {
       "auth_provider": {
         "kind": "FlexibleForeignKey",
@@ -743,6 +770,7 @@
     ]
   },
   "sentry.authidentityreplica": {
+    "dangling": false,
     "foreign_keys": {
       "auth_identity_id": {
         "kind": "HybridCloudForeignKey",
@@ -784,6 +812,7 @@
     ]
   },
   "sentry.authprovider": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "HybridCloudForeignKey",
@@ -807,6 +836,7 @@
     ]
   },
   "sentry.authproviderdefaultteams": {
+    "dangling": false,
     "foreign_keys": {
       "authprovider_id": {
         "kind": "ImplicitForeignKey",
@@ -832,6 +862,7 @@
     ]
   },
   "sentry.authproviderreplica": {
+    "dangling": false,
     "foreign_keys": {
       "auth_provider_id": {
         "kind": "HybridCloudForeignKey",
@@ -863,6 +894,7 @@
     ]
   },
   "sentry.broadcast": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.broadcast",
     "relocation_scope": "Excluded",
@@ -877,6 +909,7 @@
     ]
   },
   "sentry.broadcastseen": {
+    "dangling": false,
     "foreign_keys": {
       "broadcast": {
         "kind": "FlexibleForeignKey",
@@ -906,6 +939,7 @@
     ]
   },
   "sentry.commit": {
+    "dangling": false,
     "foreign_keys": {
       "author": {
         "kind": "FlexibleForeignKey",
@@ -940,6 +974,7 @@
     ]
   },
   "sentry.commitauthor": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "ImplicitForeignKey",
@@ -968,6 +1003,7 @@
     ]
   },
   "sentry.commitfilechange": {
+    "dangling": false,
     "foreign_keys": {
       "commit": {
         "kind": "FlexibleForeignKey",
@@ -997,6 +1033,7 @@
     ]
   },
   "sentry.controlfile": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.controlfile",
     "relocation_scope": "Excluded",
@@ -1011,6 +1048,7 @@
     ]
   },
   "sentry.controlfileblob": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.controlfileblob",
     "relocation_scope": "Excluded",
@@ -1028,6 +1066,7 @@
     ]
   },
   "sentry.controlfileblobindex": {
+    "dangling": true,
     "foreign_keys": {
       "blob": {
         "kind": "FlexibleForeignKey",
@@ -1058,6 +1097,7 @@
     ]
   },
   "sentry.controlfileblobowner": {
+    "dangling": false,
     "foreign_keys": {
       "blob": {
         "kind": "FlexibleForeignKey",
@@ -1087,6 +1127,7 @@
     ]
   },
   "sentry.controloption": {
+    "dangling": false,
     "foreign_keys": {},
     "model": "sentry.controloption",
     "relocation_scope": "Config",
@@ -1104,6 +1145,7 @@
     ]
   },
   "sentry.controloutbox": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.controloutbox",
     "relocation_scope": "Excluded",
@@ -1118,6 +1160,7 @@
     ]
   },
   "sentry.controltombstone": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.controltombstone",
     "relocation_scope": "Excluded",
@@ -1132,6 +1175,7 @@
     ]
   },
   "sentry.counter": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -1155,6 +1199,7 @@
     ]
   },
   "sentry.customdynamicsamplingrule": {
+    "dangling": false,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -1175,6 +1220,7 @@
     ]
   },
   "sentry.customdynamicsamplingruleproject": {
+    "dangling": false,
     "foreign_keys": {
       "custom_dynamic_sampling_rule": {
         "kind": "FlexibleForeignKey",
@@ -1204,6 +1250,7 @@
     ]
   },
   "sentry.dashboard": {
+    "dangling": false,
     "foreign_keys": {
       "created_by_id": {
         "kind": "HybridCloudForeignKey",
@@ -1233,6 +1280,7 @@
     ]
   },
   "sentry.dashboardproject": {
+    "dangling": false,
     "foreign_keys": {
       "dashboard": {
         "kind": "FlexibleForeignKey",
@@ -1262,6 +1310,7 @@
     ]
   },
   "sentry.dashboardtombstone": {
+    "dangling": false,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -1286,6 +1335,7 @@
     ]
   },
   "sentry.dashboardwidget": {
+    "dangling": false,
     "foreign_keys": {
       "dashboard": {
         "kind": "FlexibleForeignKey",
@@ -1310,6 +1360,7 @@
     ]
   },
   "sentry.dashboardwidgetquery": {
+    "dangling": false,
     "foreign_keys": {
       "widget": {
         "kind": "FlexibleForeignKey",
@@ -1334,6 +1385,7 @@
     ]
   },
   "sentry.debugidartifactbundle": {
+    "dangling": false,
     "foreign_keys": {
       "artifact_bundle": {
         "kind": "FlexibleForeignKey",
@@ -1359,6 +1411,7 @@
     ]
   },
   "sentry.deletedorganization": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.deletedorganization",
     "relocation_scope": "Excluded",
@@ -1373,11 +1426,12 @@
     ]
   },
   "sentry.deletedproject": {
+    "dangling": true,
     "foreign_keys": {
       "organization_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.organization",
-        "nullable": false
+        "nullable": true
       }
     },
     "model": "sentry.deletedproject",
@@ -1393,11 +1447,12 @@
     ]
   },
   "sentry.deletedteam": {
+    "dangling": true,
     "foreign_keys": {
       "organization_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.organization",
-        "nullable": false
+        "nullable": true
       }
     },
     "model": "sentry.deletedteam",
@@ -1413,6 +1468,7 @@
     ]
   },
   "sentry.deploy": {
+    "dangling": false,
     "foreign_keys": {
       "environment_id": {
         "kind": "ImplicitForeignKey",
@@ -1443,6 +1499,7 @@
     ]
   },
   "sentry.discoversavedquery": {
+    "dangling": false,
     "foreign_keys": {
       "created_by_id": {
         "kind": "HybridCloudForeignKey",
@@ -1468,6 +1525,7 @@
     ]
   },
   "sentry.discoversavedqueryproject": {
+    "dangling": false,
     "foreign_keys": {
       "discover_saved_query": {
         "kind": "FlexibleForeignKey",
@@ -1497,6 +1555,7 @@
     ]
   },
   "sentry.distribution": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "ImplicitForeignKey",
@@ -1526,6 +1585,7 @@
     ]
   },
   "sentry.docintegration": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.docintegration",
     "relocation_scope": "Excluded",
@@ -1543,11 +1603,12 @@
     ]
   },
   "sentry.docintegrationavatar": {
+    "dangling": true,
     "foreign_keys": {
       "control_file_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.controlfile",
-        "nullable": false
+        "nullable": true
       },
       "doc_integration": {
         "kind": "FlexibleForeignKey",
@@ -1557,7 +1618,7 @@
       "file_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.file",
-        "nullable": false
+        "nullable": true
       }
     },
     "model": "sentry.docintegrationavatar",
@@ -1582,6 +1643,7 @@
     ]
   },
   "sentry.email": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.email",
     "relocation_scope": "User",
@@ -1599,6 +1661,7 @@
     ]
   },
   "sentry.environment": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "ImplicitForeignKey",
@@ -1623,6 +1686,7 @@
     ]
   },
   "sentry.environmentproject": {
+    "dangling": false,
     "foreign_keys": {
       "environment": {
         "kind": "FlexibleForeignKey",
@@ -1652,6 +1716,7 @@
     ]
   },
   "sentry.eventattachment": {
+    "dangling": false,
     "foreign_keys": {
       "file_id": {
         "kind": "ImplicitForeignKey",
@@ -1661,7 +1726,7 @@
       "group_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.group",
-        "nullable": false
+        "nullable": true
       },
       "project_id": {
         "kind": "ImplicitForeignKey",
@@ -1687,6 +1752,7 @@
     ]
   },
   "sentry.eventprocessingissue": {
+    "dangling": false,
     "foreign_keys": {
       "processing_issue": {
         "kind": "FlexibleForeignKey",
@@ -1716,6 +1782,7 @@
     ]
   },
   "sentry.eventuser": {
+    "dangling": false,
     "foreign_keys": {
       "project_id": {
         "kind": "ImplicitForeignKey",
@@ -1744,11 +1811,12 @@
     ]
   },
   "sentry.exporteddata": {
+    "dangling": false,
     "foreign_keys": {
       "file_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.file",
-        "nullable": false
+        "nullable": true
       },
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -1774,6 +1842,7 @@
     ]
   },
   "sentry.exporteddatablob": {
+    "dangling": false,
     "foreign_keys": {
       "data_export": {
         "kind": "FlexibleForeignKey",
@@ -1799,6 +1868,7 @@
     ]
   },
   "sentry.externalactor": {
+    "dangling": false,
     "foreign_keys": {
       "integration_id": {
         "kind": "HybridCloudForeignKey",
@@ -1846,6 +1916,7 @@
     ]
   },
   "sentry.externalissue": {
+    "dangling": false,
     "foreign_keys": {
       "integration_id": {
         "kind": "HybridCloudForeignKey",
@@ -1876,6 +1947,7 @@
     ]
   },
   "sentry.featureadoption": {
+    "dangling": false,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -1900,6 +1972,7 @@
     ]
   },
   "sentry.file": {
+    "dangling": true,
     "foreign_keys": {
       "blob": {
         "kind": "FlexibleForeignKey",
@@ -1920,6 +1993,7 @@
     ]
   },
   "sentry.fileblob": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.fileblob",
     "relocation_scope": "Excluded",
@@ -1937,6 +2011,7 @@
     ]
   },
   "sentry.fileblobindex": {
+    "dangling": true,
     "foreign_keys": {
       "blob": {
         "kind": "FlexibleForeignKey",
@@ -1967,6 +2042,7 @@
     ]
   },
   "sentry.fileblobowner": {
+    "dangling": false,
     "foreign_keys": {
       "blob": {
         "kind": "FlexibleForeignKey",
@@ -1996,6 +2072,7 @@
     ]
   },
   "sentry.flatfileindexstate": {
+    "dangling": false,
     "foreign_keys": {
       "artifact_bundle": {
         "kind": "FlexibleForeignKey",
@@ -2025,6 +2102,7 @@
     ]
   },
   "sentry.group": {
+    "dangling": false,
     "foreign_keys": {
       "first_release": {
         "kind": "FlexibleForeignKey",
@@ -2058,6 +2136,7 @@
     ]
   },
   "sentry.groupassignee": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2100,6 +2179,7 @@
     ]
   },
   "sentry.groupbookmark": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2135,6 +2215,7 @@
     ]
   },
   "sentry.groupcommitresolution": {
+    "dangling": false,
     "foreign_keys": {
       "commit_id": {
         "kind": "ImplicitForeignKey",
@@ -2164,6 +2245,7 @@
     ]
   },
   "sentry.groupemailthread": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2197,6 +2279,7 @@
     ]
   },
   "sentry.groupenvironment": {
+    "dangling": false,
     "foreign_keys": {
       "environment": {
         "kind": "FlexibleForeignKey",
@@ -2231,6 +2314,7 @@
     ]
   },
   "sentry.grouphash": {
+    "dangling": true,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2240,7 +2324,7 @@
       "group_tombstone_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.grouptombstone",
-        "nullable": false
+        "nullable": true
       },
       "project": {
         "kind": "FlexibleForeignKey",
@@ -2265,6 +2349,7 @@
     ]
   },
   "sentry.grouphistory": {
+    "dangling": false,
     "foreign_keys": {
       "actor": {
         "kind": "FlexibleForeignKey",
@@ -2305,6 +2390,7 @@
     ]
   },
   "sentry.groupinbox": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2338,6 +2424,7 @@
     ]
   },
   "sentry.grouplink": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2368,6 +2455,7 @@
     ]
   },
   "sentry.groupmeta": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2392,6 +2480,7 @@
     ]
   },
   "sentry.groupowner": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2432,6 +2521,7 @@
     ]
   },
   "sentry.groupredirect": {
+    "dangling": false,
     "foreign_keys": {
       "group_id": {
         "kind": "ImplicitForeignKey",
@@ -2441,7 +2531,7 @@
       "organization_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.organization",
-        "nullable": false
+        "nullable": true
       }
     },
     "model": "sentry.groupredirect",
@@ -2465,6 +2555,7 @@
     ]
   },
   "sentry.grouprelease": {
+    "dangling": false,
     "foreign_keys": {
       "group_id": {
         "kind": "ImplicitForeignKey",
@@ -2500,6 +2591,7 @@
     ]
   },
   "sentry.groupresolution": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2528,6 +2620,7 @@
     ]
   },
   "sentry.grouprulestatus": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2562,6 +2655,7 @@
     ]
   },
   "sentry.groupseen": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2596,6 +2690,7 @@
     ]
   },
   "sentry.groupshare": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2632,6 +2727,7 @@
     ]
   },
   "sentry.groupsnooze": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2655,6 +2751,7 @@
     ]
   },
   "sentry.groupsubscription": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -2698,6 +2795,7 @@
     ]
   },
   "sentry.grouptombstone": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -2721,6 +2819,7 @@
     ]
   },
   "sentry.identity": {
+    "dangling": false,
     "foreign_keys": {
       "idp": {
         "kind": "FlexibleForeignKey",
@@ -2754,6 +2853,7 @@
     ]
   },
   "sentry.identityprovider": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.identityprovider",
     "relocation_scope": "Excluded",
@@ -2772,6 +2872,7 @@
     ]
   },
   "sentry.incident": {
+    "dangling": false,
     "foreign_keys": {
       "alert_rule": {
         "kind": "FlexibleForeignKey",
@@ -2801,6 +2902,7 @@
     ]
   },
   "sentry.incidentactivity": {
+    "dangling": false,
     "foreign_keys": {
       "incident": {
         "kind": "FlexibleForeignKey",
@@ -2826,6 +2928,7 @@
     ]
   },
   "sentry.incidentproject": {
+    "dangling": false,
     "foreign_keys": {
       "incident": {
         "kind": "FlexibleForeignKey",
@@ -2855,6 +2958,7 @@
     ]
   },
   "sentry.incidentseen": {
+    "dangling": false,
     "foreign_keys": {
       "incident": {
         "kind": "FlexibleForeignKey",
@@ -2884,6 +2988,7 @@
     ]
   },
   "sentry.incidentsnapshot": {
+    "dangling": false,
     "foreign_keys": {
       "event_stats_snapshot": {
         "kind": "FlexibleForeignKey",
@@ -2912,6 +3017,7 @@
     ]
   },
   "sentry.incidentsubscription": {
+    "dangling": false,
     "foreign_keys": {
       "incident": {
         "kind": "FlexibleForeignKey",
@@ -2941,6 +3047,7 @@
     ]
   },
   "sentry.incidenttrigger": {
+    "dangling": false,
     "foreign_keys": {
       "alert_rule_trigger": {
         "kind": "FlexibleForeignKey",
@@ -2970,6 +3077,7 @@
     ]
   },
   "sentry.integration": {
+    "dangling": false,
     "foreign_keys": {},
     "model": "sentry.integration",
     "relocation_scope": "Global",
@@ -2988,6 +3096,7 @@
     ]
   },
   "sentry.integrationexternalproject": {
+    "dangling": false,
     "foreign_keys": {
       "organization_integration_id": {
         "kind": "ImplicitForeignKey",
@@ -3012,6 +3121,7 @@
     ]
   },
   "sentry.integrationfeature": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.integrationfeature",
     "relocation_scope": "Excluded",
@@ -3031,6 +3141,7 @@
     ]
   },
   "sentry.latestappconnectbuildscheck": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -3055,16 +3166,17 @@
     ]
   },
   "sentry.latestreporeleaseenvironment": {
+    "dangling": false,
     "foreign_keys": {
       "commit_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.commit",
-        "nullable": false
+        "nullable": true
       },
       "deploy_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.deploy",
-        "nullable": false
+        "nullable": true
       },
       "environment_id": {
         "kind": "ImplicitForeignKey",
@@ -3099,6 +3211,7 @@
     ]
   },
   "sentry.lostpasswordhash": {
+    "dangling": false,
     "foreign_keys": {
       "user": {
         "kind": "FlexibleForeignKey",
@@ -3122,6 +3235,7 @@
     ]
   },
   "sentry.metricskeyindexer": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.metricskeyindexer",
     "relocation_scope": "Excluded",
@@ -3136,6 +3250,7 @@
     ]
   },
   "sentry.monitor": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "ImplicitForeignKey",
@@ -3168,6 +3283,7 @@
     ]
   },
   "sentry.monitorcheckin": {
+    "dangling": false,
     "foreign_keys": {
       "location": {
         "kind": "FlexibleForeignKey",
@@ -3206,6 +3322,7 @@
     ]
   },
   "sentry.monitorenvironment": {
+    "dangling": false,
     "foreign_keys": {
       "environment": {
         "kind": "FlexibleForeignKey",
@@ -3235,6 +3352,7 @@
     ]
   },
   "sentry.monitorincident": {
+    "dangling": false,
     "foreign_keys": {
       "monitor": {
         "kind": "FlexibleForeignKey",
@@ -3270,6 +3388,7 @@
     ]
   },
   "sentry.monitorlocation": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.monitorlocation",
     "relocation_scope": "Excluded",
@@ -3287,6 +3406,7 @@
     ]
   },
   "sentry.neglectedrule": {
+    "dangling": false,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -3312,6 +3432,7 @@
     ]
   },
   "sentry.notificationaction": {
+    "dangling": false,
     "foreign_keys": {
       "integration_id": {
         "kind": "HybridCloudForeignKey",
@@ -3345,6 +3466,7 @@
     ]
   },
   "sentry.notificationactionproject": {
+    "dangling": false,
     "foreign_keys": {
       "action": {
         "kind": "FlexibleForeignKey",
@@ -3373,6 +3495,7 @@
     ]
   },
   "sentry.notificationsetting": {
+    "dangling": true,
     "foreign_keys": {
       "target_id": {
         "kind": "HybridCloudForeignKey",
@@ -3410,6 +3533,7 @@
     ]
   },
   "sentry.notificationsettingoption": {
+    "dangling": true,
     "foreign_keys": {
       "team_id": {
         "kind": "HybridCloudForeignKey",
@@ -3442,6 +3566,7 @@
     ]
   },
   "sentry.notificationsettingprovider": {
+    "dangling": true,
     "foreign_keys": {
       "team_id": {
         "kind": "HybridCloudForeignKey",
@@ -3475,6 +3600,7 @@
     ]
   },
   "sentry.option": {
+    "dangling": false,
     "foreign_keys": {},
     "model": "sentry.option",
     "relocation_scope": "Config",
@@ -3492,6 +3618,7 @@
     ]
   },
   "sentry.organization": {
+    "dangling": false,
     "foreign_keys": {},
     "model": "sentry.organization",
     "relocation_scope": "Organization",
@@ -3509,6 +3636,7 @@
     ]
   },
   "sentry.organizationaccessrequest": {
+    "dangling": false,
     "foreign_keys": {
       "member": {
         "kind": "FlexibleForeignKey",
@@ -3543,11 +3671,12 @@
     ]
   },
   "sentry.organizationavatar": {
+    "dangling": false,
     "foreign_keys": {
       "file_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.file",
-        "nullable": false
+        "nullable": true
       },
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -3577,6 +3706,7 @@
     ]
   },
   "sentry.organizationintegration": {
+    "dangling": false,
     "foreign_keys": {
       "integration": {
         "kind": "FlexibleForeignKey",
@@ -3606,6 +3736,7 @@
     ]
   },
   "sentry.organizationmapping": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "ImplicitForeignKey",
@@ -3632,6 +3763,7 @@
     ]
   },
   "sentry.organizationmember": {
+    "dangling": false,
     "foreign_keys": {
       "inviter_id": {
         "kind": "HybridCloudForeignKey",
@@ -3673,6 +3805,7 @@
     ]
   },
   "sentry.organizationmembermapping": {
+    "dangling": false,
     "foreign_keys": {
       "inviter": {
         "kind": "FlexibleForeignKey",
@@ -3687,7 +3820,7 @@
       "organizationmember_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.organizationmember",
-        "nullable": false
+        "nullable": true
       },
       "user": {
         "kind": "FlexibleForeignKey",
@@ -3712,6 +3845,7 @@
     ]
   },
   "sentry.organizationmemberteam": {
+    "dangling": false,
     "foreign_keys": {
       "organizationmember": {
         "kind": "FlexibleForeignKey",
@@ -3741,6 +3875,7 @@
     ]
   },
   "sentry.organizationmemberteamreplica": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "HybridCloudForeignKey",
@@ -3781,6 +3916,7 @@
     ]
   },
   "sentry.organizationonboardingtask": {
+    "dangling": false,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -3815,6 +3951,7 @@
     ]
   },
   "sentry.organizationoption": {
+    "dangling": false,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -3839,6 +3976,7 @@
     ]
   },
   "sentry.organizationslugreservation": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "HybridCloudForeignKey",
@@ -3871,6 +4009,7 @@
     ]
   },
   "sentry.orgauthtoken": {
+    "dangling": false,
     "foreign_keys": {
       "created_by": {
         "kind": "FlexibleForeignKey",
@@ -3904,6 +4043,7 @@
     ]
   },
   "sentry.pendingincidentsnapshot": {
+    "dangling": false,
     "foreign_keys": {
       "incident": {
         "kind": "OneToOneCascadeDeletes",
@@ -3927,6 +4067,7 @@
     ]
   },
   "sentry.perfstringindexer": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "ImplicitForeignKey",
@@ -3947,6 +4088,7 @@
     ]
   },
   "sentry.platformexternalissue": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -3976,6 +4118,7 @@
     ]
   },
   "sentry.processingissue": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -4001,6 +4144,7 @@
     ]
   },
   "sentry.proguardartifactrelease": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "ImplicitForeignKey",
@@ -4036,6 +4180,7 @@
     ]
   },
   "sentry.project": {
+    "dangling": false,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -4060,6 +4205,7 @@
     ]
   },
   "sentry.projectartifactbundle": {
+    "dangling": false,
     "foreign_keys": {
       "artifact_bundle": {
         "kind": "FlexibleForeignKey",
@@ -4090,11 +4236,12 @@
     ]
   },
   "sentry.projectavatar": {
+    "dangling": false,
     "foreign_keys": {
       "file_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.file",
-        "nullable": false
+        "nullable": true
       },
       "project": {
         "kind": "FlexibleForeignKey",
@@ -4124,6 +4271,7 @@
     ]
   },
   "sentry.projectbookmark": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -4153,6 +4301,7 @@
     ]
   },
   "sentry.projectcodeowners": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -4181,6 +4330,7 @@
     ]
   },
   "sentry.projectdebugfile": {
+    "dangling": true,
     "foreign_keys": {
       "file": {
         "kind": "FlexibleForeignKey",
@@ -4190,7 +4340,7 @@
       "project_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.project",
-        "nullable": false
+        "nullable": true
       }
     },
     "model": "sentry.projectdebugfile",
@@ -4206,6 +4356,7 @@
     ]
   },
   "sentry.projectintegration": {
+    "dangling": false,
     "foreign_keys": {
       "integration_id": {
         "kind": "HybridCloudForeignKey",
@@ -4235,6 +4386,7 @@
     ]
   },
   "sentry.projectkey": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -4261,6 +4413,7 @@
     ]
   },
   "sentry.projectoption": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -4285,6 +4438,7 @@
     ]
   },
   "sentry.projectownership": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -4308,6 +4462,7 @@
     ]
   },
   "sentry.projectplatform": {
+    "dangling": false,
     "foreign_keys": {
       "project_id": {
         "kind": "ImplicitForeignKey",
@@ -4332,6 +4487,7 @@
     ]
   },
   "sentry.projectredirect": {
+    "dangling": false,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -4361,6 +4517,7 @@
     ]
   },
   "sentry.projectteam": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -4390,6 +4547,7 @@
     ]
   },
   "sentry.projecttransactionthreshold": {
+    "dangling": false,
     "foreign_keys": {
       "edited_by_id": {
         "kind": "HybridCloudForeignKey",
@@ -4423,6 +4581,7 @@
     ]
   },
   "sentry.projecttransactionthresholdoverride": {
+    "dangling": false,
     "foreign_keys": {
       "edited_by_id": {
         "kind": "HybridCloudForeignKey",
@@ -4457,6 +4616,7 @@
     ]
   },
   "sentry.promptsactivity": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "ImplicitForeignKey",
@@ -4493,6 +4653,7 @@
     ]
   },
   "sentry.pullrequest": {
+    "dangling": false,
     "foreign_keys": {
       "author": {
         "kind": "FlexibleForeignKey",
@@ -4527,6 +4688,7 @@
     ]
   },
   "sentry.pullrequestcomment": {
+    "dangling": false,
     "foreign_keys": {
       "pull_request": {
         "kind": "FlexibleForeignKey",
@@ -4551,6 +4713,7 @@
     ]
   },
   "sentry.pullrequestcommit": {
+    "dangling": false,
     "foreign_keys": {
       "commit": {
         "kind": "FlexibleForeignKey",
@@ -4580,6 +4743,7 @@
     ]
   },
   "sentry.querysubscription": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -4608,6 +4772,7 @@
     ]
   },
   "sentry.rawevent": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -4632,6 +4797,7 @@
     ]
   },
   "sentry.recentsearch": {
+    "dangling": false,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -4663,6 +4829,7 @@
     ]
   },
   "sentry.regionoutbox": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.regionoutbox",
     "relocation_scope": "Excluded",
@@ -4677,6 +4844,7 @@
     ]
   },
   "sentry.regionscheduleddeletion": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.regionscheduleddeletion",
     "relocation_scope": "Excluded",
@@ -4699,6 +4867,7 @@
     ]
   },
   "sentry.regiontombstone": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.regiontombstone",
     "relocation_scope": "Excluded",
@@ -4713,6 +4882,7 @@
     ]
   },
   "sentry.relay": {
+    "dangling": false,
     "foreign_keys": {},
     "model": "sentry.relay",
     "relocation_scope": "Config",
@@ -4730,6 +4900,7 @@
     ]
   },
   "sentry.relayusage": {
+    "dangling": false,
     "foreign_keys": {},
     "model": "sentry.relayusage",
     "relocation_scope": "Config",
@@ -4748,6 +4919,7 @@
     ]
   },
   "sentry.release": {
+    "dangling": false,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -4762,7 +4934,7 @@
       "project_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.project",
-        "nullable": false
+        "nullable": true
       }
     },
     "model": "sentry.release",
@@ -4782,6 +4954,7 @@
     ]
   },
   "sentry.releaseactivity": {
+    "dangling": false,
     "foreign_keys": {
       "release": {
         "kind": "FlexibleForeignKey",
@@ -4802,6 +4975,7 @@
     ]
   },
   "sentry.releaseartifactbundle": {
+    "dangling": false,
     "foreign_keys": {
       "artifact_bundle": {
         "kind": "FlexibleForeignKey",
@@ -4827,6 +5001,7 @@
     ]
   },
   "sentry.releasecommit": {
+    "dangling": false,
     "foreign_keys": {
       "commit": {
         "kind": "FlexibleForeignKey",
@@ -4841,7 +5016,7 @@
       "project_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.project",
-        "nullable": false
+        "nullable": true
       },
       "release": {
         "kind": "FlexibleForeignKey",
@@ -4870,6 +5045,7 @@
     ]
   },
   "sentry.releaseenvironment": {
+    "dangling": false,
     "foreign_keys": {
       "environment": {
         "kind": "FlexibleForeignKey",
@@ -4884,7 +5060,7 @@
       "project_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.project",
-        "nullable": false
+        "nullable": true
       },
       "release": {
         "kind": "FlexibleForeignKey",
@@ -4910,6 +5086,7 @@
     ]
   },
   "sentry.releasefile": {
+    "dangling": false,
     "foreign_keys": {
       "file": {
         "kind": "FlexibleForeignKey",
@@ -4924,7 +5101,7 @@
       "project_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.project",
-        "nullable": false
+        "nullable": true
       },
       "release_id": {
         "kind": "ImplicitForeignKey",
@@ -4949,6 +5126,7 @@
     ]
   },
   "sentry.releaseheadcommit": {
+    "dangling": false,
     "foreign_keys": {
       "commit": {
         "kind": "FlexibleForeignKey",
@@ -4988,6 +5166,7 @@
     ]
   },
   "sentry.releaseproject": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -5017,6 +5196,7 @@
     ]
   },
   "sentry.releaseprojectenvironment": {
+    "dangling": false,
     "foreign_keys": {
       "environment": {
         "kind": "FlexibleForeignKey",
@@ -5052,6 +5232,7 @@
     ]
   },
   "sentry.releasethreshold": {
+    "dangling": false,
     "foreign_keys": {
       "environment": {
         "kind": "FlexibleForeignKey",
@@ -5077,11 +5258,12 @@
     ]
   },
   "sentry.repository": {
+    "dangling": false,
     "foreign_keys": {
       "integration_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.integration",
-        "nullable": false
+        "nullable": true
       },
       "organization_id": {
         "kind": "ImplicitForeignKey",
@@ -5107,6 +5289,7 @@
     ]
   },
   "sentry.repositoryprojectpathconfig": {
+    "dangling": false,
     "foreign_keys": {
       "integration_id": {
         "kind": "ImplicitForeignKey",
@@ -5151,6 +5334,7 @@
     ]
   },
   "sentry.reprocessingreport": {
+    "dangling": false,
     "foreign_keys": {
       "project": {
         "kind": "FlexibleForeignKey",
@@ -5175,11 +5359,12 @@
     ]
   },
   "sentry.rule": {
+    "dangling": false,
     "foreign_keys": {
       "environment_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.environment",
-        "nullable": false
+        "nullable": true
       },
       "owner": {
         "kind": "FlexibleForeignKey",
@@ -5205,6 +5390,7 @@
     ]
   },
   "sentry.ruleactivity": {
+    "dangling": false,
     "foreign_keys": {
       "rule": {
         "kind": "FlexibleForeignKey",
@@ -5230,6 +5416,7 @@
     ]
   },
   "sentry.rulefirehistory": {
+    "dangling": false,
     "foreign_keys": {
       "group": {
         "kind": "FlexibleForeignKey",
@@ -5260,6 +5447,7 @@
     ]
   },
   "sentry.rulesnooze": {
+    "dangling": true,
     "foreign_keys": {
       "alert_rule": {
         "kind": "FlexibleForeignKey",
@@ -5303,6 +5491,7 @@
     ]
   },
   "sentry.savedsearch": {
+    "dangling": true,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -5328,6 +5517,7 @@
     ]
   },
   "sentry.scheduleddeletion": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.scheduleddeletion",
     "relocation_scope": "Excluded",
@@ -5350,6 +5540,7 @@
     ]
   },
   "sentry.sentryapp": {
+    "dangling": false,
     "foreign_keys": {
       "application": {
         "kind": "DefaultOneToOneField",
@@ -5394,16 +5585,17 @@
     ]
   },
   "sentry.sentryappavatar": {
+    "dangling": false,
     "foreign_keys": {
       "control_file_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.controlfile",
-        "nullable": false
+        "nullable": true
       },
       "file_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.file",
-        "nullable": false
+        "nullable": true
       },
       "sentry_app": {
         "kind": "FlexibleForeignKey",
@@ -5433,6 +5625,7 @@
     ]
   },
   "sentry.sentryappcomponent": {
+    "dangling": false,
     "foreign_keys": {
       "sentry_app": {
         "kind": "FlexibleForeignKey",
@@ -5456,16 +5649,17 @@
     ]
   },
   "sentry.sentryappinstallation": {
+    "dangling": false,
     "foreign_keys": {
       "api_grant": {
         "kind": "DefaultOneToOneField",
         "model": "sentry.apigrant",
-        "nullable": false
+        "nullable": true
       },
       "api_token": {
         "kind": "DefaultOneToOneField",
         "model": "sentry.apitoken",
-        "nullable": false
+        "nullable": true
       },
       "organization_id": {
         "kind": "HybridCloudForeignKey",
@@ -5497,6 +5691,7 @@
     ]
   },
   "sentry.sentryappinstallationforprovider": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "HybridCloudForeignKey",
@@ -5526,6 +5721,7 @@
     ]
   },
   "sentry.sentryappinstallationtoken": {
+    "dangling": false,
     "foreign_keys": {
       "api_token": {
         "kind": "FlexibleForeignKey",
@@ -5555,6 +5751,7 @@
     ]
   },
   "sentry.sentryfunction": {
+    "dangling": false,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -5585,6 +5782,7 @@
     ]
   },
   "sentry.servicehook": {
+    "dangling": true,
     "foreign_keys": {
       "application_id": {
         "kind": "HybridCloudForeignKey",
@@ -5599,12 +5797,12 @@
       "organization_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.organization",
-        "nullable": false
+        "nullable": true
       },
       "project_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.project",
-        "nullable": false
+        "nullable": true
       }
     },
     "model": "sentry.servicehook",
@@ -5623,6 +5821,7 @@
     ]
   },
   "sentry.servicehookproject": {
+    "dangling": false,
     "foreign_keys": {
       "project_id": {
         "kind": "ImplicitForeignKey",
@@ -5652,6 +5851,7 @@
     ]
   },
   "sentry.snubaquery": {
+    "dangling": true,
     "foreign_keys": {
       "environment": {
         "kind": "FlexibleForeignKey",
@@ -5672,6 +5872,7 @@
     ]
   },
   "sentry.snubaqueryeventtype": {
+    "dangling": true,
     "foreign_keys": {
       "snuba_query": {
         "kind": "FlexibleForeignKey",
@@ -5696,6 +5897,7 @@
     ]
   },
   "sentry.stringindexer": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "ImplicitForeignKey",
@@ -5716,6 +5918,7 @@
     ]
   },
   "sentry.team": {
+    "dangling": false,
     "foreign_keys": {
       "actor": {
         "kind": "FlexibleForeignKey",
@@ -5748,11 +5951,12 @@
     ]
   },
   "sentry.teamavatar": {
+    "dangling": false,
     "foreign_keys": {
       "file_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.file",
-        "nullable": false
+        "nullable": true
       },
       "team": {
         "kind": "FlexibleForeignKey",
@@ -5782,6 +5986,7 @@
     ]
   },
   "sentry.teamkeytransaction": {
+    "dangling": false,
     "foreign_keys": {
       "organization": {
         "kind": "FlexibleForeignKey",
@@ -5811,6 +6016,7 @@
     ]
   },
   "sentry.teamreplica": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "HybridCloudForeignKey",
@@ -5840,6 +6046,7 @@
     ]
   },
   "sentry.timeseriessnapshot": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sentry.timeseriessnapshot",
     "relocation_scope": "Organization",
@@ -5854,6 +6061,7 @@
     ]
   },
   "sentry.user": {
+    "dangling": false,
     "foreign_keys": {},
     "model": "sentry.user",
     "relocation_scope": "User",
@@ -5871,16 +6079,17 @@
     ]
   },
   "sentry.useravatar": {
+    "dangling": false,
     "foreign_keys": {
       "control_file_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.controlfile",
-        "nullable": false
+        "nullable": true
       },
       "file_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.file",
-        "nullable": false
+        "nullable": true
       },
       "user": {
         "kind": "FlexibleForeignKey",
@@ -5913,6 +6122,7 @@
     ]
   },
   "sentry.useremail": {
+    "dangling": false,
     "foreign_keys": {
       "user": {
         "kind": "FlexibleForeignKey",
@@ -5937,6 +6147,7 @@
     ]
   },
   "sentry.userip": {
+    "dangling": false,
     "foreign_keys": {
       "user": {
         "kind": "FlexibleForeignKey",
@@ -5961,6 +6172,7 @@
     ]
   },
   "sentry.useroption": {
+    "dangling": false,
     "foreign_keys": {
       "organization_id": {
         "kind": "HybridCloudForeignKey",
@@ -6001,6 +6213,7 @@
     ]
   },
   "sentry.userpermission": {
+    "dangling": false,
     "foreign_keys": {
       "user": {
         "kind": "FlexibleForeignKey",
@@ -6025,21 +6238,22 @@
     ]
   },
   "sentry.userreport": {
+    "dangling": false,
     "foreign_keys": {
       "environment_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.environment",
-        "nullable": false
+        "nullable": true
       },
       "event_user_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.eventuser",
-        "nullable": false
+        "nullable": true
       },
       "group_id": {
         "kind": "ImplicitForeignKey",
         "model": "sentry.group",
-        "nullable": false
+        "nullable": true
       },
       "project_id": {
         "kind": "ImplicitForeignKey",
@@ -6064,6 +6278,7 @@
     ]
   },
   "sentry.userrole": {
+    "dangling": false,
     "foreign_keys": {},
     "model": "sentry.userrole",
     "relocation_scope": "Config",
@@ -6081,6 +6296,7 @@
     ]
   },
   "sentry.userroleuser": {
+    "dangling": false,
     "foreign_keys": {
       "role": {
         "kind": "FlexibleForeignKey",
@@ -6106,6 +6322,7 @@
     ]
   },
   "sessions.session": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sessions.session",
     "relocation_scope": "Excluded",
@@ -6120,6 +6337,7 @@
     ]
   },
   "sites.site": {
+    "dangling": true,
     "foreign_keys": {},
     "model": "sites.site",
     "relocation_scope": "Excluded",
@@ -6137,6 +6355,7 @@
     ]
   },
   "social_auth.usersocialauth": {
+    "dangling": false,
     "foreign_keys": {
       "user": {
         "kind": "DefaultForeignKey",

--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from dataclasses import dataclass
 from enum import Enum, auto, unique
 from functools import lru_cache
 from typing import Dict, FrozenSet, NamedTuple, Optional, Set, Tuple, Type
@@ -12,55 +13,6 @@ from sentry.backup.helpers import EXCLUDED_APPS
 from sentry.backup.scopes import RelocationScope
 from sentry.silo import SiloMode
 from sentry.utils import json
-
-
-@unique
-class ForeignFieldKind(Enum):
-    """Kinds of foreign fields that we care about."""
-
-    # Uses our `FlexibleForeignKey` wrapper.
-    FlexibleForeignKey = auto()
-
-    # Uses our `HybridCloudForeignKey` wrapper.
-    HybridCloudForeignKey = auto()
-
-    # Uses our `OneToOneCascadeDeletes` wrapper.
-    OneToOneCascadeDeletes = auto()
-
-    # A naked usage of Django's `ForeignKey`.
-    DefaultForeignKey = auto()
-
-    # A naked usage of Django's `OneToOneField`.
-    DefaultOneToOneField = auto()
-
-    # A ForeignKey-like dependency that is opaque to Django because it uses `BoundedBigIntegerField`
-    # instead of one of the Django's default relational field types like `ForeignKey`,
-    # `OneToOneField`, etc.dd
-    ImplicitForeignKey = auto()
-
-
-class ForeignField(NamedTuple):
-    """A field that creates a dependency on another Sentry model."""
-
-    model: Type[models.base.Model]
-    kind: ForeignFieldKind
-    nullable: bool
-
-
-class ModelRelations(NamedTuple):
-    """What other models does this model depend on, and how?"""
-
-    foreign_keys: dict[str, ForeignField]
-    model: Type[models.base.Model]
-    relocation_scope: RelocationScope | set[RelocationScope]
-    silos: list[SiloMode]
-    table_name: str
-    uniques: list[frozenset[str]]
-
-    def flatten(self) -> set[Type[models.base.Model]]:
-        """Returns a flat list of all related models, omitting the kind of relation they have."""
-
-        return {ff.model for ff in self.foreign_keys.values()}
 
 
 class NormalizedModelName:
@@ -98,6 +50,96 @@ class NormalizedModelName:
         return self.__model_name
 
 
+# A "root" model is one that is the source of a particular relocation scope - ex, `User` is the root
+# of the `User` relocation scope, the model from which all other (non-dangling; see below) models in
+# that scope are referenced.
+#
+# TODO(getsentry/team-ospo#190): We should find a better way to store this information than a magic
+# list in this file. We should probably make a field (or method?) on `BaseModel` instead.
+@unique
+class RelocationRootModels(Enum):
+    """
+    Record the "root" models for a given `RelocationScope`.
+    """
+
+    Excluded: list[NormalizedModelName] = []
+    User = [NormalizedModelName("sentry.user")]
+    Organization = [NormalizedModelName("sentry.organization")]
+    Config = [
+        NormalizedModelName("sentry.controloption"),
+        NormalizedModelName("sentry.option"),
+        NormalizedModelName("sentry.relay"),
+        NormalizedModelName("sentry.relayusage"),
+        NormalizedModelName("sentry.userrole"),
+    ]
+    # TODO(getsentry/team-ospo#188): Split out extension scope root models from this list.
+    Global = [
+        NormalizedModelName("sentry.apiapplication"),
+        NormalizedModelName("sentry.integration"),
+        NormalizedModelName("sentry.sentryapp"),
+    ]
+
+
+@unique
+class ForeignFieldKind(Enum):
+    """Kinds of foreign fields that we care about."""
+
+    # Uses our `FlexibleForeignKey` wrapper.
+    FlexibleForeignKey = auto()
+
+    # Uses our `HybridCloudForeignKey` wrapper.
+    HybridCloudForeignKey = auto()
+
+    # Uses our `OneToOneCascadeDeletes` wrapper.
+    OneToOneCascadeDeletes = auto()
+
+    # A naked usage of Django's `ForeignKey`.
+    DefaultForeignKey = auto()
+
+    # A naked usage of Django's `OneToOneField`.
+    DefaultOneToOneField = auto()
+
+    # A ForeignKey-like dependency that is opaque to Django because it uses `BoundedBigIntegerField`
+    # instead of one of the Django's default relational field types like `ForeignKey`,
+    # `OneToOneField`, etc.dd
+    ImplicitForeignKey = auto()
+
+
+class ForeignField(NamedTuple):
+    """A field that creates a dependency on another Sentry model."""
+
+    model: Type[models.base.Model]
+    kind: ForeignFieldKind
+    nullable: bool
+
+
+@dataclass
+class ModelRelations:
+    """What other models does this model depend on, and how?"""
+
+    # A "dangling" model is one that does not transitively contain a non-nullable `ForeignField`
+    # reference to at least one of the `RelocationRootModels` listed above.
+    #
+    # TODO(getsentry/team-ospo#190): A model may or may not be "dangling" in different
+    # `ExportScope`s - for example, a model in `RelocationScope.Organization` may have a single,
+    # non-nullable `ForeignField` reference to a root model in `RelocationScope.Config`. This would
+    # cause it to be dangling when we do an `ExportScope.Organization` export, but non-dangling if
+    # we do an `ExportScope.Global` export. HOWEVER, as best as I can tell, this situation does not
+    # actually exist today, so we can ignore this subtlety for now and just us a boolean here.
+    dangling: Optional[bool]
+    foreign_keys: dict[str, ForeignField]
+    model: Type[models.base.Model]
+    relocation_scope: RelocationScope | set[RelocationScope]
+    silos: list[SiloMode]
+    table_name: str
+    uniques: list[frozenset[str]]
+
+    def flatten(self) -> set[Type[models.base.Model]]:
+        """Returns a flat list of all related models, omitting the kind of relation they have."""
+
+        return {ff.model for ff in self.foreign_keys.values()}
+
+
 def get_model_name(model: type[models.Model] | models.Model) -> NormalizedModelName:
     return NormalizedModelName(f"{model._meta.app_label}.{model._meta.object_name}")
 
@@ -119,6 +161,8 @@ class DependenciesJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if meta := getattr(obj, "_meta", None):
             return f"{meta.app_label}.{meta.object_name}".lower()
+        if isinstance(obj, ModelRelations):
+            return obj.__dict__
         if isinstance(obj, ForeignFieldKind):
             return obj.name
         if isinstance(obj, RelocationScope):
@@ -226,8 +270,8 @@ def dependencies() -> dict[NormalizedModelName, ModelRelations]:
     from sentry.models.actor import Actor
     from sentry.models.team import Team
 
-    # Process the list of models, and get the list of dependencies
-    model_dependencies_list: Dict[NormalizedModelName, ModelRelations] = {}
+    # Process the list of models, and get the list of dependencies.
+    model_dependencies_dict: Dict[NormalizedModelName, ModelRelations] = {}
     app_configs = apps.get_app_configs()
     models_from_names = {
         get_model_name(model): model
@@ -285,6 +329,10 @@ def dependencies() -> dict[NormalizedModelName, ModelRelations]:
                 field for field in model._meta.get_fields() if isinstance(field, OneToOneField)
             ]
             for field in one_to_one_fields:
+                is_nullable = getattr(field, "null", False)
+                if getattr(field, "unique", False):
+                    uniques.add(frozenset({field.name}))
+
                 rel_model = getattr(field.remote_field, "model", None)
                 if rel_model is not None and rel_model != model:
                     if isinstance(field, OneToOneCascadeDeletes):
@@ -311,6 +359,10 @@ def dependencies() -> dict[NormalizedModelName, ModelRelations]:
                 or isinstance(field, BoundedPositiveIntegerField)
             ]
             for field in simple_integer_fields:
+                is_nullable = getattr(field, "null", False)
+                if getattr(field, "unique", False):
+                    uniques.add(frozenset({field.name}))
+
                 # "actor_id", when used as a simple integer field rather than a `ForeignKey` into an
                 # `Actor`, refers to a unified but loosely specified means by which to index into a
                 # either a `Team` or `User`, before this pattern was formalized by the official
@@ -322,12 +374,13 @@ def dependencies() -> dict[NormalizedModelName, ModelRelations]:
                         foreign_keys[field.name] = ForeignField(
                             model=models_from_names[candidate],
                             kind=ForeignFieldKind.ImplicitForeignKey,
-                            nullable=False,
+                            nullable=is_nullable,
                         )
 
-            model_dependencies_list[get_model_name(model)] = ModelRelations(
-                model=model,
+            model_dependencies_dict[get_model_name(model)] = ModelRelations(
+                dangling=None,
                 foreign_keys=foreign_keys,
+                model=model,
                 relocation_scope=getattr(model, "__relocation_scope__", RelocationScope.Excluded),
                 silos=list(
                     getattr(model._meta, "silo_limit", ModelSiloLimit(SiloMode.MONOLITH)).modes
@@ -336,7 +389,54 @@ def dependencies() -> dict[NormalizedModelName, ModelRelations]:
                 # Sort the constituent sets alphabetically, so that we get consistent JSON output.
                 uniques=sorted(list(uniques), key=lambda u: ":".join(sorted(list(u)))),
             )
-    return model_dependencies_list
+
+    # Get a flat list of "root" models, then mark all of them as non-dangling.
+    relocation_root_models: list[NormalizedModelName] = []
+    for root_models in RelocationRootModels:
+        relocation_root_models.extend(root_models.value)
+    for model_name in relocation_root_models:
+        model_dependencies_dict[model_name].dangling = False
+
+    # Now that all `ModelRelations` have been added to the `model_dependencies_dict`, we can circle
+    # back and figure out which ones are actually dangling. We do this by marking all of the root
+    # models non-dangling, then traversing from every other model to a (possible) root model
+    # recursively. At this point there should be no circular reference chains, so if we encounter
+    # them, fail immediately.
+    def resolve_dangling(seen: Set[NormalizedModelName], model_name: NormalizedModelName) -> bool:
+        model_relations = model_dependencies_dict[model_name]
+        model_name = get_model_name(model_relations.model)
+        if model_name in seen:
+            raise RuntimeError(
+                f"Circular dependency: {model_name} cannot transitively reference itself"
+            )
+        if model_relations.dangling is not None:
+            return model_relations.dangling
+
+        # TODO(getsentry/team-ospo#190): Maybe make it so that `Global` models are never "dangling",
+        # since we want to export 100% of models in `ExportScope.Global` anyway?
+
+        seen.add(model_name)
+
+        # If we are able to successfully over all of the foreign keys without encountering a
+        # dangling reference, we know that this model is dangling as well.
+        model_relations.dangling = True
+        for ff in model_relations.foreign_keys.values():
+            if not ff.nullable:
+                foreign_model_name = get_model_name(ff.model)
+                if not resolve_dangling(seen, foreign_model_name):
+                    # We only need one non-dangling reference to mark this model as non-dangling as
+                    # well.
+                    model_relations.dangling = False
+                    break
+
+        seen.remove(model_name)
+        return model_relations.dangling
+
+    for model_name in model_dependencies_dict.keys():
+        if model_name not in relocation_root_models:
+            resolve_dangling(set(), model_name)
+
+    return model_dependencies_dict
 
 
 # No arguments, so we lazily cache the result after the first calculation.
@@ -347,9 +447,9 @@ def sorted_dependencies() -> list[Type[models.base.Model]]:
     Similar to Django's algorithm except that we discard the importance of natural keys
     when sorting dependencies (ie, it works without them)."""
 
-    model_dependencies_list = list(dependencies().values())
-    model_dependencies_list.reverse()
-    model_set = {md.model for md in model_dependencies_list}
+    model_dependencies_dict = list(dependencies().values())
+    model_dependencies_dict.reverse()
+    model_set = {md.model for md in model_dependencies_dict}
 
     # Now sort the models to ensure that dependencies are met. This
     # is done by repeatedly iterating over the input list of models.
@@ -360,11 +460,11 @@ def sorted_dependencies() -> list[Type[models.base.Model]]:
     # If we do a full iteration without a promotion, that means there are
     # circular dependencies in the list.
     model_list = []
-    while model_dependencies_list:
+    while model_dependencies_dict:
         skipped = []
         changed = False
-        while model_dependencies_list:
-            model_deps = model_dependencies_list.pop()
+        while model_dependencies_dict:
+            model_deps = model_dependencies_dict.pop()
             deps = model_deps.flatten()
             model = model_deps.model
 
@@ -388,6 +488,6 @@ def sorted_dependencies() -> list[Type[models.base.Model]]:
                     for m in sorted(skipped, key=lambda mr: get_model_name(mr.model))
                 )
             )
-        model_dependencies_list = skipped
+        model_dependencies_dict = skipped
 
     return model_list


### PR DESCRIPTION
This change introduces the idea of a "dangling" model: a model that has no transitive, non-nullable references to one of the "root" models that define their respective relocation scopes. This is important, because dangling models cannot be filtered using the usual method of "does the foreign key exist", since they do not reliably have foreign key references into filtered models.

Changes have also been made to the graphviz visualization binary at `bin/model-dependency-graphviz`. One may view the new output by invoking something like `bin/model-dependency-graphviz | pbcopy` from a terminal `cd`'ed to the root of this repository, and pasting the output to a graphviz viewer like https://dreampuf.github.io/GraphvizOnline.

Issue: getsentry/team-ospo#196
Issue: getsentry/team-ospo#201
