### PR TITLE
fix(bug reports): Fix word wrapping inside the description/message area

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -130,5 +130,6 @@ const Blockquote = styled('blockquote')`
     font-size: ${p => p.theme.fontSizeMedium};
     line-height: 1.6;
     padding: 0;
+    word-break: break-word;
   }
 `;


### PR DESCRIPTION
**Before:**
This is looking at the right edge of an example feedback message. Before words would wrap anyplace, so we have this weird "c" and then the rest of the word on the next line, also we can see "For exam" where the "ple" is on the next line.
<img width="117" alt="SCR-20231002-ofkq" src="https://github.com/getsentry/sentry/assets/187460/63acc735-869d-4ea0-b6b1-7ba1bcd5811c">

**After:**
Afterwards wrapping applies to full-words, nothing is cutoff like before.
<img width="133" alt="SCR-20231002-ofjx" src="https://github.com/getsentry/sentry/assets/187460/d9998cb4-fbbf-4e8e-a45b-645063f3bb06">

