### PR TITLE
fix(statistical-detectors): fix txn breakpoint metric

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -185,7 +185,7 @@ def detect_transaction_change_points(
 
     metrics.incr(
         "statistical_detectors.breakpoint.transactions",
-        amount=len(breakpoints),
+        amount=breakpoint_count,
         sample_rate=1.0,
     )
 


### PR DESCRIPTION
`breakpoint_count` stores the running total after chunking.