### PR TITLE
Avoid a double-`save()` in file assembly

### DIFF
--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -305,7 +305,7 @@ class AbstractFile(Model):
         return results
 
     @sentry_sdk.tracing.trace
-    def assemble_from_file_blob_ids(self, file_blob_ids, checksum, commit=True):
+    def assemble_from_file_blob_ids(self, file_blob_ids, checksum):
         """
         This creates a file, from file blobs and returns a temp file with the
         contents.
@@ -356,8 +356,8 @@ class AbstractFile(Model):
                 raise AssembleChecksumMismatch("Checksum mismatch")
 
         metrics.timing("filestore.file-size", offset)
-        if commit:
-            self.save()
+        self.save()
+
         tf.flush()
         tf.seek(0)
         return tf

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -141,10 +141,8 @@ def assemble_file(
             detail="Reported checksum mismatch",
         )
         return None
-    else:
-        file.save()
 
-        return AssembleResult(bundle=file, bundle_temp_file=temp_file)
+    return AssembleResult(bundle=file, bundle_temp_file=temp_file)
 
 
 def _get_cache_key(task, scope, checksum):


### PR DESCRIPTION
There was an (effectively unconditional) `save()` call in `assemble_from_file_blob_ids`.
And another one right outside of it. No need to save twice.