### PR TITLE
fix(ui): Give up loading team avatar

### DIFF
--- a/static/app/components/avatar/actorAvatar.tsx
+++ b/static/app/components/avatar/actorAvatar.tsx
@@ -31,9 +31,9 @@ function LoadTeamAvatar({
   ...props
 }: {teamId: string} & Omit<React.ComponentProps<typeof TeamAvatar>, 'team'>) {
   const {teams, isLoading} = useTeamsById({ids: [teamId]});
-  const team = teams.find(t => t.id === teamId);
+  const team = teams.find(t => t.id === teamId) ?? null;
 
-  if (isLoading || !team) {
+  if (isLoading) {
     return <LoadingIndicator mini />;
   }
 

--- a/static/app/components/avatar/actorAvatar.tsx
+++ b/static/app/components/avatar/actorAvatar.tsx
@@ -31,7 +31,7 @@ function LoadTeamAvatar({
   ...props
 }: {teamId: string} & Omit<React.ComponentProps<typeof TeamAvatar>, 'team'>) {
   const {teams, isLoading} = useTeamsById({ids: [teamId]});
-  const team = teams.find(t => t.id === teamId) ?? null;
+  const team = teams.find(t => t.id === teamId);
 
   if (isLoading) {
     return <LoadingIndicator mini />;

--- a/static/app/components/avatar/teamAvatar.tsx
+++ b/static/app/components/avatar/teamAvatar.tsx
@@ -3,7 +3,7 @@ import type {Team} from 'sentry/types';
 import {explodeSlug} from 'sentry/utils';
 
 interface TeamAvatarProps extends Omit<BaseAvatar['props'], 'uploadPath' | 'uploadId'> {
-  team: Team | null;
+  team: Team | null | undefined;
 }
 
 function TeamAvatar({team, tooltip: tooltipProp, ...props}: TeamAvatarProps) {


### PR DESCRIPTION
If the team does not exist, returns null instead of loading forever