### PR TITLE
feat(crons): Add confirmation modal to delete monitor environment

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -4,6 +4,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
+import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {IconEllipsis} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -71,7 +72,16 @@ export function TimelineTableRow({
                       label: t('Delete Environment'),
                       key: 'delete',
                       onAction: () => {
-                        onDeleteEnvironment(name);
+                        openConfirmModal({
+                          onConfirm: () => onDeleteEnvironment(name),
+                          header: t('Delete Environment?'),
+                          message: tct(
+                            'Are you sure you want to permanently delete the "[envName]" environment?',
+                            {envName: name}
+                          ),
+                          confirmText: t('Delete'),
+                          priority: 'danger',
+                        });
                       },
                     },
                   ]}


### PR DESCRIPTION
<img width="975" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/d36a8f54-afd0-45fe-bb62-22562d59201b">

Fixes: https://github.com/getsentry/team-crons/issues/92