### PR TITLE
feat(onboarding): Simplify multi snippet docs javascript [part 1]

### DIFF
--- a/static/app/gettingStartedDocs/electron/electron.tsx
+++ b/static/app/gettingStartedDocs/electron/electron.tsx
@@ -31,7 +31,7 @@ export const steps = ({
             code: 'npm install --save @sentry/electron',
           },
           {
-            label: 'Yarn',
+            label: 'yarn',
             value: 'yarn',
             language: 'bash',
             code: 'yarn add @sentry/electron',

--- a/static/app/gettingStartedDocs/electron/electron.tsx
+++ b/static/app/gettingStartedDocs/electron/electron.tsx
@@ -23,14 +23,20 @@ export const steps = ({
     description: t('Add the Sentry Electron SDK package as a dependency:'),
     configurations: [
       {
-        language: 'bash',
-        code: `
-# Using yarn
-yarn add @sentry/electron
-
-# Using npm
-npm install --save @sentry/electron
-        `,
+        code: [
+          {
+            label: 'npm',
+            value: 'npm',
+            language: 'bash',
+            code: 'npm install --save @sentry/electron',
+          },
+          {
+            label: 'Yarn',
+            value: 'yarn',
+            language: 'bash',
+            code: 'yarn add @sentry/electron',
+          },
+        ],
       },
     ],
   },

--- a/static/app/gettingStartedDocs/javascript/angular.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.spec.tsx
@@ -3,7 +3,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 
-import {GettingStartedWithAngular, nextSteps, steps} from './angular';
+import {AngularVersion, GettingStartedWithAngular, nextSteps, steps} from './angular';
 
 describe('GettingStartedWithAngular', function () {
   it('all products are selected', function () {
@@ -19,7 +19,11 @@ describe('GettingStartedWithAngular', function () {
     );
 
     // Steps
-    for (const step of steps()) {
+    for (const step of steps({
+      angularVersion: AngularVersion.V12,
+      errorHandlerProviders: 'test-error-handler-providers',
+      sentryInitContent: 'test-init-content',
+    })) {
       expect(
         screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
       ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -97,7 +97,7 @@ export const steps = ({
     description: (
       <p>
         {tct(
-          'Add the Sentry SDK as a dependency using [codeYarn:yarn] or [codeNpm:npm]:',
+          'Add the Sentry SDK as a dependency using [codeNpm:npm] or [codeYarn:yarn]:',
           {
             codeYarn: <code />,
             codeNpm: <code />,
@@ -116,7 +116,7 @@ export const steps = ({
             code: `npm install --save ${getNpmPackage(angularVersion)}`,
           },
           {
-            label: 'Yarn',
+            label: 'yarn',
             value: 'yarn',
             language: 'bash',
             code: `yarn add ${getNpmPackage(angularVersion)}`,

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -1,26 +1,49 @@
-import styled from '@emotion/styled';
-
-import List from 'sentry/components/list/';
-import ListItem from 'sentry/components/list/listItem';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
+import {
+  PlatformOption,
+  useUrlPlatformOptions,
+} from 'sentry/components/onboarding/platformOptionsControl';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Organization, PlatformKey} from 'sentry/types';
 
+export enum AngularVersion {
+  V10 = 'v10',
+  V12 = 'v12',
+}
+
+type PlaformOptionKey = 'angularVersion';
+
 type StepProps = {
+  angularVersion: AngularVersion;
   errorHandlerProviders: string;
-  newOrg: boolean;
-  organization: Organization;
-  platformKey: PlatformKey;
-  projectId: string;
   sentryInitContent: string;
+  newOrg?: boolean;
+  organization?: Organization;
+  platformKey?: PlatformKey;
+  projectId?: string;
 };
 
 // Configuration Start
+const platformOptions: Record<PlaformOptionKey, PlatformOption> = {
+  angularVersion: {
+    label: t('Spring Boot Version'),
+    items: [
+      {
+        label: t('Angular 12+'),
+        value: AngularVersion.V12,
+      },
+      {
+        label: t('Angular 10 and 11'),
+        value: AngularVersion.V10,
+      },
+    ],
+  },
+};
+
 const replayIntegration = `
 new Sentry.Replay(),
 `;
@@ -57,57 +80,48 @@ const performanceErrorHandler = `
 },
 `;
 
+function getNpmPackage(angularVersion: AngularVersion) {
+  return angularVersion === AngularVersion.V12
+    ? '@sentry/angular-ivy'
+    : '@sentry/angular';
+}
+
 export const steps = ({
   sentryInitContent,
   errorHandlerProviders,
+  angularVersion,
   ...props
-}: Partial<StepProps> = {}): LayoutProps['steps'] => [
+}: StepProps): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
     description: (
-      <InstallDescription>
-        <p>
-          {tct(
-            "To use Sentry with your Angular application, you'll need [sentryAngularIvyCode:@sentry/angular-ivy] or [sentryAngularCode:@sentry/angular], Sentry’s Browser Angular SDKs:",
-            {
-              sentryAngularIvyCode: <code />,
-              sentryAngularCode: <code />,
-            }
-          )}
-        </p>
-        <List symbol="bullet">
-          <ListItem>
-            {tct("If you're using Angular 12 or newer, use [code:@sentry/angular-ivy]", {
-              code: <code />,
-            })}
-          </ListItem>
-          <ListItem>
-            {tct("If you're using Angular 10 or 11, use [code:@sentry/angular]", {
-              code: <code />,
-            })}
-          </ListItem>
-        </List>
-        <p>
-          {tct('Add the Sentry SDK as a dependency using [code:yarn] or [code:npm]:', {
-            code: <code />,
-          })}
-        </p>
-      </InstallDescription>
+      <p>
+        {tct(
+          'Add the Sentry SDK as a dependency using [codeYarn:yarn] or [codeNpm:npm]:',
+          {
+            codeYarn: <code />,
+            codeNpm: <code />,
+          }
+        )}
+      </p>
     ),
     configurations: [
       {
         language: 'bash',
-        code: `
-# Using yarn (Angular 12+)
-yarn add @sentry/angular-ivy
-# Using yarn (Angular 10 and 11)
-yarn add @sentry/angular
-
-# Using npm (Angular 12+)
-npm install --save @sentry/angular-ivy
-# Using npm (Angular 10 and 11)
-npm install --save @sentry/angular
-        `,
+        code: [
+          {
+            label: 'npm',
+            value: 'npm',
+            language: 'bash',
+            code: `npm install --save ${getNpmPackage(angularVersion)}`,
+          },
+          {
+            label: 'Yarn',
+            value: 'yarn',
+            language: 'bash',
+            code: `yarn add ${getNpmPackage(angularVersion)}`,
+          },
+        ],
       },
     ],
   },
@@ -120,23 +134,22 @@ npm install --save @sentry/angular
       {
         language: 'javascript',
         code: `
-        import { enableProdMode } from "@angular/core";
-        import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
-        // import * as Sentry from "@sentry/angular" // for Angular 10/11 instead
-        import * as Sentry from "@sentry/angular-ivy";
+import { enableProdMode } from "@angular/core";
+import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
+import * as Sentry from "${getNpmPackage(angularVersion)}";
 
-        import { AppModule } from "./app/app.module";
+import { AppModule } from "./app/app.module";
 
-        Sentry.init({
-          ${sentryInitContent}
-        });
+Sentry.init({
+  ${sentryInitContent}
+});
 
-        enableProdMode();
-        platformBrowserDynamic()
-          .bootstrapModule(AppModule)
-          .then((success) => console.log('Bootstrap success'))
-          .catch((err) => console.error(err));
-        `,
+enableProdMode();
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .then((success) => console.log('Bootstrap success'))
+  .catch((err) => console.error(err));
+`,
       },
       {
         description: t(
@@ -144,25 +157,23 @@ npm install --save @sentry/angular
         ),
         language: 'javascript',
         code: `
-        import { APP_INITIALIZER, ErrorHandler, NgModule } from "@angular/core";
-        import { Router } from "@angular/router";
-        // import * as Sentry from "@sentry/angular" // for Angular 10/11 instead
-        import * as Sentry from "@sentry/angular-ivy";
+import { APP_INITIALIZER, ErrorHandler, NgModule } from "@angular/core";
+import { Router } from "@angular/router";
+import * as Sentry from "${getNpmPackage(angularVersion)}";
 
-        @NgModule({
-          // ...
-          providers: [
-            {
-              provide: ErrorHandler,
-              useValue: Sentry.createErrorHandler({
-                showDialog: true,
-              }),
-            },${errorHandlerProviders}
-          ],
-          // ...
-        })
-        export class AppModule {}
-        `,
+@NgModule({
+  // ...
+  providers: [
+    {
+      provide: ErrorHandler,
+      useValue: Sentry.createErrorHandler({
+        showDialog: true,
+      }),
+    },${errorHandlerProviders}
+  ],
+  // ...
+})
+export class AppModule {}`,
       },
     ],
   },
@@ -219,6 +230,7 @@ export function GettingStartedWithAngular({
   projectId,
   ...props
 }: ModuleProps) {
+  const optionValues = useUrlPlatformOptions(platformOptions);
   const integrations: string[] = [];
   const otherConfigs: string[] = [];
 
@@ -257,12 +269,14 @@ export function GettingStartedWithAngular({
       steps={steps({
         sentryInitContent: sentryInitContent.join('\n'),
         errorHandlerProviders: errorHandlerProviders.join('\n'),
+        angularVersion: optionValues.angularVersion as AngularVersion,
         organization,
         newOrg,
         platformKey,
         projectId,
       })}
       nextSteps={nextStepDocs}
+      platformOptions={platformOptions}
       newOrg={newOrg}
       platformKey={platformKey}
       {...props}
@@ -271,9 +285,3 @@ export function GettingStartedWithAngular({
 }
 
 export default GettingStartedWithAngular;
-
-const InstallDescription = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(1)};
-`;

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -46,7 +46,7 @@ export const steps = ({
     description: (
       <p>
         {tct(
-          'Add the Sentry SDK as a dependency using [codeYarn:yarn] or [codeNpm:npm]:',
+          'Add the Sentry SDK as a dependency using [codeNpm:npm] or [codeYarn:yarn]:',
           {
             codeYarn: <code />,
             codeNpm: <code />,
@@ -65,7 +65,7 @@ export const steps = ({
             code: 'npm install --save @sentry/gatsby',
           },
           {
-            label: 'Yarn',
+            label: 'yarn',
             value: 'yarn',
             language: 'bash',
             code: 'yarn add @sentry/gatsby',

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -43,19 +43,34 @@ export const steps = ({
 }: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: t(
-      'Sentry captures data by using an SDK within your application’s runtime.'
+    description: (
+      <p>
+        {tct(
+          'Add the Sentry SDK as a dependency using [codeYarn:yarn] or [codeNpm:npm]:',
+          {
+            codeYarn: <code />,
+            codeNpm: <code />,
+          }
+        )}
+      </p>
     ),
     configurations: [
       {
         language: 'bash',
-        code: `
-# Using yarn
-yarn add @sentry/gatsby
-
-# Using npm
-npm install --save @sentry/gatsby
-        `,
+        code: [
+          {
+            label: 'npm',
+            value: 'npm',
+            language: 'bash',
+            code: 'npm install --save @sentry/gatsby',
+          },
+          {
+            label: 'Yarn',
+            value: 'yarn',
+            language: 'bash',
+            code: 'yarn add @sentry/gatsby',
+          },
+        ],
       },
     ],
   },

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -57,7 +57,7 @@ export const steps = ({
             code: 'npm install --save @sentry/electron',
           },
           {
-            label: 'Yarn',
+            label: 'yarn',
             value: 'yarn',
             language: 'bash',
             code: 'yarn add @sentry/electron',

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -49,13 +49,20 @@ export const steps = ({
     configurations: [
       {
         language: 'bash',
-        code: `
-# Using yarn
-yarn add @sentry/browser
-
-# Using npm
-npm install --save @sentry/browser
-        `,
+        code: [
+          {
+            label: 'npm',
+            value: 'npm',
+            language: 'bash',
+            code: 'npm install --save @sentry/electron',
+          },
+          {
+            label: 'Yarn',
+            value: 'yarn',
+            language: 'bash',
+            code: 'yarn add @sentry/electron',
+          },
+        ],
       },
     ],
   },

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -3,7 +3,7 @@ import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDoc
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Organization, PlatformKey} from 'sentry/types';
 
 type StepProps = {
@@ -43,19 +43,34 @@ export const steps = ({
 }: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: t(
-      'Sentry captures data by using an SDK within your application’s runtime.'
+    description: (
+      <p>
+        {tct(
+          'Add the Sentry SDK as a dependency using [codeYarn:yarn] or [codeNpm:npm]:',
+          {
+            codeYarn: <code />,
+            codeNpm: <code />,
+          }
+        )}
+      </p>
     ),
     configurations: [
       {
         language: 'bash',
-        code: `
-# Using yarn
-yarn add @sentry/react
-
-# Using npm
-npm install --save @sentry/react
-        `,
+        code: [
+          {
+            label: 'npm',
+            value: 'npm',
+            language: 'bash',
+            code: 'npm install --save @sentry/react',
+          },
+          {
+            label: 'Yarn',
+            value: 'yarn',
+            language: 'bash',
+            code: 'yarn add @sentry/react',
+          },
+        ],
       },
     ],
   },

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -46,7 +46,7 @@ export const steps = ({
     description: (
       <p>
         {tct(
-          'Add the Sentry SDK as a dependency using [codeYarn:yarn] or [codeNpm:npm]:',
+          'Add the Sentry SDK as a dependency using [codeNpm:npm] or [codeYarn:yarn]:',
           {
             codeYarn: <code />,
             codeNpm: <code />,
@@ -65,7 +65,7 @@ export const steps = ({
             code: 'npm install --save @sentry/react',
           },
           {
-            label: 'Yarn',
+            label: 'yarn',
             value: 'yarn',
             language: 'bash',
             code: 'yarn add @sentry/react',

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -49,7 +49,7 @@ export const steps = ({
     description: (
       <p>
         {tct(
-          'Add the Sentry SDK as a dependency using [codeYarn:yarn] or [codeNpm:npm]:',
+          'Add the Sentry SDK as a dependency using [codeNpm:npm] or [codeYarn:yarn]:',
           {
             codeYarn: <code />,
             codeNpm: <code />,
@@ -68,7 +68,7 @@ export const steps = ({
             code: 'npm install --save @sentry/remix',
           },
           {
-            label: 'Yarn',
+            label: 'yarn',
             value: 'yarn',
             language: 'bash',
             code: 'yarn add @sentry/remix',

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -46,19 +46,34 @@ export const steps = ({
 } = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: t(
-      'Sentry captures data by using an SDK within your application’s runtime.'
+    description: (
+      <p>
+        {tct(
+          'Add the Sentry SDK as a dependency using [codeYarn:yarn] or [codeNpm:npm]:',
+          {
+            codeYarn: <code />,
+            codeNpm: <code />,
+          }
+        )}
+      </p>
     ),
     configurations: [
       {
         language: 'bash',
-        code: `
-# Using yarn
-yarn add @sentry/remix
-
-# Using npm
-npm install --save @sentry/remix
-        `,
+        code: [
+          {
+            label: 'npm',
+            value: 'npm',
+            language: 'bash',
+            code: 'npm install --save @sentry/remix',
+          },
+          {
+            label: 'Yarn',
+            value: 'yarn',
+            language: 'bash',
+            code: 'yarn add @sentry/remix',
+          },
+        ],
       },
     ],
   },

--- a/static/app/gettingStartedDocs/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.tsx
@@ -43,19 +43,34 @@ export const steps = ({
 }: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: t(
-      'Sentry captures data by using an SDK within your application’s runtime.'
+    description: (
+      <p>
+        {tct(
+          'Add the Sentry SDK as a dependency using [codeYarn:yarn] or [codeNpm:npm]:',
+          {
+            codeYarn: <code />,
+            codeNpm: <code />,
+          }
+        )}
+      </p>
     ),
     configurations: [
       {
         language: 'bash',
-        code: `
-# Using yarn
-yarn add @sentry/svelte
-
-# Using npm
-npm install --save @sentry/svelte
-        `,
+        code: [
+          {
+            label: 'npm',
+            value: 'npm',
+            language: 'bash',
+            code: 'npm install --save @sentry/svelte',
+          },
+          {
+            label: 'Yarn',
+            value: 'yarn',
+            language: 'bash',
+            code: 'yarn add @sentry/svelte',
+          },
+        ],
       },
     ],
   },

--- a/static/app/gettingStartedDocs/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.tsx
@@ -46,7 +46,7 @@ export const steps = ({
     description: (
       <p>
         {tct(
-          'Add the Sentry SDK as a dependency using [codeYarn:yarn] or [codeNpm:npm]:',
+          'Add the Sentry SDK as a dependency using [codeNpm:npm] or [codeYarn:yarn]:',
           {
             codeYarn: <code />,
             codeNpm: <code />,
@@ -65,7 +65,7 @@ export const steps = ({
             code: 'npm install --save @sentry/svelte',
           },
           {
-            label: 'Yarn',
+            label: 'yarn',
             value: 'yarn',
             language: 'bash',
             code: 'yarn add @sentry/svelte',

--- a/static/app/gettingStartedDocs/javascript/vue.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.spec.tsx
@@ -3,7 +3,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 
-import {GettingStartedWithVue, nextSteps, steps} from './vue';
+import {GettingStartedWithVue, nextSteps, steps, VueVersion} from './vue';
 
 describe('GettingStartedWithVue', function () {
   it('all products are selected', function () {
@@ -19,7 +19,10 @@ describe('GettingStartedWithVue', function () {
     );
 
     // Steps
-    for (const step of steps()) {
+    for (const step of steps({
+      vueVersion: VueVersion.V3,
+      sentryInitContent: 'test-init-content',
+    })) {
       expect(
         screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
       ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -2,19 +2,47 @@ import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDo
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
+import {
+  PlatformOption,
+  useUrlPlatformOptions,
+} from 'sentry/components/onboarding/platformOptionsControl';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Organization, PlatformKey} from 'sentry/types';
 
+export enum VueVersion {
+  V3 = 'v3',
+  V2 = 'v2',
+}
+
+type PlaformOptionKey = 'vueVersion';
+
 type StepProps = {
-  newOrg: boolean;
-  organization: Organization;
-  platformKey: PlatformKey;
-  projectId: string;
   sentryInitContent: string;
+  vueVersion: VueVersion;
+  newOrg?: boolean;
+  organization?: Organization;
+  platformKey?: PlatformKey;
+  projectId?: string;
 };
 
 // Configuration Start
+const platformOptions: Record<PlaformOptionKey, PlatformOption> = {
+  vueVersion: {
+    label: t('Spring Boot Version'),
+    items: [
+      {
+        label: t('Vue 3'),
+        value: VueVersion.V3,
+      },
+      {
+        label: t('Vue 2'),
+        value: VueVersion.V2,
+      },
+    ],
+  },
+};
+
 const replayIntegration = `
 new Sentry.Replay(),
 `;
@@ -40,23 +68,39 @@ tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production
 
 export const steps = ({
   sentryInitContent,
+  vueVersion,
   ...props
-}: Partial<StepProps> = {}): LayoutProps['steps'] => [
+}: StepProps): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: t(
-      'Sentry captures data by using an SDK within your application’s runtime.'
+    description: (
+      <p>
+        {tct(
+          'Add the Sentry SDK as a dependency using [codeYarn:yarn] or [codeNpm:npm]:',
+          {
+            codeYarn: <code />,
+            codeNpm: <code />,
+          }
+        )}
+      </p>
     ),
     configurations: [
       {
         language: 'bash',
-        code: `
-# Using yarn
-yarn add @sentry/vue
-
-# Using npm
-npm install --save @sentry/vue
-        `,
+        code: [
+          {
+            label: 'npm',
+            value: 'npm',
+            language: 'bash',
+            code: 'npm install --save @sentry/vue',
+          },
+          {
+            label: 'Yarn',
+            value: 'yarn',
+            language: 'bash',
+            code: 'yarn add @sentry/vue',
+          },
+        ],
       },
     ],
   },
@@ -65,11 +109,12 @@ npm install --save @sentry/vue
     description: t(
       "Initialize Sentry as early as possible in your application's lifecycle."
     ),
-    configurations: [
-      {
-        description: <h5>Vue 3</h5>,
-        language: 'javascript',
-        code: `
+    configurations:
+      vueVersion === VueVersion.V3
+        ? [
+            {
+              language: 'javascript',
+              code: `
         import { createApp } from "vue";
         import { createRouter } from "vue-router";
         import * as Sentry from "@sentry/vue";
@@ -89,11 +134,12 @@ npm install --save @sentry/vue
         app.use(router);
         app.mount("#app");
         `,
-      },
-      {
-        description: <h5>Vue 2</h5>,
-        language: 'javascript',
-        code: `
+            },
+          ]
+        : [
+            {
+              language: 'javascript',
+              code: `
         import Vue from "vue";
         import Router from "vue-router";
         import * as Sentry from "@sentry/vue";
@@ -116,8 +162,8 @@ npm install --save @sentry/vue
           render: (h) => h(App),
         }).$mount("#app");
         `,
-      },
-    ],
+            },
+          ],
   },
   getUploadSourceMapsStep({
     guideLink: 'https://docs.sentry.io/platforms/javascript/guides/vue/sourcemaps/',
@@ -178,6 +224,7 @@ export function GettingStartedWithVue({
   projectId,
   ...props
 }: ModuleProps) {
+  const optionValues = useUrlPlatformOptions(platformOptions);
   const integrations: string[] = [];
   const otherConfigs: string[] = [];
 
@@ -213,6 +260,7 @@ export function GettingStartedWithVue({
     <Layout
       steps={steps({
         sentryInitContent: sentryInitContent.join('\n'),
+        vueVersion: optionValues.vueVersion as VueVersion,
         organization,
         newOrg,
         platformKey,
@@ -221,6 +269,7 @@ export function GettingStartedWithVue({
       nextSteps={nextStepDocs}
       newOrg={newOrg}
       platformKey={platformKey}
+      platformOptions={platformOptions}
       {...props}
     />
   );

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -76,7 +76,7 @@ export const steps = ({
     description: (
       <p>
         {tct(
-          'Add the Sentry SDK as a dependency using [codeYarn:yarn] or [codeNpm:npm]:',
+          'Add the Sentry SDK as a dependency using [codeNpm:npm] or [codeYarn:yarn]:',
           {
             codeYarn: <code />,
             codeNpm: <code />,
@@ -95,7 +95,7 @@ export const steps = ({
             code: 'npm install --save @sentry/vue',
           },
           {
-            label: 'Yarn',
+            label: 'yarn',
             value: 'yarn',
             language: 'bash',
             code: 'yarn add @sentry/vue',


### PR DESCRIPTION
* Simplify multi snippet docs for the platforms `electron`, `javascript`, `javascript-angular`, `javascript-gatsby`, `javascript-react`, `javascript-remix`, `javascript-svelte`, `javascript-vue`.
* Add code tabs for yarn / npm installation
* add selector for vue & angular versions

Relates to https://github.com/getsentry/sentry/issues/56839
