### PR TITLE
feat(crons): Adds quota methods

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -218,10 +218,10 @@ class Quota(Service):
         "get_quotas",
         "get_blended_sample_rate",
         "get_transaction_sampling_tier_for_volume",
-        "assign_seat",
-        "unassign_seat",
-        "set_billing_seat_recreate",
-        "remove_billing_seat_recreate",
+        "assign_monitor_seat",
+        "unassign_monitor_seat",
+        "enable_seat_recreate",
+        "disable_seat_recreate",
     )
 
     def __init__(self, **options):
@@ -497,7 +497,7 @@ class Quota(Service):
         :param volume: The volume of transaction of the given project.
         """
 
-    def assign_seat(
+    def assign_monitor_seat(
         self,
         monitor: Monitor,
     ) -> int:
@@ -511,7 +511,7 @@ class Quota(Service):
         monitor.update(status=MonitorStatus.OK)
         return Outcome.ACCEPTED
 
-    def unassign_seat(
+    def unassign_monitor_seat(
         self,
         monitor: Monitor,
     ):
@@ -522,8 +522,8 @@ class Quota(Service):
 
         monitor.update(status=MonitorStatus.DISABLED)
 
-    def set_billing_seat_recreate(self, monitor: Monitor):
+    def enable_seat_recreate(self, monitor: Monitor):
         """Sets the monitor's seat assignment to automatically be recreated at renewal."""
 
-    def remove_billing_seat_recreate(self, monitor: Monitor):
+    def disable_seat_recreate(self, monitor: Monitor):
         """Removes the monitor's seat assignment so it is NOT automatically be recreated at renewal."""

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -2,9 +2,11 @@ import pytest
 
 from sentry.constants import DataCategory
 from sentry.models import OrganizationOption, ProjectKey
+from sentry.monitors.models import Monitor, MonitorStatus, MonitorType
 from sentry.quotas.base import Quota, QuotaConfig, QuotaScope
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
+from sentry.utils.outcomes import Outcome
 
 
 @region_silo_test(stable=True)
@@ -89,6 +91,54 @@ class QuotaTest(TestCase):
     def test_get_blended_sample_rate(self):
         org = self.create_organization()
         assert self.backend.get_blended_sample_rate(organization_id=org.id) is None
+
+    def test_assign_seat(self):
+        monitor = Monitor.objects.create(
+            slug="test-monitor",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            name="test monitor",
+            status=MonitorStatus.ACTIVE,
+            type=MonitorType.CRON_JOB,
+        )
+        assert self.backend.assign_seat(monitor) == Outcome.ACCEPTED
+        monitor.refresh_from_db()
+        assert monitor.status == MonitorStatus.OK
+
+    def test_unassign_seat(self):
+        monitor = Monitor.objects.create(
+            slug="test-monitor",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            name="test monitor",
+            status=MonitorStatus.OK,
+            type=MonitorType.CRON_JOB,
+        )
+        assert self.backend.unassign_seat(monitor) is None
+        monitor.refresh_from_db()
+        assert monitor.status == MonitorStatus.DISABLED
+
+    def test_set_billing_seat_recreate(self):
+        monitor = Monitor.objects.create(
+            slug="test-monitor",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            name="test monitor",
+            status=MonitorStatus.OK,
+            type=MonitorType.CRON_JOB,
+        )
+        assert self.backend.set_billing_seat_recreate(monitor) is None
+
+    def test_remove_billing_seat_recreate(self):
+        monitor = Monitor.objects.create(
+            slug="test-monitor",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            name="test monitor",
+            status=MonitorStatus.OK,
+            type=MonitorType.CRON_JOB,
+        )
+        assert self.backend.remove_billing_seat_recreate(monitor) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -92,7 +92,7 @@ class QuotaTest(TestCase):
         org = self.create_organization()
         assert self.backend.get_blended_sample_rate(organization_id=org.id) is None
 
-    def test_assign_seat(self):
+    def test_assign_monitor_seat(self):
         monitor = Monitor.objects.create(
             slug="test-monitor",
             organization_id=self.organization.id,
@@ -101,11 +101,11 @@ class QuotaTest(TestCase):
             status=MonitorStatus.ACTIVE,
             type=MonitorType.CRON_JOB,
         )
-        assert self.backend.assign_seat(monitor) == Outcome.ACCEPTED
+        assert self.backend.assign_monitor_seat(monitor) == Outcome.ACCEPTED
         monitor.refresh_from_db()
         assert monitor.status == MonitorStatus.OK
 
-    def test_unassign_seat(self):
+    def test_unassign_monitor_seat(self):
         monitor = Monitor.objects.create(
             slug="test-monitor",
             organization_id=self.organization.id,
@@ -114,11 +114,11 @@ class QuotaTest(TestCase):
             status=MonitorStatus.OK,
             type=MonitorType.CRON_JOB,
         )
-        assert self.backend.unassign_seat(monitor) is None
+        assert self.backend.unassign_monitor_seat(monitor) is None
         monitor.refresh_from_db()
         assert monitor.status == MonitorStatus.DISABLED
 
-    def test_set_billing_seat_recreate(self):
+    def test_enable_seat_recreate(self):
         monitor = Monitor.objects.create(
             slug="test-monitor",
             organization_id=self.organization.id,
@@ -127,9 +127,9 @@ class QuotaTest(TestCase):
             status=MonitorStatus.OK,
             type=MonitorType.CRON_JOB,
         )
-        assert self.backend.set_billing_seat_recreate(monitor) is None
+        assert self.backend.enable_seat_recreate(monitor) is None
 
-    def test_remove_billing_seat_recreate(self):
+    def test_disable_seat_recreate(self):
         monitor = Monitor.objects.create(
             slug="test-monitor",
             organization_id=self.organization.id,
@@ -138,7 +138,7 @@ class QuotaTest(TestCase):
             status=MonitorStatus.OK,
             type=MonitorType.CRON_JOB,
         )
-        assert self.backend.remove_billing_seat_recreate(monitor) is None
+        assert self.backend.disable_seat_recreate(monitor) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds methods to the Quota service to handle assigning, unassigning, and updating whether or not a monitor should automatically be recreated when billing is necessary. [RV-1328](https://getsentry.atlassian.net/browse/RV-1328)


[RV-1328]: https://getsentry.atlassian.net/browse/RV-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ