### PR TITLE
feat(escalating-issues): Create Metrics Query for is_escalating

### DIFF
--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -461,14 +461,19 @@ def _get_group_hourly_count_with_metrics(
             use_case_id=UseCaseID.ESCALATING_ISSUES,
         )
 
-        metrics_hourly_count = next(
-            iter(
-                next(iter(metrics_series_results.get("groups", [])), {})
-                .get("series", {})
-                .get("event_ingested", [])
-            ),
-            0,
-        )
+        groups: List[Dict[str, Any]] = metrics_series_results.get("groups", [])
+
+        # Get the first item from groups or use a default empty dict
+        first_group: Dict[str, Any] = next(iter(groups), {})
+
+        # Get the "series" dict from the first group or default to an empty dict
+        series_dict: Dict[str, Any] = first_group.get("series", {})
+
+        # Finally, get the "event_ingested" list or default to an empty list
+        event_ingested: List[int] = series_dict.get("event_ingested", [])
+
+        # Extract the hourly count
+        metrics_hourly_count = next(iter(event_ingested), 0)
 
         if metrics_hourly_count != hourly_count:
             logger.info(
@@ -485,7 +490,7 @@ def _get_group_hourly_count_with_metrics(
 
 def _query_metrics_for_group_hourly_count(
     group: Group, now: datetime, current_hour: datetime
-) -> int:
+) -> MetricsQuery:
     """
     This function generates a query to fetch the current hour's events
     for a group_id through the Generic Metrics Backend.

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -454,7 +454,15 @@ def _get_group_hourly_count_with_metrics(
     if group.issue_category == GroupCategory.ERROR and features.has(
         "organizations:escalating-issues-v2", organization
     ):
-        metrics_query = _query_metrics_for_group_hourly_count(group, now, current_hour)
+        try:
+            metrics_query = _query_metrics_for_group_hourly_count(group, now, current_hour)
+        except Exception as e:
+            logger.info(
+                "Failed to create metrics query",
+                extra={"message": str(e), "group_id": group.id, "current_hour": current_hour},
+            )
+            return
+
         metrics_series_results = get_series(
             projects=[group.project],
             metrics_query=metrics_query,

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -472,7 +472,7 @@ def _get_group_hourly_count_with_metrics(
 
         if metrics_hourly_count != hourly_count:
             logger.info(
-                "Generics Metrics Backend query results not the same as Errors dataset query.",
+                "_get_group_hourly_count_with_metrics results not the same as Errors dataset query.",
                 extra={
                     "metrics_hourly_count": metrics_hourly_count,
                     "hourly_count": hourly_count,

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -443,6 +443,12 @@ def get_group_hourly_count(group: Group) -> int:
 def _get_group_hourly_count_with_metrics(
     group: Group, now: datetime, current_hour: datetime, hourly_count: int
 ):
+    """
+    Return the number of events a group has had today in the last hour
+
+    Checks if the returned results are equivalent to `hourly_count`.
+    If not equivalent, it will generate a log.
+    """
     organization = Organization.objects.get(id=group.project.organization_id)
 
     if group.issue_category == GroupCategory.ERROR and features.has(
@@ -480,6 +486,13 @@ def _get_group_hourly_count_with_metrics(
 def _query_metrics_for_group_hourly_count(
     group: Group, now: datetime, current_hour: datetime
 ) -> int:
+    """
+    This function generates a query to fetch the current hour's events
+    for a group_id through the Generic Metrics Backend.
+
+    The Generic Metrics Backend only contains data for Errors.
+    """
+
     if group.issue_category != GroupCategory.ERROR:
         raise Exception("Invalid category.")
 


### PR DESCRIPTION
## Objective:
We want to start making queries to the Generic Metrics backend during post_process where we check if a Group has started `escalating`. However, I want to check if the results from the queries are equivalent to the results from the Dataset queries. So we will still rely on the Dataset queries to fetch the current hour's count and if the values are not equal, we will log an exception in Sentry for visibility.