### PR TITLE
fix(replay): Stop upselling replay on backend projects

### DIFF
--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -181,11 +181,11 @@ function Entries({
   );
 
   const eventEntryProps = {
-    projectSlug,
-    group,
-    organization,
     event: definedEvent,
+    group,
     isShare,
+    organization,
+    projectSlug,
   };
 
   return (

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -181,11 +181,11 @@ function Entries({
   );
 
   const eventEntryProps = {
-    event: definedEvent,
-    group,
-    isShare,
-    organization,
     projectSlug,
+    group,
+    organization,
+    event: definedEvent,
+    isShare,
   };
 
   return (

--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -15,11 +15,14 @@ import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
 type Props = {
   event: Event;
   projectSlug: string;
-  replayId: undefined | string;
   group?: Group;
 };
 
-function EventReplayContent({event, group, replayId}: Props) {
+function EventReplayContent({
+  event,
+  group,
+  replayId,
+}: Props & {replayId: undefined | string}) {
   const organization = useOrganization();
   const {hasOrgSentReplays, fetching} = useHasOrganizationSentAnyReplayEvents();
 
@@ -70,7 +73,7 @@ function EventReplayContent({event, group, replayId}: Props) {
   );
 }
 
-export default function EventReplay({projectSlug, event, group}: Props) {
+export default function EventReplay({event, group, projectSlug}: Props) {
   const organization = useOrganization();
   const hasReplaysFeature = organization.features.includes('session-replay');
 
@@ -78,12 +81,15 @@ export default function EventReplay({projectSlug, event, group}: Props) {
   const canUpsellReplay = projectCanUpsellReplay(project);
   const replayId = getReplayIdFromEvent(event);
 
-  if (!hasReplaysFeature) {
-    return null;
-  }
-
-  if (replayId || canUpsellReplay) {
-    return <EventReplayContent {...{projectSlug, event, group, replayId}} />;
+  if (hasReplaysFeature && (replayId || canUpsellReplay)) {
+    return (
+      <EventReplayContent
+        event={event}
+        group={group}
+        projectSlug={projectSlug}
+        replayId={replayId}
+      />
+    );
   }
 
   return null;

--- a/static/app/utils/replays/projectSupportsReplay.tsx
+++ b/static/app/utils/replays/projectSupportsReplay.tsx
@@ -20,10 +20,14 @@ export function projectCanLinkToReplay(project: undefined | MinimalProject) {
     return false;
   }
 
-  return (
-    replayPlatforms.includes(project.platform) ||
-    backend.some(val => val === project.platform)
-  );
+  return replayPlatforms.includes(project.platform) || backend.includes(project.platform);
+}
+
+export function projectCanUpsellReplay(project: undefined | MinimalProject) {
+  if (!project || !project.platform) {
+    return false;
+  }
+  return replayPlatforms.includes(project.platform);
 }
 
 export default projectSupportsReplay;


### PR DESCRIPTION
The logic before was too coarse in this area.
1. We started with no replay-preview for any backend project. But if, for example, a PHP project which also has Vue.js events going into has replays setup... well then we wanted to see those replays on the issue details page.
    - So we added the Replay Preview (with the banner) for all projects.
2. That was no good, so we filtered it down so that only backend projects would see the Preview (or upsell banner) 
   - But that meant that we're upselling replay for all these backend projects that might not have js at all, like native mobile
3. So now here we are, at the end (?). The new logic is:
    - if the org doesn't have replays, you see nothing
    - if the event does have a replayID OR if they're a frontend project (and should see the upsell) then we show it
    - otherwise.. see nothing


The upsell banner looks like this: 
![CleanShot 2023-05-17 at 13 50 07](https://github.com/getsentry/sentry/assets/187460/403d4d2d-dc1f-4d96-953f-371e5bebac30)

Related to https://github.com/getsentry/sentry/pull/48100
Related to https://github.com/getsentry/sentry/pull/49354
Fixes https://github.com/getsentry/team-replay/issues/202