### PR TITLE
ref(replays): convert ReplayTable to GridEditable

### DIFF
--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -95,19 +95,20 @@ type GridEditableProps<DataRow, ColumnKey> = {
   location: Location;
   emptyMessage?: React.ReactNode;
   error?: React.ReactNode | null;
+  errorMessage?: ReactNode;
   /**
    * Inject a set of buttons into the top of the grid table.
    * The controlling component is responsible for handling any actions
    * in these buttons and updating props to the GridEditable instance.
    */
   headerButtons?: () => React.ReactNode;
-  height?: string | number;
 
+  height?: string | number;
   isLoading?: boolean;
+
   scrollable?: boolean;
 
   stickyHeader?: boolean;
-
   /**
    * GridEditable (mostly) do not maintain any internal state and relies on the
    * parent component to tell it how/what to render and will mutate the view
@@ -394,11 +395,14 @@ class GridEditable<
   };
 
   renderError() {
+    const {errorMessage} = this.props;
     return (
       <GridRow>
-        <GridBodyCellStatus>
-          <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
-        </GridBodyCellStatus>
+        {errorMessage ?? (
+          <GridBodyCellStatus>
+            <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
+          </GridBodyCellStatus>
+        )}
       </GridRow>
     );
   }

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -96,7 +96,6 @@ type GridEditableProps<DataRow, ColumnKey> = {
   customTestId?: string;
   emptyMessage?: React.ReactNode;
   error?: React.ReactNode | null;
-  errorMessage?: ReactNode;
 
   /**
    * Inject a set of buttons into the top of the grid table.
@@ -396,14 +395,11 @@ class GridEditable<
   };
 
   renderError() {
-    const {errorMessage} = this.props;
     return (
       <GridRow>
-        {errorMessage ?? (
-          <GridBodyCellStatus>
-            <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
-          </GridBodyCellStatus>
-        )}
+        <GridBodyCellStatus>
+          <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
+        </GridBodyCellStatus>
       </GridRow>
     );
   }
@@ -463,5 +459,4 @@ class GridEditable<
     );
   }
 }
-
 export default GridEditable;

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -93,21 +93,22 @@ type GridEditableProps<DataRow, ColumnKey> = {
     ) => React.ReactNode[];
   };
   location: Location;
+  customTestId?: string;
   emptyMessage?: React.ReactNode;
   error?: React.ReactNode | null;
   errorMessage?: ReactNode;
+
   /**
    * Inject a set of buttons into the top of the grid table.
    * The controlling component is responsible for handling any actions
    * in these buttons and updating props to the GridEditable instance.
    */
   headerButtons?: () => React.ReactNode;
-
   height?: string | number;
+
   isLoading?: boolean;
 
   scrollable?: boolean;
-
   stickyHeader?: boolean;
   /**
    * GridEditable (mostly) do not maintain any internal state and relies on the
@@ -433,7 +434,7 @@ class GridEditable<
   }
 
   render() {
-    const {title, headerButtons, scrollable, height} = this.props;
+    const {title, headerButtons, scrollable, height, customTestId} = this.props;
     const showHeader = title || headerButtons;
     return (
       <Fragment>
@@ -448,7 +449,7 @@ class GridEditable<
           )}
           <Body>
             <Grid
-              data-test-id="grid-editable"
+              data-test-id={customTestId ?? 'grid-editable'}
               scrollable={scrollable}
               height={height}
               ref={this.refGrid}

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -20,10 +20,6 @@ import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {DeadRageSelectorItem, ReplayClickElement} from 'sentry/views/replays/types';
 
-export interface UrlState {
-  widths: string[];
-}
-
 export function getAriaLabel(str: string) {
   const pre = str.split('aria="')[1];
   if (!pre) {
@@ -100,7 +96,7 @@ interface Props {
   data: DeadRageSelectorItem[];
   isError: boolean;
   isLoading: boolean;
-  location: Location<any>;
+  location: Location;
   title?: ReactNode;
 }
 
@@ -136,7 +132,6 @@ export default function SelectorTable({
   isError,
   isLoading,
   location,
-  title,
   clickCountSortable,
 }: Props) {
   const {currentSort, makeSortLinkGenerator} = useQueryBasedSorting({
@@ -215,7 +210,6 @@ export default function SelectorTable({
         renderBodyCell,
       }}
       location={location as Location<any>}
-      title={title}
     />
   );
 }

--- a/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
+++ b/static/app/views/replays/list/replaysErroneousDeadRageCards.tsx
@@ -185,6 +185,7 @@ function CardTable({
         saveLocation
         gridRows={`auto repeat(${rows}, 1fr)`}
         showDropdownFilters={false}
+        isOldDeadRageCard
       />
       {children}
     </Fragment>

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -97,7 +97,7 @@ function ReplaysListTable({
   ];
 
   return (
-    <Fragment>
+    <NoMarginContainer>
       <ReplayTable
         fetchError={fetchError}
         isFetching={isFetching}
@@ -132,7 +132,7 @@ function ReplaysListTable({
           });
         }}
       />
-    </Fragment>
+    </NoMarginContainer>
   );
 }
 
@@ -145,4 +145,9 @@ const ReplayPagination = styled(Pagination)`
   margin-top: 0;
 `;
 
+const NoMarginContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+`;
 export default ReplaysList;

--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -28,7 +28,7 @@ export const colToHeader = {
 };
 
 // GridEditable headers only allow strings, not ReactNodes, so we can't have tooltips anymore.
-// If we convert to GridEditable, we can delete the following function since
+// If we fully convert to GridEditable, we can delete the following function since
 // we'll only need to use the enum to string mapping above.
 function HeaderCell({column, sort}: Props) {
   switch (column) {

--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -27,6 +27,9 @@ export const colToHeader = {
   [ReplayColumn.MOST_ERRONEOUS_REPLAYS]: t('Most Erroneous Replays'),
 };
 
+// GridEditable headers only allow strings, not ReactNodes, so we can't have tooltips anymore.
+// If we convert to GridEditable, we can delete the following function since
+// we'll only need to use the enum to string mapping above.
 function HeaderCell({column, sort}: Props) {
   switch (column) {
     case ReplayColumn.ACTIVITY:

--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -10,6 +10,23 @@ type Props = {
   sort?: Sort;
 };
 
+export const colToHeader = {
+  [ReplayColumn.ACTIVITY]: t('Activity'),
+  [ReplayColumn.BROWSER]: t('Browser'),
+  [ReplayColumn.COUNT_DEAD_CLICKS]: t('Dead Clicks'),
+  [ReplayColumn.COUNT_DEAD_CLICKS_NO_HEADER]: '',
+  [ReplayColumn.COUNT_ERRORS]: t('Errors'),
+  [ReplayColumn.COUNT_RAGE_CLICKS]: t('Rage Clicks'),
+  [ReplayColumn.COUNT_RAGE_CLICKS_NO_HEADER]: '',
+  [ReplayColumn.DURATION]: t('Duration'),
+  [ReplayColumn.OS]: t('OS'),
+  [ReplayColumn.REPLAY]: t('Replay'),
+  [ReplayColumn.SLOWEST_TRANSACTION]: t('Slowest Transaction'),
+  [ReplayColumn.MOST_RAGE_CLICKS]: t('Most Rage Clicks'),
+  [ReplayColumn.MOST_DEAD_CLICKS]: t('Most Dead Clicks'),
+  [ReplayColumn.MOST_ERRONEOUS_REPLAYS]: t('Most Erroneous Replays'),
+};
+
 function HeaderCell({column, sort}: Props) {
   switch (column) {
     case ReplayColumn.ACTIVITY:

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -361,13 +361,6 @@ function ReplayTable({
   );
 }
 
-const StyledAlert = styled(Alert)`
-  border-radius: 0;
-  border-width: 1px 0 0 0;
-  grid-column: 1/-1;
-  margin-bottom: 0;
-`;
-
 const flexibleColumns = [
   ReplayColumn.REPLAY,
   ReplayColumn.MOST_RAGE_CLICKS,
@@ -398,6 +391,13 @@ const StyledPanelTable = styled(PanelTable)<{
     props.gridRows
       ? `grid-template-rows: ${props.gridRows};`
       : `grid-template-rows: 44px max-content;`}
+`;
+
+const StyledAlert = styled(Alert)`
+  border-radius: 0;
+  border-width: 1px 0 0 0;
+  grid-column: 1/-1;
+  margin-bottom: 0;
 `;
 
 export default ReplayTable;

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -258,12 +258,12 @@ function ReplayTable({
   // Using handleResizeColumn causes refetching of replay data every time you resize
   const {columns, handleResizeColumn} = useQueryBasedColumnResize({
     columns: gridCols,
-    location: newLocation,
+    location,
   });
 
   const {currentSort, makeSortLinkGenerator} = useQueryBasedSorting({
     defaultSort: {field: gridCols[0].key, kind: 'desc'},
-    location: newLocation,
+    location,
   });
 
   const renderHeadCell = useMemo(
@@ -341,7 +341,7 @@ function ReplayTable({
         </StyledAlert>
       }
       isLoading={isFetching}
-      data-test-id="replay-table"
+      customTestId="replay-table"
       data={replays ?? []}
       columnOrder={columns}
       emptyMessage={

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -11,6 +11,7 @@ import renderSortableHeaderCell from 'sentry/components/replays/renderSortableHe
 import useQueryBasedColumnResize from 'sentry/components/replays/useQueryBasedColumnResize';
 import useQueryBasedSorting from 'sentry/components/replays/useQueryBasedSorting';
 import {t} from 'sentry/locale';
+import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
@@ -46,15 +47,23 @@ type Props = {
   showDropdownFilters?: boolean;
 };
 
-function getTableCell(
+function getTableCell({
   key,
   replay,
   showDropdownFilters,
   organization,
   referrer,
   eventView,
-  noPadding = true
-) {
+  noPadding = true,
+}: {
+  eventView: EventView;
+  key: string;
+  organization: Organization;
+  referrer: string;
+  replay: ReplayListRecord | ReplayListRecordWithTx;
+  noPadding?: boolean;
+  showDropdownFilters?: boolean;
+}) {
   switch (key) {
     case ReplayColumn.ACTIVITY:
       return (
@@ -217,11 +226,11 @@ function ReplayTable({
   fetchError,
   isFetching,
   replays,
-  visibleColumns,
   sort,
+  visibleColumns,
   emptyMessage,
-  gridRows,
   saveLocation,
+  gridRows,
   showDropdownFilters,
   isOldDeadRageCard,
 }: Props) {
@@ -272,14 +281,14 @@ function ReplayTable({
   const renderBodyCell = useCallback(
     (column, dataRow) => {
       const replay = dataRow;
-      return getTableCell(
-        column.key,
+      return getTableCell({
+        key: column.key,
         replay,
         showDropdownFilters,
         organization,
         referrer,
-        eventView
-      );
+        eventView,
+      });
     },
     [organization, showDropdownFilters, eventView, referrer]
   );
@@ -305,15 +314,15 @@ function ReplayTable({
         return (
           <Fragment key={replay.id}>
             {visibleColumns.map(column => {
-              return getTableCell(
-                column,
+              return getTableCell({
+                key: column,
                 replay,
                 showDropdownFilters,
                 organization,
                 referrer,
                 eventView,
-                false // should have padding
-              );
+                noPadding: false, // old card should have padding
+              });
             })}
           </Fragment>
         );

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -1,6 +1,8 @@
 import {ReactNode, useCallback, useMemo} from 'react';
+import styled from '@emotion/styled';
 import {Location} from 'history';
 
+import Alert from 'sentry/components/alert';
 import GridEditable from 'sentry/components/gridEditable';
 import renderSortableHeaderCell from 'sentry/components/replays/renderSortableHeaderCell';
 import useQueryBasedColumnResize from 'sentry/components/replays/useQueryBasedColumnResize';
@@ -258,15 +260,20 @@ function ReplayTable({
   return (
     <GridEditable
       error={fetchError}
+      errorMessage={
+        <StyledAlert type="error" showIcon>
+          {typeof fetchError === 'string'
+            ? fetchError
+            : t(
+                'Sorry, the list of replays could not be loaded. This could be due to invalid search parameters or an internal systems error.'
+              )}
+        </StyledAlert>
+      }
       isLoading={isFetching}
+      data-test-id="replay-table"
       data={replays ?? []}
       columnOrder={columns}
-      emptyMessage={
-        emptyMessage ??
-        t(
-          'Sorry, the list of replays could not be loaded. This could be due to invalid search parameters or an internal systems error.'
-        )
-      }
+      emptyMessage={emptyMessage}
       columnSortBy={[]}
       stickyHeader
       grid={{
@@ -279,4 +286,10 @@ function ReplayTable({
   );
 }
 
+const StyledAlert = styled(Alert)`
+  border-radius: 0;
+  border-width: 1px 0 0 0;
+  grid-column: 1/-1;
+  margin-bottom: 0;
+`;
 export default ReplayTable;

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -11,6 +11,7 @@ import renderSortableHeaderCell from 'sentry/components/replays/renderSortableHe
 import useQueryBasedColumnResize from 'sentry/components/replays/useQueryBasedColumnResize';
 import useQueryBasedSorting from 'sentry/components/replays/useQueryBasedSorting';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
@@ -293,12 +294,30 @@ function ReplayTable({
     [organization, showDropdownFilters, eventView, referrer]
   );
 
-  // Old replay table code, still used for the old dead rage cards
+  // For StyledPanelTable
   const tableHeaders = visibleColumns
     .filter(Boolean)
     .map(column => <HeaderCell key={column} column={column} sort={sort} />);
 
-  return isOldDeadRageCard ? (
+  // Separate case for error because GridEditable doesn't like custom alert inside the table
+  return fetchError && !isFetching ? (
+    <ErrorStyledPanelTable
+      headers={tableHeaders}
+      isLoading={false}
+      visibleColumns={visibleColumns}
+      data-test-id="replay-table"
+      gridRows={undefined}
+    >
+      <StyledAlert type="error" showIcon>
+        {typeof fetchError === 'string'
+          ? fetchError
+          : t(
+              'Sorry, the list of replays could not be loaded. This could be due to invalid search parameters or an internal systems error.'
+            )}
+      </StyledAlert>
+    </ErrorStyledPanelTable>
+  ) : // Old replay table code, still used for the old dead rage cards
+  isOldDeadRageCard ? (
     <StyledPanelTable
       headers={tableHeaders}
       isEmpty={replays?.length === 0}
@@ -330,16 +349,7 @@ function ReplayTable({
     </StyledPanelTable>
   ) : (
     <GridEditable
-      error={fetchError}
-      errorMessage={
-        <StyledAlert type="error" showIcon>
-          {typeof fetchError === 'string'
-            ? fetchError
-            : t(
-                'Sorry, the list of replays could not be loaded. This could be due to invalid search parameters or an internal systems error.'
-              )}
-        </StyledAlert>
-      }
+      error={false}
       isLoading={isFetching}
       customTestId="replay-table"
       data={replays ?? []}
@@ -398,6 +408,10 @@ const StyledAlert = styled(Alert)`
   border-width: 1px 0 0 0;
   grid-column: 1/-1;
   margin-bottom: 0;
+`;
+
+const ErrorStyledPanelTable = styled(StyledPanelTable)`
+  margin-bottom: ${space(2)};
 `;
 
 export default ReplayTable;

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -346,7 +346,7 @@ function ReplayTable({
       columnOrder={columns}
       emptyMessage={
         <EmptyStateWarning>
-          <p>{emptyMessage}</p>
+          <p>{emptyMessage ?? t('There are no items to display')}</p>
         </EmptyStateWarning>
       }
       columnSortBy={[]}

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import Alert from 'sentry/components/alert';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import GridEditable from 'sentry/components/gridEditable';
 import renderSortableHeaderCell from 'sentry/components/replays/renderSortableHeaderCell';
 import useQueryBasedColumnResize from 'sentry/components/replays/useQueryBasedColumnResize';
@@ -273,7 +274,13 @@ function ReplayTable({
       data-test-id="replay-table"
       data={replays ?? []}
       columnOrder={columns}
-      emptyMessage={emptyMessage}
+      emptyMessage={
+        emptyMessage ?? (
+          <EmptyStateWarning>
+            <p>{t('There are no items to display')}</p>
+          </EmptyStateWarning>
+        )
+      }
       columnSortBy={[]}
       stickyHeader
       grid={{

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -292,12 +292,14 @@ export function ReplayCell({
   replay,
   referrer_table,
   isWidget,
+  noPadding,
 }: Props & {
   eventView: EventView;
   organization: Organization;
   referrer: string;
   referrer_table: ReferrerTableType;
   isWidget?: boolean;
+  noPadding?: boolean;
 }) {
   const {projects} = useProjects();
   const project = projects.find(p => p.id === replay.project_id);
@@ -353,7 +355,7 @@ export function ReplayCell({
 
   if (replay.is_archived) {
     return (
-      <Item noPadding isArchived={replay.is_archived}>
+      <Item noPadding={noPadding} isArchived={replay.is_archived}>
         <Row gap={1}>
           <StyledIconDelete color="gray500" size="md" />
           <div>
@@ -386,7 +388,7 @@ export function ReplayCell({
   );
 
   return (
-    <Item noPadding isWidget={isWidget}>
+    <Item noPadding={noPadding} isWidget={isWidget}>
       <UserBadge
         avatarSize={24}
         displayName={
@@ -431,16 +433,17 @@ const MainLink = styled(Link)`
 export function TransactionCell({
   organization,
   replay,
+  noPadding,
 }: Props & {organization: Organization}) {
   const location = useLocation();
 
   if (replay.is_archived) {
-    return <Item noPadding isArchived />;
+    return <Item noPadding={noPadding} isArchived />;
   }
   const hasTxEvent = 'txEvent' in replay;
   const txDuration = hasTxEvent ? replay.txEvent?.['transaction.duration'] : undefined;
   return hasTxEvent ? (
-    <Item noPadding>
+    <Item noPadding={noPadding}>
       <SpanOperationBreakdown>
         {txDuration ? <div>{txDuration}ms</div> : null}
         {spanOperationRelativeBreakdownRenderer(
@@ -453,16 +456,16 @@ export function TransactionCell({
   ) : null;
 }
 
-export function OSCell({replay, showDropdownFilters}: Props) {
+export function OSCell({replay, showDropdownFilters, noPadding}: Props) {
   const {name, version} = replay.os ?? {};
   const theme = useTheme();
   const hasRoomForColumns = useMedia(`(min-width: ${theme.breakpoints.large})`);
 
   if (replay.is_archived) {
-    return <Item noPadding isArchived />;
+    return <Item noPadding={noPadding} isArchived />;
   }
   return (
-    <Item noPadding>
+    <Item noPadding={noPadding}>
       <Container>
         <Tooltip title={`${name} ${version}`}>
           <ContextIcon
@@ -480,16 +483,16 @@ export function OSCell({replay, showDropdownFilters}: Props) {
   );
 }
 
-export function BrowserCell({replay, showDropdownFilters}: Props) {
+export function BrowserCell({replay, showDropdownFilters, noPadding}: Props) {
   const {name, version} = replay.browser ?? {};
   const theme = useTheme();
   const hasRoomForColumns = useMedia(`(min-width: ${theme.breakpoints.large})`);
 
   if (replay.is_archived) {
-    return <Item noPadding isArchived />;
+    return <Item noPadding={noPadding} isArchived />;
   }
   return (
-    <Item noPadding>
+    <Item noPadding={noPadding}>
       <Container>
         <Tooltip title={`${name} ${version}`}>
           <ContextIcon
@@ -507,12 +510,12 @@ export function BrowserCell({replay, showDropdownFilters}: Props) {
   );
 }
 
-export function DurationCell({replay, showDropdownFilters}: Props) {
+export function DurationCell({replay, showDropdownFilters, noPadding}: Props) {
   if (replay.is_archived) {
-    return <Item noPadding isArchived />;
+    return <Item noPadding={noPadding} isArchived />;
   }
   return (
-    <Item noPadding>
+    <Item noPadding={noPadding}>
       <Container>
         <Time>{formatTime(replay.duration.asMilliseconds())}</Time>
         {showDropdownFilters ? (
@@ -523,12 +526,12 @@ export function DurationCell({replay, showDropdownFilters}: Props) {
   );
 }
 
-export function RageClickCountCell({replay, showDropdownFilters}: Props) {
+export function RageClickCountCell({replay, showDropdownFilters, noPadding}: Props) {
   if (replay.is_archived) {
-    return <Item noPadding isArchived />;
+    return <Item noPadding={noPadding} isArchived />;
   }
   return (
-    <Item noPadding data-test-id="replay-table-count-rage-clicks">
+    <Item noPadding={noPadding} data-test-id="replay-table-count-rage-clicks">
       <Container>
         {replay.count_rage_clicks ? (
           <RageClickCount>
@@ -549,12 +552,12 @@ export function RageClickCountCell({replay, showDropdownFilters}: Props) {
   );
 }
 
-export function DeadClickCountCell({replay, showDropdownFilters}: Props) {
+export function DeadClickCountCell({replay, showDropdownFilters, noPadding}: Props) {
   if (replay.is_archived) {
-    return <Item noPadding isArchived />;
+    return <Item noPadding={noPadding} isArchived />;
   }
   return (
-    <Item noPadding data-test-id="replay-table-count-dead-clicks">
+    <Item noPadding={noPadding} data-test-id="replay-table-count-dead-clicks">
       <Container>
         {replay.count_dead_clicks ? (
           <DeadClickCount>
@@ -575,12 +578,12 @@ export function DeadClickCountCell({replay, showDropdownFilters}: Props) {
   );
 }
 
-export function ErrorCountCell({replay, showDropdownFilters}: Props) {
+export function ErrorCountCell({replay, showDropdownFilters, noPadding}: Props) {
   if (replay.is_archived) {
-    return <Item noPadding isArchived />;
+    return <Item noPadding={noPadding} isArchived />;
   }
   return (
-    <Item noPadding data-test-id="replay-table-count-errors">
+    <Item noPadding={noPadding} data-test-id="replay-table-count-errors">
       <Container>
         {replay.count_errors ? (
           <ErrorCount>
@@ -598,13 +601,13 @@ export function ErrorCountCell({replay, showDropdownFilters}: Props) {
   );
 }
 
-export function ActivityCell({replay, showDropdownFilters}: Props) {
+export function ActivityCell({replay, showDropdownFilters, noPadding}: Props) {
   if (replay.is_archived) {
-    return <Item noPadding isArchived />;
+    return <Item noPadding={noPadding} isArchived />;
   }
   const scoreBarPalette = new Array(10).fill([CHART_PALETTE[0][0]]);
   return (
-    <Item noPadding>
+    <Item noPadding={noPadding}>
       <Container>
         <ScoreBar
           size={20}

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -39,6 +39,7 @@ import type {ReplayListLocationQuery, ReplayListRecord} from 'sentry/views/repla
 
 type Props = {
   replay: ReplayListRecord | ReplayListRecordWithTx;
+  noPadding?: boolean;
   showDropdownFilters?: boolean;
 };
 
@@ -352,7 +353,7 @@ export function ReplayCell({
 
   if (replay.is_archived) {
     return (
-      <Item isArchived={replay.is_archived}>
+      <Item noPadding isArchived={replay.is_archived}>
         <Row gap={1}>
           <StyledIconDelete color="gray500" size="md" />
           <div>
@@ -377,8 +378,6 @@ export function ReplayCell({
           <Link to={detailsTab} onClick={trackNavigationEvent}>
             {getShortEventId(replay.id)}
           </Link>
-        </Row>
-        <Row gap={0.5}>
           <IconCalendar color="gray300" size="xs" />
           <TimeSince date={replay.started_at} />
         </Row>
@@ -387,7 +386,7 @@ export function ReplayCell({
   );
 
   return (
-    <Item isWidget={isWidget}>
+    <Item noPadding isWidget={isWidget}>
       <UserBadge
         avatarSize={24}
         displayName={
@@ -436,12 +435,12 @@ export function TransactionCell({
   const location = useLocation();
 
   if (replay.is_archived) {
-    return <Item isArchived />;
+    return <Item noPadding isArchived />;
   }
   const hasTxEvent = 'txEvent' in replay;
   const txDuration = hasTxEvent ? replay.txEvent?.['transaction.duration'] : undefined;
   return hasTxEvent ? (
-    <Item>
+    <Item noPadding>
       <SpanOperationBreakdown>
         {txDuration ? <div>{txDuration}ms</div> : null}
         {spanOperationRelativeBreakdownRenderer(
@@ -460,10 +459,10 @@ export function OSCell({replay, showDropdownFilters}: Props) {
   const hasRoomForColumns = useMedia(`(min-width: ${theme.breakpoints.large})`);
 
   if (replay.is_archived) {
-    return <Item isArchived />;
+    return <Item noPadding isArchived />;
   }
   return (
-    <Item>
+    <Item noPadding>
       <Container>
         <Tooltip title={`${name} ${version}`}>
           <ContextIcon
@@ -487,10 +486,10 @@ export function BrowserCell({replay, showDropdownFilters}: Props) {
   const hasRoomForColumns = useMedia(`(min-width: ${theme.breakpoints.large})`);
 
   if (replay.is_archived) {
-    return <Item isArchived />;
+    return <Item noPadding isArchived />;
   }
   return (
-    <Item>
+    <Item noPadding>
       <Container>
         <Tooltip title={`${name} ${version}`}>
           <ContextIcon
@@ -510,10 +509,10 @@ export function BrowserCell({replay, showDropdownFilters}: Props) {
 
 export function DurationCell({replay, showDropdownFilters}: Props) {
   if (replay.is_archived) {
-    return <Item isArchived />;
+    return <Item noPadding isArchived />;
   }
   return (
-    <Item>
+    <Item noPadding>
       <Container>
         <Time>{formatTime(replay.duration.asMilliseconds())}</Time>
         {showDropdownFilters ? (
@@ -526,10 +525,10 @@ export function DurationCell({replay, showDropdownFilters}: Props) {
 
 export function RageClickCountCell({replay, showDropdownFilters}: Props) {
   if (replay.is_archived) {
-    return <Item isArchived />;
+    return <Item noPadding isArchived />;
   }
   return (
-    <Item data-test-id="replay-table-count-rage-clicks">
+    <Item noPadding data-test-id="replay-table-count-rage-clicks">
       <Container>
         {replay.count_rage_clicks ? (
           <RageClickCount>
@@ -552,10 +551,10 @@ export function RageClickCountCell({replay, showDropdownFilters}: Props) {
 
 export function DeadClickCountCell({replay, showDropdownFilters}: Props) {
   if (replay.is_archived) {
-    return <Item isArchived />;
+    return <Item noPadding isArchived />;
   }
   return (
-    <Item data-test-id="replay-table-count-dead-clicks">
+    <Item noPadding data-test-id="replay-table-count-dead-clicks">
       <Container>
         {replay.count_dead_clicks ? (
           <DeadClickCount>
@@ -578,10 +577,10 @@ export function DeadClickCountCell({replay, showDropdownFilters}: Props) {
 
 export function ErrorCountCell({replay, showDropdownFilters}: Props) {
   if (replay.is_archived) {
-    return <Item isArchived />;
+    return <Item noPadding isArchived />;
   }
   return (
-    <Item data-test-id="replay-table-count-errors">
+    <Item noPadding data-test-id="replay-table-count-errors">
       <Container>
         {replay.count_errors ? (
           <ErrorCount>
@@ -601,11 +600,11 @@ export function ErrorCountCell({replay, showDropdownFilters}: Props) {
 
 export function ActivityCell({replay, showDropdownFilters}: Props) {
   if (replay.is_archived) {
-    return <Item isArchived />;
+    return <Item noPadding isArchived />;
   }
   const scoreBarPalette = new Array(10).fill([CHART_PALETTE[0][0]]);
   return (
-    <Item>
+    <Item noPadding>
       <Container>
         <ScoreBar
           size={20}
@@ -625,13 +624,19 @@ export function ActivityCell({replay, showDropdownFilters}: Props) {
   );
 }
 
-const Item = styled('div')<{isArchived?: boolean; isWidget?: boolean}>`
+const Item = styled('div')<{
+  isArchived?: boolean;
+  isWidget?: boolean;
+  noPadding?: boolean;
+}>`
   display: flex;
   align-items: center;
   gap: ${space(1)};
   ${p =>
     p.isWidget
       ? `padding: ${space(0.75)} ${space(1.5)} ${space(1.5)} ${space(1.5)};`
+      : p.noPadding
+      ? `padding: ${space(0.5)} ${space(0.5)} ${space(0.5)} 0;`
       : `padding: ${space(1.5)};`};
   ${p => (p.isArchived ? 'opacity: 0.5;' : '')};
 `;

--- a/static/app/views/replays/tabs.tsx
+++ b/static/app/views/replays/tabs.tsx
@@ -30,7 +30,15 @@ export default function ReplayTabs({selected}: Props) {
             key={tab.key}
             to={{
               ...location,
-              query: location.query,
+              query: {
+                query: undefined,
+                cursor: undefined,
+                end: location.query.end,
+                start: location.query.start,
+                statsPeriod: location.query.statsPeriod,
+                utc: location.query.utc,
+                widths: [],
+              },
               pathname: normalizeUrl(
                 `/organizations/${organization.slug}/replays/${tab.to}`
               ),

--- a/static/app/views/replays/tabs.tsx
+++ b/static/app/views/replays/tabs.tsx
@@ -30,14 +30,13 @@ export default function ReplayTabs({selected}: Props) {
             key={tab.key}
             to={{
               ...location,
+              // don't preserve these across tab changes
               query: {
+                ...location.query,
                 query: undefined,
                 cursor: undefined,
-                end: location.query.end,
-                start: location.query.start,
-                statsPeriod: location.query.statsPeriod,
-                utc: location.query.utc,
-                widths: [],
+                sort: undefined,
+                width: undefined,
               },
               pathname: normalizeUrl(
                 `/organizations/${organization.slug}/replays/${tab.to}`


### PR DESCRIPTION


| table | img |
| ---------- | --- |
| better overlap when screen size is tiny | <img width="581" alt="SCR-20231006-pbrc" src="https://github.com/getsentry/sentry/assets/56095982/cc3333ed-c3e6-4d8d-ae81-65e2640ef61d"> |
| replay index using `GridEditable` | <img width="1165" alt="SCR-20231006-qjxg" src="https://github.com/getsentry/sentry/assets/56095982/062c4e8d-b371-4524-a6bf-2e31c90f0fc3"> |
| transactions replays using `GridEditable` | <img width="1156" alt="SCR-20231006-qjrr" src="https://github.com/getsentry/sentry/assets/56095982/714ea28d-e380-4584-9e0b-c908e249d4ec"> |
| issues replays using `GridEditable` | <img width="1165" alt="SCR-20231006-qjob" src="https://github.com/getsentry/sentry/assets/56095982/75616aa7-93c3-4977-be3d-38fe2a8cca82">  | 
| replay index using `GridEditable` but old cards using `StyledPanelTable` | <img width="1205" alt="SCR-20231006-qhcz" src="https://github.com/getsentry/sentry/assets/56095982/99166162-823e-478e-b4ee-54c29e2b645e">
| `GridEditable` empty state | <img width="1187" alt="SCR-20231006-slph" src="https://github.com/getsentry/sentry/assets/56095982/9ad5887f-8500-4f84-b13a-2a4217d50808"> |
| `StyledPanelTable` error state | <img width="1180" alt="SCR-20231006-snlq" src="https://github.com/getsentry/sentry/assets/56095982/f7393ed0-80f4-4a21-afdc-71d0e4687683"> |


hopefully closes https://github.com/getsentry/sentry/issues/57682