### PR TITLE
fix(hybridcloud) Generate region URLs correctly in control

### DIFF
--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -265,6 +265,7 @@ def _find_orgs_for_user(user_id: int) -> Set[int]:
     }
 
 
+@control_silo_function
 def find_regions_for_orgs(org_ids: Container[int]) -> Set[str]:
     from sentry.models.organizationmapping import OrganizationMapping
 

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -221,11 +221,14 @@ class _ClientConfig:
             generate_organization_url(self.last_org_slug) if self.last_org_slug else None
         )
         region_url = None
-        if self.last_org and SiloMode.get_current_mode() == SiloMode.CONTROL:
-            organization_mapping = OrganizationMapping.objects.get(organization_id=self.last_org.id)
-            region_url = generate_region_url(organization_mapping.region_name)
-        else:
-            region_url = generate_region_url()
+        if self.last_org:
+            if SiloMode.get_current_mode() == SiloMode.CONTROL:
+                organization_mapping = OrganizationMapping.objects.get(
+                    organization_id=self.last_org.id
+                )
+                region_url = generate_region_url(organization_mapping.region_name)
+            else:
+                region_url = generate_region_url()
 
         yield "organizationUrl", organization_url
         yield "regionUrl", region_url

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -14,12 +14,14 @@ from sentry import features, options
 from sentry.api.utils import generate_organization_url, generate_region_url
 from sentry.auth import superuser
 from sentry.auth.superuser import is_active_superuser
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.auth import AuthenticatedToken, AuthenticationContext
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.services.hybrid_cloud.project_key import ProjectKeyRole, project_key_service
 from sentry.services.hybrid_cloud.user import UserSerializeType
 from sentry.services.hybrid_cloud.user.serial import serialize_generic_user
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.silo.base import SiloMode
 from sentry.types.region import find_all_multitenant_region_names, get_region_by_name
 from sentry.utils import auth, json
 from sentry.utils.assets import get_frontend_dist_prefix
@@ -214,12 +216,19 @@ class _ClientConfig:
         return self.request is not None and self.user is not None and self.user.is_superuser
 
     @property
-    def links(self) -> Iterable[Tuple[str, str]]:
+    def links(self) -> Iterable[Tuple[str, str | None]]:
         organization_url = (
             generate_organization_url(self.last_org_slug) if self.last_org_slug else None
         )
+        region_url = None
+        if self.last_org and SiloMode.get_current_mode() == SiloMode.CONTROL:
+            organization_mapping = OrganizationMapping.objects.get(organization_id=self.last_org.id)
+            region_url = generate_region_url(organization_mapping.region_name)
+        else:
+            region_url = generate_region_url()
+
         yield "organizationUrl", organization_url
-        yield "regionUrl", generate_region_url() if self.last_org_slug else None
+        yield "regionUrl", region_url
         yield "sentryUrl", options.get("system.url-prefix")
 
         if self._is_superuser() and superuser.ORG_ID is not None:


### PR DESCRIPTION
We get the initial page response from control silo, and because of that we can't rely on the implicit ambient region. Instead we have to fetch the mapping record to access an org's region.