### PR TITLE
chore(org): Add syntax/syntaxfm to reserved slugs

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -178,6 +178,8 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         "staff",
         "subscribe",
         "support",
+        "syntax",
+        "syntaxfm",
         "team-avatar",
         "teams",
         "terms",


### PR DESCRIPTION
Add syntax/syntaxfm to reserved org slugs for internal Sentry use.