### PR TITLE
feat(browser-starfish): fetch real resources in resource module

### DIFF
--- a/static/app/views/performance/browser/resources/index.tsx
+++ b/static/app/views/performance/browser/resources/index.tsx
@@ -116,9 +116,9 @@ function ResourceTypeSelector({value}: {value?: string}) {
 
   const options: Option[] = [
     {value: '', label: 'All'},
-    {value: 'resource.script', label: 'JavaScript (.js)'},
-    {value: '.css', label: 'Stylesheets (.css)'},
-    {value: 'resource.img', label: 'Images (.png, .jpg, .jpeg, .gif, etc)'},
+    {value: 'resource.script', label: `${t('JavaScript')} (.js)`},
+    {value: '.css', label: `${t('Stylesheet')} (.css)`},
+    {value: 'resource.img', label: `${t('Images')} (.png, .jpg, .jpeg, .gif, etc)`},
   ];
   return (
     <SelectControlWithProps

--- a/static/app/views/performance/browser/resources/index.tsx
+++ b/static/app/views/performance/browser/resources/index.tsx
@@ -116,7 +116,7 @@ function ResourceTypeSelector({value}: {value?: string}) {
 
   const options: Option[] = [
     {value: '', label: 'All'},
-    {value: 'resource.script', label: 'Javscript (.js)'},
+    {value: 'resource.script', label: 'JavaScript (.js)'},
     {value: '.css', label: 'Stylesheets (.css)'},
     {value: 'resource.img', label: 'Images (.png, .jpg, .jpeg, .gif, etc)'},
   ];

--- a/static/app/views/performance/browser/resources/index.tsx
+++ b/static/app/views/performance/browser/resources/index.tsx
@@ -116,9 +116,9 @@ function ResourceTypeSelector({value}: {value?: string}) {
 
   const options: Option[] = [
     {value: '', label: 'All'},
-    {value: '.js', label: 'Javscript (.js)'},
+    {value: 'resource.script', label: 'Javscript (.js)'},
     {value: '.css', label: 'Stylesheets (.css)'},
-    {value: '.png', label: 'Images (.png, .jpg, .jpeg, .gif, etc)'},
+    {value: 'resource.img', label: 'Images (.png, .jpg, .jpeg, .gif, etc)'},
   ];
   return (
     <SelectControlWithProps

--- a/static/app/views/performance/browser/resources/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceTable.tsx
@@ -103,7 +103,7 @@ function ResourceTable({sort}: Props) {
       return <DurationCell milliseconds={row[key]} />;
     }
     if (key === 'span.op') {
-      const opName = row[key] === 'resource.script' ? 'Javascript' : 'Image';
+      const opName = row[key] === 'resource.script' ? t('Javascript') : t('Image');
       return <span>{opName}</span>;
     }
     if (key === 'http.decoded_response_content_length') {

--- a/static/app/views/performance/browser/resources/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceTable.tsx
@@ -10,12 +10,14 @@ import GridEditable, {
 } from 'sentry/components/gridEditable';
 import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
+import {RateUnits} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {BrowserStarfishFields} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {ValidSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
 import {useResourcesQuery} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
+import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
 
 type Row = {
   'avg(span.self_time)': number;
@@ -26,6 +28,7 @@ type Row = {
   'span.description': string;
   'span.group': string;
   'span.op': 'resource.script' | 'resource.img';
+  'spm()': number;
 };
 
 type Column = GridColumnHeader<keyof Row>;
@@ -40,8 +43,13 @@ function ResourceTable({sort}: Props) {
 
   const columnOrder: GridColumnOrder<keyof Row>[] = [
     {key: 'span.description', width: COL_WIDTH_UNDEFINED, name: 'Resource name'},
-    {key: 'span.op', width: COL_WIDTH_UNDEFINED, name: 'Resource type'},
+    {key: 'span.op', width: COL_WIDTH_UNDEFINED, name: 'Type'},
     {key: 'avg(span.self_time)', width: COL_WIDTH_UNDEFINED, name: 'Avg Duration'},
+    {
+      key: 'spm()',
+      width: COL_WIDTH_UNDEFINED,
+      name: 'Throughput',
+    },
     {
       key: 'http.response_content_length',
       width: COL_WIDTH_UNDEFINED,
@@ -84,6 +92,9 @@ function ResourceTable({sort}: Props) {
           {row[key]}
         </Link>
       );
+    }
+    if (key === 'spm()') {
+      return <ThroughputCell rate={row[key]} unit={RateUnits.PER_SECOND} />;
     }
     if (key === 'http.response_content_length') {
       return <FileSize bytes={row[key]} />;

--- a/static/app/views/performance/browser/resources/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceTable.tsx
@@ -8,22 +8,24 @@ import GridEditable, {
   GridColumnHeader,
   GridColumnOrder,
 } from 'sentry/components/gridEditable';
+import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
 import {BrowserStarfishFields} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {ValidSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
+import {useResourcesQuery} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 
 type Row = {
-  'avg(span.duration)': number;
-  description: string;
+  'avg(span.self_time)': number;
   domain: string;
   'http.decoded_response_content_length': number;
   'http.response_content_length': number;
   'resource.render_blocking_status': string;
+  'span.description': string;
   'span.group': string;
-  type: string;
+  'span.op': 'resource.script' | 'resource.img';
 };
 
 type Column = GridColumnHeader<keyof Row>;
@@ -34,9 +36,12 @@ type Props = {
 
 function ResourceTable({sort}: Props) {
   const location = useLocation();
+  const {data, isLoading, pageLinks} = useResourcesQuery({sort});
+
   const columnOrder: GridColumnOrder<keyof Row>[] = [
-    {key: 'description', width: COL_WIDTH_UNDEFINED, name: 'Resource name'},
-    {key: 'avg(span.duration)', width: COL_WIDTH_UNDEFINED, name: 'Avg Duration'},
+    {key: 'span.description', width: COL_WIDTH_UNDEFINED, name: 'Resource name'},
+    {key: 'span.op', width: COL_WIDTH_UNDEFINED, name: 'Resource type'},
+    {key: 'avg(span.self_time)', width: COL_WIDTH_UNDEFINED, name: 'Avg Duration'},
     {
       key: 'http.response_content_length',
       width: COL_WIDTH_UNDEFINED,
@@ -53,33 +58,23 @@ function ResourceTable({sort}: Props) {
       name: 'Uncompressed',
     },
   ];
-  const tableData: Row[] = [
-    {
-      'avg(span.duration)': 20,
-      description:
-        'app_components_events_interfaces_spans_constants_tsx-app_components_gridEditable_styles_tsx-a-1f90d6.***.js',
-      domain: 's1.sentry-cdn.com',
-      'http.decoded_response_content_length': 300,
-      'http.response_content_length': 300,
-      'resource.render_blocking_status': 'non-blocking',
-      type: '.js',
-      'span.group': 'group123',
-    },
-    {
-      'avg(span.duration)': 25,
-      description: 'app_bootstrap_initializeMain_tsx.***.js',
-      domain: 's1.sentry-cdn.com',
-      'http.decoded_response_content_length': 150,
-      'http.response_content_length': 200,
-      'resource.render_blocking_status': 'blocking',
-      type: '.js',
-      'span.group': 'group456',
-    },
-  ];
+  const tableData: Row[] = data.length
+    ? data.map(span => ({
+        ...span,
+        'http.decoded_response_content_length': Math.floor(
+          Math.random() * (1000 - 500) + 500
+        ),
+        'http.response_content_length': Math.floor(Math.random() * (500 - 50) + 50),
+        'resource.render_blocking_status':
+          Math.random() > 0.5 ? 'blocking' : 'non-blocking',
+        'span.group': 'group123',
+        domain: 's1.sentry-cdn.com',
+      }))
+    : [];
 
   const renderBodyCell = (col: Column, row: Row) => {
     const {key} = col;
-    if (key === 'description') {
+    if (key === 'span.description') {
       const query = {
         ...location.query,
         [BrowserStarfishFields.DESCRIPTION]: row[key],
@@ -93,8 +88,12 @@ function ResourceTable({sort}: Props) {
     if (key === 'http.response_content_length') {
       return <FileSize bytes={row[key]} />;
     }
-    if (key === 'avg(span.duration)') {
+    if (key === 'avg(span.self_time)') {
       return <DurationCell milliseconds={row[key]} />;
+    }
+    if (key === 'span.op') {
+      const opName = row[key] === 'resource.script' ? 'Javascript' : 'Image';
+      return <span>{opName}</span>;
     }
     if (key === 'http.decoded_response_content_length') {
       const isCompressed =
@@ -109,7 +108,7 @@ function ResourceTable({sort}: Props) {
     <Fragment>
       <GridEditable
         data={tableData}
-        isLoading={false}
+        isLoading={isLoading}
         columnOrder={columnOrder}
         columnSortBy={[
           {
@@ -128,6 +127,7 @@ function ResourceTable({sort}: Props) {
         }}
         location={location}
       />
+      <Pagination pageLinks={pageLinks} />
     </Fragment>
   );
 }

--- a/static/app/views/performance/browser/resources/utils/useResourceFilters.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceFilters.ts
@@ -12,7 +12,7 @@ export enum BrowserStarfishFields {
 
 export type ModuleFilters = {
   [BrowserStarfishFields.DOMAIN]?: string;
-  [BrowserStarfishFields.RESOURCE_TYPE]?: string;
+  [BrowserStarfishFields.RESOURCE_TYPE]?: 'resource.script' | 'resource.img';
   [BrowserStarfishFields.PAGE]?: string;
 };
 

--- a/static/app/views/performance/browser/resources/utils/useResourceSort.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceSort.ts
@@ -7,7 +7,7 @@ type Query = {
   sort?: string;
 };
 
-const SORTABLE_FIELDS = ['avg(span.duration)'] as const;
+const SORTABLE_FIELDS = ['avg(span.self_time)', 'span.description'] as const;
 
 export type ValidSort = Sort & {
   field: (typeof SORTABLE_FIELDS)[number];

--- a/static/app/views/performance/browser/resources/utils/useResourceSort.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceSort.ts
@@ -7,7 +7,7 @@ type Query = {
   sort?: string;
 };
 
-const SORTABLE_FIELDS = ['avg(span.self_time)', 'span.description'] as const;
+const SORTABLE_FIELDS = ['avg(span.self_time)', 'span.description', 'spm()'] as const;
 
 export type ValidSort = Sort & {
   field: (typeof SORTABLE_FIELDS)[number];

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -1,0 +1,46 @@
+import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
+import {ValidSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
+
+export const useResourcesQuery = ({sort}: {sort: ValidSort}) => {
+  const pageFilters = usePageFilters();
+  const location = useLocation();
+  const resourceFilters = useResourceModuleFilters();
+  const {slug: orgSlug} = useOrganization();
+  const queryConditions = [
+    `span.op:[${resourceFilters.type || 'resource.script, resource.img'}]`,
+  ];
+
+  // TODO - we should be using metrics data here
+  const eventView = EventView.fromNewQueryWithPageFilters(
+    {
+      fields: ['span.description', 'span.op', 'count()', 'avg(span.self_time)'],
+      name: 'Resource module - resource table',
+      query: queryConditions.join(' '),
+      orderby: '-count',
+      version: 2,
+      dataset: DiscoverDatasets.SPANS_METRICS,
+    },
+    pageFilters.selection
+  );
+
+  if (sort) {
+    eventView.sorts = [sort];
+  }
+
+  const result = useDiscoverQuery({eventView, limit: 100, location, orgSlug});
+
+  const data = result?.data?.data.map(row => ({
+    'span.op': row['span.op'].toString() as 'resource.script' | 'resource.img',
+    'span.description': row['span.description'].toString(),
+    'avg(span.self_time)': row['avg(span.self_time)'] as number,
+    'count()': row['count()'] as number,
+  }));
+
+  return {...result, data: data || []};
+};

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -19,7 +19,7 @@ export const useResourcesQuery = ({sort}: {sort: ValidSort}) => {
   // TODO - we should be using metrics data here
   const eventView = EventView.fromNewQueryWithPageFilters(
     {
-      fields: ['span.description', 'span.op', 'count()', 'avg(span.self_time)'],
+      fields: ['span.description', 'span.op', 'count()', 'avg(span.self_time)', 'spm()'],
       name: 'Resource module - resource table',
       query: queryConditions.join(' '),
       orderby: '-count',
@@ -40,6 +40,7 @@ export const useResourcesQuery = ({sort}: {sort: ValidSort}) => {
     'span.description': row['span.description'].toString(),
     'avg(span.self_time)': row['avg(span.self_time)'] as number,
     'count()': row['count()'] as number,
+    'spm()': row['spm()'] as number,
   }));
 
   return {...result, data: data || []};


### PR DESCRIPTION
3 main changes.
1. Fetch actual resource data (exception here is the size, uncompressed, and render blocking, we're working on adding those)
2. Allow sorting on avg duration
3. Allow filtering on javascript or image resoruces in the resource type dropdown.

<img width="940" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/04fa9a52-a9ad-48a5-850b-41c3443d225e">
