### PR TITLE
fix(github-invite): email logic fixes

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -47,11 +47,13 @@ FILTERED_CHARACTERS = {"+"}
 
 class MissingOrgMemberSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
+        formatted_external_id = obj.external_id
+        if obj.external_id is not None and ":" in obj.external_id:
+            formatted_external_id = obj.external_id.split(":")[1]
+
         return {
             "email": obj.email,
-            "externalId": obj.external_id.split(":")[1]
-            if ":" in obj.external_id
-            else obj.external_id,
+            "externalId": formatted_external_id,
             "commitCount": obj.commit__count,
         }
 

--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 
 FILTERED_EMAIL_DOMAINS = {
     "gmail.com",
+    "yahoo.com",
     "icloud.com",
     "hotmail.com",
     "outlook.com",
@@ -47,9 +48,7 @@ FILTERED_CHARACTERS = {"+"}
 
 class MissingOrgMemberSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
-        formatted_external_id = obj.external_id
-        if obj.external_id is not None and ":" in obj.external_id:
-            formatted_external_id = obj.external_id.split(":")[1]
+        formatted_external_id = _format_external_id(obj.external_id)
 
         return {
             "email": obj.email,
@@ -60,6 +59,15 @@ class MissingOrgMemberSerializer(Serializer):
 
 class MissingMembersPermission(OrganizationPermission):
     scope_map = {"GET": ["org:write"]}
+
+
+def _format_external_id(external_id):
+    formatted_external_id = external_id
+
+    if external_id is not None and ":" in external_id:
+        formatted_external_id = external_id.split(":")[1]
+
+    return formatted_external_id
 
 
 def _get_missing_organization_members(

--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -61,7 +61,7 @@ class MissingMembersPermission(OrganizationPermission):
     scope_map = {"GET": ["org:write"]}
 
 
-def _format_external_id(external_id):
+def _format_external_id(external_id: str | None) -> str | None:
     formatted_external_id = external_id
 
     if external_id is not None and ":" in external_id:

--- a/src/sentry/tasks/invite_missing_org_members.py
+++ b/src/sentry/tasks/invite_missing_org_members.py
@@ -1,7 +1,12 @@
 import logging
 
 from sentry import features
-from sentry.api.endpoints.organization_missing_org_members import _get_missing_organization_members
+from sentry.api.endpoints.organization_missing_org_members import (
+    FILTERED_CHARACTERS,
+    FILTERED_EMAIL_DOMAINS,
+    _get_missing_organization_members,
+    _get_shared_email_domain,
+)
 from sentry.constants import ObjectStatus
 from sentry.models.options import OrganizationOption
 from sentry.models.organization import Organization
@@ -84,18 +89,29 @@ def send_nudge_email(org_id):
         )
         return
 
+    shared_domain = _get_shared_email_domain(organization)
+
+    if shared_domain:
+        commit_author_query = commit_author_query.filter(email__endswith=shared_domain)
+    else:
+        for filtered_email in FILTERED_EMAIL_DOMAINS:
+            commit_author_query = commit_author_query.exclude(email__endswith=filtered_email)
+
+    for filtered_character in FILTERED_CHARACTERS:
+        commit_author_query = commit_author_query.exclude(email__icontains=filtered_character)
+
     commit_authors = []
-    for commit_author in commit_author_query:
+    for commit_author in commit_author_query[:3]:
         commit_authors.append(
             {
                 "email": commit_author.email,
-                "external_id": commit_author.external_id,
+                "external_id": commit_author.external_id.replace("github:", ""),
                 "commit_count": commit_author.commit__count,
             }
         )
 
     notification = MissingMembersNudgeNotification(
-        organization=organization, commit_authors=commit_authors[:3], provider="github"
+        organization=organization, commit_authors=commit_authors, provider="github"
     )
 
     logger.info(

--- a/src/sentry/tasks/invite_missing_org_members.py
+++ b/src/sentry/tasks/invite_missing_org_members.py
@@ -4,6 +4,7 @@ from sentry import features
 from sentry.api.endpoints.organization_missing_org_members import (
     FILTERED_CHARACTERS,
     FILTERED_EMAIL_DOMAINS,
+    _format_external_id,
     _get_missing_organization_members,
     _get_shared_email_domain,
 )
@@ -102,9 +103,7 @@ def send_nudge_email(org_id):
 
     commit_authors = []
     for commit_author in commit_author_query[:3]:
-        formatted_external_id = commit_author.external_id
-        if commit_author.external_id is not None and ":" in commit_author.external_id:
-            formatted_external_id = commit_author.external_id.split(":")[1]
+        formatted_external_id = _format_external_id(commit_author.external_id)
 
         commit_authors.append(
             {

--- a/src/sentry/tasks/invite_missing_org_members.py
+++ b/src/sentry/tasks/invite_missing_org_members.py
@@ -102,10 +102,14 @@ def send_nudge_email(org_id):
 
     commit_authors = []
     for commit_author in commit_author_query[:3]:
+        formatted_external_id = commit_author.external_id
+        if commit_author.external_id is not None and ":" in commit_author.external_id:
+            formatted_external_id = commit_author.external_id.split(":")[1]
+
         commit_authors.append(
             {
                 "email": commit_author.email,
-                "external_id": commit_author.external_id.replace("github:", ""),
+                "external_id": formatted_external_id,
                 "commit_count": commit_author.commit__count,
             }
         )

--- a/tests/sentry/api/endpoints/test_organization_missing_org_members.py
+++ b/tests/sentry/api/endpoints/test_organization_missing_org_members.py
@@ -32,20 +32,26 @@ class OrganizationMissingMembersTestCase(APITestCase):
         self.nonmember_commit_author1 = self.create_commit_author(
             project=self.project, email="c@example.com"
         )
-        self.nonmember_commit_author1.external_id = "c"
+        self.nonmember_commit_author1.external_id = "github:c"
         self.nonmember_commit_author1.save()
 
         self.nonmember_commit_author2 = self.create_commit_author(
             project=self.project, email="d@example.com"
         )
-        self.nonmember_commit_author2.external_id = "d"
+        self.nonmember_commit_author2.external_id = "github:d"
         self.nonmember_commit_author2.save()
 
         nonmember_commit_author_invalid_char = self.create_commit_author(
             project=self.project, email="hi+1@example.com"
         )
-        nonmember_commit_author_invalid_char.external_id = "hi+1"
+        nonmember_commit_author_invalid_char.external_id = "github:hi+1"
         nonmember_commit_author_invalid_char.save()
+
+        nonmember_commit_author_invalid_domain = self.create_commit_author(
+            project=self.project, email="gmail@gmail.com"
+        )
+        nonmember_commit_author_invalid_domain.external_id = "github:gmail"
+        nonmember_commit_author_invalid_domain.save()
 
         self.integration = self.create_integration(
             organization=self.organization, provider="github", name="Github", external_id="github:1"
@@ -57,11 +63,13 @@ class OrganizationMissingMembersTestCase(APITestCase):
         self.create_commit(repo=self.repo, author=self.nonmember_commit_author1)
         self.create_commit(repo=self.repo, author=self.nonmember_commit_author1)
         self.create_commit(repo=self.repo, author=self.nonmember_commit_author2)
+        self.create_commit(repo=self.repo, author=nonmember_commit_author_invalid_char)
+        self.create_commit(repo=self.repo, author=nonmember_commit_author_invalid_domain)
 
         not_shared_domain_author = self.create_commit_author(
             project=self.project, email="a@exampletwo.com"
         )
-        not_shared_domain_author.external_id = "not"
+        not_shared_domain_author.external_id = "github:not"
         not_shared_domain_author.save()
         self.create_commit(repo=self.repo, author=not_shared_domain_author)
 
@@ -151,7 +159,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
         noreply_email_author = self.create_commit_author(
             project=self.project, email="hi@noreply.github.com"
         )
-        noreply_email_author.external_id = "hi"
+        noreply_email_author.external_id = "github:hi"
         noreply_email_author.save()
         self.create_commit(
             repo=self.repo,
@@ -203,7 +211,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
         nonmember_commit_author = self.create_commit_author(
             project=self.project, email="c2@example.com"
         )
-        nonmember_commit_author.external_id = "c@example.com"
+        nonmember_commit_author.external_id = "github:c@example.com"
         nonmember_commit_author.save()
 
         self.create_commit(repo=self.repo, author=nonmember_commit_author)
@@ -283,7 +291,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
             nonmember_commit_author = self.create_commit_author(
                 project=self.project, email=str(i) + "@example.com"
             )
-            nonmember_commit_author.external_id = str(i)
+            nonmember_commit_author.external_id = "github:" + str(i)
             nonmember_commit_author.save()
             self.create_commit(repo=repo, author=nonmember_commit_author)
 

--- a/tests/sentry/tasks/test_invite_missing_org_members.py
+++ b/tests/sentry/tasks/test_invite_missing_org_members.py
@@ -94,7 +94,9 @@ class InviteMissingMembersTestCase(TestCase):
         "sentry.notifications.notifications.missing_members_nudge.MissingMembersNudgeNotification.__init__",
         return_value=None,
     )
-    def test_email_content(self, mock_init_notification, mock_send_email, mock_send_notification):
+    def test_excludes_filtered_emails(
+        self, mock_init_notification, mock_send_email, mock_send_notification
+    ):
         integration = self.create_integration(
             organization=self.organization, provider="github", name="Github", external_id="github:1"
         )

--- a/tests/sentry/tasks/test_invite_missing_org_members.py
+++ b/tests/sentry/tasks/test_invite_missing_org_members.py
@@ -34,25 +34,39 @@ class InviteMissingMembersTestCase(TestCase):
         self.nonmember_commit_author1 = self.create_commit_author(
             project=self.project, email="c@example.com"
         )
-        self.nonmember_commit_author1.external_id = "c"
+        self.nonmember_commit_author1.external_id = "github:c"
         self.nonmember_commit_author1.save()
 
         self.nonmember_commit_author2 = self.create_commit_author(
             project=self.project, email="d@example.com"
         )
-        self.nonmember_commit_author2.external_id = "d"
+        self.nonmember_commit_author2.external_id = "github:d"
         self.nonmember_commit_author2.save()
+
+        nonmember_commit_author_invalid_char = self.create_commit_author(
+            project=self.project, email="hi+1@example.com"
+        )
+        nonmember_commit_author_invalid_char.external_id = "github:hi+1"
+        nonmember_commit_author_invalid_char.save()
+
+        nonmember_commit_author_invalid_domain = self.create_commit_author(
+            project=self.project, email="gmail@gmail.com"
+        )
+        nonmember_commit_author_invalid_domain.external_id = "github:gmail"
+        nonmember_commit_author_invalid_domain.save()
 
         self.repo = self.create_repo(project=self.project, provider="integrations:github")
         self.create_commit(repo=self.repo, author=self.member_commit_author)
         self.create_commit(repo=self.repo, author=self.nonmember_commit_author1)
         self.create_commit(repo=self.repo, author=self.nonmember_commit_author1)
         self.create_commit(repo=self.repo, author=self.nonmember_commit_author2)
+        self.create_commit(repo=self.repo, author=nonmember_commit_author_invalid_char)
+        self.create_commit(repo=self.repo, author=nonmember_commit_author_invalid_domain)
 
         not_shared_domain_author = self.create_commit_author(
             project=self.project, email="a@exampletwo.com"
         )
-        not_shared_domain_author.external_id = "not"
+        not_shared_domain_author.external_id = "github:not"
         not_shared_domain_author.save()
         self.create_commit(repo=self.repo, author=not_shared_domain_author)
 
@@ -74,6 +88,29 @@ class InviteMissingMembersTestCase(TestCase):
         send_nudge_email(org_id=self.organization.id)
 
         assert mock_send_notification.called
+
+    @with_feature("organizations:integrations-gh-invite")
+    @patch(
+        "sentry.notifications.notifications.missing_members_nudge.MissingMembersNudgeNotification.__init__",
+        return_value=None,
+    )
+    def test_email_content(self, mock_init_notification, mock_send_email, mock_send_notification):
+        integration = self.create_integration(
+            organization=self.organization, provider="github", name="Github", external_id="github:1"
+        )
+        self.repo.integration_id = integration.id
+        self.repo.save()
+
+        send_nudge_email(org_id=self.organization.id)
+
+        commit_authors = [
+            {"email": "c@example.com", "external_id": "c", "commit_count": 2},
+            {"email": "d@example.com", "external_id": "d", "commit_count": 1},
+        ]
+
+        mock_init_notification.assert_called_once_with(
+            organization=self.organization, commit_authors=commit_authors, provider="github"
+        )
 
     def test_no_github_repos(self, mock_send_email, mock_send_notification):
         self.repo.delete()


### PR DESCRIPTION
Changes:

- Filters out invalid email domains and characters when sending the email notification
- Removes the `github:` prefix from commit authors' external ids for emails as well as the API
- Adds a test to ensure the email notification is initialized with the correct values
- Updates tests to add the `github:` prefix to ensure it's removed correctly