### PR TITLE
fix(issue-platform): use isoformat for default received

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -134,7 +134,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                     "level": occurrence_data["level"],
                     "project_id": event_payload.get("project_id"),
                     "platform": event_payload.get("platform"),
-                    "received": event_payload.get("received", timezone.now()),
+                    "received": event_payload.get("received", timezone.now().isoformat()),
                     "tags": event_payload.get("tags"),
                     "timestamp": event_payload.get("timestamp"),
                 }

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -143,6 +143,27 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
             with self.feature("organizations:profile-file-io-main-thread-ingest"):
                 _process_message(message)
 
+    @django_db_all
+    def test_occurrence_consumer_no_received(self) -> None:
+        message = get_test_message(self.project.id)
+        del message["event"]["received"]
+        with self.feature("organizations:profile-file-io-main-thread-ingest"):
+            result = _process_message(message)
+        assert result is not None
+        occurrence = result[0]
+
+        fetched_occurrence = IssueOccurrence.fetch(occurrence.id, self.project.id)
+        assert fetched_occurrence is not None
+        self.assert_occurrences_identical(occurrence, fetched_occurrence)
+        assert fetched_occurrence.event_id is not None
+        fetched_event = self.eventstore.get_event_by_id(
+            self.project.id, fetched_occurrence.event_id
+        )
+        assert fetched_event is not None
+        assert fetched_event.get_event_type() == "generic"
+
+        assert Group.objects.filter(grouphash__hash=occurrence.fingerprint[0]).exists()
+
 
 class IssueOccurrenceLookupEventIdTest(IssueOccurrenceTestBase):
     def test_lookup_event_doesnt_exist(self) -> None:


### PR DESCRIPTION
In the event schema, it was expecting received to be a string, but the default value was a datetime. This PR changes it so the default format is now a string, using `isoformat`, with a test to validate.