### PR TITLE
fix(ui) Update vercel proxy configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
       "source": "/(api|organization-avatar|avatar)/(.*)",
       "destination": "https://sentry.io/$1/$2"
     },
+    {
+      "source": "/region/(\\w+)/(.*)",
+      "destination": "https://$1.sentry.io/$2"
+    },
     {"source": "/_assets/(.*)", "destination": "/$1"},
     {"source": "/(.*)", "destination": "/index.html"}
   ],


### PR DESCRIPTION
With frontend split domains we need to proxy across multiple domains. Because both webpack local development and vercel can't use multiple domains (due to cors). Instead of domains, webpack local dev uses path segments that are rewritten into hosts. These changes should align vercel previews with webpack proxying.
