### PR TITLE
fix(hybridcloud) Fix omission in similarOrigin logic

### DIFF
--- a/static/app/api.spec.tsx
+++ b/static/app/api.spec.tsx
@@ -204,10 +204,12 @@ describe('isSimilarOrigin', function () {
     ['https://sentry.io/api/0/broadcasts/', 'https://woof.sentry.io', true],
     ['https://sentry.io/api/0/users/', 'https://sentry.sentry.io', true],
     ['https://sentry.io/api/0/users/', 'https://io.sentry.io', true],
+    // request to subdomain from parent
+    ['https://us.sentry.io/api/0/users/', 'https://sentry.io', true],
 
     // Not siblings
     ['https://sentry.io/api/0/broadcasts/', 'https://sentry.example.io', false],
-    ['https://woof.example.sentry.io', 'https://example.sentry.io', false],
+    ['https://acme.sentry.io', 'https://acme.sent.ryio', false],
     ['https://woof.example.io', 'https://woof.sentry.io', false],
     ['https://woof.sentry.io', 'https://sentry.woof.io', false],
   ])('allows sibling domains %s and %s is %s', (target, origin, expected) => {

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -93,7 +93,11 @@ function csrfSafeMethod(method?: string): boolean {
 export function isSimilarOrigin(target: string, origin: string): boolean {
   const targetUrl = new URL(target, origin);
   const originUrl = new URL(origin);
-  if (originUrl.hostname.endsWith(targetUrl.hostname)) {
+  // If one of the domains is a child of the other.
+  if (
+    originUrl.hostname.endsWith(targetUrl.hostname) ||
+    targetUrl.hostname.endsWith(originUrl.hostname)
+  ) {
     return true;
   }
   // Check if the target and origin are on sibiling subdomains.


### PR DESCRIPTION
I missed a case earlier of origin=sentry.io and request=us.sentry.io This is allowed as a the parent domain can make requests to any subdomain.