### PR TITLE
ref(platform-categories): Move the sync-comments above the constants

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -1,5 +1,3 @@
-// Mirrors src/sentry/utils/platform_categories.py
-// When changing this file, make sure to keep src/sentry/utils/platform_categories.py in sync.
 import {PlatformKey} from 'sentry/types';
 
 export enum PlatformCategory {
@@ -11,37 +9,41 @@ export enum PlatformCategory {
   OTHER,
 }
 
+// Mirrors `FRONTEND` in src/sentry/utils/platform_categories.py
+// When changing this file, make sure to keep src/sentry/utils/platform_categories.py in sync.
 export const frontend: PlatformKey[] = [
   'dart',
   'javascript',
-  'javascript-react',
   'javascript-angular',
   'javascript-angularjs',
   'javascript-backbone',
   'javascript-ember',
   'javascript-gatsby',
-  'javascript-vue',
   'javascript-nextjs',
+  'javascript-react',
   'javascript-remix',
   'javascript-svelte',
   'javascript-sveltekit',
+  'javascript-vue',
   'unity',
 ];
 
+// Mirrors `MOBILE` in src/sentry/utils/platform_categories.py
+// When changing this file, make sure to keep src/sentry/utils/platform_categories.py in sync.
 export const mobile: PlatformKey[] = [
   'android',
   'apple-ios',
-  'cordova',
   'capacitor',
-  'javascript-cordova',
-  'javascript-capacitor',
-  'ionic',
-  'react-native',
-  'flutter',
+  'cordova',
   'dart-flutter',
-  'unity',
   'dotnet-maui',
   'dotnet-xamarin',
+  'flutter',
+  'ionic',
+  'javascript-capacitor',
+  'javascript-cordova',
+  'react-native',
+  'unity',
   'unreal',
   // Old platforms
   'java-android',
@@ -49,6 +51,8 @@ export const mobile: PlatformKey[] = [
   'cocoa-swift',
 ];
 
+// Mirrors `BACKEND` in src/sentry/utils/platform_categories.py
+// When changing this file, make sure to keep src/sentry/utils/platform_categories.py in sync.
 export const backend: PlatformKey[] = [
   'bun',
   'dotnet',
@@ -65,6 +69,7 @@ export const backend: PlatformKey[] = [
   'java-logging',
   'java-spring',
   'java-spring-boot',
+  'kotlin',
   'native',
   'node',
   'node-express',
@@ -76,62 +81,65 @@ export const backend: PlatformKey[] = [
   'php-monolog',
   'php-symfony',
   'python',
-  'python-django',
-  'python-flask',
-  'python-fastapi',
-  'python-starlette',
-  'python-sanic',
-  'python-celery',
   'python-aiohttp',
-  'python-chalice',
-  'python-falcon',
-  'python-quart',
-  'python-tryton',
-  'python-wsgi',
   'python-asgi',
   'python-bottle',
+  'python-celery',
+  'python-chalice',
+  'python-django',
+  'python-falcon',
+  'python-fastapi',
+  'python-flask',
   'python-pylons',
-  'python-pyramid',
-  'python-tornado',
-  'python-rq',
   'python-pymongo',
+  'python-pyramid',
+  'python-quart',
+  'python-rq',
+  'python-sanic',
+  'python-starlette',
+  'python-tornado',
+  'python-tryton',
+  'python-wsgi',
   'ruby',
   'ruby-rails',
   'ruby-rack',
   'rust',
-  'kotlin',
 ];
 
+// Mirrors `SERVERLESS` in src/sentry/utils/platform_categories.py
+// When changing this file, make sure to keep src/sentry/utils/platform_categories.py in sync.
 export const serverless: PlatformKey[] = [
+  'dotnet-awslambda',
+  'dotnet-gcpfunctions',
+  'node-awslambda',
+  'node-azurefunctions',
+  'node-gcpfunctions',
   'python-awslambda',
   'python-azurefunctions',
   'python-gcpfunctions',
   'python-serverless',
-  'node-awslambda',
-  'node-azurefunctions',
-  'node-gcpfunctions',
-  'dotnet-awslambda',
-  'dotnet-gcpfunctions',
 ];
 
+// Mirrors `DESKTOP` in src/sentry/utils/platform_categories.py
+// When changing this file, make sure to keep src/sentry/utils/platform_categories.py in sync.
 export const desktop: PlatformKey[] = [
   'apple-macos',
-  'dotnet',
+  'dotnet-maui',
   'dotnet-winforms',
   'dotnet-wpf',
-  'dotnet-maui',
-  'java',
+  'dotnet',
   'electron',
+  'flutter',
+  'java',
   'javascript-electron',
+  'kotlin',
+  'minidump',
   'native',
-  'native-crashpad',
   'native-breakpad',
+  'native-crashpad',
   'native-minidump',
   'native-qt',
-  'minidump',
   'unity',
-  'flutter',
-  'kotlin',
   'unreal',
 ];
 


### PR DESCRIPTION
* Sort alphabetically to easy syncing
* Add a "sync-comment" above each constant that needs syncing

Relates to https://github.com/getsentry/sentry/issues/57047