### PR TITLE
feat(escalating-issues): Wrap Group updates in db transaction

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -436,15 +436,15 @@ class GroupManager(BaseManager):
 
             Group.objects.bulk_update(modified_groups_list, ["status", "substatus"])
 
-            for group in modified_groups_list:
-                Activity.objects.create_group_activity(
-                    group,
-                    activity_type,
-                    data=activity_data,
-                    send_notification=send_activity_notification,
-                )
+        for group in modified_groups_list:
+            Activity.objects.create_group_activity(
+                group,
+                activity_type,
+                data=activity_data,
+                send_notification=send_activity_notification,
+            )
 
-                record_group_history_from_activity_type(group, activity_type.value)
+            record_group_history_from_activity_type(group, activity_type.value)
 
     def from_share_id(self, share_id: str) -> Group:
         if not share_id or len(share_id) != 32:

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -421,7 +421,7 @@ class GroupManager(BaseManager):
         """For each groups, update status to `status` and create an Activity."""
         from sentry.models import Activity
 
-        groups_list = []
+        modified_groups_list = []
         with transaction.atomic(router.db_for_write(Group)):
             selected_groups = (
                 Group.objects.filter(id__in=[g.id for g in groups])
@@ -432,11 +432,11 @@ class GroupManager(BaseManager):
             for group in selected_groups:
                 group.status = status
                 group.substatus = substatus
-                groups_list.append(group)
+                modified_groups_list.append(group)
 
-            Group.objects.bulk_update(groups_list, ["status", "substatus"])
+            Group.objects.bulk_update(modified_groups_list, ["status", "substatus"])
 
-            for group in groups_list:
+            for group in modified_groups_list:
                 Activity.objects.create_group_activity(
                     group,
                     activity_type,

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -22,7 +22,7 @@ from sentry.utils.query import RangeQuerySetWrapper
 logger = logging.getLogger(__name__)
 
 TRANSITION_AFTER_DAYS = 7
-ITERATOR_CHUNK = 500
+ITERATOR_CHUNK = 10_000
 
 
 def log_error_if_queue_has_items(func):

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -22,7 +22,7 @@ from sentry.utils.query import RangeQuerySetWrapper
 logger = logging.getLogger(__name__)
 
 TRANSITION_AFTER_DAYS = 7
-ITERATOR_CHUNK = 10_000
+ITERATOR_CHUNK = 500
 
 
 def log_error_if_queue_has_items(func):


### PR DESCRIPTION
## Objective:
We are getting timeouts when executing the update SQL query. This PR wraps that method in a database transaction. This ensures atomicity and can improve performance for grouped write operations. 