### PR TITLE
ref(tsc): Convert ProjectCspReport to FC and useApiQuery

### DIFF
--- a/static/app/views/settings/projectSecurityHeaders/csp.spec.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/csp.spec.tsx
@@ -24,10 +24,34 @@ describe('ProjectCspReports', function () {
     });
   });
 
-  it('renders', function () {
+  it('renders', async function () {
     render(<ProjectCspReports />, {
       organization,
     });
+
+    // Renders the loading indication initially
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+
+    // Heading
+    expect(
+      await screen.findByText('Content Security Policy', {selector: 'h4'})
+    ).toBeInTheDocument();
+  });
+
+  it('renders loading error', async function () {
+    MockApiClient.addMockResponse({
+      url: projectUrl,
+      method: 'GET',
+      statusCode: 400,
+      body: {},
+    });
+    render(<ProjectCspReports />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByText('There was an error loading data.')
+    ).toBeInTheDocument();
   });
 
   it('can enable default ignored sources', async function () {

--- a/static/app/views/settings/projectSecurityHeaders/csp.spec.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/csp.spec.tsx
@@ -4,10 +4,9 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import ProjectCspReports from 'sentry/views/settings/projectSecurityHeaders/csp';
 
 describe('ProjectCspReports', function () {
-  const {project, organization, router} = initializeOrg();
+  const {project, organization} = initializeOrg();
 
   const projectUrl = `/projects/${organization.slug}/${project.slug}/`;
-  const routeUrl = `/projects/${organization.slug}/${project.slug}/csp/`;
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
@@ -26,31 +25,15 @@ describe('ProjectCspReports', function () {
   });
 
   it('renders', function () {
-    render(
-      <ProjectCspReports
-        route={{}}
-        routeParams={router.params}
-        router={router}
-        routes={router.routes}
-        location={TestStubs.location({pathname: routeUrl})}
-        organization={organization}
-        params={{projectId: project.slug}}
-      />
-    );
+    render(<ProjectCspReports />, {
+      organization,
+    });
   });
 
   it('can enable default ignored sources', async function () {
-    render(
-      <ProjectCspReports
-        route={{}}
-        routeParams={router.params}
-        router={router}
-        routes={router.routes}
-        location={TestStubs.location({pathname: routeUrl})}
-        organization={organization}
-        params={{projectId: project.slug}}
-      />
-    );
+    render(<ProjectCspReports />, {
+      organization,
+    });
 
     const mock = MockApiClient.addMockResponse({
       url: projectUrl,
@@ -61,7 +44,7 @@ describe('ProjectCspReports', function () {
 
     // Click Regenerate Token
     await userEvent.click(
-      screen.getByRole('checkbox', {name: 'Use default ignored sources'})
+      await screen.findByRole('checkbox', {name: 'Use default ignored sources'})
     );
 
     expect(mock).toHaveBeenCalledWith(
@@ -78,17 +61,9 @@ describe('ProjectCspReports', function () {
   });
 
   it('can set additional ignored sources', async function () {
-    render(
-      <ProjectCspReports
-        route={{}}
-        routeParams={router.params}
-        router={router}
-        routes={router.routes}
-        location={TestStubs.location({pathname: routeUrl})}
-        organization={organization}
-        params={{projectId: project.slug}}
-      />
-    );
+    render(<ProjectCspReports />, {
+      organization,
+    });
 
     const mock = MockApiClient.addMockResponse({
       url: projectUrl,
@@ -98,7 +73,7 @@ describe('ProjectCspReports', function () {
     expect(mock).not.toHaveBeenCalled();
 
     await userEvent.type(
-      screen.getByRole('textbox', {name: 'Additional ignored sources'}),
+      await screen.findByRole('textbox', {name: 'Additional ignored sources'}),
       'test\ntest2'
     );
 

--- a/static/app/views/settings/projectSecurityHeaders/csp.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/csp.tsx
@@ -1,5 +1,3 @@
-import {RouteComponentProps} from 'react-router';
-
 import Access from 'sentry/components/acl/access';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
@@ -8,76 +6,68 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import PreviewFeature from 'sentry/components/previewFeature';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import formGroups from 'sentry/data/forms/cspReports';
 import {t, tct} from 'sentry/locale';
-import {Organization, Project, ProjectKey} from 'sentry/types';
+import {Project, ProjectKey} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import routeTitleGen from 'sentry/utils/routeTitle';
-import DeprecatedAsyncView from 'sentry/views/deprecatedAsyncView';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import ReportUri, {
   getSecurityDsn,
 } from 'sentry/views/settings/projectSecurityHeaders/reportUri';
 
-type Props = RouteComponentProps<{projectId: string}, {}> & {
-  organization: Organization;
-};
+function getInstructions(keyList: ProjectKey[]) {
+  return (
+    'def middleware(request, response):\n' +
+    "    response['Content-Security-Policy'] = \\\n" +
+    '        "default-src *; " \\\n' +
+    "        \"script-src 'self' 'unsafe-eval' 'unsafe-inline' cdn.example.com cdn.ravenjs.com; \" \\\n" +
+    "        \"style-src 'self' 'unsafe-inline' cdn.example.com; \" \\\n" +
+    '        "img-src * data:; " \\\n' +
+    '        "report-uri ' +
+    getSecurityDsn(keyList) +
+    '"\n' +
+    '    return response\n'
+  );
+}
 
-type State = {
-  keyList: null | ProjectKey[];
-  project: null | Project;
-} & DeprecatedAsyncView['state'];
+function getReportOnlyInstructions(keyList: ProjectKey[]) {
+  return (
+    'def middleware(request, response):\n' +
+    "    response['Content-Security-Policy-Report-Only'] = \\\n" +
+    '        "default-src \'self\'; " \\\n' +
+    '        "report-uri ' +
+    getSecurityDsn(keyList) +
+    '"\n' +
+    '    return response\n'
+  );
+}
 
-export default class ProjectCspReports extends DeprecatedAsyncView<Props, State> {
-  getEndpoints(): ReturnType<DeprecatedAsyncView['getEndpoints']> {
-    const {organization} = this.props;
-    const {projectId} = this.props.params;
-    return [
-      ['keyList', `/projects/${organization.slug}/${projectId}/keys/`],
-      ['project', `/projects/${organization.slug}/${projectId}/`],
-    ];
+export default function ProjectCspReports() {
+  const organization = useOrganization();
+  const params = useParams();
+  const projectId = params.projectId;
+
+  const {data: keyList} = useApiQuery<ProjectKey[]>(
+    [`/projects/${organization.slug}/${projectId}/keys/`],
+    {staleTime: 0}
+  );
+  const {data: project} = useApiQuery<Project>(
+    [`/projects/${organization.slug}/${projectId}/`],
+    {staleTime: 0}
+  );
+
+  if (!keyList || !project) {
+    return null;
   }
 
-  getTitle() {
-    const {projectId} = this.props.params;
-    return routeTitleGen(t('Content Security Policy (CSP)'), projectId, false);
-  }
-
-  getInstructions(keyList: ProjectKey[]) {
-    return (
-      'def middleware(request, response):\n' +
-      "    response['Content-Security-Policy'] = \\\n" +
-      '        "default-src *; " \\\n' +
-      "        \"script-src 'self' 'unsafe-eval' 'unsafe-inline' cdn.example.com cdn.ravenjs.com; \" \\\n" +
-      "        \"style-src 'self' 'unsafe-inline' cdn.example.com; \" \\\n" +
-      '        "img-src * data:; " \\\n' +
-      '        "report-uri ' +
-      getSecurityDsn(keyList) +
-      '"\n' +
-      '    return response\n'
-    );
-  }
-
-  getReportOnlyInstructions(keyList: ProjectKey[]) {
-    return (
-      'def middleware(request, response):\n' +
-      "    response['Content-Security-Policy-Report-Only'] = \\\n" +
-      '        "default-src \'self\'; " \\\n' +
-      '        "report-uri ' +
-      getSecurityDsn(keyList) +
-      '"\n' +
-      '    return response\n'
-    );
-  }
-
-  renderBody() {
-    const {organization} = this.props;
-    const {projectId} = this.props.params;
-    const {project, keyList} = this.state;
-    if (!keyList || !project) {
-      return null;
-    }
-
-    return (
+  return (
+    <SentryDocumentTitle
+      title={routeTitleGen(t('Content Security Policy (CSP)'), projectId, false)}
+    >
       <div>
         <SettingsPageHeader title={t('Content Security Policy')} />
 
@@ -132,13 +122,13 @@ export default class ProjectCspReports extends DeprecatedAsyncView<Props, State>
                 'For example, in Python you might achieve this via a simple web middleware'
               )}
             </p>
-            <pre>{this.getInstructions(keyList)}</pre>
+            <pre>{getInstructions(keyList)}</pre>
 
             <p>
               {t(`Alternatively you can setup CSP reports to simply send reports rather than
               actually enforcing the policy`)}
             </p>
-            <pre>{this.getReportOnlyInstructions(keyList)}</pre>
+            <pre>{getReportOnlyInstructions(keyList)}</pre>
 
             <p>
               {tct(
@@ -155,6 +145,6 @@ export default class ProjectCspReports extends DeprecatedAsyncView<Props, State>
           </PanelBody>
         </Panel>
       </div>
-    );
-  }
+    </SentryDocumentTitle>
+  );
 }

--- a/static/app/views/settings/projectSecurityHeaders/csp.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/csp.tsx
@@ -2,6 +2,8 @@ import Access from 'sentry/components/acl/access';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
@@ -51,17 +53,36 @@ export default function ProjectCspReports() {
   const params = useParams();
   const projectId = params.projectId;
 
-  const {data: keyList} = useApiQuery<ProjectKey[]>(
-    [`/projects/${organization.slug}/${projectId}/keys/`],
-    {staleTime: 0}
-  );
-  const {data: project} = useApiQuery<Project>(
-    [`/projects/${organization.slug}/${projectId}/`],
-    {staleTime: 0}
-  );
+  const {
+    data: keyList,
+    isLoading: isLoadingKeyList,
+    error: keyListError,
+    refetch: refetchKeyList,
+  } = useApiQuery<ProjectKey[]>([`/projects/${organization.slug}/${projectId}/keys/`], {
+    staleTime: 0,
+  });
+  const {
+    data: project,
+    isLoading: isLoadingProject,
+    error: projectError,
+    refetch: refetchProject,
+  } = useApiQuery<Project>([`/projects/${organization.slug}/${projectId}/`], {
+    staleTime: 0,
+  });
 
-  if (!keyList || !project) {
-    return null;
+  if (isLoadingKeyList || isLoadingProject) {
+    return <LoadingIndicator />;
+  }
+
+  if (keyListError || projectError) {
+    return (
+      <LoadingError
+        onRetry={() => {
+          refetchKeyList();
+          refetchProject();
+        }}
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
Convert to FC and useApiQuery.
Use `useOrganization` and `useParams` instead of receiving them via props.

- Ref https://github.com/getsentry/frontend-tsc/issues/2
