### PR TITLE
fix(alerts): Use a real issue alert rule condition/action in test mock

### DIFF
--- a/fixtures/js-stubs/projectAlertRule.ts
+++ b/fixtures/js-stubs/projectAlertRule.ts
@@ -8,13 +8,15 @@ export function ProjectAlertRule(params: Partial<IssueAlertRule> = {}): IssueAle
     actionMatch: 'all',
     filterMatch: 'all',
     conditions: [
-      {name: 'An alert is first seen', id: 'sentry.rules.conditions.1', label: ''},
+      {
+        id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
+        name: 'A new issue is created',
+      },
     ],
     actions: [
       {
-        name: 'Send a notification to all services',
-        id: 'sentry.rules.actions.notify1',
-        label: '',
+        id: 'sentry.rules.actions.notify_event.NotifyEventAction',
+        name: 'Send a notification (for all legacy integrations)',
       },
     ],
     filters: [],

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -45,7 +45,7 @@ export type IssueAlertRuleConditionTemplate = IssueAlertRuleActionTemplate;
  * These are the action or condition data that the user is editing or has saved.
  */
 export interface IssueAlertRuleAction
-  extends Omit<IssueAlertRuleActionTemplate, 'formFields' | 'enabled'> {
+  extends Omit<IssueAlertRuleActionTemplate, 'formFields' | 'enabled' | 'label'> {
   // These are the same values as the keys in `formFields` for a template
   [key: string]: any;
   dynamic_form_fields?: IssueConfigField[];
@@ -53,7 +53,7 @@ export interface IssueAlertRuleAction
 
 export type IssueAlertRuleCondition = Omit<
   IssueAlertRuleConditionTemplate,
-  'formFields' | 'enabled'
+  'formFields' | 'enabled' | 'label'
 > & {
   dynamic_form_fields?: IssueConfigField[];
 } & {


### PR DESCRIPTION
- fixes an incorrect type, label is not included in a saved issue alert
- `notify1` is not a thing that exists and is a bad mock value