### PR TITLE
feat(ddm): scratchpads

### DIFF
--- a/static/app/utils/metrics.tsx
+++ b/static/app/utils/metrics.tsx
@@ -303,3 +303,10 @@ export function updateQuery(router: InjectedRouter, partialQuery: Record<string,
     },
   });
 }
+
+export function clearQuery(router: InjectedRouter) {
+  router.push({
+    ...router.location,
+    query: {},
+  });
+}

--- a/static/app/views/ddm/ddm.tsx
+++ b/static/app/views/ddm/ddm.tsx
@@ -14,7 +14,8 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
-import MetricDashboard from 'sentry/views/ddm/metricWidget';
+import {ScratchpadSelector} from 'sentry/views/ddm/metricScratchpad';
+import MetricScratchpad from 'sentry/views/ddm/metricWidget';
 
 function DDM() {
   const organization = useOrganization();
@@ -48,8 +49,9 @@ function DDM() {
                   <EnvironmentPageFilter />
                   <DatePageFilter />
                 </PageFilterBar>
+                <ScratchpadSelector />
               </PaddedContainer>
-              <MetricDashboard />
+              <MetricScratchpad />
             </Layout.Main>
           </Layout.Body>
         </Layout.Page>

--- a/static/app/views/ddm/metricQueryBuilder.tsx
+++ b/static/app/views/ddm/metricQueryBuilder.tsx
@@ -96,7 +96,7 @@ export function QueryBuilder({
             }}
           />
           <CompactSelect
-            triggerProps={{prefix: t('Operation'), size: 'sm'}}
+            triggerProps={{prefix: t('Op'), size: 'sm'}}
             options={
               meta[metricsQuery.mri]?.operations.filter(isAllowedOp).map(op => ({
                 label: op,

--- a/static/app/views/ddm/metricScratchpad.tsx
+++ b/static/app/views/ddm/metricScratchpad.tsx
@@ -135,7 +135,13 @@ export function ScratchpadSelector() {
       <Button
         size="sm"
         disabled={!scratchpads.selected}
-        onClick={() => scratchpads.setDefault(scratchpads.selected ?? null)}
+        onClick={() => {
+          if (isDefaultSelected) {
+            scratchpads.setDefault(null);
+          } else {
+            scratchpads.setDefault(scratchpads.selected ?? null);
+          }
+        }}
         icon={<IconBookmark isSolid={isDefaultSelected} />}
       >
         {isDefaultSelected ? t('Remove default') : t('Set as default')}

--- a/static/app/views/ddm/metricScratchpad.tsx
+++ b/static/app/views/ddm/metricScratchpad.tsx
@@ -1,0 +1,259 @@
+import {Fragment, useCallback, useEffect, useState} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import {FocusScope} from '@react-aria/focus';
+import {uuid4} from '@sentry/utils';
+import {AnimatePresence} from 'framer-motion';
+
+import {Button} from 'sentry/components/button';
+import {CompactSelect} from 'sentry/components/compactSelect';
+import {openConfirmModal} from 'sentry/components/confirm';
+import InputControl from 'sentry/components/input';
+import {Overlay, PositionWrapper} from 'sentry/components/overlay';
+import {IconBookmark, IconDelete, IconStar} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {clearQuery, updateQuery} from 'sentry/utils/metrics';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import useOverlay from 'sentry/utils/useOverlay';
+import useRouter from 'sentry/utils/useRouter';
+
+type Scratchpad = {
+  id: string;
+  name: string;
+  query: Record<string, unknown>;
+};
+
+type ScratchpadState = {
+  default: string | null;
+  scratchpads: Record<string, Scratchpad>;
+};
+
+export function useScratchpads() {
+  const [state, setState] = useLocalStorageState<ScratchpadState>('ddm-scratchpads', {
+    default: null,
+    scratchpads: {},
+  });
+  const [selected, setSelected] = useState<string | null | undefined>(); // scratchpad id
+
+  const select = useCallback(
+    (id: string | null) => {
+      setSelected(id);
+    },
+    [setSelected]
+  );
+
+  const setDefault = useCallback(
+    (id: string | null) => {
+      setState({...state, default: id});
+    },
+    [state, setState]
+  );
+
+  const add = useCallback(
+    (name: string, query: Scratchpad['query']) => {
+      const id = uuid4();
+      const newScratchpads = {...state.scratchpads, [id]: {name, id, query}};
+      setState({...state, scratchpads: newScratchpads});
+      select(id);
+    },
+    [state, setState, select]
+  );
+
+  const update = useCallback(
+    (id: string, query: Scratchpad['query']) => {
+      const oldScratchpad = state.scratchpads[id];
+      const newScratchpads = {...state.scratchpads, [id]: {...oldScratchpad, query}};
+      setState({...state, scratchpads: newScratchpads});
+    },
+    [state, setState]
+  );
+
+  const remove = useCallback(
+    (id: string) => {
+      const newScratchpads = {...state.scratchpads};
+      delete newScratchpads[id];
+      if (state.default === id) {
+        setState({...state, default: null, scratchpads: newScratchpads});
+      } else {
+        setState({...state, scratchpads: newScratchpads});
+      }
+      if (selected === id) {
+        select(null);
+      }
+    },
+    [state, setState, select, selected]
+  );
+
+  return {
+    all: state.scratchpads,
+    default: state.default,
+    selected,
+    add,
+    update,
+    remove,
+    select,
+    setDefault,
+  };
+}
+
+export function ScratchpadSelector() {
+  const scratchpads = useScratchpads();
+  const router = useRouter();
+  const queryStr = router.location.query ?? '';
+
+  // select the default scratchpad when the component mounts
+  useEffect(() => {
+    if (scratchpads.default && !scratchpads.selected) {
+      scratchpads.select(scratchpads.default);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // saves all changes to the selected scratchpad to local storage
+  useEffect(() => {
+    if (scratchpads.selected) {
+      scratchpads.update(scratchpads.selected, queryStr);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryStr]);
+
+  // changes the query when a scratchpad is selected, clears it when none is selected
+  useEffect(() => {
+    if (scratchpads.selected) {
+      const query = scratchpads.all[scratchpads.selected].query;
+      updateQuery(router, query);
+    } else if (scratchpads.selected === null) {
+      clearQuery(router);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scratchpads.selected]);
+
+  return (
+    <ScratchpadGroup>
+      <SaveAsDropdown
+        onSave={name => {
+          scratchpads.add(name, queryStr);
+        }}
+        mode={scratchpads.selected ? 'fork' : 'save'}
+      />
+      <CompactSelect
+        options={Object.values(scratchpads.all).map((s: any) => ({
+          value: s.id,
+          label: s.name,
+          trailingItems: (
+            <Fragment>
+              <StyledDropdownIcon>
+                <IconBookmark
+                  isSolid={scratchpads.default === s.id}
+                  onClick={() => {
+                    scratchpads.setDefault(s.id);
+                  }}
+                />
+              </StyledDropdownIcon>
+              <StyledDropdownIcon hover="danger">
+                <IconDelete
+                  onClick={() => {
+                    openConfirmModal({
+                      onConfirm: () => scratchpads.remove(s.id),
+                      message: t('Are you sure you want to delete this scratchpad?'),
+
+                      confirmText: t('Delete'),
+                    });
+                  }}
+                />
+              </StyledDropdownIcon>
+            </Fragment>
+          ),
+        }))}
+        value={scratchpads.selected ?? ''}
+        closeOnSelect={false}
+        onChange={option => {
+          if (option.value === scratchpads.selected) {
+            scratchpads.select(null);
+          } else {
+            scratchpads.select(option.value);
+          }
+        }}
+        triggerProps={{prefix: t('Scratchpad'), size: 'sm'}}
+        emptyMessage="No scratchpads yet."
+        disabled={false}
+      />
+    </ScratchpadGroup>
+  );
+}
+
+function SaveAsDropdown({
+  onSave,
+  mode,
+}: {
+  mode: 'save' | 'fork';
+  onSave: (name: string) => void;
+}) {
+  const {isOpen, triggerProps, overlayProps, arrowProps} = useOverlay({});
+  const theme = useTheme();
+  const [name, setName] = useState('');
+
+  return (
+    <div>
+      <Button size="sm" icon={<IconStar />} {...triggerProps}>
+        {mode === 'fork' ? t('Fork as ...') : t('Save as ...')}
+      </Button>
+      <AnimatePresence>
+        {isOpen && (
+          <FocusScope contain restoreFocus autoFocus>
+            <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayProps}>
+              <StyledOverlay arrowProps={arrowProps} animated>
+                <SaveAsInput
+                  type="txt"
+                  name="scratchpad-name"
+                  placeholder={t('Scratchpad name')}
+                  value={name}
+                  size="sm"
+                  onChange={({target}) => setName(target.value)}
+                />
+                <SaveAsButton
+                  disabled={!name}
+                  onClick={() => {
+                    onSave(name);
+                  }}
+                  size="sm"
+                  priority="primary"
+                >
+                  {mode === 'fork' ? t('Fork') : t('Save')}
+                </SaveAsButton>
+              </StyledOverlay>
+            </PositionWrapper>
+          </FocusScope>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+const ScratchpadGroup = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+`;
+
+const StyledOverlay = styled(Overlay)`
+  padding: ${space(1)};
+`;
+
+const SaveAsButton = styled(Button)`
+  width: 100%;
+`;
+
+const SaveAsInput = styled(InputControl)`
+  margin-bottom: ${space(1)};
+`;
+
+const StyledDropdownIcon = styled('span')<{hover?: string}>`
+  padding-top: ${space(0.5)};
+  opacity: 0.6;
+
+  :hover {
+    opacity: 0.9;
+    color: ${p => (p.hover === 'danger' ? p.theme.red300 : p.theme.purple300)};
+  }
+`;

--- a/static/app/views/ddm/metricScratchpad.tsx
+++ b/static/app/views/ddm/metricScratchpad.tsx
@@ -164,7 +164,6 @@ export function ScratchpadSelector() {
                     openConfirmModal({
                       onConfirm: () => scratchpads.remove(s.id),
                       message: t('Are you sure you want to delete this scratchpad?'),
-
                       confirmText: t('Delete'),
                     });
                   }}

--- a/static/app/views/ddm/metricWidget.tsx
+++ b/static/app/views/ddm/metricWidget.tsx
@@ -445,28 +445,20 @@ function MetricChart({
                     theme: theme as Theme,
                   })
                 : undefined;
+
+              const props = {
+                series: [...seriesToShow, ...releaseSeries],
+                legend,
+                ...chartProps,
+                ...zoomRenderProps,
+              };
+
               return displayType === MetricDisplayType.LINE ? (
-                <LineChart
-                  series={[...seriesToShow, ...releaseSeries]}
-                  legend={legend}
-                  {...chartProps}
-                  {...zoomRenderProps}
-                />
+                <LineChart {...props} />
               ) : displayType === MetricDisplayType.AREA ? (
-                <AreaChart
-                  series={[...seriesToShow, ...releaseSeries]}
-                  legend={legend}
-                  {...chartProps}
-                  {...zoomRenderProps}
-                />
+                <AreaChart {...props} />
               ) : (
-                <BarChart
-                  stacked
-                  series={[...seriesToShow, ...releaseSeries]}
-                  legend={legend}
-                  {...chartProps}
-                  {...zoomRenderProps}
-                />
+                <BarChart stacked {...props} />
               );
             }}
           </ReleaseSeries>

--- a/static/app/views/ddm/metricWidget.tsx
+++ b/static/app/views/ddm/metricWidget.tsx
@@ -107,15 +107,6 @@ function useMetricWidgets() {
   };
 }
 
-// function useMetricWidget(position: number) {
-//   const {widgets, onChange} = useMetricWidgets();
-
-//   return {
-//     widget: widgets[position],
-//     onChange: (data: Partial<MetricWidgetProps>) => onChange(position, data),
-//   };
-// }
-
 function MetricDashboard() {
   const {widgets, onChange, addWidget} = useMetricWidgets();
   const {selection} = usePageFilters();
@@ -415,7 +406,7 @@ function MetricChart({
     isGroupedByDate: true,
     height: 300,
     colors: seriesToShow.map(s => s.color),
-    grid: {top: 20, bottom: 20, left: 20, right: 20},
+    grid: {top: 20, bottom: 20, left: 15, right: 25},
     tooltip: {
       valueFormatter: (value: number) => {
         return formatMetricsUsingUnitAndOp(value, unit, operation);


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/57269

Adds ability to save current selection of widgets as scratchpad in local storage. Adds basic Scratchpad management.

https://github.com/getsentry/sentry/assets/86684834/358c8018-39dc-4e07-a11a-501d4946831c

