### PR TITLE
feat(stacktrace): Add source_link processing for stacktrace linking

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -193,9 +193,13 @@ class Frame(Interface):
         )
 
     def get_api_context(self, is_public=False, pad_addr=None, platform=None):
-        from sentry.stacktraces.functions import get_function_name_for_frame
+        from sentry.stacktraces.functions import (
+            get_function_name_for_frame,
+            get_source_link_for_frame,
+        )
 
         function = get_function_name_for_frame(self, platform)
+        source_link = get_source_link_for_frame(self)
         data = {
             "filename": self.filename,
             "absPath": self.abs_path,
@@ -219,7 +223,7 @@ class Frame(Interface):
             "trust": self.trust,
             "errors": self.errors,
             "lock": self.lock,
-            "sourceLink": self.source_link,
+            "sourceLink": source_link,
         }
 
         if not is_public:

--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -298,7 +298,7 @@ def get_source_link_for_frame(frame: Frame) -> str | None:
             # the path starts with a "/" so the first element is empty string
             del path_parts[0]
 
-        # at minimum, the path must have an author/org, a repo, and a file TODO: how to detect the last element is a valid file (don't want to link to a folder)
+        # at minimum, the path must have an author/org, a repo, and a file
         if len(path_parts) >= 3:
             source_link = "https://www.github.com/" + path_parts[0] + "/" + path_parts[1] + "/blob"
             for remaining_part in path_parts[2:]:

--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -4,6 +4,9 @@ import re
 from typing import Any
 from urllib.parse import urlparse
 
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
+
 from sentry.interfaces.stacktrace import Frame
 from sentry.stacktraces.platform import get_behavior_family_for_platform
 from sentry.utils.safe import setdefault_path
@@ -282,6 +285,12 @@ def get_source_link_for_frame(frame: Frame) -> str | None:
         source_link = frame.get("source_link")
     except KeyError:
         return None
+
+    try:
+        URLValidator()(source_link)
+    except ValidationError:
+        return None
+
     parse_result = urlparse(source_link)
     if parse_result.netloc == "raw.githubusercontent.com":
         path_parts = parse_result.path.split("/")

--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -4,6 +4,7 @@ import re
 from typing import Any
 from urllib.parse import urlparse
 
+from sentry.interfaces.stacktrace import Frame
 from sentry.stacktraces.platform import get_behavior_family_for_platform
 from sentry.utils.safe import setdefault_path
 
@@ -272,7 +273,7 @@ def get_function_name_for_frame(frame, platform=None):
         return trim_function_name(rv, frame.get("platform") or platform)
 
 
-def get_source_link_for_frame(frame: dict[str, Any]) -> str:
+def get_source_link_for_frame(frame: Frame) -> str:
     """If source_link points to a GitHub raw content link, process it so that
     we can return the GitHub equivalent with the line number, and use it as a
     stacktrace link. Otherwise, return the link as is.

--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -280,19 +280,18 @@ def get_source_link_for_frame(frame: dict[str, Any]) -> str:
     source_link = frame.get("source_link")
     parse_result = urlparse(source_link)
     if parse_result.netloc == "raw.githubusercontent.com":
-        github_url_parse = parse_result.path.split(
-            "/"
-        )  # TODO: are there cases where the github raw content is actually invalid? ie. doesn't have the repo/user/file name
-        if github_url_parse[0] == "":
+        path_parts = parse_result.path.split("/")
+        if path_parts[0] == "":
             # the path starts with a "/" so the first element is empty string
-            del github_url_parse[0]
-        source_link = (
-            "https://www.github.com/" + github_url_parse[0] + "/" + github_url_parse[1] + "/blob"
-        )
-        for remaining_part in github_url_parse[2:]:
-            source_link += "/" + remaining_part
-        if frame.get("lineno"):
-            source_link += "#L" + frame.get("lineno")
+            del path_parts[0]
+
+        # at minimum, the path must have an author/org, a repo, and a file TODO: how to detect the last element is a valid file (don't want to link to a folder)
+        if len(path_parts) >= 3:
+            source_link = "https://www.github.com/" + path_parts[0] + "/" + path_parts[1] + "/blob"
+            for remaining_part in path_parts[2:]:
+                source_link += "/" + remaining_part
+            if frame.get("lineno"):
+                source_link += "#L" + frame.get("lineno")
     return source_link
 
 

--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -273,12 +273,15 @@ def get_function_name_for_frame(frame, platform=None):
         return trim_function_name(rv, frame.get("platform") or platform)
 
 
-def get_source_link_for_frame(frame: Frame) -> str:
+def get_source_link_for_frame(frame: Frame) -> str | None:
     """If source_link points to a GitHub raw content link, process it so that
     we can return the GitHub equivalent with the line number, and use it as a
     stacktrace link. Otherwise, return the link as is.
     """
-    source_link = frame.get("source_link")
+    try:
+        source_link = frame.get("source_link")
+    except KeyError:
+        return None
     parse_result = urlparse(source_link)
     if parse_result.netloc == "raw.githubusercontent.com":
         path_parts = parse_result.path.split("/")

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -233,6 +233,7 @@ def test_trim_function_name_cocoa():
             "https://notraw.githubusercontent.com/notauthor/notrepo/notfile/foo/bar/baz.js",
         ],
         [{"lineno": "543"}, None],
+        [{"source_link": "woejfdsiwjidsoi", "lineNo": "7"}, None],
     ],
 )
 def test_get_source_link_for_frame(input, output):

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -232,6 +232,7 @@ def test_trim_function_name_cocoa():
             },
             "https://notraw.githubusercontent.com/notauthor/notrepo/notfile/foo/bar/baz.js",
         ],
+        [{"lineno": "543"}, None],
     ],
 )
 def test_get_source_link_for_frame(input, output):

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -1,6 +1,7 @@
 import pytest
 
 from sentry.stacktraces.functions import (
+    get_source_link_for_frame,
     replace_enclosed_string,
     split_func_tokens,
     trim_function_name,
@@ -202,3 +203,32 @@ def test_trim_function_name_cocoa():
         == "(anonymous namespace)::foo"
     )
     assert trim_function_name("foo::bar::foo(int)", "native") == "foo::bar::foo"
+
+
+@pytest.mark.parametrize(
+    "input,output",
+    [
+        [
+            {
+                "source_link": "https://raw.githubusercontent.com/author/repo/abc123456789/foo/bar/baz.js",
+                "lineno": "200",
+            },
+            "https://www.github.com/author/repo/blob/abc123456789/foo/bar/baz.js#L200",
+        ],
+        [
+            {
+                "source_link": "https://raw.githubusercontent.com/author/repo/abc123456789/foo/bar/baz.js"
+            },
+            "https://www.github.com/author/repo/blob/abc123456789/foo/bar/baz.js",
+        ],
+        [
+            {
+                "source_link": "https://notraw.githubusercontent.com/notauthor/notrepo/notfile/foo/bar/baz.js",
+                "lineno": "122",
+            },
+            "https://notraw.githubusercontent.com/notauthor/notrepo/notfile/foo/bar/baz.js",
+        ],
+    ],
+)
+def test_get_source_link_for_frame(input, output):
+    assert get_source_link_for_frame(input) == output

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -222,6 +222,10 @@ def test_trim_function_name_cocoa():
             "https://www.github.com/author/repo/blob/abc123456789/foo/bar/baz.js",
         ],
         [
+            {"source_link": "https://raw.githubusercontent.com/author/repo"},
+            "https://raw.githubusercontent.com/author/repo",
+        ],
+        [
             {
                 "source_link": "https://notraw.githubusercontent.com/notauthor/notrepo/notfile/foo/bar/baz.js",
                 "lineno": "122",


### PR DESCRIPTION
If a frame's source link is raw GitHub user content, `get_source_link_for_frame` processes it into a regular GitHub url so that it can be used for stacktrace linking for .NET issues.

Part of #53249 