### PR TITLE
ref(database): Add min Android SDK version

### DIFF
--- a/static/app/views/performance/database/settings.ts
+++ b/static/app/views/performance/database/settings.ts
@@ -11,4 +11,5 @@ export const MIN_SDK_VERSION_BY_PLATFORM: {[platform: string]: string} = {
   'sentry.ruby': '5.11.0',
   'sentry.dotnet': '3.39.0',
   'sentry.symfony': '4.11.0',
+  'sentry.android': '6.30.0',
 };


### PR DESCRIPTION
As per https://www.notion.so/sentry/DB-Module-Minimum-SDK-Version-e1573de944504838add4e3ab606429f3 and https://github.com/getsentry/sentry-docs/pull/8147