### PR TITLE
fix(replay): Use transaction startTimestamp when deeplinking into a replay

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -42,10 +42,10 @@ function EventReplayContent({event, group}: Props) {
     return null;
   }
 
-  const timeOfEvent = event?.dateCreated ?? event.dateReceived;
-  const eventTimestampMs = timeOfEvent
-    ? Math.floor(new Date(timeOfEvent).getTime() / 1000) * 1000
-    : 0;
+  const startTimestampMS =
+    'startTimestamp' in event ? event.startTimestamp * 1000 : undefined;
+  const timeOfEvent = event.dateCreated ?? startTimestampMS ?? event.dateReceived;
+  const eventTimestampMs = timeOfEvent ? Math.floor(new Date(timeOfEvent).getTime()) : 0;
 
   return (
     <EventReplaySection>


### PR DESCRIPTION
**Before:**
before, when we had a transaction, we were falling back to `event.dateReceived` because transactions don't have `event.dateCreated`. This was a _vsastly_ different time than expected, and always looked weird in the replay timeline because it didn't align with any network bars.
| example 1 | example 2 |
| --- | --- |
| ![SCR-20231006-ifec](https://github.com/getsentry/sentry/assets/187460/b8fa2eb8-2e35-40c4-b195-dd562a8abe18) | ![SCR-20231006-idjw](https://github.com/getsentry/sentry/assets/187460/1bb09556-cdc1-4d8c-b365-f03fc6544db9) |

**After:**
Now we use the correct time, and don't round to the nearest second, so it's more exact
| example 2 | example 2 |
| --- | --- |
| ![SCR-20231006-ifez](https://github.com/getsentry/sentry/assets/187460/1ff1bb4b-ca10-4f1a-b330-a9a6b9af96e9) | ![SCR-20231006-idkj](https://github.com/getsentry/sentry/assets/187460/5a397eba-74ae-4f02-8080-f8b775a2caeb) |



Fixes https://github.com/getsentry/sentry/issues/56350
