### PR TITLE
feat(apis): Publish Spike Protection from getsentry

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -218,6 +218,9 @@
     },
     "/api/0/organizations/{organization_slug}/scim/v2/Groups": {
       "$ref": "paths/scim/team_index.json"
+    },
+    "/api/0/organizations/{organization_slug}/spike-protections/": {
+      "$ref": "paths/projects/spike-protection.json"
     }
   },
   "components": {

--- a/api-docs/paths/projects/spike-protection.json
+++ b/api-docs/paths/projects/spike-protection.json
@@ -1,0 +1,112 @@
+{
+    "post": {
+        "tags": ["Projects"],
+        "description": "Enables Spike Protection feature for some of the projects within the organization.",
+        "operationId": "Enable Spike Protection",
+        "parameters": [
+            {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization the projects belong to",
+            "required": true,
+            "schema": {
+                "type": "string"
+            }
+            }
+        ],
+        "requestBody": {
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "description": "Django Rest Framework serializer for incoming Spike Protection API payloads",
+                        "properties": {
+                            "projects": {
+                                "description": "Slugs of projects to enable Spike Protection for. Set to `$all` to enable Spike Protection for all the projects in the organization.",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "required": [
+                            "projects"
+                        ]
+                    }
+                }
+            },
+            "required": true
+        },
+        "responses": {
+            "201": {
+                "description": "Success"
+            },
+            "400": {
+                "description": "Bad Request"
+            },
+            "403": {
+                "description": "Forbidden"
+            }
+        },
+        "security": [
+            {
+                "auth_token": ["project:read", "project:write", "project:admin"]
+            }
+        ]
+    },
+    "delete": {
+        "tags": ["Projects"],
+        "description": "Disables Spike Protection feature for some of the projects within the organization.",
+        "operationId": "Disable Spike Protection",
+        "parameters": [
+            {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization the projects belong to",
+            "required": true,
+            "schema": {
+                "type": "string"
+            }
+            }
+        ],
+        "requestBody": {
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "description": "Django Rest Framework serializer for incoming Spike Protection API payloads",
+                        "properties": {
+                            "projects": {
+                                "description": "Slugs of projects to disable Spike Protection for. Set to `$all` to disable Spike Protection for all the projects in the organization.",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "required": [
+                            "projects"
+                        ]
+                    }
+                }
+            },
+            "required": true
+        },
+        "responses": {
+            "200": {
+                "description": "Success"
+            },
+            "400": {
+                "description": "Bad Request"
+            },
+            "403": {
+                "description": "Forbidden"
+            }
+        },
+        "security": [
+            {
+                "auth_token": ["project:read", "project:write", "project:admin"]
+            }
+        ]
+    }
+  }

--- a/src/sentry/apidocs/api_ownership_stats_dont_modify.json
+++ b/src/sentry/apidocs/api_ownership_stats_dont_modify.json
@@ -653,6 +653,7 @@
             "OrganizationStatsEndpointV2::GET"
         ],
         "private": [
+            "OrganizationIntegrationMigrateOpsgenieEndpoint::PUT",
             "ReleaseThresholdDetailsEndpoint::GET",
             "ReleaseThresholdEndpoint::GET",
             "ReleaseThresholdEndpoint::POST"
@@ -666,6 +667,7 @@
             "NotificationActionsIndexEndpoint::POST",
             "OrganizationAuditLogsEndpoint::GET",
             "OrganizationMissingMembersEndpoint::GET",
+            "OrganizationProjectsExperimentEndpoint::POST",
             "OrganizationSCIMMemberDetails::PUT",
             "OrganizationSCIMTeamDetails::PUT",
             "ReleaseThresholdStatusIndexEndpoint::GET"
@@ -688,8 +690,6 @@
             "OrganizationAuthProviderDetailsEndpoint::GET",
             "OrganizationAuthProviderSendRemindersEndpoint::POST",
             "OrganizationAuthProvidersEndpoint::GET",
-            "OrganizationIntegrationMigrateOpsgenieEndpoint::PUT",
-            "OrganizationProjectsExperimentEndpoint::POST",
             "OrganizationSCIMSchemaIndex::GET",
             "OrganizationStatsEndpoint::GET",
             "UserAuthenticatorDetailsEndpoint::DELETE",


### PR DESCRIPTION
Depends on https://github.com/getsentry/getsentry/pull/11706

These APIs don't exist in Sentry so I'm documenting them the old way by writing a json file and adding it to open-api.json.

![Screenshot 2023-09-28 at 2 50 37 PM](https://github.com/getsentry/sentry/assets/132939361/459d60ad-3049-40a7-90bc-bded8ebae26b)
![Screenshot 2023-09-28 at 2 50 47 PM](https://github.com/getsentry/sentry/assets/132939361/a2a2c997-6908-4a0c-91be-61d2be1fb4cf)
