### PR TITLE
fix(crons): Correctly compute next_checkin for missed check-ins

### DIFF
--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -28,12 +28,12 @@ from sentry.monitors.tasks import (
 from sentry.testutils.cases import TestCase
 
 
-def make_ref_time():
+def make_ref_time(**kwargs):
     """
     To accurately reflect the real usage of this task, we want the ref time
     to be truncated down to a minute for our tests.
     """
-    ts = timezone.now()
+    ts = timezone.now().replace(**kwargs)
 
     # Typically the task will not run exactly on the minute, but it will
     # run very close, let's say for our test that it runs 12 seconds after
@@ -106,16 +106,19 @@ class MonitorTaskCheckMissingTest(TestCase):
         # last_checkin was NOT updated. We only update this for real user check-ins.
         assert monitor_environment.last_checkin == ts - timedelta(minutes=2)
 
+        # next_checkin IS updated for when we're expecting the next checkin
+        assert monitor_environment.next_checkin == ts
+
         # Because our checkin was a minute ago we'll have produced a missed checkin
         missed_checkin = MonitorCheckIn.objects.get(
             monitor_environment=monitor_environment.id, status=CheckInStatus.MISSED
         )
-        assert missed_checkin.date_added == (
-            monitor_environment.last_checkin + timedelta(minutes=1)
-        ).replace(second=0, microsecond=0)
-        assert missed_checkin.expected_time == (
-            monitor_environment.last_checkin + timedelta(minutes=1)
-        ).replace(second=0, microsecond=0)
+
+        next_checkin = monitor_environment.last_checkin + timedelta(minutes=1)
+        next_checkin = next_checkin.replace(second=0, microsecond=0)
+
+        assert missed_checkin.date_added == next_checkin
+        assert missed_checkin.expected_time == next_checkin
         assert missed_checkin.monitor_config == monitor.config
 
     @mock.patch("sentry.monitors.tasks.mark_environment_missing")
@@ -157,11 +160,14 @@ class MonitorTaskCheckMissingTest(TestCase):
         assert mark_environment_missing_mock.delay.call_count == 0
 
         assert not MonitorEnvironment.objects.filter(
-            id=monitor_environment.id, status=MonitorStatus.MISSED_CHECKIN
+            id=monitor_environment.id,
+            status=MonitorStatus.MISSED_CHECKIN,
         ).exists()
+
         assert not MonitorCheckIn.objects.filter(
-            monitor_environment=monitor_environment.id, status=CheckInStatus.MISSED
-        )
+            monitor_environment=monitor_environment.id,
+            status=CheckInStatus.MISSED,
+        ).exists()
 
         # Missed check-in generated as clock now exceeds expected time plus margin
         check_missing(task_run_ts + timedelta(minutes=4))
@@ -182,33 +188,192 @@ class MonitorTaskCheckMissingTest(TestCase):
             id=monitor_environment.id, status=MonitorStatus.MISSED_CHECKIN
         )
 
-        # last_checkin was NOT updated. We only update this for real user check-ins.
-        assert monitor_environment.last_checkin == ts - timedelta(minutes=12)
+        missed_checkin = MonitorCheckIn.objects.filter(
+            monitor_environment=monitor_environment.id,
+            status=CheckInStatus.MISSED,
+        )
 
-        assert MonitorCheckIn.objects.filter(
-            monitor_environment=monitor_environment.id, status=CheckInStatus.MISSED
-        )
-        missed_check = MonitorCheckIn.objects.get(
-            monitor_environment=monitor_environment.id, status=CheckInStatus.MISSED
-        )
+        assert missed_checkin.exists()
+        missed_checkin = missed_checkin[0]
 
         # Missed checkins are back-dated to when the checkin was expected to
         # happen. In this case the expected_time is equal to the date_added.
-        assert missed_check.date_added == (
-            monitor_environment.last_checkin + timedelta(minutes=10)
-        ).replace(second=0, microsecond=0)
-        assert missed_check.expected_time == (
-            monitor_environment.last_checkin + timedelta(minutes=10)
-        ).replace(second=0, microsecond=0)
+        checkin_date = monitor_environment.last_checkin + timedelta(minutes=10)
+        checkin_date = checkin_date.replace(second=0, microsecond=0)
 
-        assert missed_check.monitor_config == monitor.config
+        assert missed_checkin.date_added == checkin_date
+        assert missed_checkin.expected_time == checkin_date
+        assert missed_checkin.monitor_config == monitor.config
 
-        # Monitor environment next_checkin values are updated correctly
-        monitor_environment_updated = MonitorEnvironment.objects.get(id=monitor_environment.id)
-        assert (
-            monitor_environment_updated.next_checkin_latest
-            == monitor_environment_updated.next_checkin + timedelta(minutes=5)
+        monitor_env = MonitorEnvironment.objects.get(id=monitor_environment.id)
+
+        # next_checkin should happen 10 minutes after the missed checkin, or 8
+        # minutes after the reference ts
+        assert monitor_env.next_checkin == missed_checkin.date_added + timedelta(minutes=10)
+        assert monitor_env.next_checkin == ts + timedelta(minutes=8)
+
+        # next_checkin_latest has the correct margin offset
+        assert monitor_env.next_checkin_latest == monitor_env.next_checkin + timedelta(minutes=5)
+
+    @mock.patch("sentry.monitors.tasks.mark_environment_missing")
+    def test_missing_checkin_with_margin_schedule_overlap(self, mark_environment_missing_mock):
+        """
+        Tests the case where the checkin_margin is configured to be larger than
+        the gap in the schedule.
+
+        In this scenario we will not mark missed check-ins while it's waiting
+        for the checkin_margin to pass.
+        """
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+
+        # ts falls on the 5 minute schedule so our every 5 minute schedule
+        # makes sense
+        task_run_ts, sub_task_run_ts, ts = make_ref_time(minute=15)
+
+        monitor = Monitor.objects.create(
+            organization_id=org.id,
+            project_id=project.id,
+            type=MonitorType.CRON_JOB,
+            config={
+                # Every 5 minutes
+                "schedule": "*/5 * * * *",
+                "schedule_type": ScheduleType.CRONTAB,
+                "max_runtime": None,
+                "checkin_margin": 10,
+            },
         )
+
+        # Last check-in was 5 minutes ago. Next checkin is now, latest 10
+        # minutes from now. There will be 5 minutes of overlap.
+        monitor_environment = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment=self.environment,
+            last_checkin=ts - timedelta(minutes=5),
+            next_checkin=ts,
+            next_checkin_latest=ts + timedelta(minutes=10),
+            status=MonitorStatus.OK,
+        )
+
+        # No missed check-in generated as we're still within the check-in margin
+        check_missing(task_run_ts)
+        assert mark_environment_missing_mock.delay.call_count == 0
+
+        # Missed checkin is STILL not produced 5 minutes in, even though this
+        # is when another check-in should be happening.
+        check_missing(task_run_ts + timedelta(minutes=5))
+        assert mark_environment_missing_mock.delay.call_count == 0
+
+        # Still nothing 9 minutes in
+        check_missing(task_run_ts + timedelta(minutes=9))
+        assert mark_environment_missing_mock.delay.call_count == 0
+
+        # We have missed our check-in at 10 minutes
+        check_missing(task_run_ts + timedelta(minutes=10))
+        assert mark_environment_missing_mock.delay.call_count == 1
+
+        assert mark_environment_missing_mock.delay.mock_calls[0] == mock.call(
+            monitor_environment.id,
+            sub_task_run_ts + timedelta(minutes=10),
+        )
+
+        mark_environment_missing(
+            monitor_environment.id,
+            sub_task_run_ts + timedelta(minutes=10),
+        )
+
+        # The missed checkin is created when it was supposed to happen
+        missed_checkin = MonitorCheckIn.objects.get(
+            monitor_environment=monitor_environment.id,
+            status=CheckInStatus.MISSED,
+        )
+        assert missed_checkin.date_added == ts
+        assert missed_checkin.expected_time == ts
+
+        monitor_env = MonitorEnvironment.objects.get(
+            id=monitor_environment.id,
+            status=MonitorStatus.MISSED_CHECKIN,
+        )
+
+        # The next checkin is at the 10 minute mark now
+        assert monitor_env.next_checkin == ts + timedelta(minutes=10)
+
+    @mock.patch("sentry.monitors.tasks.mark_environment_missing")
+    def test_missing_checkin_with_skipped_clock_ticks(self, mark_environment_missing_mock):
+        """
+        Test that skipped check_missing tasks does NOT cause the missed
+        check-ins to fall behind, and instead that missed check-ins simply will
+        be skipped, but at the correct times
+        """
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+
+        task_run_ts, sub_task_run_ts, ts = make_ref_time()
+
+        monitor = Monitor.objects.create(
+            organization_id=org.id,
+            project_id=project.id,
+            type=MonitorType.CRON_JOB,
+            config={
+                "schedule_type": ScheduleType.CRONTAB,
+                "schedule": "* * * * *",
+                "checkin_margin": None,
+                "max_runtime": None,
+            },
+        )
+
+        monitor_environment = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment=self.environment,
+            last_checkin=ts - timedelta(minutes=1),
+            next_checkin=ts,
+            next_checkin_latest=ts + timedelta(minutes=1),
+            status=MonitorStatus.OK,
+        )
+
+        # Nothing happens first run, we're not at the next_checkin_latest
+        check_missing(task_run_ts)
+        assert mark_environment_missing_mock.delay.call_count == 0
+
+        # Generate a missed-checkin
+        check_missing(task_run_ts + timedelta(minutes=1))
+        assert mark_environment_missing_mock.delay.call_count == 1
+        mark_environment_missing(
+            monitor_environment.id,
+            sub_task_run_ts + timedelta(minutes=1),
+        )
+
+        # MonitorEnvironment is correctly updated with the next checkin time
+        monitor_environment.refresh_from_db()
+        assert monitor_environment.next_checkin == ts + timedelta(minutes=1)
+
+        # One minute later we SKIP the task...
+        # noop
+
+        # Two minutes later we do NOT skip the task
+        check_missing(task_run_ts + timedelta(minutes=3))
+        assert mark_environment_missing_mock.delay.call_count == 2
+        mark_environment_missing(
+            monitor_environment.id,
+            sub_task_run_ts + timedelta(minutes=3),
+        )
+
+        # MonitorEnvironment is updated with the next_checkin correctly being
+        # computed from the most most recent check-in that should have happened
+        monitor_environment.refresh_from_db()
+        assert monitor_environment.next_checkin == ts + timedelta(minutes=3)
+
+        # Missed check-in is created at the time it should have happened, NOT
+        # at the most recent expected check in time, that slot was missed.
+        missed_checkin = (
+            MonitorCheckIn.objects.filter(
+                monitor_environment=monitor_environment.id,
+                status=CheckInStatus.MISSED,
+            )
+            .order_by("-date_added")
+            .first()
+        )
+        assert missed_checkin.date_added == ts + timedelta(minutes=1)
 
     @mock.patch("sentry.monitors.tasks.mark_environment_missing")
     def assert_state_does_not_change_for_status(self, state, mark_environment_missing_mock):


### PR DESCRIPTION
Part of GH-55874

In the previous implementation we used `timezone.now()`, which is not appropriate for these tasks, as they are run on "stream time". That is to say, these tasks are dispatched based on how much of the Monitor Ingest kafka topic has been consumed, so it will not always be true that they are run close to wall clock time.

On top of that, using the time the task was run as the reference time for when to compute the next checkin **is incorrect**.

Imagine the scenario where we have a once a minute schedule. If our task does not check in at 12:00, at 12:01 we would ask "when is the next check in after 12:01 which would be 12:02. **We completely skipped 12:01**.

This change fixes that by first using the tasks clock reference time instead of `timezone.now` and then using that to compute when the "previous" expected check in was. Typically this would be the same as the missed check-in we just created. But in the scenario where the clock skips or the missed margin is larger than the schedule gap, it may be farther in the future.