### PR TITLE
feat(replays): enable searching for selector upon click

### DIFF
--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -25,7 +25,10 @@ import {
   WidgetContainer,
 } from 'sentry/views/profiling/landing/styles';
 import ExampleReplaysList from 'sentry/views/replays/deadRageClick/exampleReplaysList';
-import {SelectorLink} from 'sentry/views/replays/deadRageClick/selectorTable';
+import {
+  SelectorLink,
+  transformSelectorQuery,
+} from 'sentry/views/replays/deadRageClick/selectorTable';
 
 function DeadRageSelectorCards() {
   return (
@@ -147,13 +150,6 @@ function AccordionWidget({
       />
     </StyledWidgetContainer>
   );
-}
-
-export function transformSelectorQuery(selector: string) {
-  return selector
-    .replaceAll('"', `\\"`)
-    .replaceAll('aria=', 'aria-label=')
-    .replaceAll('testid=', 'data-test-id=');
 }
 
 function AccordionItemHeader({

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -25,6 +25,7 @@ import {
   WidgetContainer,
 } from 'sentry/views/profiling/landing/styles';
 import ExampleReplaysList from 'sentry/views/replays/deadRageClick/exampleReplaysList';
+import {SelectorLink} from 'sentry/views/replays/deadRageClick/selectorTable';
 
 function DeadRageSelectorCards() {
   return (
@@ -88,7 +89,7 @@ function AccordionWidget({
   });
   const location = useLocation();
   const filteredData = data.filter(d => (d[clickType] ?? 0) > 0);
-  const clickColor = deadOrRage === 'dead' ? ('yellow300' as ColorOrAlias) : 'red300';
+  const clickColor = deadOrRage === 'dead' ? 'yellow300' : 'red300';
 
   return (
     <StyledWidgetContainer>
@@ -115,21 +116,23 @@ function AccordionWidget({
             expandedIndex={selectedListIndex}
             setExpandedIndex={setSelectListIndex}
             items={filteredData.map(d => {
+              const selectorQuery = `${deadOrRage}.selector:"${transformSelectorQuery(
+                d.dom_element
+              )}"`;
               return {
                 header: () => (
                   <AccordionItemHeader
                     count={d[clickType] ?? 0}
                     selector={d.dom_element}
                     clickColor={clickColor}
+                    selectorQuery={selectorQuery}
                   />
                 ),
                 content: () => (
                   <ExampleReplaysList
                     location={location}
                     clickType={clickType}
-                    query={`${deadOrRage}.selector:"${transformSelectorQuery(
-                      d.dom_element
-                    )}"`}
+                    selectorQuery={selectorQuery}
                   />
                 ),
               };
@@ -146,7 +149,7 @@ function AccordionWidget({
   );
 }
 
-function transformSelectorQuery(selector: string) {
+export function transformSelectorQuery(selector: string) {
   return selector
     .replaceAll('"', `\\"`)
     .replaceAll('aria=', 'aria-label=')
@@ -157,10 +160,12 @@ function AccordionItemHeader({
   count,
   clickColor,
   selector,
+  selectorQuery,
 }: {
   clickColor: ColorOrAlias;
   count: number;
   selector: string;
+  selectorQuery: string;
 }) {
   const clickCount = (
     <ClickColor color={clickColor}>
@@ -170,9 +175,7 @@ function AccordionItemHeader({
   );
   return (
     <StyledAccordionHeader>
-      <TextOverflow>
-        <code>{selector}</code>
-      </TextOverflow>
+      <SelectorLink value={selector} selectorQuery={selectorQuery} />
       <RightAlignedCell>{clickCount}</RightAlignedCell>
     </StyledAccordionHeader>
   );
@@ -222,8 +225,8 @@ const SplitCardContainer = styled('div')`
 const ClickColor = styled(TextOverflow)<{color: ColorOrAlias}>`
   color: ${p => p.theme[p.color]};
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: ${space(0.5)};
+  grid-template-columns: auto auto;
+  gap: ${space(0.75)};
   align-items: center;
 `;
 

--- a/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
+++ b/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
@@ -15,11 +15,11 @@ import {ReplayCell} from 'sentry/views/replays/replayTable/tableCell';
 export default function ExampleReplaysList({
   location,
   clickType,
-  query,
+  selectorQuery,
 }: {
   clickType: 'count_dead_clicks' | 'count_rage_clicks';
   location: Location;
-  query: string;
+  selectorQuery: string;
 }) {
   const organization = useOrganization();
   const {project, environment, start, statsPeriod, utc, end} = location.query;
@@ -54,12 +54,12 @@ export default function ExampleReplaysList({
             'urls',
           ],
           projects: [],
-          query,
+          query: selectorQuery,
           orderby: `-${clickType}`,
         },
         emptyLocation
       ),
-    [emptyLocation, query, clickType]
+    [emptyLocation, selectorQuery, clickType]
   );
 
   const {replays, isFetching, fetchError} = useReplayList({
@@ -87,7 +87,7 @@ export default function ExampleReplaysList({
         replays?.map(r => {
           return (
             <ReplayCell
-              key="session"
+              key={r.id}
               replay={r}
               eventView={eventView}
               organization={organization}

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -1,4 +1,4 @@
-import {ReactNode, useCallback, useMemo} from 'react';
+import {Fragment, ReactNode, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -8,13 +8,14 @@ import renderSortableHeaderCell from 'sentry/components/replays/renderSortableHe
 import useQueryBasedColumnResize from 'sentry/components/replays/useQueryBasedColumnResize';
 import useQueryBasedSorting from 'sentry/components/replays/useQueryBasedSorting';
 import TextOverflow from 'sentry/components/textOverflow';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconCursorArrow} from 'sentry/icons';
+import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {ColorOrAlias} from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import {transformSelectorQuery} from 'sentry/views/replays/deadRageClick/deadRageSelectorCards';
 import {DeadRageSelectorItem} from 'sentry/views/replays/types';
 
 export interface UrlState {
@@ -41,6 +42,13 @@ export function hydratedSelectorData(data, clickType?): DeadRageSelectorItem[] {
     element: d.dom_element.split(/[#.]+/)[0],
     aria_label: getAriaLabel(d.dom_element),
   }));
+}
+
+export function transformSelectorQuery(selector: string) {
+  return selector
+    .replaceAll('"', `\\"`)
+    .replaceAll('aria=', 'aria-label=')
+    .replaceAll('testid=', 'data-test-id=');
 }
 
 interface Props {
@@ -146,20 +154,31 @@ export function SelectorLink({
   const organization = useOrganization();
   const location = useLocation();
   return (
-    <Link
-      to={{
-        pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
-        query: {
-          ...location.query,
-          query: selectorQuery,
-          cursor: undefined,
-        },
-      }}
+    <Tooltip
+      title={tct('Search for replays with clicks on: [selector]', {
+        selector: (
+          <Fragment>
+            <br />
+            <code>{value}</code>
+          </Fragment>
+        ),
+      })}
     >
-      <StyledTextOverflow>
-        <code>{value}</code>
-      </StyledTextOverflow>
-    </Link>
+      <Link
+        to={{
+          pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
+          query: {
+            ...location.query,
+            query: selectorQuery,
+            cursor: undefined,
+          },
+        }}
+      >
+        <StyledTextOverflow>
+          <code>{value}</code>
+        </StyledTextOverflow>
+      </Link>
+    </Tooltip>
   );
 }
 

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -106,9 +106,9 @@ export default function SelectorTable({
         case 'element':
         case 'aria_label':
           return (
-            <StyledTextOverflow>
+            <TextOverflow>
               <code>{value}</code>
-            </StyledTextOverflow>
+            </TextOverflow>
           );
         default:
           return renderSimpleBodyCell<DeadRageSelectorItem>(column, dataRow);

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -111,7 +111,7 @@ export default function SelectorTable({
             </TextOverflow>
           );
         default:
-          return renderSimpleBodyCell<DeadRageSelectorItem>(column, dataRow);
+          return renderClickCount<DeadRageSelectorItem>(column, dataRow);
       }
     },
     [queryPrefix]
@@ -163,13 +163,8 @@ export function SelectorLink({
   );
 }
 
-function renderSimpleBodyCell<T>(column: GridColumnOrder<string>, dataRow: T) {
-  const color =
-    column.key === 'count_rage_clicks'
-      ? 'red300'
-      : column.key === 'count_dead_clicks'
-      ? 'yellow300'
-      : 'gray300';
+function renderClickCount<T>(column: GridColumnOrder<string>, dataRow: T) {
+  const color = column.key === 'count_rage_clicks' ? 'red300' : 'yellow300';
 
   return (
     <ClickColor color={color}>

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -164,7 +164,7 @@ export function SelectorLink({
 }
 
 function renderClickCount<T>(column: GridColumnOrder<string>, dataRow: T) {
-  const color = column.key === 'count_rage_clicks' ? 'red300' : 'yellow300';
+  const color = column.key === 'count_dead_clicks' ? 'yellow300' : 'red300';
 
   return (
     <ClickColor color={color}>


### PR DESCRIPTION
Tooltips over the links for clarity:
<img width="328" alt="SCR-20230928-nclo" src="https://github.com/getsentry/sentry/assets/56095982/8d4df6fc-880a-451c-a2fe-a3d4bc3cb23b">

https://github.com/getsentry/sentry/assets/56095982/faaaab28-8898-4e23-a4e0-91abdb817afe

For the selector index, the prefix `dead` or `rage` is determined by which column is sorted.

Closes https://github.com/getsentry/team-replay/issues/179