### PR TITLE
fix(inbound-filters): Generalize chunk load error glob

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -151,7 +151,7 @@ def get_filter_settings(project: Project) -> Mapping[str, Any]:
     if project.get_option("filters:chunk-load-error") == "1":
         # ChunkLoadError: Loading chunk 3662 failed.\n(error:
         # https://xxx.com/_next/static/chunks/29107295-0151559bd23117ba.js)
-        error_messages += ["ChunkLoadError: Loading chunk * failed.\n(error: *)"]
+        error_messages += ["ChunkLoadError: Loading chunk *"]
 
     if error_messages:
         filter_settings["errorMessages"] = {"patterns": error_messages}

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
@@ -83,9 +83,7 @@ config:
     errorMessages:
       patterns:
       - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
-      - 'ChunkLoadError: Loading chunk * failed.
-
-        (error: *)'
+      - 'ChunkLoadError: Loading chunk *'
     ignoreTransactions:
       isEnabled: true
       patterns:

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -83,7 +83,7 @@ config:
     errorMessages:
       patterns:
       - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
-      - 'ChunkLoadError: Loading chunk'
+      - 'ChunkLoadError: Loading chunk *'
     ignoreTransactions:
       isEnabled: true
       patterns:

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -83,9 +83,7 @@ config:
     errorMessages:
       patterns:
       - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
-      - 'ChunkLoadError: Loading chunk * failed.
-
-        (error: *)'
+      - 'ChunkLoadError: Loading chunk'
     ignoreTransactions:
       isEnabled: true
       patterns:


### PR DESCRIPTION
This PR changes the `ChunkLoadError` glob pattern to be more generic in order to account for edge cases in which the length of the message truncates components that are needed by the glob, resulting in no match.