### PR TITLE
feat(ui): Remove ids option from `useTeams`

### DIFF
--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.spec.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.spec.tsx
@@ -1,0 +1,55 @@
+import selectEvent from 'react-select-event';
+import {Project} from 'sentry-fixture/project';
+import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import MemberListStore from 'sentry/stores/memberListStore';
+import OrganizationStore from 'sentry/stores/organizationStore';
+import TeamStore from 'sentry/stores/teamStore';
+
+import SentryMemberTeamSelectorField from './sentryMemberTeamSelectorField';
+
+describe('SentryMemberTeamSelectorField', () => {
+  const org = TestStubs.Organization();
+  const mockUsers = [User()];
+  const mockTeams = [Team()];
+  const mockProjects = [Project()];
+
+  beforeEach(() => {
+    MemberListStore.init();
+    MemberListStore.loadInitialData(mockUsers);
+    TeamStore.init();
+    TeamStore.loadInitialData(mockTeams);
+    OrganizationStore.onUpdate(org, {replace: true});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/user-teams/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/teams/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/members/`,
+      body: [],
+    });
+  });
+
+  it('can change values', async () => {
+    const mock = jest.fn();
+    render(
+      <SentryMemberTeamSelectorField
+        onChange={mock}
+        name="team-or-member"
+        projects={mockProjects}
+      />
+    );
+
+    await selectEvent.select(screen.getByText(/Choose Teams and Members/i), '#team-slug');
+
+    expect(mock).toHaveBeenCalledWith('team:1', expect.anything());
+  });
+});

--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
@@ -5,6 +5,7 @@ import {t} from 'sentry/locale';
 import {Project} from 'sentry/types';
 import {useMembers} from 'sentry/utils/useMembers';
 import {useTeams} from 'sentry/utils/useTeams';
+import {useTeamsById} from 'sentry/utils/useTeamsById';
 
 import FormContext from '../formContext';
 
@@ -60,7 +61,7 @@ function SentryMemberTeamSelectorField({
       currentItems?.filter(item => item.startsWith('team:')).map(user => user.slice(5)),
     [currentItems]
   );
-  useTeams({ids: ensureTeamIds});
+  useTeamsById({ids: ensureTeamIds});
 
   const {
     teams,

--- a/static/app/utils/useTeams.spec.tsx
+++ b/static/app/utils/useTeams.spec.tsx
@@ -107,41 +107,6 @@ describe('useTeams', function () {
     expect(teams).toEqual(expect.arrayContaining(mockTeams));
   });
 
-  it('can load teams by id', async function () {
-    const requestedTeams = [TestStubs.Team({id: '2', slug: 'requested-team'})];
-    const mockRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/teams/`,
-      method: 'GET',
-      body: requestedTeams,
-    });
-
-    TeamStore.loadInitialData(mockTeams);
-
-    const {result, waitFor} = reactHooks.renderHook(useTeams, {
-      initialProps: {ids: ['2']},
-    });
-
-    expect(result.current.initiallyLoaded).toBe(false);
-    expect(mockRequest).toHaveBeenCalled();
-
-    await waitFor(() => expect(result.current.teams.length).toBe(1));
-
-    const {teams} = result.current;
-    expect(teams).toEqual(expect.arrayContaining(requestedTeams));
-  });
-
-  it('only loads ids when needed', function () {
-    TeamStore.loadInitialData(mockTeams);
-
-    const {result} = reactHooks.renderHook(useTeams, {
-      initialProps: {ids: [mockTeams[0].id]},
-    });
-
-    const {teams, initiallyLoaded} = result.current;
-    expect(initiallyLoaded).toBe(true);
-    expect(teams).toEqual(expect.arrayContaining(mockTeams));
-  });
-
   it('correctly returns hasMore before and after store update', async function () {
     const {result, waitFor} = reactHooks.renderHook(useTeams);
 

--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -64,12 +64,6 @@ type Result = {
 
 type Options = {
   /**
-   * When provided, fetches specified teams by id if necessary and only provides those teams.
-   *
-   * @deprecated use `useTeamsById({ids: []})`
-   */
-  ids?: string[];
-  /**
    * Number of teams to return when not using `props.slugs`
    */
   limit?: number;
@@ -99,6 +93,7 @@ type FetchTeamOptions = {
 
 /**
  * Helper function to actually load teams
+ *
  */
 async function fetchTeams(
   api: Client,
@@ -164,8 +159,15 @@ async function fetchTeams(
  * loaded, so you should use this hook with the intention of providing specific
  * slugs, or loading more through search.
  *
+ * @deprecated use the alternatives to this hook (except for search and pagination)
+ * new alternatives:
+ * - useTeamsById({ids: []}) - get teams by id
+ * - useTeamsById({slugs: []}) - get teams by slug
+ * - useTeamsById() - just reading from the teams store
+ * - useUserTeams() - same as `provideUserTeams: true`
+ *
  */
-export function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
+export function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
   const api = useApi();
   const {organization} = useLegacyStore(OrganizationStore);
   const store = useLegacyStore(TeamStore);
@@ -173,19 +175,12 @@ export function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
   const orgId = organization?.slug;
 
   const storeSlugs = useMemo(() => new Set(store.teams.map(t => t.slug)), [store.teams]);
-  const storeIds = useMemo(() => new Set(store.teams.map(t => t.id)), [store.teams]);
 
   const slugsToLoad = useMemo(
     () => slugs?.filter(slug => !storeSlugs.has(slug)) ?? [],
     [slugs, storeSlugs]
   );
-
-  const idsToLoad = useMemo(
-    () => ids?.filter(id => !storeIds.has(id)) ?? [],
-    [ids, storeIds]
-  );
-
-  const shouldLoadByQuery = slugsToLoad.length > 0 || idsToLoad.length > 0;
+  const shouldLoadByQuery = slugsToLoad.length > 0;
   const shouldLoadUserTeams = provideUserTeams && !store.loadedUserTeams;
 
   // If we don't need to make a request either for slugs or user teams, set
@@ -236,7 +231,6 @@ export function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
       try {
         const {results, hasMore, nextCursor} = await fetchTeams(api, orgId, {
           slugs: slugsToLoad,
-          ids: idsToLoad,
           limit,
         });
 
@@ -262,7 +256,7 @@ export function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
         }));
       }
     },
-    [api, idsToLoad, limit, orgId, slugsToLoad, store.teams]
+    [api, limit, orgId, slugsToLoad, store.teams]
   );
 
   const handleFetchAdditionalTeams = useCallback(
@@ -370,12 +364,10 @@ export function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
   const filteredTeams = useMemo(() => {
     return slugs
       ? store.teams.filter(t => slugs.includes(t.slug))
-      : ids
-      ? store.teams.filter(t => ids.includes(t.id))
       : provideUserTeams && !isSuperuser
       ? store.teams.filter(t => t.isMember)
       : store.teams;
-  }, [store.teams, ids, slugs, provideUserTeams, isSuperuser]);
+  }, [store.teams, slugs, provideUserTeams, isSuperuser]);
 
   const result: Result = {
     teams: filteredTeams,

--- a/static/app/utils/useTeamsById.tsx
+++ b/static/app/utils/useTeamsById.tsx
@@ -7,11 +7,11 @@ import type {Team} from 'sentry/types';
 import {ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
 
 interface UseTeamsById {
-  ids: string[];
+  ids: string[] | undefined;
 }
 
 interface UseTeamsBySlug {
-  slugs: string[];
+  slugs: string[] | undefined;
 }
 
 interface UseAllTeams {}
@@ -44,14 +44,14 @@ function buildTeamsQueryKey(orgSlug: string, teamQuery: TeamQuery | null): ApiQu
  */
 function getQueryFromOptions(options: UseTeamOptions): TeamQuery | null {
   if ('ids' in options) {
-    if (!options.ids.length) {
+    if (!options.ids?.length) {
       return null;
     }
     return ['id', options.ids];
   }
 
   if ('slugs' in options) {
-    if (!options.slugs.length) {
+    if (!options.slugs?.length) {
       return null;
     }
     return ['slug', options.slugs];


### PR DESCRIPTION
had to revert #57151 attempt number 2 allowing for undefined instead of always an array

fixes JAVASCRIPT-2P0M