### PR TITLE
feat: Create helpers to render JSX nodes/properties in stories easier

### DIFF
--- a/static/app/components/badge.stories.tsx
+++ b/static/app/components/badge.stories.tsx
@@ -1,4 +1,5 @@
 import Badge from 'sentry/components/badge';
+import JSXProperty from 'sentry/components/stories/jsxProperty';
 import SideBySide from 'sentry/components/stories/sideBySide';
 import storyBook from 'sentry/stories/storyBook';
 
@@ -7,7 +8,7 @@ export default storyBook(Badge, story => {
     <SideBySide>
       <Badge text="Text Prop" />
       <Badge>
-        Using <em>Children</em>
+        Using <JSXProperty name="children" value="" />
       </Badge>
     </SideBySide>
   ));

--- a/static/app/components/container/negativeSpaceContainer.stories.tsx
+++ b/static/app/components/container/negativeSpaceContainer.stories.tsx
@@ -4,15 +4,17 @@ import backgroundLighthouse from 'sentry-images/spot/background-lighthouse.svg';
 import onboardingFrameworkSelectionJavascript from 'sentry-images/spot/onboarding-framework-selection-javascript.svg';
 
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
+import JSXNode from 'sentry/components/stories/jsxNode';
 import storyBook from 'sentry/stories/storyBook';
 
 export default storyBook(NegativeSpaceContainer, story => {
   story('Empty', () => (
     <Fragment>
       <p>
-        A <var>NegativeSpaceContainer</var> is a container that will preserve the aspect
-        ratio of whatever is inside it. It's a flex element, so the children are free to
-        expand/contract depending on whether things like <kbd>flex-grow: 1</kbd> are set.
+        A <JSXNode name="NegativeSpaceContainer" /> is a container that will preserve the
+        aspect ratio of whatever is inside it. It's a flex element, so the children are
+        free to expand/contract depending on whether things like <kbd>flex-grow: 1</kbd>{' '}
+        are set.
       </p>
       <p>Here's one with nothing inside it:</p>
       <NegativeSpaceContainer style={{width: '100%', height: '100px'}} />

--- a/static/app/components/stories/jsxNode.tsx
+++ b/static/app/components/stories/jsxNode.tsx
@@ -1,0 +1,55 @@
+import {Fragment, ReactNode} from 'react';
+import styled from '@emotion/styled';
+
+import JSXProperty from 'sentry/components/stories/jsxProperty';
+import {space} from 'sentry/styles/space';
+
+interface Props {
+  name: string;
+  children?: ReactNode;
+  props?: Record<string, unknown>;
+}
+
+export default function JSXNode({name, props = {}, children}: Props) {
+  if (children) {
+    return (
+      <Code data-node>
+        {`<${name}`}
+        {Object.entries(props).map(([propName, value]) => (
+          <Fragment key={propName}>
+            {' '}
+            <JSXProperty name={propName} value={value} />
+          </Fragment>
+        ))}
+        {`>`}
+        <br />
+        {children}
+        <br />
+        {`</${name}>`}
+      </Code>
+    );
+  }
+  return (
+    <Code data-node>
+      {`<${name} `}
+      {Object.entries(props).map(([propName, value]) => (
+        <Fragment key={propName}>
+          <JSXProperty name={propName} value={value} />{' '}
+        </Fragment>
+      ))}
+      {`/>`}
+    </Code>
+  );
+}
+
+const Code = styled('code')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  padding-inline: 0;
+  & > [data-property] {
+    font-size: ${p => p.theme.fontSizeMedium};
+    padding-inline: 0;
+  }
+  & > [data-node] {
+    padding-left: ${space(2)};
+  }
+`;

--- a/static/app/components/stories/jsxProperty.tsx
+++ b/static/app/components/stories/jsxProperty.tsx
@@ -1,0 +1,40 @@
+import {isValidElement} from 'react';
+
+interface Props {
+  name: string;
+  value: unknown;
+}
+
+export default function JSXProperty({name, value}: Props) {
+  if (name === 'children') {
+    return <code data-property="children">{`{children}`}</code>;
+  }
+  if (value === null || value === undefined) {
+    return <code data-property="nullish">{`${name}={${value}}`}</code>;
+  }
+  if (value === true) {
+    return <code data-property="boolean">{name}</code>;
+  }
+  if (value === false) {
+    return <code data-property="boolean">{`${name}={${value}}`}</code>;
+  }
+  if (value === Number || value === Boolean || value === Function) {
+    // @ts-expect-error
+    return <code data-property="constructor">{`${name}={${value.name}}`}</code>;
+  }
+  if (typeof value === 'string') {
+    return <code data-property="string">{`${name}=${JSON.stringify(value)}`}</code>;
+  }
+  if (typeof value === 'number') {
+    return <code data-property="number">{`${name}={${value}}`}</code>;
+  }
+  if (typeof value === 'function') {
+    return (
+      <code data-property="function">{`${name}={${value.name || 'Function'}}`}</code>
+    );
+  }
+  if (isValidElement(value)) {
+    return <code data-property="element">{`${name}=${value}`}</code>;
+  }
+  return <code data-property="object">{`${name}={${JSON.stringify(value)}}`}</code>;
+}

--- a/static/app/components/stories/matrix.tsx
+++ b/static/app/components/stories/matrix.tsx
@@ -1,7 +1,7 @@
 import {type ElementType} from 'react';
-import {isValidElement} from 'react';
 import styled from '@emotion/styled';
 
+import JSXProperty from 'sentry/components/stories/jsxProperty';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import {space} from 'sentry/styles/space';
 
@@ -24,7 +24,7 @@ export default function Matrix({component, propMatrix, selectedProps}: Props) {
   const items = values1.flatMap(value1 => {
     const label = (
       <div>
-        <samp>{selectedProps[0]}</samp>=<PropValue value={value1} />
+        <JSXProperty name={String(selectedProps[0])} value={value1} />
       </div>
     );
     const content = values2.map(value2 => {
@@ -50,7 +50,7 @@ export default function Matrix({component, propMatrix, selectedProps}: Props) {
         <div key="space-head" />
         {values2.map(value2 => (
           <div key={`title-2-${value2}`}>
-            <samp>{selectedProps[1]}</samp>=<PropValue value={value2} />
+            <JSXProperty name={String(selectedProps[1])} value={value2} />
           </div>
         ))}
         {items}
@@ -71,19 +71,6 @@ function item(Component, props) {
       <Component {...props} />
     </SizingWindow>
   );
-}
-
-function PropValue({value}: {value: unknown}) {
-  if (['string', 'boolean', 'number'].includes(typeof value)) {
-    return <kbd>{String(value)}</kbd>;
-  }
-  if (value === null || value === undefined) {
-    return <var>{String(value)}</var>;
-  }
-  if (isValidElement(value)) {
-    return value;
-  }
-  return <var>{JSON.stringify(value)}</var>;
 }
 
 const Grid = styled('section')`

--- a/static/app/components/tabs/index.stories.tsx
+++ b/static/app/components/tabs/index.stories.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useState} from 'react';
 import range from 'lodash/range';
 
+import JSXNode from 'sentry/components/stories/jsxNode';
 import Matrix from 'sentry/components/stories/matrix';
 import SideBySide from 'sentry/components/stories/sideBySide';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
@@ -17,9 +18,9 @@ export default storyBook(Tabs, story => {
   story('Default', () => (
     <Fragment>
       <p>
-        You should be using all of <var>{'<Tabs>'}</var>, <var>{'<TabList>'}</var>,{' '}
-        <var>{'<TabList.Item>'}</var>, <var>{'<TabPanels>'}</var> and
-        <var>{'<TabPanels.Item>'}</var> components.
+        You should be using all of <JSXNode name="Tabs" />, <JSXNode name="TabList" />,{' '}
+        <JSXNode name="TabList.Item" />, <JSXNode name="TabPanels" /> and
+        <JSXNode name="TabPanels.Item" /> components.
       </p>
       <p>
         This will give you all kinds of accessibility and state tracking out of the box.
@@ -70,7 +71,7 @@ export default storyBook(Tabs, story => {
   story('Default Value', () => (
     <Fragment>
       <p>
-        Set <var>{'<Tabs defaultValue="...">'}</var>
+        Set <JSXNode name="Tabs" props={{defaultValue: String}} />
       </p>
       <SizingWindow>
         <Tabs defaultValue="two">
@@ -96,11 +97,11 @@ export default storyBook(Tabs, story => {
         <p>
           If you want to control the state of the tabs from outside, you can call{' '}
           <var>{'useState()'}</var> and set{' '}
-          <var>{'<Tabs value={selected} onChange={selected => ...}>'}</var> manually.
+          <JSXNode name="Tabs" props={{value: String, onChange: Function}} /> manually.
         </p>
         <p>
           This is useful if you want to detect button clicks and do something different.{' '}
-          The <var>{'<Tabs>'}</var> context wrapper is not required in this case.
+          The <JSXNode name="Tabs" /> context wrapper is not required in this case.
         </p>
         <p>selected={selected}</p>
         <SizingWindow>
@@ -149,7 +150,7 @@ export default storyBook(Tabs, story => {
     <SideBySide>
       <div>
         <p>
-          Use <var>&lt;Tabs disabled&gt;</var> to disable everything.
+          Use <JSXNode name="Tabs" props={{disabled: true}} /> to disable everything.
         </p>
         <SizingWindow>
           <Tabs disabled>
@@ -168,8 +169,8 @@ export default storyBook(Tabs, story => {
       </div>
       <div>
         <p>
-          Use <var>{'<TabList disabledKeys={[...]}>'}</var> to disable individual{' '}
-          <var>{'<TabList.Item>'}</var> children.
+          Use <JSXNode name="TabList" props={{disabledKeys: Array}} /> to disable
+          individual <JSXNode name="TabList.Item" /> children.
         </p>
         <SizingWindow>
           <Tabs>

--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -4,6 +4,7 @@ import {PlatformIcon} from 'platformicons';
 
 import Input from 'sentry/components/input';
 import {Sticky} from 'sentry/components/sticky';
+import JSXNode from 'sentry/components/stories/jsxNode';
 import {Tooltip} from 'sentry/components/tooltip';
 import * as Icons from 'sentry/icons';
 import {space} from 'sentry/styles/space';
@@ -1368,7 +1369,7 @@ function Section({section}: {section: TSection}) {
           return (
             <Tooltip
               key={icon.id}
-              title={formatObjAsReactStatement(name, props)}
+              title={<JSXNode name={name} props={props} />}
               isHoverable
             >
               <Cell>
@@ -1400,7 +1401,7 @@ function PlatformIconsSection({searchTerm}: {searchTerm: string}) {
         {platforms.map(platform => (
           <Tooltip
             key={platform}
-            title={formatObjAsReactStatement('PlatformIcon', {platform})}
+            title={<JSXNode name="PlatformIcon" props={{platform}} />}
             isHoverable
           >
             <Cell>
@@ -1411,13 +1412,6 @@ function PlatformIconsSection({searchTerm}: {searchTerm: string}) {
       </Grid>
     </section>
   );
-}
-
-function formatObjAsReactStatement(name, props: Record<string, unknown>) {
-  const keyValues = Object.entries(props)
-    .map(([prop, val]) => (val === true ? prop : `${prop}=${JSON.stringify(val)}`))
-    .join(' ');
-  return `<${name} ${keyValues} />`;
 }
 
 const StyledSticky = styled(Sticky)`


### PR DESCRIPTION
Create <JSXNode> and <JSXProperty> helpers, intended for use in stories, to easily & consistently describe components and the properties available.


| Before | After |
| --- | --- |
| <img width="594" alt="matrix before" src="https://github.com/getsentry/sentry/assets/187460/8b3888e0-13ac-446e-8465-2b2ce959d4ff"> | <img width="605" alt="matrix after" src="https://github.com/getsentry/sentry/assets/187460/20c87d26-4dc9-4891-8f5a-285a54d59d74"> |