### PR TITLE
docs(ui): Update `dart` getting started sample

### DIFF
--- a/static/app/gettingStartedDocs/dart/dart.tsx
+++ b/static/app/gettingStartedDocs/dart/dart.tsx
@@ -59,9 +59,14 @@ Future<void> main() async {
       // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
       // We recommend adjusting this value in production.
       options.tracesSampleRate = 1.0;
-    });
-
+    },
+    appRunner: initApp, // Init your App.
+  );
   // or define SENTRY_DSN via Dart environment variable (--dart-define)
+}
+
+void initApp() {
+  // your app code
 }
         `,
         additionalInfo: (


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry-dart/issues/1585

Update the dart sample code to use appRunner.

This way, when getting started, users will configure sentry to run their code inside of `runZonedGuarded` zone, so sentry can pick up thrown erros which are not handled.



