### PR TITLE
fix(statistical-detectors): Remove bad assert in functions trends

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -365,5 +365,5 @@ def forward_regression_occurrences(
             }
         )
 
-    get_from_profiling_service(method="POST", path="/regressed", json_data=payloads)
-    assert 0
+    if payloads:
+        get_from_profiling_service(method="POST", path="/regressed", json_data=payloads)


### PR DESCRIPTION
Make sure there is a payload prior to making the request and remove bad assert.