### PR TITLE
test_auth_login: remove unused provision_middleware

### DIFF
--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -497,15 +497,6 @@ class AuthLoginNewsletterTest(TestCase):
         assert not results[0].verified
 
 
-def provision_middleware():
-    # TODO: to be removed once CustomerDomainMiddleware is activated.
-    middleware = list(settings.MIDDLEWARE)
-    if "sentry.middleware.customer_domain.CustomerDomainMiddleware" not in middleware:
-        index = middleware.index("sentry.middleware.auth.AuthenticationMiddleware")
-        middleware.insert(index + 1, "sentry.middleware.customer_domain.CustomerDomainMiddleware")
-    return middleware
-
-
 @control_silo_test(stable=True)
 @override_settings(
     SENTRY_USE_CUSTOMER_DOMAINS=True,
@@ -596,55 +587,52 @@ class AuthLoginCustomerDomainTest(TestCase):
         with self.disable_registration():
             self.create_organization(name="albertos-apples", owner=self.user)
 
-            with override_settings(MIDDLEWARE=tuple(provision_middleware())):
-                # load it once for test cookie
-                self.client.get(self.path)
-                resp = self.client.post(
-                    self.path,
-                    {"username": self.user.username, "password": "admin", "op": "login"},
-                    # This should preferably be HTTP_HOST.
-                    # Using SERVER_NAME until https://code.djangoproject.com/ticket/32106 is fixed.
-                    SERVER_NAME="invalid.testserver",
-                    follow=True,
-                )
+            # load it once for test cookie
+            self.client.get(self.path)
+            resp = self.client.post(
+                self.path,
+                {"username": self.user.username, "password": "admin", "op": "login"},
+                # This should preferably be HTTP_HOST.
+                # Using SERVER_NAME until https://code.djangoproject.com/ticket/32106 is fixed.
+                SERVER_NAME="invalid.testserver",
+                follow=True,
+            )
 
-                assert resp.status_code == 200
-                assert resp.redirect_chain == [
-                    ("http://invalid.testserver/auth/login/", 302),
-                    ("http://albertos-apples.testserver/auth/login/", 302),
-                    ("http://albertos-apples.testserver/issues/", 302),
-                ]
+            assert resp.status_code == 200
+            assert resp.redirect_chain == [
+                ("http://invalid.testserver/auth/login/", 302),
+                ("http://albertos-apples.testserver/auth/login/", 302),
+                ("http://albertos-apples.testserver/issues/", 302),
+            ]
 
     def test_login_valid_credentials_non_staff(self):
         with self.disable_registration():
             org = self.create_organization(name="albertos-apples")
             non_staff_user = self.create_user(is_staff=False)
             self.create_member(organization=org, user=non_staff_user)
-            with override_settings(MIDDLEWARE=tuple(provision_middleware())):
-                # load it once for test cookie
-                self.client.get(self.path)
 
-                resp = self.client.post(
-                    self.path,
-                    {"username": non_staff_user.username, "password": "admin", "op": "login"},
-                    # This should preferably be HTTP_HOST.
-                    # Using SERVER_NAME until https://code.djangoproject.com/ticket/32106 is fixed.
-                    SERVER_NAME="albertos-apples.testserver",
-                    follow=True,
-                )
-                assert resp.status_code == 200
-                assert resp.redirect_chain == [
-                    ("http://albertos-apples.testserver/auth/login/", 302),
-                    ("http://albertos-apples.testserver/issues/", 302),
-                ]
+            # load it once for test cookie
+            self.client.get(self.path)
+
+            resp = self.client.post(
+                self.path,
+                {"username": non_staff_user.username, "password": "admin", "op": "login"},
+                # This should preferably be HTTP_HOST.
+                # Using SERVER_NAME until https://code.djangoproject.com/ticket/32106 is fixed.
+                SERVER_NAME="albertos-apples.testserver",
+                follow=True,
+            )
+            assert resp.status_code == 200
+            assert resp.redirect_chain == [
+                ("http://albertos-apples.testserver/auth/login/", 302),
+                ("http://albertos-apples.testserver/issues/", 302),
+            ]
 
     def test_login_valid_credentials_not_a_member(self):
         user = self.create_user()
         self.create_organization(name="albertos-apples")
         self.create_member(organization=self.organization, user=user)
-        with override_settings(
-            MIDDLEWARE=tuple(provision_middleware())
-        ), self.disable_registration():
+        with self.disable_registration():
             # load it once for test cookie
             self.client.get(self.path)
 
@@ -667,9 +655,7 @@ class AuthLoginCustomerDomainTest(TestCase):
     def test_login_valid_credentials_orgless(self):
         user = self.create_user()
         self.create_organization(name="albertos-apples")
-        with override_settings(
-            MIDDLEWARE=tuple(provision_middleware())
-        ), self.disable_registration():
+        with self.disable_registration():
             # load it once for test cookie
             self.client.get(self.path)
 
@@ -688,9 +674,7 @@ class AuthLoginCustomerDomainTest(TestCase):
 
     def test_login_valid_credentials_org_does_not_exist(self):
         user = self.create_user()
-        with override_settings(
-            MIDDLEWARE=tuple(provision_middleware())
-        ), self.disable_registration():
+        with self.disable_registration():
             # load it once for test cookie
             self.client.get(self.path)
 


### PR DESCRIPTION
CustomerDomainMiddleware was activated 1 year ago in https://github.com/getsentry/sentry/pull/38038

Quick check, pytest was happy:
```
$ pytest tests/sentry/web/frontend/test_auth_login.py
==================================================================================== test session starts ====================================================================================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-0.13.1
rootdir: /Users/oioki/code/sentry, configfile: pyproject.toml
plugins: fail-slow-0.3.0, rerunfailures-11.0, sentry-0.1.11, time-machine-2.13.0, xdist-3.0.2, cov-4.0.0, django-4.4.0
collected 76 items

tests/sentry/web/frontend/test_auth_login.py ............................................................................                                                             [100%]

==================================================================================== 76 passed in 19.43s ====================================================================================
```