### PR TITLE
chore(migrations) Remove intermediate foriegn keys

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -4337,17 +4337,15 @@ class Migration(CheckedMigration):
                     models.DateTimeField(db_index=True, default=django.utils.timezone.now),
                 ),
                 (
-                    "file",
-                    sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        db_constraint=False,
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="sentry.File",
+                    "file_id",
+                    sentry.db.models.fields.bounded.BoundedBigIntegerField(
+                        db_index=True,
                     ),
                 ),
             ],
             options={
                 "db_table": "sentry_eventattachment",
-                "unique_together": {("project_id", "event_id", "file")},
+                "unique_together": {("project_id", "event_id", "file_id")},
                 "index_together": {("project_id", "date_added")},
             },
         ),
@@ -6400,44 +6398,6 @@ class Migration(CheckedMigration):
             model_name="release",
             name="last_commit_id",
             field=sentry.db.models.fields.bounded.BoundedBigIntegerField(null=True),
-        ),
-        migrations.SeparateDatabaseAndState(
-            database_operations=[
-                migrations.AlterField(
-                    model_name="eventattachment",
-                    name="file",
-                    field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        db_constraint=False,
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="sentry.File",
-                    ),
-                ),
-            ],
-            state_operations=[
-                migrations.AddField(
-                    model_name="eventattachment",
-                    name="file_id",
-                    field=sentry.db.models.fields.bounded.BoundedBigIntegerField(
-                        db_index=True, default=1
-                    ),
-                    preserve_default=False,
-                ),
-                migrations.RemoveField(
-                    model_name="eventattachment",
-                    name="file",
-                ),
-                migrations.AlterUniqueTogether(
-                    name="eventattachment",
-                    unique_together={("project_id", "event_id", "file_id")},
-                ),
-                migrations.AlterIndexTogether(
-                    name="eventattachment",
-                    index_together={
-                        ("project_id", "date_added", "file_id"),
-                        ("project_id", "date_added"),
-                    },
-                ),
-            ],
         ),
         migrations.AlterField(
             model_name="dashboardwidget",
@@ -8554,11 +8514,6 @@ class Migration(CheckedMigration):
             model_name="environment",
             name="project_id",
             field=sentry.db.models.fields.bounded.BoundedBigIntegerField(null=True),
-        ),
-        migrations.AlterField(
-            model_name="eventuser",
-            name="project_id",
-            field=sentry.db.models.fields.bounded.BoundedBigIntegerField(db_index=True),
         ),
         migrations.AlterField(
             model_name="grouprelease",

--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -3173,30 +3173,30 @@ class Migration(CheckedMigration):
                     models.DateTimeField(db_index=True, default=django.utils.timezone.now),
                 ),
                 (
-                    "environment",
-                    sentry.db.models.fields.foreignkey.FlexibleForeignKey(
+                    "environment_id",
+                    sentry.db.models.fields.bounded.BoundedBigIntegerField(
                         null=True,
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="sentry.Environment",
+                        db_index=True,
                     ),
                 ),
                 (
-                    "group",
-                    sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        null=True, on_delete=django.db.models.deletion.CASCADE, to="sentry.Group"
+                    "group_id",
+                    sentry.db.models.fields.bounded.BoundedBigIntegerField(
+                        null=True,
+                        db_index=True,
                     ),
                 ),
                 (
-                    "project",
-                    sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE, to="sentry.Project"
+                    "project_id",
+                    sentry.db.models.fields.bounded.BoundedBigIntegerField(
+                        db_index=True,
                     ),
                 ),
             ],
             options={
                 "db_table": "sentry_userreport",
-                "unique_together": {("project", "event_id")},
-                "index_together": {("project", "date_added"), ("project", "event_id")},
+                "unique_together": {("project_id", "event_id")},
+                "index_together": {("project_id", "date_added"), ("project_id", "event_id")},
             },
         ),
         migrations.CreateModel(
@@ -6412,62 +6412,11 @@ class Migration(CheckedMigration):
                         to="sentry.File",
                     ),
                 ),
-                migrations.AlterField(
-                    model_name="userreport",
-                    name="environment",
-                    field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        db_constraint=False,
-                        null=True,
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="sentry.Environment",
-                    ),
-                ),
-                migrations.AlterField(
-                    model_name="userreport",
-                    name="group",
-                    field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        db_constraint=False,
-                        null=True,
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="sentry.Group",
-                    ),
-                ),
-                migrations.AlterField(
-                    model_name="userreport",
-                    name="project",
-                    field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        db_constraint=False,
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="sentry.Project",
-                    ),
-                ),
             ],
             state_operations=[
                 migrations.AddField(
                     model_name="eventattachment",
                     name="file_id",
-                    field=sentry.db.models.fields.bounded.BoundedBigIntegerField(
-                        db_index=True, default=1
-                    ),
-                    preserve_default=False,
-                ),
-                migrations.AddField(
-                    model_name="userreport",
-                    name="environment_id",
-                    field=sentry.db.models.fields.bounded.BoundedBigIntegerField(
-                        db_index=True, null=True
-                    ),
-                ),
-                migrations.AddField(
-                    model_name="userreport",
-                    name="group_id",
-                    field=sentry.db.models.fields.bounded.BoundedBigIntegerField(
-                        db_index=True, null=True
-                    ),
-                ),
-                migrations.AddField(
-                    model_name="userreport",
-                    name="project_id",
                     field=sentry.db.models.fields.bounded.BoundedBigIntegerField(
                         db_index=True, default=1
                     ),
@@ -6481,32 +6430,12 @@ class Migration(CheckedMigration):
                     name="eventattachment",
                     unique_together={("project_id", "event_id", "file_id")},
                 ),
-                migrations.RemoveField(
-                    model_name="userreport",
-                    name="environment",
-                ),
-                migrations.RemoveField(
-                    model_name="userreport",
-                    name="group",
-                ),
-                migrations.RemoveField(
-                    model_name="userreport",
-                    name="project",
-                ),
-                migrations.AlterUniqueTogether(
-                    name="userreport",
-                    unique_together={("project_id", "event_id")},
-                ),
                 migrations.AlterIndexTogether(
                     name="eventattachment",
                     index_together={
                         ("project_id", "date_added", "file_id"),
                         ("project_id", "date_added"),
                     },
-                ),
-                migrations.AlterIndexTogether(
-                    name="userreport",
-                    index_together={("project_id", "event_id"), ("project_id", "date_added")},
                 ),
             ],
         ),

--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -4346,7 +4346,10 @@ class Migration(CheckedMigration):
             options={
                 "db_table": "sentry_eventattachment",
                 "unique_together": {("project_id", "event_id", "file_id")},
-                "index_together": {("project_id", "date_added")},
+                "index_together": {
+                    ("project_id", "date_added"),
+                    ("project_id", "date_added", "file_id"),
+                },
             },
         ),
         migrations.AlterUniqueTogether(
@@ -5480,24 +5483,6 @@ class Migration(CheckedMigration):
                 default=0,
                 null=True,
             ),
-        ),
-        migrations.SeparateDatabaseAndState(
-            database_operations=[
-                migrations.RunSQL(
-                    sql='\n                    CREATE INDEX CONCURRENTLY "sentry_eventattachment_project_id_date_added_fi_f3b0597f_idx" ON "sentry_eventattachment" ("project_id", "date_added", "file_id");\n                    ',
-                    reverse_sql='\n                        DROP INDEX CONCURRENTLY "sentry_eventattachment_project_id_date_added_fi_f3b0597f_idx";\n                        ',
-                    hints={"tables": ["sentry_eventattachment"]},
-                ),
-            ],
-            state_operations=[
-                migrations.AlterIndexTogether(
-                    name="eventattachment",
-                    index_together={
-                        ("project_id", "date_added", "file"),
-                        ("project_id", "date_added"),
-                    },
-                ),
-            ],
         ),
         migrations.AlterField(
             model_name="alertrule",


### PR DESCRIPTION
When I squashed migrations, I tested the control/region split, but did not test the multi-db configuration that we operate with in saas. These temporary foreign keys result in migrations not running when generating new regions.

cc @tonyo @rgibert 