### PR TITLE
ref(replay): Extract JumpButtons to its own component and put it on all lists

### DIFF
--- a/static/app/components/replays/jumpButtons.tsx
+++ b/static/app/components/replays/jumpButtons.tsx
@@ -2,13 +2,17 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import {t} from 'sentry/locale';
+import toPixels from 'sentry/utils/number/toPixels';
 
 interface Props {
   jump: undefined | 'up' | 'down';
   onClick: () => void;
+  tableHeaderHeight: number;
 }
 
-export default function JumpButtons({jump, onClick}: Props) {
+const offsetFromEdge = 5;
+
+export default function JumpButtons({jump, onClick, tableHeaderHeight}: Props) {
   if (jump === 'up') {
     return (
       <JumpButton
@@ -16,7 +20,7 @@ export default function JumpButtons({jump, onClick}: Props) {
         aria-label={t('Jump Up')}
         priority="primary"
         size="xs"
-        style={{top: '30px'}}
+        style={{top: toPixels(tableHeaderHeight + offsetFromEdge)}}
       >
         {t('↑ Jump to current timestamp')}
       </JumpButton>
@@ -29,7 +33,7 @@ export default function JumpButtons({jump, onClick}: Props) {
         aria-label={t('Jump Down')}
         priority="primary"
         size="xs"
-        style={{bottom: '5px'}}
+        style={{bottom: toPixels(offsetFromEdge)}}
       >
         {t('↓ Jump to current timestamp')}
       </JumpButton>

--- a/static/app/components/replays/jumpButtons.tsx
+++ b/static/app/components/replays/jumpButtons.tsx
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {t} from 'sentry/locale';
+
+interface Props {
+  jump: undefined | 'up' | 'down';
+  onClick: () => void;
+}
+
+export default function JumpButtons({jump, onClick}: Props) {
+  if (jump === 'up') {
+    return (
+      <JumpButton
+        onClick={onClick}
+        aria-label={t('Jump Up')}
+        priority="primary"
+        size="xs"
+        style={{top: '30px'}}
+      >
+        {t('↑ Jump to current timestamp')}
+      </JumpButton>
+    );
+  }
+  if (jump === 'down') {
+    return (
+      <JumpButton
+        onClick={onClick}
+        aria-label={t('Jump Down')}
+        priority="primary"
+        size="xs"
+        style={{bottom: '5px'}}
+      >
+        {t('↓ Jump to current timestamp')}
+      </JumpButton>
+    );
+  }
+  return null;
+}
+
+const JumpButton = styled(Button)`
+  position: absolute;
+  justify-self: center;
+`;

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-virtualized';
 
 import Placeholder from 'sentry/components/placeholder';
+import JumpButtons from 'sentry/components/replays/jumpButtons';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
@@ -83,6 +84,9 @@ function Console() {
     );
   };
 
+  const showJumpUpButton = false;
+  const showJumpDownButton = false;
+
   return (
     <FluidHeight>
       <ConsoleFilters frames={frames} {...filterProps} />
@@ -113,6 +117,10 @@ function Console() {
         ) : (
           <Placeholder height="100%" />
         )}
+        <JumpButtons
+          jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
+          onClick={() => {}}
+        />
       </TabItemContainer>
     </FluidHeight>
   );

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -120,6 +120,7 @@ function Console() {
         <JumpButtons
           jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
           onClick={() => {}}
+          tableHeaderHeight={0}
         />
       </TabItemContainer>
     </FluidHeight>

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -120,6 +120,7 @@ function DomMutations() {
         <JumpButtons
           jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
           onClick={() => {}}
+          tableHeaderHeight={0}
         />
       </TabItemContainer>
     </FluidHeight>

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -8,6 +8,7 @@ import {
 import {useQuery} from '@tanstack/react-query';
 
 import Placeholder from 'sentry/components/placeholder';
+import JumpButtons from 'sentry/components/replays/jumpButtons';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
@@ -81,6 +82,9 @@ function DomMutations() {
     );
   };
 
+  const showJumpUpButton = false;
+  const showJumpDownButton = false;
+
   return (
     <FluidHeight>
       <FilterLoadingIndicator isLoading={isFetching}>
@@ -113,6 +117,10 @@ function DomMutations() {
             )}
           </AutoSizer>
         )}
+        <JumpButtons
+          jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
+          onClick={() => {}}
+        />
       </TabItemContainer>
     </FluidHeight>
   );

--- a/static/app/views/replays/detail/errorList/index.tsx
+++ b/static/app/views/replays/detail/errorList/index.tsx
@@ -3,6 +3,7 @@ import {AutoSizer, CellMeasurer, GridCellProps, MultiGrid} from 'react-virtualiz
 import styled from '@emotion/styled';
 
 import Placeholder from 'sentry/components/placeholder';
+import JumpButtons from 'sentry/components/replays/jumpButtons';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
@@ -96,6 +97,9 @@ function ErrorList() {
     );
   };
 
+  const showJumpUpButton = false;
+  const showJumpDownButton = false;
+
   return (
     <FluidHeight>
       <ErrorFilters errorFrames={errorFrames} {...filterProps} />
@@ -135,6 +139,10 @@ function ErrorList() {
         ) : (
           <Placeholder height="100%" />
         )}
+        <JumpButtons
+          jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
+          onClick={() => {}}
+        />
       </ErrorTable>
     </FluidHeight>
   );
@@ -149,6 +157,7 @@ const OverflowHidden = styled('div')`
 const ErrorTable = styled(FluidHeight)`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
+  display: grid;
 
   .beforeHoverTime + .afterHoverTime:before {
     border-top: 1px solid ${p => p.theme.purple200};

--- a/static/app/views/replays/detail/errorList/index.tsx
+++ b/static/app/views/replays/detail/errorList/index.tsx
@@ -135,14 +135,15 @@ function ErrorList() {
                 />
               )}
             </AutoSizer>
+            <JumpButtons
+              jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
+              onClick={() => {}}
+              tableHeaderHeight={HEADER_HEIGHT}
+            />
           </OverflowHidden>
         ) : (
           <Placeholder height="100%" />
         )}
-        <JumpButtons
-          jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
-          onClick={() => {}}
-        />
       </ErrorTable>
     </FluidHeight>
   );
@@ -152,12 +153,12 @@ const OverflowHidden = styled('div')`
   position: relative;
   height: 100%;
   overflow: hidden;
+  display: grid;
 `;
 
 const ErrorTable = styled(FluidHeight)`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
-  display: grid;
 
   .beforeHoverTime + .afterHoverTime:before {
     border-top: 1px solid ${p => p.theme.purple200};

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -2,8 +2,8 @@ import {useCallback, useMemo, useRef, useState} from 'react';
 import {AutoSizer, CellMeasurer, GridCellProps, MultiGrid} from 'react-virtualized';
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/button';
 import Placeholder from 'sentry/components/placeholder';
+import JumpButtons from 'sentry/components/replays/jumpButtons';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -251,28 +251,10 @@ function NetworkList() {
                   />
                 )}
               </AutoSizer>
-              {showJumpUpButton ? (
-                <JumpButton
-                  onClick={handleClick}
-                  aria-label={t('Jump Up')}
-                  priority="primary"
-                  size="xs"
-                  style={{top: '30px'}}
-                >
-                  {t('↑ Jump to current timestamp')}
-                </JumpButton>
-              ) : null}
-              {showJumpDownButton ? (
-                <JumpButton
-                  onClick={handleClick}
-                  aria-label={t('Jump Down')}
-                  priority="primary"
-                  size="xs"
-                  style={{bottom: '5px'}}
-                >
-                  {t('↓ Jump to current timestamp')}
-                </JumpButton>
-              ) : null}
+              <JumpButtons
+                jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
+                onClick={handleClick}
+              />
             </OverflowHidden>
           ) : (
             <Placeholder height="100%" />
@@ -311,11 +293,6 @@ const OverflowHidden = styled('div')`
   height: 100%;
   overflow: hidden;
   display: grid;
-`;
-
-const JumpButton = styled(Button)`
-  position: absolute;
-  justify-self: center;
 `;
 
 const NetworkTable = styled(FluidHeight)`

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -254,6 +254,7 @@ function NetworkList() {
               <JumpButtons
                 jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
                 onClick={handleClick}
+                tableHeaderHeight={HEADER_HEIGHT}
               />
             </OverflowHidden>
           ) : (

--- a/static/app/views/replays/detail/tabItemContainer.tsx
+++ b/static/app/views/replays/detail/tabItemContainer.tsx
@@ -6,6 +6,7 @@ const TabItemContainer = styled('div')`
   overflow: hidden;
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
+  display: grid;
 
   .beforeHoverTime + .afterHoverTime {
     border-top-color: ${p => p.theme.purple200};


### PR DESCRIPTION
In this PR I'm just extracted the two "Jump Up" and "Jump Down" buttons into their own component, and then put that component into all the replay tabs we have (remains on network.... added to console, dom, error lists... skipped trace, perf and memory).

These buttons are not wired up, they all have `const showJump*Button = false;` so will not appear yet.

In a follow up I'll do the same kind of refactor to extract the logic that controls when things appear. In that PR i'll move things like `indexAtCurrentTime()` and `pixelsToRow()` into a shared space, so all these same files can import it.


Here's how it looks with/without a table header when i force the buttons to appear:
| |  No table | Inside a Table | 
| --- | --- | --- |
| Top | <img width="594" alt="SCR-20231004-moyc" src="https://github.com/getsentry/sentry/assets/187460/c3cdf20c-5878-41ec-be82-a6d56c8cb049"> | <img width="589" alt="SCR-20231004-moys" src="https://github.com/getsentry/sentry/assets/187460/9bac1216-1564-4322-bab1-6c770af25989"> |
| Bottom | <img width="592" alt="SCR-20231004-mpcb" src="https://github.com/getsentry/sentry/assets/187460/d3e3ed4e-bff3-4c8e-8d00-ecc5175bf62f"> | <img width="596" alt="SCR-20231004-mpcy" src="https://github.com/getsentry/sentry/assets/187460/00f578d1-829d-4a28-a6fc-81a5aacfeeb4"> |
