### PR TITLE
chore: cleanup health checks to use service options

### DIFF
--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import http
 import os
 import platform
 import shutil
@@ -293,7 +294,7 @@ def up(
                 executor.submit(
                     check_health,
                     name,
-                    containers,
+                    containers[name],
                 )
             )
         for future in as_completed(futures):
@@ -561,7 +562,7 @@ Are you sure you want to continue?"""
                 network.remove()
 
 
-def check_health(service_name: str, containers: dict[str, Any]) -> None:
+def check_health(service_name: str, options: dict[str, Any]) -> None:
     healthcheck = service_healthchecks.get(service_name, None)
     if healthcheck is None:
         return
@@ -569,7 +570,7 @@ def check_health(service_name: str, containers: dict[str, Any]) -> None:
     click.secho(f"> Checking container health '{service_name}'", fg="yellow")
 
     def hc() -> None:
-        healthcheck.check(containers)
+        healthcheck.check(options)
 
     try:
         run_with_retries(
@@ -590,7 +591,11 @@ def run_with_retries(
     for retry in range(1, retries + 1):
         try:
             cmd()
-        except (subprocess.CalledProcessError, urllib.error.HTTPError):
+        except (
+            subprocess.CalledProcessError,
+            urllib.error.HTTPError,
+            http.client.RemoteDisconnected,
+        ):
             if retry == retries:
                 raise
             else:
@@ -603,13 +608,12 @@ def run_with_retries(
             return
 
 
-def check_postgres(containers: dict[str, Any]) -> None:
-    pg_options = containers["postgres"]
+def check_postgres(options: dict[str, Any]) -> None:
     subprocess.run(
         (
             "docker",
             "exec",
-            pg_options["name"],
+            options["name"],
             "pg_isready",
             "-U",
             "postgres",
@@ -620,8 +624,7 @@ def check_postgres(containers: dict[str, Any]) -> None:
     )
 
 
-def check_rabbitmq(containers: dict[str, Any]) -> None:
-    options = containers["rabbitmq"]
+def check_rabbitmq(options: dict[str, Any]) -> None:
     subprocess.run(
         (
             "docker",
@@ -637,13 +640,12 @@ def check_rabbitmq(containers: dict[str, Any]) -> None:
     )
 
 
-def check_redis(containers: dict[str, Any]) -> None:
-    redis_options = containers["redis"]
+def check_redis(options: dict[str, Any]) -> None:
     subprocess.run(
         (
             "docker",
             "exec",
-            redis_options["name"],
+            options["name"],
             "redis-cli",
             "ping",
         ),
@@ -653,8 +655,7 @@ def check_redis(containers: dict[str, Any]) -> None:
     )
 
 
-def check_vroom(containers: dict[str, Any]) -> None:
-    options = containers["vroom"]
+def check_vroom(options: dict[str, Any]) -> None:
     (port,) = options["ports"].values()
 
     # Vroom is a slim debian based image and does not have curl, wget or
@@ -662,8 +663,7 @@ def check_vroom(containers: dict[str, Any]) -> None:
     urllib.request.urlopen(f"http://{port[0]}:{port[1]}/health", timeout=1)
 
 
-def check_clickhouse(containers: dict[str, Any]) -> None:
-    options = containers["clickhouse"]
+def check_clickhouse(options: dict[str, Any]) -> None:
     port = options["ports"]["8123/tcp"]
     subprocess.run(
         (
@@ -681,8 +681,7 @@ def check_clickhouse(containers: dict[str, Any]) -> None:
     )
 
 
-def check_kafka(containers: dict[str, Any]) -> None:
-    options = containers["kafka"]
+def check_kafka(options: dict[str, Any]) -> None:
     (port,) = options["ports"].values()
     subprocess.run(
         (
@@ -701,8 +700,7 @@ def check_kafka(containers: dict[str, Any]) -> None:
     )
 
 
-def check_symbolicator(containers: dict[str, Any]) -> None:
-    options = containers["symbolicator"]
+def check_symbolicator(options: dict[str, Any]) -> None:
     (port,) = options["ports"].values()
     subprocess.run(
         (
@@ -730,9 +728,7 @@ else:
 """
 
 
-def check_chartcuterie(containers: dict[str, Any]) -> None:
-    options = containers["chartcuterie"]
-
+def check_chartcuterie(options: dict[str, Any]) -> None:
     # Chartcuterie binds the internal port to a different port
     internal_port = 9090
     port = options["ports"][f"{internal_port}/tcp"]
@@ -752,8 +748,7 @@ def check_chartcuterie(containers: dict[str, Any]) -> None:
     )
 
 
-def check_snuba(containers: dict[str, Any]) -> None:
-    options = containers["snuba"]
+def check_snuba(options: dict[str, Any]) -> None:
     port = options["ports"]["1218/tcp"]
 
     url = f"http://{port[0]}:{port[1]}/health_envoy"


### PR DESCRIPTION
This makes adding health checks to pytest fixtures a little easier

This also adds an exception that I noticed vroom healthcheck throws