### PR TITLE
fix(hybridcloud) Expose Link to cors responses

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -126,7 +126,10 @@ def allow_cors_options(func):
             "Content-Type, Authentication, Authorization, Content-Encoding, "
             "sentry-trace, baggage, X-CSRFToken"
         )
-        response["Access-Control-Expose-Headers"] = "X-Sentry-Error, Retry-After, Link"
+        response["Access-Control-Expose-Headers"] = (
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "Endpoint, Retry-After, Link"
+        )
 
         if request.META.get("HTTP_ORIGIN") == "null":
             # if ORIGIN header is explicitly specified as 'null' leave it alone

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -126,7 +126,7 @@ def allow_cors_options(func):
             "Content-Type, Authentication, Authorization, Content-Encoding, "
             "sentry-trace, baggage, X-CSRFToken"
         )
-        response["Access-Control-Expose-Headers"] = "X-Sentry-Error, Retry-After"
+        response["Access-Control-Expose-Headers"] = "X-Sentry-Error, Retry-After, Link"
 
         if request.META.get("HTTP_ORIGIN") == "null":
             # if ORIGIN header is explicitly specified as 'null' leave it alone

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -130,7 +130,7 @@ class EndpointTest(APITestCase):
             "Content-Type, Authentication, Authorization, Content-Encoding, "
             "sentry-trace, baggage, X-CSRFToken"
         )
-        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After"
+        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After, Link"
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert "Access-Control-Allow-Credentials" not in response
 
@@ -155,7 +155,7 @@ class EndpointTest(APITestCase):
             "Content-Type, Authentication, Authorization, Content-Encoding, "
             "sentry-trace, baggage, X-CSRFToken"
         )
-        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After"
+        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After, Link"
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert response["Access-Control-Allow-Credentials"] == "true"
 
@@ -180,7 +180,7 @@ class EndpointTest(APITestCase):
             "Content-Type, Authentication, Authorization, Content-Encoding, "
             "sentry-trace, baggage, X-CSRFToken"
         )
-        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After"
+        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After, Link"
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert response["Access-Control-Allow-Credentials"] == "true"
 
@@ -236,7 +236,7 @@ class EndpointTest(APITestCase):
             "Content-Type, Authentication, Authorization, Content-Encoding, "
             "sentry-trace, baggage, X-CSRFToken"
         )
-        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After"
+        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After, Link"
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
 
     @mock.patch("sentry.api.base.Endpoint.convert_args")

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -130,7 +130,10 @@ class EndpointTest(APITestCase):
             "Content-Type, Authentication, Authorization, Content-Encoding, "
             "sentry-trace, baggage, X-CSRFToken"
         )
-        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After, Link"
+        assert response["Access-Control-Expose-Headers"] == (
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "Endpoint, Retry-After, Link"
+        )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert "Access-Control-Allow-Credentials" not in response
 
@@ -155,7 +158,10 @@ class EndpointTest(APITestCase):
             "Content-Type, Authentication, Authorization, Content-Encoding, "
             "sentry-trace, baggage, X-CSRFToken"
         )
-        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After, Link"
+        assert response["Access-Control-Expose-Headers"] == (
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "Endpoint, Retry-After, Link"
+        )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert response["Access-Control-Allow-Credentials"] == "true"
 
@@ -180,7 +186,10 @@ class EndpointTest(APITestCase):
             "Content-Type, Authentication, Authorization, Content-Encoding, "
             "sentry-trace, baggage, X-CSRFToken"
         )
-        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After, Link"
+        assert response["Access-Control-Expose-Headers"] == (
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "Endpoint, Retry-After, Link"
+        )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert response["Access-Control-Allow-Credentials"] == "true"
 
@@ -236,7 +245,10 @@ class EndpointTest(APITestCase):
             "Content-Type, Authentication, Authorization, Content-Encoding, "
             "sentry-trace, baggage, X-CSRFToken"
         )
-        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After, Link"
+        assert response["Access-Control-Expose-Headers"] == (
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "Endpoint, Retry-After, Link"
+        )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
 
     @mock.patch("sentry.api.base.Endpoint.convert_args")


### PR DESCRIPTION
When the application is operating under split domains we need to allow `Link` header to be read across domains.

Fixes HC-924