### PR TITLE
feat(source-map-debugger): Mention potential dist mismatch in 'not found' case

### DIFF
--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -840,6 +840,19 @@ function ReleaseSourceFileMatchingChecklistItem({
             </li>
           ))}
         </InstructionList>
+        <p>
+          {/* wrong-dist is not deterministically returned in the case of wrong dist values because of database restrictions */}
+          {sourceResolutionResults.dist
+            ? tct(
+                'This event has a dist value [dist]. Please check that you uploaded your artifacts with dist [dist].',
+                {
+                  dist: <MonoBlock>{sourceResolutionResults.dist}</MonoBlock>,
+                }
+              )
+            : t(
+                "This event doesn't have a dist value. Please check that you uploaded your artifacts without dist value."
+              )}
+        </p>
         {/* TODO: Link to uploaded files for this release. */}
         <p>
           {tct(
@@ -945,6 +958,19 @@ function ReleaseSourceMapMatchingChecklistItem({
               ),
             }
           )}
+        </p>
+        <p>
+          {/* wrong-dist is not deterministically returned in the case of wrong dist values because of database restrictions */}
+          {sourceResolutionResults.dist
+            ? tct(
+                'This event has a dist value [dist]. Please check that you uploaded your sourcemaps with dist [dist].',
+                {
+                  dist: <MonoBlock>{sourceResolutionResults.dist}</MonoBlock>,
+                }
+              )
+            : t(
+                "This event doesn't have a dist value. Please check that you uploaded your sourcemaps without dist value."
+              )}
         </p>
         {/* TODO: Link to Uploaded Artifacts */}
       </CheckListInstruction>

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -842,7 +842,7 @@ function ReleaseSourceFileMatchingChecklistItem({
         </InstructionList>
         <p>
           {/* wrong-dist is not deterministically returned in the case of wrong dist values because of database restrictions */}
-          {sourceResolutionResults.dist
+          {sourceResolutionResults.dist !== null
             ? tct(
                 'This event has a dist value [dist]. Please check that you uploaded your artifacts with dist [dist].',
                 {
@@ -961,7 +961,7 @@ function ReleaseSourceMapMatchingChecklistItem({
         </p>
         <p>
           {/* wrong-dist is not deterministically returned in the case of wrong dist values because of database restrictions */}
-          {sourceResolutionResults.dist
+          {sourceResolutionResults.dist !== null
             ? tct(
                 'This event has a dist value [dist]. Please check that you uploaded your sourcemaps with dist [dist].',
                 {


### PR DESCRIPTION
Since we have database restrictions in the backend we can still have a dist mismatch even though `not-found` is returned instead of `dist`.

We need to adjust the text in the modal to still show a hint about a potential dist mismatch, even when we hit the `not-found` case.

Fixes https://github.com/getsentry/sentry/issues/57553