### PR TITLE
feat: Lower default max.poll.interval.ms on the unified consumer

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -686,7 +686,7 @@ def profiles_consumer(**options):
 @click.option(
     "--max-poll-interval-ms",
     type=int,
-    default=45000,
+    default=30000,
 )
 @click.option(
     "--group-instance-id",


### PR DESCRIPTION
We've been running with 30 seconds for a while now on the metrics indexer, and it's helped with minimizing the impact of rebalancing on rolling deploys. Let's change the default everywhere.