### PR TITLE
ref(ts): Override complicated memo type

### DIFF
--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -194,11 +194,16 @@ function BaseMenuListItem({
   );
 }
 
-const MenuListItem = memo(
-  reactForwardRef<HTMLLIElement, MenuListItemProps & OtherProps>((props, ref) => (
-    <BaseMenuListItem {...props} forwardRef={ref} />
-  ))
+interface AllBaseMenuProps extends MenuListItemProps, OtherProps {}
+const ForwardRefBaseMenuComponent = reactForwardRef<HTMLLIElement, AllBaseMenuProps>(
+  (props, ref) => <BaseMenuListItem {...props} forwardRef={ref} />
 );
+
+const MenuListItem = memo(
+  ForwardRefBaseMenuComponent
+  // Override the memo type to avoid complex union types
+  // Should be no change in behavior
+) as typeof ForwardRefBaseMenuComponent;
 
 export default MenuListItem;
 


### PR DESCRIPTION
memo returns a MemoExoticComponent that wraps the ForwardRefExoticComponent from the forward ref and typescript spends a bunch of time doing something.

![Screenshot 2023-10-03 at 9 39 56 PM](https://github.com/getsentry/sentry/assets/1400464/4310a965-6d74-48ca-bd48-e623c959fb5f)



![Screenshot 2023-10-03 at 9 40 17 PM](https://github.com/getsentry/sentry/assets/1400464/0d2b4959-bf95-4f9c-b633-4c2744c5e4ca)

