### PR TITLE
feat(crons): Backlink to monitors from crons issue

### DIFF
--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -1,9 +1,12 @@
 import {Fragment, useRef} from 'react';
 import styled from '@emotion/styled';
 
+import {LinkButton} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {Overlay} from 'sentry/components/overlay';
 import Panel from 'sentry/components/panels/panel';
+import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {fadeIn} from 'sentry/styles/animations';
 import {space} from 'sentry/styles/space';
@@ -73,12 +76,25 @@ export function CronTimelineSection({event, organization}: Props) {
   const eventTickLeft =
     (new Date(event.dateReceived).valueOf() - start.valueOf()) / msPerPixel;
 
+  const actions = (
+    <ButtonBar gap={1}>
+      <MonitorLinkButton
+        size="sm"
+        icon={<IconOpen size="xs" />}
+        to={`/organizations/${organization.slug}/crons/${monitorSlug}`}
+      >
+        {t('View in monitor details')}
+      </MonitorLinkButton>
+      <ResolutionSelector />
+    </ButtonBar>
+  );
+
   return (
     <EventDataSection
       title={t('Check-ins')}
       type="check-ins"
       help={t('A timeline of check-ins that happened before and after this event')}
-      actions={<ResolutionSelector />}
+      actions={actions}
     >
       <TimelineContainer>
         <TimelineWidthTracker ref={elementRef} />
@@ -119,6 +135,11 @@ export function CronTimelineSection({event, organization}: Props) {
     </EventDataSection>
   );
 }
+
+const MonitorLinkButton = styled(LinkButton)`
+  height: 26px;
+  min-height: 26px;
+`;
 
 const TimelineContainer = styled(Panel)`
   display: grid;

--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -78,13 +78,13 @@ export function CronTimelineSection({event, organization}: Props) {
 
   const actions = (
     <ButtonBar gap={1}>
-      <MonitorLinkButton
-        size="sm"
+      <LinkButton
+        size="xs"
         icon={<IconOpen size="xs" />}
         to={`/organizations/${organization.slug}/crons/${monitorSlug}`}
       >
-        {t('View in monitor details')}
-      </MonitorLinkButton>
+        {t('View in Monitor Details')}
+      </LinkButton>
       <ResolutionSelector />
     </ButtonBar>
   );
@@ -135,11 +135,6 @@ export function CronTimelineSection({event, organization}: Props) {
     </EventDataSection>
   );
 }
-
-const MonitorLinkButton = styled(LinkButton)`
-  height: 26px;
-  min-height: 26px;
-`;
 
 const TimelineContainer = styled(Panel)`
   display: grid;


### PR DESCRIPTION
Adds a `View in monitor details` button. Placement of this button is subject to a bit of discussion, but will leave this as is for now, with opportunity to relocate the button into the issue details header in the future (perhaps next to `Open in Discover`)

<img width="904" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/c2c8ac9b-56af-44d3-ba3e-3f709c9f6b4a">


Fixes: https://github.com/getsentry/sentry/issues/57445
