### PR TITLE
chore: Switch to SENTRY_SNUBA for healthcheck

### DIFF
--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -749,9 +749,9 @@ def check_chartcuterie(options: dict[str, Any]) -> None:
 
 
 def check_snuba(options: dict[str, Any]) -> None:
-    port = options["ports"]["1218/tcp"]
+    from django.conf import settings
 
-    url = f"http://{port[0]}:{port[1]}/health_envoy"
+    url = f"{settings.SENTRY_SNUBA}/health_envoy"
     subprocess.run(
         (
             "docker",


### PR DESCRIPTION
This seems to be how snuba is accessed in sentry code base (i.e. used in skips.py and else where).

Description of the value isn't super helpful, but it does remove the need to hardcode a specific port number in the healthcheck.

```
# Snuba configuration
SENTRY_SNUBA = os.environ.get("SNUBA", "http://127.0.0.1:1218")
```