### PR TITLE
feat(adv-analysis): Incorporate new spans to RCA

### DIFF
--- a/src/sentry/api/helpers/span_analysis.py
+++ b/src/sentry/api/helpers/span_analysis.py
@@ -35,48 +35,30 @@ def span_analysis(data):
         row["avg_duration"] = avg_col[i]
         row["span_key"] = span_keys[i]
 
-    # get constant, removed, and new spans
-    spans_before = {row["span_key"] for row in data if row["period"] == "before"}
-    spans_after = {row["span_key"] for row in data if row["period"] == "after"}
-    constant_spans = spans_before.intersection(spans_after)
-
-    # TODO: Add logic to surface removed/new spans
-    # removed_spans = [x for x in spans_before if x not in spans_after]
-    # new_spans = [x for x in spans_after if x not in spans_before]
-
     # create two dataframes for period 0 and 1 and keep only the same spans in both periods
+    span_data_p0 = {row["span_key"]: row for row in data if row["period"] == "before"}
+    span_data_p1 = {row["span_key"]: row for row in data if row["period"] == "after"}
 
-    span_data_p0 = {
-        row["span_key"]: row
-        for row in data
-        if row["period"] == "before" and row["span_key"] in constant_spans
-    }
-    span_data_p1 = {
-        row["span_key"]: row
-        for row in data
-        if row["period"] == "after" and row["span_key"] in constant_spans
-    }
+    all_keys = set(span_data_p0.keys()).union(span_data_p1.keys())
 
     # merge the dataframes to do span analysis
     problem_spans = []
 
     # Perform the join operation
-    for key in span_data_p0.keys():
-        row1 = span_data_p0[key]
-        row2 = span_data_p1[key]
+    for key in all_keys:
+        row1 = span_data_p0.get(key)
+        row2 = span_data_p1.get(key)
+        new_span = False
 
-        # Merge the rows from df1 and df2 into a single dictionary and get the delta between period 0/1
-        score_delta = (row2["score"] - row1["score"]) / row1["score"] if row1["score"] != 0 else 0
-        freq_delta = (
-            (row2["relative_freq"] - row1["relative_freq"]) / row1["relative_freq"]
-            if row1["relative_freq"] != 0
-            else 0
-        )
-        duration_delta = (
-            (row2["avg_duration"] - row1["avg_duration"]) / row1["avg_duration"]
-            if row1["avg_duration"] != 0
-            else 0
-        )
+        if row1 and row2:
+            score_delta = row2["score"] - row1["score"]
+            freq_delta = row2["relative_freq"] - row1["relative_freq"]
+            duration_delta = row2["avg_duration"] - row1["avg_duration"]
+        elif row2:
+            score_delta = row2["score"]
+            freq_delta = row2["relative_freq"]
+            duration_delta = row2["avg_duration"]
+            new_span = True
 
         # We're only interested in span changes if they positively impacted duration
         if score_delta > 0:
@@ -92,6 +74,7 @@ def span_analysis(data):
                     "duration_delta": duration_delta,
                     "duration_before": row1["avg_duration"],
                     "duration_after": row2["avg_duration"],
+                    "is_new_span": new_span,
                 }
             )
 

--- a/src/sentry/api/helpers/span_analysis.py
+++ b/src/sentry/api/helpers/span_analysis.py
@@ -66,13 +66,13 @@ def span_analysis(data):
                 {
                     "span_op": key.split(",")[0],
                     "span_group": key.split(",")[1],
-                    "sample_event_id": row1["sample_event_id"],
+                    "sample_event_id": row1["sample_event_id"] if row1 else row2["sample_event_id"],
                     "score_delta": score_delta,
-                    "freq_before": row1["relative_freq"],
+                    "freq_before": row1["relative_freq"] if row1 else 0,
                     "freq_after": row2["relative_freq"],
                     "freq_delta": freq_delta,
                     "duration_delta": duration_delta,
-                    "duration_before": row1["avg_duration"],
+                    "duration_before": row1["avg_duration"] if row1 else 0,
                     "duration_after": row2["avg_duration"],
                     "is_new_span": new_span,
                 }

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -254,13 +254,14 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                 "span_op": "django.middleware",
                 "span_group": "2b9cbb96dbf59baa",
                 "span_description": "middleware span",
-                "score_delta": 10.666666666666666,
+                "score_delta": 640.0,
                 "freq_before": 1.0,
                 "freq_after": 3.0,
                 "freq_delta": 2.0,
-                "duration_delta": 2.888888888888889,
+                "duration_delta": 173.33333333333334,
                 "duration_before": 60.0,
                 "duration_after": 233.33333333333334,
+                "is_new_span": False,
             }
         ]
 
@@ -340,15 +341,16 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
         assert len(response.data) == 1
         assert response.data == [
             {
-                "span_op": "django.middleware",
-                "span_group": "2b9cbb96dbf59baa",
-                "score_delta": 0.6666666666666666,
-                "freq_before": 1.0,
+                "span_op": "db",
+                "span_group": "d77d5e503ad1439f",
+                "score_delta": 100.0,
+                "freq_before": 0,
                 "freq_after": 1.0,
-                "freq_delta": 0.0,
-                "duration_delta": 0.6666666666666666,
-                "duration_before": 60.0,
+                "freq_delta": 1.0,
+                "duration_delta": 100.0,
+                "duration_before": 0,
                 "duration_after": 100.0,
-                "span_description": "middleware span",
+                "span_description": "db",
+                "is_new_span": True,
             }
         ]


### PR DESCRIPTION
- Incorporate new spans into RCA
- Switch from % change to absolute change (this simplifies the logic if we want to account for new spans, and I actually think it's a better metric than % change if we are sorting by `score` ultimately). If we sort by % change, a fairly inconsequential span that has a big regression could shoot to the top, even though it's not ultimately the main driver of the regression itself.
- Add additional element to response `is_new_span` - could be used for some UI business logic if we want to highlight new spans

**TODOS:**
- Any UI/UX changes needed to account for change from % change to absolute change
- Validate that my logic works as expected
- For the RCA, we should probably drop all data within X hours of the breakpoint because we know it won't be exact. I suggest ~12 hours (6 hours before and after) to start and we can see how that works. This is especially important if we want to support new spans, because if we don't do this we may incorrectly assume they existed in the `before` period just bc of the breakpoint not being exact