### PR TITLE
ref(alerts): Type AlertRuleSerializer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,7 +314,6 @@ module = [
     "sentry.api.issue_search",
     "sentry.api.paginator",
     "sentry.api.permissions",
-    "sentry.api.serializers.models.alert_rule",
     "sentry.api.serializers.models.auth_provider",
     "sentry.api.serializers.models.authenticator",
     "sentry.api.serializers.models.dashboard",

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from collections import defaultdict
-from typing import MutableMapping
+from typing import Any, Mapping, MutableMapping, Sequence
 
 from django.db.models import Max, Q, prefetch_related_objects
 
@@ -17,6 +19,7 @@ from sentry.incidents.models import (
 from sentry.models.actor import ACTOR_TYPES, Actor, actor_type_to_string
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
+from sentry.models.user import User
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
@@ -25,14 +28,16 @@ from sentry.snuba.models import SnubaQueryEventType
 
 @register(AlertRule)
 class AlertRuleSerializer(Serializer):
-    def __init__(self, expand=None):
+    def __init__(self, expand: list[str] | None = None):
         self.expand = expand or []
 
-    def get_attrs(self, item_list, user, **kwargs):
+    def get_attrs(
+        self, item_list: Sequence[Any], user: User | RpcUser, **kwargs: Any
+    ) -> defaultdict[AlertRule, Any]:
         alert_rules = {item.id: item for item in item_list}
         prefetch_related_objects(item_list, "snuba_query__environment")
 
-        result = defaultdict(dict)
+        result: defaultdict[AlertRule, dict[str, Any]] = defaultdict(dict)
         triggers = AlertRuleTrigger.objects.filter(alert_rule__in=item_list).order_by("label")
         serialized_triggers = serialize(list(triggers), **kwargs)
 
@@ -94,7 +99,7 @@ class AlertRuleSerializer(Serializer):
             if item.owner_id is not None:
                 owners_by_type[actor_type_to_string(item.owner.type)].append(item.owner_id)
 
-        resolved_actors = {}
+        resolved_actors: dict[str, dict[int | None, int | None]] = {}
         for k, v in ACTOR_TYPES.items():
             actors = Actor.objects.filter(type=v, id__in=owners_by_type[k])
             if k == "team":
@@ -105,10 +110,11 @@ class AlertRuleSerializer(Serializer):
         for alert_rule in alert_rules.values():
             if alert_rule.owner_id:
                 owner_type = actor_type_to_string(alert_rule.owner.type)
-                if alert_rule.owner_id in resolved_actors[owner_type]:
-                    result[alert_rule][
-                        "owner"
-                    ] = f"{owner_type}:{resolved_actors[owner_type][alert_rule.owner_id]}"
+                if owner_type:
+                    if alert_rule.owner_id in resolved_actors[owner_type]:
+                        result[alert_rule][
+                            "owner"
+                        ] = f"{owner_type}:{resolved_actors[owner_type][alert_rule.owner_id]}"
 
         if "original_alert_rule" in self.expand:
             snapshot_activities = AlertRuleActivity.objects.filter(
@@ -131,10 +137,11 @@ class AlertRuleSerializer(Serializer):
                 incident_map[incident.alert_rule_id] = serialize(incident, user=user)
             for alert_rule in alert_rules.values():
                 result[alert_rule]["latestIncident"] = incident_map.get(alert_rule.id, None)
-
         return result
 
-    def serialize(self, obj, attrs, user, **kwargs):
+    def serialize(
+        self, obj: AlertRule, attrs: Mapping[Any, Any], user: User | RpcUser, **kwargs: Any
+    ) -> dict[str, Any]:
         from sentry.incidents.endpoints.utils import translate_threshold
         from sentry.incidents.logic import translate_aggregate_field
 
@@ -181,7 +188,9 @@ class AlertRuleSerializer(Serializer):
 
 
 class DetailedAlertRuleSerializer(AlertRuleSerializer):
-    def get_attrs(self, item_list, user, **kwargs):
+    def get_attrs(
+        self, item_list: Sequence[Any], user: User | RpcUser, **kwargs: Any
+    ) -> defaultdict[AlertRule, Any]:
         result = super().get_attrs(item_list, user, **kwargs)
         alert_rules = {item.id: item for item in item_list}
         for alert_rule_id, project_slug in AlertRuleExcludedProjects.objects.filter(
@@ -202,7 +211,9 @@ class DetailedAlertRuleSerializer(AlertRuleSerializer):
 
         return result
 
-    def serialize(self, obj, attrs, user, **kwargs):
+    def serialize(
+        self, obj: AlertRule, attrs: Mapping[Any, Any], user: User | RpcUser, **kwargs
+    ) -> dict[str, Any]:
         data = super().serialize(obj, attrs, user)
         data["excludedProjects"] = sorted(attrs.get("excluded_projects", []))
         data["eventTypes"] = sorted(attrs.get("event_types", []))
@@ -211,16 +222,18 @@ class DetailedAlertRuleSerializer(AlertRuleSerializer):
 
 
 class CombinedRuleSerializer(Serializer):
-    def __init__(self, expand=None):
+    def __init__(self, expand: list[str] | None = None):
         self.expand = expand or []
 
-    def get_attrs(self, item_list, user, **kwargs):
+    def get_attrs(
+        self, item_list: Sequence[Any], user: User | RpcUser, **kwargs: Any
+    ) -> MutableMapping[Any, Any]:
         results = super().get_attrs(item_list, user)
 
         alert_rules = [x for x in item_list if isinstance(x, AlertRule)]
         incident_map = {}
         if "latestIncident" in self.expand:
-            for incident in Incident.objects.filter(id__in=[x.incident_id for x in alert_rules]):
+            for incident in Incident.objects.filter(alert_rule_id__in=[x.id for x in alert_rules]):
                 incident_map[incident.id] = serialize(incident, user=user)
 
         serialized_alert_rules = serialize(alert_rules, user=user)
@@ -234,19 +247,33 @@ class CombinedRuleSerializer(Serializer):
             if isinstance(item, AlertRule):
                 alert_rule = serialized_alert_rules.pop(0)
                 if "latestIncident" in self.expand:
-                    alert_rule["latestIncident"] = incident_map.get(item.incident_id)
+                    incident = (
+                        Incident.objects.filter(alert_rule_id=item.id)
+                        .order_by("-date_detected")
+                        .first()
+                    )
+                    if incident:
+                        alert_rule["latestIncident"] = incident_map.get(incident.id)
                 results[item] = alert_rule
             elif isinstance(item, Rule):
                 results[item] = rules.pop(0)
 
         return results
 
-    def serialize(self, obj, attrs, user, **kwargs):
+    def serialize(
+        self,
+        obj: Rule | AlertRule,
+        attrs: Mapping[Any, Any],
+        user: User | RpcUser,
+        **kwargs: Any,
+    ) -> MutableMapping[Any, Any]:
         if isinstance(obj, AlertRule):
-            attrs["type"] = "alert_rule"
-            return attrs
+            alert_rule_attrs: MutableMapping[Any, Any] = {**attrs}
+            alert_rule_attrs["type"] = "alert_rule"
+            return alert_rule_attrs
         elif isinstance(obj, Rule):
-            attrs["type"] = "rule"
-            return attrs
+            rule_attrs: MutableMapping[Any, Any] = {**attrs}
+            rule_attrs["type"] = "rule"
+            return rule_attrs
         else:
             raise AssertionError(f"Invalid rule to serialize: {type(obj)}")

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -24,6 +26,7 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
         """
         Fetches alert rules and legacy rules for a project
         """
+        expand: list[str] = request.GET.getlist("expand", [])
         alert_rules = AlertRule.objects.fetch_for_project(project)
         if not features.has("organizations:performance-view", project.organization):
             # Filter to only error alert rules
@@ -41,7 +44,7 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
         return self.paginate(
             request,
             paginator_cls=CombinedQuerysetPaginator,
-            on_results=lambda x: serialize(x, request.user, CombinedRuleSerializer()),
+            on_results=lambda x: serialize(x, request.user, CombinedRuleSerializer(expand=expand)),
             default_per_page=25,
             intermediaries=[alert_rule_intermediary, rule_intermediary],
             desc=True,

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -5,7 +5,7 @@ import requests
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
-from sentry.incidents.models import AlertRule
+from sentry.incidents.models import AlertRule, IncidentStatus
 from sentry.models import AuditLogEntry
 from sentry.silo import SiloMode
 from sentry.snuba.dataset import Dataset
@@ -155,6 +155,26 @@ class AlertRuleCreateEndpointTest(APITestCase):
 @region_silo_test(stable=True)
 class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestCase):
     endpoint = "sentry-api-0-project-combined-rules"
+
+    def test_expand_latest_incident(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(
+            organization=self.organization,
+            title="Incident #1",
+            projects=[self.project],
+            alert_rule=alert_rule,
+            status=IncidentStatus.CRITICAL.value,
+        )
+
+        self.login_as(self.user)
+        with self.feature("organizations:incidents"):
+            expand_resp = self.get_success_response(
+                self.organization.slug, self.project.slug, expand=["latestIncident"]
+            )
+
+        assert expand_resp.data[0]["latestIncident"] is not None
+        assert expand_resp.data[0]["latestIncident"]["id"] == str(incident.id)
 
     def test_no_perf_alerts(self):
         self.create_team(organization=self.organization, members=[self.user])


### PR DESCRIPTION
A follow up to https://github.com/getsentry/sentry/pull/57310 that types the `AlertRuleSerializer` and the serializers that use it. 

The only behavioral change is in the `CombinedRuleSerializer` where after typing the whole file, I realized `expand` was never actually passed to it so we had never hit the code path that incorrectly tried to get an `incident_id` from an `AlertRule` (there is no such column on that model) so I fixed the queries, passed `expand`, and wrote a test for it. 

Closes https://github.com/getsentry/sentry/issues/56122