### PR TITLE
chore(codeowners): Add rules for platform definitions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -456,6 +456,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /static/app/actionCreators/metrics.spec.tsx                                      @getsentry/telemetry-experience
 /static/app/types/metrics.tsx                                                    @getsentry/telemetry-experience
 
+/static/app/types/project.tsx                                                    @getsentry/telemetry-experience
 /static/app/gettingStartedDocs/                                                  @getsentry/telemetry-experience
 /static/app/data/platforms.tsx                                                   @getsentry/telemetry-experience
 /static/app/data/platformPickerCategories.tsx                                    @getsentry/telemetry-experience

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -368,7 +368,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/models/organization.py            @getsentry/data
 /src/sentry/models/organizationmember.py      @getsentry/data
 /src/sentry/models/organizationoption.py      @getsentry/data
-/src/sentry/models/project.py                 @getsentry/data
+/src/sentry/models/project.py                 @getsentry/data @getsentry/telemetry-experience
 /src/sentry/models/projectoption.py           @getsentry/data
 /src/sentry/models/release.py                 @getsentry/data
 /src/sentry/models/sentryapp.py               @getsentry/data @getsentry/issues
@@ -457,6 +457,10 @@ yarn.lock                                                @getsentry/owners-js-de
 /static/app/types/metrics.tsx                                                    @getsentry/telemetry-experience
 
 /static/app/gettingStartedDocs/                                                  @getsentry/telemetry-experience
+/static/app/data/platforms.tsx                                                   @getsentry/telemetry-experience
+/static/app/data/platformPickerCategories.tsx                                    @getsentry/telemetry-experience
+/static/app/data/platformCategories.tsx                                          @getsentry/telemetry-experience
+/src/sentry/utils/platform_categories.py                                         @getsentry/telemetry-experience
 ## End of Telemetry Experience
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -438,6 +438,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/api/endpoints/project_dynamic_sampling.py                            @getsentry/telemetry-experience
 /src/sentry/dynamic_sampling/                                                    @getsentry/telemetry-experience
 /src/sentry/release_health/metrics_sessions_v2.py                                @getsentry/telemetry-experience
+/src/sentry/utils/platform_categories.py                                         @getsentry/telemetry-experience
 /tests/sentry/api/endpoints/test_organization_metric_data.py                     @getsentry/telemetry-experience
 /tests/sentry/api/endpoints/test_organization_metric_details.py                  @getsentry/telemetry-experience
 /tests/sentry/api/endpoints/test_organization_metric_tag_details.py              @getsentry/telemetry-experience
@@ -448,20 +449,18 @@ yarn.lock                                                @getsentry/owners-js-de
 /tests/sentry/snuba/metrics/                                                     @getsentry/telemetry-experience
 /tests/snuba/api/endpoints/test_organization_sessions.py                         @getsentry/telemetry-experience
 
-/static/app/views/settings/project/dynamicSampling/                              @getsentry/telemetry-experience
-/static/app/views/performance/landing/dynamicSamplingMetricsAccuracyAlert.tsx    @getsentry/telemetry-experience
-/static/app/views/performance/landing/dynamicSamplingMetricsAccuracy.spec.tsx    @getsentry/telemetry-experience
-/static/app/utils/metrics/                                                       @getsentry/telemetry-experience
-/static/app/actionCreators/metrics.tsx                                           @getsentry/telemetry-experience
 /static/app/actionCreators/metrics.spec.tsx                                      @getsentry/telemetry-experience
-/static/app/types/metrics.tsx                                                    @getsentry/telemetry-experience
-
-/static/app/types/project.tsx                                                    @getsentry/telemetry-experience
-/static/app/gettingStartedDocs/                                                  @getsentry/telemetry-experience
-/static/app/data/platforms.tsx                                                   @getsentry/telemetry-experience
-/static/app/data/platformPickerCategories.tsx                                    @getsentry/telemetry-experience
+/static/app/actionCreators/metrics.tsx                                           @getsentry/telemetry-experience
 /static/app/data/platformCategories.tsx                                          @getsentry/telemetry-experience
-/src/sentry/utils/platform_categories.py                                         @getsentry/telemetry-experience
+/static/app/data/platformPickerCategories.tsx                                    @getsentry/telemetry-experience
+/static/app/data/platforms.tsx                                                   @getsentry/telemetry-experience
+/static/app/gettingStartedDocs/                                                  @getsentry/telemetry-experience
+/static/app/types/metrics.tsx                                                    @getsentry/telemetry-experience
+/static/app/types/project.tsx                                                    @getsentry/telemetry-experience
+/static/app/utils/metrics/                                                       @getsentry/telemetry-experience
+/static/app/views/performance/landing/dynamicSamplingMetricsAccuracy.spec.tsx    @getsentry/telemetry-experience
+/static/app/views/performance/landing/dynamicSamplingMetricsAccuracyAlert.tsx    @getsentry/telemetry-experience
+/static/app/views/settings/project/dynamicSampling/                              @getsentry/telemetry-experience
 ## End of Telemetry Experience
 
 


### PR DESCRIPTION
Add `getsentry/telemetry-experience` as codeowner for platform & platform category definitions.

Closes https://github.com/getsentry/sentry/issues/57047