### PR TITLE
chore(crons) Exclude frequent task from monitors

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -495,6 +495,7 @@ def configure_sdk():
         "flush-buffers",
         "sync-options",
         "schedule-digests",
+        "check-symbolicator-lpq-project-eligibility",  # defined in getsentry
     ]
 
     # turn on minimetrics


### PR DESCRIPTION
This task runs every 10s and generates a lot of noise in production logs.
