### PR TITLE
ref(replays): group selectors by project_id and add proj icon

### DIFF
--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -25,6 +25,7 @@ import {
 } from 'sentry/views/profiling/landing/styles';
 import ExampleReplaysList from 'sentry/views/replays/deadRageClick/exampleReplaysList';
 import {
+  ProjectInfo,
   SelectorLink,
   transformSelectorQuery,
 } from 'sentry/views/replays/deadRageClick/selectorTable';
@@ -129,6 +130,7 @@ function AccordionWidget({
                     selector={d.dom_element}
                     clickColor={clickColor}
                     selectorQuery={selectorQuery}
+                    id={d.project_id}
                   />
                 ),
                 content: () => (
@@ -158,9 +160,11 @@ function AccordionItemHeader({
   clickColor,
   selector,
   selectorQuery,
+  id,
 }: {
   clickColor: ColorOrAlias;
   count: number;
+  id: number;
   selector: string;
   selectorQuery: string;
 }) {
@@ -173,7 +177,10 @@ function AccordionItemHeader({
   return (
     <StyledAccordionHeader>
       <SelectorLink value={selector} selectorQuery={selectorQuery} />
-      <RightAlignedCell>{clickCount}</RightAlignedCell>
+      <RightAlignedCell>
+        {clickCount}
+        <ProjectInfo id={id} isWidget />
+      </RightAlignedCell>
     </StyledAccordionHeader>
   );
 }
@@ -275,6 +282,7 @@ export const RightAlignedCell = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: ${space(1)};
 `;
 
 export default DeadRageSelectorCards;

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -136,6 +136,7 @@ function AccordionWidget({
                     location={location}
                     clickType={clickType}
                     selectorQuery={selectorQuery}
+                    projectId={d.project_id}
                   />
                 ),
               };

--- a/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
+++ b/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
@@ -16,9 +16,11 @@ export default function ExampleReplaysList({
   location,
   clickType,
   selectorQuery,
+  projectId,
 }: {
   clickType: 'count_dead_clicks' | 'count_rage_clicks';
   location: Location;
+  projectId: number;
   selectorQuery: string;
 }) {
   const organization = useOrganization();
@@ -53,13 +55,13 @@ export default function ExampleReplaysList({
             'started_at',
             'urls',
           ],
-          projects: [],
+          projects: [projectId],
           query: selectorQuery,
           orderby: `-${clickType}`,
         },
         emptyLocation
       ),
-    [emptyLocation, selectorQuery, clickType]
+    [emptyLocation, selectorQuery, clickType, projectId]
   );
 
   const {replays, isFetching, fetchError} = useReplayList({

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -65,21 +65,27 @@ interface Props {
 }
 
 const BASE_COLUMNS: GridColumnOrder<string>[] = [
-  {key: 'project_id', name: 'project'},
+  {key: 'project_id', name: 'project', width: 100},
   {key: 'element', name: 'element'},
   {key: 'dom_element', name: 'selector'},
   {key: 'aria_label', name: 'aria label'},
 ];
 
-function ProjectInfo({id}: {id: number}) {
+export function ProjectInfo({id, isWidget}: {id: number; isWidget: boolean}) {
   const {projects} = useProjects();
   const project = projects.find(p => p.id === id.toString());
   const platform = project?.platform;
   const slug = project?.slug;
-  return (
+  return isWidget ? (
+    <ProjectContainer>
+      <Tooltip title={slug}>
+        <PlatformIcon size={16} platform={platform ?? 'default'} />
+      </Tooltip>
+    </ProjectContainer>
+  ) : (
     <ProjectContainer>
       <PlatformIcon size={16} platform={platform ?? 'default'} />
-      <ProjectText>{slug}</ProjectText>
+      <TextOverflow>{slug}</TextOverflow>
     </ProjectContainer>
   );
 }
@@ -132,7 +138,7 @@ export default function SelectorTable({
         case 'aria_label':
           return <TextOverflow>{value}</TextOverflow>;
         case 'project_id':
-          return <ProjectInfo id={value} />;
+          return <ProjectInfo id={value} isWidget={false} />;
         default:
           return renderClickCount<DeadRageSelectorItem>(column, dataRow);
       }
@@ -224,8 +230,4 @@ const ProjectContainer = styled('div')`
   flex-direction: row;
   align-items: center;
   gap: ${space(0.75)};
-`;
-
-const ProjectText = styled(TextOverflow)`
-  max-width: 100px;
 `;

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -1,6 +1,7 @@
 import {ReactNode, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
+import {PlatformIcon} from 'platformicons';
 
 import GridEditable, {GridColumnOrder} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
@@ -15,6 +16,7 @@ import {space} from 'sentry/styles/space';
 import {ColorOrAlias} from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {DeadRageSelectorItem} from 'sentry/views/replays/types';
 
@@ -52,7 +54,6 @@ export function transformSelectorQuery(selector: string) {
     .replaceAll('testid=', 'data-test-id=')
     .replaceAll(':', '\\:');
 }
-
 interface Props {
   clickCountColumns: {key: string; name: string}[];
   clickCountSortable: boolean;
@@ -64,10 +65,24 @@ interface Props {
 }
 
 const BASE_COLUMNS: GridColumnOrder<string>[] = [
+  {key: 'project_id', name: 'project'},
   {key: 'element', name: 'element'},
   {key: 'dom_element', name: 'selector'},
   {key: 'aria_label', name: 'aria label'},
 ];
+
+function ProjectInfo({id}: {id: number}) {
+  const {projects} = useProjects();
+  const project = projects.find(p => p.id === id.toString());
+  const platform = project?.platform;
+  const slug = project?.slug;
+  return (
+    <ProjectContainer>
+      <PlatformIcon size={16} platform={platform ?? 'default'} />
+      <ProjectText>{slug}</ProjectText>
+    </ProjectContainer>
+  );
+}
 
 export default function SelectorTable({
   clickCountColumns,
@@ -116,6 +131,8 @@ export default function SelectorTable({
         case 'element':
         case 'aria_label':
           return <TextOverflow>{value}</TextOverflow>;
+        case 'project_id':
+          return <ProjectInfo id={value} />;
         default:
           return renderClickCount<DeadRageSelectorItem>(column, dataRow);
       }
@@ -200,4 +217,15 @@ const StyledTextOverflow = styled(TextOverflow)`
 
 const StyledTooltip = styled(Tooltip)`
   display: inherit;
+`;
+
+const ProjectContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${space(0.75)};
+`;
+
+const ProjectText = styled(TextOverflow)`
+  max-width: 100px;
 `;

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -65,7 +65,7 @@ interface Props {
 }
 
 const BASE_COLUMNS: GridColumnOrder<string>[] = [
-  {key: 'project_id', name: 'project', width: 100},
+  {key: 'project_id', name: 'project'},
   {key: 'element', name: 'element'},
   {key: 'dom_element', name: 'selector'},
   {key: 'aria_label', name: 'aria label'},

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -41,6 +41,7 @@ export function hydratedSelectorData(data, clickType?): DeadRageSelectorItem[] {
     dom_element: d.dom_element,
     element: d.dom_element.split(/[#.]+/)[0],
     aria_label: getAriaLabel(d.dom_element),
+    project_id: d.project_id,
   }));
 }
 

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -230,4 +230,5 @@ const ProjectContainer = styled('div')`
   flex-direction: row;
   align-items: center;
   gap: ${space(0.75)};
+  padding-right: ${space(1)};
 `;

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -77,16 +77,16 @@ export function ProjectInfo({id, isWidget}: {id: number; isWidget: boolean}) {
   const platform = project?.platform;
   const slug = project?.slug;
   return isWidget ? (
-    <ProjectContainer>
+    <WidgetProjectContainer>
       <Tooltip title={slug}>
         <PlatformIcon size={16} platform={platform ?? 'default'} />
       </Tooltip>
-    </ProjectContainer>
+    </WidgetProjectContainer>
   ) : (
-    <ProjectContainer>
+    <IndexProjectContainer>
       <PlatformIcon size={16} platform={platform ?? 'default'} />
       <TextOverflow>{slug}</TextOverflow>
-    </ProjectContainer>
+    </IndexProjectContainer>
   );
 }
 
@@ -225,10 +225,13 @@ const StyledTooltip = styled(Tooltip)`
   display: inherit;
 `;
 
-const ProjectContainer = styled('div')`
+const WidgetProjectContainer = styled('div')`
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: ${space(0.75)};
+`;
+
+const IndexProjectContainer = styled(WidgetProjectContainer)`
   padding-right: ${space(1)};
 `;

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -172,6 +172,7 @@ export type DeadRageSelectorItem = {
   aria_label: string;
   dom_element: string;
   element: string;
+  project_id: number;
   count_dead_clicks?: number;
   count_rage_clicks?: number;
 };


### PR DESCRIPTION
Same selectors from different projects are now separated. We also added the platform icon and project slug in the selector tables.

Before: selectors could contain example replays from diff projects
<img width="573" alt="SCR-20231003-mvqc" src="https://github.com/getsentry/sentry/assets/56095982/e3b1444f-d3ec-46bd-acdb-cbb699948b0d">

After: selectors only contain example replays from one project

<img width="602" alt="SCR-20231003-owox" src="https://github.com/getsentry/sentry/assets/56095982/b20766be-c812-46b6-aa46-e2254d578449">
<img width="1229" alt="SCR-20231003-nxfy" src="https://github.com/getsentry/sentry/assets/56095982/bce8d9bb-421b-4465-82f5-4ee8fa6d92e3">

