### PR TITLE
ref(alerts): Add Issues Team as Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -313,6 +313,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/api/endpoints/sentry_app/                                @getsentry/issues
 /src/sentry/api/endpoints/project_rule*.py                           @getsentry/issues
 /src/sentry/api/serializers/models/rule.py 							 @getsentry/issues
+/src/sentry/api/serializers/models/alert_rule.py 				     @getsentry/issues
 
 /static/app/views/organizationIntegrations                           @getsentry/issues
 /static/app/views/settings/project/projectOwnership/                 @getsentry/issues


### PR DESCRIPTION
I noticed while working on the alert rule serializer that nobody is a codeowner for that file and the issues team should be 