### PR TITLE
ref(replays): move start time to under email in replay details

### DIFF
--- a/static/app/components/replays/header/replayMetaData.tsx
+++ b/static/app/components/replays/header/replayMetaData.tsx
@@ -1,11 +1,9 @@
-import {Fragment} from 'react';
 import {Link} from 'react-router';
 import styled from '@emotion/styled';
 
 import ErrorCounts from 'sentry/components/replays/header/errorCounts';
 import HeaderPlaceholder from 'sentry/components/replays/header/headerPlaceholder';
-import TimeSince from 'sentry/components/timeSince';
-import {IconCalendar, IconCursorArrow} from 'sentry/icons';
+import {IconCursorArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import EventView from 'sentry/utils/discover/eventView';
@@ -66,17 +64,6 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
         )}
       </KeyMetricData>
 
-      <KeyMetricLabel>{t('Start Time')}</KeyMetricLabel>
-      <KeyMetricData>
-        {replayRecord ? (
-          <Fragment>
-            <IconCalendar color="gray300" />
-            <TimeSince date={replayRecord.started_at} unitStyle="regular" />
-          </Fragment>
-        ) : (
-          <HeaderPlaceholder width="80px" height="16px" />
-        )}
-      </KeyMetricData>
       <KeyMetricLabel>{t('Errors')}</KeyMetricLabel>
       <KeyMetricData>
         {replayRecord ? (

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -11,6 +11,8 @@ import HeaderPlaceholder from 'sentry/components/replays/header/headerPlaceholde
 import ReplayMetaData from 'sentry/components/replays/header/replayMetaData';
 import ShareButton from 'sentry/components/replays/shareButton';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import TimeSince from 'sentry/components/timeSince';
+import {IconCalendar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {ReplayError, ReplayRecord} from 'sentry/views/replays/types';
@@ -60,7 +62,18 @@ function Page({children, orgSlug, replayRecord, projectSlug, replayErrors}: Prop
             id: replayRecord.user.id || '',
           }}
           // this is the subheading for the avatar, so displayEmail in this case is a misnomer
-          displayEmail={<div>{undefined}</div>}
+          displayEmail={
+            <div>
+              {replayRecord ? (
+                <TimeContainer>
+                  <IconCalendar color="gray300" size="xs" />
+                  <TimeSince date={replayRecord.started_at} unitStyle="regular" />
+                </TimeContainer>
+              ) : (
+                <HeaderPlaceholder width="80px" height="16px" />
+              )}
+            </div>
+          }
         />
       ) : (
         <HeaderPlaceholder width="100%" height="58px" />
@@ -97,6 +110,12 @@ const ButtonActionsWrapper = styled(Layout.HeaderActions)`
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     margin-bottom: 0;
   }
+`;
+
+const TimeContainer = styled('div')`
+  display: flex;
+  gap: ${space(0.5)};
+  align-items: center;
 `;
 
 export default Page;


### PR DESCRIPTION

<img width="1156" alt="SCR-20231005-hbcz" src="https://github.com/getsentry/sentry/assets/56095982/e52ac4e7-da4d-471e-9353-c6824bc562ad">

closes https://github.com/getsentry/sentry/issues/57270#issuecomment-1748595383