### PR TITLE
fix(statistical-detectors): Memo current time for function issue queries

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/eventAffectedTransactions.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventAffectedTransactions.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect} from 'react';
+import {Fragment, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
@@ -77,7 +77,10 @@ function EventAffectedTransactionsInner({
   project,
 }: EventAffectedTransactionsInnerProps) {
   const organization = useOrganization();
-  const maxDateTime = Date.now();
+
+  // Make sure to memo this. Otherwise, each re-render will have
+  // a different min/max date time, causing the query to refetch.
+  const maxDateTime = useMemo(() => Date.now(), []);
   const minDateTime = maxDateTime - 90 * DAY;
 
   const breakpointTime = breakpoint * 1000;

--- a/static/app/components/events/eventStatisticalDetector/eventFunctionComparisonList.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventFunctionComparisonList.tsx
@@ -94,7 +94,10 @@ function EventComparisonListInner({
   project,
 }: EventComparisonListInnerProps) {
   const organization = useOrganization();
-  const maxDateTime = Date.now();
+
+  // Make sure to memo this. Otherwise, each re-render will have
+  // a different min/max date time, causing the query to refetch.
+  const maxDateTime = useMemo(() => Date.now(), []);
   const minDateTime = maxDateTime - 90 * DAY;
 
   const breakpointTime = breakpoint * 1000;


### PR DESCRIPTION
Make sure to memo the current time otherwise each re-render will get a different min/max time for the queries resulting in another request being made.