### PR TITLE
fix(issue-details): Add organization to issue preview to fix prefetching

### DIFF
--- a/static/app/components/groupPreviewTooltip/evidencePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/evidencePreview.spec.tsx
@@ -10,7 +10,7 @@ describe('EvidencePreview', () => {
     jest.restoreAllMocks();
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: '/issues/group-id/',
+      url: '/organizations/org-slug/issues/group-id/',
     });
   });
 
@@ -50,7 +50,7 @@ describe('EvidencePreview', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/issues/group-id/events/recommended/`,
+      url: `/organizations/org-slug/issues/group-id/events/recommended/`,
       body: event,
     });
 

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
@@ -16,7 +16,7 @@ describe('SpanEvidencePreview', () => {
 
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: '/issues/group-id/',
+      url: '/organizations/org-slug/issues/group-id/',
     });
   });
 
@@ -99,7 +99,7 @@ describe('SpanEvidencePreview', () => {
       .getEvent();
 
     MockApiClient.addMockResponse({
-      url: `/issues/group-id/events/recommended/`,
+      url: `/organizations/org-slug/issues/group-id/events/recommended/`,
       body: event,
     });
 

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
@@ -17,14 +17,14 @@ const makeEvent = (event: Partial<Event> = {}): Event => {
 beforeEach(() => {
   MockApiClient.clearMockResponses();
   MockApiClient.addMockResponse({
-    url: '/issues/123/',
+    url: '/organizations/org-slug/issues/123/',
   });
 });
 
 describe('StackTracePreview', () => {
   it('renders error message', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/123/events/recommended/`,
+      url: `/organizations/org-slug/issues/123/events/recommended/`,
       statusCode: 400,
     });
 
@@ -37,7 +37,7 @@ describe('StackTracePreview', () => {
 
   it('warns about no stacktrace', async () => {
     MockApiClient.addMockResponse({
-      url: `/issues/123/events/recommended/`,
+      url: `/organizations/org-slug/issues/123/events/recommended/`,
       body: makeEvent({id: '456', entries: []}),
     });
 
@@ -105,7 +105,7 @@ describe('StackTracePreview', () => {
     } as EventError;
 
     MockApiClient.addMockResponse({
-      url: `/issues/123/events/recommended/`,
+      url: `/organizations/org-slug/issues/123/events/recommended/`,
       body: makeEvent(errorEvent),
     });
 

--- a/static/app/components/groupPreviewTooltip/utils.tsx
+++ b/static/app/components/groupPreviewTooltip/utils.tsx
@@ -3,6 +3,7 @@ import {useCallback, useState} from 'react';
 import {Event} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
 import useTimeout from 'sentry/utils/useTimeout';
 import {
   getGroupDetailsQueryData,
@@ -44,13 +45,14 @@ export function usePreviewEvent<T = Event>({
   groupId: string;
   query?: string;
 }) {
+  const organization = useOrganization();
   const defaultIssueEvent = useDefaultIssueEvent();
 
   // This query should match the one on group details so that the event will
   // be fully loaded already if you preview then click.
   const eventQuery = useApiQuery<T>(
     [
-      `/issues/${groupId}/events/${defaultIssueEvent}/`,
+      `/organizations/${organization.slug}/issues/${groupId}/events/${defaultIssueEvent}/`,
       {
         query: getGroupEventDetailsQueryData({
           query,
@@ -61,11 +63,17 @@ export function usePreviewEvent<T = Event>({
   );
 
   // Prefetch the group as well, but don't use the result
-  useApiQuery([`/issues/${groupId}/`, {query: getGroupDetailsQueryData()}], {
-    staleTime: 30000,
-    cacheTime: 30000,
-    enabled: defined(groupId),
-  });
+  useApiQuery(
+    [
+      `/organizations/${organization.slug}/issues/${groupId}/`,
+      {query: getGroupDetailsQueryData()},
+    ],
+    {
+      staleTime: 30000,
+      cacheTime: 30000,
+      enabled: defined(groupId),
+    }
+  );
 
   return eventQuery;
 }


### PR DESCRIPTION
In order to properly prefetch issues from the stream, the queries need to be identical. The query on the issue details page was modified to include the organization in https://github.com/getsentry/sentry/pull/55208, which broke this.