### PR TITLE
fix(replays): don't show 'jump to current timestamp' button if network tab empty

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -192,7 +192,7 @@ function NetworkList() {
 
   const currentIndex = indexAtCurrentTime();
   const showJumpDownButton = currentIndex > visibleRange[1];
-  const showJumpUpButton = currentIndex < visibleRange[0];
+  const showJumpUpButton = currentIndex < visibleRange[0] && networkFrames?.length;
 
   return (
     <FluidHeight>

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -191,9 +191,14 @@ function NetworkList() {
   }
 
   const currentIndex = indexAtCurrentTime();
-  const showJumpDownButton = currentIndex > visibleRange[1];
-  const showJumpUpButton = currentIndex < visibleRange[0];
-  const tabNotEmpty = networkFrames?.length;
+  const showJumpDownButton =
+    sortConfig.by === 'startTimestamp' &&
+    currentIndex > visibleRange[1] &&
+    networkFrames?.length;
+  const showJumpUpButton =
+    sortConfig.by === 'startTimestamp' &&
+    currentIndex < visibleRange[0] &&
+    networkFrames?.length;
 
   return (
     <FluidHeight>
@@ -246,7 +251,7 @@ function NetworkList() {
                   />
                 )}
               </AutoSizer>
-              {sortConfig.by === 'startTimestamp' && showJumpUpButton && tabNotEmpty ? (
+              {showJumpUpButton ? (
                 <JumpButton
                   onClick={handleClick}
                   aria-label={t('Jump Up')}
@@ -257,7 +262,7 @@ function NetworkList() {
                   {t('↑ Jump to current timestamp')}
                 </JumpButton>
               ) : null}
-              {sortConfig.by === 'startTimestamp' && showJumpDownButton && tabNotEmpty ? (
+              {showJumpDownButton ? (
                 <JumpButton
                   onClick={handleClick}
                   aria-label={t('Jump Down')}

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -192,7 +192,8 @@ function NetworkList() {
 
   const currentIndex = indexAtCurrentTime();
   const showJumpDownButton = currentIndex > visibleRange[1];
-  const showJumpUpButton = currentIndex < visibleRange[0] && networkFrames?.length;
+  const showJumpUpButton = currentIndex < visibleRange[0];
+  const tabNotEmpty = networkFrames?.length;
 
   return (
     <FluidHeight>
@@ -245,7 +246,7 @@ function NetworkList() {
                   />
                 )}
               </AutoSizer>
-              {sortConfig.by === 'startTimestamp' && showJumpUpButton ? (
+              {sortConfig.by === 'startTimestamp' && showJumpUpButton && tabNotEmpty ? (
                 <JumpButton
                   onClick={handleClick}
                   aria-label={t('Jump Up')}
@@ -256,7 +257,7 @@ function NetworkList() {
                   {t('↑ Jump to current timestamp')}
                 </JumpButton>
               ) : null}
-              {sortConfig.by === 'startTimestamp' && showJumpDownButton ? (
+              {sortConfig.by === 'startTimestamp' && showJumpDownButton && tabNotEmpty ? (
                 <JumpButton
                   onClick={handleClick}
                   aria-label={t('Jump Down')}


### PR DESCRIPTION
before:
<img width="610" alt="SCR-20231002-jwjh" src="https://github.com/getsentry/sentry/assets/56095982/991e2e92-c172-4795-8d85-e2f0ea8a123d">

after:
<img width="616" alt="SCR-20231002-jwib" src="https://github.com/getsentry/sentry/assets/56095982/4d3c86c9-659b-4185-a3e0-a186824d9129">

closes https://github.com/getsentry/sentry/issues/56859