### PR TITLE
feat(statistical-detectors): Add p95 chart to function regression issue

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/eventAffectedTransactions.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventAffectedTransactions.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo} from 'react';
+import {Fragment, useEffect} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
@@ -14,6 +14,7 @@ import {defined} from 'sentry/utils';
 import {Container} from 'sentry/utils/discover/styles';
 import {getDuration} from 'sentry/utils/formatters';
 import {useProfileFunctions} from 'sentry/utils/profiling/hooks/useProfileFunctions';
+import {useRelativeDateTime} from 'sentry/utils/profiling/hooks/useRelativeDateTime';
 import {generateProfileSummaryRouteWithQuery} from 'sentry/utils/profiling/routes';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -63,8 +64,6 @@ export function EventAffectedTransactions({
   );
 }
 
-const DAY = 24 * 60 * 60 * 1000;
-
 interface EventAffectedTransactionsInnerProps {
   breakpoint: number;
   fingerprint: number;
@@ -78,32 +77,17 @@ function EventAffectedTransactionsInner({
 }: EventAffectedTransactionsInnerProps) {
   const organization = useOrganization();
 
-  // Make sure to memo this. Otherwise, each re-render will have
-  // a different min/max date time, causing the query to refetch.
-  const maxDateTime = useMemo(() => Date.now(), []);
-  const minDateTime = maxDateTime - 90 * DAY;
-
-  const breakpointTime = breakpoint * 1000;
-
-  // Try to create a query for a 14 day period around the breakpoint.
-  const beforeTime = breakpointTime - 7 * DAY;
-  const beforeDateTime =
-    beforeTime >= minDateTime ? new Date(beforeTime) : new Date(minDateTime);
-  const afterTime = breakpointTime + 7 * DAY;
-  const afterDateTime =
-    afterTime <= maxDateTime ? new Date(afterTime) : new Date(maxDateTime);
+  const datetime = useRelativeDateTime({
+    anchor: breakpoint,
+    relativeDays: 7,
+  });
 
   const percentileBefore = `percentile_before(function.duration, 0.95, ${breakpoint})`;
   const percentileAfter = `percentile_after(function.duration, 0.95, ${breakpoint})`;
   const percentileDelta = `percentile_delta(function.duration, 0.95, ${breakpoint})`;
 
   const transactionsDeltaQuery = useProfileFunctions({
-    datetime: {
-      start: beforeDateTime,
-      end: afterDateTime,
-      utc: true,
-      period: null,
-    },
+    datetime,
     fields: ['transaction', percentileBefore, percentileAfter, percentileDelta],
     sort: {
       key: percentileDelta,

--- a/static/app/components/events/eventStatisticalDetector/functionBreakpointChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/functionBreakpointChart.tsx
@@ -1,0 +1,102 @@
+import {useEffect, useMemo} from 'react';
+import * as Sentry from '@sentry/react';
+
+import Chart from 'sentry/components/events/eventStatisticalDetector/lineChart';
+import {DataSection} from 'sentry/components/events/styles';
+import {Event} from 'sentry/types';
+import {defined} from 'sentry/utils';
+import {useProfileEventsStats} from 'sentry/utils/profiling/hooks/useProfileEventsStats';
+import {useRelativeDateTime} from 'sentry/utils/profiling/hooks/useRelativeDateTime';
+import {NormalizedTrendsTransaction} from 'sentry/views/performance/trends/types';
+
+type EventFunctionBreakpointChartProps = {
+  event: Event;
+};
+
+export function EventFunctionBreakpointChart({event}: EventFunctionBreakpointChartProps) {
+  const evidenceData = event.occurrence?.evidenceData;
+  const fingerprint = evidenceData?.fingerprint;
+  const breakpoint = evidenceData?.breakpoint;
+
+  const isValid = defined(fingerprint) && defined(breakpoint);
+
+  useEffect(() => {
+    if (isValid) {
+      return;
+    }
+
+    Sentry.withScope(scope => {
+      scope.setContext('evidence data fields', {
+        fingerprint,
+        breakpoint,
+      });
+
+      Sentry.captureException(
+        new Error('Missing required evidence data on function regression issue.')
+      );
+    });
+  }, [isValid, fingerprint, breakpoint]);
+
+  return (
+    <EventFunctionBreakpointChartInner
+      breakpoint={breakpoint}
+      evidenceData={evidenceData!}
+      fingerprint={fingerprint}
+    />
+  );
+}
+
+type EventFunctionBreakpointChartInnerProps = {
+  breakpoint: number;
+  evidenceData: Record<string, any>;
+  fingerprint: number;
+};
+
+const SERIES = 'p95()';
+
+function EventFunctionBreakpointChartInner({
+  breakpoint,
+  evidenceData,
+  fingerprint,
+}: EventFunctionBreakpointChartInnerProps) {
+  const datetime = useRelativeDateTime({
+    anchor: breakpoint,
+    relativeDays: 7,
+  });
+
+  const functionStats = useProfileEventsStats({
+    dataset: 'profileFunctions',
+    datetime,
+    query: `fingerprint:${fingerprint}`,
+    referrer: 'api.profiling.functions.regression.stats',
+    yAxes: [SERIES],
+  });
+
+  const series = useMemo(() => {
+    const rawData = functionStats?.data?.data?.find(({axis}) => axis === SERIES);
+    const timestamps = functionStats?.data?.timestamps;
+    if (!rawData || !timestamps) {
+      return [];
+    }
+
+    return timestamps.map((timestamp, i) => [timestamp, [{count: rawData.values[i]}]]);
+  }, [functionStats]);
+
+  const normalizedOccurrenceEvent = {
+    aggregate_range_1: evidenceData.aggregateRange1 / 1e6,
+    aggregate_range_2: evidenceData.aggregateRange2 / 1e6,
+    breakpoint: evidenceData.breakpoint,
+  } as NormalizedTrendsTransaction;
+
+  return (
+    <DataSection>
+      <Chart
+        statsData={series}
+        evidenceData={normalizedOccurrenceEvent}
+        start={(datetime.start as Date).toISOString()}
+        end={(datetime.end as Date).toISOString()}
+        chartLabel={SERIES}
+      />
+    </DataSection>
+  );
+}

--- a/static/app/utils/profiling/hooks/useRelativeDateTime.tsx
+++ b/static/app/utils/profiling/hooks/useRelativeDateTime.tsx
@@ -1,0 +1,39 @@
+import {useMemo} from 'react';
+
+import {PageFilters} from 'sentry/types';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+interface UseRelativeDateTimeOptions {
+  anchor: number;
+  relativeDays: number;
+  retentionDays?: number;
+}
+
+export function useRelativeDateTime({
+  anchor,
+  relativeDays,
+  retentionDays,
+}: UseRelativeDateTimeOptions): PageFilters['datetime'] {
+  const anchorTime = anchor * 1000;
+
+  // Make sure to memo this. Otherwise, each re-render will have
+  // a different min/max date time, causing the query to refetch.
+  const maxDateTime = useMemo(() => Date.now(), []);
+  const minDateTime = maxDateTime - (retentionDays ?? 90) * DAY;
+
+  const beforeTime = anchorTime - relativeDays * DAY;
+  const beforeDateTime =
+    beforeTime >= minDateTime ? new Date(beforeTime) : new Date(minDateTime);
+
+  const afterTime = anchorTime + relativeDays * DAY;
+  const afterDateTime =
+    afterTime <= maxDateTime ? new Date(afterTime) : new Date(maxDateTime);
+
+  return {
+    start: beforeDateTime,
+    end: afterDateTime,
+    utc: true,
+    period: null,
+  };
+}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -21,6 +21,7 @@ import EventBreakpointChart from 'sentry/components/events/eventStatisticalDetec
 import {EventAffectedTransactions} from 'sentry/components/events/eventStatisticalDetector/eventAffectedTransactions';
 import EventComparison from 'sentry/components/events/eventStatisticalDetector/eventComparison';
 import {EventFunctionComparisonList} from 'sentry/components/events/eventStatisticalDetector/eventFunctionComparisonList';
+import {EventFunctionBreakpointChart} from 'sentry/components/events/eventStatisticalDetector/functionBreakpointChart';
 import RegressionMessage from 'sentry/components/events/eventStatisticalDetector/regressionMessage';
 import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScreenshot';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
@@ -231,6 +232,9 @@ function ProfilingDurationRegressionIssueDetailsContent({
     >
       <Fragment>
         <RegressionMessage event={event} group={group} />
+        <ErrorBoundary mini>
+          <EventFunctionBreakpointChart event={event} />
+        </ErrorBoundary>
         <ErrorBoundary mini>
           <EventAffectedTransactions event={event} group={group} project={project} />
         </ErrorBoundary>


### PR DESCRIPTION
This adds a p95 chart to the function regression issue highlighting the before and after as well as where the regression started.

# Screenshot

![image](https://github.com/getsentry/sentry/assets/10239353/fcb5a5ed-5399-4751-bb43-87e9139b852a)
