### PR TITLE
feat(starfish): Add mobile screen load spans page

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -302,6 +302,13 @@ function Sidebar({location, organization}: Props) {
           id="performance-browser-page-loads"
           icon={<SubitemDot collapsed={collapsed} />}
         />
+        <SidebarItem
+          {...sidebarItemProps}
+          label={<GuideAnchor target="starfish">{t('Screen Load')}</GuideAnchor>}
+          to={`/organizations/${organization.slug}/starfish/pageload/`}
+          id="starfish-mobile-screen-loads"
+          icon={<SubitemDot collapsed={collapsed} />}
+        />
       </SidebarAccordion>
     </Feature>
   );

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1769,6 +1769,12 @@ function buildRoutes() {
         <IndexRoute
           component={make(() => import('sentry/views/starfish/modules/mobile/pageload'))}
         />
+        <Route
+          path="spans/"
+          component={make(
+            () => import('sentry/views/starfish/views/screens/screenLoadSpans')
+          )}
+        />
       </Route>
       <Route path="responsiveness/">
         <IndexRoute

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -137,8 +137,12 @@ function getSortKeyFromField(
   return getSortField(fieldString, tableMeta);
 }
 
-export function isFieldSortable(field: Field, tableMeta?: MetaType): boolean {
-  return !!getSortKeyFromField(field, tableMeta);
+export function isFieldSortable(
+  field: Field,
+  tableMeta?: MetaType,
+  useFunctionFormat?: boolean
+): boolean {
+  return !!getSortKeyFromField(field, tableMeta, useFunctionFormat);
 }
 
 const decodeFields = (location: Location): Array<Field> => {

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -1197,6 +1197,7 @@ const alignedTypes: ColumnValueType[] = [
   'integer',
   'percentage',
   'percent_change',
+  'rate',
 ];
 
 export function fieldAlignment(

--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -5,9 +5,11 @@ import {CompactSelect} from 'sentry/components/compactSelect';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
-import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useReleases} from 'sentry/views/starfish/queries/useReleases';
+import {
+  useReleases,
+  useReleaseSelection,
+} from 'sentry/views/starfish/queries/useReleases';
 
 const ALL_RELEASES = {
   value: '',
@@ -17,13 +19,13 @@ const ALL_RELEASES = {
 type Props = {
   selectorKey: string;
   selectorName: string;
+  selectorValue?: string;
 };
 
-export function ReleaseSelector({selectorName, selectorKey}: Props) {
+export function ReleaseSelector({selectorName, selectorKey, selectorValue}: Props) {
   const {data, isLoading} = useReleases();
   const location = useLocation();
-  let value =
-    decodeScalar(location.query[selectorKey]) ?? data?.[0]?.version ?? undefined;
+  let value = selectorValue;
 
   if (!isLoading && !defined(value)) {
     value = ALL_RELEASES.value;
@@ -33,7 +35,7 @@ export function ReleaseSelector({selectorName, selectorKey}: Props) {
       triggerProps={{
         prefix: selectorName,
       }}
-      value={value}
+      value={selectorValue}
       options={[
         ...(data ?? [ALL_RELEASES]).map(release => ({
           value: release.version,
@@ -54,12 +56,18 @@ export function ReleaseSelector({selectorName, selectorKey}: Props) {
 }
 
 export function ReleaseComparisonSelector() {
+  const {primaryRelease, secondaryRelease} = useReleaseSelection();
   return (
     <PageFilterBar condensed>
-      <ReleaseSelector selectorKey="primaryRelease" selectorName={t('Primary Release')} />
+      <ReleaseSelector
+        selectorKey="primaryRelease"
+        selectorName={t('Primary Release')}
+        selectorValue={primaryRelease}
+      />
       <ReleaseSelector
         selectorKey="secondaryRelease"
         selectorName={t('Secondary Release')}
+        selectorValue={secondaryRelease}
       />
     </PageFilterBar>
   );

--- a/static/app/views/starfish/modules/mobile/pageload.tsx
+++ b/static/app/views/starfish/modules/mobile/pageload.tsx
@@ -1,7 +1,10 @@
 import styled from '@emotion/styled';
 
+import DatePageFilter from 'sentry/components/datePageFilter';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {space} from 'sentry/styles/space';
 import {
@@ -9,10 +12,7 @@ import {
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
 import useOrganization from 'sentry/utils/useOrganization';
-import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
-import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
-import {StarfishProjectSelector} from 'sentry/views/starfish/components/starfishProjectSelector';
 import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 import {ScreensView, YAxis} from 'sentry/views/starfish/views/screens';
 import {ScreensTable} from 'sentry/views/starfish/views/screens/screensTable';
@@ -33,17 +33,17 @@ export default function PageloadModule() {
           <Layout.Body>
             <Layout.Main fullWidth>
               <PageErrorAlert />
-              <StarfishPageFiltersContainer>
-                <SearchContainerWithFilterAndMetrics>
+              <PageFiltersContainer>
+                <Container>
                   <PageFilterBar condensed>
-                    <StarfishProjectSelector />
-                    <StarfishDatePicker />
+                    <ProjectPageFilter />
+                    <DatePageFilter alignDropdown="left" />
                   </PageFilterBar>
                   <ReleaseComparisonSelector />
-                </SearchContainerWithFilterAndMetrics>
+                </Container>
                 <ScreensView yAxes={[YAxis.TTID, YAxis.TTFD]} />
                 <ScreensTable />
-              </StarfishPageFiltersContainer>
+              </PageFiltersContainer>
             </Layout.Main>
           </Layout.Body>
         </PageErrorProvider>
@@ -52,7 +52,7 @@ export default function PageloadModule() {
   );
 }
 
-const SearchContainerWithFilterAndMetrics = styled('div')`
+const Container = styled('div')`
   display: grid;
   grid-template-rows: auto auto auto;
   gap: ${space(2)};

--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -34,7 +34,9 @@ export function useReleaseSelection() {
     decodeScalar(location.query.primaryRelease) ?? releases?.[0]?.version ?? undefined;
 
   const secondaryRelease =
-    decodeScalar(location.query.secondaryRelease) ?? releases?.[0]?.version ?? undefined;
+    decodeScalar(location.query.secondaryRelease) ?? (releases && releases.length > 1)
+      ? releases?.[1]?.version
+      : undefined;
 
   return {primaryRelease, secondaryRelease, isLoading};
 }

--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -34,9 +34,8 @@ export function useReleaseSelection() {
     decodeScalar(location.query.primaryRelease) ?? releases?.[0]?.version ?? undefined;
 
   const secondaryRelease =
-    decodeScalar(location.query.secondaryRelease) ?? (releases && releases.length > 1)
-      ? releases?.[1]?.version
-      : undefined;
+    decodeScalar(location.query.secondaryRelease) ??
+    (releases && releases.length > 1 ? releases?.[1]?.version : undefined);
 
   return {primaryRelease, secondaryRelease, isLoading};
 }

--- a/static/app/views/starfish/views/mobileServiceView/utils.tsx
+++ b/static/app/views/starfish/views/mobileServiceView/utils.tsx
@@ -1,0 +1,15 @@
+import {Location} from 'history';
+
+import {decodeScalar} from 'sentry/utils/queryString';
+
+export function getPrimaryRelease(location: Location): string | undefined {
+  const {primaryRelease} = location.query;
+
+  return decodeScalar(primaryRelease);
+}
+
+export function getSecondaryRelease(location: Location): string | undefined {
+  const {secondaryRelease} = location.query;
+
+  return decodeScalar(secondaryRelease);
+}

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -1,0 +1,108 @@
+import styled from '@emotion/styled';
+import {LocationDescriptor} from 'history';
+import omit from 'lodash/omit';
+
+import Breadcrumbs, {Crumb} from 'sentry/components/breadcrumbs';
+import DatePageFilter from 'sentry/components/datePageFilter';
+import * as Layout from 'sentry/components/layouts/thirds';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {
+  PageErrorAlert,
+  PageErrorProvider,
+} from 'sentry/utils/performance/contexts/pageError';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {getTransactionName} from 'sentry/views/performance/utils';
+import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
+import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
+import {useRoutingContext} from 'sentry/views/starfish/utils/routingContext';
+import {
+  getPrimaryRelease,
+  getSecondaryRelease,
+} from 'sentry/views/starfish/views/mobileServiceView/utils';
+import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
+import {ScreensView, YAxis} from 'sentry/views/starfish/views/screens';
+import {ScreenLoadSpansTable} from 'sentry/views/starfish/views/screens/screenLoadSpans/table';
+
+function ScreenLoadSpans() {
+  const location = useLocation();
+  const organization = useOrganization();
+  const transactionName = getTransactionName(location);
+  const primaryRelease = getPrimaryRelease(location);
+  const secondaryRelease = getSecondaryRelease(location);
+  const routingContext = useRoutingContext();
+
+  const screenLoadModule: LocationDescriptor = {
+    pathname: `${routingContext.baseURL}/pageload/`,
+    query: {
+      ...omit(location.query, QueryParameterNames.SPANS_SORT),
+    },
+  };
+
+  const crumbs: Crumb[] = [
+    {
+      to: screenLoadModule,
+      label: t('Module View'),
+      preservePageFilters: true,
+    },
+    {
+      to: '',
+      label: t('Screen Load'),
+    },
+  ];
+
+  return (
+    <SentryDocumentTitle title={transactionName} orgSlug={organization.slug}>
+      <Layout.Page>
+        <PageErrorProvider>
+          <Layout.Header>
+            <Layout.HeaderContent>
+              <Breadcrumbs crumbs={crumbs} />
+              <Layout.Title>{transactionName}</Layout.Title>
+            </Layout.HeaderContent>
+          </Layout.Header>
+          <Layout.Body>
+            <Layout.Main fullWidth>
+              <PageErrorAlert />
+              <StarfishPageFiltersContainer>
+                <Container>
+                  <PageFilterBar condensed>
+                    <DatePageFilter alignDropdown="left" />
+                  </PageFilterBar>
+                  <ReleaseComparisonSelector />
+                </Container>
+              </StarfishPageFiltersContainer>
+              <ScreensView
+                yAxes={[YAxis.THROUGHPUT, YAxis.TTID, YAxis.TTFD]}
+                additionalFilters={[`transaction:${transactionName}`]}
+                chartHeight={120}
+              />
+              <ScreenLoadSpansTable
+                transaction={transactionName}
+                primaryRelease={primaryRelease}
+                secondaryRelease={secondaryRelease}
+              />
+            </Layout.Main>
+          </Layout.Body>
+        </PageErrorProvider>
+      </Layout.Page>
+    </SentryDocumentTitle>
+  );
+}
+
+export default ScreenLoadSpans;
+
+const Container = styled('div')`
+  display: grid;
+  grid-template-rows: auto auto auto;
+  gap: ${space(2)};
+  margin-bottom: ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    grid-template-rows: auto;
+    grid-template-columns: auto 1fr auto;
+  }
+`;

--- a/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
@@ -1,0 +1,187 @@
+import {Fragment} from 'react';
+
+import {getInterval} from 'sentry/components/charts/utils';
+import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
+import SortLink from 'sentry/components/gridEditable/sortLink';
+import Pagination from 'sentry/components/pagination';
+import {t} from 'sentry/locale';
+import {NewQuery} from 'sentry/types';
+import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
+import EventView, {isFieldSortable, MetaType} from 'sentry/utils/discover/eventView';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {fieldAlignment, Sort} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {TableColumn} from 'sentry/views/discover/table/types';
+import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
+import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
+import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
+import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
+import {DataTitles} from 'sentry/views/starfish/views/spans/types';
+import {useModuleSort} from 'sentry/views/starfish/views/spans/useModuleSort';
+
+const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, PROJECT_ID} =
+  SpanMetricsField;
+
+type Props = {
+  primaryRelease?: string;
+  secondaryRelease?: string;
+  transaction?: string;
+};
+
+export function ScreenLoadSpansTable({
+  transaction,
+  primaryRelease,
+  secondaryRelease,
+}: Props) {
+  const location = useLocation();
+  const {selection} = usePageFilters();
+  const organization = useOrganization();
+
+  const searchQuery = new MutableSearch([
+    'transaction.op:ui.load',
+    `transaction:${transaction}`,
+    'span.op:[file.read,file.write,ui.load,http.client,db,db.sql.room,db.sql.query,db.sql.transaction]',
+  ]);
+  const queryStringPrimary = appendReleaseFilters(
+    searchQuery,
+    primaryRelease,
+    secondaryRelease
+  );
+
+  const sort = useModuleSort(QueryParameterNames.SPANS_SORT, {
+    kind: 'desc',
+    field: `${SpanFunction.TIME_SPENT_PERCENTAGE}(local)`,
+  });
+
+  const newQuery: NewQuery = {
+    name: '',
+    fields: [
+      PROJECT_ID,
+      SPAN_OP,
+      SPAN_GROUP,
+      SPAN_DESCRIPTION,
+      `avg(${SPAN_SELF_TIME})`, // TODO: Update these to avgIf with primary release when available
+      `avg_compare(${SPAN_SELF_TIME},release,${primaryRelease},${secondaryRelease})`,
+      'spm()',
+      'time_spent_percentage(local)',
+      `sum(${SPAN_SELF_TIME})`,
+    ],
+    query: queryStringPrimary,
+    dataset: DiscoverDatasets.SPANS_METRICS,
+    version: 2,
+    projects: selection.projects,
+    interval: getInterval(selection.datetime, STARFISH_CHART_INTERVAL_FIDELITY),
+  };
+
+  const eventView = EventView.fromNewQueryWithLocation(newQuery, location);
+  eventView.sorts = [sort];
+
+  const {data, isLoading, pageLinks} = useTableQuery({
+    eventView,
+    enabled: true,
+  });
+
+  const eventViewColumns = eventView.getColumns();
+
+  const columnNameMap = {
+    [SPAN_OP]: t('Operation'),
+    [SPAN_DESCRIPTION]: t('Span Description'),
+    'spm()': DataTitles.throughput,
+    [`avg(${SPAN_SELF_TIME})`]: DataTitles.avg,
+    [`avg_compare(${SPAN_SELF_TIME},release,${primaryRelease},${secondaryRelease})`]:
+      DataTitles.change,
+    'time_spent_percentage(local)': DataTitles.timeSpent,
+  };
+
+  function renderBodyCell(column, row): React.ReactNode {
+    if (!data?.meta || !data?.meta.fields) {
+      return row[column.key];
+    }
+
+    const renderer = getFieldRenderer(column.key, data?.meta.fields, false);
+    const rendered = renderer(row, {
+      location,
+      organization,
+      unit: data?.meta.units?.[column.key],
+    });
+    return rendered;
+  }
+
+  function renderHeadCell(
+    column: GridColumnHeader,
+    tableMeta?: MetaType
+  ): React.ReactNode {
+    const fieldType = tableMeta?.fields?.[column.key];
+    const alignment = fieldAlignment(column.key as string, fieldType);
+    const field = {
+      field: column.key as string,
+      width: column.width,
+    };
+
+    function generateSortLink() {
+      if (!tableMeta) {
+        return undefined;
+      }
+
+      let newSortDirection: Sort['kind'] = 'desc';
+      if (sort?.field === column.key) {
+        if (sort.kind === 'desc') {
+          newSortDirection = 'asc';
+        }
+      }
+
+      const newSort = `${newSortDirection === 'desc' ? '-' : ''}${column.key}`;
+
+      return {
+        ...location,
+        query: {...location.query, [QueryParameterNames.SPANS_SORT]: newSort},
+      };
+    }
+
+    const canSort = isFieldSortable(field, tableMeta?.fields, true);
+
+    const sortLink = (
+      <SortLink
+        align={alignment}
+        title={column.name}
+        direction={sort?.field === column.key ? sort.kind : undefined}
+        canSort={canSort}
+        generateSortLink={generateSortLink}
+      />
+    );
+    return sortLink;
+  }
+
+  const columnSortBy = eventView.getSorts();
+
+  return (
+    <Fragment>
+      <GridEditable
+        isLoading={isLoading}
+        data={data?.data as TableDataRow[]}
+        columnOrder={eventViewColumns
+          .filter(
+            (col: TableColumn<React.ReactText>) =>
+              col.name !== PROJECT_ID &&
+              col.name !== SPAN_GROUP &&
+              col.name !== `sum(${SPAN_SELF_TIME})`
+          )
+          .map((col: TableColumn<React.ReactText>) => {
+            return {...col, name: columnNameMap[col.key]};
+          })}
+        columnSortBy={columnSortBy}
+        location={location}
+        grid={{
+          renderHeadCell: column => renderHeadCell(column, data?.meta),
+          renderBodyCell,
+        }}
+      />
+      <Pagination pageLinks={pageLinks} />
+    </Fragment>
+  );
+}


### PR DESCRIPTION
Adds a screen load spans page that you can access by clicking on a specific screen in the screen load module.
Adds Screen Load to the left nav bar under Starfish.
Updates release selectors to use first and second release (instead of just first)
Adds an "unknown" device type when it is empty (but need to investigate why this is happening in the first place)

![Screenshot 2023-10-04 at 6 37 40 PM](https://github.com/getsentry/sentry/assets/63818634/b51237f4-2ec6-488e-bdf6-2bb0dfaad729)
![Screenshot 2023-10-04 at 6 37 49 PM](https://github.com/getsentry/sentry/assets/63818634/f0d1fd77-c0b6-472d-bfd1-52fe5cd2d6a2)

