### PR TITLE
Do not re-open `ArtifactBundleArchive` on indexing

### DIFF
--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -2,6 +2,7 @@ import io
 import os
 from datetime import datetime, timedelta, timezone
 from hashlib import sha1
+from unittest import mock
 from unittest.mock import patch
 
 from django.core.files.base import ContentFile
@@ -667,9 +668,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         # Since the threshold is now passed, we expect the system to perform indexing.
         index_artifact_bundles_for_release.assert_called_with(
             organization_id=self.organization.id,
-            artifact_bundles=[bundles[0], bundles[1]],
-            release=release,
-            dist=dist,
+            artifact_bundles=[(bundles[0], None), (bundles[1], mock.ANY)],
         )
 
     def test_bundle_flat_file_indexing(self):
@@ -888,7 +887,7 @@ class ArtifactBundleIndexingTest(TestCase):
             project_ids=[],
         ) as post_assembler:
             post_assembler._index_bundle_if_needed(
-                release=release, dist=dist, date_snapshot=datetime.now()
+                artifact_bundle=None, release=release, dist=dist, date_snapshot=datetime.now()
             )
 
         index_artifact_bundles_for_release.assert_not_called()
@@ -916,7 +915,7 @@ class ArtifactBundleIndexingTest(TestCase):
             project_ids=[],
         ) as post_assembler:
             post_assembler._index_bundle_if_needed(
-                release=release, dist=dist, date_snapshot=datetime.now()
+                artifact_bundle=None, release=release, dist=dist, date_snapshot=datetime.now()
             )
 
         index_artifact_bundles_for_release.assert_not_called()
@@ -952,14 +951,15 @@ class ArtifactBundleIndexingTest(TestCase):
             project_ids=[],
         ) as post_assembler:
             post_assembler._index_bundle_if_needed(
-                release=release, dist=dist, date_snapshot=datetime.now()
+                artifact_bundle=artifact_bundle_2,
+                release=release,
+                dist=dist,
+                date_snapshot=datetime.now(),
             )
 
         index_artifact_bundles_for_release.assert_called_with(
             organization_id=self.organization.id,
-            artifact_bundles=[artifact_bundle_1, artifact_bundle_2],
-            release=release,
-            dist=dist,
+            artifact_bundles=[(artifact_bundle_1, None), (artifact_bundle_2, mock.ANY)],
         )
 
     @patch("sentry.tasks.assemble.index_artifact_bundles_for_release")
@@ -991,7 +991,7 @@ class ArtifactBundleIndexingTest(TestCase):
             project_ids=[],
         ) as post_assembler:
             post_assembler._index_bundle_if_needed(
-                release=release, dist=dist, date_snapshot=datetime.now()
+                artifact_bundle=None, release=release, dist=dist, date_snapshot=datetime.now()
             )
 
         index_artifact_bundles_for_release.assert_not_called()
@@ -1037,12 +1037,13 @@ class ArtifactBundleIndexingTest(TestCase):
             project_ids=[],
         ) as post_assembler:
             post_assembler._index_bundle_if_needed(
-                release=release, dist=dist, date_snapshot=datetime.now()
+                artifact_bundle=artifact_bundle_1,
+                release=release,
+                dist=dist,
+                date_snapshot=datetime.now(),
             )
 
         index_artifact_bundles_for_release.assert_called_with(
             organization_id=self.organization.id,
-            artifact_bundles=[artifact_bundle_1, artifact_bundle_2],
-            release=release,
-            dist=dist,
+            artifact_bundles=[(artifact_bundle_1, mock.ANY), (artifact_bundle_2, None)],
         )


### PR DESCRIPTION
The current DB-indexing of `ArtifactBundle`s is written in such a way that you can pass a number of bundles to it at the same time. Which up until now meant that it would re-open the Archive which we are currently assembling, which is an unnecessary overhead.

This will now thread through the currently open archive to avoid this costly work.