### PR TITLE
fix(ui) Fetch organizations from all regions in command-k

### DIFF
--- a/static/app/components/modals/commandPalette.tsx
+++ b/static/app/components/modals/commandPalette.tsx
@@ -43,7 +43,7 @@ function CommandPalette({Body}: ModalRenderProps) {
                   autoFocus
                   {...getInputProps({
                     type: 'text',
-                    placeholder: t('Search for projects, teams, settings, etc...'),
+                    placeholder: t('Search for projects, teams, settings, etc\u{2026}'),
                   })}
                 />
               </InputWrapper>


### PR DESCRIPTION
when users search for organizations with command-k we need to fan out requests to all regions that the user has access to.

Fixes HC-918