### PR TITLE
fix(discord): Ensure flag in correct part of logic

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1419,10 +1419,13 @@ def get_available_action_integrations_for_org(organization):
     filtered by the list of registered providers.
     :param organization:
     """
+    # Avoids the case where the discord feature flag is off and the action type is discord
     providers = [
         registration.integration_provider
         for registration in AlertRuleTriggerAction.get_registered_types()
         if registration.integration_provider is not None
+        if registration.type != AlertRuleTriggerAction.Type.DISCORD
+        or features.has("organizations:integrations-discord-metric-alerts", organization)
     ]
     return Integration.objects.get_active_integrations(organization.id).filter(
         provider__in=providers

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1479,11 +1479,6 @@ class CreateAlertRuleTriggerActionTest(BaseAlertRuleTriggerActionTest, TestCase)
         type = AlertRuleTriggerAction.Type.DISCORD
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
         channel_id = "channel-id"
-        responses.add(
-            method=responses.GET,
-            url=f"https://discord.com/api/v10/channels/{channel_id}",
-            json=metadata,
-        )
 
         with pytest.raises(InvalidTriggerActionError):
             create_alert_rule_trigger_action(

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1462,7 +1462,6 @@ class CreateAlertRuleTriggerActionTest(BaseAlertRuleTriggerActionTest, TestCase)
         assert action.target_display == channel_id
         assert action.integration_id == integration.id
 
-    @responses.activate
     def test_discord_flag_off(self):
         guild_id = "example-discord-server"
         metadata = {


### PR DESCRIPTION
Ensure endpoint checks for flag before getting available actions. Ensures that user can't see the discord option if their flag is not enabled. Additionally prevents user from saving a poorly serialized alert due to no flag.