### PR TITLE
feat(stat-detectors): Use event-facets in tags tab list page

### DIFF
--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -420,6 +420,8 @@ type FetchIssueTagsParameters = {
   isStatisticalDetector?: boolean;
   statisticalDetectorParameters?: {
     durationBaseline: number;
+    end: string;
+    start: string;
     transaction: string;
   };
 };
@@ -440,9 +442,11 @@ const makeFetchStatisticalDetectorTagsQueryKey = ({
   environment,
   statisticalDetectorParameters,
 }: FetchIssueTagsParameters): ApiQueryKey => {
-  const {transaction, durationBaseline} = statisticalDetectorParameters ?? {
+  const {transaction, durationBaseline, start, end} = statisticalDetectorParameters ?? {
     transaction: '',
     durationBaseline: 0,
+    start: undefined,
+    end: undefined,
   };
   return [
     `/organizations/${orgSlug}/events-facets/`,
@@ -452,6 +456,8 @@ const makeFetchStatisticalDetectorTagsQueryKey = ({
         transaction,
         includeAll: true,
         query: getSampleEventQuery({transaction, durationBaseline, addUpperBound: false}),
+        start,
+        end,
       },
     },
   ];

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -130,15 +130,21 @@ export default function TagFacets({
 }: Props) {
   const organization = useOrganization();
 
+  const {transaction, aggregateRange2, breakpoint, requestEnd} =
+    event?.occurrence?.evidenceData ?? {};
   const {isLoading, isError, data, refetch} = useFetchIssueTagsForDetailsPage({
     groupId,
     orgSlug: organization.slug,
     environment: environments,
     isStatisticalDetector,
-    statisticalDetectorParameters: {
-      transaction: event?.occurrence?.evidenceData?.transaction,
-      durationBaseline: event?.occurrence?.evidenceData?.aggregateRange2,
-    },
+    statisticalDetectorParameters: breakpoint
+      ? {
+          transaction,
+          durationBaseline: aggregateRange2,
+          start: new Date(breakpoint * 1000).toISOString(),
+          end: new Date(requestEnd * 1000).toISOString(),
+        }
+      : undefined,
   });
 
   const tagsData = useMemo(() => {

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -73,36 +73,39 @@ export function TAGS_FORMATTER(tagsData: Record<string, GroupTagResponseItem>) {
   return transformedTagsData;
 }
 
+export function sumTagFacetsForTopValues(tag: Tag) {
+  return {
+    ...tag,
+    name: tag.key,
+    totalValues: tag.topValues.reduce((acc, {count}) => acc + count, 0),
+    topValues: tag.topValues.map(({name, count}) => ({
+      key: tag.key,
+      name,
+      value: name,
+      count,
+
+      // These values aren't displayed in the sidebar
+      firstSeen: '',
+      lastSeen: '',
+    })),
+  };
+}
+
 // Statistical detector issues need to use a Discover query
 // which means we need to massage the values to fit the component API
 function transformTagFacetDataToGroupTagResponseItems(
   tagFacetData: Record<string, Tag>
 ): Record<string, GroupTagResponseItem> {
   const keyedResponse = {};
-  Object.keys(tagFacetData).forEach(tagKey => {
-    if (tagKey === 'transaction') {
-      // Statistical detectors are scoped to a single transaction so
-      // this tag doesn't add anything to the user experience
-      return;
-    }
 
-    const tagData = tagFacetData[tagKey];
-    keyedResponse[tagKey] = {
-      ...tagData,
-      name: tagData.key,
-      totalValues: tagData.topValues.reduce((acc, {count}) => acc + count, 0),
-      topValues: tagData.topValues.map(({name, count}) => ({
-        key: tagData.key,
-        name,
-        value: name,
-        count,
-
-        // These values aren't displayed in the sidebar
-        firstSeen: '',
-        lastSeen: '',
-      })),
-    };
-  });
+  // Statistical detectors are scoped to a single transaction so
+  // the filter out transaction since the tag is not helpful in the UI
+  Object.keys(tagFacetData)
+    .filter(tagKey => tagKey !== 'transaction')
+    .forEach(tagKey => {
+      const tagData = tagFacetData[tagKey];
+      keyedResponse[tagKey] = sumTagFacetsForTopValues(tagData);
+    });
 
   return keyedResponse;
 }

--- a/static/app/views/issueDetails/groupTags.tsx
+++ b/static/app/views/issueDetails/groupTags.tsx
@@ -25,9 +25,9 @@ import withOrganization from 'sentry/utils/withOrganization';
 type Props = DeprecatedAsyncComponent['props'] & {
   baseUrl: string;
   environments: string[];
-  event: Event;
   group: Group;
   organization: Organization;
+  event?: Event;
 } & RouteComponentProps<{}, {}>;
 
 type State = DeprecatedAsyncComponent['state'] & {

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -163,6 +163,8 @@ export const useFetchIssueTagsForDetailsPage = (
     isStatisticalDetector?: boolean;
     statisticalDetectorParameters?: {
       durationBaseline: number;
+      end: string;
+      start: string;
       transaction: string;
     };
   },


### PR DESCRIPTION
This PR redirects the tags query from the group tags endpoint to the events facets endpoint. This is necessary because the tags we require are not stored on the group explicitly, but rather through transactions past a specific time period (the detection breakpoint).

Since we require the breakpoint timestamp, we need the latest event to be loaded. If you're coming from the Overview page, an event is fetched and cached from that visit. If you're refreshing the tags tab, there is no preloaded event so we must make a query to fetch it, then that can be used to fetch the tag facets.

I also realized the tags sidebar wasn't using any start/end time so I added that as well. I will be converting the end timestamps to the current time, but for now I am using `requestEnd` to be consistent with where I made this assumption elsewhere on the page.