### PR TITLE
feat(profiling): link to flamechart and use area chart

### DIFF
--- a/static/app/views/profiling/landing/profilesSummaryChart.tsx
+++ b/static/app/views/profiling/landing/profilesSummaryChart.tsx
@@ -2,8 +2,8 @@ import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {AreaChart, AreaChartProps} from 'sentry/components/charts/areaChart';
 import ChartZoom from 'sentry/components/charts/chartZoom';
-import {LineChart, LineChartProps} from 'sentry/components/charts/lineChart';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {PageFilters} from 'sentry/types';
@@ -100,8 +100,8 @@ export function ProfilesSummaryChart({
     return allSeries;
   }, [profileStats, seriesOrder]);
 
-  const chartProps: LineChartProps = useMemo(() => {
-    const baseProps: LineChartProps = {
+  const chartProps: AreaChartProps = useMemo(() => {
+    const baseProps: AreaChartProps = {
       height: 150,
       series,
       grid: [
@@ -177,7 +177,7 @@ export function ProfilesSummaryChart({
       <ProfilesChartTitle>{t('Profile durations')}</ProfilesChartTitle>
       <ChartZoom router={router} {...selection?.datetime}>
         {zoomRenderProps => (
-          <LineChart
+          <AreaChart
             {...chartProps}
             isGroupedByDate
             showTimeInTooltip

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -542,6 +542,7 @@ const ProfileDigestContainer = styled('div')`
   flex: 1 1 100%;
   flex-direction: column;
   position: relative;
+  overflow: hidden;
 `;
 
 const ProfileDigestScrollContainer = styled('div')`
@@ -551,7 +552,8 @@ const ProfileDigestScrollContainer = styled('div')`
   right: 0;
   top: 0;
   bottom: 0;
-  overflow: auto;
+  display: flex;
+  flex-direction: column;
 `;
 
 const ProfileVisualizationContainer = styled('div')`

--- a/static/app/views/profiling/profileSummary/regressedProfileFunctions.tsx
+++ b/static/app/views/profiling/profileSummary/regressedProfileFunctions.tsx
@@ -11,8 +11,8 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 
-const MAX_REGRESSED_FUNCTIONS = 5;
-const REGRESSIONS_CURSOR = 'functionRegressionCursor';
+const REGRESSED_FUNCTIONS_LIMIT = 5;
+const REGRESSED_FUNCTIONS_CURSOR = 'functionRegressionCursor';
 
 interface MostRegressedProfileFunctionsProps {
   transaction: string;
@@ -22,14 +22,14 @@ export function MostRegressedProfileFunctions(props: MostRegressedProfileFunctio
   const location = useLocation();
 
   const fnTrendCursor = useMemo(
-    () => decodeScalar(location.query[REGRESSIONS_CURSOR]),
+    () => decodeScalar(location.query[REGRESSED_FUNCTIONS_CURSOR]),
     [location.query]
   );
 
   const handleRegressedFunctionsCursor = useCallback((cursor, pathname, query) => {
     browserHistory.push({
       pathname,
-      query: {...query, [REGRESSIONS_CURSOR]: cursor},
+      query: {...query, [REGRESSED_FUNCTIONS_CURSOR]: cursor},
     });
   }, []);
 
@@ -44,7 +44,7 @@ export function MostRegressedProfileFunctions(props: MostRegressedProfileFunctio
     trendFunction: 'p95()',
     trendType: 'regression',
     query: functionQuery,
-    limit: MAX_REGRESSED_FUNCTIONS,
+    limit: REGRESSED_FUNCTIONS_LIMIT,
     cursor: fnTrendCursor,
   });
 
@@ -80,7 +80,7 @@ export function MostRegressedProfileFunctions(props: MostRegressedProfileFunctio
 }
 
 const RegressedFunctionsContainer = styled('div')`
-  min-height: 80px;
+  flex-basis: 80px;
   margin-top: ${space(0.5)};
 `;
 


### PR DESCRIPTION
Adjusts UI so that the lists on the right hand side are scrollable and uses an area chart

<img width="1298" alt="CleanShot 2023-10-05 at 16 04 54@2x" src="https://github.com/getsentry/sentry/assets/9317857/9fbde8cc-35e1-433d-baa6-9dbfab925a5d">
