### PR TITLE
fix(source-map-debugger): Don't show debugger when 'Minified' is checked

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -204,6 +204,7 @@ export function Content({
           meta={meta?.[excIdx]?.stacktrace}
           threadId={threadId}
           frameSourceMapDebuggerData={frameSourceMapDebuggerData}
+          stackType={type}
         />
       </div>
     );

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
@@ -2,7 +2,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import ExceptionStacktraceContent from 'sentry/components/events/interfaces/crashContent/exception/stackTrace';
-import {StackView} from 'sentry/types/stacktrace';
+import {StackType, StackView} from 'sentry/types/stacktrace';
 
 const frames = [
   {
@@ -58,6 +58,7 @@ const props: React.ComponentProps<typeof ExceptionStacktraceContent> = {
   expandFirstFrame: true,
   newestFirst: true,
   chainedException: false,
+  stackType: StackType.ORIGINAL,
   event: {
     ...TestStubs.Event(),
     entries: [],

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
@@ -5,7 +5,7 @@ import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {ExceptionValue, Group, PlatformKey} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {StackView} from 'sentry/types/stacktrace';
+import {StackType, StackView} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {isNativePlatform} from 'sentry/utils/platform';
 
@@ -19,6 +19,7 @@ type Props = {
   event: Event;
   hasHierarchicalGrouping: boolean;
   platform: PlatformKey;
+  stackType: StackType;
   stacktrace: ExceptionValue['stacktrace'];
   expandFirstFrame?: boolean;
   frameSourceMapDebuggerData?: FrameSourceMapDebuggerData[];
@@ -43,6 +44,7 @@ function StackTrace({
   meta,
   threadId,
   frameSourceMapDebuggerData,
+  stackType,
 }: Props) {
   if (!defined(stacktrace)) {
     return null;
@@ -125,6 +127,7 @@ function StackTrace({
       meta={meta}
       threadId={threadId}
       frameSourceMapDebuggerData={frameSourceMapDebuggerData}
+      hideSourceMapDebugger={stackType === StackType.MINIFIED}
     />
   );
 }

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -35,6 +35,7 @@ type Props = {
   className?: string;
   frameSourceMapDebuggerData?: FrameSourceMapDebuggerData[];
   hideIcon?: boolean;
+  hideSourceMapDebugger?: boolean;
   isHoverPreviewed?: boolean;
   lockAddress?: string;
   maxDepth?: number;
@@ -61,6 +62,7 @@ function Content({
   lockAddress,
   organization,
   frameSourceMapDebuggerData,
+  hideSourceMapDebugger,
 }: Props) {
   const [showingAbsoluteAddresses, setShowingAbsoluteAddresses] = useState(false);
   const [showCompleteFunctionName, setShowCompleteFunctionName] = useState(false);
@@ -248,6 +250,7 @@ function Content({
           hiddenFrameCount: frameCountMap[frameIndex],
           organization,
           frameSourceResolutionResults: frameSourceMapDebuggerData?.[frameIndex],
+          hideSourceMapDebugger,
         };
 
         nRepeats = 0;

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -58,6 +58,7 @@ export interface DeprecatedLineProps {
   frameMeta?: Record<any, any>;
   frameSourceResolutionResults?: FrameSourceMapDebuggerData;
   hiddenFrameCount?: number;
+  hideSourceMapDebugger?: boolean;
   image?: React.ComponentProps<typeof DebugImage>['image'];
   includeSystemFrames?: boolean;
   isANR?: boolean;
@@ -316,7 +317,8 @@ export class DeprecatedLine extends Component<Props, State> {
       );
 
     const shouldShowSourceMapDebuggerToggle =
-      data.inApp &&
+      !this.props.hideSourceMapDebugger &&
+      // data.inApp &&
       this.props.frameSourceResolutionResults &&
       (!this.props.frameSourceResolutionResults.frameIsResolved ||
         !hasContextSource(data));

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -318,7 +318,7 @@ export class DeprecatedLine extends Component<Props, State> {
 
     const shouldShowSourceMapDebuggerToggle =
       !this.props.hideSourceMapDebugger &&
-      // data.inApp &&
+      data.inApp &&
       this.props.frameSourceResolutionResults &&
       (!this.props.frameSourceResolutionResults.frameIsResolved ||
         !hasContextSource(data));


### PR DESCRIPTION
It doesn't make sense to show the "Not your source code?" pill when people check the "Minified" checkmark in the stack trace view since, obviously, all frames are not gonna be the user's source code.

This PR will just not show the pill when that checkmark is checked.

Fixes https://github.com/getsentry/sentry/issues/57567