### PR TITLE
fix(span-clusterer): Fix per-project task name

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -129,7 +129,7 @@ def spawn_clusterers_span_descs(**kwargs: Any) -> None:
 
 
 @instrumented_task(
-    name="sentry.ingest.transaction_clusterer.tasks.cluster_projects_span_descs",
+    name="sentry.ingest.span_clusterer.tasks.cluster_projects_span_descs",
     queue="transactions.name_clusterer",  # XXX(iker): we should use a different queue
     default_retry_delay=5,  # copied from transaction name clusterer
     max_retries=5,  # copied from transaction name clusterer


### PR DESCRIPTION
Fixes the name of the task running the span description clusterer for projects. Note this task is invoked from the parent [`spawn_clusterers_span_descs`](https://github.com/getsentry/sentry/blob/841b717d0f30e57c1ec412c1f494f7bd966168d0/src/sentry/ingest/transaction_clusterer/tasks.py#L116), and it's the parent one [started in the cron](https://github.com/getsentry/sentry/blob/841b717d0f30e57c1ec412c1f494f7bd966168d0/src/sentry/conf/server.py#L1097), so this PR should not cause any behavior changes. The task name of the parent task is correct.

This child task is not referenced by name anywhere: there are some [string matching in tests](https://github.com/search?q=repo%3Agetsentry%2Fgetsentry+OR+repo%3Agetsentry%2Fsentry+%2Fsentry.ingest.transaction_clusterer.tasks.cluster_projects_span_descs%2F&type=code), but that's just a coincidence with the module name (tests look for the module name to mock the task).