### PR TITLE
chore(agg-spans): Check sentry_tags first for scrubbed span descriptions

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -252,9 +252,11 @@ class AggregateNodestoreSpans(BaseAggregateSpans):
                         "span_id": span["span_id"],
                         "is_segment": False,
                         "parent_span_id": span["parent_span_id"],
-                        "group": span.get("data", {}).get("span.group", NULL_GROUP),
+                        "group": span.get("sentry_tags", {}).get("group")
+                        or span.get("data", {}).get("span.group", NULL_GROUP),
                         "group_raw": span["hash"],
-                        "description": span.get("data", {}).get("span.description")
+                        "description": span.get("sentry_tags", {}).get("description")
+                        or span.get("data", {}).get("span.description")
                         or span.get("description", ""),
                         "op": span.get("op", ""),
                         "start_timestamp_ms": span["start_timestamp"]


### PR DESCRIPTION
Relay now double-writes span tags to span.data and span.sentry_tags - [example](https://sentry.sentry.io/api/0/projects/sentry/javascript/events/e55d61d855254371a14814c4a3eb9198/json/).
Read from `sentry_tags`, fallback to `data` (for older events that don't have `sentry_tags`
Remove references to data in a couple weeks.