### PR TITLE
fix(apidocs): Move Issue Alert Rule APIs to Alerts & Notifications

### DIFF
--- a/src/sentry/api/endpoints/notifications/notification_actions_details.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_details.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 @region_silo_endpoint
-@extend_schema(tags=["Notifications"])
+@extend_schema(tags=["Alerts"])
 class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
         "DELETE": ApiPublishStatus.PUBLIC,

--- a/src/sentry/api/endpoints/notifications/notification_actions_index.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_index.py
@@ -48,7 +48,7 @@ class NotificationActionsPermission(OrganizationPermission):
 
 
 @region_silo_endpoint
-@extend_schema(tags=["Notifications"])
+@extend_schema(tags=["Alerts"])
 class NotificationActionsIndexEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -94,7 +94,7 @@ class ProjectRuleDetailsPutSerializer(serializers.Serializer):
     )
 
 
-@extend_schema(tags=["Events"])
+@extend_schema(tags=["Alerts"])
 @region_silo_endpoint
 class ProjectRuleDetailsEndpoint(RuleEndpoint):
     publish_status = {

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -441,7 +441,7 @@ A list of filters that determine if a rule fires after the necessary conditions 
     )
 
 
-@extend_schema(tags=["Events"])
+@extend_schema(tags=["Alerts"])
 @region_silo_endpoint
 class ProjectRulesEndpoint(ProjectEndpoint):
     publish_status = {

--- a/src/sentry/apidocs/api_ownership_stats_dont_modify.json
+++ b/src/sentry/apidocs/api_ownership_stats_dont_modify.json
@@ -671,6 +671,7 @@
             "OrganizationProjectsExperimentEndpoint::POST",
             "OrganizationSCIMMemberDetails::PUT",
             "OrganizationSCIMTeamDetails::PUT",
+            "ReleaseThresholdIndexEndpoint::GET",
             "ReleaseThresholdStatusIndexEndpoint::GET"
         ],
         "unknown": [
@@ -707,7 +708,7 @@
         ]
     },
     "telemetry-experience": {
-        "block_start": 709,
+        "block_start": 710,
         "public": [],
         "private": [],
         "experimental": [
@@ -726,7 +727,7 @@
         ]
     },
     "team-starfish": {
-        "block_start": 727,
+        "block_start": 729,
         "public": [],
         "private": [],
         "experimental": [],
@@ -736,7 +737,7 @@
         ]
     },
     "growth": {
-        "block_start": 737,
+        "block_start": 739,
         "public": [],
         "private": [],
         "experimental": [],
@@ -745,7 +746,7 @@
         ]
     },
     "feedback-backend": {
-        "block_start": 746,
+        "block_start": 748,
         "public": [],
         "private": [],
         "experimental": [
@@ -757,7 +758,7 @@
         "unknown": []
     },
     "replay-backend": {
-        "block_start": 758,
+        "block_start": 760,
         "public": [],
         "private": [],
         "experimental": [],
@@ -766,7 +767,7 @@
         ]
     },
     "profiling": {
-        "block_start": 767,
+        "block_start": 769,
         "public": [],
         "private": [],
         "experimental": [],
@@ -782,7 +783,7 @@
         ]
     },
     "team-web-sdk-frontend": {
-        "block_start": 783,
+        "block_start": 785,
         "public": [],
         "private": [
             "SourceMapDebugBlueThunderEditionEndpoint::GET"
@@ -791,7 +792,7 @@
         "unknown": []
     },
     "hybrid-cloud": {
-        "block_start": 792,
+        "block_start": 794,
         "public": [],
         "private": [],
         "experimental": [],

--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -123,9 +123,9 @@ OPENAPI_TAGS = [
         },
     },
     {
-        "name": "Notifications",
-        "x-sidebar-name": "Notifications",
-        "description": "Endpoints for Notifications",
+        "name": "Alerts",
+        "x-sidebar-name": "Alerts & Notifications",
+        "description": "Endpoints for Alerts and Notifications",
         "x-display-description": False,
         "externalDocs": {
             "description": "Found an error? Let us know.",


### PR DESCRIPTION
This PR renames the Notifications section to Alerts & Notifications, and moves the Issue Alert Rule APIs to this section.

<img width="1512" alt="image" src="https://github.com/getsentry/sentry/assets/45607721/2716783b-af50-4f6a-86e7-d95db55ef08c">
