### PR TITLE
feat(profiling): add flamegraph toolbar

### DIFF
--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   Fragment,
   ReactElement,
   useEffect,
@@ -19,10 +19,14 @@ import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {
   CanvasPoolManager,
+  CanvasScheduler,
   useCanvasScheduler,
 } from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
-import {Flamegraph as FlamegraphModel} from 'sentry/utils/profiling/flamegraph';
+import {
+  Flamegraph,
+  Flamegraph as FlamegraphModel,
+} from 'sentry/utils/profiling/flamegraph';
 import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphPreferences';
 import {useFlamegraphProfiles} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphProfiles';
 import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
@@ -46,6 +50,11 @@ const LOADING_OR_FALLBACK_FLAMEGRAPH = FlamegraphModel.Empty();
 interface AggregateFlamegraphProps {
   hideSystemFrames: boolean;
   setHideSystemFrames: (hideSystemFrames: boolean) => void;
+  children?: (props: {
+    canvasPoolManager: CanvasPoolManager;
+    flamegraph: Flamegraph;
+    scheduler: CanvasScheduler;
+  }) => React.ReactNode;
   hideToolbar?: boolean;
 }
 
@@ -267,6 +276,7 @@ export function AggregateFlamegraph(props: AggregateFlamegraphProps): ReactEleme
 
   return (
     <Fragment>
+      {props.children ? props.children({canvasPoolManager, scheduler, flamegraph}) : null}
       <FlamegraphZoomView
         canvasBounds={flamegraphCanvasBounds}
         canvasPoolManager={canvasPoolManager}

--- a/static/app/views/profiling/landing/profilesSummaryChart.tsx
+++ b/static/app/views/profiling/landing/profilesSummaryChart.tsx
@@ -198,4 +198,5 @@ const ProfilesChartTitle = styled('div')`
 
 const ProfilesChartContainer = styled('div')`
   background-color: ${p => p.theme.background};
+  border-bottom: 1px solid ${p => p.theme.border};
 `;

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -3,7 +3,9 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
-import {LinkButton} from 'sentry/components/button';
+import {Button, LinkButton} from 'sentry/components/button';
+import {CompactSelect} from 'sentry/components/compactSelect';
+import type {SelectOption} from 'sentry/components/compactSelect/types';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -13,10 +15,12 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {AggregateFlamegraph} from 'sentry/components/profiling/flamegraph/aggregateFlamegraph';
+import {FlamegraphSearch} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch';
 import {
   ProfilingBreadcrumbs,
   ProfilingBreadcrumbsProps,
 } from 'sentry/components/profiling/profilingBreadcrumbs';
+import {SegmentedControl} from 'sentry/components/segmentedControl';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import type {SmartSearchBarProps} from 'sentry/components/smartSearchBar';
 import SmartSearchBar from 'sentry/components/smartSearchBar';
@@ -27,13 +31,20 @@ import type {Organization, PageFilters, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {isAggregateField} from 'sentry/utils/discover/fields';
+import type {
+  CanvasPoolManager,
+  CanvasScheduler,
+} from 'sentry/utils/profiling/canvasScheduler';
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {FlamegraphStateProvider} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider';
 import {FlamegraphThemeProvider} from 'sentry/utils/profiling/flamegraph/flamegraphThemeProvider';
+import {Frame} from 'sentry/utils/profiling/frame';
 import {useAggregateFlamegraphQuery} from 'sentry/utils/profiling/hooks/useAggregateFlamegraphQuery';
 import {useCurrentProjectFromRouteParam} from 'sentry/utils/profiling/hooks/useCurrentProjectFromRouteParam';
 import {useProfileFilters} from 'sentry/utils/profiling/hooks/useProfileFilters';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {ProfilesSummaryChart} from 'sentry/views/profiling/landing/profilesSummaryChart';
@@ -257,6 +268,38 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
 
   const {data} = useAggregateFlamegraphQuery({transaction});
 
+  const [visualization, setVisualization] = useLocalStorageState<
+    'flamegraph' | 'call tree'
+  >('flamegraph-visualization', 'flamegraph');
+
+  const onVisualizationChange = useCallback(
+    (value: 'flamegraph' | 'call tree') => {
+      setVisualization(value);
+    },
+    [setVisualization]
+  );
+
+  const [frameFilter, setFrameFilter] = useLocalStorageState<
+    'system' | 'application' | 'all'
+  >('flamegraph-frame-filter', 'application');
+
+  const onFrameFilterChange = useCallback(
+    (value: 'system' | 'application' | 'all') => {
+      setFrameFilter(value);
+    },
+    [setFrameFilter]
+  );
+
+  const flamegraphFrameFilter: ((frame: Frame) => boolean) | undefined = useMemo(() => {
+    if (frameFilter === 'all') {
+      return () => true;
+    }
+    if (frameFilter === 'application') {
+      return frame => frame.is_application;
+    }
+    return frame => !frame.is_application;
+  }, [frameFilter]);
+
   return (
     <SentryDocumentTitle
       title={t('Profiling \u2014 Profile Summary')}
@@ -300,7 +343,7 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
                 type="flamegraph"
                 input={data ?? null}
                 traceID=""
-                frameFilter={undefined}
+                frameFilter={flamegraphFrameFilter}
               >
                 <FlamegraphStateProvider
                   initialState={{
@@ -310,11 +353,29 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
                   }}
                 >
                   <FlamegraphThemeProvider>
-                    <AggregateFlamegraph
-                      hideToolbar
-                      hideSystemFrames={false}
-                      setHideSystemFrames={() => void 0}
-                    />
+                    {visualization === 'flamegraph' ? (
+                      <AggregateFlamegraph
+                        hideToolbar
+                        hideSystemFrames={false}
+                        setHideSystemFrames={() => void 0}
+                      >
+                        {p => {
+                          return (
+                            <AggregateFlamegraphToolbar
+                              {...p}
+                              visualization={visualization}
+                              onVisualizationChange={onVisualizationChange}
+                              frameFilter={frameFilter}
+                              onFrameFilterChange={onFrameFilterChange}
+                              hideSystemFrames={false}
+                              setHideSystemFrames={() => void 0}
+                            />
+                          );
+                        }}
+                      </AggregateFlamegraph>
+                    ) : (
+                      <div />
+                    )}
                   </FlamegraphThemeProvider>
                 </FlamegraphStateProvider>
               </ProfileGroupProvider>
@@ -329,6 +390,82 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
     </SentryDocumentTitle>
   );
 }
+
+interface AggregateFlamegraphToolbarProps {
+  canvasPoolManager: CanvasPoolManager;
+  flamegraph: Flamegraph;
+  frameFilter: 'system' | 'application' | 'all';
+  hideSystemFrames: boolean;
+  onFrameFilterChange: (value: 'system' | 'application' | 'all') => void;
+  onVisualizationChange: (value: 'flamegraph' | 'call tree') => void;
+  scheduler: CanvasScheduler;
+  setHideSystemFrames: (value: boolean) => void;
+  visualization: 'flamegraph' | 'call tree';
+}
+function AggregateFlamegraphToolbar(props: AggregateFlamegraphToolbarProps) {
+  const flamegraphs = useMemo(() => [props.flamegraph], [props.flamegraph]);
+  const spans = useMemo(() => [], []);
+
+  const frameSelectOptions: SelectOption<'system' | 'application' | 'all'>[] =
+    useMemo(() => {
+      return [
+        {value: 'system', label: t('System Frames')},
+        {value: 'application', label: t('Application Frames')},
+        {value: 'all', label: t('All Frames')},
+      ];
+    }, []);
+
+  const onResetZoom = useCallback(() => {
+    props.scheduler.dispatch('reset zoom');
+  }, [props.scheduler]);
+
+  const onFrameFilterChange = useCallback(
+    (value: {value: 'application' | 'system' | 'all'}) => {
+      props.onFrameFilterChange(value.value);
+    },
+    [props]
+  );
+
+  return (
+    <AggregateFlamegraphToolbarContainer>
+      <SegmentedControl
+        aria-label={t('View')}
+        size="xs"
+        value={props.visualization}
+        onChange={props.onVisualizationChange}
+      >
+        <SegmentedControl.Item key="flamegraph">{t('Flamegraph')}</SegmentedControl.Item>
+        <SegmentedControl.Item key="call tree">{t('Call Tree')}</SegmentedControl.Item>
+      </SegmentedControl>
+      <AggregateFlamegraphSearch
+        spans={spans}
+        canvasPoolManager={props.canvasPoolManager}
+        flamegraphs={flamegraphs}
+      />
+      <Button size="xs" onClick={onResetZoom}>
+        {t('Reset Zoom')}
+      </Button>
+      <CompactSelect
+        onChange={onFrameFilterChange}
+        value={props.frameFilter}
+        size="xs"
+        options={frameSelectOptions}
+      />
+    </AggregateFlamegraphToolbarContainer>
+  );
+}
+
+const AggregateFlamegraphToolbarContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  gap: ${space(1)};
+  padding: ${space(0.5)};
+  background: ${p => p.theme.background};
+`;
+
+const AggregateFlamegraphSearch = styled(FlamegraphSearch)`
+  max-width: 300px;
+`;
 
 const ProfileVisualization = styled('div')`
   grid-area: visualization;


### PR DESCRIPTION
Adds a flamegraph toolbar to the aggregate view. 

While adding the toolbar I realized that the coupling between aggregate flamegraph and the view rendering will be problematic when we start adding the call tree as we will want to toggle between graph representations without having to rebuild the graph. As a solution, we need to create an intermediary component that only creates the graph structure and passes it onto the child components who then decide how to render it.

https://github.com/getsentry/sentry/assets/9317857/8e6023d1-a3e2-4f1f-87d7-7f2db614b23e

