### PR TITLE
fix(crons): Ensure distinct rows for monitor environment query

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -106,9 +106,11 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
             if request.GET.get("includeNew"):
                 queryset = queryset.filter(
                     Q(monitorenvironment__environment__in=environments) | Q(monitorenvironment=None)
-                )
+                ).distinct()
             else:
-                queryset = queryset.filter(monitorenvironment__environment__in=environments)
+                queryset = queryset.filter(
+                    monitorenvironment__environment__in=environments
+                ).distinct()
         else:
             environments = list(Environment.objects.filter(organization_id=organization.id))
 


### PR DESCRIPTION
Ensures that only one row per monitor is returned when multiple environments are specified in the dropdown
<img width="722" alt="image" src="https://github.com/getsentry/sentry/assets/7078270/c56f868b-8461-488d-8933-f1fee0094697">
