### PR TITLE
feat(ui): Remove ids option from `useTeams`

### DIFF
--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
@@ -5,6 +5,7 @@ import {t} from 'sentry/locale';
 import {Project} from 'sentry/types';
 import {useMembers} from 'sentry/utils/useMembers';
 import {useTeams} from 'sentry/utils/useTeams';
+import {useTeamsById} from 'sentry/utils/useTeamsById';
 
 import FormContext from '../formContext';
 
@@ -60,7 +61,7 @@ function SentryMemberTeamSelectorField({
       currentItems?.filter(item => item.startsWith('team:')).map(user => user.slice(5)),
     [currentItems]
   );
-  useTeams({ids: ensureTeamIds});
+  useTeamsById({ids: ensureTeamIds});
 
   const {
     teams,

--- a/static/app/utils/useTeams.spec.tsx
+++ b/static/app/utils/useTeams.spec.tsx
@@ -107,41 +107,6 @@ describe('useTeams', function () {
     expect(teams).toEqual(expect.arrayContaining(mockTeams));
   });
 
-  it('can load teams by id', async function () {
-    const requestedTeams = [TestStubs.Team({id: '2', slug: 'requested-team'})];
-    const mockRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/teams/`,
-      method: 'GET',
-      body: requestedTeams,
-    });
-
-    TeamStore.loadInitialData(mockTeams);
-
-    const {result, waitFor} = reactHooks.renderHook(useTeams, {
-      initialProps: {ids: ['2']},
-    });
-
-    expect(result.current.initiallyLoaded).toBe(false);
-    expect(mockRequest).toHaveBeenCalled();
-
-    await waitFor(() => expect(result.current.teams.length).toBe(1));
-
-    const {teams} = result.current;
-    expect(teams).toEqual(expect.arrayContaining(requestedTeams));
-  });
-
-  it('only loads ids when needed', function () {
-    TeamStore.loadInitialData(mockTeams);
-
-    const {result} = reactHooks.renderHook(useTeams, {
-      initialProps: {ids: [mockTeams[0].id]},
-    });
-
-    const {teams, initiallyLoaded} = result.current;
-    expect(initiallyLoaded).toBe(true);
-    expect(teams).toEqual(expect.arrayContaining(mockTeams));
-  });
-
   it('correctly returns hasMore before and after store update', async function () {
     const {result, waitFor} = reactHooks.renderHook(useTeams);
 

--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -93,6 +93,7 @@ type FetchTeamOptions = {
 
 /**
  * Helper function to actually load teams
+ *
  */
 async function fetchTeams(
   api: Client,
@@ -157,6 +158,13 @@ async function fetchTeams(
  * NOTE: It is NOT guaranteed that all teams for an organization will be
  * loaded, so you should use this hook with the intention of providing specific
  * slugs, or loading more through search.
+ *
+ * @deprecated use the alternatives to this hook (except for search and pagination)
+ * new alternatives:
+ * - useTeamsById({ids: []}) - get teams by id
+ * - useTeamsById({slugs: []}) - get teams by slug
+ * - useTeamsById() - just reading from the teams store
+ * - useUserTeams() - same as `provideUserTeams: true`
  *
  */
 export function useTeams({limit, slugs, provideUserTeams}: Options = {}) {


### PR DESCRIPTION
- removes the last ids[] useage
- use the new `useTeamsById` instead

depends on #57144 being merged first