### PR TITLE
ref(integrations): Hide User/Team mappings behind CODEOWNERS feature

### DIFF
--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -125,8 +125,11 @@ class ConfigureIntegration extends DeprecatedAsyncView<Props, State> {
     );
   }
 
-  hasCodeOwners() {
-    return this.props.organization.features.includes('integrations-codeowners');
+  hasCodeOwners(provider: IntegrationProvider) {
+    return (
+      provider.features.includes('codeowners') &&
+      this.props.organization.features.includes('integrations-codeowners')
+    );
   }
 
   onTabChange = (value: Tab) => {
@@ -428,8 +431,8 @@ class ConfigureIntegration extends DeprecatedAsyncView<Props, State> {
     const tabs = [
       ['repos', t('Repositories')],
       ['codeMappings', t('Code Mappings')],
-      ...(this.hasCodeOwners() ? [['userMappings', t('User Mappings')]] : []),
-      ...(this.hasCodeOwners() ? [['teamMappings', t('Team Mappings')]] : []),
+      ...(this.hasCodeOwners(provider) ? [['userMappings', t('User Mappings')]] : []),
+      ...(this.hasCodeOwners(provider) ? [['teamMappings', t('Team Mappings')]] : []),
     ] as [id: Tab, label: string][];
 
     return (


### PR DESCRIPTION
This PR hides the User and Team mappings tabs behind [the CODEOWNERS feature](https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/base.py#L119) on the provider, not just the Stacktrace Linking one. This way, providers with stack trace links but no codeowners, don't show these tabs just yet (i.e. Bitbucket and VSTS at the moment).

Once CODEOWNERS is ready for these integrations, adding the feature to the installation class will show these tabs on the Frontend.

**before**
![image](https://github.com/getsentry/sentry/assets/35509934/fb0ac637-b755-4a25-b19b-880b436e4396)


**after**
![image](https://github.com/getsentry/sentry/assets/35509934/74996d48-7d71-4809-93e6-a21d48825f36)


**unaffected**

Nothing changes for Github because it has the CODEOWNERS feature, in the pill badge under the title.

![image](https://github.com/getsentry/sentry/assets/35509934/1a89d77b-e2dc-4db9-b322-8c1af421f9a0)

![image](https://github.com/getsentry/sentry/assets/35509934/e307fd58-cec0-4e4e-974b-3ed935e37839)
