### PR TITLE
Avoid extracting DebugIds from ArtifactBundles twice

### DIFF
--- a/src/sentry/debug_files/artifact_bundle_indexing.py
+++ b/src/sentry/debug_files/artifact_bundle_indexing.py
@@ -60,7 +60,7 @@ class BundleManifest:
     ) -> BundleManifest:
         meta = BundleMeta.from_artifact_bundle(artifact_bundle)
         urls = archive.get_all_urls()
-        debug_ids = archive.get_all_debug_ids()
+        debug_ids = list({debug_id for debug_id, _ty in archive.get_all_debug_ids()})
 
         return BundleManifest(meta=meta, urls=urls, debug_ids=debug_ids)
 

--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import zipfile
 from enum import Enum
-from typing import IO, Callable, Dict, List, Mapping, Optional, Set, Tuple
+from typing import IO, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 
 import sentry_sdk
 from django.conf import settings
@@ -379,33 +379,11 @@ class ArtifactBundleArchive:
     def get_all_urls(self) -> List[str]:
         return [url for url in self._entries_by_url.keys()]
 
-    def get_all_debug_ids(self) -> List[str]:
-        return list({debug_id for debug_id, _ty in self._entries_by_debug_id.keys()})
+    def get_all_debug_ids(self) -> Sequence[Tuple[SourceFileType, str]]:
+        return self._entries_by_debug_id.keys()
 
     def has_debug_ids(self):
         return len(self._entries_by_debug_id) > 0
-
-    def extract_debug_ids_from_manifest(
-        self,
-    ) -> Set[Tuple[SourceFileType, str]]:
-        # We use a set, since we might have the same debug_id and file_type.
-        debug_ids_with_types = set()
-
-        files = self.manifest.get("files", {})
-        for info in files.values():
-            headers = self.normalize_headers(info.get("headers", {}))
-            if (debug_id := headers.get("debug-id")) is not None:
-                debug_id = self.normalize_debug_id(debug_id)
-                file_type = info.get("type")
-                if (
-                    debug_id is not None
-                    and file_type is not None
-                    and (source_file_type := SourceFileType.from_lowercase_key(file_type))
-                    is not None
-                ):
-                    debug_ids_with_types.add((source_file_type, debug_id))
-
-        return debug_ids_with_types
 
     def extract_bundle_id(self) -> Optional[str]:
         bundle_id = self.manifest.get("debug_id")

--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -379,7 +379,7 @@ class ArtifactBundleArchive:
     def get_all_urls(self) -> List[str]:
         return [url for url in self._entries_by_url.keys()]
 
-    def get_all_debug_ids(self) -> Sequence[Tuple[SourceFileType, str]]:
+    def get_all_debug_ids(self) -> Sequence[Tuple[str, SourceFileType]]:
         return self._entries_by_debug_id.keys()
 
     def has_debug_ids(self):

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -527,10 +527,6 @@ class ArtifactBundlePostAssembler(PostAssembler[ArtifactBundleArchive]):
                 if len(project_ids) > 0:
                     self.project_ids = project_ids
 
-        # We want to measure how much time it takes to extract debug ids from manifest.
-        with metrics.timer("tasks.assemble.artifact_bundle.extract_debug_ids"):
-            debug_ids_with_types = self.archive.extract_debug_ids_from_manifest()
-
         bundle_id = self.archive.extract_bundle_id()
         if not bundle_id:
             # In case we didn't find the bundle_id in the manifest, we will just generate our own.
@@ -545,7 +541,7 @@ class ArtifactBundlePostAssembler(PostAssembler[ArtifactBundleArchive]):
 
         # We don't allow the creation of a bundle if no debug ids and release are present, since we are not able to
         # efficiently index
-        if len(debug_ids_with_types) == 0 and not self.release:
+        if not self.archive.has_debug_ids() and not self.release:
             raise AssembleArtifactsError(
                 "uploading a bundle without debug ids or release is prohibited"
             )
@@ -609,7 +605,7 @@ class ArtifactBundlePostAssembler(PostAssembler[ArtifactBundleArchive]):
                         source_file_type=source_file_type.value,
                         date_added=date_snapshot,
                     )
-                    for source_file_type, debug_id in debug_ids_with_types
+                    for debug_id, source_file_type in self.archive.get_all_debug_ids()
                 ]
                 DebugIdArtifactBundle.objects.bulk_create(
                     debug_id_to_insert, batch_size=50, ignore_conflicts=True

--- a/tests/sentry/debug_files/test_artifact_bundle_indexing.py
+++ b/tests/sentry/debug_files/test_artifact_bundle_indexing.py
@@ -383,8 +383,8 @@ class FlatFileIndexTest(FlatFileTestCase):
             }
         )
 
-        with ArtifactBundleArchive(artifact_bundle.file.getfile()) as bundle_archive:
-            debug_ids = bundle_archive.get_all_debug_ids()
+        with ArtifactBundleArchive(artifact_bundle.file.getfile()) as archive:
+            debug_ids = list({debug_id for debug_id, _ty in archive.get_all_debug_ids()})
 
         flat_file_index = FlatFileIndex()
         bundle_meta = BundleMeta(
@@ -493,8 +493,8 @@ class FlatFileIndexTest(FlatFileTestCase):
             }
         )
 
-        with ArtifactBundleArchive(artifact_bundle.file.getfile()) as bundle_archive:
-            debug_ids = bundle_archive.get_all_debug_ids()
+        with ArtifactBundleArchive(artifact_bundle.file.getfile()) as archive:
+            debug_ids = list({debug_id for debug_id, _ty in archive.get_all_debug_ids()})
 
         flat_file_index = FlatFileIndex()
         flat_file_index.from_json(json.dumps(existing_json_index))


### PR DESCRIPTION
The `ArtifactBundleArchive` constructor is already by default building an in-memory map of DebugIds.
So there is no need to iterate over the manifest and do the same a second time.