### PR TITLE
feat(statistical-detectors): call breakpoint microservice for txns

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -322,6 +322,9 @@ class Referrer(Enum):
         "api.performance.transaction-summary.vitals-chart"
     )
     API_PERFORMANCE_TRANSACTION_SUMMARY = "api.performance.transaction-summary"
+    API_PERFORMANCE_TRANSACTIONS_STATISTICAL_DETECTOR_STATS = (
+        "api.performance.transactions.statistical-detector-stats"
+    )
     API_PERFORMANCE_VITAL_DETAIL = "api.performance.vital-detail"
     API_PERFORMANCE_VITALS_CARDS = "api.performance.vitals-cards"
     API_PROFILING_LANDING_CHART = "api.profiling.landing-chart"

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -320,7 +320,7 @@ def query_transactions_timeseries(
         }
         results = metrics_performance.timeseries_query(
             selected_columns=[agg_function],
-            query=f"transaction:#{transaction_name}",
+            query=f"transaction:{transaction_name}",
             params=params,
             rollup=interval,
             referrer=Referrer.API_PERFORMANCE_TRANSACTIONS_STATISTICAL_DETECTOR_STATS.value,

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -318,9 +318,13 @@ def query_transactions_timeseries(
             "project_id": [project_id],
             "project_objects": [Project.objects.get(id=project_id)],
         }
+
+        escaped_transaction_name = transaction_name.replace('"', '\\"')
+        query = f'transaction:"{escaped_transaction_name}"'
+
         results = metrics_performance.timeseries_query(
             selected_columns=[agg_function],
-            query=f"transaction:{transaction_name}",
+            query=query,
             params=params,
             rollup=interval,
             referrer=Referrer.API_PERFORMANCE_TRANSACTIONS_STATISTICAL_DETECTOR_STATS.value,

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Generator, List, Optional, Set, Tuple
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union
 
 import sentry_sdk
 from django.utils import timezone as django_timezone
@@ -190,7 +190,7 @@ def detect_transaction_change_points(
 
 
 def _detect_transaction_change_points(
-    transactions: List[Tuple[int, str]],
+    transactions: List[Tuple[int, Union[int, str]]],
     start: datetime,
 ) -> Generator[BreakpointData, None, None]:
     serializer = SnubaTSResultSerializer(None, None, None)
@@ -307,7 +307,7 @@ def query_transactions_timeseries(
     transactions: List[Tuple[int, int | str]],
     start: datetime,
     agg_function: str,
-) -> Generator[Tuple[int, int, Any], None, None]:
+) -> Generator[Tuple[int, Union[int, str], Any], None, None]:
     end = start.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
     interval = 3600  # 1 hour
 
@@ -320,7 +320,7 @@ def query_transactions_timeseries(
         }
         results = metrics_performance.timeseries_query(
             selected_columns=[agg_function],
-            query=f"transaction:{transaction_name}",
+            query=f"transaction:#{transaction_name}",
             params=params,
             rollup=interval,
             referrer=Referrer.API_PERFORMANCE_TRANSACTIONS_STATISTICAL_DETECTOR_STATS.value,

--- a/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
+++ b/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
@@ -7,7 +7,7 @@ from sentry.statistical_detectors.issue_platform_adapter import send_regressions
 
 
 @mock.patch("sentry.statistical_detectors.issue_platform_adapter.produce_occurrence_to_kafka")
-def test_send_regressions_to_platform(mock_produce_occurrence_to_kafka):
+def test_send_regressions_to_plaform(mock_produce_occurrence_to_kafka):
     project_id = "123"
 
     mock_regressions: List[BreakpointData] = [

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -347,51 +347,6 @@ def test_detect_function_change_points(
     assert mock_emit_function_regression_issue.called
 
 
-@mock.patch("sentry.tasks.statistical_detectors.detect_breakpoints")
-@mock.patch("sentry.tasks.statistical_detectors.raw_snql_query")
-@django_db_all
-@pytest.mark.sentry_metrics
-def test_detect_transaction_change_points(
-    mock_raw_snql_query, mock_detect_breakpoints, timestamp, project
-):
-    start_of_hour = timestamp.replace(minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-
-    transaction_name = "/12345"
-
-    mock_raw_snql_query.return_value = {
-        "data": [
-            {
-                "time": (start_of_hour - timedelta(days=day, hours=hour)).isoformat(),
-                "project.id": project.id,
-                "transaction_name": transaction_name,
-                "p95": 2 if day < 1 and hour < 8 else 1,
-            }
-            for day in reversed(range(14))
-            for hour in reversed(range(24))
-        ]
-    }
-
-    mock_detect_breakpoints.return_value = {
-        "data": [
-            {
-                "absolute_percentage_change": 5.0,
-                "aggregate_range_1": 100000000.0,
-                "aggregate_range_2": 500000000.0,
-                "breakpoint": 1687323600,
-                "change": "regression",
-                "project": str(project.id),
-                "transaction": transaction_name,
-                "trend_difference": 400000000.0,
-                "trend_percentage": 5.0,
-                "unweighted_p_value": 0.0,
-                "unweighted_t_value": -float("inf"),
-            },
-        ]
-    }
-
-    detect_transaction_change_points([(project.id, transaction_name)], timestamp)
-
-
 @region_silo_test(stable=True)
 class FunctionsTasksTest(ProfilesSnubaTestCase):
     def setUp(self):
@@ -540,3 +495,79 @@ class TestTransactionsQuery(MetricsAPIBaseTestCase):
             # one sample at 9.5, but it should be close
             assert trend_payload.value > 9
             assert trend_payload.timestamp == self.hour_ago
+
+
+@region_silo_test(stable=True)
+@pytest.mark.sentry_metrics
+class TestTransactionChangePointDetection(MetricsAPIBaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.num_projects = 2
+        self.num_transactions = 4
+
+        self.hour_ago = (self.now - timedelta(hours=1)).replace(
+            minute=0, second=0, microsecond=0, tzinfo=timezone.utc
+        )
+        self.hour_ago_seconds = int(self.hour_ago.timestamp())
+        self.org = self.create_organization(owner=self.user)
+        self.projects = [
+            self.create_project(organization=self.org) for _ in range(self.num_projects)
+        ]
+
+        def store_metric(project_id, transaction, minutes_ago, value):
+            self.store_metric(
+                self.org.id,
+                project_id,
+                "distribution",
+                TransactionMRI.DURATION.value,
+                {"transaction": transaction},
+                int((self.now - timedelta(minutes=minutes_ago)).timestamp()),
+                value,
+                UseCaseID.TRANSACTIONS,
+            )
+
+        for project in self.projects:
+            for i in range(self.num_transactions):
+                store_metric(project.id, f"transaction_{i}", 20, 9.5)
+                store_metric(project.id, f"transaction_{i}", 40, 9.5)
+                store_metric(project.id, f"transaction_{i}", 60, 9.5)
+                store_metric(project.id, f"transaction_{i}", 80, 1.0)
+                store_metric(project.id, f"transaction_{i}", 100, 1.0)
+                store_metric(project.id, f"transaction_{i}", 120, 1.0)
+
+    @property
+    def now(self):
+        return MetricsAPIBaseTestCase.MOCK_DATETIME
+
+    @mock.patch("sentry.tasks.statistical_detectors.send_regressions_to_plaform")
+    @mock.patch("sentry.tasks.statistical_detectors.detect_breakpoints")
+    def test_transaction_change_point_detection(
+        self, mock_detect_breakpoints, mock_send_regressions_to_platform
+    ) -> None:
+        mock_detect_breakpoints.return_value = {
+            "data": [
+                {
+                    "absolute_percentage_change": 5.0,
+                    "aggregate_range_1": 100000000.0,
+                    "aggregate_range_2": 500000000.0,
+                    "breakpoint": 1687323600,
+                    "change": "regression",
+                    "project": str(self.projects[0].id),
+                    "transaction": "transaction_1",
+                    "trend_difference": 400000000.0,
+                    "trend_percentage": 5.0,
+                    "unweighted_p_value": 0.0,
+                    "unweighted_t_value": -float("inf"),
+                },
+            ]
+        }
+        with override_options({"statistical_detectors.enable": True}):
+            detect_transaction_change_points(
+                [
+                    (self.projects[0].id, "transaction_1"),
+                    (self.projects[0].id, "transaction_2"),
+                    (self.projects[1].id, "transaction_1"),
+                ],
+                self.now,
+            )
+        assert mock_send_regressions_to_platform.called

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -262,7 +262,7 @@ def test_detect_transaction_trends(
     with override_options({"statistical_detectors.enable": True}), TaskRunner():
         for ts in timestamps:
             detect_transaction_trends([organization.id], [project.id], ts)
-    assert detect_transaction_change_points.delay.called
+    assert detect_transaction_change_points.apply_async.called
 
 
 @mock.patch("sentry.tasks.statistical_detectors.query_functions")
@@ -389,7 +389,7 @@ def test_detect_transaction_change_points(
         ]
     }
 
-    all(detect_transaction_change_points([(project.id, transaction_name)], timestamp))
+    detect_transaction_change_points([(project.id, transaction_name)], timestamp)
 
 
 @region_silo_test(stable=True)


### PR DESCRIPTION
When a potential transaction regression is found via moving average, query its timeseries and use the breakpoint microservice to check if an actual regression is present.