### PR TITLE
fix(source_link): Update source_link retrieval for processing

### DIFF
--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -281,10 +281,7 @@ def get_source_link_for_frame(frame: Frame) -> str | None:
     we can return the GitHub equivalent with the line number, and use it as a
     stacktrace link. Otherwise, return the link as is.
     """
-    try:
-        source_link = getattr(frame, "source_link", None) or frame.get("source_link")
-    except KeyError:
-        return None
+    source_link = getattr(frame, "source_link", None)
 
     try:
         URLValidator()(source_link)
@@ -303,8 +300,8 @@ def get_source_link_for_frame(frame: Frame) -> str | None:
             source_link = "https://www.github.com/" + path_parts[0] + "/" + path_parts[1] + "/blob"
             for remaining_part in path_parts[2:]:
                 source_link += "/" + remaining_part
-            if frame.get("lineno"):
-                source_link += "#L" + frame.get("lineno")
+            if getattr(frame, "lineno", None):
+                source_link += "#L" + str(frame.lineno)
     return source_link
 
 

--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -282,7 +282,7 @@ def get_source_link_for_frame(frame: Frame) -> str | None:
     stacktrace link. Otherwise, return the link as is.
     """
     try:
-        source_link = frame.get("source_link")
+        source_link = getattr(frame, "source_link", None) or frame.get("source_link")
     except KeyError:
         return None
 

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -1,5 +1,6 @@
 import pytest
 
+from sentry.interfaces.stacktrace import Frame
 from sentry.stacktraces.functions import (
     get_source_link_for_frame,
     replace_enclosed_string,
@@ -237,4 +238,4 @@ def test_trim_function_name_cocoa():
     ],
 )
 def test_get_source_link_for_frame(input, output):
-    assert get_source_link_for_frame(input) == output
+    assert get_source_link_for_frame(Frame.to_python(input)) == output


### PR DESCRIPTION
This PR updates how source_link is retrieved from frame for processing to work with the typing used in the function signature (basically `.get` -> `getattr`)