### PR TITLE
ref: add stubs for email-reply-parser

### DIFF
--- a/fixtures/stubs-for-mypy/email_reply_parser.pyi
+++ b/fixtures/stubs-for-mypy/email_reply_parser.pyi
@@ -1,0 +1,3 @@
+class EmailReplyParser:
+    @classmethod
+    def parse_reply(cls, s: str) -> str: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ module = [
     "datadog.*",
     "django_zero_downtime_migrations.backends.postgres.schema.*",
     "docker.*",
-    "email_reply_parser.*",
     "fido2.*",
     "honcho.manager.*",
     "honcho.printer.*",


### PR DESCRIPTION
the upstream library is dead -- so adding the minimum type stubs we need here