### PR TITLE
feat(jira-server): handle special error blank field

### DIFF
--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -295,11 +295,17 @@ export default class AbstractExternalIssueForm<
     throw new Error("Method 'getFormProps()' must be implemented.");
   };
 
+  hasErrorInFields = (): boolean => {
+    // check if we have any form fields with name error and type blank
+    const fields = this.getCleanedFields();
+    return fields.some(field => field.name === 'error' && field.type === 'blank');
+  };
+
   getDefaultFormProps = (): FormProps => {
     return {
       footerClass: 'modal-footer',
       onFieldChange: this.onFieldChange,
-      submitDisabled: this.state.reloading,
+      submitDisabled: this.state.reloading || this.hasErrorInFields(),
       model: this.model,
       // Other form props implemented by child classes.
     };

--- a/static/app/components/group/externalIssueForm.spec.tsx
+++ b/static/app/components/group/externalIssueForm.spec.tsx
@@ -77,6 +77,24 @@ describe('ExternalIssueForm', () => {
     it('renders', async () => {
       await renderComponent();
     });
+    it('if we have an error fields, we should disable the create button', async () => {
+      formConfig = {
+        createIssueConfig: [
+          {
+            name: 'error',
+            type: 'blank',
+          },
+        ],
+      };
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/issues/${group.id}/integrations/${integration.id}/`,
+        body: formConfig,
+      });
+      await renderComponent();
+
+      const submitButton = screen.getByRole('button', {name: 'Create Issue'});
+      expect(submitButton).toBeDisabled();
+    });
   });
   describe('link', () => {
     let externalIssueField, getFormConfigRequest;


### PR DESCRIPTION
In some cases, we can't load info for a project in Jira Server. When that happens, we need to let the user select a different project. So to do this we will send a special form field that tells us there is an error so we can disable the submit button.
<img width="665" alt="Screen Shot 2023-09-28 at 3 31 25 PM" src="https://github.com/getsentry/sentry/assets/8533851/4da257c9-bedd-4170-b814-bdd4168db532">

