### PR TITLE
fix(uncompressed-asset): Update transfer size key

### DIFF
--- a/fixtures/events/performance_problems/uncompressed-assets/uncompressed-script-asset.json
+++ b/fixtures/events/performance_problems/uncompressed-assets/uncompressed-script-asset.json
@@ -56,7 +56,7 @@
       "data": {
         "http.decoded_response_content_length": 3,
         "http.response_content_length": 2,
-        "http.transfer_size": 3
+        "http.response_transfer_size": 3
       },
       "hash": "b2978b51d54d9078"
     },
@@ -72,7 +72,7 @@
       "data": {
         "http.decoded_response_content_length": 571733,
         "http.response_content_length": 571733,
-        "http.transfer_size": 571833
+        "http.response_transfer_size": 571833
       },
       "hash": "a2978b51d54d9079"
     }

--- a/src/sentry/utils/mockdata/core.py
+++ b/src/sentry/utils/mockdata/core.py
@@ -1049,7 +1049,7 @@ def create_mock_transactions(
                     "span_id": uuid4().hex[:16],
                     "hash": "858fea692d4d93e9",
                     "data": {
-                        "http.transfer_size": 1_000_000,
+                        "http.response_transfer_size": 1_000_000,
                         "http.response_content_length": 1_000_000,
                         "http.decoded_response_content_length": 1_000_000,
                     },

--- a/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
@@ -47,7 +47,7 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
         # TODO(nar): The sentence-style keys can be removed once SDK adoption has increased and
         # we are receiving snake_case keys consistently, likely beyond October 2023
         transfer_size = data and (
-            data.get("http.transfer_size", None) or data.get("Transfer Size", None)
+            data.get("http.response_transfer_size", None) or data.get("Transfer Size", None)
         )
         encoded_body_size = data and (
             data.get("http.response_content_length", None) or data.get("Encoded Body Size", None)

--- a/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
+++ b/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
@@ -40,7 +40,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 "GET /api/0/organizations/endpoint1",
                 "hash1",
                 data={
-                    "http.transfer_size": 50_000_000,
+                    "http.response_transfer_size": 50_000_000,
                     "http.response_content_length": 50_000_000,
                     "http.decoded_response_content_length": 50_000_000,
                 },
@@ -76,7 +76,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 "GET /api/0/organizations/endpoint1",
                 "hash1",
                 data={
-                    "http.transfer_size": 50_000_000,
+                    "http.response_transfer_size": 50_000_000,
                     "http.response_content_length": 50_000_000,
                     "http.decoded_response_content_length": 50_000_000,
                 },
@@ -108,7 +108,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
                 duration=1000.0,
                 data={
-                    "http.transfer_size": 50_000_000,
+                    "http.response_transfer_size": 50_000_000,
                     "http.response_content_length": 50_000_000,
                     "http.decoded_response_content_length": 50_000_000,
                 },
@@ -125,7 +125,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.mp3",
                 duration=1000.0,
                 data={
-                    "http.transfer_size": 50_000_000,
+                    "http.response_transfer_size": 50_000_000,
                     "http.response_content_length": 50_000_000,
                     "http.decoded_response_content_length": 50_000_000,
                 },
@@ -142,7 +142,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.json",
                 duration=1000.0,
                 data={
-                    "http.transfer_size": 50_000_000,
+                    "http.response_transfer_size": 50_000_000,
                     "http.response_content_length": 50_000_000,
                     "http.decoded_response_content_length": 50_000_000,
                 },
@@ -176,7 +176,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.json?foo=bar",
                 duration=1000.0,
                 data={
-                    "http.transfer_size": 50_000_000,
+                    "http.response_transfer_size": 50_000_000,
                     "http.response_content_length": 50_000_000,
                     "http.decoded_response_content_length": 50_000_000,
                 },
@@ -210,7 +210,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.json/?foo=bar",
                 duration=1000.0,
                 data={
-                    "http.transfer_size": 50_000_000,
+                    "http.response_transfer_size": 50_000_000,
                     "http.response_content_length": 50_000_000,
                     "http.decoded_response_content_length": 50_000_000,
                 },
@@ -244,7 +244,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.json/?foo=bar",
                 duration=1.0,
                 data={
-                    "http.transfer_size": 50_000_000,
+                    "http.response_transfer_size": 50_000_000,
                     "http.response_content_length": 50_000_000,
                     "http.decoded_response_content_length": 50_000_000,
                 },

--- a/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
+++ b/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
@@ -39,7 +39,7 @@ def _valid_render_blocking_asset_event(url: str) -> dict[str, Any]:
                 desc=url,
                 duration=1000.0,
                 data={
-                    "http.transfer_size": 1200000,
+                    "http.response_transfer_size": 1200000,
                     "http.response_content_length": 1200000,
                     "http.decoded_response_content_length": 2000000,
                     "resource.render_blocking_status": "blocking",

--- a/tests/sentry/utils/performance_issues/test_uncompressed_asset_detector.py
+++ b/tests/sentry/utils/performance_issues/test_uncompressed_asset_detector.py
@@ -34,7 +34,7 @@ def create_compressed_asset_span():
         desc="https://someothersite.example.com/app.js",
         duration=1.0,
         data={
-            "http.transfer_size": 5,
+            "http.response_transfer_size": 5,
             "http.response_content_length": 4,
             "http.decoded_response_content_length": 5,
         },
@@ -62,7 +62,7 @@ class UncompressedAssetsDetectorTest(TestCase):
                 create_asset_span(
                     duration=1000.0,
                     data={
-                        "http.transfer_size": 1_000_000,
+                        "http.response_transfer_size": 1_000_000,
                         "http.response_content_length": 1_000_000,
                         "http.decoded_response_content_length": 1_000_000,
                     },
@@ -99,7 +99,7 @@ class UncompressedAssetsDetectorTest(TestCase):
                 create_asset_span(
                     duration=1000.0,
                     data={
-                        "http.transfer_size": 1_000_000,
+                        "http.response_transfer_size": 1_000_000,
                         "http.response_content_length": 1_000_000,
                         "http.decoded_response_content_length": 1_000_000,
                     },
@@ -138,7 +138,7 @@ class UncompressedAssetsDetectorTest(TestCase):
                     desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.css",
                     duration=1000.0,
                     data={
-                        "http.transfer_size": 1_000_000,
+                        "http.response_transfer_size": 1_000_000,
                         "http.response_content_length": 1_000_000,
                         "http.decoded_response_content_length": 1_000_000,
                     },
@@ -177,7 +177,7 @@ class UncompressedAssetsDetectorTest(TestCase):
                     desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.css",
                     duration=1000.0,
                     data={
-                        "http.transfer_size": 1_000_000,
+                        "http.response_transfer_size": 1_000_000,
                         "http.response_content_length": 1_000_000,
                         "http.decoded_response_content_length": 1_000_000,
                     },
@@ -211,7 +211,7 @@ class UncompressedAssetsDetectorTest(TestCase):
                 desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/some.jpg",
                 duration=1000.0,
                 data={
-                    "http.transfer_size": 1_000_000,
+                    "http.response_transfer_size": 1_000_000,
                     "http.response_content_length": 1_000_000,
                     "http.decoded_response_content_length": 1_000_000,
                 },
@@ -232,7 +232,7 @@ class UncompressedAssetsDetectorTest(TestCase):
                     desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.css",
                     duration=1000.0,
                     data={
-                        "http.transfer_size": 1_000_000,
+                        "http.response_transfer_size": 1_000_000,
                         "http.response_content_length": 1_000_000,
                         "http.decoded_response_content_length": 1_000_000,
                     },
@@ -266,7 +266,7 @@ class UncompressedAssetsDetectorTest(TestCase):
                 desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.woff2",
                 duration=1000.0,
                 data={
-                    "http.transfer_size": 1_000_000,
+                    "http.response_transfer_size": 1_000_000,
                     "http.response_content_length": 1_000_000,
                     "http.decoded_response_content_length": 1_000_000,
                 },
@@ -285,7 +285,7 @@ class UncompressedAssetsDetectorTest(TestCase):
                 create_asset_span(
                     duration=1000.0,
                     data={
-                        "http.transfer_size": 1_000_000,
+                        "http.response_transfer_size": 1_000_000,
                         "http.response_content_length": 1_000_000,
                         "http.decoded_response_content_length": 1_000_000,
                     },
@@ -304,7 +304,7 @@ class UncompressedAssetsDetectorTest(TestCase):
                 create_asset_span(
                     duration=1000.0,
                     data={
-                        "http.transfer_size": 1_000_000,
+                        "http.response_transfer_size": 1_000_000,
                         "http.response_content_length": 99_999,
                         "http.decoded_response_content_length": 99_999,
                     },
@@ -323,7 +323,7 @@ class UncompressedAssetsDetectorTest(TestCase):
                 create_asset_span(
                     duration=1000.0,
                     data={
-                        "http.transfer_size": 1_000_000,
+                        "http.response_transfer_size": 1_000_000,
                         "http.response_content_length": 101_000,
                         "http.decoded_response_content_length": 100_999,
                     },
@@ -342,7 +342,7 @@ class UncompressedAssetsDetectorTest(TestCase):
                 create_asset_span(
                     duration=50.0,
                     data={
-                        "http.transfer_size": 1_000_000,
+                        "http.response_transfer_size": 1_000_000,
                         "http.response_content_length": 101_000,
                         "http.decoded_response_content_length": 101_000,
                     },


### PR DESCRIPTION
There was a migration from sentence-styled keys to snake case keys that are more aligned with OTel standards. This key was changed last minute and didn't get the new one.

See: https://develop.sentry.dev/sdk/performance/span-data-conventions/#deprecated