### PR TITLE
Abdk/widget indicators backend validation

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -346,7 +346,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer):
                                 )
 
                 if len(max_values) < len(ThresholdMaxKeys):
-                    for key in [key.value for key in ThresholdMaxKeys]:
+                    for key in allowed_max_keys:
                         if max_values.get(key) is None:
                             raise serializers.ValidationError(
                                 {

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -311,11 +311,6 @@ class DashboardWidgetSerializer(CamelSnakeSerializer):
         # Validate widget thresholds
         thresholds = data.get("thresholds")
         if thresholds:
-            if thresholds.get("unit") and thresholds.get("max_values") is None:
-                raise serializers.ValidationError(
-                    {"thresholds": "Max values must be set before a unit can be chosen."}
-                )
-
             max_values = thresholds.get("max_values")
             allowed_max_keys = [key.value for key in ThresholdMaxKeys]
             if max_values:


### PR DESCRIPTION
For project: [link](https://www.notion.so/sentry/Big-Number-Widget-Improvements-d4b03c4f5b1d4630a5c011a775f2914f)

This PR adds validation for thresholds set from the dashboard widget builder under the feature flag `organizations:dashboard-widget-indicators`.  

![Screenshot 2023-09-29 at 12 52 15 PM](https://github.com/getsentry/sentry/assets/60121741/c1b0b205-c056-4ee1-b148-44b5d74fbf7c)

