### PR TITLE
chore(agg-spans): Fallback to span op if description is not scrubbed

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -146,7 +146,7 @@ class BaseAggregateSpans:
                 "parent_node_fingerprint": parent_node_fingerprint,
                 "group": span_tree["group"],
                 "op": span_tree["op"],
-                "description": f"<<unparametrized>> {description}"
+                "description": f"{description}"
                 if span_tree["group"] == NULL_GROUP
                 else description,
                 "start_timestamp": start_timestamp,
@@ -266,11 +266,9 @@ class AggregateNodestoreSpans(BaseAggregateSpans):
                         "exclusive_time": span["exclusive_time"],
                         "children": [],
                     }
-                    # Fallback to if sentry/suspect spans scrubbed group (group_raw here) if group doesn't exist.
-                    # Note this is a different implementation from what we do for indexed spans. Because if starfish
-                    # isn't enabled for the org, we won't have the starfish scrubbed description at all.
+                    # Fallback to op if group doesn't exist for now
                     spans_dict["key"] = (
-                        spans_dict["group_raw"]
+                        spans_dict["op"]
                         if spans_dict["group"] == NULL_GROUP
                         else spans_dict["group"]
                     )

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -146,7 +146,7 @@ class BaseAggregateSpans:
                 "parent_node_fingerprint": parent_node_fingerprint,
                 "group": span_tree["group"],
                 "op": span_tree["op"],
-                "description": f"{description}"
+                "description": description
                 if span_tree["group"] == NULL_GROUP
                 else description,
                 "start_timestamp": start_timestamp,

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -146,9 +146,7 @@ class BaseAggregateSpans:
                 "parent_node_fingerprint": parent_node_fingerprint,
                 "group": span_tree["group"],
                 "op": span_tree["op"],
-                "description": description
-                if span_tree["group"] == NULL_GROUP
-                else description,
+                "description": description if span_tree["group"] == NULL_GROUP else description,
                 "start_timestamp": start_timestamp,
                 "start_ms": start_timestamp,  # TODO: Remove after updating frontend, duplicated for backward compatibility
                 "avg(exclusive_time)": span_tree["exclusive_time"],

--- a/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
+++ b/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
@@ -475,12 +475,7 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
 
             assert response.data
             data = response.data
-            if backend == "indexedSpans":
-                root_fingerprint = hashlib.md5(b"e238e6c2e2466b07-C-discover.snql").hexdigest()[:16]
-            else:
-                root_fingerprint = hashlib.md5(b"e238e6c2e2466b07-C-76de16d455e99f9c").hexdigest()[
-                    :16
-                ]
+            root_fingerprint = hashlib.md5(b"e238e6c2e2466b07-C-discover.snql").hexdigest()[:16]
             assert root_fingerprint in data
-            assert data[root_fingerprint]["description"] == "<<unparametrized>> resolve_columns"
+            assert data[root_fingerprint]["description"] == "resolve_columns"
             assert data[root_fingerprint]["count()"] == 2


### PR DESCRIPTION
I thought we were storing the sentry scrubbed span
description in nodestore, but it looks like we actually
store the non-parametrized version. So falling back
to span op of scrubbed span description isn't available.
Also removes the <<unparametrized>> string I added
so I could tell on the FE what was parametrized and
what wasn't while developing.