### PR TITLE
fix(escalating-issues): Delete count query causing Postgres timeouts

### DIFF
--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -145,8 +145,6 @@ def schedule_auto_transition_issues_new_to_ongoing(
         id__lte=most_recent_group_first_seen_seven_days_ago.id,
     )
 
-    groups_to_update_count = base_queryset._clone().count()
-
     with sentry_sdk.start_span(description="iterate_chunked_group_ids"):
         for new_group_ids in chunked(
             RangeQuerySetWrapper(
@@ -162,20 +160,10 @@ def schedule_auto_transition_issues_new_to_ongoing(
                 group_ids=new_group_ids,
             )
 
-    with sentry_sdk.start_span(description="get_remaining_groups") as span:
-        remaining_groups = groups_to_update_count - total_count
-
-        span.set_tag("remaining_groups", remaining_groups)
-
     metrics.incr(
         "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.executed",
         sample_rate=1.0,
         tags={"count": total_count},
-    )
-    metrics.incr(
-        "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.remaining",
-        sample_rate=1.0,
-        tags={"count": remaining_groups},
     )
 
 
@@ -247,8 +235,6 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
         .filter(recent_regressed_history__lte=datetime.fromtimestamp(date_added_lte, timezone.utc))
     )
 
-    groups_to_update_count = base_queryset._clone().count()
-
     with sentry_sdk.start_span(description="iterate_chunked_group_ids"):
         for group_ids_with_regressed_history in chunked(
             RangeQuerySetWrapper(
@@ -264,20 +250,10 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
                 group_ids=group_ids_with_regressed_history,
             )
 
-    with sentry_sdk.start_span(description="get_remaining_groups") as span:
-        remaining_groups = groups_to_update_count - total_count
-
-        span.set_tag("remaining_groups", remaining_groups)
-
     metrics.incr(
         "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.executed",
         sample_rate=1.0,
         tags={"count": total_count},
-    )
-    metrics.incr(
-        "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.remaining",
-        sample_rate=1.0,
-        tags={"count": remaining_groups},
     )
 
 
@@ -349,8 +325,6 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
         .filter(recent_escalating_history__lte=datetime.fromtimestamp(date_added_lte, timezone.utc))
     )
 
-    groups_to_update_count = base_queryset._clone().count()
-
     with sentry_sdk.start_span(description="iterate_chunked_group_ids"):
         for new_group_ids in chunked(
             RangeQuerySetWrapper(
@@ -366,20 +340,10 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
                 group_ids=new_group_ids,
             )
 
-    with sentry_sdk.start_span(description="get_remaining_groups") as span:
-        remaining_groups = groups_to_update_count - total_count
-
-        span.set_tag("remaining_groups", remaining_groups)
-
     metrics.incr(
         "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.executed",
         sample_rate=1.0,
         tags={"count": total_count},
-    )
-    metrics.incr(
-        "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.remaining",
-        sample_rate=1.0,
-        tags={"count": remaining_groups},
     )
 
 

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -201,29 +201,15 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
             sample_rate=1.0,
             tags={"count": 100},
         )
-        mock_metrics_incr.assert_any_call(
-            "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.remaining",
-            sample_rate=1.0,
-            tags={"count": 10},
-        )
 
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.executed",
             sample_rate=1.0,
             tags={"count": 0},
         )
-        mock_metrics_incr.assert_any_call(
-            "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.remaining",
-            sample_rate=1.0,
-            tags={"count": 0},
-        )
+
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.executed",
-            sample_rate=1.0,
-            tags={"count": 0},
-        )
-        mock_metrics_incr.assert_any_call(
-            "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.remaining",
             sample_rate=1.0,
             tags={"count": 0},
         )
@@ -318,29 +304,15 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
             sample_rate=1.0,
             tags={"count": 0},
         )
-        mock_metrics_incr.assert_any_call(
-            "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.remaining",
-            sample_rate=1.0,
-            tags={"count": 0},
-        )
 
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.executed",
             sample_rate=1.0,
             tags={"count": 100},
         )
-        mock_metrics_incr.assert_any_call(
-            "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.remaining",
-            sample_rate=1.0,
-            tags={"count": 10},
-        )
+
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.executed",
-            sample_rate=1.0,
-            tags={"count": 0},
-        )
-        mock_metrics_incr.assert_any_call(
-            "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.remaining",
             sample_rate=1.0,
             tags={"count": 0},
         )
@@ -436,29 +408,15 @@ class ScheduleAutoEscalatingOngoingIssuesTest(TestCase):
             sample_rate=1.0,
             tags={"count": 0},
         )
-        mock_metrics_incr.assert_any_call(
-            "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.remaining",
-            sample_rate=1.0,
-            tags={"count": 0},
-        )
 
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.executed",
             sample_rate=1.0,
             tags={"count": 0},
         )
-        mock_metrics_incr.assert_any_call(
-            "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.remaining",
-            sample_rate=1.0,
-            tags={"count": 0},
-        )
+
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.executed",
             sample_rate=1.0,
             tags={"count": 100},
-        )
-        mock_metrics_incr.assert_any_call(
-            "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.remaining",
-            sample_rate=1.0,
-            tags={"count": 10},
         )


### PR DESCRIPTION
## Objective:

Quick fix to delete the offending query causing Postgres timeouts. This query is only used for metrics. We will find another way to get this data.

Fixes SENTRY-16DC