### PR TITLE
fix(alerts): Undo CombinedRuleSerializer change

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -233,7 +233,7 @@ class CombinedRuleSerializer(Serializer):
         alert_rules = [x for x in item_list if isinstance(x, AlertRule)]
         incident_map = {}
         if "latestIncident" in self.expand:
-            for incident in Incident.objects.filter(alert_rule_id__in=[x.id for x in alert_rules]):
+            for incident in Incident.objects.filter(id__in=[x.incident_id for x in alert_rules]):
                 incident_map[incident.id] = serialize(incident, user=user)
 
         serialized_alert_rules = serialize(alert_rules, user=user)
@@ -247,13 +247,7 @@ class CombinedRuleSerializer(Serializer):
             if isinstance(item, AlertRule):
                 alert_rule = serialized_alert_rules.pop(0)
                 if "latestIncident" in self.expand:
-                    incident = (
-                        Incident.objects.filter(alert_rule_id=item.id)
-                        .order_by("-date_detected")
-                        .first()
-                    )
-                    if incident:
-                        alert_rule["latestIncident"] = incident_map.get(incident.id)
+                    alert_rule["latestIncident"] = incident_map.get(item.incident_id)
                 results[item] = alert_rule
             elif isinstance(item, Rule):
                 results[item] = rules.pop(0)

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -233,7 +233,7 @@ class CombinedRuleSerializer(Serializer):
         alert_rules = [x for x in item_list if isinstance(x, AlertRule)]
         incident_map = {}
         if "latestIncident" in self.expand:
-            for incident in Incident.objects.filter(id__in=[x.incident_id for x in alert_rules]):
+            for incident in Incident.objects.filter(id__in=[x.incident_id for x in alert_rules]):  # type: ignore
                 incident_map[incident.id] = serialize(incident, user=user)
 
         serialized_alert_rules = serialize(alert_rules, user=user)
@@ -247,7 +247,7 @@ class CombinedRuleSerializer(Serializer):
             if isinstance(item, AlertRule):
                 alert_rule = serialized_alert_rules.pop(0)
                 if "latestIncident" in self.expand:
-                    alert_rule["latestIncident"] = incident_map.get(item.incident_id)
+                    alert_rule["latestIncident"] = incident_map.get(item.incident_id)  # type: ignore
                 results[item] = alert_rule
             elif isinstance(item, Rule):
                 results[item] = rules.pop(0)

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -26,7 +26,6 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
         """
         Fetches alert rules and legacy rules for a project
         """
-        expand: list[str] = request.GET.getlist("expand", [])
         alert_rules = AlertRule.objects.fetch_for_project(project)
         if not features.has("organizations:performance-view", project.organization):
             # Filter to only error alert rules
@@ -44,7 +43,7 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
         return self.paginate(
             request,
             paginator_cls=CombinedQuerysetPaginator,
-            on_results=lambda x: serialize(x, request.user, CombinedRuleSerializer(expand=expand)),
+            on_results=lambda x: serialize(x, request.user, CombinedRuleSerializer()),
             default_per_page=25,
             intermediaries=[alert_rule_intermediary, rule_intermediary],
             desc=True,

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -5,7 +5,7 @@ import requests
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
-from sentry.incidents.models import AlertRule, IncidentStatus
+from sentry.incidents.models import AlertRule
 from sentry.models import AuditLogEntry
 from sentry.silo import SiloMode
 from sentry.snuba.dataset import Dataset
@@ -155,25 +155,6 @@ class AlertRuleCreateEndpointTest(APITestCase):
 @region_silo_test(stable=True)
 class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestCase):
     endpoint = "sentry-api-0-project-combined-rules"
-
-    def test_expand_latest_incident(self):
-        self.create_team(organization=self.organization, members=[self.user])
-        alert_rule = self.create_alert_rule()
-        incident = self.create_incident(
-            organization=self.organization,
-            title="Incident #1",
-            projects=[self.project],
-            alert_rule=alert_rule,
-            status=IncidentStatus.CRITICAL.value,
-        )
-
-        self.login_as(self.user)
-        with self.feature("organizations:incidents"):
-            expand_resp = self.get_success_response(
-                self.organization.slug, self.project.slug, expand=["latestIncident"]
-            )
-        assert expand_resp.data[0]["latestIncident"] is not None
-        assert expand_resp.data[0]["latestIncident"]["id"] == str(incident.id)
 
     def test_no_perf_alerts(self):
         self.create_team(organization=self.organization, members=[self.user])


### PR DESCRIPTION
Undo a piece of https://github.com/getsentry/sentry/pull/57310/files that caused the alert rule page to [load really slowly](https://sentry.sentry.io/performance/summary/?project=1&query=http.method%3AGET&referrer=performance-transaction-summary&statsPeriod=24h&transaction=%2Fapi%2F0%2Forganizations%2F%7Borganization_slug%7D%2Fcombined-rules%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29). I had missed [this annotation](https://github.com/getsentry/sentry/blob/master/src/sentry/incidents/endpoints/organization_alert_rule_index.py#L183-L194) leading me to believe this was incorrect.