### PR TITLE
fix(group-tag-values): Get Link header and pass to query correctly

### DIFF
--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -487,6 +487,7 @@ type FetchIssueTagValuesParameters = {
   groupId: string;
   orgSlug: string;
   tagKey: string;
+  cursor?: string;
   environment?: string[];
   sort?: string | string[];
 };
@@ -497,9 +498,10 @@ export const makeFetchIssueTagValuesQueryKey = ({
   tagKey,
   environment,
   sort,
+  cursor,
 }: FetchIssueTagValuesParameters): ApiQueryKey => [
   `/organizations/${orgSlug}/issues/${groupId}/tags/${tagKey}/values/`,
-  {query: {environment, sort}},
+  {query: {environment, sort, cursor}},
 ];
 
 export function useFetchIssueTagValues(

--- a/static/app/views/issueDetails/groupTagValues.tsx
+++ b/static/app/views/issueDetails/groupTagValues.tsx
@@ -48,10 +48,12 @@ function useTagQueries({
   tagKey,
   environments,
   sort,
+  cursor,
 }: {
   group: Group;
   sort: string | string[];
   tagKey: string;
+  cursor?: string;
   environments?: string[];
 }) {
   const organization = useOrganization();
@@ -67,6 +69,7 @@ function useTagQueries({
     tagKey,
     environment: environments,
     sort,
+    cursor,
   });
   const {data: tag, isError: tagIsError} = useFetchIssueTag({
     orgSlug: organization.slug,
@@ -85,7 +88,7 @@ function useTagQueries({
     tag,
     isLoading: tagValueListIsLoading,
     isError: tagValueListIsError,
-    pageLinks: getResponseHeader?.('pageLinks'),
+    pageLinks: getResponseHeader?.('Link'),
   };
 }
 
@@ -93,7 +96,7 @@ function GroupTagValues({baseUrl, project, group, environments}: Props) {
   const organization = useOrganization();
   const location = useLocation();
   const {orgId, tagKey = ''} = useParams<RouteParams>();
-  const {cursor: _cursor, page: _page, ...currentQuery} = location.query;
+  const {cursor, page: _page, ...currentQuery} = location.query;
 
   const title = tagKey === 'user' ? t('Affected Users') : tagKey;
   const sort = location.query.sort || DEFAULT_SORT;
@@ -104,6 +107,7 @@ function GroupTagValues({baseUrl, project, group, environments}: Props) {
     sort,
     tagKey,
     environments,
+    cursor: typeof cursor === 'string' ? cursor : undefined,
   });
 
   const lastSeenColumnHeader = (


### PR DESCRIPTION
Missed a couple things with the conversion to useApiQuery (https://github.com/getsentry/sentry/pull/57112):

- Typo on page links, should be getting from the `Link` header, not `pageLinks`
- Wasn't passing `cursor` into the query. I missed this because AsyncComponent passes `cursor` by default. I actually wrote about this in the notion guide but had forgotten 😞 ([notion doc here](https://www.notion.so/sentry/How-to-convert-AsyncComponent-to-useApiQuery-55751df48dc04df5b4b0da42ba5e4fbd))