### PR TITLE
feat(browser-starfish): init resource module

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -14,6 +14,7 @@ import {isDone} from 'sentry/components/sidebar/utils';
 import {
   IconChevron,
   IconDashboard,
+  IconFile,
   IconGraph,
   IconIssues,
   IconLightning,
@@ -286,6 +287,13 @@ function Sidebar({location, organization}: Props) {
           to={`/organizations/${organization.slug}/performance/browser/interactions`}
           id="performance-browser-interactions"
           icon={<SubitemDot collapsed={collapsed} />}
+        />
+        <SidebarItem
+          {...sidebarItemProps}
+          label={<GuideAnchor target="starfish">{t('Resources')}</GuideAnchor>}
+          to={`/organizations/${organization.slug}/performance/browser/resources`}
+          id="performance-browser-resources"
+          icon={<IconFile />}
         />
         <SidebarItem
           {...sidebarItemProps}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1630,6 +1630,12 @@ function buildRoutes() {
               import('sentry/views/performance/browser/webVitals/webVitalsLandingPage')
           )}
         />
+        <Route
+          path="resources/"
+          component={make(
+            () => import('sentry/views/performance/browser/resources/index')
+          )}
+        />
       </Route>
       <Route path="summary/">
         <IndexRoute

--- a/static/app/views/performance/browser/resources/index.tsx
+++ b/static/app/views/performance/browser/resources/index.tsx
@@ -1,0 +1,185 @@
+import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
+
+import Breadcrumbs from 'sentry/components/breadcrumbs';
+import DatePageFilter from 'sentry/components/datePageFilter';
+import FeatureBadge from 'sentry/components/featureBadge';
+import SelectControl, {
+  ControlProps,
+} from 'sentry/components/forms/controls/selectControl';
+import * as Layout from 'sentry/components/layouts/thirds';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {ResourceSidebar} from 'sentry/views/performance/browser/resources/resourceSidebar';
+import ResourceTable from 'sentry/views/performance/browser/resources/resourceTable';
+import {
+  BrowserStarfishFields,
+  useResourceModuleFilters,
+} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
+import {useResourceSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
+import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
+
+const {RESOURCE_TYPE, DOMAIN, PAGE, DESCRIPTION} = BrowserStarfishFields;
+
+type Option = {
+  label: string;
+  value: string;
+};
+
+function ResourcesLandingPage() {
+  const organization = useOrganization();
+  const filters = useResourceModuleFilters();
+  const sort = useResourceSort();
+
+  return (
+    <ModulePageProviders title={[t('Performance'), t('Resources')].join(' — ')}>
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Breadcrumbs
+            crumbs={[
+              {
+                label: 'Performance',
+                to: normalizeUrl(`/organizations/${organization.slug}/performance/`),
+                preservePageFilters: true,
+              },
+              {
+                label: 'Resources',
+              },
+            ]}
+          />
+
+          <Layout.Title>
+            {t('Resources')}
+            <FeatureBadge type="alpha" />
+          </Layout.Title>
+        </Layout.HeaderContent>
+      </Layout.Header>
+
+      <Layout.Body>
+        <Layout.Main fullWidth>
+          <PaddedContainer>
+            <PageFilterBar condensed>
+              <ProjectPageFilter />
+              <DatePageFilter alignDropdown="left" />
+            </PageFilterBar>
+          </PaddedContainer>
+
+          <FilterOptionsContainer>
+            <DomainSelector value={filters[DOMAIN] || ''} />
+            <ResourceTypeSelector value={filters[RESOURCE_TYPE] || ''} />
+            <PageSelector value={filters[PAGE] || ''} />
+          </FilterOptionsContainer>
+
+          <ResourceTable sort={sort} />
+          <ResourceSidebar groupId={filters[DESCRIPTION]} />
+        </Layout.Main>
+      </Layout.Body>
+    </ModulePageProviders>
+  );
+}
+
+function DomainSelector({value}: {value?: string}) {
+  const location = useLocation();
+
+  const options: Option[] = [
+    {value: '', label: 'All'},
+    {value: 'https://s1.sentry-cdn.com', label: 'https://s1.sentry-cdn.com'},
+    {value: 'https://s2.sentry-cdn.com', label: 'https://s2.sentry-cdn.com'},
+    {value: 'https://cdn.pendo.io', label: 'https://cdn.pendo.io'},
+  ];
+
+  return (
+    <SelectControlWithProps
+      inFieldLabel={`${t('Domain')}:`}
+      options={options}
+      value={value}
+      onChange={newValue => {
+        browserHistory.push({
+          ...location,
+          query: {
+            ...location.query,
+            [DOMAIN]: newValue?.value,
+          },
+        });
+      }}
+    />
+  );
+}
+
+function ResourceTypeSelector({value}: {value?: string}) {
+  const location = useLocation();
+
+  const options: Option[] = [
+    {value: '', label: 'All'},
+    {value: '.js', label: 'Javscript (.js)'},
+    {value: '.css', label: 'Stylesheets (.css)'},
+    {value: '.png', label: 'Images (.png, .jpg, .jpeg, .gif, etc)'},
+  ];
+  return (
+    <SelectControlWithProps
+      inFieldLabel={`${t('Type')}:`}
+      options={options}
+      value={value}
+      onChange={newValue => {
+        browserHistory.push({
+          ...location,
+          query: {
+            ...location.query,
+            [RESOURCE_TYPE]: newValue?.value,
+          },
+        });
+      }}
+    />
+  );
+}
+
+function PageSelector({value}: {value?: string}) {
+  const location = useLocation();
+
+  const options: Option[] = [
+    {value: '', label: 'All'},
+    {value: '/performance', label: '/performance'},
+    {value: '/profiling', label: '/profiling'},
+    {value: '/starfish', label: '/starfish'},
+  ];
+
+  return (
+    <SelectControlWithProps
+      inFieldLabel={`${t('Page')}:`}
+      options={options}
+      value={value}
+      onChange={newValue => {
+        browserHistory.push({
+          ...location,
+          query: {
+            ...location.query,
+            [PAGE]: newValue?.value,
+          },
+        });
+      }}
+    />
+  );
+}
+
+function SelectControlWithProps(props: ControlProps & {options: Option[]}) {
+  return <SelectControl {...props} />;
+}
+
+export const PaddedContainer = styled('div')`
+  margin-bottom: ${space(2)};
+`;
+
+const FilterOptionsContainer = styled('div')`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: ${space(2)};
+  margin-bottom: ${space(2)};
+  max-width: 800px;
+`;
+
+export default ResourcesLandingPage;

--- a/static/app/views/performance/browser/resources/resourceSidebar.tsx
+++ b/static/app/views/performance/browser/resources/resourceSidebar.tsx
@@ -1,0 +1,48 @@
+import omit from 'lodash/omit';
+import {PlatformIcon} from 'platformicons';
+
+import FileSize from 'sentry/components/fileSize';
+import useRouter from 'sentry/utils/useRouter';
+import {BrowserStarfishFields} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
+import DetailPanel from 'sentry/views/starfish/components/detailPanel';
+import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
+
+type Props = {
+  description?: string;
+  groupId?: string;
+};
+
+export function ResourceSidebar(props: Props) {
+  const router = useRouter();
+  const key = props.groupId;
+  const description = props.description || props.groupId;
+  return (
+    <DetailPanel
+      detailKey={key}
+      onClose={() => {
+        router.replace({
+          pathname: router.location.pathname,
+          query: omit(router.location.query, [BrowserStarfishFields.DESCRIPTION]),
+        });
+      }}
+    >
+      <PlatformIcon platform="javascript" />
+      <h3>{description}</h3>
+      <ResourceInfo />
+      <div>Span samples, charts for duration overtime and size overtime</div>
+    </DetailPanel>
+  );
+}
+
+function ResourceInfo() {
+  return (
+    <BlockContainer>
+      <Block title="Avg Duration" alignment="left">
+        20.00ms
+      </Block>
+      <Block title="Resource Size" alignment="left">
+        <FileSize bytes={200} />
+      </Block>
+    </BlockContainer>
+  );
+}

--- a/static/app/views/performance/browser/resources/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceTable.tsx
@@ -1,0 +1,144 @@
+import {Fragment} from 'react';
+import {Link} from 'react-router';
+import * as qs from 'query-string';
+
+import FileSize from 'sentry/components/fileSize';
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  GridColumnHeader,
+  GridColumnOrder,
+} from 'sentry/components/gridEditable';
+import {t} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
+import {BrowserStarfishFields} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
+import {ValidSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
+import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
+import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
+
+type Row = {
+  'avg(span.duration)': number;
+  description: string;
+  domain: string;
+  'http.decoded_response_content_length': number;
+  'http.response_content_length': number;
+  'resource.render_blocking_status': string;
+  'span.group': string;
+  type: string;
+};
+
+type Column = GridColumnHeader<keyof Row>;
+
+type Props = {
+  sort: ValidSort;
+};
+
+function ResourceTable({sort}: Props) {
+  const location = useLocation();
+  const columnOrder: GridColumnOrder<keyof Row>[] = [
+    {key: 'description', width: COL_WIDTH_UNDEFINED, name: 'Resource name'},
+    {key: 'avg(span.duration)', width: COL_WIDTH_UNDEFINED, name: 'Avg Duration'},
+    {
+      key: 'http.response_content_length',
+      width: COL_WIDTH_UNDEFINED,
+      name: 'Resource size',
+    },
+    {
+      key: 'resource.render_blocking_status',
+      width: COL_WIDTH_UNDEFINED,
+      name: 'Render blocking',
+    },
+    {
+      key: 'http.decoded_response_content_length',
+      width: COL_WIDTH_UNDEFINED,
+      name: 'Uncompressed',
+    },
+  ];
+  const tableData: Row[] = [
+    {
+      'avg(span.duration)': 20,
+      description:
+        'app_components_events_interfaces_spans_constants_tsx-app_components_gridEditable_styles_tsx-a-1f90d6.***.js',
+      domain: 's1.sentry-cdn.com',
+      'http.decoded_response_content_length': 300,
+      'http.response_content_length': 300,
+      'resource.render_blocking_status': 'non-blocking',
+      type: '.js',
+      'span.group': 'group123',
+    },
+    {
+      'avg(span.duration)': 25,
+      description: 'app_bootstrap_initializeMain_tsx.***.js',
+      domain: 's1.sentry-cdn.com',
+      'http.decoded_response_content_length': 150,
+      'http.response_content_length': 200,
+      'resource.render_blocking_status': 'blocking',
+      type: '.js',
+      'span.group': 'group456',
+    },
+  ];
+
+  const renderBodyCell = (col: Column, row: Row) => {
+    const {key} = col;
+    if (key === 'description') {
+      const query = {
+        ...location.query,
+        [BrowserStarfishFields.DESCRIPTION]: row[key],
+      };
+      return (
+        <Link to={`/performance/browser/resources/?${qs.stringify(query)}`}>
+          {row[key]}
+        </Link>
+      );
+    }
+    if (key === 'http.response_content_length') {
+      return <FileSize bytes={row[key]} />;
+    }
+    if (key === 'avg(span.duration)') {
+      return <DurationCell milliseconds={row[key]} />;
+    }
+    if (key === 'http.decoded_response_content_length') {
+      const isCompressed =
+        row['http.response_content_length'] !==
+        row['http.decoded_response_content_length'];
+      return <span>{isCompressed ? t('true') : t('false')}</span>;
+    }
+    return <span>{row[key]}</span>;
+  };
+
+  return (
+    <Fragment>
+      <GridEditable
+        data={tableData}
+        isLoading={false}
+        columnOrder={columnOrder}
+        columnSortBy={[
+          {
+            key: sort.field,
+            order: sort.kind,
+          },
+        ]}
+        grid={{
+          renderHeadCell: column =>
+            renderHeadCell({
+              column,
+              location,
+              sort,
+            }),
+          renderBodyCell,
+        }}
+        location={location}
+      />
+    </Fragment>
+  );
+}
+
+export const getActionName = (transactionOp: string) => {
+  switch (transactionOp) {
+    case 'ui.action.click':
+      return 'Click';
+    default:
+      return transactionOp;
+  }
+};
+
+export default ResourceTable;

--- a/static/app/views/performance/browser/resources/utils/useResourceFilters.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceFilters.ts
@@ -1,0 +1,29 @@
+import pick from 'lodash/pick';
+
+import {useLocation} from 'sentry/utils/useLocation';
+
+export enum BrowserStarfishFields {
+  RESOURCE_TYPE = 'type',
+  PAGE = 'transaction',
+  DOMAIN = 'domain',
+  GROUP_ID = 'groupId',
+  DESCRIPTION = 'description',
+}
+
+export type ModuleFilters = {
+  [BrowserStarfishFields.DOMAIN]?: string;
+  [BrowserStarfishFields.RESOURCE_TYPE]?: string;
+  [BrowserStarfishFields.PAGE]?: string;
+};
+
+export const useResourceModuleFilters = () => {
+  const location = useLocation<ModuleFilters>();
+
+  return pick(location.query, [
+    BrowserStarfishFields.DOMAIN,
+    BrowserStarfishFields.RESOURCE_TYPE,
+    BrowserStarfishFields.PAGE,
+    BrowserStarfishFields.GROUP_ID,
+    BrowserStarfishFields.DESCRIPTION,
+  ]);
+};

--- a/static/app/views/performance/browser/resources/utils/useResourceSort.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceSort.ts
@@ -1,0 +1,36 @@
+import {fromSorts} from 'sentry/utils/discover/eventView';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {useLocation} from 'sentry/utils/useLocation';
+import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
+
+type Query = {
+  sort?: string;
+};
+
+const SORTABLE_FIELDS = ['avg(span.duration)'] as const;
+
+export type ValidSort = Sort & {
+  field: (typeof SORTABLE_FIELDS)[number];
+};
+
+/**
+ * Parses a `Sort` object from the URL. In case of multiple specified sorts
+ * picks the first one, since span module UIs only support one sort at a time.
+ */
+export function useResourceSort(
+  sortParameterName: QueryParameterNames | 'sort' = 'sort',
+  fallback: Sort = DEFAULT_SORT
+) {
+  const location = useLocation<Query>();
+
+  return fromSorts(location.query[sortParameterName]).filter(isAValidSort)[0] ?? fallback;
+}
+
+const DEFAULT_SORT: Sort = {
+  kind: 'desc',
+  field: SORTABLE_FIELDS[0],
+};
+
+function isAValidSort(sort: Sort): sort is ValidSort {
+  return (SORTABLE_FIELDS as unknown as string[]).includes(sort.field);
+}


### PR DESCRIPTION
Inits resource module, this is all hardcoded data rn, and we can adjust things off of this.
Resource table
<img width="1271" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/c4f9e692-520a-45df-b050-bffa0edf9a70">

Sidebar
<img width="1270" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/8a3e88d5-c4c2-4f22-a886-c57b3ecea583">
