### PR TITLE
fix(team-roles): Allow superusers to edit team roles

### DIFF
--- a/src/sentry/api/endpoints/organization_member/__init__.py
+++ b/src/sentry/api/endpoints/organization_member/__init__.py
@@ -58,7 +58,18 @@ def save_team_assignments(
             )
 
 
-def can_set_team_role(access: Access, team: Team, new_role: TeamRole) -> bool:
+def can_set_team_role(request: Request, team: Team, new_role: TeamRole) -> bool:
+    """
+    User can set a team role:
+
+    * If they are an active superuser
+    * If they are an org owner/manager/admin
+    * If they are a team admin on the team
+    """
+    if is_active_superuser(request):
+        return True
+
+    access: Access = request.access
     if not can_admin_team(access, team):
         return False
 

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -344,7 +344,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
             except KeyError:
                 return Response(status=400)
 
-            if not can_set_team_role(request.access, team, new_role):
+            if not can_set_team_role(request, team, new_role):
                 return Response({"detail": ERR_INSUFFICIENT_ROLE}, status=400)
 
             self._change_team_member_role(omt, new_role)

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -774,6 +774,35 @@ class UpdateOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
         assert updated_omt.role == "admin"
 
     @with_feature("organizations:team-roles")
+    def test_superuser_can_promote_member(self):
+        superuser = self.create_user(is_superuser=True)
+        self.login_as(superuser, superuser=True)
+
+        resp = self.get_response(
+            self.org.slug, self.member_on_team.id, self.team.slug, teamRole="admin"
+        )
+        assert resp.status_code == 200
+
+        updated_omt = OrganizationMemberTeam.objects.get(
+            team=self.team, organizationmember=self.member_on_team
+        )
+        assert updated_omt.role == "admin"
+
+    @with_feature("organizations:team-roles")
+    def test_admin_can_promote_member(self):
+        self.login_as(self.admin_on_team)
+
+        resp = self.get_response(
+            self.org.slug, self.member_on_team.id, self.team.slug, teamRole="admin"
+        )
+        assert resp.status_code == 200
+
+        updated_omt = OrganizationMemberTeam.objects.get(
+            team=self.team, organizationmember=self.member_on_team
+        )
+        assert updated_omt.role == "admin"
+
+    @with_feature("organizations:team-roles")
     def test_member_cannot_promote_member(self):
         self.login_as(self.member_on_team)
         other_member = self.create_member(


### PR DESCRIPTION
Fixes a bug where superusers couldn't change team roles