### PR TITLE
ref(backup): Fetch limited model set when exporting

### DIFF
--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -139,6 +139,13 @@ class ModelRelations:
 
         return {ff.model for ff in self.foreign_keys.values()}
 
+    def get_possible_relocation_scopes(self) -> set[RelocationScope]:
+        from sentry.db.models import BaseModel
+
+        if issubclass(self.model, BaseModel):
+            return self.model.get_possible_relocation_scopes()
+        return set()
+
 
 def get_model_name(model: type[models.Model] | models.Model) -> NormalizedModelName:
     return NormalizedModelName(f"{model._meta.app_label}.{model._meta.object_name}")
@@ -227,6 +234,13 @@ class PrimaryKeyMap:
             return None
 
         return entry[0]
+
+    def get_pks(self, model_name: NormalizedModelName) -> Set[int]:
+        """
+        Get a list of all of the pks for a specific model.
+        """
+
+        return {entry[0] for entry in self.mapping[str(model_name)].items()}
 
     def get_kind(self, model_name: NormalizedModelName, old: int) -> Optional[ImportKind]:
         """

--- a/src/sentry/backup/exports.py
+++ b/src/sentry/backup/exports.py
@@ -67,6 +67,7 @@ def _export(
     filters = []
     if filter_by is not None:
         filters.append(filter_by)
+        user_pks = []
 
         if filter_by.model == Organization:
             org_pks = [o.pk for o in Organization.objects.filter(slug__in=filter_by.values)]
@@ -76,12 +77,19 @@ def _export(
             ]
             filters.append(Filter(User, "pk", set(user_pks)))
         elif filter_by.model == User:
-            user_pks = [u.pk for u in User.objects.filter(username__in=filter_by.values)]
+            if filter_by.field == "pk":
+                user_pks = [u.pk for u in User.objects.filter(id__in=filter_by.values)]
+            elif filter_by.field == "username":
+                user_pks = [u.pk for u in User.objects.filter(username__in=filter_by.values)]
+            else:
+                raise ValueError(
+                    "Filter arguments must only apply to `User`'s `pk`' or `username` fields"
+                )
         else:
-            raise TypeError("Filter arguments must only apply to `Organization` or `User` models")
+            raise ValueError("Filter arguments must only apply to `Organization` or `User` models")
 
-        # `sentry.Email` models don't have any explicit dependencies on `User`, so we need to find
-        # them manually via `UserEmail`.
+        # `Sentry.Email` models don't have any explicit dependencies on `Sentry.User`, so we need to
+        # find them manually via `UserEmail`.
         emails = [ue.email for ue in UserEmail.objects.filter(user__in=user_pks)]
         filters.append(Filter(Email, "email", set(emails)))
 
@@ -120,18 +128,57 @@ def _export(
 
     def yield_objects():
         from sentry.db.models.base import BaseModel
+        from sentry.models.actor import Actor
+
+        deps = dependencies()
 
         # Collate the objects to be serialized.
         for model in sorted_dependencies():
             if not issubclass(model, BaseModel):
                 continue
 
+            model_name = get_model_name(model)
+            model_relations = deps[model_name]
             possible_relocation_scopes = model.get_possible_relocation_scopes()
             includable = possible_relocation_scopes & allowed_relocation_scopes
             if not includable or model._meta.proxy:
                 continue
 
-            queryset = model._base_manager.order_by(model._meta.pk.name)  # type: ignore
+            q = Q()
+
+            # Only do database query filtering if this is a non-global export. If it is a global
+            # export, we want absolutely every relocatable model, so no need to filter.
+            if scope != ExportScope.Global:
+                # Create a Django filter from the relevant `filter_by` clauses.
+                query = dict()
+                for f in filters:
+                    if f.model == model:
+                        query[f.field + "__in"] = f.values
+                q &= Q(**query)
+
+                # TODO: actor refactor. Remove this conditional. For now, we do no filtering on
+                # actors.
+                if model_name != get_model_name(Actor):
+                    # Create a filter for each possible FK reference to constrain the amount of data
+                    # being sent over from the database. We only want models where every FK field
+                    # references into a model whose PK we've already exported (or `NULL`, if the FK
+                    # field is nullable).
+                    for field_name, foreign_field in model_relations.foreign_keys.items():
+                        foreign_field_model_name = get_model_name(foreign_field.model)
+                        matched_fks = set(pk_map.get_pks(foreign_field_model_name))
+                        matched_fks_query = dict()
+                        if len(matched_fks) > 0:
+                            matched_fks_query[field_name + "__in"] = matched_fks
+
+                        if foreign_field.nullable:
+                            match_on_null_query = dict()
+                            match_on_null_query[field_name + "__isnull"] = True
+                            q &= Q(**matched_fks_query) | Q(**match_on_null_query)
+                        else:
+                            q &= Q(**matched_fks_query)
+
+            pk_name = model._meta.pk.name  # type: ignore
+            queryset = model._base_manager.filter(q).order_by(pk_name)
             yield from filter_objects(queryset.iterator())
 
     serialize(

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -132,18 +132,18 @@ def import_users(src, filter_usernames, merge_users, silent):
 @import_.command(name="organizations")
 @click.argument("src", type=click.File("rb"))
 @click.option(
-    "--merge_users",
-    default=False,
-    is_flag=True,
-    help=MERGE_USERS_HELP,
-)
-@click.option(
     "--filter_org_slugs",
     default="",
     type=str,
     help="An optional comma-separated list of organization slugs to include. "
     "If this option is not set, all encountered organizations are imported. "
     "Users not members of at least one organization in this set will not be imported.",
+)
+@click.option(
+    "--merge_users",
+    default=False,
+    is_flag=True,
+    help=MERGE_USERS_HELP,
 )
 @click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration

--- a/tests/sentry/backup/test_exhaustive.py
+++ b/tests/sentry/backup/test_exhaustive.py
@@ -72,6 +72,8 @@ class UniquenessTests(BackupTestCase):
             with open(tmp_expect) as tmp_file:
                 # Back-to-back global scope imports are disallowed (global scope assume a clean
                 # database), so use organization scope instead.
+                #
+                # TODO(getsentry/team-ospo#201): Change to global scope once have collision tests.
                 import_in_organization_scope(tmp_file, printer=NOOP_PRINTER)
 
                 actual = export_to_file(tmp_actual, ExportScope.Global)
@@ -92,6 +94,8 @@ class UniquenessTests(BackupTestCase):
             with open(tmp_expect) as tmp_file:
                 # Back-to-back global scope imports are disallowed (global scope assume a clean
                 # database), so use organization scope instead.
+                #
+                # TODO(getsentry/team-ospo#201): Change to global scope once have collision tests.
                 import_in_organization_scope(tmp_file, printer=NOOP_PRINTER)
 
                 actual = export_to_file(tmp_actual, ExportScope.Global)

--- a/tests/sentry/backup/test_exports.py
+++ b/tests/sentry/backup/test_exports.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import tempfile
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Type
 
-from sentry.backup.dependencies import get_model_name
-from sentry.backup.helpers import get_exportable_sentry_models
+from sentry.backup.dependencies import NormalizedModelName, get_model, get_model_name
 from sentry.backup.scopes import ExportScope
 from sentry.db import models
 from sentry.models.email import Email
@@ -18,6 +18,7 @@ from sentry.models.userpermission import UserPermission
 from sentry.models.userrole import UserRole, UserRoleUser
 from sentry.testutils.helpers.backups import BackupTestCase, export_to_file
 from sentry.utils.json import JSONData
+from tests.sentry.backup import get_matching_exportable_models
 
 
 class ExportTestCase(BackupTestCase):
@@ -32,65 +33,56 @@ class ScopingTests(ExportTestCase):
     """
 
     @staticmethod
-    def get_models_for_scope(scope: ExportScope) -> set[str]:
-        matching_models = set()
-        for model in get_exportable_sentry_models():
-            if model.get_possible_relocation_scopes() & scope.value:
-                obj_name = model._meta.object_name
-                if obj_name is not None:
-                    matching_models.add("sentry." + obj_name.lower())
-        return matching_models
+    def verify_model_inclusion(data: JSONData, scope: ExportScope):
+        """
+        Ensure all in-scope models are included, and that no out-of-scope models are included.
+        """
+        matching_models = get_matching_exportable_models(
+            lambda mr: len(mr.get_possible_relocation_scopes() & scope.value) > 0
+        )
+        unseen_models = deepcopy(matching_models)
+
+        for entry in data:
+            model_name = NormalizedModelName(entry["model"])
+            model = get_model(model_name)
+            if model is not None:
+                unseen_models.discard(model)
+                if model not in matching_models:
+                    raise AssertionError(
+                        f"Model `{model_name}` was included in export despite not containing one of these relocation scopes: {scope.value}"
+                    )
+
+        if unseen_models:
+            raise AssertionError(
+                f"The following models were not included in the export: ${unseen_models}; this is despite it being included in at least one of the following relocation scopes: {scope.value}"
+            )
 
     def test_user_export_scoping(self):
-        matching_models = self.get_models_for_scope(ExportScope.User)
         self.create_exhaustive_instance(is_superadmin=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
             data = self.export(tmp_dir, scope=ExportScope.User)
-            for entry in data:
-                model_name = entry["model"]
-                if model_name not in matching_models:
-                    raise AssertionError(
-                        f"Model `${model_name}` was included in export despite not being `RelocationScope.User`"
-                    )
+            self.verify_model_inclusion(data, ExportScope.User)
 
     def test_organization_export_scoping(self):
-        matching_models = self.get_models_for_scope(ExportScope.Organization)
         self.create_exhaustive_instance(is_superadmin=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
             data = self.export(tmp_dir, scope=ExportScope.Organization)
-            for entry in data:
-                model_name = entry["model"]
-                if model_name not in matching_models:
-                    raise AssertionError(
-                        f"Model `${model_name}` was included in export despite not being `RelocationScope.User` or `RelocationScope.Organization`"
-                    )
+            self.verify_model_inclusion(data, ExportScope.Organization)
 
     def test_config_export_scoping(self):
-        matching_models = self.get_models_for_scope(ExportScope.Config)
         self.create_exhaustive_instance(is_superadmin=True)
         self.create_exhaustive_user("admin", is_admin=True)
         self.create_exhaustive_user("staff", is_staff=True)
         self.create_exhaustive_user("superuser", is_superuser=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
             data = self.export(tmp_dir, scope=ExportScope.Config)
-            for entry in data:
-                model_name = entry["model"]
-                if model_name not in matching_models:
-                    raise AssertionError(
-                        f"Model `${model_name}` was included in export despite not being `RelocationScope.User` or `RelocationScope.Config`"
-                    )
+            self.verify_model_inclusion(data, ExportScope.Config)
 
     def test_global_export_scoping(self):
-        matching_models = self.get_models_for_scope(ExportScope.Global)
         self.create_exhaustive_instance(is_superadmin=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
             data = self.export(tmp_dir, scope=ExportScope.Global)
-            for entry in data:
-                model_name = entry["model"]
-                if model_name not in matching_models:
-                    raise AssertionError(
-                        f"Model `${model_name}` was included in export despite being labeled `RelocationScope.Excluded"
-                    )
+            self.verify_model_inclusion(data, ExportScope.Global)
 
 
 class FilteringTests(ExportTestCase):


### PR DESCRIPTION
Before, the method by which an export occurred was to simply pull down ALL instances of a model, and filter them in-memory. This is obviously extraordinarily inefficient and wasteful. This new method filters those models down constructing a database query that only includes models that could possibly be included in the export via the set of FKs they rely on.

Issue: getsentry/team-ospo#201