### PR TITLE
ref: Add test datadog slack issue alert metric

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -91,6 +91,9 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 )
             rule = rules[0] if rules else None
             self.record_notification_sent(event, channel, rule, notification_uuid)
+            metrics.incr(
+                "test.notifications.sent", instance="test.slack.notification", skip_internal=False
+            )
 
         key = f"slack:{integration.id}:{channel}"
 


### PR DESCRIPTION
Add test datadog slack issue alert metric to investigate if datadog is undercounting