### PR TITLE
style(replays): fix padding on widget

### DIFF
--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -266,6 +266,7 @@ const StyledWidgetHeader = styled(HeaderTitleLegend)`
 
 const StyledWidgetContainer = styled(WidgetContainer)`
   margin-bottom: 0;
+  padding-top: ${space(1.5)};
 `;
 
 export const RightAlignedCell = styled('div')`

--- a/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
+++ b/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
@@ -93,6 +93,7 @@ export default function ExampleReplaysList({
               referrer={referrer}
               showUrl={false}
               referrer_table="selector-widget"
+              isWidget
             />
           );
         })

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -292,12 +292,14 @@ export function ReplayCell({
   replay,
   showUrl,
   referrer_table,
+  isWidget,
 }: Props & {
   eventView: EventView;
   organization: Organization;
   referrer: string;
   referrer_table: ReferrerTableType;
   showUrl: boolean;
+  isWidget?: boolean;
 }) {
   const {projects} = useProjects();
   const project = projects.find(p => p.id === replay.project_id);
@@ -389,7 +391,7 @@ export function ReplayCell({
   );
 
   return (
-    <Item>
+    <Item isWidget={isWidget}>
       <UserBadgeFullWidth
         avatarSize={24}
         displayName={
@@ -632,11 +634,14 @@ export function ActivityCell({replay, showDropdownFilters}: Props) {
   );
 }
 
-const Item = styled('div')<{isArchived?: boolean}>`
+const Item = styled('div')<{isArchived?: boolean; isWidget?: boolean}>`
   display: flex;
   align-items: center;
   gap: ${space(1)};
-  padding: ${space(1.5)};
+  ${p =>
+    p.isWidget
+      ? `padding: ${space(0.75)} ${space(1.5)} ${space(1.5)} ${space(1.5)};`
+      : `padding: ${space(1.5)};`};
   ${p => (p.isArchived ? 'opacity: 0.5;' : '')};
 `;
 


### PR DESCRIPTION
BEFORE:
- padding top on header a bit too large at `16px`
- padding top on example replays a bit too large, leading to weird gap between accordion panel and panel content
<img width="480" alt="SCR-20231002-jtwt" src="https://github.com/getsentry/sentry/assets/56095982/ecb4d348-35d0-439a-91e0-77d983ee317f">


AFTER:
- padding top `12px`
- gap reduced

<img width="469" alt="SCR-20231002-jtte" src="https://github.com/getsentry/sentry/assets/56095982/69c4862a-180b-40f1-b58c-d4ad904ec506">
