### PR TITLE
feat(escalating-issues): Send timestamp of Event to metrics backend

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -131,6 +131,7 @@ def _update_escalating_metrics(event: Event) -> None:
         metric_name="event_ingested",
         value=1,
         tags={"group": str(event.group_id)},
+        timestamp=event.data["timestamp"],
         unit=None,
     )
 


### PR DESCRIPTION
## Objective:
We will send the Event's timestamp to the Generic Metrics backend. This requires the new API to be ready first.