### PR TITLE
feat(perf-issue): Improve perf issues on spantree

### DIFF
--- a/fixtures/js-stubs/tracePerformanceIssue.tsx
+++ b/fixtures/js-stubs/tracePerformanceIssue.tsx
@@ -10,8 +10,12 @@ export function TracePerformanceIssue(
     project_slug: 'santry',
     title: 'Large HTTP payload',
     level: 'info',
-    issue: '',
     type: 1015,
+    culprit: '',
+    start: 0,
+    end: 0,
+    span: [],
+    suspect_spans: [],
     ...params,
   };
 }

--- a/fixtures/js-stubs/tracePerformanceIssue.tsx
+++ b/fixtures/js-stubs/tracePerformanceIssue.tsx
@@ -1,0 +1,17 @@
+import {TracePerformanceIssue as PerformanceIssue} from 'sentry/utils/performance/quickTrace/types';
+
+export function TracePerformanceIssue(
+  params: Partial<PerformanceIssue> = {}
+): PerformanceIssue {
+  return {
+    event_id: '09384ee83c9145e79b5f6fbed5c37a51',
+    issue_id: 301,
+    project_id: 8,
+    project_slug: 'santry',
+    title: 'Large HTTP payload',
+    level: 'info',
+    issue: '',
+    type: 1015,
+    ...params,
+  };
+}

--- a/static/app/components/events/interfaces/spans/aggregateSpanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/aggregateSpanDetail.tsx
@@ -5,7 +5,10 @@ import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {AggregateEventTransaction} from 'sentry/types/event';
 import {formatPercentage, getDuration} from 'sentry/utils/formatters';
-import {QuickTraceEvent, TraceError} from 'sentry/utils/performance/quickTrace/types';
+import {
+  QuickTraceEvent,
+  TraceErrorOrIssue,
+} from 'sentry/utils/performance/quickTrace/types';
 
 import {AggregateSpanType, ParsedTraceType} from './types';
 
@@ -14,7 +17,7 @@ type Props = {
   event: Readonly<AggregateEventTransaction>;
   isRoot: boolean;
   organization: Organization;
-  relatedErrors: TraceError[] | null;
+  relatedErrors: TraceErrorOrIssue[] | null;
   resetCellMeasureCache: () => void;
   scrollToHash: (hash: string) => void;
   span: AggregateSpanType;

--- a/static/app/components/events/interfaces/spans/index.tsx
+++ b/static/app/components/events/interfaces/spans/index.tsx
@@ -72,10 +72,14 @@ function TraceErrorAlerts({
 
   return (
     <AlertContainer>
-      <Alert type={getCumulativeAlertLevelFromErrors(errors)}>
+      <Alert type={getCumulativeAlertLevelFromErrors(traceErrors)}>
         <ErrorLabel>{label}</ErrorLabel>
 
-        <TraceErrorList trace={parsedTrace} errors={traceErrors} />
+        <TraceErrorList
+          trace={parsedTrace}
+          errors={errors ?? []}
+          performanceIssues={performanceIssues}
+        />
       </Alert>
     </AlertContainer>
   );
@@ -83,7 +87,6 @@ function TraceErrorAlerts({
 
 function SpansInterface({event, affectedSpanIds, organization}: Props) {
   const parsedTrace = useMemo(() => parseTrace(event), [event]);
-
   const waterfallModel = useMemo(
     () => new WaterfallModel(event, affectedSpanIds),
     [event, affectedSpanIds]

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -146,6 +146,7 @@ export type SpanBarProps = {
   resetCellMeasureCache: () => void;
   showEmbeddedChildren: boolean;
   showSpanTree: boolean;
+  span: ProcessedSpanType | AggregateSpanType;
   spanNumber: number;
   storeSpanBar: (spanBar: SpanBar) => void;
   toggleEmbeddedChildren:
@@ -163,7 +164,6 @@ export type SpanBarProps = {
   measure?: () => void;
   spanBarColor?: string;
   spanBarType?: SpanBarType;
-  span: ProcessedSpanType | AggregateSpanType;
   toggleSiblingSpanGroup?: ((span: SpanType, occurrence: number) => void) | undefined;
 };
 

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -610,6 +610,7 @@ class SpanTree extends Component<PropType> {
             addContentSpanBarRef,
             removeContentSpanBarRef,
             storeSpanBar,
+            isSpanInEmbeddedTree: waterfallModel.isEmbeddedSpanTree,
             getCurrentLeftPos: this.props.getCurrentLeftPos,
             resetCellMeasureCache: () => this.cache.clear(index, 0),
           },

--- a/static/app/components/events/interfaces/spans/traceErrorList.tsx
+++ b/static/app/components/events/interfaces/spans/traceErrorList.tsx
@@ -1,4 +1,4 @@
-import {memo} from 'react';
+import {Fragment, memo} from 'react';
 import flatten from 'lodash/flatten';
 import groupBy from 'lodash/groupBy';
 
@@ -13,32 +13,55 @@ import {
 import {ParsedTraceType, SpanType} from './types';
 
 interface TraceErrorListProps {
-  errors: (TraceError | TracePerformanceIssue)[];
+  errors: TraceError[];
   trace: ParsedTraceType;
+  performanceIssues?: TracePerformanceIssue[];
 }
 
-function TraceErrorList({trace, errors}: TraceErrorListProps) {
+function TraceErrorList({trace, errors, performanceIssues}: TraceErrorListProps) {
   return (
     <List symbol="bullet" data-test-id="trace-error-list">
-      {flatten(
-        Object.entries(groupBy(errors, 'span')).map(([spanId, spanErrors]) => {
-          return Object.entries(groupBy(spanErrors, 'level')).map(
-            ([level, spanLevelErrors]) => (
-              <ListItem key={`${spanId}-${level}`}>
-                {tct('[errors] [link]', {
-                  errors: tn(
-                    '%s %s error in ',
-                    '%s %s errors in ',
-                    spanLevelErrors.length,
-                    level === 'error' ? '' : level // Prevents awkward "error errors" copy if the level is "error"
-                  ),
-                  link: findSpanById(trace, spanId).op,
-                })}
-              </ListItem>
-            )
-          );
-        })
-      )}
+      <Fragment>
+        {flatten(
+          Object.entries(groupBy(errors, 'span')).map(([spanId, spanErrors]) => {
+            return Object.entries(groupBy(spanErrors, 'level')).map(
+              ([level, spanLevelErrors]) => (
+                <ListItem key={`${spanId}-${level}`}>
+                  {tct('[errors] [link]', {
+                    errors: tn(
+                      '%s %s error in ',
+                      '%s %s errors in ',
+                      spanLevelErrors.length,
+                      level === 'error' ? '' : level // Prevents awkward "error errors" copy if the level is "error"
+                    ),
+                    link: findSpanById(trace, spanId).op,
+                  })}
+                </ListItem>
+              )
+            );
+          })
+        )}
+        {flatten(
+          Object.entries(groupBy(performanceIssues, 'span')).map(
+            ([spanId, spanErrors]) => {
+              return Object.entries(groupBy(spanErrors, 'level')).map(
+                ([level, spanLevelErrors]) => (
+                  <ListItem key={`${spanId}-${level}`}>
+                    {tct('[errors] [link]', {
+                      errors: tn(
+                        '%s performance issue in ',
+                        '%s performance issues in ',
+                        spanLevelErrors.length
+                      ),
+                      link: findSpanById(trace, spanId).op,
+                    })}
+                  </ListItem>
+                )
+              );
+            }
+          )
+        )}
+      </Fragment>
     </List>
   );
 }

--- a/static/app/components/events/interfaces/spans/traceErrorList.tsx
+++ b/static/app/components/events/interfaces/spans/traceErrorList.tsx
@@ -43,22 +43,18 @@ function TraceErrorList({trace, errors, performanceIssues}: TraceErrorListProps)
         )}
         {flatten(
           Object.entries(groupBy(performanceIssues, 'span')).map(
-            ([spanId, spanErrors]) => {
-              return Object.entries(groupBy(spanErrors, 'level')).map(
-                ([level, spanLevelErrors]) => (
-                  <ListItem key={`${spanId}-${level}`}>
-                    {tct('[errors] [link]', {
-                      errors: tn(
-                        '%s performance issue in ',
-                        '%s performance issues in ',
-                        spanLevelErrors.length
-                      ),
-                      link: findSpanById(trace, spanId).op,
-                    })}
-                  </ListItem>
-                )
-              );
-            }
+            ([spanId, spanErrors]) => (
+              <ListItem key={`${spanId}`}>
+                {tct('[errors] [link]', {
+                  errors: tn(
+                    '%s performance issue in ',
+                    '%s performance issues in ',
+                    spanErrors.length
+                  ),
+                  link: findSpanById(trace, spanId).op,
+                })}
+              </ListItem>
+            )
           )
         )}
       </Fragment>

--- a/static/app/components/events/interfaces/spans/traceView.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.tsx
@@ -81,10 +81,16 @@ function TraceView(props: Props) {
       </EmptyStateWarning>
     );
   }
-  if (!waterfallModel.affectedSpanIds && performanceIssues) {
-    waterfallModel.affectedSpanIds = performanceIssues
-      .map(issue => issue.suspect_spans)
-      .flat();
+  if (
+    (!waterfallModel.affectedSpanIds || !waterfallModel.affectedSpanIds.length) &&
+    performanceIssues
+  ) {
+    const suspectSpans = performanceIssues.map(issue => issue.suspect_spans).flat();
+    if (suspectSpans.length) {
+      waterfallModel.affectedSpanIds = performanceIssues
+        .map(issue => [...issue.suspect_spans, ...issue.span])
+        .flat();
+    }
   }
 
   return (

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -961,15 +961,24 @@ export function getSpanGroupBounds(
 }
 
 export function getCumulativeAlertLevelFromErrors(
-  errors?: Pick<TraceError, 'level'>[]
+  errors?: Pick<TraceError, 'level' | 'type'>[]
 ): keyof Theme['alert'] | undefined {
   const highestErrorLevel = maxBy(errors || [], error => ERROR_LEVEL_WEIGHTS[error.level])
     ?.level;
 
+  if (errors?.some(isErrorPerformanceError)) {
+    return 'error';
+  }
+
   if (!highestErrorLevel) {
     return undefined;
   }
+
   return ERROR_LEVEL_TO_ALERT_TYPE[highestErrorLevel];
+}
+
+export function isErrorPerformanceError(error: {type?: number}): boolean {
+  return !!error.type && error.type >= 1000 && error.type < 2000;
 }
 
 // Maps the known error levels to an Alert component types

--- a/static/app/utils/performance/quickTrace/types.tsx
+++ b/static/app/utils/performance/quickTrace/types.tsx
@@ -35,6 +35,7 @@ export type TraceError = {
   event_type?: string;
   generation?: number;
   timestamp?: number;
+  type?: number;
 };
 
 export type TracePerformanceIssue = Omit<TraceError, 'issue' | 'span'> & {
@@ -46,6 +47,7 @@ export type TracePerformanceIssue = Omit<TraceError, 'issue' | 'span'> & {
   type: number;
   issue_short_id?: string;
 };
+export type TraceErrorOrIssue = TracePerformanceIssue | TraceError;
 
 export type TraceLite = EventLite[];
 


### PR DESCRIPTION
### Summary
This improves how we show performance issues on the spantree, previously it wasn't obvious on the transaction detail page that a performance issue occurred. This splits copy and highlighting up to special case performance issues, since they are more important in performance contexts.



### Screenshots
Before            |  After
:-------------------------:|:-------------------------:
![Screenshot 2023-10-06 at 3 18 08 PM](https://github.com/getsentry/sentry/assets/6111995/91a384cd-be2b-4aac-9295-aff978e6ed10) | ![Screenshot 2023-10-06 at 3 17 51 PM](https://github.com/getsentry/sentry/assets/6111995/9c94822b-b050-47ac-9f9e-888e62f5c336)
![Screenshot 2023-10-06 at 3 41 14 PM](https://github.com/getsentry/sentry/assets/6111995/421e98c2-5c2a-4acd-ba4c-a88b5fe419ee) | ![Screenshot 2023-10-06 at 3 41 03 PM](https://github.com/getsentry/sentry/assets/6111995/dd60af6c-37b2-45df-9c5c-924cd9c137a0)


#### Other
![Screenshot 2023-10-06 at 3 35 56 PM](https://github.com/getsentry/sentry/assets/6111995/4f113354-aca0-403f-b3f2-06e8bc07c83c)

