### PR TITLE
feat(inbound-filters): Add inbound filter for ChunkLoadError (OLD)

### DIFF
--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -94,6 +94,7 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
             FilterStatKeys.LOCALHOST,
             FilterStatKeys.WEB_CRAWLER,
             FilterStatKeys.HEALTH_CHECK,
+            FilterStatKeys.CHUNK_LOAD_ERROR,
         ):
             returned_state = filter_id
             removed = current_state - new_state

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -280,7 +280,4 @@ _chunk_load_error_filter = _FilterSpec(
     description="It can happen that in full automatic deploy environments like Next.js & Vercel the frontend gets out "
     "of sync with the backend which results in a ChunkLoadError. The application refreshes and everything "
     "should work as expected.",
-    serializer_cls=None,
-    # This filter is an error message filter and multiple such filters can exist.
-    config_name="errorMessages",
 )

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -24,6 +24,7 @@ class FilterStatKeys:
     DISCARDED_HASH = "discarded-hash"  # Not replicated in Relay
     CRASH_REPORT_LIMIT = "crash-report-limit"  # Not replicated in Relay
     HEALTH_CHECK = "filtered-transaction"  # Ignore health-check transactions
+    CHUNK_LOAD_ERROR = "chunk-load-error"  # Ignore NextJS ChunkLoadError
 
 
 FILTER_STAT_KEYS_TO_VALUES = {
@@ -38,6 +39,7 @@ FILTER_STAT_KEYS_TO_VALUES = {
     FilterStatKeys.CORS: TSDBModel.project_total_received_cors,
     FilterStatKeys.DISCARDED_HASH: TSDBModel.project_total_received_discarded,
     FilterStatKeys.HEALTH_CHECK: TSDBModel.project_total_healthcheck,
+    FilterStatKeys.CHUNK_LOAD_ERROR: TSDBModel.project_total_chunk_load_error,
 }
 
 
@@ -65,6 +67,7 @@ def get_all_filter_specs():
         _legacy_browsers_filter,
         _web_crawlers_filter,
         _healthcheck_filter,
+        _chunk_load_error_filter,
     ]
 
     return tuple(filters)  # returning tuple for backwards compatibility
@@ -269,4 +272,15 @@ _healthcheck_filter = _FilterSpec(
     description="Filter transactions that match most common naming patterns for health checks.",
     serializer_cls=None,
     config_name="ignoreTransactions",
+)
+
+_chunk_load_error_filter = _FilterSpec(
+    id=FilterStatKeys.CHUNK_LOAD_ERROR,
+    name="Filter out ChunkLoadError(s)",
+    description="It can happen that in full automatic deploy environments like Next.js & Vercel the frontend gets out "
+    "of sync with the backend which results in a ChunkLoadError. The application refreshes and everything "
+    "should work as expected.",
+    serializer_cls=None,
+    # This filter is an error message filter and multiple such filters can exist.
+    config_name="errorMessages",
 )

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -39,7 +39,6 @@ FILTER_STAT_KEYS_TO_VALUES = {
     FilterStatKeys.CORS: TSDBModel.project_total_received_cors,
     FilterStatKeys.DISCARDED_HASH: TSDBModel.project_total_received_discarded,
     FilterStatKeys.HEALTH_CHECK: TSDBModel.project_total_healthcheck,
-    FilterStatKeys.CHUNK_LOAD_ERROR: TSDBModel.project_total_chunk_load_error,
 }
 
 

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -79,6 +79,9 @@ register(key="filters:localhost", epoch_defaults={1: "0"})
 # Default react hydration errors filter
 register(key="filters:react-hydration-errors", epoch_defaults={1: "1"})
 
+# Default NextJS ChunkLoadError filter
+register(key="filters:chunk-load-error", epoch_defaults={1: "1"})
+
 # Default breakdowns config
 register(
     key="sentry:breakdowns",

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -654,6 +654,7 @@ class Referrer(Enum):
     TSDB_MODELID_609 = "tsdb-modelid:609"
     TSDB_MODELID_610 = "tsdb-modelid:610"
     TSDB_MODELID_611 = "tsdb-modelid:611"
+    TSDB_MODELID_612 = "tsdb-modelid:612"
     TSDB_MODELID_700 = "tsdb-modelid:700"
     TSDB_MODELID_800 = "tsdb-modelid:800"
     TSDB_MODELID_801 = "tsdb-modelid:801"

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -92,6 +92,8 @@ class TSDBModel(Enum):
     project_total_received_discarded = 610
     # the number of events filtered because they refer to a healthcheck endpoint
     project_total_healthcheck = 611
+    # the number of events filtered because the error is a ChunkLoadError
+    project_total_chunk_load_error = 612
 
     servicehook_fired = 700
 

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -92,8 +92,6 @@ class TSDBModel(Enum):
     project_total_received_discarded = 610
     # the number of events filtered because they refer to a healthcheck endpoint
     project_total_healthcheck = 611
-    # the number of events filtered because the error is a ChunkLoadError
-    project_total_chunk_load_error = 612
 
     servicehook_fired = 700
 

--- a/tests/sentry/api/endpoints/snapshots/ProjectFiltersTest/test_get.pysnap
+++ b/tests/sentry/api/endpoints/snapshots/ProjectFiltersTest/test_get.pysnap
@@ -1,8 +1,12 @@
 ---
+created: '2023-10-03T06:55:40.049770Z'
+creator: sentry
 source: tests/sentry/api/endpoints/test_project_filters.py
 ---
 - active: false
   id: browser-extensions
+- active: true
+  id: chunk-load-error
 - active: true
   id: filtered-transaction
 - active: false

--- a/tests/sentry/api/endpoints/snapshots/ProjectFiltersTest__InRegionMode/test_get.pysnap
+++ b/tests/sentry/api/endpoints/snapshots/ProjectFiltersTest__InRegionMode/test_get.pysnap
@@ -4,6 +4,8 @@ source: tests/sentry/api/endpoints/test_project_filters.py
 - active: false
   id: browser-extensions
 - active: true
+  id: chunk-load-error
+- active: true
   id: filtered-transaction
 - active: false
   id: legacy-browsers

--- a/tests/sentry/api/endpoints/test_project_filter_details.py
+++ b/tests/sentry/api/endpoints/test_project_filter_details.py
@@ -45,6 +45,28 @@ class ProjectFilterDetailsTest(APITestCase):
         # option was changed by the request
         assert project.get_option("filters:filtered-transaction") == "0"
 
+    def test_put_chunk_load_error_filter(self):
+        """
+        Tests that it accepts to set the ChunkLoadError filter.
+        """
+        org = self.create_organization(name="baz", slug="1", owner=self.user)
+        team = self.create_team(organization=org, name="foo", slug="foo")
+        project = self.create_project(name="Bar", slug="bar", teams=[team])
+
+        project.update_option("filters:chunk-load-error", "0")
+        self.get_success_response(
+            org.slug, project.slug, "chunk-load-error", active=True, status_code=204
+        )
+        # option was changed by the request
+        assert project.get_option("filters:chunk-load-error") == "1"
+
+        project.update_option("filters:chunk-load-error", "1")
+        self.get_success_response(
+            org.slug, project.slug, "chunk-load-error", active=False, status_code=204
+        )
+        # option was changed by the request
+        assert project.get_option("filters:chunk-load-error") == "0"
+
     def test_put_legacy_browsers(self):
         org = self.create_organization(name="baz", slug="1", owner=self.user)
         team = self.create_team(organization=org, name="foo", slug="foo")

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-09-15T07:41:54.167449Z'
+created: '2023-10-03T07:37:36.283989Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -82,6 +82,9 @@ config:
       - promfflinkdev.com
     errorMessages:
       patterns:
+      - 'ChunkLoadError: Loading chunk * failed.
+
+        (error: *)'
       - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
     ignoreTransactions:
       isEnabled: true

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-09-15T07:41:54.637425Z'
+created: '2023-10-03T07:37:36.532678Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -82,6 +82,9 @@ config:
       - promfflinkdev.com
     errorMessages:
       patterns:
+      - 'ChunkLoadError: Loading chunk * failed.
+
+        (error: *)'
       - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
     ignoreTransactions:
       isEnabled: true

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -654,9 +654,7 @@ def test_project_config_with_chunk_load_error_filter(default_project):
     _validate_project_config(cfg["config"])
     cfg_error_messages = get_path(cfg, "config", "filterSettings", "errorMessages")
 
-    assert cfg_error_messages == {
-        "patterns": ["ChunkLoadError: Loading chunk * failed.\n(error: *)"]
-    }
+    assert len(cfg_error_messages) == 1
 
 
 @django_db_all

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -179,6 +179,7 @@ def test_project_config_uses_filter_features(
     default_project.update_option("sentry:error_messages", error_messages)
     default_project.update_option("sentry:releases", releases)
     default_project.update_option("filters:react-hydration-errors", False)
+    default_project.update_option("filters:chunk-load-error", "0")
 
     if has_blacklisted_ips:
         default_project.update_option("sentry:blacklisted_ips", blacklisted_ips)


### PR DESCRIPTION
This PR implements a new inbound filter for `ChunkLoadError`s in the form:
```
ChunkLoadError: Loading chunk 3662 failed. (error: https://xxx.com/_next/static/chunks/29107295-0151559bd23117ba.js)
```

Such inbound filter idea emerged in https://github.com/vercel/next.js/issues/38507.

Closes https://github.com/getsentry/sentry/issues/57131