### PR TITLE
feat(aggregate-waterfall): Implement design for frequency values in aggregate waterfall

### DIFF
--- a/static/app/components/events/interfaces/spans/aggregateSpans.tsx
+++ b/static/app/components/events/interfaces/spans/aggregateSpans.tsx
@@ -137,6 +137,10 @@ export function AggregateSpans({transaction}: Props) {
       ],
       startTimestamp: 0,
       type: EventOrGroupType.AGGREGATE_TRANSACTION,
+      // TODO: No need for optional chaining here, we should not return anything if the event is not loaded
+      frequency: parentSpan?.frequency ?? 0,
+      count: parentSpan?.count ?? 0,
+      total: parentSpan?.total ?? 0,
     };
   }, [parentSpan, flattenedSpans]);
   const waterfallModel = useMemo(() => new WaterfallModel(event, undefined), [event]);

--- a/static/app/components/events/interfaces/spans/aggregateSpans.tsx
+++ b/static/app/components/events/interfaces/spans/aggregateSpans.tsx
@@ -84,6 +84,7 @@ export function AggregateSpans({transaction}: Props) {
       start_timestamp: start_timestamp / 1000,
       trace_id: '1', // not actually trace_id just a placeholder
       count,
+      total,
       duration,
       frequency: count / total,
       type: 'aggregate',

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -58,7 +58,6 @@ import {
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
-import {formatPercentage} from 'sentry/utils/formatters';
 import toPercent from 'sentry/utils/number/toPercent';
 import {
   QuickTraceContext,
@@ -1122,10 +1121,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
       : null;
 
     const durationDisplay = getDurationDisplay(bounds);
-    let frequency: number | undefined = undefined;
-    if (span.type === 'aggregate') {
-      frequency = span.frequency;
-    }
+
     return (
       <Fragment>
         <RowRectangle
@@ -1147,9 +1143,6 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
           </DurationPill>
         </RowRectangle>
         {subSpans}
-        <PercentageContainer>
-          <Percentage>{frequency && formatPercentage(frequency)}</Percentage>
-        </PercentageContainer>
       </Fragment>
     );
   }
@@ -1232,16 +1225,3 @@ const StyledIconWarning = styled(IconWarning)`
 const Regroup = styled('span')``;
 
 export const ProfiledSpanBar = withProfiler(SpanBar);
-
-const PercentageContainer = styled('div')`
-  position: absolute;
-  left: 100%;
-  padding-left: 10px;
-  white-space: nowrap;
-  color: ${p => p.theme.gray300};
-  font-size: ${p => p.theme.fontSizeSmall};
-`;
-
-const Percentage = styled('div')`
-  position: fixed;
-`;

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -1,12 +1,16 @@
 import 'intersection-observer'; // this is a polyfill
 
-import {Component, createRef, Fragment, useRef} from 'react';
+import {Component, createRef, Fragment} from 'react';
 import {CellMeasurerCache, List as ReactVirtualizedList} from 'react-virtualized';
 import styled from '@emotion/styled';
 import {withProfiler} from '@sentry/react';
 
 import Count from 'sentry/components/count';
 import AggregateSpanDetail from 'sentry/components/events/interfaces/spans/aggregateSpanDetail';
+import {
+  FREQUENCY_BOX_WIDTH,
+  SpanFrequencyBox,
+} from 'sentry/components/events/interfaces/spans/spanFrequencyBox';
 import {ROW_HEIGHT, SpanBarType} from 'sentry/components/performance/waterfall/constants';
 import {MessageRow} from 'sentry/components/performance/waterfall/messageRow';
 import {
@@ -106,10 +110,6 @@ import {
   SpanViewBoundsType,
   unwrapTreeDepth,
 } from './utils';
-import {
-  FREQUENCY_BOX_WIDTH,
-  SpanFrequencyBox,
-} from 'sentry/components/events/interfaces/spans/spanFrequencyBox';
 
 // TODO: maybe use babel-plugin-preval
 // for (let i = 0; i <= 1.0; i += 0.01) {
@@ -588,9 +588,9 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
       titleFragments.push(
         <Regroup
           key={`regroup-${span.timestamp}`}
-          onClick={event => {
-            event.stopPropagation();
-            event.preventDefault();
+          onClick={e => {
+            e.stopPropagation();
+            e.preventDefault();
             if (groupType === GroupType.SIBLINGS && 'op' in span) {
               toggleSiblingSpanGroup?.(span, groupOccurrence ?? 0);
             } else {
@@ -600,8 +600,8 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
         >
           <a
             href="#regroup"
-            onClick={event => {
-              event.preventDefault();
+            onClick={e => {
+              e.preventDefault();
             }}
           >
             {t('Regroup')}

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -84,6 +84,7 @@ import {MeasurementMarker} from './styles';
 import {
   AggregateSpanType,
   FetchEmbeddedChildrenState,
+  GapSpanType,
   GroupType,
   ParsedTraceType,
   ProcessedSpanType,
@@ -627,7 +628,9 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
 
     return (
       <Fragment>
-        {isAggregateEvent && <SpanFrequencyBox span={span as AggregateSpanType} />}
+        {isAggregateEvent && (
+          <SpanFrequencyBox span={span as AggregateSpanType | GapSpanType} />
+        )}
         <RowTitleContainer
           data-debug-id="SpanBarTitleContainer"
           ref={ref => {

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -616,19 +616,18 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
 
     titleFragments = titleFragments.flatMap(current => [current, ' \u2014 ']);
 
-    const isAggregateSpan =
-      event.type === EventOrGroupType.AGGREGATE_TRANSACTION && span.type === 'aggregate';
+    const isAggregateEvent = event.type === EventOrGroupType.AGGREGATE_TRANSACTION;
 
     const left =
       treeDepth * (TOGGLE_BORDER_BOX / 2) +
       MARGIN_LEFT +
-      (isAggregateSpan ? FREQUENCY_BOX_WIDTH : 0);
+      (isAggregateEvent ? FREQUENCY_BOX_WIDTH : 0);
 
     const errored = Boolean(errors && errors.length > 0);
 
     return (
       <Fragment>
-        {isAggregateSpan && <SpanFrequencyBox span={span} />}
+        {isAggregateEvent && <SpanFrequencyBox span={span as AggregateSpanType} />}
         <RowTitleContainer
           data-debug-id="SpanBarTitleContainer"
           ref={ref => {

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -1,6 +1,6 @@
 import 'intersection-observer'; // this is a polyfill
 
-import {Component, createRef, Fragment} from 'react';
+import {Component, createRef, Fragment, useRef} from 'react';
 import {CellMeasurerCache, List as ReactVirtualizedList} from 'react-virtualized';
 import styled from '@emotion/styled';
 import {withProfiler} from '@sentry/react';
@@ -106,7 +106,10 @@ import {
   SpanViewBoundsType,
   unwrapTreeDepth,
 } from './utils';
-import {SpanFrequencyBox} from 'sentry/components/events/interfaces/spans/spanFrequencyBox';
+import {
+  FREQUENCY_BOX_WIDTH,
+  SpanFrequencyBox,
+} from 'sentry/components/events/interfaces/spans/spanFrequencyBox';
 
 // TODO: maybe use babel-plugin-preval
 // for (let i = 0; i <= 1.0; i += 0.01) {
@@ -573,6 +576,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
       addContentSpanBarRef,
       removeContentSpanBarRef,
       groupType,
+      event,
     } = this.props;
 
     let titleFragments: React.ReactNode[] = [];
@@ -613,12 +617,19 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
 
     titleFragments = titleFragments.flatMap(current => [current, ' \u2014 ']);
 
-    const left = treeDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
+    const isAggregateSpan =
+      event.type === EventOrGroupType.AGGREGATE_TRANSACTION && span.type === 'aggregate';
+
+    const left =
+      treeDepth * (TOGGLE_BORDER_BOX / 2) +
+      MARGIN_LEFT +
+      (isAggregateSpan ? FREQUENCY_BOX_WIDTH : 0);
+
     const errored = Boolean(errors && errors.length > 0);
 
     return (
       <Fragment>
-        <SpanFrequencyBox frequency={100} />
+        {isAggregateSpan && <SpanFrequencyBox frequency={span.frequency ?? 0} />}
         <RowTitleContainer
           data-debug-id="SpanBarTitleContainer"
           ref={ref => {

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -106,6 +106,7 @@ import {
   SpanViewBoundsType,
   unwrapTreeDepth,
 } from './utils';
+import {SpanFrequencyBox} from 'sentry/components/events/interfaces/spans/spanFrequencyBox';
 
 // TODO: maybe use babel-plugin-preval
 // for (let i = 0; i <= 1.0; i += 0.01) {
@@ -616,34 +617,37 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
     const errored = Boolean(errors && errors.length > 0);
 
     return (
-      <RowTitleContainer
-        data-debug-id="SpanBarTitleContainer"
-        ref={ref => {
-          if (!ref) {
-            removeContentSpanBarRef(this.spanContentRef);
-            return;
-          }
+      <Fragment>
+        <SpanFrequencyBox frequency={100} />
+        <RowTitleContainer
+          data-debug-id="SpanBarTitleContainer"
+          ref={ref => {
+            if (!ref) {
+              removeContentSpanBarRef(this.spanContentRef);
+              return;
+            }
 
-          addContentSpanBarRef(ref);
-          this.spanContentRef = ref;
-        }}
-      >
-        {this.renderSpanTreeToggler({left, errored})}
-        <RowTitle
-          style={{
-            left: `${left}px`,
-            width: '100%',
+            addContentSpanBarRef(ref);
+            this.spanContentRef = ref;
           }}
         >
-          <RowTitleContent
-            errored={errored}
-            data-test-id={`row-title-content${spanBarType ? `-${spanBarType}` : ''}`}
+          {this.renderSpanTreeToggler({left, errored})}
+          <RowTitle
+            style={{
+              left: `${left}px`,
+              width: '100%',
+            }}
           >
-            <strong>{titleFragments}</strong>
-            {formatSpanTreeLabel(span)}
-          </RowTitleContent>
-        </RowTitle>
-      </RowTitleContainer>
+            <RowTitleContent
+              errored={errored}
+              data-test-id={`row-title-content${spanBarType ? `-${spanBarType}` : ''}`}
+            >
+              <strong>{titleFragments}</strong>
+              {formatSpanTreeLabel(span)}
+            </RowTitleContent>
+          </RowTitle>
+        </RowTitleContainer>
+      </Fragment>
     );
   }
 

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -629,7 +629,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
 
     return (
       <Fragment>
-        {isAggregateSpan && <SpanFrequencyBox frequency={span.frequency ?? 0} />}
+        {isAggregateSpan && <SpanFrequencyBox span={span} />}
         <RowTitleContainer
           data-debug-id="SpanBarTitleContainer"
           ref={ref => {

--- a/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
+++ b/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
@@ -1,0 +1,64 @@
+import {Theme} from '@emotion/react';
+import styled from '@emotion/styled';
+import {useRef} from 'react';
+
+export const FREQUENCY_BOX_WIDTH = 40;
+
+type Props = {
+  frequency: number;
+};
+
+export function SpanFrequencyBox({frequency}: Props) {
+  const frequencyRef = useRef<number>(Math.round(Math.random() * 100));
+  return <StyledBox frequency={frequencyRef.current}>{frequencyRef.current}%</StyledBox>;
+}
+
+function getBoxColors(frequency: number, theme: Theme) {
+  if (frequency > 90) {
+    return `
+      background: ${theme.white};
+      color: ${theme.black};
+    `;
+  }
+
+  if (frequency > 70) {
+    return `
+      background: ${theme.purple100};
+      color: ${theme.black};
+    `;
+  }
+
+  if (frequency > 50) {
+    return `
+      background: ${theme.purple200};
+      color: ${theme.black};
+    `;
+  }
+
+  if (frequency > 30) {
+    return `
+      background: ${theme.purple300};
+      color: ${theme.white};
+    `;
+  }
+
+  return `
+      background: ${theme.purple400};
+      color: ${theme.white};
+    `;
+}
+
+const StyledBox = styled('div')<{frequency: number}>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: ${p => p.theme.purple200};
+  height: 100%;
+  width: ${FREQUENCY_BOX_WIDTH}px;
+  border-left: 1px solid ${p => p.theme.gray200};
+  border-right: 1px solid ${p => p.theme.gray200};
+
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+
+  ${p => getBoxColors(p.frequency, p.theme)}
+`;

--- a/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
+++ b/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
@@ -8,6 +8,9 @@ type Props = {
   frequency: number;
 };
 
+// Colors are copied from tagsHeatMap.tsx, as they are not available on the theme
+const purples = ['#D1BAFC', '#9282F3', '#6056BA', '#313087', '#021156'];
+
 export function SpanFrequencyBox({frequency}: Props) {
   const frequencyRef = useRef<number>(Math.round(Math.random() * 100));
   return <StyledBox frequency={frequencyRef.current}>{frequencyRef.current}%</StyledBox>;
@@ -23,27 +26,27 @@ function getBoxColors(frequency: number, theme: Theme) {
 
   if (frequency > 70) {
     return `
-      background: ${theme.purple100};
+      background: ${purples[0]};
       color: ${theme.black};
     `;
   }
 
   if (frequency > 50) {
     return `
-      background: ${theme.purple200};
+      background: ${purples[1]};
       color: ${theme.black};
     `;
   }
 
   if (frequency > 30) {
     return `
-      background: ${theme.purple300};
+      background: ${purples[2]};
       color: ${theme.white};
     `;
   }
 
   return `
-      background: ${theme.purple400};
+      background: ${purples[3]};
       color: ${theme.white};
     `;
 }

--- a/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
+++ b/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
@@ -1,7 +1,10 @@
 import {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Tooltip} from 'sentry/components/tooltip';
+import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {formatPercentage} from 'sentry/utils/formatters';
 
 export const FREQUENCY_BOX_WIDTH = 40;
 
@@ -13,32 +16,44 @@ type Props = {
 const purples = ['#D1BAFC', '#9282F3', '#6056BA', '#313087', '#021156'];
 
 export function SpanFrequencyBox({frequency}: Props) {
-  return <StyledBox frequency={frequency}>{frequency}%</StyledBox>;
+  return (
+    <StyledBox frequency={frequency}>
+      <Tooltip
+        isHoverable
+        title={tct(
+          'This span occurs in [x] out of every [total] events ([percentage] frequency)',
+          {x: 3, total: 100, percentage: formatPercentage(frequency, 0)}
+        )}
+      >
+        {formatPercentage(frequency, 0)}
+      </Tooltip>
+    </StyledBox>
+  );
 }
 
 function getBoxColors(frequency: number, theme: Theme) {
-  if (frequency > 90) {
+  if (frequency >= 0.9) {
     return `
       background: ${theme.white};
       color: ${theme.black};
     `;
   }
 
-  if (frequency > 70) {
+  if (frequency >= 0.7) {
     return `
       background: ${purples[0]};
       color: ${theme.black};
     `;
   }
 
-  if (frequency > 50) {
+  if (frequency >= 0.5) {
     return `
       background: ${purples[1]};
       color: ${theme.black};
     `;
   }
 
-  if (frequency > 30) {
+  if (frequency >= 0.3) {
     return `
       background: ${purples[2]};
       color: ${theme.white};

--- a/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
+++ b/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
@@ -65,6 +65,7 @@ const StyledBox = styled('div')<{frequency: number}>`
   padding-right: ${space(1)};
 
   font-size: ${p => p.theme.fontSizeExtraSmall};
-
   ${p => getBoxColors(p.frequency, p.theme)}
+
+  z-index: 9;
 `;

--- a/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
+++ b/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
@@ -1,6 +1,6 @@
-import {useRef} from 'react';
 import {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
+
 import {space} from 'sentry/styles/space';
 
 export const FREQUENCY_BOX_WIDTH = 40;
@@ -13,8 +13,7 @@ type Props = {
 const purples = ['#D1BAFC', '#9282F3', '#6056BA', '#313087', '#021156'];
 
 export function SpanFrequencyBox({frequency}: Props) {
-  const frequencyRef = useRef<number>(Math.round(Math.random() * 100));
-  return <StyledBox frequency={frequencyRef.current}>{frequencyRef.current}%</StyledBox>;
+  return <StyledBox frequency={frequency}>{frequency}%</StyledBox>;
 }
 
 function getBoxColors(frequency: number, theme: Theme) {

--- a/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
+++ b/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
@@ -1,6 +1,7 @@
+import {useRef} from 'react';
 import {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
-import {useRef} from 'react';
+import {space} from 'sentry/styles/space';
 
 export const FREQUENCY_BOX_WIDTH = 40;
 
@@ -53,13 +54,15 @@ function getBoxColors(frequency: number, theme: Theme) {
 
 const StyledBox = styled('div')<{frequency: number}>`
   display: flex;
-  justify-content: center;
+  justify-content: right;
   align-items: center;
-  background: ${p => p.theme.purple200};
+
   height: 100%;
   width: ${FREQUENCY_BOX_WIDTH}px;
+
   border-left: 1px solid ${p => p.theme.gray200};
   border-right: 1px solid ${p => p.theme.gray200};
+  padding-right: ${space(1)};
 
   font-size: ${p => p.theme.fontSizeExtraSmall};
 

--- a/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
+++ b/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
@@ -1,24 +1,36 @@
 import {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {AggregateSpanType} from 'sentry/components/events/interfaces/spans/types';
+import {
+  AggregateSpanType,
+  GapSpanType,
+} from 'sentry/components/events/interfaces/spans/types';
 import {Tooltip} from 'sentry/components/tooltip';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {formatPercentage} from 'sentry/utils/formatters';
 
 export const FREQUENCY_BOX_WIDTH = 40;
 
 type Props = {
-  span: AggregateSpanType;
+  span: AggregateSpanType | GapSpanType;
 };
 
 // Colors are copied from tagsHeatMap.tsx, as they are not available on the theme
 const purples = ['#D1BAFC', '#9282F3', '#6056BA', '#313087', '#021156'];
 
 export function SpanFrequencyBox({span}: Props) {
-  const {frequency, count, total} = span;
+  if (span.type === 'gap') {
+    return (
+      <StyledBox>
+        <Tooltip isHoverable title={t('This frequency of this span is unknown')}>
+          {'—'}
+        </Tooltip>
+      </StyledBox>
+    );
+  }
 
+  const {frequency, count, total} = span;
   return (
     <StyledBox frequency={frequency ?? 0}>
       <Tooltip
@@ -34,8 +46,8 @@ export function SpanFrequencyBox({span}: Props) {
   );
 }
 
-function getBoxColors(frequency: number, theme: Theme) {
-  if (frequency >= 0.9) {
+function getBoxColors(theme: Theme, frequency?: number) {
+  if (!frequency || frequency >= 0.9) {
     return `
       background: ${theme.white};
       color: ${theme.black};
@@ -69,7 +81,7 @@ function getBoxColors(frequency: number, theme: Theme) {
     `;
 }
 
-const StyledBox = styled('div')<{frequency: number}>`
+const StyledBox = styled('div')<{frequency?: number}>`
   display: flex;
   justify-content: right;
   align-items: center;
@@ -82,7 +94,7 @@ const StyledBox = styled('div')<{frequency: number}>`
   padding-right: ${space(1)};
 
   font-size: ${p => p.theme.fontSizeExtraSmall};
-  ${p => getBoxColors(p.frequency, p.theme)}
+  ${p => getBoxColors(p.theme, p.frequency)}
 
   z-index: 9;
 `;

--- a/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
+++ b/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
@@ -1,6 +1,7 @@
 import {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {AggregateSpanType} from 'sentry/components/events/interfaces/spans/types';
 import {Tooltip} from 'sentry/components/tooltip';
 import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -9,23 +10,25 @@ import {formatPercentage} from 'sentry/utils/formatters';
 export const FREQUENCY_BOX_WIDTH = 40;
 
 type Props = {
-  frequency: number;
+  span: AggregateSpanType;
 };
 
 // Colors are copied from tagsHeatMap.tsx, as they are not available on the theme
 const purples = ['#D1BAFC', '#9282F3', '#6056BA', '#313087', '#021156'];
 
-export function SpanFrequencyBox({frequency}: Props) {
+export function SpanFrequencyBox({span}: Props) {
+  const {frequency, count, total} = span;
+
   return (
-    <StyledBox frequency={frequency}>
+    <StyledBox frequency={frequency ?? 0}>
       <Tooltip
         isHoverable
         title={tct(
           'This span occurs in [x] out of every [total] events ([percentage] frequency)',
-          {x: 3, total: 100, percentage: formatPercentage(frequency, 0)}
+          {x: count, total, percentage: formatPercentage(frequency ?? 0, 0)}
         )}
       >
-        {formatPercentage(frequency, 0)}
+        {formatPercentage(frequency ?? 0, 0)}
       </Tooltip>
     </StyledBox>
   );

--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -50,7 +50,7 @@ import {PerformanceInteraction} from 'sentry/utils/performanceForSentry';
 import * as DividerHandlerManager from './dividerHandlerManager';
 import SpanBarCursorGuide from './spanBarCursorGuide';
 import {MeasurementMarker} from './styles';
-import {EnhancedSpan, ProcessedSpanType} from './types';
+import {AggregateSpanType, EnhancedSpan, ProcessedSpanType} from './types';
 import {
   getMeasurementBounds,
   getMeasurements,
@@ -271,15 +271,18 @@ export function SpanGroupBar(props: Props) {
           endTimestamp: span.timestamp,
         });
 
-        const isAggregateSpan =
-          event.type === EventOrGroupType.AGGREGATE_TRANSACTION &&
-          span.type === 'aggregate';
+        const firstAggregateSpan = spanGrouping.find(
+          ({span: currentSpan}) => currentSpan.type === 'aggregate'
+        );
+
+        const isAggregateEvent =
+          event.type === EventOrGroupType.AGGREGATE_TRANSACTION && firstAggregateSpan;
 
         const {dividerPosition, addGhostDividerLineRef} = dividerHandlerChildrenProps;
         const left =
           treeDepth * (TOGGLE_BORDER_BOX / 2) +
           MARGIN_LEFT +
-          (isAggregateSpan ? FREQUENCY_BOX_WIDTH : 0);
+          (isAggregateEvent ? FREQUENCY_BOX_WIDTH : 0);
 
         return (
           <Row
@@ -300,7 +303,9 @@ export function SpanGroupBar(props: Props) {
                 }}
                 ref={spanTitleRef}
               >
-                {isAggregateSpan && <SpanFrequencyBox span={span} />}
+                {isAggregateEvent && (
+                  <SpanFrequencyBox span={firstAggregateSpan.span as AggregateSpanType} />
+                )}
                 <RowTitleContainer ref={setTransformCallback}>
                   {renderGroupedSpansToggler(props)}
                   <RowTitle

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -33,6 +33,8 @@ export type RawSpanType = {
 };
 
 export type AggregateSpanType = RawSpanType & {
+  count: number;
+  total: number;
   type: 'aggregate';
   frequency?: number;
 };

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -34,9 +34,9 @@ export type RawSpanType = {
 
 export type AggregateSpanType = RawSpanType & {
   count: number;
+  frequency: number;
   total: number;
   type: 'aggregate';
-  frequency?: number;
 };
 
 /**
@@ -157,10 +157,13 @@ export type ParsedTraceType = {
   traceEndTimestamp: number;
   traceID: string;
   traceStartTimestamp: number;
+  count?: number;
   description?: string;
   exclusiveTime?: number;
+  frequency?: number;
   hash?: string;
   parentSpanID?: string;
+  total?: number;
 };
 
 export enum TickAlignment {
@@ -170,13 +173,16 @@ export enum TickAlignment {
 }
 
 export type TraceContextType = {
+  count?: number;
   description?: string;
   exclusive_time?: number;
+  frequency?: number;
   hash?: string;
   op?: string;
   parent_span_id?: string;
   span_id?: string;
   status?: string;
+  total?: number;
   trace_id?: string;
   type?: 'trace';
 };

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -244,8 +244,10 @@ export const boundsGenerator = (bounds: {
   };
 };
 
-export function generateRootSpan(trace: ParsedTraceType): RawSpanType {
-  const rootSpan: RawSpanType = {
+export function generateRootSpan(
+  trace: ParsedTraceType
+): RawSpanType | AggregateSpanType {
+  const rootSpan = {
     trace_id: trace.traceID,
     span_id: trace.rootSpanID,
     parent_span_id: trace.parentSpanID,
@@ -257,6 +259,9 @@ export function generateRootSpan(trace: ParsedTraceType): RawSpanType {
     status: trace.rootSpanStatus,
     hash: trace.hash,
     exclusive_time: trace.exclusiveTime,
+    count: trace.count,
+    frequency: trace.frequency,
+    total: trace.total,
   };
 
   return rootSpan;
@@ -473,6 +478,9 @@ export function parseTrace(
   const rootSpanStatus = traceContext && traceContext.status;
   const hash = traceContext && traceContext.hash;
   const exclusiveTime = traceContext && traceContext.exclusive_time;
+  const count = traceContext && traceContext.count;
+  const frequency = traceContext && traceContext.frequency;
+  const total = traceContext && traceContext.total;
 
   if (!spanEntry || spans.length <= 0) {
     return {
@@ -488,6 +496,9 @@ export function parseTrace(
       description,
       hash,
       exclusiveTime,
+      count,
+      frequency,
+      total,
     };
   }
 
@@ -516,6 +527,9 @@ export function parseTrace(
     description,
     hash,
     exclusiveTime,
+    count,
+    frequency,
+    total,
   };
 
   const reduced: ParsedTraceType = spans.reduce((acc, inputSpan) => {

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -824,6 +824,9 @@ export interface AggregateEventTransaction
     | 'tags'
     | 'title'
   > {
+  count: number;
+  frequency: number;
+  total: number;
   type: EventOrGroupType.AGGREGATE_TRANSACTION;
 }
 

--- a/static/app/views/performance/transactionSummary/aggregateSpanWaterfall/index.tsx
+++ b/static/app/views/performance/transactionSummary/aggregateSpanWaterfall/index.tsx
@@ -1,6 +1,3 @@
-import {Fragment} from 'react';
-import styled from '@emotion/styled';
-
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
 import {AggregateSpans} from 'sentry/components/events/interfaces/spans/aggregateSpans';
@@ -45,12 +42,9 @@ function AggregateSpanWaterfall(): React.ReactElement {
         getDocumentTitle={() => t(`Aggregate Waterfall: %s`, transaction)}
         childComponent={() => {
           return (
-            <Fragment>
-              <TitleWrapper>{t('Aggregate Span Waterfall')}</TitleWrapper>
-              <Layout.Main>
-                {defined(transaction) && <AggregateSpans transaction={transaction} />}
-              </Layout.Main>
-            </Fragment>
+            <Layout.Main>
+              {defined(transaction) && <AggregateSpans transaction={transaction} />}
+            </Layout.Main>
           );
         }}
       />
@@ -59,10 +53,3 @@ function AggregateSpanWaterfall(): React.ReactElement {
 }
 
 export default AggregateSpanWaterfall;
-
-const TitleWrapper = styled('div')`
-  padding: 0px 30px 0px 0px;
-  font-size: ${p => p.theme.headerFontSize};
-  font-weight: bold;
-  margin-top: 20px;
-`;


### PR DESCRIPTION
Upgrades the aggregate span waterfall to show the frequencies of spans on the left side.

![image](https://github.com/getsentry/sentry/assets/16740047/3550e2d1-29ae-4941-bdce-5b178499fc87)

In the case of a set of autogrouped spans, the frequency will be taken from the span with the highest frequency within the grouping.

Some things to be included in followup PRs:

- [x] Add a loading spinner for the aggregate waterfall so it doesn't initially show an empty transaction
- [ ] In the span details, show a list of span samples to navigate to
