### PR TITLE
fix(statistical-detectors): Extend request period to 3 days

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -383,8 +383,8 @@ def _detect_function_change_points(
                 "data": serialized["data"],
                 "data_start": serialized["start"],
                 "data_end": serialized["end"],
-                # only look at the last 24 hours as the request data
-                "request_start": serialized["end"] - 24 * 60 * 60,
+                # only look at the last 3 days of the request data
+                "request_start": serialized["end"] - 3 * 24 * 60 * 60,
                 "request_end": serialized["end"],
             }
 


### PR DESCRIPTION
There's some magic numbers embedded in the breakpoint detection that implies a minimum request period of 25 hours.