### PR TITLE
feat(agg-spans): Return sample span ids

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -1,7 +1,7 @@
 import hashlib
 from collections import defaultdict, namedtuple
 from datetime import datetime
-from typing import Any, Dict, List, Mapping, TypedDict
+from typing import Any, Dict, List, Mapping, Set, Tuple, TypedDict
 
 import sentry_sdk
 from rest_framework import status
@@ -60,6 +60,7 @@ AggregateSpanRow = TypedDict(
         "avg(absolute_offset)": float,
         "avg(relative_offset)": float,
         "count()": int,
+        "samples": Set[Tuple[str, str]],
     },
 )
 

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -1,7 +1,7 @@
 import hashlib
 from collections import defaultdict, namedtuple
 from datetime import datetime
-from typing import Any, Dict, List, Mapping, Set, Tuple, TypedDict
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, TypedDict
 
 import sentry_sdk
 from rest_framework import status
@@ -60,7 +60,7 @@ AggregateSpanRow = TypedDict(
         "avg(absolute_offset)": float,
         "avg(relative_offset)": float,
         "count()": int,
-        "samples": Set[Tuple[str, str]],
+        "samples": Set[Tuple[Optional[str], str]],
     },
 )
 
@@ -70,7 +70,7 @@ NULL_GROUP = "00"
 class BaseAggregateSpans:
     def __init__(self) -> None:
         self.aggregated_tree: Dict[str, AggregateSpanRow] = {}
-        self.current_transaction = None
+        self.current_transaction: Optional[str] = None
 
     def fingerprint_nodes(
         self,

--- a/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
+++ b/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
@@ -227,7 +227,7 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
         )
         self.trace_id_1 = uuid4().hex
 
-        self.root_event = self.create_event(
+        self.root_event_1 = self.create_event(
             trace=self.trace_id_1,
             trace_context={
                 "trace_id": self.trace_id_1,
@@ -306,7 +306,7 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
         )
         self.trace_id_2 = uuid4().hex
 
-        self.root_event = self.create_event(
+        self.root_event_2 = self.create_event(
             trace=self.trace_id_2,
             trace_context={
                 "trace_id": self.trace_id_2,
@@ -418,6 +418,17 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
             assert data[root_fingerprint]["count()"] == 2
             assert data[root_fingerprint]["description"] == "api/0/foo"
             assert round(data[root_fingerprint]["avg(duration)"]) == 850
+
+            if backend == "indexedSpans":
+                assert data[root_fingerprint]["samples"] == {
+                    ("80fe542aea4945ffbe612646987ee449", "root_1"),
+                    ("86b21833d1854d9b811000b91e7fccfa", "root_2"),
+                }
+            else:
+                assert data[root_fingerprint]["samples"] == {
+                    (self.root_event_1.event_id, self.span_ids_event_1["A"]),
+                    (self.root_event_2.event_id, self.span_ids_event_2["A"]),
+                }
 
             fingerprint = hashlib.md5(b"e238e6c2e2466b07-B").hexdigest()[:16]
             assert data[fingerprint]["description"] == "connect"


### PR DESCRIPTION
Returns up to 5 sample span ids per fingerprint:
samples array is a tuple of transaction_id, span_id