### PR TITLE
ref(replays): add rage/dead selectors to click fields in searchbar

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1221,6 +1221,8 @@ export enum ReplayClickFieldKey {
   CLICK_LABEL = 'click.label',
   CLICK_ROLE = 'click.role',
   CLICK_SELECTOR = 'click.selector',
+  DEAD_SELECTOR = 'dead.selector',
+  RAGE_SELECTOR = 'rage.selector',
   CLICK_TAG = 'click.tag',
   CLICK_TESTID = 'click.testid',
   CLICK_TEXT_CONTENT = 'click.textContent',
@@ -1342,6 +1344,8 @@ export const REPLAY_CLICK_FIELDS = [
   ReplayClickFieldKey.CLICK_LABEL,
   ReplayClickFieldKey.CLICK_ROLE,
   ReplayClickFieldKey.CLICK_SELECTOR,
+  ReplayClickFieldKey.DEAD_SELECTOR,
+  ReplayClickFieldKey.RAGE_SELECTOR,
   ReplayClickFieldKey.CLICK_TAG,
   ReplayClickFieldKey.CLICK_TEXT_CONTENT,
   ReplayClickFieldKey.CLICK_TITLE,
@@ -1376,6 +1380,20 @@ const REPLAY_CLICK_FIELD_DEFINITIONS: Record<ReplayClickFieldKey, FieldDefinitio
     valueType: FieldValueType.STRING,
   },
   [ReplayClickFieldKey.CLICK_SELECTOR]: {
+    desc: t(
+      'query using CSS selector-like syntax, supports class, id, and attribute selectors'
+    ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [ReplayClickFieldKey.DEAD_SELECTOR]: {
+    desc: t(
+      'query using CSS selector-like syntax, supports class, id, and attribute selectors'
+    ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [ReplayClickFieldKey.RAGE_SELECTOR]: {
     desc: t(
       'query using CSS selector-like syntax, supports class, id, and attribute selectors'
     ),


### PR DESCRIPTION
before:
<img width="744" alt="SCR-20230927-kbjx" src="https://github.com/getsentry/sentry/assets/56095982/f8653f1f-a390-4c37-9a6b-e82323bc2937">

after:
<img width="629" alt="SCR-20230928-kxdx" src="https://github.com/getsentry/sentry/assets/56095982/33f1a19d-a3f2-4a4f-9bc6-90a0c47a41fc">
<img width="669" alt="SCR-20230928-kxao" src="https://github.com/getsentry/sentry/assets/56095982/6c758423-6a14-4a80-8628-1185ea6290db">
