### PR TITLE
feat(alerts): Consolidate issue alert filter/action types

### DIFF
--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -2,6 +2,39 @@ import type {SchemaFormConfig} from 'sentry/views/settings/organizationIntegrati
 
 import type {IssueConfigField} from './integrations';
 
+export const enum IssueAlertActionType {
+  SLACK = 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction',
+  NOTIFY_EMAIL = 'sentry.mail.actions.NotifyEmailAction',
+  DISCORD = 'sentry.integrations.discord.notify_action.DiscordNotifyServiceAction',
+  JIRA_CREATE_TICKET = 'sentry.integrations.jira.notify_action.JiraCreateTicketAction',
+  AZURE_DEVOPS_CREATE_TICKET = 'sentry.integrations.vsts.notify_action.AzureDevopsCreateTicketAction',
+  SENTRY_APP = 'sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction',
+  MS_TEAMS = 'sentry.integrations.msteams.notify_action.MsTeamsNotifyServiceAction',
+  PAGER_DUTY = 'sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction',
+  OPSGENIE = 'sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction',
+}
+
+export const enum IssueAlertConditionType {
+  EVERY_EVENT = 'sentry.rules.conditions.every_event.EveryEventCondition',
+  FIRST_SEEN_EVENT = 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
+  REGRESSION_EVENT = 'sentry.rules.conditions.regression_event.RegressionEventCondition',
+  REAPPEARED_EVENT = 'sentry.rules.conditions.reappeared_event.ReappearedEventCondition',
+  EVENT_FREQUENCY = 'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
+  EVENT_UNIQUE_USER_FREQUENCY = 'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition',
+  EVENT_FREQUENCY_PERCENT = 'sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition',
+}
+
+export const enum IssueAlertFilterType {
+  AGE_COMPARISON = 'sentry.rules.filters.age_comparison.AgeComparisonFilter',
+  ISSUE_OCCURRENCES = 'sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter',
+  ASSIGNED_TO = 'sentry.rules.filters.assigned_to.AssignedToFilter',
+  LATEST_RELEASE = 'sentry.rules.filters.latest_release.LatestReleaseFilter',
+  ISSUE_CATEGORY = 'sentry.rules.filters.issue_category.IssueCategoryFilter',
+  EVENT_ATTRIBUTE = 'sentry.rules.filters.event_attribute.EventAttributeFilter',
+  TAGGED_EVENT = 'sentry.rules.filters.tagged_event.TaggedEventFilter',
+  LEVEL = 'sentry.rules.filters.level.LevelFilter',
+}
+
 type IssueAlertRuleFormField =
   | {
       type: 'choice';

--- a/static/app/views/alerts/rules/issue/details/textRule.tsx
+++ b/static/app/views/alerts/rules/issue/details/textRule.tsx
@@ -2,14 +2,14 @@ import {Fragment} from 'react';
 
 import {t} from 'sentry/locale';
 import type {Member, Team} from 'sentry/types';
-import type {IssueAlertRule} from 'sentry/types/alerts';
+import {
+  IssueAlertActionType,
+  IssueAlertConditionType,
+  type IssueAlertRule,
+} from 'sentry/types/alerts';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AlertRuleComparisonType} from 'sentry/views/alerts/rules/metric/types';
 import {CHANGE_ALERT_CONDITION_IDS} from 'sentry/views/alerts/utils/constants';
-import {
-  EVENT_FREQUENCY_PERCENT_CONDITION,
-  REAPPEARED_EVENT_CONDITION,
-} from 'sentry/views/projectInstall/issueAlertOptions';
 
 /**
  * Translate Issue Alert Conditions to text
@@ -23,7 +23,7 @@ export function TextCondition({
 
   if (CHANGE_ALERT_CONDITION_IDS.includes(condition.id)) {
     if (condition.comparisonType === AlertRuleComparisonType.PERCENT) {
-      if (condition.id === EVENT_FREQUENCY_PERCENT_CONDITION) {
+      if (condition.id === IssueAlertConditionType.EVENT_FREQUENCY_PERCENT) {
         return (
           <Fragment>
             {t(
@@ -60,7 +60,7 @@ export function TextCondition({
     );
   }
   if (
-    condition.id === REAPPEARED_EVENT_CONDITION &&
+    condition.id === IssueAlertConditionType.REAPPEARED_EVENT &&
     organization.features.includes('escalating-issues')
   ) {
     return (
@@ -96,7 +96,7 @@ export function TextAction({
     );
   }
 
-  if (action.id === 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction') {
+  if (action.id === IssueAlertActionType.SLACK) {
     const name = action.name
       // Hide the id "(optionally, an ID: XXX)"
       .replace(/\(optionally.*\)/, '')

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -54,6 +54,9 @@ import {
   Team,
 } from 'sentry/types';
 import {
+  IssueAlertActionType,
+  IssueAlertConditionType,
+  IssueAlertFilterType,
   IssueAlertRule,
   IssueAlertRuleAction,
   IssueAlertRuleActionTemplate,
@@ -610,11 +613,8 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
       transaction.setTag('operation', isNew ? 'create' : 'edit');
       if (rule) {
         for (const action of rule.actions) {
-          // Grab the last part of something like 'sentry.mail.actions.NotifyEmailAction'
-          const splitActionId = action.id.split('.');
-          const actionName = splitActionId[splitActionId.length - 1];
-          if (actionName === 'SlackNotifyServiceAction') {
-            transaction.setTag(actionName, true);
+          if (action.id === IssueAlertActionType.SLACK) {
+            transaction.setTag('SlackNotifyServiceAction', true);
           }
           // to avoid storing inconsistent data in the db, don't pass the name fields
           delete action.name;
@@ -1623,19 +1623,19 @@ export const findIncompatibleRules = (
     let userFrequency = -1;
     for (let i = 0; i < conditions.length; i++) {
       const id = conditions[i].id;
-      if (id.endsWith('FirstSeenEventCondition')) {
+      if (id === IssueAlertConditionType.FIRST_SEEN_EVENT) {
         firstSeen = i;
-      } else if (id.endsWith('RegressionEventCondition')) {
+      } else if (id === IssueAlertConditionType.REGRESSION_EVENT) {
         regression = i;
-      } else if (id.endsWith('ReappearedEventCondition')) {
+      } else if (id === IssueAlertConditionType.REAPPEARED_EVENT) {
         reappeared = i;
       } else if (
-        id.endsWith('EventFrequencyCondition') &&
+        id === IssueAlertConditionType.EVENT_FREQUENCY &&
         (conditions[i].value as number) >= 1
       ) {
         eventFrequency = i;
       } else if (
-        id.endsWith('EventUniqueUserFrequencyCondition') &&
+        id === IssueAlertConditionType.EVENT_UNIQUE_USER_FREQUENCY &&
         (conditions[i].value as number) >= 1
       ) {
         userFrequency = i;
@@ -1663,7 +1663,7 @@ export const findIncompatibleRules = (
     for (let i = 0; i < filters.length; i++) {
       const filter = filters[i];
       const id = filter.id;
-      if (id.endsWith('IssueOccurrencesFilter') && filter) {
+      if (id === IssueAlertFilterType.ISSUE_OCCURRENCES && filter) {
         if (
           (rule.filterMatch === 'all' && (filter.value as number) > 1) ||
           (rule.filterMatch === 'none' && (filter.value as number) <= 1)
@@ -1673,7 +1673,7 @@ export const findIncompatibleRules = (
         if (rule.filterMatch === 'any' && (filter.value as number) > 1) {
           incompatibleFilters += 1;
         }
-      } else if (id.endsWith('AgeComparisonFilter')) {
+      } else if (id === IssueAlertFilterType.AGE_COMPARISON) {
         if (rule.filterMatch !== 'none') {
           if (filter.comparison_type === 'older') {
             if (rule.filterMatch === 'all') {

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -15,6 +15,9 @@ import {space} from 'sentry/styles/space';
 import {Choices, IssueOwnership, Organization, Project} from 'sentry/types';
 import {
   AssigneeTargetType,
+  IssueAlertActionType,
+  IssueAlertConditionType,
+  IssueAlertFilterType,
   IssueAlertRuleAction,
   IssueAlertRuleActionTemplate,
   IssueAlertRuleCondition,
@@ -24,13 +27,7 @@ import {
 import MemberTeamFields from 'sentry/views/alerts/rules/issue/memberTeamFields';
 import SentryAppRuleModal from 'sentry/views/alerts/rules/issue/sentryAppRuleModal';
 import TicketRuleModal from 'sentry/views/alerts/rules/issue/ticketRuleModal';
-import {
-  EVENT_FREQUENCY_PERCENT_CONDITION,
-  REAPPEARED_EVENT_CONDITION,
-} from 'sentry/views/projectInstall/issueAlertOptions';
 import {SchemaFormConfig} from 'sentry/views/settings/organizationIntegrations/sentryAppExternalForm';
-
-const NOTIFY_EMAIL_ACTION = 'sentry.mail.actions.NotifyEmailAction';
 
 export function hasStreamlineTargeting(organization: Organization): boolean {
   return organization.features.includes('streamline-targeting-context');
@@ -62,7 +59,7 @@ function NumberField({
   // Set default value of number fields to the placeholder value
   useEffect(() => {
     if (
-      data.id === 'sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter' &&
+      data.id === IssueAlertFilterType.ISSUE_OCCURRENCES &&
       isNaN(value) &&
       !isNaN(Number(fieldConfig.placeholder))
     ) {
@@ -312,7 +309,7 @@ function RuleNode({
     let {label} = node;
 
     if (
-      data.id === NOTIFY_EMAIL_ACTION &&
+      data.id === IssueAlertActionType.NOTIFY_EMAIL &&
       data.targetType !== MailActionTargetType.ISSUE_OWNERS &&
       organization.features.includes('issue-alert-fallback-targeting')
     ) {
@@ -321,7 +318,7 @@ function RuleNode({
     }
 
     if (
-      data.id === REAPPEARED_EVENT_CONDITION &&
+      data.id === IssueAlertConditionType.REAPPEARED_EVENT &&
       organization.features.includes('escalating-issues')
     ) {
       label = t('The issue changes state from archived to escalating');
@@ -423,7 +420,7 @@ function RuleNode({
   }
 
   function conditionallyRenderHelpfulBanner() {
-    if (data.id === EVENT_FREQUENCY_PERCENT_CONDITION) {
+    if (data.id === IssueAlertConditionType.EVENT_FREQUENCY_PERCENT) {
       if (!project.platform || !releaseHealth.includes(project.platform)) {
         return (
           <MarginlessAlert type="error">
@@ -453,7 +450,7 @@ function RuleNode({
       );
     }
 
-    if (data.id === 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction') {
+    if (data.id === IssueAlertActionType.SLACK) {
       return (
         <MarginlessAlert
           type="info"
@@ -473,9 +470,7 @@ function RuleNode({
       );
     }
 
-    if (
-      data.id === 'sentry.integrations.discord.notify_action.DiscordNotifyServiceAction'
-    ) {
+    if (data.id === IssueAlertActionType.DISCORD) {
       return (
         <MarginlessAlert
           type="info"
@@ -496,7 +491,7 @@ function RuleNode({
     }
 
     if (
-      data.id === NOTIFY_EMAIL_ACTION &&
+      data.id === IssueAlertActionType.NOTIFY_EMAIL &&
       data.targetType === MailActionTargetType.ISSUE_OWNERS &&
       !organization.features.includes('issue-alert-fallback-targeting')
     ) {

--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -6,6 +6,8 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {IssueOwnership, Organization, Project} from 'sentry/types';
 import {
+  IssueAlertActionType,
+  IssueAlertConditionType,
   IssueAlertRuleAction,
   IssueAlertRuleActionTemplate,
   IssueAlertRuleCondition,
@@ -17,7 +19,6 @@ import {
   COMPARISON_TYPE_CHOICE_VALUES,
   COMPARISON_TYPE_CHOICES,
 } from 'sentry/views/alerts/utils/constants';
-import {REAPPEARED_EVENT_CONDITION} from 'sentry/views/projectInstall/issueAlertOptions';
 
 import {AlertRuleComparisonType} from '../metric/types';
 
@@ -60,7 +61,7 @@ const createSelectOptions = (
   value: IssueAlertRuleActionTemplate;
 }> => {
   return actions.map(node => {
-    if (node.id.includes('NotifyEmailAction')) {
+    if (node.id === IssueAlertActionType.NOTIFY_EMAIL) {
       let label = t('Issue Owners, Team, or Member');
       if (hasStreamlineTargeting(organization)) {
         label = t('Suggested Assignees, Team, or Member');
@@ -72,7 +73,7 @@ const createSelectOptions = (
     }
 
     if (
-      node.id === REAPPEARED_EVENT_CONDITION &&
+      node.id === IssueAlertConditionType.REAPPEARED_EVENT &&
       organization.features.includes('escalating-issues')
     ) {
       const label = t('The issue changes state from archived to escalating');

--- a/static/app/views/alerts/rules/utils.tsx
+++ b/static/app/views/alerts/rules/utils.tsx
@@ -1,7 +1,11 @@
 import IdBadge from 'sentry/components/idBadge';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
-import {IssueAlertRule, RuleActionsCategories} from 'sentry/types/alerts';
+import {
+  IssueAlertActionType,
+  IssueAlertRule,
+  RuleActionsCategories,
+} from 'sentry/types/alerts';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 
@@ -67,7 +71,7 @@ function renderIdBadge(project: Project) {
 
 export function getRuleActionCategory(rule: IssueAlertRule) {
   const numDefaultActions = rule.actions.filter(
-    action => action.id === 'sentry.mail.actions.NotifyEmailAction'
+    action => action.id === IssueAlertActionType.NOTIFY_EMAIL
   ).length;
 
   switch (numDefaultActions) {

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -11,7 +11,11 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
-import {IssueAlertRuleAction} from 'sentry/types/alerts';
+import {
+  IssueAlertActionType,
+  IssueAlertConditionType,
+  IssueAlertRuleAction,
+} from 'sentry/types/alerts';
 import withOrganization from 'sentry/utils/withOrganization';
 
 export enum MetricValues {
@@ -25,25 +29,17 @@ export enum RuleAction {
   CREATE_ALERT_LATER,
 }
 
-const UNIQUE_USER_FREQUENCY_CONDITION =
-  'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition';
-const EVENT_FREQUENCY_CONDITION =
-  'sentry.rules.conditions.event_frequency.EventFrequencyCondition';
-export const EVENT_FREQUENCY_PERCENT_CONDITION =
-  'sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition';
-export const REAPPEARED_EVENT_CONDITION =
-  'sentry.rules.conditions.reappeared_event.ReappearedEventCondition';
 const ISSUE_ALERT_DEFAULT_ACTION: Omit<
   IssueAlertRuleAction,
   'label' | 'name' | 'prompt'
 > = {
-  id: 'sentry.mail.actions.NotifyEmailAction',
+  id: IssueAlertActionType.NOTIFY_EMAIL,
   targetType: 'IssueOwners',
 };
 
 const METRIC_CONDITION_MAP = {
-  [MetricValues.ERRORS]: EVENT_FREQUENCY_CONDITION,
-  [MetricValues.USERS]: UNIQUE_USER_FREQUENCY_CONDITION,
+  [MetricValues.ERRORS]: IssueAlertConditionType.EVENT_FREQUENCY,
+  [MetricValues.USERS]: IssueAlertConditionType.EVENT_UNIQUE_USER_FREQUENCY,
 } as const;
 
 type StateUpdater = (updatedData: RequestDataFragment) => void;
@@ -85,10 +81,10 @@ function getConditionFrom(
   let condition: string;
   switch (metricValue) {
     case MetricValues.ERRORS:
-      condition = EVENT_FREQUENCY_CONDITION;
+      condition = IssueAlertConditionType.EVENT_FREQUENCY;
       break;
     case MetricValues.USERS:
-      condition = UNIQUE_USER_FREQUENCY_CONDITION;
+      condition = IssueAlertConditionType.EVENT_UNIQUE_USER_FREQUENCY;
       break;
     default:
       throw new RangeError('Supplied metric value is not handled');


### PR DESCRIPTION
will be using these to narrow typescript types. They were kinda all over the place

for example
```ts
interface SlackAction {
 id: SlackActionType
 other_stuff
}