### PR TITLE
ref(types): Consolidate platform key and type

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/index.tsx
@@ -1,5 +1,5 @@
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import {ExceptionType, Group, PlatformType, Project} from 'sentry/types';
+import {ExceptionType, Group, PlatformKey, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {StackType, StackView} from 'sentry/types/stacktrace';
 
@@ -10,7 +10,7 @@ type Props = {
   event: Event;
   hasHierarchicalGrouping: boolean;
   newestFirst: boolean;
-  platform: PlatformType;
+  platform: PlatformKey;
   projectSlug: Project['slug'];
   stackType: StackType;
   groupingCurrentLevel?: Group['metadata']['current_level'];

--- a/static/app/components/events/interfaces/crashContent/exception/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/rawContent.tsx
@@ -7,7 +7,7 @@ import ClippedBox from 'sentry/components/clippedBox';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
-import {ExceptionType, Organization, PlatformType, Project} from 'sentry/types';
+import {ExceptionType, Organization, PlatformKey, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -17,7 +17,7 @@ import rawStacktraceContent from '../stackTrace/rawContent';
 type Props = {
   api: Client;
   eventId: Event['id'];
-  platform: PlatformType;
+  platform: PlatformKey;
   projectSlug: Project['slug'];
   type: 'original' | 'minified';
   // XXX: Organization is NOT available for Shared Issues!

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
@@ -3,7 +3,7 @@ import {FrameSourceMapDebuggerData} from 'sentry/components/events/interfaces/so
 import Panel from 'sentry/components/panels/panel';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {ExceptionValue, Group, PlatformType} from 'sentry/types';
+import {ExceptionValue, Group, PlatformKey} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {StackView} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
@@ -18,7 +18,7 @@ type Props = {
   data: ExceptionValue['stacktrace'];
   event: Event;
   hasHierarchicalGrouping: boolean;
-  platform: PlatformType;
+  platform: PlatformKey;
   stacktrace: ExceptionValue['stacktrace'];
   expandFirstFrame?: boolean;
   frameSourceMapDebuggerData?: FrameSourceMapDebuggerData[];

--- a/static/app/components/events/interfaces/crashContent/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/index.tsx
@@ -1,4 +1,4 @@
-import {ExceptionType, ExceptionValue, PlatformType} from 'sentry/types';
+import {ExceptionType, ExceptionValue, PlatformKey} from 'sentry/types';
 
 import {ExceptionContent} from './exception';
 import {StackTraceContent} from './stackTrace';
@@ -29,7 +29,7 @@ export function CrashContent({
   exception,
   stacktrace,
 }: Props) {
-  const platform = (event.platform ?? 'other') as PlatformType;
+  const platform = (event.platform ?? 'other') as PlatformKey;
 
   if (exception) {
     return (

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -5,7 +5,7 @@ import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {FrameSourceMapDebuggerData} from 'sentry/components/events/interfaces/sourceMapsDebuggerModal';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
-import {Frame, Organization, PlatformType} from 'sentry/types';
+import {Frame, Organization, PlatformKey} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {StackTraceMechanism, StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
@@ -31,7 +31,7 @@ type DefaultProps = {
 type Props = {
   data: StacktraceType;
   event: Event;
-  platform: PlatformType;
+  platform: PlatformKey;
   className?: string;
   frameSourceMapDebuggerData?: FrameSourceMapDebuggerData[];
   hideIcon?: boolean;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/hierarchicalGroupingContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/hierarchicalGroupingContent.tsx
@@ -5,7 +5,7 @@ import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
-import {Frame, Group, PlatformType} from 'sentry/types';
+import {Frame, Group, PlatformKey} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
@@ -18,7 +18,7 @@ import StacktracePlatformIcon from './platformIcon';
 type Props = {
   data: StacktraceType;
   event: Event;
-  platform: PlatformType;
+  platform: PlatformKey;
   className?: string;
   expandFirstFrame?: boolean;
   groupingCurrentLevel?: Group['metadata']['current_level'];

--- a/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import {PlatformType} from 'sentry/types';
+import {PlatformKey} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {StacktraceType, StackView} from 'sentry/types/stacktrace';
 import {isNativePlatform} from 'sentry/utils/platform';
@@ -18,7 +18,7 @@ type Props = Pick<
   event: Event;
   hasHierarchicalGrouping: boolean;
   newestFirst: boolean;
-  platform: PlatformType;
+  platform: PlatformKey;
   stacktrace: StacktraceType;
   inlined?: boolean;
   lockAddress?: string;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Frame, Group, PlatformType} from 'sentry/types';
+import {Frame, Group, PlatformKey} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
@@ -21,7 +21,7 @@ import {
 type Props = {
   data: StacktraceType;
   event: Event;
-  platform: PlatformType;
+  platform: PlatformKey;
   expandFirstFrame?: boolean;
   groupingCurrentLevel?: Group['metadata']['current_level'];
   hiddenFrameCount?: number;

--- a/static/app/components/events/interfaces/exception.tsx
+++ b/static/app/components/events/interfaces/exception.tsx
@@ -1,5 +1,5 @@
 import {t} from 'sentry/locale';
-import {ExceptionType, Group, PlatformType, Project} from 'sentry/types';
+import {ExceptionType, Group, PlatformKey, Project} from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
 import {StackType, StackView} from 'sentry/types/stacktrace';
 
@@ -40,7 +40,7 @@ export function Exception({
 
   const meta = event._meta?.entries?.[entryIndex]?.data?.values;
 
-  function getPlatform(): PlatformType {
+  function getPlatform(): PlatformKey {
     const dataValue = data.values?.find(
       value => !!value.stacktrace?.frames?.some(frame => !!frame.platform)
     );

--- a/static/app/components/events/interfaces/exceptionV2.tsx
+++ b/static/app/components/events/interfaces/exceptionV2.tsx
@@ -1,5 +1,5 @@
 import {t} from 'sentry/locale';
-import {ExceptionType, Group, PlatformType, Project} from 'sentry/types';
+import {ExceptionType, Group, PlatformKey, Project} from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
 import {StackType, StackView} from 'sentry/types/stacktrace';
 
@@ -40,7 +40,7 @@ export function ExceptionV2({
 
   const meta = event._meta?.entries?.[entryIndex]?.data?.values;
 
-  function getPlatform(): PlatformType {
+  function getPlatform(): PlatformKey {
     const dataValue = data.values?.find(
       value => !!value.stacktrace?.frames?.some(frame => !!frame.platform)
     );

--- a/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
+++ b/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
@@ -9,7 +9,7 @@ import {SLOW_TOOLTIP_DELAY} from 'sentry/constants';
 import {IconOpen, IconQuestion} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Frame, Meta, PlatformType} from 'sentry/types';
+import {Frame, Meta, PlatformKey} from 'sentry/types';
 import {defined, isUrl} from 'sentry/utils';
 
 import {FunctionName} from '../functionName';
@@ -20,7 +20,7 @@ import OriginalSourceInfo from './originalSourceInfo';
 
 type Props = {
   frame: Frame;
-  platform: PlatformType;
+  platform: PlatformKey;
   /**
    * Is the stack trace being previewed in a hovercard?
    */

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -22,7 +22,7 @@ import {space} from 'sentry/styles/space';
 import {
   Frame,
   Organization,
-  PlatformType,
+  PlatformKey,
   SentryAppComponent,
   SentryAppSchemaStacktraceLink,
 } from 'sentry/types';
@@ -80,7 +80,7 @@ export interface DeprecatedLineProps {
   onFunctionNameToggle?: (event: React.MouseEvent<SVGElement>) => void;
   onShowFramesToggle?: (event: React.MouseEvent<HTMLElement>) => void;
   organization?: Organization;
-  platform?: PlatformType;
+  platform?: PlatformKey;
   prevFrame?: Frame;
   registersMeta?: Record<any, any>;
   showCompleteFunctionName?: boolean;

--- a/static/app/components/events/interfaces/frame/line/expander.tsx
+++ b/static/app/components/events/interfaces/frame/line/expander.tsx
@@ -5,12 +5,12 @@ import {SLOW_TOOLTIP_DELAY} from 'sentry/constants';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {PlatformType} from 'sentry/types';
+import {PlatformKey} from 'sentry/types';
 
 type Props = {
   isExpandable: boolean;
   onToggleContext: (evt: React.MouseEvent) => void;
-  platform: PlatformType;
+  platform: PlatformKey;
   isExpanded?: boolean;
   isHoverPreviewed?: boolean;
 };

--- a/static/app/components/events/interfaces/frame/line/index.tsx
+++ b/static/app/components/events/interfaces/frame/line/index.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import ListItem from 'sentry/components/list/listItem';
 import StrictClick from 'sentry/components/strictClick';
 import {
-  PlatformType,
+  PlatformKey,
   SentryAppComponent,
   SentryAppSchemaStacktraceLink,
 } from 'sentry/types';
@@ -70,7 +70,7 @@ function Line({
 }: Props) {
   // Prioritize the frame platform but fall back to the platform
   // of the stack trace / exception
-  const platform = getPlatform(frame.platform, props.platform ?? 'other') as PlatformType;
+  const platform = getPlatform(frame.platform, props.platform ?? 'other') as PlatformKey;
   const leadsToApp = !frame.inApp && ((nextFrame && nextFrame.inApp) || !nextFrame);
 
   const expandable =

--- a/static/app/components/events/interfaces/frame/utils.tsx
+++ b/static/app/components/events/interfaces/frame/utils.tsx
@@ -1,6 +1,6 @@
 import {IconQuestion, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {Event, EventOrGroupType, Frame, PlatformType} from 'sentry/types';
+import {Event, EventOrGroupType, Frame, PlatformKey} from 'sentry/types';
 import {defined, objectIsEmpty} from 'sentry/utils';
 
 import {SymbolicatorStatus} from '../types';
@@ -11,7 +11,7 @@ export function trimPackage(pkg: string) {
   return filename.replace(/\.(dylib|so|a|dll|exe)$/, '');
 }
 
-export function getPlatform(dataPlatform: PlatformType | null, platform: string) {
+export function getPlatform(dataPlatform: PlatformKey | null, platform: string) {
   // prioritize the frame platform but fall back to the platform
   // of the stack trace / exception
   return dataPlatform || platform;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -28,7 +28,7 @@ import DebugMetaStore from 'sentry/stores/debugMetaStore';
 import {space} from 'sentry/styles/space';
 import {
   Frame,
-  PlatformType,
+  PlatformKey,
   SentryAppComponent,
   SentryAppSchemaStacktraceLink,
 } from 'sentry/types';
@@ -47,7 +47,7 @@ type Props = {
   event: Event;
   frame: Frame;
   isUsedForGrouping: boolean;
-  platform: PlatformType;
+  platform: PlatformKey;
   registers: Record<string, string>;
   emptySourceNotation?: boolean;
   frameMeta?: Record<any, any>;

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -9,7 +9,8 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconChevron, IconProfiling} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {EntryType, EventTransaction, Frame, PlatformType} from 'sentry/types/event';
+import type {EventTransaction, Frame, PlatformKey} from 'sentry/types';
+import {EntryType} from 'sentry/types/event';
 import {StackView} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {formatPercentage} from 'sentry/utils/formatters';
@@ -314,7 +315,7 @@ function hasApplicationFrame(node: CallTreeNode | null) {
   return false;
 }
 
-function extractFrames(node: CallTreeNode | null, platform: PlatformType): Frame[] {
+function extractFrames(node: CallTreeNode | null, platform: PlatformKey): Frame[] {
   const frames: Frame[] = [];
 
   while (node && !node.isRoot) {

--- a/static/app/components/events/interfaces/stackTrace.tsx
+++ b/static/app/components/events/interfaces/stackTrace.tsx
@@ -1,6 +1,6 @@
 import {CrashContent} from 'sentry/components/events/interfaces/crashContent';
 import {t} from 'sentry/locale';
-import {Group, PlatformType, Project} from 'sentry/types';
+import {Group, PlatformKey, Project} from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
 import {StackView} from 'sentry/types/stacktrace';
 
@@ -36,7 +36,7 @@ export function StackTrace({
 
   const meta = event._meta?.entries?.[entryIndex]?.data;
 
-  function getPlatform(): PlatformType {
+  function getPlatform(): PlatformKey {
     const framePlatform = data.frames?.find(frame => !!frame.platform);
     return framePlatform?.platform ?? event.platform ?? 'other';
   }

--- a/static/app/components/events/interfaces/utils.tsx
+++ b/static/app/components/events/interfaces/utils.tsx
@@ -7,7 +7,7 @@ import * as qs from 'query-string';
 import getThreadException from 'sentry/components/events/interfaces/threads/threadSelector/getThreadException';
 import {FILTER_MASK} from 'sentry/constants';
 import ConfigStore from 'sentry/stores/configStore';
-import {Frame, PlatformType, StacktraceType} from 'sentry/types';
+import {Frame, PlatformKey, StacktraceType} from 'sentry/types';
 import {Image} from 'sentry/types/debugImage';
 import {EntryRequest, EntryThreads, EntryType, Event, Thread} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
@@ -317,7 +317,7 @@ export function parseAssembly(assembly: string | null) {
   return {name, version, culture, publicKeyToken};
 }
 
-export function stackTracePlatformIcon(platform: PlatformType, frames: Frame[]) {
+export function stackTracePlatformIcon(platform: PlatformKey, frames: Frame[]) {
   const fileExtensions = uniq(
     compact(frames.map(frame => getFileExtension(frame.filename ?? '')))
   );
@@ -364,7 +364,7 @@ export function getThreadById(event: Event, tid?: number) {
   return threads?.data.values?.find(thread => thread.id === tid);
 }
 
-export function inferPlatform(event: Event, thread?: Thread): PlatformType {
+export function inferPlatform(event: Event, thread?: Thread): PlatformKey {
   const exception = getThreadException(event, thread);
   let exceptionFramePlatform: Frame | undefined = undefined;
 

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -15,7 +15,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconEllipsis, IconLink, IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {PlatformType, Project} from 'sentry/types';
+import {PlatformKey, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isMobilePlatform, isNativePlatform} from 'sentry/utils/platform';
@@ -55,7 +55,7 @@ type Props = {
   hasMinified: boolean;
   hasNewestFirst: boolean;
   hasVerboseFunctionNames: boolean;
-  platform: PlatformType;
+  platform: PlatformKey;
   projectSlug: Project['slug'];
   recentFirst: boolean;
   stackTraceNotFound: boolean;

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
@@ -16,7 +16,7 @@ import {
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {PlatformType} from 'sentry/types';
+import {PlatformKey} from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
 import {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
@@ -70,7 +70,7 @@ export function StackTracePreviewContent({
   }, [stacktrace]);
 
   const framePlatform = stacktrace?.frames?.find(frame => !!frame.platform)?.platform;
-  const platform = (framePlatform ?? event.platform ?? 'other') as PlatformType;
+  const platform = (framePlatform ?? event.platform ?? 'other') as PlatformKey;
   const newestFirst = isStacktraceNewestFirst();
 
   const commonProps = {

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -11,8 +11,6 @@ import type {Image} from './debugImage';
 import type {IssueAttachment, IssueCategory} from './group';
 import type {Release} from './release';
 import type {RawStacktrace, StackTraceMechanism, StacktraceType} from './stacktrace';
-// TODO(epurkhiser): objc and cocoa should almost definitely be moved into PlatformKey
-export type PlatformType = PlatformKey | 'objc' | 'cocoa';
 
 export type Level = 'error' | 'fatal' | 'info' | 'warning' | 'sample' | 'unknown';
 
@@ -182,7 +180,7 @@ export type Frame = {
   lineNo: number | null;
   module: string | null;
   package: string | null;
-  platform: PlatformType | null;
+  platform: PlatformKey | null;
   rawFunction: string | null;
   symbol: string | null;
   symbolAddr: string | null;
@@ -772,7 +770,7 @@ interface EventBase {
   nextEventID?: string | null;
   oldestEventID?: string | null;
   packages?: Record<string, string>;
-  platform?: PlatformType;
+  platform?: PlatformKey;
   previousEventID?: string | null;
   projectSlug?: string;
   release?: EventRelease | null;

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -217,6 +217,7 @@ export type PlatformKey =
   // legacy platforms – not included in the create project flow
   | 'cocoa-objc'
   | 'cocoa-swift'
+  | 'cocoa'
   | 'csharp'
   | 'dart-flutter'
   | 'java-android'
@@ -231,6 +232,7 @@ export type PlatformKey =
   | 'native-breakpad'
   | 'native-crashpad'
   | 'native-minidump'
+  | 'objc'
   | 'perl'
   | 'php-monolog'
   | 'php-symfony'

--- a/static/app/utils/analytics/ecosystemAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/ecosystemAnalyticsEvents.tsx
@@ -1,4 +1,4 @@
-import type {PlatformType} from 'sentry/types';
+import type {PlatformKey} from 'sentry/types';
 import type {BaseEventAnalyticsParams} from 'sentry/utils/analytics/workflowAnalyticsEvents';
 
 type SetupType = 'automatic' | 'manual';
@@ -36,7 +36,7 @@ export type EcosystemEventParameters = {
     provider: string;
     setup_type: SetupType;
     view: StackTraceView;
-    platform?: PlatformType;
+    platform?: PlatformKey;
     // BaseEventAnalyticsParams partial because it is not always present
   } & Partial<BaseEventAnalyticsParams>;
   'integrations.stacktrace_submit_config': {

--- a/static/app/utils/displayReprocessEventAction.tsx
+++ b/static/app/utils/displayReprocessEventAction.tsx
@@ -3,12 +3,12 @@ import {
   EntryType,
   Event,
   ExceptionValue,
-  PlatformType,
+  PlatformKey,
   StacktraceType,
   Thread,
 } from 'sentry/types';
 
-const NATIVE_PLATFORMS = ['cocoa', 'native'] as Array<PlatformType>;
+const NATIVE_PLATFORMS: PlatformKey[] = ['cocoa', 'native'];
 
 // Finds all frames in a given data blob and returns it's platforms
 function getPlatforms(exceptionValue: ExceptionValue | StacktraceType | null) {

--- a/static/app/utils/issueTypeConfig/types.tsx
+++ b/static/app/utils/issueTypeConfig/types.tsx
@@ -1,4 +1,4 @@
-import {IssueType, PlatformType} from 'sentry/types';
+import {IssueType, PlatformKey} from 'sentry/types';
 
 export type ResourceLink = {
   link: string;
@@ -53,7 +53,7 @@ export type IssueTypeConfig = {
     /**
      * Platform-specific resource links
      */
-    linksByPlatform: Partial<Record<PlatformType, ResourceLink[]>>;
+    linksByPlatform: Partial<Record<PlatformKey, ResourceLink[]>>;
   } | null;
   /**
    * Is the Similar Issues tab shown for this issue

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -141,8 +141,8 @@ export function platformToPerformanceType(
   if (!uniquePerformanceTypeCount || uniquePerformanceTypeCount > 1) {
     return ProjectPerformanceType.ANY;
   }
-  const [platformType] = projectPerformanceTypes;
-  return platformType;
+  const [PlatformKey] = projectPerformanceTypes;
+  return PlatformKey;
 }
 
 /**


### PR DESCRIPTION
`PlatformType` was defined as `PlatformKey | 'cocoa' | 'objc'`.
This PR adds `'cocoa'` and `'objc'` to `PlatformKey` and removes `PlatformType`.

Relates to https://github.com/getsentry/sentry/issues/57047