### PR TITLE
feat(sourcemaps): Add more metadata in sourcemaps endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_artifact_bundle_files.py
+++ b/src/sentry/api/endpoints/project_artifact_bundle_files.py
@@ -1,4 +1,5 @@
-from typing import Dict, List
+from datetime import datetime
+from typing import Dict, List, Optional
 
 from django.utils.functional import cached_property
 from rest_framework.request import Request
@@ -105,9 +106,15 @@ class ProjectArtifactBundleFilesEndpoint(ProjectEndpoint):
                 project.organization.id, artifact_bundle
             )
 
+            def format_date(date: Optional[datetime]) -> Optional[str]:
+                return None if date is None else date.isoformat()[:19] + "Z"
+
             return serialize(
                 {
                     "bundleId": str(artifact_bundle.bundle_id),
+                    "date": format_date(artifact_bundle.date_uploaded),
+                    "dateModified": format_date(artifact_bundle.date_last_modified),
+                    "fileCount": artifact_bundle.artifact_count,
                     "associations": associations,
                     "files": serialize(
                         # We need to convert the dictionary to a list in order to properly use the serializer.

--- a/src/sentry/api/serializers/models/artifactbundle.py
+++ b/src/sentry/api/serializers/models/artifactbundle.py
@@ -1,4 +1,5 @@
 import base64
+from typing import Dict, List, Tuple
 
 from sentry.api.serializers import Serializer
 from sentry.models import ReleaseArtifactBundle, SourceFileType
@@ -29,7 +30,7 @@ class ArtifactBundlesSerializer(Serializer):
             artifact_bundle_id__in=[r[0] for r in item_list]
         ).order_by("-id")
 
-        grouped_bundles = {}
+        grouped_bundles: Dict[int, List[Tuple[str, str]]] = {}
         for release in release_artifact_bundles:
             bundles = grouped_bundles.setdefault(release.artifact_bundle_id, [])
             bundles.append((release.release_name, release.dist_name))

--- a/src/sentry/api/serializers/models/artifactbundle.py
+++ b/src/sentry/api/serializers/models/artifactbundle.py
@@ -1,5 +1,4 @@
 import base64
-from collections import defaultdict
 
 from sentry.api.serializers import Serializer
 from sentry.models import ReleaseArtifactBundle, SourceFileType
@@ -13,8 +12,8 @@ class ArtifactBundlesSerializer(Serializer):
         associations = []
 
         grouped_bundle = grouped_bundles.get(item[0], [])
-        # We want to sort the set, since we want consistent ordering in the UI.
-        for release, dist in sorted(grouped_bundle):
+        # We preserve the order of the list inside the grouped bundle.
+        for release, dist in grouped_bundle:
             associations.append({"release": release or None, "dist": dist or None})
 
         return associations
@@ -24,15 +23,16 @@ class ArtifactBundlesSerializer(Serializer):
         return None if date is None else date.isoformat()[:19] + "Z"
 
     def get_attrs(self, item_list, user):
+        # We sort by id, since it's the best (already existing) field to define total order of
+        # release associations that is somehow consistent with upload sequence.
         release_artifact_bundles = ReleaseArtifactBundle.objects.filter(
             artifact_bundle_id__in=[r[0] for r in item_list]
-        )
+        ).order_by("-id")
 
-        grouped_bundles = defaultdict(set)
+        grouped_bundles = {}
         for release in release_artifact_bundles:
-            grouped_bundles[release.artifact_bundle_id].add(
-                (release.release_name, release.dist_name)
-            )
+            bundles = grouped_bundles.setdefault(release.artifact_bundle_id, [])
+            bundles.append((release.release_name, release.dist_name))
 
         return {
             item: {

--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -94,9 +94,11 @@ class ArtifactBundle(Model):
     def get_release_associations(
         cls, organization_id: int, artifact_bundle: ArtifactBundle
     ) -> List[Mapping[str, str | None]]:
+        # We sort by id, since it's the best (already existing) field to define total order of
+        # release associations that is somehow consistent with upload sequence.
         release_artifact_bundles = ReleaseArtifactBundle.objects.filter(
             organization_id=organization_id, artifact_bundle=artifact_bundle
-        )
+        ).order_by("-id")
 
         return [
             {

--- a/tests/sentry/api/endpoints/test_artifact_bundles.py
+++ b/tests/sentry/api/endpoints/test_artifact_bundles.py
@@ -289,11 +289,7 @@ class ArtifactBundlesEndpointTest(APITestCase):
                 "bundleId": str(artifact_bundle.bundle_id),
                 "associations": [
                     {
-                        "release": "1.0",
-                        "dist": "android",
-                    },
-                    {
-                        "release": "1.0",
+                        "release": "2.0",
                         "dist": "ios",
                     },
                     {
@@ -301,8 +297,12 @@ class ArtifactBundlesEndpointTest(APITestCase):
                         "dist": "android",
                     },
                     {
-                        "release": "2.0",
+                        "release": "1.0",
                         "dist": "ios",
+                    },
+                    {
+                        "release": "1.0",
+                        "dist": "android",
                     },
                 ],
                 "dateModified": "2023-03-15T00:00:00Z",
@@ -322,11 +322,7 @@ class ArtifactBundlesEndpointTest(APITestCase):
                 "bundleId": str(artifact_bundle.bundle_id),
                 "associations": [
                     {
-                        "release": "1.0",
-                        "dist": "android",
-                    },
-                    {
-                        "release": "1.0",
+                        "release": "2.0",
                         "dist": "ios",
                     },
                     {
@@ -334,8 +330,12 @@ class ArtifactBundlesEndpointTest(APITestCase):
                         "dist": "android",
                     },
                     {
-                        "release": "2.0",
+                        "release": "1.0",
                         "dist": "ios",
+                    },
+                    {
+                        "release": "1.0",
+                        "dist": "android",
                     },
                 ],
                 "dateModified": "2023-03-15T00:00:00Z",

--- a/tests/sentry/api/endpoints/test_project_artifact_bundle_files.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_bundle_files.py
@@ -56,8 +56,8 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
         assert response.data == {
             "bundleId": str(artifact_bundle.bundle_id),
             "associations": [
-                {"release": "1.0", "dist": "android"},
                 {"release": "2.0", "dist": "android"},
+                {"release": "1.0", "dist": "android"},
             ],
             "date": "2023-03-15T00:00:00Z",
             "dateModified": "2023-03-15T01:00:00Z",

--- a/tests/sentry/api/endpoints/test_project_artifact_bundle_files.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_bundle_files.py
@@ -1,4 +1,7 @@
+from datetime import timedelta
+
 from django.urls import reverse
+from django.utils import timezone
 
 from sentry.models import ProjectArtifactBundle, ReleaseArtifactBundle
 from sentry.testutils.cases import APITestCase
@@ -13,7 +16,10 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
         project = self.create_project(name="foo")
 
         artifact_bundle = self.create_artifact_bundle(
-            self.organization, artifact_count=6, fixture_path="artifact_bundle_debug_ids"
+            self.organization,
+            artifact_count=6,
+            fixture_path="artifact_bundle_debug_ids",
+            date_last_modified=(timezone.now() + timedelta(hours=1)),
         )
         ProjectArtifactBundle.objects.create(
             organization_id=self.organization.id,
@@ -53,6 +59,9 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                 {"release": "1.0", "dist": "android"},
                 {"release": "2.0", "dist": "android"},
             ],
+            "date": "2023-03-15T00:00:00Z",
+            "dateModified": "2023-03-15T01:00:00Z",
+            "fileCount": 6,
             "files": [
                 {
                     "debugId": None,
@@ -135,6 +144,9 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
             {
                 "bundleId": str(artifact_bundle.bundle_id),
                 "associations": [{"release": "1.0", "dist": None}],
+                "date": "2023-03-15T00:00:00Z",
+                "dateModified": None,
+                "fileCount": 6,
                 "files": [
                     {
                         "debugId": None,
@@ -157,6 +169,9 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
             {
                 "bundleId": str(artifact_bundle.bundle_id),
                 "associations": [{"release": "1.0", "dist": None}],
+                "date": "2023-03-15T00:00:00Z",
+                "dateModified": None,
+                "fileCount": 6,
                 "files": [
                     {
                         "debugId": None,
@@ -179,6 +194,9 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
             {
                 "bundleId": str(artifact_bundle.bundle_id),
                 "associations": [{"release": "1.0", "dist": None}],
+                "date": "2023-03-15T00:00:00Z",
+                "dateModified": None,
+                "fileCount": 6,
                 "files": [
                     {
                         "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
@@ -237,6 +255,9 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
         assert response.data == {
             "bundleId": str(artifact_bundle.bundle_id),
             "associations": [],
+            "date": "2023-03-15T00:00:00Z",
+            "dateModified": None,
+            "fileCount": 6,
             "files": [
                 {
                     "debugId": None,
@@ -256,6 +277,9 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
         assert response.data == {
             "bundleId": str(artifact_bundle.bundle_id),
             "associations": [],
+            "date": "2023-03-15T00:00:00Z",
+            "dateModified": None,
+            "fileCount": 6,
             "files": [
                 {
                     "debugId": None,
@@ -291,6 +315,9 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
         assert response.data == {
             "bundleId": str(artifact_bundle.bundle_id),
             "associations": [],
+            "date": "2023-03-15T00:00:00Z",
+            "dateModified": None,
+            "fileCount": 6,
             "files": [
                 {
                     "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
@@ -317,6 +344,9 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
         assert response.data == {
             "bundleId": str(artifact_bundle.bundle_id),
             "associations": [],
+            "date": "2023-03-15T00:00:00Z",
+            "dateModified": None,
+            "fileCount": 6,
             "files": [
                 {
                     "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
@@ -343,6 +373,9 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
         assert response.data == {
             "bundleId": str(artifact_bundle.bundle_id),
             "associations": [],
+            "date": "2023-03-15T00:00:00Z",
+            "dateModified": None,
+            "fileCount": 6,
             "files": [
                 {
                     "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",


### PR DESCRIPTION
This PR improves the sourcemaps endpoint to support new UI features. The changes include:
* Added file count, date last modified and date uploaded fields to the response of the artifact bundle files endpoint.
* Change sorting order of associations by using the primary key order, which is the best field we have to define total order of associations without having to add an additional date field in the `ReleaseArtifactBundle` table.