### PR TITLE
fix(metrics): Remove `org_id` being emitted in metrics

### DIFF
--- a/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
+++ b/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
@@ -156,7 +156,6 @@ class TimeseriesCardinalityLimiter:
 
             substrings = grant.request.prefix.split("-")
             grant_use_case_id = substrings[3]
-            grant_org_id = substrings[-1]
 
             metrics.incr(
                 "sentry_metrics.indexer.process_messages.dropped_message",
@@ -164,7 +163,6 @@ class TimeseriesCardinalityLimiter:
                 tags={
                     "reason": "cardinality_limit",
                     "use_case_id": grant_use_case_id,
-                    "org_id": grant_org_id,
                 },
             )
 


### PR DESCRIPTION
### Overview

There is an `org_id` in the metrics that gets emitted when metrics are being cardinality filtered. Removing this because this could potentially create high cardinality.