### PR TITLE
fix(escalating): Fix forecast out of range error

### DIFF
--- a/src/sentry/issues/escalating_group_forecast.py
+++ b/src/sentry/issues/escalating_group_forecast.py
@@ -77,12 +77,16 @@ class EscalatingGroupForecast:
 
         date_added = escalating_forecast.date_added.date()
         forecast_today_index = (date_now - date_added).days
-        if forecast_today_index >= len(escalating_forecast.forecast):
+
+        if forecast_today_index == len(escalating_forecast.forecast):
+            # Use last available forecast since the previous nodestore forecast hasn't expired yet
+            forecast_today_index = -1
+        elif forecast_today_index > len(escalating_forecast.forecast):
+            # This should not happen, but exists as a check
+            forecast_today_index = -1
             logger.error(
                 f"Forecast list index is out of range. Index: {forecast_today_index}. Date now: {date_now}. Forecast date added: {date_added}."
             )
-            # Use last available forecast as a fallback
-            forecast_today_index = -1
         return escalating_forecast.forecast[forecast_today_index]
 
     @classmethod

--- a/tests/sentry/issues/test_escalating.py
+++ b/tests/sentry/issues/test_escalating.py
@@ -356,3 +356,31 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
             )
             assert is_escalating(archived_group) == (True, 1)
             logger.error.assert_called_once()
+
+    @freeze_time(datetime(2023, 10, 5, hour=6, minute=6, second=0, microsecond=0))
+    def test_is_escalating_two_weeks(self) -> None:
+        """
+        Test when an archived until escalating issue starts escalating after exactly 2 weeks.
+        This can happen when the previous nodestore forecast hasn't expired yet.
+        """
+        with self.feature("organizations:escalating-issues"):
+            # The group had 6 events in the last hour
+            event = self._create_events_for_group(count=6)
+            assert event.group is not None
+            archived_group = event.group
+            self.archive_until_escalating(archived_group)
+
+            # The escalating forecast for today is 5, thus, it should escalate
+            forecast_values = [5] * 14
+            self.save_mock_escalating_group_forecast(
+                group=archived_group,
+                forecast_values=forecast_values,
+                date_added=datetime(2023, 9, 21),
+            )
+            assert is_escalating(archived_group) == (True, 5)
+
+            # Test cache
+            assert (
+                cache.get(f"hourly-group-count:{archived_group.project.id}:{archived_group.id}")
+                == 6
+            )


### PR DESCRIPTION
When the index = 14, it's not actually out of range as it is within 2 weeks.
Use the 14th day forecast in this case.

fixes SENTRY-150N
