### PR TITLE
fix(stat-detector): Account for Added spans

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
@@ -164,6 +164,10 @@ function renderBodyCell({
     const strippedLabel = Math.abs(percentDelta).toFixed(2);
     const isPositive = percentDelta > 0;
 
+    const labelContent =
+      row[`${prefix}_before`] !== 0
+        ? `${isPositive ? '+' : '-'}${strippedLabel}%`
+        : t('Added');
     return (
       <Tooltip
         title={tct('From [before] to [after]', {
@@ -171,9 +175,7 @@ function renderBodyCell({
           after: `${row[`${prefix}_after`].toFixed(2)}${unitSuffix}`,
         })}
       >
-        <ChangeLabel isPositive={isPositive}>{`${
-          isPositive ? '+' : '-'
-        }${strippedLabel}%`}</ChangeLabel>
+        <ChangeLabel isPositive={isPositive}>{labelContent}</ChangeLabel>
       </Tooltip>
     );
   }


### PR DESCRIPTION
When calculating the percent change in the aggregate span view, a new span shows "Infinity" because we divide by 0. This checks the before to change the label to "Added" instead of "+Infinity"
