### PR TITLE
ref(crons): Extract duplicate logic for monitor updates

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -27,10 +27,10 @@ def mark_failed(
     ts: datetime,
 ):
     """
-    Given a failing check-in, mark the monitor environent as failed and trigger
+    Given a failing check-in, mark the monitor environment as failed and trigger
     side-effects for creating monitor incidents and issues.
 
-    The provided `ts` is the reference time for when the next checkin time is
+    The provided `ts` is the reference time for when the next check-in time is
     calculated from. This typically would be the failed check-in's `date_added`
     or completion time. Though for the missed and timedout tasks this may be
     computed based on the tasks reference time.
@@ -38,26 +38,12 @@ def mark_failed(
     monitor_env = failed_checkin.monitor_environment
     failure_issue_threshold = monitor_env.monitor.config.get("failure_issue_threshold", 0)
 
-    if failure_issue_threshold:
-        return mark_failed_threshold(failed_checkin, ts, failure_issue_threshold)
-    else:
-        return mark_failed_no_threshold(failed_checkin, ts)
-
-
-def mark_failed_threshold(
-    failed_checkin: MonitorCheckIn,
-    ts: datetime,
-    failure_issue_threshold: int,
-):
-    from sentry.signals import monitor_environment_failed
-
-    monitor_env = failed_checkin.monitor_environment
-
+    # Compute the next check-in time from our reference time
     next_checkin = monitor_env.monitor.get_next_expected_checkin(ts)
     next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(ts)
 
-    # Whe the failed check-in is a synthetic missed check-in we do not move the
-    # `last_checkin` timestamp forward.
+    # When the failed check-in is a synthetic missed check-in we do not move
+    # the `last_checkin` timestamp forward.
     if failed_checkin.status == CheckInStatus.MISSED:
         # When a monitor is MISSED it MUST have already had a `last_checkin`. A
         # monitor cannot be missed without having checked in.
@@ -65,25 +51,56 @@ def mark_failed_threshold(
     else:
         last_checkin = failed_checkin.date_added
 
-    # update monitor environment timestamps without updating status
-    # affected returns number of rows returned from the filter() call
-    # not the number of rows that actually modify their values via update()
-    affected = MonitorEnvironment.objects.filter(
-        Q(last_checkin__lte=last_checkin) | Q(last_checkin__isnull=True), id=monitor_env.id
-    ).update(
-        next_checkin=next_checkin,
-        next_checkin_latest=next_checkin_latest,
-        last_checkin=last_checkin,
+    # Select the MonitorEnvironment for update. We ONLY want to update the
+    # monitor if there have not been newer check-ins.
+    monitors_to_update = MonitorEnvironment.objects.filter(
+        Q(last_checkin__lte=last_checkin) | Q(last_checkin__isnull=True),
+        id=monitor_env.id,
     )
 
-    # If we did not update the monitor enviromnent it means there was a newer
+    field_updates = {
+        "last_checkin": last_checkin,
+        "next_checkin": next_checkin,
+        "next_checkin_latest": next_checkin_latest,
+    }
+
+    if not failure_issue_threshold:
+        # Additionaly update status when not using thresholds. The threshold based
+        # failure will only update status once it has passed the threshold.
+        failed_status_map = {
+            CheckInStatus.MISSED: MonitorStatus.MISSED_CHECKIN,
+            CheckInStatus.TIMEOUT: MonitorStatus.TIMEOUT,
+        }
+        new_status = failed_status_map.get(failed_checkin.status, MonitorStatus.ERROR)
+
+        affected = monitors_to_update.update(**field_updates, status=new_status)
+    else:
+        affected = monitors_to_update.update(**field_updates)
+
+    # If we did not update the monitor environment it means there was a newer
     # check-in. We have nothing to do in this case.
+    #
+    # XXX: The `affected` result is the number of rows returned from the
+    # filter. Not the number of rows that had their values modified by the
+    # update.
     if not affected:
         return False
 
     # refresh the object from the database so we have the updated values in our
     # cached instance
     monitor_env.refresh_from_db()
+
+    # Create incidents + issues
+    if failure_issue_threshold:
+        return mark_failed_threshold(failed_checkin, failure_issue_threshold)
+    else:
+        return mark_failed_no_threshold(failed_checkin)
+
+
+def mark_failed_threshold(failed_checkin: MonitorCheckIn, failure_issue_threshold: int):
+    from sentry.signals import monitor_environment_failed
+
+    monitor_env = failed_checkin.monitor_environment
 
     # check to see if we need to update the status
     if monitor_env.status == MonitorStatus.OK:
@@ -101,7 +118,7 @@ def mark_failed_threshold(
 
         # change monitor status + update fingerprint timestamp
         monitor_env.status = MonitorStatus.ERROR
-        monitor_env.last_state_change = last_checkin
+        monitor_env.last_state_change = monitor_env.last_checkin
         monitor_env.save(update_fields=("status", "last_state_change"))
     elif monitor_env.status in [
         MonitorStatus.ERROR,
@@ -138,50 +155,10 @@ def mark_failed_threshold(
     return True
 
 
-def mark_failed_no_threshold(
-    failed_checkin: MonitorCheckIn,
-    ts: datetime,
-):
+def mark_failed_no_threshold(failed_checkin: MonitorCheckIn):
     from sentry.signals import monitor_environment_failed
 
     monitor_env = failed_checkin.monitor_environment
-
-    failed_status_map = {
-        CheckInStatus.MISSED: MonitorStatus.MISSED_CHECKIN,
-        CheckInStatus.TIMEOUT: MonitorStatus.TIMEOUT,
-    }
-    new_status = failed_status_map.get(failed_checkin.status, MonitorStatus.ERROR)
-
-    next_checkin = monitor_env.monitor.get_next_expected_checkin(ts)
-    next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(ts)
-
-    # Whe the failed check-in is a synthetic missed check-in we do not move the
-    # `last_checkin` timestamp forward.
-    if failed_checkin.status == CheckInStatus.MISSED:
-        # When a monitor is MISSED it MUST have already had a `last_checkin`. A
-        # monitor cannot be missed without having checked in.
-        last_checkin = monitor_env.last_checkin
-    else:
-        last_checkin = failed_checkin.date_added
-
-    # affected returns number of rows returned from the filter() call
-    # not the number of rows that actually modify their values via update()
-    affected = MonitorEnvironment.objects.filter(
-        Q(last_checkin__lte=last_checkin) | Q(last_checkin__isnull=True), id=monitor_env.id
-    ).update(
-        next_checkin=next_checkin,
-        next_checkin_latest=next_checkin_latest,
-        status=new_status,
-        last_checkin=last_checkin,
-    )
-
-    # If we did not update the monitor enviromnent it means there was a newer
-    # check-in. We have nothing to do in this case.
-    if not affected:
-        return False
-
-    # refresh the object from the database so we have the updated values
-    monitor_env.refresh_from_db()
 
     # Do not create event if monitor is disabled
     if monitor_env.monitor.status == ObjectStatus.DISABLED:


### PR DESCRIPTION
Moves the logic for updating the monitor environment up out of the individual functions for creating incidents / issues / legacy issues