### PR TITLE
fix(crons): Persist conditions on monitor change

### DIFF
--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -299,6 +299,7 @@ def update_alert_rule(request: Request, project: Project, alert_rule: Rule, aler
             "project": project,
             "actions": data.get("actions", []),
             "environment": data.get("environment", None),
+            "conditions": data.get("conditions", []),
         }
 
         updated_rule = project_rules.Updater.run(rule=alert_rule, request=request, **kwargs)

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -299,7 +299,8 @@ def update_alert_rule(request: Request, project: Project, alert_rule: Rule, aler
             "project": project,
             "actions": data.get("actions", []),
             "environment": data.get("environment", None),
-            "conditions": data.get("conditions", []),
+            # TODO(davidenwang): This is kind of a hack to get around updater removing conditions if not passed
+            "conditions": alert_rule.data.get("conditions", []),
         }
 
         updated_rule = project_rules.Updater.run(rule=alert_rule, request=request, **kwargs)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2708,13 +2708,23 @@ class MonitorTestCase(APITestCase):
         )
 
     def _create_alert_rule(self, monitor):
+        conditions = [
+            {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
+            {"id": "sentry.rules.conditions.regression_event.RegressionEventCondition"},
+            {
+                "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
+                "key": "monitor.slug",
+                "match": "eq",
+                "value": monitor.slug,
+            },
+        ]
         rule = Creator(
             name="New Cool Rule",
             owner=None,
             project=self.project,
-            action_match="all",
-            filter_match="any",
-            conditions=[],
+            action_match="any",
+            filter_match="all",
+            conditions=conditions,
             actions=[],
             frequency=5,
             environment=self.environment.id,

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -230,6 +230,8 @@ class UpdateMonitorTest(MonitorTestCase):
         monitor_rule = monitor.get_alert_rule()
         assert monitor_rule.id == rule.id
         assert monitor_rule.data["actions"] != rule.data["actions"]
+        # Verify the conditions haven't changed
+        assert monitor_rule.data["conditions"] == rule.data["conditions"]
         rule_environment = Environment.objects.get(id=monitor_rule.environment_id)
         assert rule_environment.name == new_environment.name
 


### PR DESCRIPTION
More details in the linked issue, but prevents editing the monitor from changing the alert rule conditions

Fixes: https://github.com/getsentry/sentry/issues/57419