### PR TITLE
fix(hc): Fix user_option_service query when deleting invite

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -418,12 +418,13 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         proj_list = list(
             Project.objects.filter(organization=organization).values_list("id", flat=True)
         )
-        uos = [
-            uo
-            for uo in user_option_service.get_many(
+
+        if member.user_id is None:
+            uos = ()
+        else:
+            uos = user_option_service.get_many(
                 filter=dict(user_ids=[member.user_id], project_ids=proj_list, key="mail:email")
             )
-        ]
 
         with transaction.atomic(router.db_for_write(Project)):
             # Delete instances of `UserOption` that are scoped to the projects within the

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -723,6 +723,12 @@ class DeleteOrganizationMemberTest(OrganizationMemberTestBase):
             user_id=member_user.id, organization=self.organization
         ).exists()
 
+    def test_can_delete_pending_invite(self):
+        invite = self.create_member(
+            organization=self.organization, user=None, email="invitee@example.com", role="member"
+        )
+        self.get_success_response(self.organization.slug, invite.id)
+
 
 @region_silo_test(stable=True)
 class ResetOrganizationMember2faTest(APITestCase):


### PR DESCRIPTION
Fix a bug where the user_option_service query would fail if the OrganizationMember being deleted had a null user_id, which occurs normally when clicking the "remove member" button on an invited user who has not yet accepted the invite. The bug is observed only if the service makes an RPC in a split silo environment.

Add a test case that exposes the bug.