### PR TITLE
fix(profiling): Align the profile preview with the transaction

### DIFF
--- a/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
@@ -73,11 +73,22 @@ export function GapSpanDetails({
     return new FlamegraphModel(profile, threadId, {});
   }, [transactionHasProfile, profile, threadId]);
 
+  // The most recent profile formats should contain a timestamp indicating
+  // the beginning of the profile. This timestamp can be after the start
+  // timestamp on the transaction, so we need to account for the gap and
+  // make sure the relative start timestamps we compute for the span is
+  // relative to the start of the profile.
+  //
+  // If the profile does not contain a timestamp, we fall back to using the
+  // start timestamp on the transaction. This won't be as accurate but it's
+  // the next best thing.
+  const startTimestamp = profile?.timestamp ?? event.startTimestamp;
+
   const relativeStartTimestamp = transactionHasProfile
-    ? span.start_timestamp - event.startTimestamp
+    ? span.start_timestamp - startTimestamp
     : 0;
   const relativeStopTimestamp = transactionHasProfile
-    ? span.timestamp - event.startTimestamp
+    ? span.timestamp - startTimestamp
     : flamegraph.configSpace.width;
 
   // Found the profile, render the preview

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -75,13 +75,24 @@ export function SpanProfileDetails({
       return [];
     }
 
+    // The most recent profile formats should contain a timestamp indicating
+    // the beginning of the profile. This timestamp can be after the start
+    // timestamp on the transaction, so we need to account for the gap and
+    // make sure the relative start timestamps we compute for the span is
+    // relative to the start of the profile.
+    //
+    // If the profile does not contain a timestamp, we fall back to using the
+    // start timestamp on the transaction. This won't be as accurate but it's
+    // the next best thing.
+    const startTimestamp = profile.timestamp ?? event.startTimestamp;
+
     const relativeStartTimestamp = formatTo(
-      span.start_timestamp - event.startTimestamp,
+      span.start_timestamp - startTimestamp,
       'second',
       profile.unit
     );
     const relativeStopTimestamp = formatTo(
-      span.timestamp - event.startTimestamp,
+      span.timestamp - startTimestamp,
       'second',
       profile.unit
     );


### PR DESCRIPTION
When rendering the preview for the missing instrumentation spans and picking a stack to the most frequent stacks in the transaction waterfall, we currently compute a relative timestamp relative to the start of the transaction. However, the start of the profile is not always equal to the start of the transaction. So we need to account for the gap between the start of the transaction and the start of the profile to ensure that the data is correctly aligned.