### PR TITLE
Network Error Logging: frontend part

### DIFF
--- a/fixtures/js-stubs/projectKeys.ts
+++ b/fixtures/js-stubs/projectKeys.ts
@@ -9,6 +9,7 @@ export function ProjectKeys(params: ProjectKey[] = []): ProjectKey[] {
           'http://188ee45a58094d939428d8585aa6f661:a33bf9aba64c4bbdaf873bb9023b6d2d@dev.getsentry.net:8000/1',
         minidump:
           'http://dev.getsentry.net:8000/api/1/minidump?sentry_key=188ee45a58094d939428d8585aa6f661',
+        nel: 'http://dev.getsentry.net:8000/api/1/nel/?sentry_key=188ee45a58094d939428d8585aa6f661',
         public: 'http://188ee45a58094d939428d8585aa6f661@dev.getsentry.net:8000/1',
         cdn: 'http://dev.getsentry.net:800/js-sdk-loader/188ee45a58094d939428d8585aa6f661.min.js',
         csp: 'http://dev.getsentry.net:8000/api/1/csp-report/?sentry_key=188ee45a58094d939428d8585aa6f661',

--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -16,6 +16,7 @@ import {DebugMeta} from './interfaces/debugMeta';
 import {Exception} from './interfaces/exception';
 import {Generic} from './interfaces/generic';
 import {Message} from './interfaces/message';
+import {Nel} from './interfaces/nel';
 import {SpanEvidenceSection} from './interfaces/performance/spanEvidence';
 import {Request} from './interfaces/request';
 import {Spans} from './interfaces/spans';
@@ -80,6 +81,9 @@ function EventEntryContent({
 
     case EntryType.CSP:
       return <Csp event={event} data={entry.data} />;
+
+    case EntryType.NEL:
+      return <Nel event={event} data={entry.data} />;
 
     case EntryType.EXPECTCT:
     case EntryType.EXPECTSTAPLE:

--- a/static/app/components/events/interfaces/nel/help/index.tsx
+++ b/static/app/components/events/interfaces/nel/help/index.tsx
@@ -1,0 +1,55 @@
+import styled from '@emotion/styled';
+
+import ExternalLink from 'sentry/components/links/externalLink';
+import {IconOpen} from 'sentry/icons';
+import {space} from 'sentry/styles/space';
+
+import nelProperties from './nelProperties';
+
+function NELHelp({data}) {
+  const getLink = () => {
+    const href =
+      'https://developer.mozilla.org/en-US/docs/Web/HTTP/Network_Error_Logging#error_reports';
+
+    return (
+      <StyledExternalLink href={href}>
+        {'developer.mozilla.org'}
+        <IconOpen size="xs" className="external-icon" />
+      </StyledExternalLink>
+    );
+  };
+
+  let output = '';
+  for (const [nelProperty, nelExplanation] of Object.entries(nelProperties)) {
+    output += `<span><b>${nelProperty}</b></span>: <span>${nelExplanation}</span><br/>`;
+  }
+
+  return (
+    <div>
+      <h4>
+        <code>{data.message}</code>
+      </h4>
+      <blockquote>{data.culprit}</blockquote>
+      <blockquote dangerouslySetInnerHTML={{__html: output}} />
+      <StyledP>
+        <span>{'\u2023 MDN ('}</span>
+        <span>{getLink()}</span>
+        <span>{')'}</span>
+      </StyledP>
+    </div>
+  );
+}
+
+export default NELHelp;
+
+const StyledP = styled('p')`
+  text-align: right;
+  display: grid;
+  grid-template-columns: repeat(3, max-content);
+  gap: ${space(0.25)};
+`;
+
+const StyledExternalLink = styled(ExternalLink)`
+  display: inline-flex;
+  align-items: center;
+`;

--- a/static/app/components/events/interfaces/nel/help/nelProperties.tsx
+++ b/static/app/components/events/interfaces/nel/help/nelProperties.tsx
@@ -1,0 +1,35 @@
+import {t} from 'sentry/locale';
+
+const nelProperties = {
+  referrer: t(
+    `Request's referrer, as determined by the referrer policy associated with its client.`
+  ),
+  sampling_fraction: t(`sampling rate`),
+  server_ip: t(
+    `The IP address of the server to which the user agent sent the request, if available. Otherwise, an empty string.`
+  ),
+  protocol: t(
+    `The network protocol used to fetch the resource as identified by the ALPN Protocol ID, if available. Otherwise, "".`
+  ),
+  method: t(`request's request method.`),
+  request_headers: t(
+    `The result of executing <a href="https://w3c.github.io/network-error-logging/#extract-request-headers" target="_blank" rel="noreferrer">5.2 Extract request headers</a> on <em>request</em> and <em>policy</em>.`
+  ),
+  response_headers: t(
+    `The result of executing <a href="https://w3c.github.io/network-error-logging/#extract-response-headers" target="_blank" rel="noreferrer">5.3 Extract response headers</a> on <em>response</em> and <em>policy</em>.`
+  ),
+  status_code: t(
+    `The status code of the HTTP response, if available. Otherwise, <code>0</code>.`
+  ),
+  elapsed_time: t(
+    `The elapsed number of milliseconds between the start of the resource fetch and when it was completed or aborted by the user agent.`
+  ),
+  phase: t(
+    `If request failed, the phase of its network error. If request succeeded, "application".`
+  ),
+  type: t(
+    `If request failed, the type of its network error. If request succeeded, "ok".`
+  ),
+};
+
+export default nelProperties;

--- a/static/app/components/events/interfaces/nel/index.tsx
+++ b/static/app/components/events/interfaces/nel/index.tsx
@@ -1,0 +1,70 @@
+import {useState} from 'react';
+
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
+import {SegmentedControl} from 'sentry/components/segmentedControl';
+import {t} from 'sentry/locale';
+import {Event} from 'sentry/types/event';
+
+import Help from './help';
+
+type View = 'report' | 'raw' | 'help';
+
+function getView(view: View, data: Record<any, any>, event: Record<any, any>) {
+  switch (view) {
+    case 'report':
+      const viewData = data.body;
+      viewData.url = data.url;
+      viewData.elapsed_time = viewData.elapsed_time + ' ms';
+
+      return (
+        <KeyValueList
+          data={Object.entries(viewData).map(([key, value]) => {
+            return {
+              key,
+              subject: key,
+              value,
+            };
+          })}
+          isContextData
+        />
+      );
+    case 'raw':
+      return <pre>{JSON.stringify(data, null, 2)}</pre>;
+    case 'help':
+      return <Help data={event} />;
+    default:
+      throw new TypeError(`Invalid view: ${view}`);
+  }
+}
+
+type Props = {
+  data: Record<string, any>;
+  event: Event;
+};
+
+export function Nel({data, event}: Props) {
+  const [view, setView] = useState<View>('report');
+
+  const viewData = {...data};
+  viewData.body = {...data.body};
+  if (view === 'report') {
+    delete viewData.age;
+    delete viewData.body.sampling_fraction;
+    delete viewData.ty;
+  }
+
+  const actions = (
+    <SegmentedControl aria-label={t('View')} size="xs" value={view} onChange={setView}>
+      <SegmentedControl.Item key="report">{t('Report')}</SegmentedControl.Item>
+      <SegmentedControl.Item key="raw">{t('Raw')}</SegmentedControl.Item>
+      <SegmentedControl.Item key="help">{t('Help')}</SegmentedControl.Item>
+    </SegmentedControl>
+  );
+
+  return (
+    <EventDataSection type="nel" title={t('NEL Report')} actions={actions}>
+      {getView(view, viewData, event)}
+    </EventDataSection>
+  );
+}

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -260,6 +260,7 @@ export enum EventOrGroupType {
   HPKP = 'hpkp',
   EXPECTCT = 'expectct',
   EXPECTSTAPLE = 'expectstaple',
+  NEL = 'nel',
   DEFAULT = 'default',
   TRANSACTION = 'transaction',
   AGGREGATE_TRANSACTION = 'aggregateTransaction',
@@ -276,6 +277,7 @@ export enum EntryType {
   STACKTRACE = 'stacktrace',
   TEMPLATE = 'template',
   CSP = 'csp',
+  NEL = 'nel',
   EXPECTCT = 'expectct',
   EXPECTSTAPLE = 'expectstaple',
   HPKP = 'hpkp',
@@ -379,6 +381,11 @@ type EntryCsp = {
   type: EntryType.CSP;
 };
 
+type EntryNel = {
+  data: Record<string, any>;
+  type: EntryType.NEL;
+};
+
 type EntryGeneric = {
   data: Record<string, any>;
   type: EntryType.EXPECTCT | EntryType.EXPECTSTAPLE | EntryType.HPKP;
@@ -400,6 +407,7 @@ export type Entry =
   | EntryRequest
   | EntryTemplate
   | EntryCsp
+  | EntryNel
   | EntryGeneric
   | EntryResources;
 

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -75,6 +75,7 @@ export type ProjectKey = {
     cdn: string;
     csp: string;
     minidump: string;
+    nel: string;
     public: string;
     secret: string;
     security: string;

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -173,6 +173,12 @@ export function getTitle(
         subtitle: metadata.origin ?? '',
         treeLabel: undefined,
       };
+    case EventOrGroupType.NEL:
+      return {
+        title: customTitle ?? metadata.directive ?? '',
+        subtitle: metadata.uri ?? '',
+        treeLabel: undefined,
+      };
     case EventOrGroupType.DEFAULT:
       return {
         title: customTitle ?? metadata.title ?? '',

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -141,6 +141,7 @@ function DefaultGroupEventDetailsContent({
       <EventReplay event={event} group={group} projectSlug={project.slug} />
       <GroupEventEntry entryType={EntryType.HPKP} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.CSP} {...eventEntryProps} />
+      <GroupEventEntry entryType={EntryType.NEL} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.EXPECTCT} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.EXPECTSTAPLE} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.TEMPLATE} {...eventEntryProps} />


### PR DESCRIPTION
Frontend part of the NEL ([Network Error Logging](https://developer.mozilla.org/en-US/docs/Web/HTTP/Network_Error_Logging)) implementation.

Example:
<img width="1121" alt="image" src="https://github.com/getsentry/sentry/assets/1127549/42054ccf-1d73-4ebc-9975-3cea3b879b23">

Related PRs:
https://github.com/getsentry/sentry/pull/55135
https://github.com/getsentry/relay/pull/2421