### PR TITLE
ref: add typing stubs for toronado

### DIFF
--- a/fixtures/stubs-for-mypy/toronado.pyi
+++ b/fixtures/stubs-for-mypy/toronado.pyi
@@ -1,0 +1,3 @@
+import lxml.etree
+
+def inline(tree: lxml.etree._Element) -> None: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ module = [
     "requests_oauthlib.*",
     "sqlparse.*",
     "statsd.*",
-    "toronado.*",
     "u2flib_server.model.*",
     "ua_parser.user_agent_parser.*",
     "unidiff.*",

--- a/src/sentry/utils/email/message_builder.py
+++ b/src/sentry/utils/email/message_builder.py
@@ -66,7 +66,7 @@ def inline_css(value: str) -> str:
     toronado.inline(tree)
     # CSS media query support is inconsistent when the DOCTYPE declaration is
     # missing, so we force it to HTML5 here.
-    html: str = lxml.html.tostring(tree, doctype="<!DOCTYPE html>", encoding=None).decode("utf-8")
+    html = lxml.html.tostring(tree, doctype="<!DOCTYPE html>", encoding=None).decode("utf-8")
     return html
 
 


### PR DESCRIPTION
the upstream library is dead -- so adding the typing stubs here directly