### PR TITLE
chore(hybrid-cloud): Mark external user details endpoint as region silo

### DIFF
--- a/src/sentry/api/endpoints/codeowners/external_actor/user_details.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/user_details.py
@@ -8,7 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import control_silo_endpoint
+from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalUserSerializer
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -17,7 +17,7 @@ from sentry.models import ExternalActor, Organization
 logger = logging.getLogger(__name__)
 
 
-@control_silo_endpoint
+@region_silo_endpoint
 class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
     publish_status = {
         "DELETE": ApiPublishStatus.UNKNOWN,

--- a/tests/sentry/api/endpoints/test_external_user_details.py
+++ b/tests/sentry/api/endpoints/test_external_user_details.py
@@ -1,9 +1,9 @@
 from sentry.models import ExternalActor
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import region_silo_test
 
 
-@control_silo_test  # TODO(hybrid-cloud): blocked on org membership mapping
+@region_silo_test(stable=True)
 class ExternalUserDetailsTest(APITestCase):
     endpoint = "sentry-api-0-organization-external-user-details"
     method = "put"


### PR DESCRIPTION


<!-- Describe your PR here. -->