### PR TITLE
feat(replay): Highlight when Network request/resposes have different content-types

### DIFF
--- a/static/app/components/keyValueTable.tsx
+++ b/static/app/components/keyValueTable.tsx
@@ -7,6 +7,8 @@ import {space} from 'sentry/styles/space';
 type Props = {
   keyName: React.ReactNode;
   value: React.ReactNode;
+  tooltip?: string;
+  type?: undefined | 'error' | 'warning';
 };
 
 export const KeyValueTable = styled('dl')<{noMargin?: boolean}>`
@@ -15,32 +17,40 @@ export const KeyValueTable = styled('dl')<{noMargin?: boolean}>`
   ${p => (p.noMargin ? 'margin-bottom: 0;' : null)}
 `;
 
-export function KeyValueTableRow({keyName, value}: Props) {
+export function KeyValueTableRow({keyName, value, type}: Props) {
   return (
     <Fragment>
-      <Key>{keyName}</Key>
-      <Value>{value}</Value>
+      <Key type={type}>{keyName}</Key>
+      <Value type={type}>{value}</Value>
     </Fragment>
   );
 }
 
-const commonStyles = ({theme}: {theme: Theme}) => `
-font-size: ${theme.fontSizeMedium};
-padding: ${space(0.5)} ${space(1)};
-font-weight: normal;
-line-height: inherit;
-${p => p.theme.overflowEllipsis};
-&:nth-of-type(2n-1) {
-  background-color: ${theme.backgroundSecondary};
-}
+const commonStyles = ({theme, type}: {type: Props['type']} & {theme: Theme}) => `
+  font-size: ${theme.fontSizeMedium};
+  padding: ${space(0.5)} ${space(1)};
+  font-weight: normal;
+  line-height: inherit;
+  ${p => p.theme.overflowEllipsis};
+
+  background-color: ${
+    type === 'error'
+      ? theme.red100 + ' !important'
+      : type === 'warning'
+      ? 'var(--background-warning-default, rgba(245, 176, 0, 0.09)) !important'
+      : 'inherit'
+  };
+  &:nth-of-type(2n-1) {
+    background-color: ${theme.backgroundSecondary};
+  }
 `;
 
-const Key = styled('dt')`
+const Key = styled('dt')<{type: Props['type']}>`
   ${commonStyles};
   color: ${p => p.theme.textColor};
 `;
 
-const Value = styled('dd')`
+const Value = styled('dd')<{type: Props['type']}>`
   ${commonStyles};
   color: ${p => p.theme.subText};
   text-align: right;

--- a/static/app/components/keyValueTable.tsx
+++ b/static/app/components/keyValueTable.tsx
@@ -7,7 +7,6 @@ import {space} from 'sentry/styles/space';
 type Props = {
   keyName: React.ReactNode;
   value: React.ReactNode;
-  tooltip?: string;
   type?: undefined | 'error' | 'warning';
 };
 

--- a/static/app/components/replays/virtualizedGrid/bodyCell.tsx
+++ b/static/app/components/replays/virtualizedGrid/bodyCell.tsx
@@ -7,23 +7,29 @@ const cellBackground = (p: CellProps & {theme: Theme}) => {
   if (p.isSelected) {
     return `background-color: ${p.theme.textColor};`;
   }
-  if (p.hasOccurred === undefined && !p.isStatusError) {
-    return `background-color: inherit;`;
+  if (p.isStatusError) {
+    return `background-color: ${p.theme.red100};`;
   }
-  const color = p.isStatusError ? p.theme.alert.error.backgroundLight : 'inherit';
-  return `background-color: ${color};`;
+  if (p.isStatusWarning) {
+    return `background-color: var(--background-warning-default, rgba(245, 176, 0, 0.09));`;
+  }
+  return `background-color: inherit;`;
 };
 
 const cellColor = (p: CellProps & {theme: Theme}) => {
   if (p.isSelected) {
-    const colors = p.isStatusError
-      ? [p.theme.alert.error.background]
-      : [p.theme.background];
-    return `color: ${colors[0]};`;
+    const color = p.isStatusError
+      ? p.theme.red300
+      : p.isStatusWarning
+      ? p.theme.yellow300
+      : p.theme.background;
+    return `color: ${color};`;
   }
   const colors = p.isStatusError
-    ? [p.theme.alert.error.borderHover, p.theme.alert.error.iconColor]
-    : ['inherit', p.theme.gray300];
+    ? [p.theme.red300, p.theme.red400]
+    : p.isStatusWarning
+    ? [p.theme.textColor, p.theme.subText]
+    : ['inherit', p.theme.subText];
 
   return `color: ${p.hasOccurred !== false ? colors[0] : colors[1]};`;
 };
@@ -34,6 +40,7 @@ type CellProps = {
   hasOccurred?: boolean;
   isSelected?: boolean;
   isStatusError?: boolean;
+  isStatusWarning?: boolean;
   numeric?: boolean;
   onClick?: undefined | (() => void);
 };

--- a/static/app/utils/replays/resourceFrame.tsx
+++ b/static/app/utils/replays/resourceFrame.tsx
@@ -27,6 +27,19 @@ export function getFrameStatus(frame: SpanFrame) {
     : undefined;
 }
 
+export function getReqRespContentTypes(frame: SpanFrame) {
+  if (isRequestFrame(frame)) {
+    return {
+      req: frame.data.request?.headers['content-type'],
+      resp: frame.data.response?.headers['content-type'],
+    };
+  }
+  return {
+    req: undefined,
+    resp: undefined,
+  };
+}
+
 export function getResponseBodySize(frame: SpanFrame) {
   if (isRequestFrame(frame)) {
     // `data.responseBodySize` is from SDK version 7.44-7.45

--- a/static/app/views/replays/detail/network/details/components.tsx
+++ b/static/app/views/replays/detail/network/details/components.tsx
@@ -44,14 +44,22 @@ export function SizeTooltip({children}: {children: ReactNode}) {
   );
 }
 
-export function keyValueTableOrNotFound(
-  data: undefined | Record<string, string | ReactNode>,
-  notFoundText: string
-) {
-  return data ? (
+export type KeyValueTuple = {
+  key: string;
+  value: string | ReactNode;
+  type?: 'warning' | 'error';
+};
+
+export function keyValueTableOrNotFound(data: KeyValueTuple[], notFoundText: string) {
+  return data.length ? (
     <StyledKeyValueTable noMargin>
-      {Object.entries(data).map(([key, value]) => (
-        <KeyValueTableRow key={key} keyName={key} value={<span>{value}</span>} />
+      {data.map(({key, value, type}) => (
+        <KeyValueTableRow
+          key={key}
+          keyName={key}
+          type={type}
+          value={<span>{value}</span>}
+        />
       ))}
     </StyledKeyValueTable>
   ) : (

--- a/static/app/views/replays/detail/network/networkTableCell.tsx
+++ b/static/app/views/replays/detail/network/networkTableCell.tsx
@@ -12,6 +12,7 @@ import type useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import {
   getFrameMethod,
   getFrameStatus,
+  getReqRespContentTypes,
   getResponseBodySize,
 } from 'sentry/utils/replays/resourceFrame';
 import type {SpanFrame} from 'sentry/utils/replays/types';
@@ -60,6 +61,13 @@ const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
 
     const method = getFrameMethod(frame);
     const statusCode = getFrameStatus(frame);
+    const isStatus400or500 = typeof statusCode === 'number' && statusCode >= 400;
+    const contentTypeHeaders = getReqRespContentTypes(frame);
+    const isContentTypeSane =
+      contentTypeHeaders.req === undefined ||
+      contentTypeHeaders.resp === undefined ||
+      contentTypeHeaders.req === contentTypeHeaders.resp;
+
     const size = getResponseBodySize(frame);
 
     const hasOccurred = currentTime >= frame.offsetMs;
@@ -95,7 +103,8 @@ const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
       }),
       hasOccurred: isByTimestamp ? hasOccurred : undefined,
       isSelected,
-      isStatusError: typeof statusCode === 'number' && statusCode >= 400,
+      isStatusError: isStatus400or500,
+      isStatusWarning: !isContentTypeSane,
       onClick: () => onClickCell({dataIndex, rowIndex}),
       onMouseEnter: () => onMouseEnter(frame),
       onMouseLeave: () => onMouseLeave(frame),


### PR DESCRIPTION
Using yellow to highlight the network row and header information:
<img width="534" alt="SCR-20231005-qtyz" src="https://github.com/getsentry/sentry/assets/187460/68729dc3-f6ed-4d38-913c-527f8bd463c1">
<img width="533" alt="SCR-20231005-qucf" src="https://github.com/getsentry/sentry/assets/187460/87572273-75d2-40dc-b2e8-3498d745927a">




Fixes https://github.com/getsentry/sentry/issues/57627
