### PR TITLE
feat(feedback): Show loading indicators ontop of the feedback list

### DIFF
--- a/static/app/components/feedback/useFetchFeedbackInfiniteListData.tsx
+++ b/static/app/components/feedback/useFetchFeedbackInfiniteListData.tsx
@@ -65,6 +65,8 @@ class InfiniteListLoader {
   public totalHits: undefined | number = undefined;
 
   private isFetching = false;
+  public isFetchingNext = false;
+  public isFetchingPrev = false;
 
   constructor(
     private api: Client,
@@ -180,12 +182,14 @@ class InfiniteListLoader {
       return;
     }
 
+    this.isFetchingNext = true;
     const result = await this.fetch({
       end: this.minDatetime,
       perPage: PER_PAGE,
       sort: '-timestamp',
       start: startDateFromQueryView(this.queryView),
     });
+    this.isFetchingNext = false;
     this.didFetchNext(result);
   }
 
@@ -196,12 +200,14 @@ class InfiniteListLoader {
       return;
     }
 
+    this.isFetchingPrev = true;
     const result = await this.fetch({
       end: endDateFromQueryView(this.queryView),
       perPage: PER_PAGE,
       sort: 'timestamp',
       start: this.maxDatetime,
     });
+    this.isFetchingPrev = false;
     this.didFetchPrev(result);
   }
 
@@ -224,6 +230,8 @@ export const EMPTY_INFINITE_LIST_DATA: ReturnType<
   countLoadedRows: 0,
   getRow: () => undefined,
   isError: false,
+  isFetchingNext: false,
+  isFetchingPrev: false,
   isLoading: false,
   isRowLoaded: () => false,
   loadMoreRows: () => Promise.resolve(),
@@ -233,6 +241,8 @@ export const EMPTY_INFINITE_LIST_DATA: ReturnType<
 };
 
 type State = {
+  isFetchingNext: boolean;
+  isFetchingPrev: boolean;
   items: HydratedFeedbackItem[];
   totalHits: undefined | number;
 };
@@ -251,6 +261,8 @@ export default function useFetchFeedbackInfiniteListData({
   const [state, setState] = useState<State>({
     items: [],
     totalHits: undefined,
+    isFetchingNext: false,
+    isFetchingPrev: false,
   });
 
   useEffect(() => {
@@ -258,9 +270,12 @@ export default function useFetchFeedbackInfiniteListData({
     loaderRef.current = loader;
 
     return loader.onChange(() => {
+      const {totalHits, isFetchingNext, isFetchingPrev} = loader;
       setState({
         items: loader.feedbacks,
-        totalHits: loader.totalHits,
+        totalHits,
+        isFetchingNext,
+        isFetchingPrev,
       });
     });
   }, [api, organization, queryView, initialDate]);
@@ -291,15 +306,18 @@ export default function useFetchFeedbackInfiniteListData({
     loadMoreRows({startIndex: 0, stopIndex: PER_PAGE});
   }, [loadMoreRows]);
 
+  const {totalHits, isFetchingNext, isFetchingPrev} = state;
   return {
     countLoadedRows: state.items.length,
     getRow,
     isError: false,
+    isFetchingNext,
+    isFetchingPrev,
     isLoading: false,
     isRowLoaded,
     loadMoreRows,
     queryView,
-    totalHits: state.totalHits,
+    totalHits,
     updateFeedback,
   };
 }


### PR DESCRIPTION
Just some little loaders like this at the top & bottom of the list. Right now they'll showup if some loading is happening, you don't (yet) need to be scrolled to the top/bottom for them to appear

![SCR-20231006-mwiq](https://github.com/getsentry/sentry/assets/187460/71ddfb2e-03df-4502-952e-678e9cdb79b5)
