### PR TITLE
feat(statistical-detectors): Render a function regression issue

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
+++ b/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
@@ -1,8 +1,10 @@
 import DateTime from 'sentry/components/dateTime';
 import {DataSection} from 'sentry/components/events/styles';
 import Link from 'sentry/components/links/link';
+import PerformanceDuration from 'sentry/components/performanceDuration';
 import {t, tct} from 'sentry/locale';
-import {Event} from 'sentry/types';
+import {Event, Group, IssueType} from 'sentry/types';
+import {defined} from 'sentry/utils';
 import {formatPercentage} from 'sentry/utils/formatters';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
@@ -13,9 +15,36 @@ import {
 
 type EventStatisticalDetectorMessageProps = {
   event: Event;
+  group: Group;
 };
 
-function EventStatisticalDetectorMessage({event}: EventStatisticalDetectorMessageProps) {
+function EventStatisticalDetectorMessage({
+  event,
+  group,
+}: EventStatisticalDetectorMessageProps) {
+  switch (group.issueType) {
+    case IssueType.PERFORMANCE_DURATION_REGRESSION: {
+      return (
+        <EventStatisticalDetectorRegressedPerformanceMessage
+          event={event}
+          group={group}
+        />
+      );
+    }
+    case IssueType.PROFILE_FUNCTION_REGRESSION_EXPERIMENTAL: {
+      return (
+        <EventStatisticalDetectorRegressedFunctionMessage event={event} group={group} />
+      );
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
+function EventStatisticalDetectorRegressedPerformanceMessage({
+  event,
+}: EventStatisticalDetectorMessageProps) {
   const organization = useOrganization();
 
   const transactionName = event?.occurrence?.evidenceData?.transaction;
@@ -41,6 +70,37 @@ function EventStatisticalDetectorMessage({event}: EventStatisticalDetectorMessag
             ),
             amount: formatPercentage(
               event?.occurrence?.evidenceData?.trendPercentage - 1
+            ),
+            date: <DateTime date={detectionTime} dateOnly />,
+            time: <DateTime date={detectionTime} timeOnly />,
+          }
+        )}
+      </div>
+    </DataSection>
+  );
+}
+
+function EventStatisticalDetectorRegressedFunctionMessage({
+  event,
+}: EventStatisticalDetectorMessageProps) {
+  const evidenceData = event?.occurrence?.evidenceData;
+  const percentageChange = evidenceData?.trendPercentage;
+  const detectionTime = new Date(evidenceData?.breakpoint * 1000);
+
+  return (
+    <DataSection>
+      <div style={{display: 'inline'}}>
+        {tct(
+          'There was [change] in duration (P95) from [before] to [after] around [date] at [time]. The example profiles may indicate what changed in the regression.',
+          {
+            change: defined(percentageChange)
+              ? t('a %s increase', formatPercentage(percentageChange))
+              : t('an increase'),
+            before: (
+              <PerformanceDuration nanoseconds={evidenceData?.aggregateRange1 ?? 0} />
+            ),
+            after: (
+              <PerformanceDuration nanoseconds={evidenceData?.aggregateRange2 ?? 0} />
             ),
             date: <DateTime date={detectionTime} dateOnly />,
             time: <DateTime date={detectionTime} timeOnly />,

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -81,6 +81,7 @@ export enum IssueType {
   PROFILE_REGEX_MAIN_THREAD = 'profile_regex_main_thread',
   PROFILE_FRAME_DROP = 'profile_frame_drop',
   PROFILE_FRAME_DROP_EXPERIMENTAL = 'profile_frame_drop_experimental',
+  PROFILE_FUNCTION_REGRESSION_EXPERIMENTAL = 'profile_function_regression_exp',
 }
 
 export enum IssueTitle {

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -70,26 +70,18 @@ function GroupEventEntry({event, entryType, group, project}: GroupEventEntryProp
   );
 }
 
-function GroupEventDetailsContent({
+function DefaultGroupEventDetailsContent({
   group,
   event,
   project,
-}: GroupEventDetailsContentProps) {
+}: Required<GroupEventDetailsContentProps>) {
   const organization = useOrganization();
   const location = useLocation();
   const projectSlug = project.slug;
-  const hasReplay = Boolean(event?.tags?.find(({key}) => key === 'replayId')?.value);
-  const mechanism = event?.tags?.find(({key}) => key === 'mechanism')?.value;
+  const hasReplay = Boolean(event.tags?.find(({key}) => key === 'replayId')?.value);
+  const mechanism = event.tags?.find(({key}) => key === 'mechanism')?.value;
   const isANR = mechanism === 'ANR' || mechanism === 'AppExitInfo';
   const hasAnrImprovementsFeature = organization.features.includes('anr-improvements');
-
-  if (!event) {
-    return (
-      <NotFoundMessage>
-        <h3>{t('Latest event not available')}</h3>
-      </NotFoundMessage>
-    );
-  }
 
   const eventEntryProps = {group, event, project};
 
@@ -98,32 +90,6 @@ function GroupEventDetailsContent({
     organization,
     projectSlug,
   });
-
-  if (group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION) {
-    return (
-      <Feature
-        features={['performance-duration-regression-visible']}
-        organization={organization}
-        renderDisabled
-      >
-        <Fragment>
-          <RegressionMessage event={event} />
-          <ErrorBoundary mini>
-            <EventBreakpointChart event={event} />
-          </ErrorBoundary>
-          <ErrorBoundary mini>
-            <EventSpanOpBreakdown event={event} />
-          </ErrorBoundary>
-          <ErrorBoundary mini>
-            <AggregateSpanDiff event={event} projectId={project.id} />
-          </ErrorBoundary>
-          <ErrorBoundary mini>
-            <EventComparison event={event} group={group} project={project} />
-          </ErrorBoundary>
-        </Fragment>
-      </Feature>
-    );
-  }
 
   return (
     <Fragment>
@@ -214,6 +180,97 @@ function GroupEventDetailsContent({
       )}
     </Fragment>
   );
+}
+
+function PerformanceDurationRegressionIssueDetailsContent({
+  group,
+  event,
+  project,
+}: Required<GroupEventDetailsContentProps>) {
+  const organization = useOrganization();
+
+  return (
+    <Feature
+      features={['performance-duration-regression-visible']}
+      organization={organization}
+      renderDisabled
+    >
+      <Fragment>
+        <RegressionMessage event={event} group={group} />
+        <ErrorBoundary mini>
+          <EventBreakpointChart event={event} />
+        </ErrorBoundary>
+        <ErrorBoundary mini>
+          <EventSpanOpBreakdown event={event} />
+        </ErrorBoundary>
+        <ErrorBoundary mini>
+          <AggregateSpanDiff event={event} projectId={project.id} />
+        </ErrorBoundary>
+        <ErrorBoundary mini>
+          <EventComparison event={event} group={group} project={project} />
+        </ErrorBoundary>
+      </Fragment>
+    </Feature>
+  );
+}
+
+function ProfilingDurationRegressionIssueDetailsContent({
+  group,
+  event,
+}: Required<GroupEventDetailsContentProps>) {
+  const organization = useOrganization();
+
+  return (
+    <Feature
+      features={['profile-function-regression-exp-visible']}
+      organization={organization}
+      renderDisabled
+    >
+      <Fragment>
+        <RegressionMessage event={event} group={group} />
+      </Fragment>
+    </Feature>
+  );
+}
+
+function GroupEventDetailsContent({
+  group,
+  event,
+  project,
+}: GroupEventDetailsContentProps) {
+  if (!event) {
+    return (
+      <NotFoundMessage>
+        <h3>{t('Latest event not available')}</h3>
+      </NotFoundMessage>
+    );
+  }
+
+  switch (group.issueType) {
+    case IssueType.PERFORMANCE_DURATION_REGRESSION: {
+      return (
+        <PerformanceDurationRegressionIssueDetailsContent
+          group={group}
+          event={event}
+          project={project}
+        />
+      );
+    }
+    case IssueType.PROFILE_FUNCTION_REGRESSION_EXPERIMENTAL: {
+      return (
+        <ProfilingDurationRegressionIssueDetailsContent
+          group={group}
+          event={event}
+          project={project}
+        />
+      );
+    }
+    default: {
+      return (
+        <DefaultGroupEventDetailsContent group={group} event={event} project={project} />
+      );
+    }
+  }
 }
 
 const NotFoundMessage = styled('div')`


### PR DESCRIPTION
Similar to an issue for a regressed transaction, the regressed function issues do not follow the same template as a regular issue. This PR starts the work to branch away from the usual component to provide a custom component to render the issue for a regressed function.