### PR TITLE
chore(starfish): Remove span.domain_array field now that we dont use it

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -44,7 +44,6 @@ DEVICE_CLASS_ALIAS = "device.class"
 TOTAL_SPAN_DURATION_ALIAS = "total.span_duration"
 SPAN_MODULE_ALIAS = "span.module"
 SPAN_DOMAIN_ALIAS = "span.domain"
-SPAN_DOMAIN_ARRAY_ALIAS = "span.domain_array"
 SPAN_DOMAIN_SEPARATOR = ","
 UNIQUE_SPAN_DOMAIN_ALIAS = "unique.span_domains"
 

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -28,7 +28,6 @@ class SpansMetricsDatasetConfig(DatasetConfig):
     ) -> Mapping[str, Callable[[SearchFilter], Optional[WhereType]]]:
         return {
             constants.SPAN_DOMAIN_ALIAS: self._span_domain_filter_converter,
-            constants.SPAN_DOMAIN_ARRAY_ALIAS: self._span_domain_filter_converter,
         }
 
     @property


### PR DESCRIPTION
- This removes the span.domain_array field now that it's no longer used on the Frontend.