### PR TITLE
fix(loader): Use double quotes for loader link

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -142,7 +142,7 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
             flexibleControlStateSize
           >
             <TextCopyInput aria-label={t('Loader Script')}>
-              {`<script src='${loaderLink}' crossorigin="anonymous"></script>`}
+              {`<script src="${loaderLink}" crossorigin="anonymous"></script>`}
             </TextCopyInput>
           </FieldGroup>
 


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry/issues/57198

Matches the snippet with our docs: https://docs.sentry.io/platforms/javascript/install/loader/ to standardize on using double quotes.