### PR TITLE
fix(ui) Improve domain handling for dev-ui and vercel

### DIFF
--- a/static/app/utils/shouldUseLegacyRoute.tsx
+++ b/static/app/utils/shouldUseLegacyRoute.tsx
@@ -1,5 +1,6 @@
 import {OrganizationSummary} from 'sentry/types';
 
+// TODO rename to shouldUseSlugPathRoute ?
 function shouldUseLegacyRoute(organization: OrganizationSummary) {
   const {organizationUrl} = organization.links;
   return !organizationUrl || !organization.features.includes('customer-domains');

--- a/static/app/utils/useResolveRoute.spec.tsx
+++ b/static/app/utils/useResolveRoute.spec.tsx
@@ -4,6 +4,18 @@ import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import useResolveRoute from './useResolveRoute';
 
+const mockDeployPreviewConfig = jest.fn();
+
+jest.mock('sentry/constants', () => {
+  const sentryConstants = jest.requireActual('sentry/constants');
+  return {
+    ...sentryConstants,
+    get DEPLOY_PREVIEW_CONFIG() {
+      return mockDeployPreviewConfig();
+    },
+  };
+});
+
 describe('useResolveRoute', () => {
   let devUi, host;
 
@@ -20,6 +32,7 @@ describe('useResolveRoute', () => {
   afterEach(() => {
     window.__SENTRY_DEV_UI = devUi;
     window.location.host = host;
+    mockDeployPreviewConfig.mockReset();
   });
 
   it('should use sentryUrl when no org is provided', () => {
@@ -67,19 +80,32 @@ describe('useResolveRoute', () => {
     expect(result.current).toBe('https://other-org.dev.getsentry.net:7999/issues/');
   });
 
-  it('should replace domains with dev-ui mode on sentry.dev', () => {
+  it('should use path slugs on sentry.dev', () => {
+    // Vercel previews don't let us have additional subdomains.
     window.__SENTRY_DEV_UI = true;
-    window.location.host = 'acme.sentry-abc123.sentry.dev';
+    window.location.host = 'sentry-abc123.sentry.dev';
+
+    mockDeployPreviewConfig.mockReturnValue({
+      branch: 'test',
+      commitSha: 'abc123',
+      githubOrg: 'getsentry',
+      githubRepo: 'sentry',
+    });
 
     const wrapper = ({children}) => (
       <OrganizationContext.Provider value={organization}>
         {children}
       </OrganizationContext.Provider>
     );
-    const {result} = reactHooks.renderHook(() => useResolveRoute('/issues/', otherOrg), {
-      wrapper,
-    });
-    expect(result.current).toBe('https://other-org.sentry-abc123.sentry.dev/issues/');
+    const {result} = reactHooks.renderHook(
+      () => useResolveRoute(`/organizations/${otherOrg.slug}/issues/`, otherOrg),
+      {
+        wrapper,
+      }
+    );
+    expect(result.current).toBe(
+      'https://sentry-abc123.sentry.dev/organizations/other-org/issues/'
+    );
   });
 
   it('will not replace domains with dev-ui mode and an unsafe host', () => {

--- a/static/app/utils/useResolveRoute.tsx
+++ b/static/app/utils/useResolveRoute.tsx
@@ -1,3 +1,4 @@
+import {DEPLOY_PREVIEW_CONFIG} from 'sentry/constants';
 import ConfigStore from 'sentry/stores/configStore';
 import {OrganizationSummary} from 'sentry/types';
 import {extractSlug} from 'sentry/utils/extractSlug';
@@ -16,6 +17,11 @@ function localizeDomain(domain?: string) {
   if (!window.__SENTRY_DEV_UI || !domain) {
     return domain;
   }
+  // Vercel doesn't support subdomains, so stay on the current host.
+  if (DEPLOY_PREVIEW_CONFIG) {
+    return `https://${window.location.host}`;
+  }
+
   const slugDomain = extractSlug(window.location.host);
   if (!slugDomain) {
     return domain;
@@ -26,6 +32,7 @@ function localizeDomain(domain?: string) {
 /**
  * If organization is passed, then a URL with the route will be returned with the customer domain prefix attached if the
  * organization has customer domain feature enabled.
+ *
  * Otherwise, if the organization is not given, then if the current organization has customer domain enabled, then we
  * use the sentry URL as the prefix.
  */

--- a/static/app/utils/withDomainRedirect.spec.tsx
+++ b/static/app/utils/withDomainRedirect.spec.tsx
@@ -28,15 +28,10 @@ describe('withDomainRedirect', function () {
   }
 
   beforeEach(function () {
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: {
-        replace: jest.fn(),
-        pathname: '/organizations/albertos-apples/issues/',
-        search: '?q=123',
-        hash: '#hash',
-      },
-    });
+    window.location.pathname = '/organizations/albertos-apples/issues/';
+    window.location.search = '?q=123';
+    window.location.hash = '#hash';
+
     window.__initialData = {
       customerDomain: {
         subdomain: 'albertos-apples',
@@ -242,5 +237,47 @@ describe('withDomainRedirect', function () {
 
     expect(screen.getByText('Org slug: no org slug')).toBeInTheDocument();
     expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('updates path when :orgId is present in the routes and there is no subdomain', function () {
+    const organization = TestStubs.Organization({
+      slug: 'albertos-apples',
+      features: ['customer-domains'],
+    });
+    window.__initialData.customerDomain = {
+      organizationUrl: 'https://sentry.io',
+      sentryUrl: 'https://sentry.io',
+      subdomain: '',
+    };
+
+    const params = {
+      orgId: organization.slug,
+      projectId: 'react',
+    };
+    const {router, route, routerContext} = initializeOrg({
+      organization,
+      router: {
+        params,
+        routes: projectRoutes,
+      },
+    });
+
+    const WrappedComponent = withDomainRedirect(MyComponent);
+    render(
+      <OrganizationContext.Provider value={organization}>
+        <WrappedComponent
+          router={router}
+          location={router.location}
+          params={params}
+          routes={router.routes}
+          routeParams={router.params}
+          route={route}
+        />
+      </OrganizationContext.Provider>,
+      {context: routerContext}
+    );
+
+    expect(router.replace).toHaveBeenCalledTimes(1);
+    expect(router.replace).toHaveBeenCalledWith('/settings/react/alerts/?q=123#hash');
   });
 });

--- a/static/app/utils/withDomainRedirect.tsx
+++ b/static/app/utils/withDomainRedirect.tsx
@@ -1,10 +1,7 @@
 import {formatPattern, RouteComponent, RouteComponentProps} from 'react-router';
-import * as Sentry from '@sentry/react';
 import trimEnd from 'lodash/trimEnd';
 import trimStart from 'lodash/trimStart';
-import * as qs from 'query-string';
 
-import {decodeScalar} from 'sentry/utils/queryString';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import Redirect from 'sentry/utils/redirect';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
@@ -15,6 +12,7 @@ import useOrganization from './useOrganization';
  * withDomainRedirect is a higher-order component (HOC) meant to be used with <Route /> components within
  * static/app/routes.tsx whose route paths contains the :orgId parameter at least once.
  * For example:
+ *
  *  <Route
  *    path="/organizations/:orgId/issues/(searches/:searchId/)"
  *    component={withDomainRedirect(errorHandler(IssueListContainer))}
@@ -42,14 +40,16 @@ function withDomainRedirect<P extends RouteComponentProps<{}, {}>>(
       const redirectPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
       const redirectURL = `${trimEnd(sentryUrl, '/')}/${trimStart(redirectPath, '/')}`;
 
-      if (currentOrganization) {
-        if (
-          currentOrganization.slug !== customerDomain.subdomain ||
-          !currentOrganization.features.includes('customer-domains')
-        ) {
-          window.location.replace(redirectURL);
-          return null;
-        }
+      // If we have domain information, but the subdomain and slug are different
+      // redirect to the slug path and let django decide what happens next.
+      if (
+        currentOrganization &&
+        customerDomain.subdomain &&
+        (currentOrganization.slug !== customerDomain.subdomain ||
+          !currentOrganization.features.includes('customer-domains'))
+      ) {
+        window.location.replace(redirectURL);
+        return null;
       }
 
       const {params, routes} = props;
@@ -71,32 +71,6 @@ function withDomainRedirect<P extends RouteComponentProps<{}, {}>>(
       const redirectOrgURL = `/${trimStart(orglessRedirectPath, '/')}${
         window.location.search
       }${window.location.hash}`;
-
-      // This is really noisy, so collect a subset.
-      const referrer = decodeScalar(qs.parse(window.location.search).referrer, '');
-      if (Math.random() < 0.2 || referrer !== '') {
-        const paramOrgId = (params as any).orgId ?? '';
-
-        Sentry.withScope(function (scope) {
-          const wrongOrgId = paramOrgId !== customerDomain.subdomain ? 'yes' : 'no';
-          scope.setTag('isCustomerDomain', 'yes');
-          scope.setTag('customerDomain.organizationUrl', customerDomain.organizationUrl);
-          scope.setTag('customerDomain.referrer', referrer);
-          scope.setTag('customerDomain.subdomain', customerDomain.subdomain);
-          scope.setTag('customerDomain.fromRoute', fullRoute);
-          scope.setTag('customerDomain.redirectRoute', orglessSlugRoute);
-          scope.setTag('customerDomain.wrongOrgId', wrongOrgId);
-          scope.setTag('customerDomain.paramOrgId', paramOrgId);
-          scope.setContext('customerDomain', {
-            customerDomain,
-            fullRoute,
-            orglessSlugRoute,
-            redirectOrgURL,
-            routeParams: params,
-          });
-          Sentry.captureMessage('Redirect with :orgId param on customer domain');
-        });
-      }
 
       // Redirect to a route path with :orgId omitted.
       return <Redirect to={redirectOrgURL} router={props.router} />;


### PR DESCRIPTION
- Don't redirect to sentry.io when the initialData is lacking a sudomain.
- Don't use customer domains with vercel previews as domains + vercel are incompatible.
- Remove sentry event for domain/slug matches as the remaining traffic is unactionable.
