### PR TITLE
feat(profiling) decouple aggregate flamegraph from model generation

### DIFF
--- a/static/app/components/profiling/aggregateFlamegraphPanel.tsx
+++ b/static/app/components/profiling/aggregateFlamegraphPanel.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
-import {AggregateFlamegraph} from 'sentry/components/profiling/flamegraph/aggregateFlamegraph';
+import {DeprecatedAggregateFlamegraph} from 'sentry/components/profiling/flamegraph/deprecatedAggregateFlamegraph';
 import {Flex} from 'sentry/components/profiling/flex';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
@@ -68,7 +68,7 @@ export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
                     <p>{t(`Aggregate flamegraph isn't available for your query`)}</p>
                   </EmptyStateWarning>
                 ) : (
-                  <AggregateFlamegraph
+                  <DeprecatedAggregateFlamegraph
                     hideSystemFrames={hideSystemFrames}
                     setHideSystemFrames={setHideSystemFrames}
                   />

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -1,0 +1,238 @@
+import {ReactElement, useEffect, useLayoutEffect, useMemo, useState} from 'react';
+import {mat3, vec2} from 'gl-matrix';
+
+import {FlamegraphZoomView} from 'sentry/components/profiling/flamegraph/flamegraphZoomView';
+import {defined} from 'sentry/utils';
+import {
+  CanvasPoolManager,
+  useCanvasScheduler,
+} from 'sentry/utils/profiling/canvasScheduler';
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {Flamegraph as FlamegraphModel} from 'sentry/utils/profiling/flamegraph';
+import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphPreferences';
+import {useFlamegraphProfiles} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphProfiles';
+import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
+import {
+  useFlamegraphTheme,
+  useMutateFlamegraphTheme,
+} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
+import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
+import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+import {
+  computeConfigViewWithStrategy,
+  useResizeCanvasObserver,
+} from 'sentry/utils/profiling/gl/utils';
+import {FlamegraphRendererWebGL} from 'sentry/utils/profiling/renderers/flamegraphRendererWebGL';
+import {Rect} from 'sentry/utils/profiling/speedscope';
+import {useDevicePixelRatio} from 'sentry/utils/useDevicePixelRatio';
+import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
+
+interface AggregateFlamegraphProps {
+  flamegraph: FlamegraphModel;
+}
+
+export function AggregateFlamegraph(props: AggregateFlamegraphProps): ReactElement {
+  const devicePixelRatio = useDevicePixelRatio();
+  const dispatch = useDispatchFlamegraphState();
+
+  const profileGroup = useProfileGroup();
+
+  const flamegraphTheme = useFlamegraphTheme();
+  const setFlamegraphThemeMutation = useMutateFlamegraphTheme();
+  const profiles = useFlamegraphProfiles();
+  const {colorCoding} = useFlamegraphPreferences();
+
+  const [flamegraphCanvasRef, setFlamegraphCanvasRef] =
+    useState<HTMLCanvasElement | null>(null);
+  const [flamegraphOverlayCanvasRef, setFlamegraphOverlayCanvasRef] =
+    useState<HTMLCanvasElement | null>(null);
+
+  const canvasPoolManager = useMemo(() => new CanvasPoolManager(), []);
+  const scheduler = useCanvasScheduler(canvasPoolManager);
+
+  const flamegraphCanvas = useMemo(() => {
+    if (!flamegraphCanvasRef) {
+      return null;
+    }
+    const yOrigin = flamegraphTheme.SIZES.TIMELINE_HEIGHT * devicePixelRatio;
+    return new FlamegraphCanvas(flamegraphCanvasRef, vec2.fromValues(0, yOrigin));
+  }, [devicePixelRatio, flamegraphCanvasRef, flamegraphTheme]);
+
+  const flamegraphView = useMemo<CanvasView<FlamegraphModel> | null>(
+    () => {
+      if (!flamegraphCanvas) {
+        return null;
+      }
+
+      const newView = new CanvasView({
+        canvas: flamegraphCanvas,
+        model: props.flamegraph,
+        options: {
+          inverted: props.flamegraph.inverted,
+          minWidth: props.flamegraph.profile.minFrameDuration,
+          barHeight: flamegraphTheme.SIZES.BAR_HEIGHT,
+          depthOffset: flamegraphTheme.SIZES.FLAMEGRAPH_DEPTH_OFFSET,
+          configSpaceTransform: undefined,
+        },
+      });
+
+      // Set to 3/4 of the view up, magic number... Would be best to comput some weighted visual score
+      // based on the number of frames and the depth of the frames, but lets see if we can make it work
+      // with this for now
+      newView.setConfigView(newView.configView.withY(newView.configView.height * 0.75));
+      return newView;
+    },
+
+    // We skip position.view dependency because it will go into an infinite loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [props.flamegraph, flamegraphCanvas, flamegraphTheme]
+  );
+
+  useEffect(() => {
+    const canvasHeight = flamegraphCanvas?.logicalSpace.height;
+    if (!canvasHeight) {
+      return;
+    }
+
+    setFlamegraphThemeMutation(theme => {
+      const flamegraphFitTo = canvasHeight / props.flamegraph.depth;
+      const minReadableRatio = 0.8; // this is quite small
+      const fitToRatio = flamegraphFitTo / theme.SIZES.BAR_HEIGHT;
+      const barHeightRatio = Math.min(Math.max(minReadableRatio, fitToRatio), 1.2);
+
+      // reduce the offset to leave just enough space for the toolbar
+      theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET = 2.5;
+      theme.SIZES.BAR_HEIGHT = theme.SIZES.BAR_HEIGHT * barHeightRatio;
+      theme.SIZES.BAR_FONT_SIZE = theme.SIZES.BAR_FONT_SIZE * barHeightRatio;
+      return theme;
+    });
+
+    // We skip `flamegraphCanvas` as it causes an infinite loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    props.flamegraph,
+    setFlamegraphThemeMutation,
+    flamegraphCanvas?.logicalSpace.height,
+  ]);
+
+  // Uses a useLayoutEffect to ensure that these top level/global listeners are added before
+  // any of the children components effects actually run. This way we do not lose events
+  // when we register/unregister these top level listeners.
+  useLayoutEffect(() => {
+    if (!flamegraphCanvas || !flamegraphView) {
+      return undefined;
+    }
+
+    // This code below manages the synchronization of the config views between spans and flamegraph
+    // We do so by listening to the config view change event and then updating the other views accordingly which
+    // allows us to keep the X axis in sync between the two views but keep the Y axis independent
+    const onConfigViewChange = (rect: Rect, sourceConfigViewChange: CanvasView<any>) => {
+      if (sourceConfigViewChange === flamegraphView) {
+        flamegraphView.setConfigView(rect.withHeight(flamegraphView.configView.height));
+      }
+
+      canvasPoolManager.draw();
+    };
+
+    const onTransformConfigView = (
+      mat: mat3,
+      sourceTransformConfigView: CanvasView<any>
+    ) => {
+      if (sourceTransformConfigView === flamegraphView) {
+        flamegraphView.transformConfigView(mat);
+      }
+
+      canvasPoolManager.draw();
+    };
+
+    const onResetZoom = () => {
+      flamegraphView.resetConfigView(flamegraphCanvas);
+
+      canvasPoolManager.draw();
+    };
+
+    const onZoomIntoFrame = (frame: FlamegraphFrame, strategy: 'min' | 'exact') => {
+      const newConfigView = computeConfigViewWithStrategy(
+        strategy,
+        flamegraphView.configView,
+        new Rect(frame.start, frame.depth, frame.end - frame.start, 1)
+      ).transformRect(flamegraphView.configSpaceTransform);
+
+      flamegraphView.setConfigView(newConfigView);
+
+      canvasPoolManager.draw();
+    };
+
+    scheduler.on('set config view', onConfigViewChange);
+    scheduler.on('transform config view', onTransformConfigView);
+    scheduler.on('reset zoom', onResetZoom);
+    scheduler.on('zoom at frame', onZoomIntoFrame);
+
+    return () => {
+      scheduler.off('set config view', onConfigViewChange);
+      scheduler.off('transform config view', onTransformConfigView);
+      scheduler.off('reset zoom', onResetZoom);
+      scheduler.off('zoom at frame', onZoomIntoFrame);
+    };
+  }, [canvasPoolManager, flamegraphCanvas, flamegraphView, scheduler]);
+
+  const flamegraphCanvases = useMemo(() => {
+    return [flamegraphCanvasRef, flamegraphOverlayCanvasRef];
+  }, [flamegraphCanvasRef, flamegraphOverlayCanvasRef]);
+
+  const flamegraphCanvasBounds = useResizeCanvasObserver(
+    flamegraphCanvases,
+    canvasPoolManager,
+    flamegraphCanvas,
+    flamegraphView
+  );
+
+  const flamegraphRenderer = useMemo(() => {
+    if (!flamegraphCanvasRef) {
+      return null;
+    }
+
+    return new FlamegraphRendererWebGL(
+      flamegraphCanvasRef,
+      props.flamegraph,
+      flamegraphTheme,
+      {
+        colorCoding,
+        draw_border: true,
+      }
+    );
+  }, [colorCoding, props.flamegraph, flamegraphCanvasRef, flamegraphTheme]);
+
+  useEffect(() => {
+    if (defined(profiles.threadId)) {
+      return;
+    }
+    const threadID =
+      typeof profileGroup.activeProfileIndex === 'number'
+        ? profileGroup.profiles[profileGroup.activeProfileIndex]?.threadId
+        : null;
+    // fall back case, when we finally load the active profile index from the profile,
+    // make sure we update the thread id so that it is show first
+    if (defined(threadID)) {
+      dispatch({
+        type: 'set thread id',
+        payload: threadID,
+      });
+    }
+  }, [profileGroup, profiles.threadId, dispatch]);
+
+  return (
+    <FlamegraphZoomView
+      canvasBounds={flamegraphCanvasBounds}
+      canvasPoolManager={canvasPoolManager}
+      flamegraph={props.flamegraph}
+      flamegraphRenderer={flamegraphRenderer}
+      flamegraphCanvas={flamegraphCanvas}
+      flamegraphCanvasRef={flamegraphCanvasRef}
+      flamegraphOverlayCanvasRef={flamegraphOverlayCanvasRef}
+      flamegraphView={flamegraphView}
+      setFlamegraphCanvasRef={setFlamegraphCanvasRef}
+      setFlamegraphOverlayCanvasRef={setFlamegraphOverlayCanvasRef}
+    />
+  );
+}

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -5,10 +5,7 @@ import {FlamegraphZoomView} from 'sentry/components/profiling/flamegraph/flamegr
 import {defined} from 'sentry/utils';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
-import {
-  Flamegraph,
-  Flamegraph as FlamegraphModel,
-} from 'sentry/utils/profiling/flamegraph';
+import {Flamegraph as FlamegraphModel} from 'sentry/utils/profiling/flamegraph';
 import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphPreferences';
 import {useFlamegraphProfiles} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphProfiles';
 import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   Fragment,
   ReactElement,
   useEffect,
@@ -19,10 +19,14 @@ import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {
   CanvasPoolManager,
+  CanvasScheduler,
   useCanvasScheduler,
 } from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
-import {Flamegraph as FlamegraphModel} from 'sentry/utils/profiling/flamegraph';
+import {
+  Flamegraph,
+  Flamegraph as FlamegraphModel,
+} from 'sentry/utils/profiling/flamegraph';
 import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphPreferences';
 import {useFlamegraphProfiles} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphProfiles';
 import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
@@ -46,6 +50,11 @@ const LOADING_OR_FALLBACK_FLAMEGRAPH = FlamegraphModel.Empty();
 interface AggregateFlamegraphProps {
   hideSystemFrames: boolean;
   setHideSystemFrames: (hideSystemFrames: boolean) => void;
+  children?: (props: {
+    canvasPoolManager: CanvasPoolManager;
+    flamegraph: Flamegraph;
+    scheduler: CanvasScheduler;
+  }) => React.ReactNode;
   hideToolbar?: boolean;
 }
 
@@ -267,6 +276,7 @@ export function AggregateFlamegraph(props: AggregateFlamegraphProps): ReactEleme
 
   return (
     <Fragment>
+      {props.children ? props.children({canvasPoolManager, scheduler, flamegraph}) : null}
       <FlamegraphZoomView
         canvasBounds={flamegraphCanvasBounds}
         canvasPoolManager={canvasPoolManager}

--- a/static/app/components/profiling/flamegraph/deprecatedAggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/deprecatedAggregateFlamegraph.tsx
@@ -47,7 +47,7 @@ import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
 
 const LOADING_OR_FALLBACK_FLAMEGRAPH = FlamegraphModel.Empty();
 
-interface AggregateFlamegraphProps {
+interface DeprecatedAggregateFlamegraphProps {
   hideSystemFrames: boolean;
   setHideSystemFrames: (hideSystemFrames: boolean) => void;
   children?: (props: {
@@ -58,7 +58,9 @@ interface AggregateFlamegraphProps {
   hideToolbar?: boolean;
 }
 
-export function AggregateFlamegraph(props: AggregateFlamegraphProps): ReactElement {
+export function DeprecatedAggregateFlamegraph(
+  props: DeprecatedAggregateFlamegraphProps
+): ReactElement {
   const devicePixelRatio = useDevicePixelRatio();
   const dispatch = useDispatchFlamegraphState();
 

--- a/static/app/views/profiling/flamegraphProvider.tsx
+++ b/static/app/views/profiling/flamegraphProvider.tsx
@@ -1,0 +1,69 @@
+import {createContext, useContext, useMemo} from 'react';
+import * as Sentry from '@sentry/react';
+
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphPreferences';
+import {useFlamegraphProfiles} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphProfiles';
+import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
+
+const LOADING_OR_FALLBACK_FLAMEGRAPH = Flamegraph.Empty();
+
+const FlamegraphContext = createContext<Flamegraph | null>(null);
+
+export const useFlamegraph = () => {
+  const context = useContext(FlamegraphContext);
+  if (!context) {
+    throw new Error('useFlamegraph was called outside of FlamegraphProvider');
+  }
+  return context;
+};
+
+interface FlamegraphProviderProps {
+  children: React.ReactNode;
+}
+
+export function FlamegraphProvider(props: FlamegraphProviderProps) {
+  const profileGroup = useProfileGroup();
+  const {threadId} = useFlamegraphProfiles();
+  const {sorting, view} = useFlamegraphPreferences();
+
+  const activeProfile = useMemo(() => {
+    return profileGroup.profiles.find(p => p.threadId === threadId);
+  }, [profileGroup, threadId]);
+
+  const flamegraph = useMemo(() => {
+    if (typeof threadId !== 'number') {
+      return LOADING_OR_FALLBACK_FLAMEGRAPH;
+    }
+
+    // This could happen if threadId was initialized from query string, but for some
+    // reason the profile was removed from the list of profiles.
+    if (!activeProfile) {
+      return LOADING_OR_FALLBACK_FLAMEGRAPH;
+    }
+
+    const transaction = Sentry.startTransaction({
+      op: 'import',
+      name: 'flamegraph.constructor',
+    });
+
+    transaction.setTag('sorting', sorting.split(' ').join('_'));
+    transaction.setTag('view', view.split(' ').join('_'));
+
+    const newFlamegraph = new Flamegraph(activeProfile, threadId, {
+      inverted: view === 'bottom up',
+      sort: sorting,
+      configSpace: undefined,
+    });
+
+    transaction.finish();
+
+    return newFlamegraph;
+  }, [activeProfile, sorting, threadId, view]);
+
+  return (
+    <FlamegraphContext.Provider value={flamegraph}>
+      {props.children}
+    </FlamegraphContext.Provider>
+  );
+}

--- a/static/app/views/profiling/landing/profilesSummaryChart.tsx
+++ b/static/app/views/profiling/landing/profilesSummaryChart.tsx
@@ -198,4 +198,5 @@ const ProfilesChartTitle = styled('div')`
 
 const ProfilesChartContainer = styled('div')`
   background-color: ${p => p.theme.background};
+  border-bottom: 1px solid ${p => p.theme.border};
 `;

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -14,7 +14,6 @@ import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
-import {DeprecatedAggregateFlamegraph} from 'sentry/components/profiling/flamegraph/deprecatedAggregateFlamegraph';
 import {FlamegraphSearch} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch';
 import {
   ProfilingBreadcrumbs,
@@ -51,6 +50,8 @@ import {ProfilesSummaryChart} from 'sentry/views/profiling/landing/profilesSumma
 import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
 import {LegacySummaryPage} from 'sentry/views/profiling/profileSummary/legacySummaryPage';
 import {DEFAULT_PROFILING_DATETIME_SELECTION} from 'sentry/views/profiling/utils';
+
+import {AggregateFlamegraph} from '../../../components/profiling/flamegraph/aggregateFlamegraph';
 
 import {MostRegressedProfileFunctions} from './regressedProfileFunctions';
 import {SlowestProfileFunctions} from './slowestProfileFunctions';
@@ -353,29 +354,15 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
                   }}
                 >
                   <FlamegraphThemeProvider>
-                    {visualization === 'flamegraph' ? (
-                      <DeprecatedAggregateFlamegraph
-                        hideToolbar
-                        hideSystemFrames={false}
-                        setHideSystemFrames={() => void 0}
-                      >
-                        {p => {
-                          return (
-                            <AggregateFlamegraphToolbar
-                              {...p}
-                              visualization={visualization}
-                              onVisualizationChange={onVisualizationChange}
-                              frameFilter={frameFilter}
-                              onFrameFilterChange={onFrameFilterChange}
-                              hideSystemFrames={false}
-                              setHideSystemFrames={() => void 0}
-                            />
-                          );
-                        }}
-                      </DeprecatedAggregateFlamegraph>
-                    ) : (
-                      <div />
-                    )}
+                    <AggregateFlamegraphToolbar
+                      visualization={visualization}
+                      onVisualizationChange={onVisualizationChange}
+                      frameFilter={frameFilter}
+                      onFrameFilterChange={onFrameFilterChange}
+                      hideSystemFrames={false}
+                      setHideSystemFrames={() => void 0}
+                    />
+                    {visualization === 'flamegraph' ? <AggregateFlamegraph /> : null}
                   </FlamegraphThemeProvider>
                 </FlamegraphStateProvider>
               </ProfileGroupProvider>

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -14,7 +14,7 @@ import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
-import {AggregateFlamegraph} from 'sentry/components/profiling/flamegraph/aggregateFlamegraph';
+import {DeprecatedAggregateFlamegraph} from 'sentry/components/profiling/flamegraph/deprecatedAggregateFlamegraph';
 import {FlamegraphSearch} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch';
 import {
   ProfilingBreadcrumbs,
@@ -354,7 +354,7 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
                 >
                   <FlamegraphThemeProvider>
                     {visualization === 'flamegraph' ? (
-                      <AggregateFlamegraph
+                      <DeprecatedAggregateFlamegraph
                         hideToolbar
                         hideSystemFrames={false}
                         setHideSystemFrames={() => void 0}
@@ -372,7 +372,7 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
                             />
                           );
                         }}
-                      </AggregateFlamegraph>
+                      </DeprecatedAggregateFlamegraph>
                     ) : (
                       <div />
                     )}

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -3,7 +3,9 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
-import {LinkButton} from 'sentry/components/button';
+import {Button, LinkButton} from 'sentry/components/button';
+import {CompactSelect} from 'sentry/components/compactSelect';
+import type {SelectOption} from 'sentry/components/compactSelect/types';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -13,10 +15,12 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {AggregateFlamegraph} from 'sentry/components/profiling/flamegraph/aggregateFlamegraph';
+import {FlamegraphSearch} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch';
 import {
   ProfilingBreadcrumbs,
   ProfilingBreadcrumbsProps,
 } from 'sentry/components/profiling/profilingBreadcrumbs';
+import {SegmentedControl} from 'sentry/components/segmentedControl';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import type {SmartSearchBarProps} from 'sentry/components/smartSearchBar';
 import SmartSearchBar from 'sentry/components/smartSearchBar';
@@ -27,13 +31,20 @@ import type {Organization, PageFilters, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {isAggregateField} from 'sentry/utils/discover/fields';
+import type {
+  CanvasPoolManager,
+  CanvasScheduler,
+} from 'sentry/utils/profiling/canvasScheduler';
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {FlamegraphStateProvider} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider';
 import {FlamegraphThemeProvider} from 'sentry/utils/profiling/flamegraph/flamegraphThemeProvider';
+import {Frame} from 'sentry/utils/profiling/frame';
 import {useAggregateFlamegraphQuery} from 'sentry/utils/profiling/hooks/useAggregateFlamegraphQuery';
 import {useCurrentProjectFromRouteParam} from 'sentry/utils/profiling/hooks/useCurrentProjectFromRouteParam';
 import {useProfileFilters} from 'sentry/utils/profiling/hooks/useProfileFilters';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {ProfilesSummaryChart} from 'sentry/views/profiling/landing/profilesSummaryChart';
@@ -257,6 +268,38 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
 
   const {data} = useAggregateFlamegraphQuery({transaction});
 
+  const [visualization, setVisualization] = useLocalStorageState<
+    'flamegraph' | 'call tree'
+  >('flamegraph-visualization', 'flamegraph');
+
+  const onVisualizationChange = useCallback(
+    (value: 'flamegraph' | 'call tree') => {
+      setVisualization(value);
+    },
+    [setVisualization]
+  );
+
+  const [frameFilter, setFrameFilter] = useLocalStorageState<
+    'system' | 'application' | 'all'
+  >('flamegraph-frame-filter', 'application');
+
+  const onFrameFilterChange = useCallback(
+    (value: 'system' | 'application' | 'all') => {
+      setFrameFilter(value);
+    },
+    [setFrameFilter]
+  );
+
+  const flamegraphFrameFilter: ((frame: Frame) => boolean) | undefined = useMemo(() => {
+    if (frameFilter === 'all') {
+      return () => true;
+    }
+    if (frameFilter === 'application') {
+      return frame => frame.is_application;
+    }
+    return frame => !frame.is_application;
+  }, [frameFilter]);
+
   return (
     <SentryDocumentTitle
       title={t('Profiling \u2014 Profile Summary')}
@@ -300,7 +343,7 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
                 type="flamegraph"
                 input={data ?? null}
                 traceID=""
-                frameFilter={undefined}
+                frameFilter={flamegraphFrameFilter}
               >
                 <FlamegraphStateProvider
                   initialState={{
@@ -310,11 +353,29 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
                   }}
                 >
                   <FlamegraphThemeProvider>
-                    <AggregateFlamegraph
-                      hideToolbar
-                      hideSystemFrames={false}
-                      setHideSystemFrames={() => void 0}
-                    />
+                    {visualization === 'flamegraph' ? (
+                      <AggregateFlamegraph
+                        hideToolbar
+                        hideSystemFrames={false}
+                        setHideSystemFrames={() => void 0}
+                      >
+                        {p => {
+                          return (
+                            <AggregateFlamegraphToolbar
+                              {...p}
+                              visualization={visualization}
+                              onVisualizationChange={onVisualizationChange}
+                              frameFilter={frameFilter}
+                              onFrameFilterChange={onFrameFilterChange}
+                              hideSystemFrames={false}
+                              setHideSystemFrames={() => void 0}
+                            />
+                          );
+                        }}
+                      </AggregateFlamegraph>
+                    ) : (
+                      <div />
+                    )}
                   </FlamegraphThemeProvider>
                 </FlamegraphStateProvider>
               </ProfileGroupProvider>
@@ -329,6 +390,82 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
     </SentryDocumentTitle>
   );
 }
+
+interface AggregateFlamegraphToolbarProps {
+  canvasPoolManager: CanvasPoolManager;
+  flamegraph: Flamegraph;
+  frameFilter: 'system' | 'application' | 'all';
+  hideSystemFrames: boolean;
+  onFrameFilterChange: (value: 'system' | 'application' | 'all') => void;
+  onVisualizationChange: (value: 'flamegraph' | 'call tree') => void;
+  scheduler: CanvasScheduler;
+  setHideSystemFrames: (value: boolean) => void;
+  visualization: 'flamegraph' | 'call tree';
+}
+function AggregateFlamegraphToolbar(props: AggregateFlamegraphToolbarProps) {
+  const flamegraphs = useMemo(() => [props.flamegraph], [props.flamegraph]);
+  const spans = useMemo(() => [], []);
+
+  const frameSelectOptions: SelectOption<'system' | 'application' | 'all'>[] =
+    useMemo(() => {
+      return [
+        {value: 'system', label: t('System Frames')},
+        {value: 'application', label: t('Application Frames')},
+        {value: 'all', label: t('All Frames')},
+      ];
+    }, []);
+
+  const onResetZoom = useCallback(() => {
+    props.scheduler.dispatch('reset zoom');
+  }, [props.scheduler]);
+
+  const onFrameFilterChange = useCallback(
+    (value: {value: 'application' | 'system' | 'all'}) => {
+      props.onFrameFilterChange(value.value);
+    },
+    [props]
+  );
+
+  return (
+    <AggregateFlamegraphToolbarContainer>
+      <SegmentedControl
+        aria-label={t('View')}
+        size="xs"
+        value={props.visualization}
+        onChange={props.onVisualizationChange}
+      >
+        <SegmentedControl.Item key="flamegraph">{t('Flamegraph')}</SegmentedControl.Item>
+        <SegmentedControl.Item key="call tree">{t('Call Tree')}</SegmentedControl.Item>
+      </SegmentedControl>
+      <AggregateFlamegraphSearch
+        spans={spans}
+        canvasPoolManager={props.canvasPoolManager}
+        flamegraphs={flamegraphs}
+      />
+      <Button size="xs" onClick={onResetZoom}>
+        {t('Reset Zoom')}
+      </Button>
+      <CompactSelect
+        onChange={onFrameFilterChange}
+        value={props.frameFilter}
+        size="xs"
+        options={frameSelectOptions}
+      />
+    </AggregateFlamegraphToolbarContainer>
+  );
+}
+
+const AggregateFlamegraphToolbarContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  gap: ${space(1)};
+  padding: ${space(0.5)};
+  background: ${p => p.theme.background};
+`;
+
+const AggregateFlamegraphSearch = styled(FlamegraphSearch)`
+  max-width: 300px;
+`;
 
 const ProfileVisualization = styled('div')`
   grid-area: visualization;


### PR DESCRIPTION
Deprecates the old AggregateFlamegraph in favor of new implementation (since these will be swapped, I opted to deprecate and start fresh instead of battle with props and configuration)

Previously, the flamegraph model was being initialized inside the flamegraph component doing the rendering. This was fine, however since we are going to be adding the call tree view, we want to avoid rebuilding that same flamegraph data structure whenever we are toggling between the views (rebuilding the graph is a common source of jank). This PR lifts the model initialization so that it can be passed to our views independently of what they are rendering.