### PR TITLE
feat(onboarding): Add auto/manual switch to Android docs

### DIFF
--- a/static/app/components/onboarding/platformOptionsControl.tsx
+++ b/static/app/components/onboarding/platformOptionsControl.tsx
@@ -17,11 +17,15 @@ export interface PlatformOption<K extends string = string> {
    * The name of the option
    */
   label: string;
+  /**
+   * The default value to be used on initial render
+   */
+  defaultValue?: string;
 }
 
 /**
  * Hook that returns the currently selected platform option values from the URL
- * it will fallback to the first option value if the value in the URL is not valid or not present
+ * it will fallback to the defaultValue or the first option value if the value in the URL is not valid or not present
  */
 export function useUrlPlatformOptions<K extends string>(
   platformOptions: Record<K, PlatformOption>
@@ -33,8 +37,9 @@ export function useUrlPlatformOptions<K extends string>(
     () =>
       Object.keys(platformOptions).reduce(
         (acc, key) => {
+          const defaultValue = platformOptions[key as K].defaultValue;
           const values = platformOptions[key as K].items.map(({value}) => value);
-          acc[key] = values.includes(query[key]) ? query[key] : values[0];
+          acc[key] = values.includes(query[key]) ? query[key] : defaultValue ?? values[0];
           return acc;
         },
         {} as Record<K, string>

--- a/static/app/gettingStartedDocs/android/android.spec.tsx
+++ b/static/app/gettingStartedDocs/android/android.spec.tsx
@@ -20,4 +20,23 @@ describe('GettingStartedWithAndroid', function () {
       ).toBeInTheDocument();
     }
   });
+  it('renders Manual mode for Windows by default', function () {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7.12) Gecko/20050915 Firefox/1.0.7',
+    });
+    render(<GettingStartedWithAndroid dsn="test-dsn" projectSlug="test-project" />);
+
+    // Steps
+    for (const step of steps({
+      dsn: 'test-dsn',
+      hasPerformance: true,
+      hasProfiling: true,
+      installationMode: InstallationMode.MANUAL,
+    })) {
+      expect(
+        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
+      ).toBeInTheDocument();
+    }
+  });
 });

--- a/static/app/gettingStartedDocs/android/android.spec.tsx
+++ b/static/app/gettingStartedDocs/android/android.spec.tsx
@@ -2,7 +2,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
 
-import {GettingStartedWithAndroid, steps} from './android';
+import {GettingStartedWithAndroid, InstallationMode, steps} from './android';
 
 describe('GettingStartedWithAndroid', function () {
   it('renders doc correctly', function () {
@@ -13,6 +13,7 @@ describe('GettingStartedWithAndroid', function () {
       dsn: 'test-dsn',
       hasPerformance: true,
       hasProfiling: true,
+      installationMode: InstallationMode.AUTO,
     })) {
       expect(
         screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -29,22 +29,6 @@ interface StepsParams {
 }
 
 // Configuration Start
-const platformOptions: Record<PlaformOptionKey, PlatformOption> = {
-  installationMode: {
-    label: t('Installation Mode'),
-    items: [
-      {
-        label: t('Auto'),
-        value: InstallationMode.AUTO,
-      },
-      {
-        label: t('Manual'),
-        value: InstallationMode.MANUAL,
-      },
-    ],
-  },
-};
-
 const autoInstallSteps = [
   {
     type: StepType.INSTALL,
@@ -289,6 +273,25 @@ export function GettingStartedWithAndroid({
   activeProductSelection = [],
   ...props
 }: ModuleProps) {
+  const platformOptions: Record<PlaformOptionKey, PlatformOption> = {
+    installationMode: {
+      label: t('Installation Mode'),
+      items: [
+        {
+          label: t('Auto'),
+          value: InstallationMode.AUTO,
+        },
+        {
+          label: t('Manual'),
+          value: InstallationMode.MANUAL,
+        },
+      ],
+      defaultValue:
+        navigator.userAgent.indexOf('Win') !== -1
+          ? InstallationMode.MANUAL
+          : InstallationMode.AUTO,
+    },
+  };
   const optionValues = useUrlPlatformOptions(platformOptions);
 
   const installationMode = optionValues.installationMode as InstallationMode;

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -6,25 +6,48 @@ import ListItem from 'sentry/components/list/listItem';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {
+  PlatformOption,
+  useUrlPlatformOptions,
+} from 'sentry/components/onboarding/platformOptionsControl';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
+
+export enum InstallationMode {
+  AUTO = 'auto',
+  MANUAL = 'manual',
+}
+
+type PlaformOptionKey = 'installationMode';
 
 interface StepsParams {
   dsn: string;
   hasPerformance: boolean;
   hasProfiling: boolean;
+  installationMode?: InstallationMode;
   sourcePackageRegistries?: ModuleProps['sourcePackageRegistries'];
 }
 
 // Configuration Start
-export const steps = ({
-  dsn,
-  sourcePackageRegistries,
-  hasPerformance,
-  hasProfiling,
-}: StepsParams): LayoutProps['steps'] => [
+const platformOptions: Record<PlaformOptionKey, PlatformOption> = {
+  installationMode: {
+    label: t('Installation Mode'),
+    items: [
+      {
+        label: t('Auto'),
+        value: InstallationMode.AUTO,
+      },
+      {
+        label: t('Manual'),
+        value: InstallationMode.MANUAL,
+      },
+    ],
+  },
+};
+
+const autoInstallSteps = [
   {
-    title: t('Auto-Install'),
+    type: StepType.INSTALL,
     description: (
       <p>
         {tct(
@@ -80,12 +103,11 @@ export const steps = ({
             </List>
             <p>
               {tct(
-                'Alternatively, you can also [manualSetupLink:set up the SDK manually]. [stepsBelow: You can skip the steps below when using the wizard].',
+                'Alternatively, you can also [manualSetupLink:set up the SDK manually].',
                 {
                   manualSetupLink: (
                     <ExternalLink href="https://docs.sentry.io/platforms/android/manual-setup/" />
                   ),
-                  stepsBelow: <strong />,
                 }
               )}
             </p>
@@ -94,29 +116,38 @@ export const steps = ({
       },
     ],
   },
-  {
-    title: t('Or Manually Install and Configure'),
-    description: (
-      <Fragment>
-        <strong>{t('Install the Sentry SDK:')}</strong>
-        <p>
-          {tct(
-            'Add the [sagpLink:Sentry Android Gradle plugin] to your [app:app] module:',
+];
+
+export const steps = ({
+  dsn,
+  sourcePackageRegistries,
+  hasPerformance,
+  hasProfiling,
+  installationMode,
+}: StepsParams): LayoutProps['steps'] =>
+  installationMode === InstallationMode.AUTO
+    ? autoInstallSteps
+    : [
+        {
+          type: StepType.INSTALL,
+          description: (
+            <p>
+              {tct(
+                'Add the [sagpLink:Sentry Android Gradle plugin] to your [app:app] module:',
+                {
+                  sagpLink: (
+                    <ExternalLink href="https://docs.sentry.io/platforms/android/configuration/gradle/" />
+                  ),
+                  app: <code />,
+                }
+              )}
+            </p>
+          ),
+          configurations: [
             {
-              sagpLink: (
-                <ExternalLink href="https://docs.sentry.io/platforms/android/configuration/gradle/" />
-              ),
-              app: <code />,
-            }
-          )}
-        </p>
-      </Fragment>
-    ),
-    configurations: [
-      {
-        language: 'groovy',
-        partialLoading: sourcePackageRegistries?.isLoading,
-        code: `
+              language: 'groovy',
+              partialLoading: sourcePackageRegistries?.isLoading,
+              code: `
 plugins {
   id "com.android.application" // should be in the same module
   id "io.sentry.android.gradle" version "${
@@ -127,25 +158,29 @@ plugins {
   }"
 }
         `,
-      },
-      {
-        description: (
-          <Fragment>
-            <strong>{t('Configure the Sentry SDK:')}</strong>
-            <p>
-              {tct(
-                'Configuration is done via the application [manifest: AndroidManifest.xml]. Under the hood Sentry uses a [provider:ContentProvider] to initialize the SDK based on the values provided below. This way the SDK can capture important crashes and metrics right from the app start.',
-                {
-                  manifest: <code />,
-                  provider: <code />,
-                }
-              )}
-            </p>
-            <p>{t("Here's an example config which should get you started:")}</p>
-          </Fragment>
-        ),
-        language: 'xml',
-        code: `
+            },
+          ],
+        },
+        {
+          type: StepType.CONFIGURE,
+          description: (
+            <Fragment>
+              <p>
+                {tct(
+                  'Configuration is done via the application [manifest: AndroidManifest.xml]. Under the hood Sentry uses a [provider:ContentProvider] to initialize the SDK based on the values provided below. This way the SDK can capture important crashes and metrics right from the app start.',
+                  {
+                    manifest: <code />,
+                    provider: <code />,
+                  }
+                )}
+              </p>
+              <p>{t("Here's an example config which should get you started:")}</p>
+            </Fragment>
+          ),
+          configurations: [
+            {
+              language: 'xml',
+              code: `
 <application>
   <!-- Required: set your sentry.io project identifier (DSN) -->
   <meta-data android:name="io.sentry.dsn" android:value="${dsn}" />
@@ -171,44 +206,44 @@ plugins {
   }
 </application>
         `,
-      },
-    ],
-  },
-  {
-    type: StepType.VERIFY,
-    description: (
-      <p>
-        {tct(
-          "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected. You can add it to your app's [mainActivity: MainActivity].",
-          {
-            mainActivity: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'kotlin',
-        code: `
+            },
+          ],
+        },
+        {
+          type: StepType.VERIFY,
+          description: (
+            <p>
+              {tct(
+                "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected. You can add it to your app's [mainActivity: MainActivity].",
+                {
+                  mainActivity: <code />,
+                }
+              )}
+            </p>
+          ),
+          configurations: [
+            {
+              language: 'kotlin',
+              code: `
 val breakWorld = Button(this).apply {
   text = "Break the world"
   setOnClickListener {
-    throw RuntimeException("Break the world")
+    Sentry.captureException(RuntimeException("This app uses Sentry! :)"))
   }
 }
 
 addContentView(breakWorld, ViewGroup.LayoutParams(
   ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
         `,
-      },
-    ],
-  },
-];
+            },
+          ],
+        },
+      ];
 
-export const nextSteps = [
+export const nextStepsManual = [
   {
-    id: 'manual-configuration',
-    name: t('Manual Configuration'),
+    id: 'advanced-configuration',
+    name: t('Advanced Configuration'),
     description: t('Customize the SDK initialization behavior.'),
     link: 'https://docs.sentry.io/platforms/android/configuration/manual-init/#manual-initialization',
   },
@@ -231,6 +266,21 @@ export const nextSteps = [
     link: 'https://docs.sentry.io/platforms/android/enhance-errors/source-context/',
   },
 ];
+
+export const nextStepsAuto = [
+  {
+    id: 'advanced-configuration',
+    name: t('Advanced Configuration'),
+    description: t('Customize the SDK initialization behavior.'),
+    link: 'https://docs.sentry.io/platforms/android/configuration/manual-init/#manual-initialization',
+  },
+  {
+    id: 'jetpack-compose',
+    name: t('Jetpack Compose'),
+    description: t('Learn about our first class integration with Jetpack Compose.'),
+    link: 'https://docs.sentry.io/platforms/android/configuration/integrations/jetpack-compose/',
+  },
+];
 // Configuration End
 
 export function GettingStartedWithAndroid({
@@ -239,14 +289,26 @@ export function GettingStartedWithAndroid({
   activeProductSelection = [],
   ...props
 }: ModuleProps) {
+  const optionValues = useUrlPlatformOptions(platformOptions);
+
+  const installationMode = optionValues.installationMode as InstallationMode;
   const hasPerformance = activeProductSelection.includes(
     ProductSolution.PERFORMANCE_MONITORING
   );
   const hasProfiling = activeProductSelection.includes(ProductSolution.PROFILING);
   return (
     <Layout
-      steps={steps({dsn, sourcePackageRegistries, hasPerformance, hasProfiling})}
-      nextSteps={nextSteps}
+      steps={steps({
+        dsn,
+        sourcePackageRegistries,
+        hasPerformance,
+        hasProfiling,
+        installationMode,
+      })}
+      platformOptions={platformOptions}
+      nextSteps={
+        installationMode === InstallationMode.AUTO ? nextStepsAuto : nextStepsManual
+      }
       {...props}
     />
   );


### PR DESCRIPTION
Closes #51792
Adds a switch to change between Auto and Manual installation steps (Manual is still relevant for Windows users)

## Manual

<img width="1251" alt="image" src="https://github.com/getsentry/sentry/assets/4999776/6c7517ab-5b85-41d2-81d9-a06df78435a7">

## Auto

<img width="955" alt="image" src="https://github.com/getsentry/sentry/assets/4999776/ca7a2814-6fc9-4596-9f80-8a5c4d0b33e8">
