### PR TITLE
feat(escalating-issues): json.loads spans polluting the trace

### DIFF
--- a/src/sentry/db/models/fields/gzippeddict.py
+++ b/src/sentry/db/models/fields/gzippeddict.py
@@ -32,7 +32,7 @@ class GzippedDictField(TextField):
         try:
             if not value:
                 return {}
-            return json.loads(value)
+            return json.loads(value, skip_trace=True)
         except (ValueError, TypeError):
             if isinstance(value, str) and value:
                 try:

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import decimal
 import uuid
+from contextlib import contextmanager
 from enum import Enum
 from typing import IO, TYPE_CHECKING, Any, Generator, Mapping, NoReturn, TypeVar, overload
 
@@ -129,9 +130,20 @@ def load(fp: IO[str] | IO[bytes], **kwargs: NoReturn) -> JSONData:
     return loads(fp.read())
 
 
+@contextmanager
+def dummy_context_manager():
+    yield None
+
+
 # NoReturn here is to make this a mypy error to pass kwargs, since they are currently silently dropped
-def loads(value: str | bytes, use_rapid_json: bool = False, **kwargs: NoReturn) -> JSONData:
-    with sentry_sdk.start_span(op="sentry.utils.json.loads"):
+def loads(
+    value: str | bytes, use_rapid_json: bool = False, skip_trace: bool = False, **kwargs: NoReturn
+) -> JSONData:
+    with (
+        sentry_sdk.start_span(op="sentry.utils.json.loads")
+        if not skip_trace
+        else dummy_context_manager()
+    ):
         if use_rapid_json is True:
             return rapidjson.loads(value)
         else:

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 import decimal
 import uuid
-from contextlib import contextmanager
+from contextlib import nullcontext
 from enum import Enum
 from typing import IO, TYPE_CHECKING, Any, Generator, Mapping, NoReturn, TypeVar, overload
 
@@ -130,20 +130,11 @@ def load(fp: IO[str] | IO[bytes], **kwargs: NoReturn) -> JSONData:
     return loads(fp.read())
 
 
-@contextmanager
-def dummy_context_manager():
-    yield None
-
-
 # NoReturn here is to make this a mypy error to pass kwargs, since they are currently silently dropped
 def loads(
     value: str | bytes, use_rapid_json: bool = False, skip_trace: bool = False, **kwargs: NoReturn
 ) -> JSONData:
-    with (
-        sentry_sdk.start_span(op="sentry.utils.json.loads")
-        if not skip_trace
-        else dummy_context_manager()
-    ):
+    with sentry_sdk.start_span(op="sentry.utils.json.loads") if not skip_trace else nullcontext():  # type: ignore
         if use_rapid_json is True:
             return rapidjson.loads(value)
         else:

--- a/tests/sentry/utils/test_json.py
+++ b/tests/sentry/utils/test_json.py
@@ -51,11 +51,11 @@ class JSONTest(TestCase):
         self.assertEqual(json.dumps(_("word")), '"word"')
 
     @patch("sentry_sdk.start_span")
-    def test_loads_with_sdk_trace(self, sentry_sdk_mock):
+    def test_loads_with_sdk_trace(self, start_span_mock):
         json.loads('{"test": "message"}')
-        sentry_sdk_mock.assert_called_once()
+        start_span_mock.assert_called_once()
 
     @patch("sentry_sdk.start_span")
-    def test_loads_without_sdk_trace(self, sentry_sdk_mock):
+    def test_loads_without_sdk_trace(self, start_span_mock):
         json.loads('{"test": "message"}', skip_trace=True)
-        sentry_sdk_mock.assert_not_called()
+        start_span_mock.assert_not_called()

--- a/tests/sentry/utils/test_json.py
+++ b/tests/sentry/utils/test_json.py
@@ -2,6 +2,7 @@ import datetime
 import uuid
 from enum import Enum
 from unittest import TestCase
+from unittest.mock import patch
 
 from django.utils.translation import gettext_lazy as _
 
@@ -48,3 +49,13 @@ class JSONTest(TestCase):
 
     def test_translation(self):
         self.assertEqual(json.dumps(_("word")), '"word"')
+
+    @patch("sentry_sdk.start_span")
+    def test_loads_with_sdk_trace(self, sentry_sdk_mock):
+        json.loads('{"test": "message"}')
+        sentry_sdk_mock.assert_called_once()
+
+    @patch("sentry_sdk.start_span")
+    def test_loads_without_sdk_trace(self, sentry_sdk_mock):
+        json.loads('{"test": "message"}', skip_trace=True)
+        sentry_sdk_mock.assert_not_called()


### PR DESCRIPTION
## Objective:
Trying to debug why the auto-transition-issue-state tasks are taking too long. But the trace from Sentry is incomplete because there are too many spans from `json.loads` while converting the values from the data GzippedDictField. And then we run out of spans.

This PR makes the custom span optional and disables it for GzippedDictFields. 

<img width="1121" alt="Screen Shot 2023-10-02 at 6 47 34 PM" src="https://github.com/getsentry/sentry/assets/10491193/44c1de0b-39ba-4906-9c9c-68eb4f1d176d">
 