### PR TITLE
fix(perf): Improve `useSpanTransactionMetrics`

### DIFF
--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -1,5 +1,6 @@
 import {Location} from 'history';
 
+import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -46,6 +47,10 @@ function getEventView(location: Location, filters: MetricsFilters = {}, sorts?: 
   const search = new MutableSearch('');
 
   Object.entries(filters).forEach(([key, value]) => {
+    if (!defined(value)) {
+      return;
+    }
+
     if (Array.isArray(value)) {
       search.addFilterValues(key, value);
     } else {

--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -5,7 +5,7 @@ import {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {MetricsFilters, SpanMetricsField} from 'sentry/views/starfish/types';
 import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
 const {SPAN_SELF_TIME} = SpanMetricsField;
@@ -22,7 +22,7 @@ export type SpanTransactionMetrics = {
 };
 
 export const useSpanTransactionMetrics = (
-  filters: {'span.group'?: string; transaction?: string[] | string},
+  filters: MetricsFilters,
   sorts?: Sort[],
   cursor?: string,
   referrer = 'api.starfish.span-transaction-metrics'
@@ -41,11 +41,7 @@ export const useSpanTransactionMetrics = (
   });
 };
 
-function getEventView(
-  location: Location,
-  filters: {[key: string]: string[] | string} = {},
-  sorts?: Sort[]
-) {
+function getEventView(location: Location, filters: MetricsFilters = {}, sorts?: Sort[]) {
   const search = new MutableSearch('');
 
   Object.entries(filters).forEach(([key, value]) => {

--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -25,6 +25,7 @@ export const useSpanTransactionMetrics = (
   filters: MetricsFilters,
   sorts?: Sort[],
   cursor?: string,
+  enabled: boolean = true,
   referrer = 'api.starfish.span-transaction-metrics'
 ) => {
   const location = useLocation();
@@ -34,7 +35,7 @@ export const useSpanTransactionMetrics = (
   return useWrappedDiscoverQuery<SpanTransactionMetrics[]>({
     eventView,
     initialData: [],
-    enabled: Boolean(filters['span.group']),
+    enabled,
     limit: 25,
     referrer,
     cursor,

--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -25,8 +25,8 @@ export const useSpanTransactionMetrics = (
   group: string,
   options: {transactions?: string[]},
   sorts?: Sort[],
-  referrer = 'api.starfish.span-transaction-metrics',
-  cursor?: string
+  cursor?: string,
+  referrer = 'api.starfish.span-transaction-metrics'
 ) => {
   const location = useLocation();
 

--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -23,13 +23,14 @@ export type SpanTransactionMetrics = {
 
 export const useSpanTransactionMetrics = (
   group: string,
-  options: {sorts?: Sort[]; transactions?: string[]},
+  options: {transactions?: string[]},
+  sorts?: Sort[],
   referrer = 'api.starfish.span-transaction-metrics',
   cursor?: string
 ) => {
   const location = useLocation();
 
-  const {transactions, sorts} = options;
+  const {transactions} = options;
 
   const eventView = getEventView(group, location, transactions ?? [], sorts);
 

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -61,6 +61,10 @@ export type MetricsResponse = {
   'time_spent_percentage(local)': number;
 };
 
+export type MetricsFilters = {
+  [Property in SpanStringFields as `${Property}`]?: string | string[];
+};
+
 export type MetricsProperty = keyof MetricsResponse;
 
 export enum SpanIndexedField {

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -37,7 +37,8 @@ export type SpanStringFields =
   | 'span.action'
   | 'span.group'
   | 'project.id'
-  | 'transaction';
+  | 'transaction'
+  | 'transaction.method';
 
 export type SpanStringArrayFields = 'span.domain';
 

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -36,7 +36,8 @@ export type SpanStringFields =
   | 'span.module'
   | 'span.action'
   | 'span.group'
-  | 'project.id';
+  | 'project.id'
+  | 'transaction';
 
 export type SpanStringArrayFields = 'span.domain';
 

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -76,7 +76,6 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
       transactions: endpoint ? [endpoint] : undefined,
     },
     [sort],
-    undefined,
     cursor
   );
 

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -74,8 +74,8 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
     span[SpanMetricsField.SPAN_GROUP],
     {
       transactions: endpoint ? [endpoint] : undefined,
-      sorts: [sort],
     },
+    [sort],
     undefined,
     cursor
   );

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -74,6 +74,7 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
     {
       'span.group': span[SpanMetricsField.SPAN_GROUP],
       transaction: endpoint,
+      'transaction.method': endpointMethod,
     },
     [sort],
     cursor,

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -76,7 +76,8 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
       transaction: endpoint,
     },
     [sort],
-    cursor
+    cursor,
+    Boolean(span[SpanMetricsField.SPAN_GROUP])
   );
 
   const spanTransactionsWithMetrics = spanTransactionMetrics.map(row => {

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -71,9 +71,9 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
     isLoading,
     pageLinks,
   } = useSpanTransactionMetrics(
-    span[SpanMetricsField.SPAN_GROUP],
     {
-      transactions: endpoint ? [endpoint] : undefined,
+      'span.group': span[SpanMetricsField.SPAN_GROUP],
+      transaction: endpoint,
     },
     [sort],
     cursor


### PR DESCRIPTION
Fixes a few issues with the API, and the logic.

- Better API
    - `sort` is its own parameter
    - `group` is no longer its own parameter, now part of `filters`
    - `filters` can be any valid filterable span string property
    - better parameter order
    - `enabled` is an explicit parameter
- Add transaction as a valid string field

Also, more importantly, makes sure that the endpoint method is part of the filtering, which was not the case before!
