### PR TITLE
Pass JS profiles to the correct Symbolicator pool

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -354,8 +354,9 @@ def run_symbolicate(
         if duration > settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT:
             raise SymbolicationTimeout
 
+    is_js = profile["platform"] in SHOULD_SYMBOLICATE_JS
     symbolicator = Symbolicator(
-        task_kind=SymbolicatorTaskKind(),
+        task_kind=SymbolicatorTaskKind(is_js=is_js),
         on_request=on_symbolicator_request,
         project=project,
         event_id=profile["event_id"],


### PR DESCRIPTION
It has always been baffling why JS events make it to the native symbolicator pool. Now we know, it was profiling all along. Now profiling should use the correct `SymbolicatorTaskKind`, so the requests end up on the correct pool.