### PR TITLE
feat(crons): Track new landing page analytics

### DIFF
--- a/static/app/utils/analytics/monitorsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/monitorsAnalyticsEvents.tsx
@@ -1,5 +1,12 @@
-export type MonitorsEventParameters = {};
+export type MonitorsEventParameters = {
+  'landing_page.platform_guide.viewed': {
+    guide: string;
+    platform: string;
+  };
+};
 
 type MonitorsAnalyticsKey = keyof MonitorsEventParameters;
 
-export const monitorsEventMap: Record<MonitorsAnalyticsKey, string> = {};
+export const monitorsEventMap: Record<MonitorsAnalyticsKey, string> = {
+  'landing_page.platform_guide.viewed': 'Crons Landing Page: Viewed Platform Guide',
+};

--- a/static/app/views/monitors/components/cronsLandingPanel.tsx
+++ b/static/app/views/monitors/components/cronsLandingPanel.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -12,6 +13,7 @@ import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -98,6 +100,18 @@ export function CronsLandingPanel() {
   const location = useLocation();
   const platform = decodeScalar(location.query?.platform) ?? null;
   const guide = decodeScalar(location.query?.guide);
+
+  useEffect(() => {
+    if (!platform || !guide) {
+      return;
+    }
+
+    trackAnalytics('landing_page.platform_guide.viewed', {
+      organization,
+      platform,
+      guide,
+    });
+  }, [organization, platform, guide]);
 
   const navigateToPlatformGuide = (
     selectedPlatform: SupportedPlatform | null,


### PR DESCRIPTION
Tracks analytics anytime a platform guide is viewed on this page (including if it was from a link):

<img width="1249" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/54b5246a-758d-4328-a55f-4941727769a1">

Fixes: https://github.com/getsentry/team-crons/issues/91
