### PR TITLE
fix(perf): Improve time spent percentage column

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -768,6 +768,7 @@ const SPECIAL_FUNCTIONS: SpecialFunctions = {
       <TimeSpentCell
         percentage={data[fieldName]}
         total={data[`sum(${SpanMetricsField.SPAN_SELF_TIME})`]}
+        op={data[`span.op`]}
       />
     );
   },

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -234,7 +234,7 @@ const CHART_HEIGHT = 160;
 
 const DEFAULT_SORT: Sort = {
   kind: 'desc',
-  field: 'time_spent_percentage(local)',
+  field: 'time_spent_percentage()',
 };
 
 const PaddedContainer = styled('div')`

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -473,7 +473,11 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                       />
                     </StyledTextOverflow>
                     <RightAlignedCell>
-                      <TimeSpentCell percentage={timeSpentPercentage} total={totalTime} />
+                      <TimeSpentCell
+                        percentage={timeSpentPercentage}
+                        total={totalTime}
+                        op="db"
+                      />
                     </RightAlignedCell>
                     {!props.withStaticFilters && (
                       <ListClose

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -62,10 +62,6 @@ export const STARFISH_FIELDS: Record<string, {outputType: AggregationOutputType}
   [SpanMetricsField.SPAN_SELF_TIME]: {
     outputType: 'duration',
   },
-  // local is only used with `time_spent_percentage` function
-  local: {
-    outputType: 'duration',
-  },
 };
 
 type Props = {

--- a/static/app/views/starfish/components/spanDescriptionLink.tsx
+++ b/static/app/views/starfish/components/spanDescriptionLink.tsx
@@ -3,10 +3,8 @@ import * as qs from 'query-string';
 
 import {useLocation} from 'sentry/utils/useLocation';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
-import {SpanFunction} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {useRoutingContext} from 'sentry/views/starfish/utils/routingContext';
-import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 
 interface Props {
   description: React.ReactNode;
@@ -32,16 +30,6 @@ export function SpanDescriptionLink({
     endpoint,
     endpointMethod,
   };
-
-  const sort: string | undefined = queryString[QueryParameterNames.SPANS_SORT];
-
-  // the spans page uses time_spent_percentage(local), so to persist the sort upon navigation we need to replace
-  if (sort?.includes(`${SpanFunction.TIME_SPENT_PERCENTAGE}()`)) {
-    queryString[QueryParameterNames.SPANS_SORT] = sort.replace(
-      `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
-      `${SpanFunction.TIME_SPENT_PERCENTAGE}(local)`
-    );
-  }
 
   return (
     <OverflowEllipsisTextContainer>

--- a/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
@@ -36,7 +36,6 @@ export const SORTABLE_FIELDS = new Set([
   `${SPS}()`,
   `${SPM}()`,
   `${TIME_SPENT_PERCENTAGE}()`,
-  `${TIME_SPENT_PERCENTAGE}(local)`,
   `${HTTP_ERROR_COUNT}()`,
 ]);
 

--- a/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
+++ b/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled';
 import clamp from 'lodash/clamp';
 
 import {Tooltip} from 'sentry/components/tooltip';
@@ -29,16 +28,7 @@ export function TimeSpentCell({percentage, total, op}: Props) {
     <TextAlignRight>
       <Tooltip isHoverable title={tooltip} showUnderline>
         {defined(total) ? formattedTotal : '--'}
-        <Deemphasized>
-          {' ('}
-          {defined(percentage) ? formattedPercentage : '--%'}
-          {')'}
-        </Deemphasized>
       </Tooltip>
     </TextAlignRight>
   );
 }
-
-const Deemphasized = styled('span')`
-  color: ${p => p.theme.gray300};
-`;

--- a/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
+++ b/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
@@ -6,19 +6,22 @@ import {tct} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {formatPercentage, getDuration} from 'sentry/utils/formatters';
 import {TextAlignRight} from 'sentry/views/starfish/components/textAlign';
+import {getSpanOperationDescription} from 'sentry/views/starfish/views/spanSummaryPage/getSpanOperationDescription';
 
 interface Props {
+  op?: string;
   percentage?: number;
   total?: number;
 }
 
-export function TimeSpentCell({percentage, total}: Props) {
+export function TimeSpentCell({percentage, total, op}: Props) {
   const formattedPercentage = formatPercentage(clamp(percentage ?? 0, 0, 1));
   const formattedTotal = getDuration((total ?? 0) / 1000, 2, true);
   const tooltip = tct(
-    'The application spent [percentage] of its total time on this span.',
+    'The application spent [percentage] of its total time on this [span].',
     {
       percentage: formattedPercentage,
+      span: getSpanOperationDescription(op ?? ''),
     }
   );
 

--- a/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
+++ b/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
@@ -3,17 +3,21 @@ import clamp from 'lodash/clamp';
 import {Tooltip} from 'sentry/components/tooltip';
 import {tct} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import {NumberContainer} from 'sentry/utils/discover/styles';
 import {formatPercentage, getDuration} from 'sentry/utils/formatters';
-import {TextAlignRight} from 'sentry/views/starfish/components/textAlign';
 import {getSpanOperationDescription} from 'sentry/views/starfish/views/spanSummaryPage/getSpanOperationDescription';
 
 interface Props {
+  containerProps?: React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >;
   op?: string;
   percentage?: number;
   total?: number;
 }
 
-export function TimeSpentCell({percentage, total, op}: Props) {
+export function TimeSpentCell({percentage, total, op, containerProps}: Props) {
   const formattedPercentage = formatPercentage(clamp(percentage ?? 0, 0, 1));
   const formattedTotal = getDuration((total ?? 0) / 1000, 2, true);
   const tooltip = tct(
@@ -25,10 +29,10 @@ export function TimeSpentCell({percentage, total, op}: Props) {
   );
 
   return (
-    <TextAlignRight>
+    <NumberContainer {...containerProps}>
       <Tooltip isHoverable title={tooltip} showUnderline>
         {defined(total) ? formattedTotal : '--'}
       </Tooltip>
-    </TextAlignRight>
+    </NumberContainer>
   );
 }

--- a/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
+++ b/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
@@ -1,11 +1,11 @@
 import clamp from 'lodash/clamp';
 
+import ExternalLink from 'sentry/components/links/externalLink';
 import {Tooltip} from 'sentry/components/tooltip';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {NumberContainer} from 'sentry/utils/discover/styles';
 import {formatPercentage, getDuration} from 'sentry/utils/formatters';
-import {getSpanOperationDescription} from 'sentry/views/starfish/views/spanSummaryPage/getSpanOperationDescription';
 
 interface Props {
   containerProps?: React.DetailedHTMLProps<
@@ -21,10 +21,13 @@ export function TimeSpentCell({percentage, total, op, containerProps}: Props) {
   const formattedPercentage = formatPercentage(clamp(percentage ?? 0, 0, 1));
   const formattedTotal = getDuration((total ?? 0) / 1000, 2, true);
   const tooltip = tct(
-    'The application spent [percentage] of its total time on this [span].',
+    'The application spent [percentage] of its total time on this [span]. Read more about Time Spent in our [documentation:documentation].',
     {
       percentage: formattedPercentage,
-      span: getSpanOperationDescription(op ?? ''),
+      span: getSpanOperationDescription(op),
+      documentation: (
+        <ExternalLink href="https://docs.sentry.io/product/performance/queries/#what-is-time-spent" />
+      ),
     }
   );
 
@@ -35,4 +38,32 @@ export function TimeSpentCell({percentage, total, op, containerProps}: Props) {
       </Tooltip>
     </NumberContainer>
   );
+}
+
+// TODO: This should use `getSpanOperationDescription` but it uppercases the
+// names. We should update `getSpanOperationDescription` to not uppercase the
+// descriptions needlessly, and use it here. Also, the names here are a little
+// shorter, which is friendlier
+function getSpanOperationDescription(spanOp?: string) {
+  if (spanOp?.startsWith('http')) {
+    return t('request');
+  }
+
+  if (spanOp?.startsWith('db')) {
+    return t('query');
+  }
+
+  if (spanOp?.startsWith('task')) {
+    return t('task');
+  }
+
+  if (spanOp?.startsWith('serialize')) {
+    return t('serializer');
+  }
+
+  if (spanOp?.startsWith('middleware')) {
+    return t('middleware');
+  }
+
+  return t('span');
 }

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -1,7 +1,6 @@
 import {Location} from 'history';
 import omit from 'lodash/omit';
 
-import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -24,7 +23,6 @@ export type SpanMetrics = {
   'spm()': number;
   'sum(span.self_time)': number;
   'time_spent_percentage()': number;
-  'time_spent_percentage(local)': number;
 };
 
 export const useSpanList = (
@@ -88,13 +86,8 @@ function getEventView(
     `sum(${SPAN_SELF_TIME})`,
     `avg(${SPAN_SELF_TIME})`,
     'http_error_count()',
+    'time_spent_percentage()',
   ];
-
-  if (defined(transaction)) {
-    fields.push('time_spent_percentage(local)');
-  } else {
-    fields.push('time_spent_percentage()');
-  }
 
   const eventView = EventView.fromNewQueryWithLocation(
     {

--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -16,7 +16,7 @@ export type SpanTransactionMetrics = {
   'http_error_count()': number;
   'spm()': number;
   'sum(span.self_time)': number;
-  'time_spent_percentage(local)': number;
+  'time_spent_percentage()': number;
   transaction: string;
   'transaction.method': string;
   'transaction.op': string;
@@ -68,11 +68,11 @@ function getEventView(location: Location, filters: MetricsFilters = {}, sorts?: 
         'spm()',
         `sum(${SPAN_SELF_TIME})`,
         `avg(${SPAN_SELF_TIME})`,
-        'time_spent_percentage(local)',
+        'time_spent_percentage()',
         'transaction.op',
         'http_error_count()',
       ],
-      orderby: '-time_spent_percentage_local',
+      orderby: '-time_spent_percentage',
       dataset: DiscoverDatasets.SPANS_METRICS,
       version: 2,
     },

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -59,8 +59,6 @@ export type MetricsResponse = {
   [Property in SpanStringFields as `${Property}`]: string;
 } & {
   [Property in SpanStringArrayFields as `${Property}`]: string[];
-} & {
-  'time_spent_percentage(local)': number;
 };
 
 export type MetricsFilters = {

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -146,5 +146,5 @@ export default SpanSummaryPage;
 
 const DEFAULT_SORT: Sort = {
   kind: 'desc',
-  field: 'time_spent_percentage(local)',
+  field: 'time_spent_percentage()',
 };

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -30,7 +30,7 @@ function SampleInfo(props: Props) {
       'spm()',
       `sum(${SPAN_SELF_TIME})`,
       `avg(${SPAN_SELF_TIME})`,
-      'time_spent_percentage(local)',
+      'time_spent_percentage()',
     ],
     'api.starfish.span-summary-panel-metrics'
   );

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -5,6 +5,7 @@ import {RateUnits} from 'sentry/utils/discover/fields';
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
+import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
@@ -53,10 +54,20 @@ function SampleInfo(props: Props) {
             unit={RateUnits.PER_MINUTE}
           />
         </Block>
+
         <Block title={DataTitles.avg} alignment="left">
           <DurationCell
             containerProps={{style}}
             milliseconds={spanMetrics?.[`avg(${SPAN_SELF_TIME})`]}
+          />
+        </Block>
+
+        <Block title={DataTitles.timeSpent} alignment="left">
+          <TimeSpentCell
+            containerProps={{style}}
+            percentage={spanMetrics?.[`time_spent_percentage()`]}
+            total={spanMetrics?.[`sum(${SPAN_SELF_TIME})`]}
+            op={spanMetrics?.['span.op']}
           />
         </Block>
       </BlockContainer>

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.spec.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.spec.tsx
@@ -18,6 +18,5 @@ describe('SpanMetricsRibbon', function () {
     expect(screen.getByText('17.8/min')).toBeInTheDocument();
     expect(screen.getByText('127.10ms')).toBeInTheDocument();
     expect(screen.getByText('19.54min')).toBeInTheDocument();
-    expect(screen.getByText(/0.2%/)).toBeInTheDocument();
   });
 });

--- a/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanMetricsRibbon.tsx
@@ -46,6 +46,7 @@ export function SpanMetricsRibbon({spanMetrics}: Props) {
         <TimeSpentCell
           percentage={spanMetrics?.[`${SpanFunction.TIME_SPENT_PERCENTAGE}()`]}
           total={spanMetrics?.[`sum(${SpanMetricsField.SPAN_SELF_TIME})`]}
+          op={op}
         />
       </Block>
     </BlockContainer>

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -126,11 +126,14 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
     }
 
     const renderer = getFieldRenderer(column.key, meta.fields, false);
-    const rendered = renderer(row, {
-      location,
-      organization,
-      unit: meta.units?.[column.key],
-    });
+    const rendered = renderer(
+      {...row, 'span.op': span['span.op']},
+      {
+        location,
+        organization,
+        unit: meta.units?.[column.key],
+      }
+    );
 
     return rendered;
   };

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -43,7 +43,7 @@ import type {ValidSort} from 'sentry/views/starfish/views/spans/useModuleSort';
 type Row = {
   'avg(span.self_time)': number;
   'spm()': number;
-  'time_spent_percentage(local)': number;
+  'time_spent_percentage()': number;
   transaction: string;
   transactionMethod: string;
 } & SpanTransactionMetrics;
@@ -217,7 +217,7 @@ const getColumnOrder = (
       ] as TableColumnHeader[])
     : []),
   {
-    key: 'time_spent_percentage(local)',
+    key: 'time_spent_percentage()',
     name: DataTitles.timeSpent,
     width: COL_WIDTH_UNDEFINED,
   },

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -8,7 +8,6 @@ import GridEditable, {
 } from 'sentry/components/gridEditable';
 import Pagination, {CursorHandler} from 'sentry/components/pagination';
 import {Organization} from 'sentry/types';
-import {defined} from 'sentry/utils';
 import {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
@@ -32,7 +31,6 @@ type Row = {
   'span.op': string;
   'spm()': number;
   'time_spent_percentage()': number;
-  'time_spent_percentage(local)': number;
 };
 
 type Column = GridColumnHeader<keyof Row>;
@@ -95,7 +93,7 @@ export default function SpansTable({
         <GridEditable
           isLoading={isLoading}
           data={data as Row[]}
-          columnOrder={columnOrder ?? getColumns(moduleName, spanCategory, endpoint)}
+          columnOrder={columnOrder ?? getColumns(moduleName, spanCategory)}
           columnSortBy={[
             {
               key: sort.field,
@@ -203,11 +201,7 @@ function getDescriptionHeader(moduleName: ModuleName, spanCategory?: string) {
   return 'Description';
 }
 
-function getColumns(
-  moduleName: ModuleName,
-  spanCategory?: string,
-  transaction?: string
-): Column[] {
+function getColumns(moduleName: ModuleName, spanCategory?: string): Column[] {
   const description = getDescriptionHeader(moduleName, spanCategory);
   const domain = getDomainHeader(moduleName);
 
@@ -254,21 +248,12 @@ function getColumns(
           } as Column,
         ]
       : []),
-  ];
-
-  if (defined(transaction)) {
-    order.push({
-      key: 'time_spent_percentage(local)',
-      name: DataTitles.timeSpent,
-      width: COL_WIDTH_UNDEFINED,
-    });
-  } else {
-    order.push({
+    {
       key: 'time_spent_percentage()',
       name: DataTitles.timeSpent,
       width: COL_WIDTH_UNDEFINED,
-    });
-  }
+    },
+  ];
 
   return order.filter((item): item is NonNullable<Column> => Boolean(item));
 }

--- a/static/app/views/starfish/views/spans/useModuleSort.ts
+++ b/static/app/views/starfish/views/spans/useModuleSort.ts
@@ -14,7 +14,6 @@ const SORTABLE_FIELDS = [
   `${SpanFunction.HTTP_ERROR_COUNT}()`,
   `${SpanFunction.SPM}()`,
   `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
-  `${SpanFunction.TIME_SPENT_PERCENTAGE}(local)`,
 ] as const;
 
 export type ValidSort = Sort & {

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -402,7 +402,7 @@ function SpanMetricsTable({
     <SpansTable
       moduleName={filter ?? ModuleName.ALL}
       sort={{
-        field: 'time_spent_percentage(local)',
+        field: 'time_spent_percentage()',
         kind: 'desc',
       }}
       endpoint={transaction}


### PR DESCRIPTION
A few major improvements!

1. No more local time spent percentage. All percentages are global to the app, for consistency. See more below
2. The percentage is only in the tooltip! It's distracting and not very important, so we're going to tuck it away
3. Time Spent comes back to the sample panel, it was missing briefly
4. Better tooltip explanation, with link to documentation.

**e.g.,**

![Screenshot 2023-10-05 at 2 37 46 PM](https://github.com/getsentry/sentry/assets/989898/b0e3f72d-348a-4bc4-af31-0cc3588d7e39)
![Screenshot 2023-10-05 at 2 37 51 PM](https://github.com/getsentry/sentry/assets/989898/1cb117cb-fbb3-4e1c-aaef-567c93706f9e)
![Screenshot 2023-10-05 at 2 37 59 PM](https://github.com/getsentry/sentry/assets/989898/70fc4f58-ea43-407c-9857-bbef0ee282c4)

## Time Spent

"Local" time spent was shown on the span summary page, in the table. Users there expected the percentage to sum to 100%, so we had to calculate time spent percentage relative to the _span_, not the app. This is confusing, hard to explain, hard to code around, and people didn't love it. Now that percentages aren't visible in the table, it's even less important. We won't be using local percentage for now.
