### PR TITLE
fix(source-map-debugger): Fix logic in modal to evaluate 'Stack Frame has debug ID' even when the SDK is officially not supporting debug IDs

### DIFF
--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -213,7 +213,8 @@ export function SourceMapsDebuggerModal({
                 <HasDebugIdChecklistItem
                   shouldValidate={
                     sourceResolutionResults.sdkDebugIdSupport === 'full' ||
-                    sourceResolutionResults.sdkDebugIdSupport === 'unofficial-sdk'
+                    sourceResolutionResults.sdkDebugIdSupport === 'unofficial-sdk' ||
+                    sourceResolutionResults.eventHasDebugIds
                   }
                   sourceResolutionResults={sourceResolutionResults}
                 />


### PR DESCRIPTION
We were showing the "Stack frame has Debug IDs" as gray in the case of React native because it in theory doesn't support debug IDs but yet it sent debug IDs.

It just looked weird and this will fix it.