### PR TITLE
nit: fix spelling

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -54,7 +54,7 @@ SENTRY_USE_SNOWFLAKE = getattr(settings, "SENTRY_USE_SNOWFLAKE", False)
 # NOTE:
 # - When you modify this list, ensure that the platform IDs listed in "sentry/static/app/data/platforms.tsx" match.
 # - Please keep this list organized alphabetically.
-GETTING_STARTD_DOCS_PLATFORMS = [
+GETTING_STARTED_DOCS_PLATFORMS = [
     "android",
     "apple",
     "apple-ios",
@@ -600,7 +600,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
 
     @staticmethod
     def is_valid_platform(value):
-        return not value or value == "other" or value in GETTING_STARTD_DOCS_PLATFORMS
+        return not value or value == "other" or value in GETTING_STARTED_DOCS_PLATFORMS
 
     @staticmethod
     def outbox_for_update(project_identifier: int, organization_identifier: int) -> RegionOutbox:


### PR DESCRIPTION
I checked and this variable is not used in `getsentry`, `sentry-docs`, or `develop` repos