### PR TITLE
fix(api): Actually order body params by required vs optional

### DIFF
--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -3,7 +3,7 @@ import os
 from collections import OrderedDict
 from typing import Any, Dict, List, Literal, Mapping, Set, Tuple, TypedDict
 
-import jsonref
+from jsonref import JsonRef
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -199,7 +199,7 @@ def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, 
 def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> Any:
     # Populate references with lazy lookup objects. This is required so we can
     # order request body parameters by required and optional.
-    result = jsonref.JsonRef.replace_refs(result)
+    result = JsonRef.replace_refs(result)
 
     for path, endpoints in result["paths"].items():
         for method_info in endpoints.values():


### PR DESCRIPTION
Closed in favor of manual dereferencing in: https://github.com/getsentry/sentry/pull/57639
There were concerns about the `jsonrefs` package and it's actually quite simple to manually dereference
-----

Previously, this ordering silently failed because the request body `schema` we were fetching only had a reference to it's actual key-value pairs. At the very start of the hook, we now replace all references with a lazy lookup object, which will replace the reference with the real key-value pairs when called upon.

See `jsonref` [documentation](https://jsonref.readthedocs.io/en/latest/#jsonref.replace_refs) for more info