### PR TITLE
fix(perf): Use average to compute bounds for query sample list

### DIFF
--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -49,11 +49,11 @@ export const useSpanSamples = (options: Options) => {
   const {isLoading: isLoadingSeries, data: spanMetricsSeriesData} = useSpanMetricsSeries(
     groupId,
     {transactionName, 'transaction.method': transactionMethod},
-    [`p95(${SPAN_SELF_TIME})`],
+    [`avg(${SPAN_SELF_TIME})`],
     'api.starfish.sidebar-span-metrics'
   );
 
-  const maxYValue = computeAxisMax([spanMetricsSeriesData?.[`p95(${SPAN_SELF_TIME})`]]);
+  const maxYValue = computeAxisMax([spanMetricsSeriesData?.[`avg(${SPAN_SELF_TIME})`]]);
 
   const enabled = Boolean(
     groupId && transactionName && !isLoadingSeries && pageFilter.isReady

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.spec.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.spec.tsx
@@ -143,7 +143,7 @@ const initializeMockRequests = () => {
         const {query} = options;
         return (
           query?.referrer === 'api.starfish.sidebar-span-metrics' &&
-          query?.yAxis === 'p95(span.self_time)'
+          query?.yAxis === 'avg(span.self_time)'
         );
       },
     ],


### PR DESCRIPTION
We're not measuring the p95, so it doesn't make sense to compute bounds using the p95. This was probably lost in the p95 --> avg shuffle! Not only is this _incorrect_, it's also much slower, and accounts for some of the slowness that people have been reporting when using this panel.

We might be able to remove this logic from the frontend altogether at some point, too.

**e.g.,**
![Screenshot 2023-10-04 at 2 11 22 PM](https://github.com/getsentry/sentry/assets/989898/6961350c-3d85-496b-b01b-2d52eaafa388)
