### PR TITLE
feat(statistical-detectors): Delay breakpoint check

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -259,10 +259,10 @@ def detect_function_trends(project_ids: List[int], start: datetime, *args, **kwa
                 [(payload.project_id, payload.group) for _, payload in regression_chunk],
                 start,
             ],
-            # delay the check by 6 hours because we want to make sure there
+            # delay the check by 12 hours because we want to make sure there
             # will be enough data after the potential change point to be confident
             # that a change has occurred
-            countdown=6 * 60 * 60,
+            countdown=12 * 60 * 60,
         )
 
 

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -280,8 +280,6 @@ def detect_function_change_points(
     for project_id, fingerprint in functions_list:
         with sentry_sdk.push_scope() as scope:
             scope.set_tag("regressed_project_id", project_id)
-            # the service was originally meant for transactions so this
-            # naming is a result of this
             scope.set_tag("regressed_function_id", fingerprint)
             scope.set_tag("breakpoint", "no")
 

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -254,9 +254,15 @@ def detect_function_trends(project_ids: List[int], start: datetime, *args, **kwa
     regressions = filter(lambda trend: trend[0] == TrendType.Regressed, trends)
 
     for regression_chunk in chunked(regressions, FUNCTIONS_PER_BATCH):
-        detect_function_change_points.delay(
-            [(payload.project_id, payload.group) for _, payload in regression_chunk],
-            start,
+        detect_function_change_points.apply_async(
+            args=[
+                [(payload.project_id, payload.group) for _, payload in regression_chunk],
+                start,
+            ],
+            # delay the check by 6 hours because we want to make sure there
+            # will be enough data after the potential change point to be confident
+            # that a change has occurred
+            countdown=6 * 60 * 60,
         )
 
 
@@ -270,6 +276,20 @@ def detect_function_change_points(
 ) -> None:
     if not options.get("statistical_detectors.enable"):
         return
+
+    for project_id, fingerprint in functions_list:
+        with sentry_sdk.push_scope() as scope:
+            scope.set_tag("regressed_project_id", project_id)
+            # the service was originally meant for transactions so this
+            # naming is a result of this
+            scope.set_tag("regressed_function_id", fingerprint)
+            scope.set_tag("breakpoint", "no")
+
+            scope.set_context(
+                "statistical_detectors",
+                {"timestamp": start.isoformat()},
+            )
+            sentry_sdk.capture_message("Potential Function Regression")
 
     breakpoint_count = 0
     emitted_count = 0
@@ -452,6 +472,7 @@ def emit_function_regression_issue(
 
     for entry in breakpoints:
         with sentry_sdk.push_scope() as scope:
+            scope.set_tag("breakpoint", "yes")
             scope.set_tag("regressed_project_id", entry["project"])
             # the service was originally meant for transactions so this
             # naming is a result of this
@@ -466,7 +487,7 @@ def emit_function_regression_issue(
                     "breakpoint_timestamp": breakpoint_ts.isoformat(),
                 },
             )
-            sentry_sdk.capture_message("Potential Regression")
+            sentry_sdk.capture_message("Potential Function Regression")
 
         project_id = int(entry["project"])
         fingerprint = int(entry["transaction"])

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -292,7 +292,7 @@ def test_detect_function_trends(
     with override_options({"statistical_detectors.enable": True}), TaskRunner():
         for ts in timestamps:
             detect_function_trends([project.id], ts)
-    assert detect_function_change_points.delay.called
+    assert detect_function_change_points.apply_async.called
 
 
 @mock.patch("sentry.tasks.statistical_detectors.emit_function_regression_issue")


### PR DESCRIPTION
Immediately checking for breakpoints likely will not result in a result because the algorithm may not have enough confidence to identify a breakpoint. For now, add a 12-hour delay before checking for breakpoints.