### PR TITLE
fix(replays): fix formatting when widget example replays load

### DIFF
--- a/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
+++ b/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
@@ -74,15 +74,14 @@ export default function ExampleReplaysList({
 
   return (
     <Fragment>
-      {isFetching && (
-        <StatusContainer>
-          <LoadingIndicator />
-        </StatusContainer>
-      )}
       {fetchError || (!isFetching && !replays?.length) ? (
         <EmptyStateWarning withIcon={false} small>
           {t('No replays found')}
         </EmptyStateWarning>
+      ) : isFetching ? (
+        <StatusContainer>
+          <LoadingIndicator />
+        </StatusContainer>
       ) : (
         replays?.map(r => {
           return (


### PR DESCRIPTION
before, the loading container was sitting on top of the example replays, rather than replacing it

bug before:

https://github.com/getsentry/sentry/assets/56095982/fdd9a406-34d1-4f54-a7d4-7e11a4a0beae



after fix:

https://github.com/getsentry/sentry/assets/56095982/444155f7-8549-4e2a-a05e-13ec4bb86f87

