### PR TITLE
test(crons): Always include checkin_margin/max_runtime in config

### DIFF
--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_attachment.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_attachment.py
@@ -12,6 +12,7 @@ from sentry.monitors.models import (
     MonitorCheckIn,
     MonitorEnvironment,
     MonitorType,
+    ScheduleType,
 )
 from sentry.testutils.cases import MonitorIngestTestCase
 from sentry.testutils.silo import region_silo_test
@@ -29,7 +30,12 @@ class MonitorIngestCheckinAttachmentEndpointTest(MonitorIngestTestCase):
             organization_id=self.organization.id,
             project_id=self.project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule": "* * * * *"},
+            config={
+                "schedule_type": ScheduleType.CRONTAB,
+                "schedule": "* * * * *",
+                "max_runtime": None,
+                "checkin_margin": None,
+            },
             date_added=timezone.now() - timedelta(minutes=1),
         )
 

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
@@ -43,7 +43,12 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
             organization_id=self.organization.id,
             project_id=self.project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule_type": ScheduleType.CRONTAB, "schedule": "* * * * *"},
+            config={
+                "schedule_type": ScheduleType.CRONTAB,
+                "schedule": "* * * * *",
+                "max_runtime": None,
+                "checkin_margin": None,
+            },
             date_added=timezone.now() - timedelta(minutes=1),
         )
 

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -450,7 +450,12 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
             organization_id=project2.organization_id,
             project_id=project2.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule": "* * * * *"},
+            config={
+                "schedule": "* * * * *",
+                "schedule_type": ScheduleType.CRONTAB,
+                "max_runtime": None,
+                "checkin_margin": None,
+            },
         )
 
         for path_func in self._get_path_functions():
@@ -471,7 +476,12 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
             organization_id=org2.id,
             project_id=project2.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
+            config={
+                "schedule": "* * * * *",
+                "schedule_type": ScheduleType.CRONTAB,
+                "max_runtime": None,
+                "checkin_margin": None,
+            },
         )
 
         path = reverse(self.endpoint, args=[monitor.slug])
@@ -523,6 +533,7 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
             monitor.config = {
                 "schedule": "* * * * *",
                 "schedule_type": ScheduleType.CRONTAB,
+                # Explicitly missing checkin_margin and max_runtime
             }
             monitor.save()
 

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -38,7 +38,12 @@ class MarkFailedTestCase(TestCase):
             organization_id=self.organization.id,
             project_id=self.project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+            config={
+                "schedule": [1, "month"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "max_runtime": None,
+                "checkin_margin": None,
+            },
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
@@ -68,7 +73,12 @@ class MarkFailedTestCase(TestCase):
                     "monitor": {
                         "status": "error",
                         "type": "cron_job",
-                        "config": {"schedule_type": 2, "schedule": [1, "month"]},
+                        "config": {
+                            "schedule_type": 2,
+                            "schedule": [1, "month"],
+                            "max_runtime": None,
+                            "checkin_margin": None,
+                        },
                         "id": str(monitor.guid),
                         "name": monitor.name,
                         "slug": monitor.slug,
@@ -89,7 +99,12 @@ class MarkFailedTestCase(TestCase):
             organization_id=self.organization.id,
             project_id=self.project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+            config={
+                "schedule": [1, "month"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "max_runtime": None,
+                "checkin_margin": None,
+            },
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
@@ -119,7 +134,12 @@ class MarkFailedTestCase(TestCase):
                     "monitor": {
                         "status": "timeout",
                         "type": "cron_job",
-                        "config": {"schedule_type": 2, "schedule": [1, "month"]},
+                        "config": {
+                            "schedule_type": 2,
+                            "schedule": [1, "month"],
+                            "max_runtime": None,
+                            "checkin_margin": None,
+                        },
                         "id": str(monitor.guid),
                         "name": monitor.name,
                         "slug": monitor.slug,
@@ -143,7 +163,12 @@ class MarkFailedTestCase(TestCase):
             organization_id=self.organization.id,
             project_id=self.project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule": [1, "hour"], "schedule_type": ScheduleType.INTERVAL},
+            config={
+                "schedule": [1, "hour"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "max_runtime": None,
+                "checkin_margin": None,
+            },
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
@@ -180,7 +205,12 @@ class MarkFailedTestCase(TestCase):
                     "monitor": {
                         "status": "missed_checkin",
                         "type": "cron_job",
-                        "config": {"schedule_type": 2, "schedule": [1, "hour"]},
+                        "config": {
+                            "schedule_type": 2,
+                            "schedule": [1, "hour"],
+                            "max_runtime": None,
+                            "checkin_margin": None,
+                        },
                         "id": str(monitor.guid),
                         "name": monitor.name,
                         "slug": monitor.slug,
@@ -201,7 +231,12 @@ class MarkFailedTestCase(TestCase):
             organization_id=self.organization.id,
             project_id=self.project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+            config={
+                "schedule": [1, "month"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "max_runtime": None,
+                "checkin_margin": None,
+            },
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
@@ -269,7 +304,12 @@ class MarkFailedTestCase(TestCase):
                     "monitor": {
                         "status": "error",
                         "type": "cron_job",
-                        "config": {"schedule_type": 2, "schedule": [1, "month"]},
+                        "config": {
+                            "schedule_type": 2,
+                            "schedule": [1, "month"],
+                            "max_runtime": None,
+                            "checkin_margin": None,
+                        },
                         "id": str(monitor.guid),
                         "name": monitor.name,
                         "slug": monitor.slug,
@@ -301,6 +341,7 @@ class MarkFailedTestCase(TestCase):
                 "schedule": [1, "month"],
                 "schedule_type": ScheduleType.INTERVAL,
                 "max_runtime": 10,
+                "checkin_margin": None,
             },
         )
         monitor_environment = MonitorEnvironment.objects.create(
@@ -366,7 +407,12 @@ class MarkFailedTestCase(TestCase):
                     "monitor": {
                         "status": "timeout",
                         "type": "cron_job",
-                        "config": {"schedule_type": 2, "schedule": [1, "month"], "max_runtime": 10},
+                        "config": {
+                            "schedule_type": 2,
+                            "schedule": [1, "month"],
+                            "max_runtime": 10,
+                            "checkin_margin": None,
+                        },
                         "id": str(monitor.guid),
                         "name": monitor.name,
                         "slug": monitor.slug,
@@ -397,7 +443,12 @@ class MarkFailedTestCase(TestCase):
             organization_id=self.organization.id,
             project_id=self.project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule": [1, "hour"], "schedule_type": ScheduleType.INTERVAL},
+            config={
+                "schedule": [1, "hour"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "max_runtime": None,
+                "checkin_margin": None,
+            },
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
@@ -462,7 +513,12 @@ class MarkFailedTestCase(TestCase):
                     "monitor": {
                         "status": "missed_checkin",
                         "type": "cron_job",
-                        "config": {"schedule_type": 2, "schedule": [1, "hour"]},
+                        "config": {
+                            "schedule_type": 2,
+                            "schedule": [1, "hour"],
+                            "max_runtime": None,
+                            "checkin_margin": None,
+                        },
                         "id": str(monitor.guid),
                         "name": monitor.name,
                         "slug": monitor.slug,
@@ -494,6 +550,8 @@ class MarkFailedTestCase(TestCase):
                 "schedule": [1, "month"],
                 "schedule_type": ScheduleType.INTERVAL,
                 "failure_issue_threshold": failure_issue_threshold,
+                "max_runtime": None,
+                "checkin_margin": None,
             },
         )
         monitor_environment = MonitorEnvironment.objects.create(

--- a/tests/sentry/monitors/logic/test_mark_ok.py
+++ b/tests/sentry/monitors/logic/test_mark_ok.py
@@ -32,6 +32,8 @@ class MarkOkTestCase(TestCase):
                 "schedule": [1, "month"],
                 "schedule_type": ScheduleType.INTERVAL,
                 "recovery_threshold": recovery_threshold,
+                "max_runtime": None,
+                "checkin_margin": None,
             },
         )
         monitor_environment = MonitorEnvironment.objects.create(

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -26,6 +26,8 @@ class MonitorTestCase(TestCase):
             config={
                 "schedule_type": ScheduleType.CRONTAB,
                 "schedule": "* * * * *",
+                "checkin_margin": None,
+                "max_runtime": None,
             }
         )
         monitor_environment = MonitorEnvironment(monitor=monitor, last_checkin=ts)
@@ -53,6 +55,7 @@ class MonitorTestCase(TestCase):
                 "schedule_type": ScheduleType.CRONTAB,
                 "schedule": "* * * * *",
                 "checkin_margin": 5,
+                "max_runtime": None,
             }
         )
         monitor_environment = MonitorEnvironment(monitor=monitor, last_checkin=ts)
@@ -72,6 +75,8 @@ class MonitorTestCase(TestCase):
                 "schedule_type": ScheduleType.CRONTAB,
                 "schedule": "0 12 * * *",
                 "timezone": "UTC",
+                "checkin_margin": None,
+                "max_runtime": None,
             },
         )
         monitor_environment = MonitorEnvironment(monitor=monitor, last_checkin=ts)
@@ -94,6 +99,8 @@ class MonitorTestCase(TestCase):
             config={
                 "schedule": [1, "month"],
                 "schedule_type": ScheduleType.INTERVAL,
+                "checkin_margin": None,
+                "max_runtime": None,
             },
         )
         monitor_environment = MonitorEnvironment(monitor=monitor, last_checkin=ts)
@@ -109,7 +116,12 @@ class MonitorTestCase(TestCase):
             project_id=self.project.id,
             type=MonitorType.CRON_JOB,
             name="My Awesome Monitor",
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+            config={
+                "schedule": [1, "month"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "checkin_margin": None,
+                "max_runtime": None,
+            },
         )
 
         assert monitor.slug == "my-awesome-monitor"
@@ -121,7 +133,12 @@ class MonitorTestCase(TestCase):
             type=MonitorType.CRON_JOB,
             name="My Awesome Monitor",
             slug="my-awesome-monitor",
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+            config={
+                "schedule": [1, "month"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "checkin_margin": None,
+                "max_runtime": None,
+            },
         )
 
         assert monitor.slug == "my-awesome-monitor"
@@ -132,7 +149,12 @@ class MonitorTestCase(TestCase):
             project_id=self.project.id,
             type=MonitorType.CRON_JOB,
             name="My Awesome Monitor",
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+            config={
+                "schedule": [1, "month"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "checkin_margin": None,
+                "max_runtime": None,
+            },
         )
 
         assert monitor.slug.startswith("my-awesome-monitor-")
@@ -146,7 +168,12 @@ class MonitorTestCase(TestCase):
                 type=MonitorType.CRON_JOB,
                 name=f"Unicron-{i}",
                 slug=f"unicron-{i}",
-                config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+                config={
+                    "schedule": [1, "month"],
+                    "schedule_type": ScheduleType.INTERVAL,
+                    "checkin_margin": None,
+                    "max_runtime": None,
+                },
             )
 
         with pytest.raises(
@@ -159,7 +186,12 @@ class MonitorTestCase(TestCase):
                 type=MonitorType.CRON_JOB,
                 name=f"Unicron-{settings.MAX_MONITORS_PER_ORG}",
                 slug=f"unicron-{settings.MAX_MONITORS_PER_ORG}",
-                config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+                config={
+                    "schedule": [1, "month"],
+                    "schedule_type": ScheduleType.INTERVAL,
+                    "checkin_margin": None,
+                    "max_runtime": None,
+                },
             )
 
 
@@ -173,7 +205,12 @@ class MonitorEnvironmentTestCase(TestCase):
             type=MonitorType.CRON_JOB,
             name="Unicron",
             slug="unicron",
-            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+            config={
+                "schedule": [1, "month"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "checkin_margin": None,
+                "max_runtime": None,
+            },
         )
 
         for i in range(settings.MAX_ENVIRONMENTS_PER_MONITOR):
@@ -198,6 +235,8 @@ class MonitorEnvironmentTestCase(TestCase):
                 "schedule": [1, "month"],
                 "schedule_type": ScheduleType.INTERVAL,
                 "alert_rule_id": 1,
+                "checkin_margin": None,
+                "max_runtime": None,
             },
         )
 
@@ -217,6 +256,7 @@ class MonitorEnvironmentTestCase(TestCase):
         assert monitor.config == {
             "schedule": "0 0 1 2 *",
             "schedule_type": ScheduleType.CRONTAB,
+            "checkin_margin": None,
             "max_runtime": 10,
             "alert_rule_id": 1,
         }

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -221,7 +221,12 @@ class MonitorTaskCheckMissingTest(TestCase):
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule": "* * * * *"},
+            config={
+                "schedule_type": ScheduleType.CRONTAB,
+                "schedule": "* * * * *",
+                "checkin_margin": None,
+                "max_runtime": None,
+            },
             status=state,
         )
         # Expected checkin was a full minute ago, if this monitor wasn't in the
@@ -266,7 +271,12 @@ class MonitorTaskCheckMissingTest(TestCase):
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule_type": ScheduleType.CRONTAB, "schedule": "* * * * *"},
+            config={
+                "schedule_type": ScheduleType.CRONTAB,
+                "schedule": "* * * * *",
+                "checkin_margin": None,
+                "max_runtime": None,
+            },
         )
         # Expected checkin is this minute
         MonitorEnvironment.objects.create(
@@ -309,6 +319,8 @@ class MonitorTaskCheckMissingTest(TestCase):
                 # XXX: Note the invalid schedule will cause an exception,
                 # typically the validator protects us against this
                 "schedule": [-2, "minute"],
+                "checkin_margin": None,
+                "max_runtime": None,
             },
         )
         failing_monitor_environment = MonitorEnvironment.objects.create(
@@ -324,7 +336,12 @@ class MonitorTaskCheckMissingTest(TestCase):
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule_type": ScheduleType.CRONTAB, "schedule": "* * * * *"},
+            config={
+                "schedule_type": ScheduleType.CRONTAB,
+                "schedule": "* * * * *",
+                "checkin_margin": None,
+                "max_runtime": None,
+            },
         )
         successful_monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
@@ -370,7 +387,12 @@ class MonitorTaskCheckTimeoutTest(TestCase):
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule_type": ScheduleType.CRONTAB, "schedule": "0 0 * * *"},
+            config={
+                "schedule_type": ScheduleType.CRONTAB,
+                "schedule": "0 0 * * *",
+                "checkin_margin": None,
+                "max_runtime": None,
+            },
         )
         # Next checkin should have been 24 hours ago
         monitor_environment = MonitorEnvironment.objects.create(
@@ -446,7 +468,12 @@ class MonitorTaskCheckTimeoutTest(TestCase):
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule_type": ScheduleType.CRONTAB, "schedule": "0 0 * * *"},
+            config={
+                "schedule_type": ScheduleType.CRONTAB,
+                "schedule": "0 0 * * *",
+                "checkin_margin": None,
+                "max_runtime": None,
+            },
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
@@ -517,6 +544,7 @@ class MonitorTaskCheckTimeoutTest(TestCase):
             config={
                 "schedule_type": ScheduleType.CRONTAB,
                 "schedule": "0 0 * * *",
+                "checkin_margin": None,
                 "max_runtime": 60,
             },
         )


### PR DESCRIPTION
Otherwise we produce lots of WARNING log output for invalid monitor
configuration when saving it as part of a check_in