### PR TITLE
feat: Process scraping_attempts sent by Symbolicator

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -248,6 +248,9 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     processing_errors = response.get("errors", [])
     if len(processing_errors) > 0:
         data.setdefault("errors", []).extend(map_symbolicator_process_js_errors(processing_errors))
+    scraping_attempts = response.get("scraping_attempts", [])
+    if len(scraping_attempts) > 0:
+        data["scraping_attempts"] = scraping_attempts
 
     assert len(stacktraces) == len(response["stacktraces"]), (stacktraces, response)
 

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -373,6 +373,12 @@ class TestJavascriptIntegration(RelayStoreHelper):
             }
         ]
 
+        assert event.data["scraping_attempts"] == [
+            {"status": "not_attempted", "url": "http://example.com/file.min.js"},
+            {"status": "not_attempted", "url": "http://example.com/file.sourcemap.js"},
+            {"status": "not_attempted", "url": "http://example.com/file1.js"},
+        ]
+
         exception = event.interfaces["exception"]
         frame_list = exception.values[0].stacktrace.frames
 
@@ -467,6 +473,13 @@ class TestJavascriptIntegration(RelayStoreHelper):
         event = self.post_and_retrieve_event(data)
         exception = event.interfaces["exception"]
         frame_list = exception.values[0].stacktrace.frames
+
+        assert event.data["scraping_attempts"] == [
+            {"url": "http://example.com/webpack1.min.js", "status": "not_attempted"},
+            {"url": "http://example.com/webpack1.min.js.map", "status": "not_attempted"},
+            {"url": "http://example.com/webpack2.min.js", "status": "not_attempted"},
+            {"url": "http://example.com/webpack2.min.js.map", "status": "not_attempted"},
+        ]
 
         # The first frame should be in_app.
         first_frame = frame_list[0]
@@ -563,6 +576,11 @@ class TestJavascriptIntegration(RelayStoreHelper):
             }
         ]
 
+        assert event.data["scraping_attempts"] == [
+            {"status": "not_attempted", "url": "http://example.com/embedded.js"},
+            {"status": "not_attempted", "url": "http://example.com/embedded.js.map"},
+        ]
+
         exception = event.interfaces["exception"]
         frame_list = exception.values[0].stacktrace.frames
 
@@ -627,6 +645,11 @@ class TestJavascriptIntegration(RelayStoreHelper):
         event = self.post_and_retrieve_event(data)
 
         assert "errors" not in event.data
+
+        assert event.data["scraping_attempts"] == [
+            {"url": "app:///nofiles.js", "status": "not_attempted"},
+            {"url": "app:///nofiles.js.map", "status": "not_attempted"},
+        ]
 
         exception = event.interfaces["exception"]
         frame_list = exception.values[0].stacktrace.frames
@@ -698,6 +721,13 @@ class TestJavascriptIntegration(RelayStoreHelper):
         event = self.post_and_retrieve_event(data)
 
         assert "errors" not in event.data
+
+        assert event.data["scraping_attempts"] == [
+            {"status": "not_attempted", "url": "http://example.com/indexed.min.js"},
+            {"status": "not_attempted", "url": "http://example.com/indexed.sourcemap.js"},
+            {"status": "not_attempted", "url": "http://example.com/file1.js"},
+            {"status": "not_attempted", "url": "http://example.com/file2.js"},
+        ]
 
         exception = event.interfaces["exception"]
         frame_list = exception.values[0].stacktrace.frames


### PR DESCRIPTION
This appends the `scraping_attempts` sent by Symbolicator since https://github.com/getsentry/symbolicator/pull/1311 to an event's data.