### PR TITLE
fix(rules): Fix user in AlertRuleSerializer

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -17,7 +17,6 @@ from sentry.incidents.models import (
 from sentry.models.actor import ACTOR_TYPES, Actor, actor_type_to_string
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
-from sentry.models.user import User
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
@@ -83,10 +82,12 @@ class AlertRuleSerializer(Serializer):
         for rule_activity in rule_activities:
             rpc_user = user_by_user_id.get(rule_activity.user_id)
             if rpc_user:
-                user = dict(id=rpc_user.id, name=rpc_user.get_display_name(), email=rpc_user.email)
+                created_by = dict(
+                    id=rpc_user.id, name=rpc_user.get_display_name(), email=rpc_user.email
+                )
             else:
-                user = None
-            result[alert_rules[rule_activity.alert_rule_id]]["created_by"] = user
+                created_by = None
+            result[alert_rules[rule_activity.alert_rule_id]]["created_by"] = created_by
 
         owners_by_type = defaultdict(list)
         for item in item_list:
@@ -103,11 +104,11 @@ class AlertRuleSerializer(Serializer):
 
         for alert_rule in alert_rules.values():
             if alert_rule.owner_id:
-                type = actor_type_to_string(alert_rule.owner.type)
-                if alert_rule.owner_id in resolved_actors[type]:
+                owner_type = actor_type_to_string(alert_rule.owner.type)
+                if alert_rule.owner_id in resolved_actors[owner_type]:
                     result[alert_rule][
                         "owner"
-                    ] = f"{type}:{resolved_actors[type][alert_rule.owner_id]}"
+                    ] = f"{owner_type}:{resolved_actors[owner_type][alert_rule.owner_id]}"
 
         if "original_alert_rule" in self.expand:
             snapshot_activities = AlertRuleActivity.objects.filter(
@@ -127,15 +128,7 @@ class AlertRuleSerializer(Serializer):
                 .annotate(incident_id=Max("id"))
                 .values("incident_id")
             ):
-                user_from_id = None
-                if user:
-                    # sometimes it's a User instance and sometimes a dict - should standardize
-                    if isinstance(user, (User, RpcUser)):
-                        user_by_user_id.get(user.id)
-                    else:
-                        user_by_user_id.get(user.get("id"))
-
-                incident_map[incident.alert_rule_id] = serialize(incident, user=user_from_id)
+                incident_map[incident.alert_rule_id] = serialize(incident, user=user)
             for alert_rule in alert_rules.values():
                 result[alert_rule]["latestIncident"] = incident_map.get(alert_rule.id, None)
 

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -24,7 +26,7 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
         """
         Fetches alert rules and legacy rules for a project
         """
-        expand = request.GET.getlist("expand", [])
+        expand: list[str] = request.GET.getlist("expand", [])
         alert_rules = AlertRule.objects.fetch_for_project(project)
         if not features.has("organizations:performance-view", project.organization):
             # Filter to only error alert rules

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -24,6 +24,7 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
         """
         Fetches alert rules and legacy rules for a project
         """
+        expand = request.GET.getlist("expand", [])
         alert_rules = AlertRule.objects.fetch_for_project(project)
         if not features.has("organizations:performance-view", project.organization):
             # Filter to only error alert rules
@@ -41,7 +42,7 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
         return self.paginate(
             request,
             paginator_cls=CombinedQuerysetPaginator,
-            on_results=lambda x: serialize(x, request.user, CombinedRuleSerializer()),
+            on_results=lambda x: serialize(x, request.user, CombinedRuleSerializer(expand=expand)),
             default_per_page=25,
             intermediaries=[alert_rule_intermediary, rule_intermediary],
             desc=True,

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -172,7 +172,6 @@ class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestC
             expand_resp = self.get_success_response(
                 self.organization.slug, self.project.slug, expand=["latestIncident"]
             )
-
         assert expand_resp.data[0]["latestIncident"] is not None
         assert expand_resp.data[0]["latestIncident"]["id"] == str(incident.id)
 

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -5,7 +5,7 @@ import requests
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
-from sentry.incidents.models import AlertRule
+from sentry.incidents.models import AlertRule, IncidentStatus
 from sentry.models import AuditLogEntry
 from sentry.silo import SiloMode
 from sentry.snuba.dataset import Dataset
@@ -155,6 +155,26 @@ class AlertRuleCreateEndpointTest(APITestCase):
 @region_silo_test(stable=True)
 class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestCase):
     endpoint = "sentry-api-0-project-combined-rules"
+
+    def test_expand_latest_incident(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(
+            organization=self.organization,
+            title="Incident #1",
+            projects=[self.project],
+            alert_rule=alert_rule,
+            status=IncidentStatus.CRITICAL.value,
+        )
+
+        self.login_as(self.user)
+        with self.feature("organizations:incidents"):
+            expand_resp = self.get_success_response(
+                self.organization.slug, self.project.slug, expand=["latestIncident"]
+            )
+
+        assert expand_resp.data[0]["latestIncident"] is not None
+        assert expand_resp.data[0]["latestIncident"]["id"] == str(incident.id)
 
     def test_no_perf_alerts(self):
         self.create_team(organization=self.organization, members=[self.user])


### PR DESCRIPTION
`user` was sometimes being passed to the `AlertRuleSerializer` as a `User` or `RpcUser` object, and sometimes it was a dictionary. This caused [this issue](https://sentry.sentry.io/issues/4457973147/) which led to an incident since the alert rule details page wouldn't load. This was "fixed" [here](https://github.com/getsentry/sentry/commit/2936554e63c58f2f0f898d4eb320fc5d70ce0ca4) by handling both types, but that wasn't ideal since we shouldn't be passing around different variable types for one variable in the first place.

Digging deeper I found that `user` was reassigned [here](https://github.com/getsentry/sentry/blob/ede26403b8a2dc127867d2c68a5b30a57b05535d/src/sentry/api/serializers/models/alert_rule.py#L90) if an `rpc_user` was found, so in [this PR](https://github.com/getsentry/sentry/pull/55868/files) that added the `RuleSnooze` data to the response, when `latestIncident` was passed to `expand` the `user` that was being passed to the serializer again was a dictionary rather than the expected `User` or `RpcUser`, so the query wouldn't work. 

This PR fixes all of that by not re-assigning `user` - when it was originally done we didn't use `user` in a meaningful way later on in the code so it didn't matter. 

I also changed the variable name `type` since as I was debugging this, I couldn't print the type of `user` which was really annoying. (e.g. `print(type(user))` threw an error that `type` hadn't been defined yet). 
