### PR TITLE
fix(hc): Use integration_service from ProjectStacktraceLinkEndpoint

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -14,7 +14,7 @@ from sentry.api.serializers import serialize
 from sentry.integrations import IntegrationFeatures
 from sentry.integrations.mixins import RepositoryMixin
 from sentry.integrations.utils.codecov import codecov_enabled, fetch_codecov_data
-from sentry.models import Integration, Project, RepositoryProjectPathConfig
+from sentry.models import Project, RepositoryProjectPathConfig
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.event_frames import munged_filename_and_frames
@@ -214,9 +214,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
 
         result: JSONData = {"config": None, "sourceUrl": None}
 
-        integrations = Integration.objects.filter(
-            organizationintegration__organization_id=project.organization_id
-        )
+        integrations = integration_service.get_integrations(organization_id=project.organization_id)
         # TODO(meredith): should use get_provider.has_feature() instead once this is
         # no longer feature gated and is added as an IntegrationFeature
         result["integrations"] = [

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -10,7 +10,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.api.serializers import serialize
+from sentry.api.serializers import IntegrationSerializer, serialize
 from sentry.integrations import IntegrationFeatures
 from sentry.integrations.mixins import RepositoryMixin
 from sentry.integrations.utils.codecov import codecov_enabled, fetch_codecov_data
@@ -218,7 +218,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         # TODO(meredith): should use get_provider.has_feature() instead once this is
         # no longer feature gated and is added as an IntegrationFeature
         result["integrations"] = [
-            serialize(i, request.user)
+            serialize(i, request.user, IntegrationSerializer())
             for i in integrations
             if i.has_feature(IntegrationFeatures.STACKTRACE_LINK)
         ]

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -217,8 +217,9 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         integrations = integration_service.get_integrations(organization_id=project.organization_id)
         # TODO(meredith): should use get_provider.has_feature() instead once this is
         # no longer feature gated and is added as an IntegrationFeature
+        serializer = IntegrationSerializer()
         result["integrations"] = [
-            serialize(i, request.user, IntegrationSerializer())
+            serialize(i, request.user, serializer)
             for i in integrations
             if i.has_feature(IntegrationFeatures.STACKTRACE_LINK)
         ]

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -31,9 +31,10 @@ def serialize_provider(provider: IntegrationProvider) -> Mapping[str, Any]:
 
 
 @register(Integration)
+@register(RpcIntegration)
 class IntegrationSerializer(Serializer):
     def serialize(
-        self, obj: RpcIntegration, attrs: Mapping[str, Any], user: User, **kwargs: Any
+        self, obj: Integration | RpcIntegration, attrs: Mapping[str, Any], user: User, **kwargs: Any
     ) -> MutableMapping[str, JSONData]:
         provider = obj.get_provider()
         return {

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -31,7 +31,6 @@ def serialize_provider(provider: IntegrationProvider) -> Mapping[str, Any]:
 
 
 @register(Integration)
-@register(RpcIntegration)
 class IntegrationSerializer(Serializer):
     def serialize(
         self, obj: Integration | RpcIntegration, attrs: Mapping[str, Any], user: User, **kwargs: Any

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -113,7 +113,7 @@ class BaseProjectStacktraceLink(APITestCase):
         }
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class ProjectStacktraceLinkTest(BaseProjectStacktraceLink):
     endpoint = "sentry-api-0-project-stacktrace-link"
 
@@ -265,7 +265,7 @@ class ProjectStacktraceLinkTest(BaseProjectStacktraceLink):
         assert response.data["integrations"] == [serialized_integration(self.integration)]
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class ProjectStacktraceLinkTestMobile(BaseProjectStacktraceLink):
     def setUp(self):
         BaseProjectStacktraceLink.setUp(self)


### PR DESCRIPTION
Resolve an AvailabilityError from accessing the Integration model from region silo. Register IntegrationSerializer for RpcIntegration.

Fixes HC-893