### PR TITLE
fix(monitors) Make monitor endpoints able to respond to OPTIONS

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1489,6 +1489,7 @@ ORGANIZATION_URLS = [
         # remove these from the explicit endpoints
         method_dispatch(
             GET=OrganizationMonitorCheckInIndexEndpoint.as_view(),
+            OPTIONS=OrganizationMonitorCheckInIndexEndpoint.as_view(),
             POST=MonitorIngestCheckInIndexEndpoint.as_view(),  # Legacy ingest endpoint
             csrf_exempt=True,
         ),
@@ -1501,6 +1502,7 @@ ORGANIZATION_URLS = [
         # remove these from the explicit endpoints
         method_dispatch(
             PUT=MonitorIngestCheckInDetailsEndpoint.as_view(),  # Legacy ingest endpoint
+            OPTIONS=MonitorIngestCheckInDetailsEndpoint.as_view(),
             csrf_exempt=True,
         ),
         name="sentry-api-0-organization-monitor-check-in-details",
@@ -1509,6 +1511,7 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_slug>[^\/]+)/monitors/(?P<monitor_slug>[^\/]+)/checkins/(?P<checkin_id>[^\/]+)/attachment/$",
         method_dispatch(
             GET=OrganizationMonitorCheckInAttachmentEndpoint.as_view(),
+            OPTIONS=OrganizationMonitorCheckInAttachmentEndpoint.as_view(),
             POST=MonitorIngestCheckinAttachmentEndpoint.as_view(),  # Legacy ingest endpoint
             csrf_exempt=True,
         ),

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_index.py
@@ -34,6 +34,28 @@ class ListMonitorCheckInsTest(MonitorTestCase):
         }
         return self.store_event(data, project_id=project_id)
 
+    def test_options_cors(self):
+        monitor = self._create_monitor()
+        monitor_environment = self._create_monitor_environment(monitor)
+
+        MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            date_added=monitor.date_added - timedelta(minutes=2),
+            status=CheckInStatus.OK,
+        )
+
+        resp = self.get_success_response(
+            self.organization.slug,
+            monitor.slug,
+            method="OPTIONS",
+            statsPeriod="1d",
+        )
+        assert resp.status_code == 200
+        assert resp["Access-Control-Allow-Origin"]
+        assert resp["Access-Control-Allow-Headers"]
+
     def test_simple(self):
         monitor = self._create_monitor()
         monitor_environment = self._create_monitor_environment(monitor)


### PR DESCRIPTION
The method_dispatch() helper needs to have handlers defined for OPTIONS so that cors preflight requests can succeed. This is required under split domains where the application runs with cors.

Fixes HC-925
