### PR TITLE
ref(backup): Convert InstanceID to NamedTuple

### DIFF
--- a/src/sentry/backup/validate.py
+++ b/src/sentry/backup/validate.py
@@ -52,7 +52,7 @@ def validate(
                 findings.append(
                     ComparatorFinding(
                         kind=ComparatorFindingKind.UnorderedInput,
-                        on=InstanceID(model_name, self.next_ordinal),
+                        on=InstanceID(str(model_name), self.next_ordinal),
                         left_pk=pk if side == Side.left else None,
                         right_pk=pk if side == Side.right else None,
                         reason=f"""instances not listed in ascending `pk` order; `pk` {pk} is less than or equal to {self.max_seen_pk} which precedes it""",
@@ -78,7 +78,7 @@ def validate(
             counter = ordinal_counters[model_name]
             ordinal, found = counter.assign(model, side)
             findings.extend(found)
-            id = InstanceID(model_name, ordinal)
+            id = InstanceID(str(model_name), ordinal)
             model_map[id] = model
         return (model_map, ordinal_counters)
 
@@ -109,7 +109,7 @@ def validate(
             findings.append(
                 ComparatorFinding(
                     kind=ComparatorFindingKind.UnequalCounts,
-                    on=InstanceID(model_name),
+                    on=InstanceID(str(model_name)),
                     reason=f"""counted {left_count} left entries and {right_count} right entries""",
                 )
             )

--- a/tests/sentry/backup/test_comparators.py
+++ b/tests/sentry/backup/test_comparators.py
@@ -23,7 +23,7 @@ from sentry.utils.json import JSONData
 
 def test_good_comparator_both_sides_existing():
     cmp = DateUpdatedComparator("my_date_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     present: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -37,7 +37,7 @@ def test_good_comparator_both_sides_existing():
 
 def test_good_comparator_neither_side_existing():
     cmp = DateUpdatedComparator("my_date_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     missing: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -49,7 +49,7 @@ def test_good_comparator_neither_side_existing():
 
 def test_bad_comparator_only_one_side_existing():
     cmp = DateUpdatedComparator("my_date_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     present: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -91,7 +91,7 @@ def test_bad_comparator_only_one_side_existing():
 
 def test_good_auto_suffix_comparator():
     cmp = AutoSuffixComparator("same", "suffixed")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -115,7 +115,7 @@ def test_good_auto_suffix_comparator():
 
 def test_bad_auto_suffix_comparator():
     cmp = AutoSuffixComparator("same", "suffixed")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -157,7 +157,7 @@ def test_bad_auto_suffix_comparator():
 
 def test_good_auto_suffix_comparator_existence():
     cmp = AutoSuffixComparator("auto_suffix_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     present: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -217,7 +217,7 @@ def test_good_auto_suffix_comparator_scrubbed():
 
 def test_good_datetime_equality_comparator():
     cmp = DatetimeEqualityComparator("my_date_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -239,7 +239,7 @@ def test_good_datetime_equality_comparator():
 
 def test_bad_datetime_equality_comparator():
     cmp = DatetimeEqualityComparator("my_date_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -272,7 +272,7 @@ def test_bad_datetime_equality_comparator():
 
 def test_good_date_updated_comparator():
     cmp = DateUpdatedComparator("my_date_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -294,7 +294,7 @@ def test_good_date_updated_comparator():
 
 def test_bad_date_updated_comparator():
     cmp = DateUpdatedComparator("my_date_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -327,7 +327,7 @@ def test_bad_date_updated_comparator():
 
 def test_good_email_obfuscating_comparator():
     cmp = EmailObfuscatingComparator("one_email", "many_emails")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     model = {
         "model": "test",
         "ordinal": 1,
@@ -345,7 +345,7 @@ def test_good_email_obfuscating_comparator():
 
 def test_bad_email_obfuscating_comparator():
     cmp = EmailObfuscatingComparator("one_email", "many_emails")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -393,7 +393,7 @@ def test_bad_email_obfuscating_comparator():
 
 def test_good_email_obfuscating_comparator_existence():
     cmp = EmailObfuscatingComparator("email_obfuscating_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     present: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -465,7 +465,7 @@ def test_good_email_obfuscating_comparator_scrubbed():
 
 def test_good_hash_obfuscating_comparator():
     cmp = HashObfuscatingComparator("one_hash", "many_hashes")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     model: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -483,7 +483,7 @@ def test_good_hash_obfuscating_comparator():
 
 def test_bad_hash_obfuscating_comparator():
     cmp = HashObfuscatingComparator("one_hash", "many_hashes")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -531,7 +531,7 @@ def test_bad_hash_obfuscating_comparator():
 
 def test_good_hash_obfuscating_comparator_existence():
     cmp = HashObfuscatingComparator("hash_obfuscating_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     present: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -606,7 +606,7 @@ def test_good_foreign_key_comparator():
     cmp = ForeignKeyComparator(
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
     )
-    id = InstanceID(NormalizedModelName("sentry.useremail"), 0)
+    id = InstanceID("sentry.useremail", 0)
     left_pk_map = PrimaryKeyMap()
     left_pk_map.insert(NormalizedModelName("sentry.user"), 12, 1, ImportKind.Inserted)
     right_pk_map = PrimaryKeyMap()
@@ -645,7 +645,7 @@ def test_good_foreign_key_comparator_existence():
     cmp = ForeignKeyComparator(
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
     )
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     present: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -713,7 +713,7 @@ def test_bad_foreign_key_comparator_set_primary_key_maps_not_called():
     cmp = ForeignKeyComparator(
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
     )
-    id = InstanceID(NormalizedModelName("sentry.useremail"), 0)
+    id = InstanceID("sentry.useremail", 0)
     left_pk_map = PrimaryKeyMap()
     left_pk_map.insert(NormalizedModelName("sentry.user"), 12, 1, ImportKind.Inserted)
     right_pk_map = PrimaryKeyMap()
@@ -752,7 +752,7 @@ def test_bad_foreign_key_comparator_unequal_mapping():
     cmp = ForeignKeyComparator(
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
     )
-    id = InstanceID(NormalizedModelName("sentry.useremail"), 0)
+    id = InstanceID("sentry.useremail", 0)
     left_pk_map = PrimaryKeyMap()
     left_pk_map.insert(NormalizedModelName("sentry.user"), 12, 1, ImportKind.Inserted)
     right_pk_map = PrimaryKeyMap()
@@ -802,7 +802,7 @@ def test_bad_foreign_key_comparator_missing_mapping():
     cmp = ForeignKeyComparator(
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
     )
-    id = InstanceID(NormalizedModelName("sentry.useremail"), 0)
+    id = InstanceID("sentry.useremail", 0)
     left_pk_map = PrimaryKeyMap()
     right_pk_map = PrimaryKeyMap()
     left: JSONData = {
@@ -855,7 +855,7 @@ def test_bad_foreign_key_comparator_missing_mapping():
 
 def test_good_ignored_comparator():
     cmp = IgnoredComparator("ignored_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     model: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -870,7 +870,7 @@ def test_good_ignored_comparator():
 
 def test_good_ignored_comparator_existence():
     cmp = IgnoredComparator("ignored_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     present: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -922,7 +922,7 @@ def test_good_ignored_comparator_scrubbed():
 
 def test_good_secret_hex_comparator():
     cmp = SecretHexComparator(8, "equal", "unequal")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -946,7 +946,7 @@ def test_good_secret_hex_comparator():
 
 def test_bad_secret_hex_comparator():
     cmp = SecretHexComparator(8, "same", "invalid_left", "invalid_right")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1020,7 +1020,7 @@ def test_good_secret_hex_comparator_scrubbed():
 
 def test_good_subscription_id_comparator():
     cmp = SubscriptionIDComparator("subscription_id_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1042,7 +1042,7 @@ def test_good_subscription_id_comparator():
 
 def test_bad_subscription_id_comparator():
     cmp = SubscriptionIDComparator("same", "invalid_left", "invalid_right")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1099,7 +1099,7 @@ def test_bad_subscription_id_comparator():
 
 def test_good_subscription_id_comparator_existence():
     cmp = SubscriptionIDComparator("subscription_id_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     present: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1155,7 +1155,7 @@ def test_good_subscription_id_comparator_scrubbed():
 
 def test_good_uuid4_comparator():
     cmp = UUID4Comparator("guid_field")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1177,7 +1177,7 @@ def test_good_uuid4_comparator():
 
 def test_bad_uuid4_comparator():
     cmp = UUID4Comparator("same", "invalid_left", "invalid_right")
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1260,7 +1260,7 @@ def test_good_uuid4_comparator_scrubbed():
 
 def test_good_user_password_obfuscating_comparator_claimed_user():
     cmp = UserPasswordObfuscatingComparator()
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     model: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1275,7 +1275,7 @@ def test_good_user_password_obfuscating_comparator_claimed_user():
 
 def test_good_user_password_obfuscating_comparator_newly_unclaimed_user():
     cmp = UserPasswordObfuscatingComparator()
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1299,7 +1299,7 @@ def test_good_user_password_obfuscating_comparator_newly_unclaimed_user():
 
 def test_good_user_password_obfuscating_comparator_already_unclaimed_user():
     cmp = UserPasswordObfuscatingComparator()
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1323,7 +1323,7 @@ def test_good_user_password_obfuscating_comparator_already_unclaimed_user():
 
 def test_bad_user_password_obfuscating_comparator_claimed_user():
     cmp = UserPasswordObfuscatingComparator()
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1358,7 +1358,7 @@ def test_bad_user_password_obfuscating_comparator_claimed_user():
 
 def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user():
     cmp = UserPasswordObfuscatingComparator()
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1392,7 +1392,7 @@ def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user():
 
 def test_bad_user_password_obfuscating_comparator_already_unclaimed_user():
     cmp = UserPasswordObfuscatingComparator()
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1426,7 +1426,7 @@ def test_bad_user_password_obfuscating_comparator_already_unclaimed_user():
 
 def test_bad_user_password_obfuscating_comparator_impossible_newly_claimed_user():
     cmp = UserPasswordObfuscatingComparator()
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     left: JSONData = {
         "model": "test",
         "ordinal": 1,
@@ -1460,7 +1460,7 @@ def test_bad_user_password_obfuscating_comparator_impossible_newly_claimed_user(
 
 def test_good_user_password_obfuscating_comparator_existence():
     cmp = UserPasswordObfuscatingComparator()
-    id = InstanceID(NormalizedModelName("sentry.test"), 0)
+    id = InstanceID("sentry.test", 0)
     present: JSONData = {
         "model": "test",
         "ordinal": 1,

--- a/tests/sentry/backup/test_findings.py
+++ b/tests/sentry/backup/test_findings.py
@@ -47,7 +47,7 @@ class TestFinding(Finding):
 class FindingsTests(TestCase):
     def test_defaults(self):
         finding = TestFinding(
-            on=InstanceID(model=get_model_name(Email)),
+            on=InstanceID(model=str(get_model_name(Email))),
             reason="test reason",
         )
 
@@ -76,7 +76,7 @@ class FindingsTests(TestCase):
     def test_no_nulls(self):
         finding = TestFinding(
             kind=TestFindingKind.Foo,
-            on=InstanceID(model=get_model_name(Email), ordinal=1),
+            on=InstanceID(model=str(get_model_name(Email)), ordinal=1),
             left_pk=2,
             right_pk=3,
             reason="test reason",

--- a/tests/sentry/backup/test_snapshots.py
+++ b/tests/sentry/backup/test_snapshots.py
@@ -1,7 +1,6 @@
 import pytest
 
 from sentry.backup.comparators import get_default_comparators
-from sentry.backup.dependencies import NormalizedModelName
 from sentry.backup.findings import ComparatorFindingKind, InstanceID
 from sentry.testutils.helpers.backups import (
     ValidationError,
@@ -46,7 +45,7 @@ def test_date_updated_with_unzeroed_milliseconds(tmp_path):
     findings = execinfo.value.info.findings
     assert len(findings) == 1
     assert findings[0].kind == ComparatorFindingKind.UnequalJSON
-    assert findings[0].on == InstanceID(NormalizedModelName("sentry.option"), 1)
+    assert findings[0].on == InstanceID("sentry.option", 1)
     assert findings[0].left_pk == 1
     assert findings[0].right_pk == 1
     assert """-  "last_updated": "2023-06-22T00:00:00Z",""" in findings[0].reason

--- a/tests/sentry/backup/test_validate.py
+++ b/tests/sentry/backup/test_validate.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 
 from sentry.backup.comparators import get_default_comparators
-from sentry.backup.dependencies import NormalizedModelName
 from sentry.backup.findings import ComparatorFindingKind, InstanceID
 from sentry.backup.validate import validate
 from sentry.testutils.factories import get_fixture_path
@@ -74,11 +73,11 @@ def test_bad_duplicate_entry(tmp_path):
 
     assert len(findings) == 2
     assert findings[0].kind == ComparatorFindingKind.UnorderedInput
-    assert findings[0].on == InstanceID(NormalizedModelName("sentry.option"), 2)
+    assert findings[0].on == InstanceID("sentry.option", 2)
     assert findings[0].left_pk == 1
     assert not findings[0].right_pk
     assert findings[1].kind == ComparatorFindingKind.UnorderedInput
-    assert findings[1].on == InstanceID(NormalizedModelName("sentry.option"), 2)
+    assert findings[1].on == InstanceID("sentry.option", 2)
     assert not findings[1].left_pk
     assert findings[1].right_pk == 1
 
@@ -123,11 +122,11 @@ def test_bad_out_of_order_entry(tmp_path):
 
     assert len(findings) == 2
     assert findings[0].kind == ComparatorFindingKind.UnorderedInput
-    assert findings[0].on == InstanceID(NormalizedModelName("sentry.option"), 3)
+    assert findings[0].on == InstanceID("sentry.option", 3)
     assert findings[0].left_pk == 2
     assert not findings[0].right_pk
     assert findings[1].kind == ComparatorFindingKind.UnorderedInput
-    assert findings[1].on == InstanceID(NormalizedModelName("sentry.option"), 3)
+    assert findings[1].on == InstanceID("sentry.option", 3)
     assert not findings[1].left_pk
     assert findings[1].right_pk == 2
 
@@ -156,7 +155,7 @@ def test_bad_extra_left_entry(tmp_path):
 
     assert len(findings) == 1
     assert findings[0].kind == ComparatorFindingKind.UnequalCounts
-    assert findings[0].on == InstanceID(NormalizedModelName("sentry.option"))
+    assert findings[0].on == InstanceID("sentry.option")
     assert not findings[0].left_pk
     assert not findings[0].right_pk
     assert "2 left" in findings[0].reason
@@ -187,7 +186,7 @@ def test_bad_extra_right_entry(tmp_path):
 
     assert len(findings) == 1
     assert findings[0].kind == ComparatorFindingKind.UnequalCounts
-    assert findings[0].on == InstanceID(NormalizedModelName("sentry.option"))
+    assert findings[0].on == InstanceID("sentry.option")
     assert not findings[0].left_pk
     assert not findings[0].right_pk
     assert "1 left" in findings[0].reason
@@ -298,7 +297,7 @@ def test_bad_left_side_comparator_field_missing(tmp_path):
 
     assert len(findings) == 1
     assert findings[0].kind == ComparatorFindingKind.DateUpdatedComparatorExistenceCheck
-    assert findings[0].on == InstanceID(NormalizedModelName("sentry.userrole"), 1)
+    assert findings[0].on == InstanceID("sentry.userrole", 1)
     assert findings[0].left_pk == 1
     assert findings[0].right_pk == 1
     assert "left `date_updated`" in findings[0].reason
@@ -342,7 +341,7 @@ def test_bad_right_side_comparator_field_missing(tmp_path):
 
     assert len(findings) == 1
     assert findings[0].kind == ComparatorFindingKind.DateUpdatedComparatorExistenceCheck
-    assert findings[0].on == InstanceID(NormalizedModelName("sentry.userrole"), 1)
+    assert findings[0].on == InstanceID("sentry.userrole", 1)
     assert findings[0].left_pk == 1
     assert findings[0].right_pk == 1
     assert "right `date_updated`" in findings[0].reason
@@ -384,7 +383,7 @@ def test_auto_assign_email_obfuscating_comparator(tmp_path):
     assert len(findings) == 1
 
     assert findings[0].kind == ComparatorFindingKind.EmailObfuscatingComparator
-    assert findings[0].on == InstanceID(NormalizedModelName("sentry.email"), 1)
+    assert findings[0].on == InstanceID("sentry.email", 1)
     assert findings[0].left_pk == 1
     assert findings[0].right_pk == 1
     assert """`email`""" in findings[0].reason


### PR DESCRIPTION
This is a bit unfortunate, as this requires the `model` to be passed as an (unparsed) `str`, rather than as an already-parsed `NormalizedModelName`, ultimately making the class easier to misuse. However, `InstanceID`s will now need to be sent over RPC, and no other solution I tried for this that retained the type-unwrapping constructor was satisfactory:

- I considered using Pydantic's `BaseModel` or `dataclass` base classes, but opted against this, as I would like to avoid Pydantic types leaking out of the RPC-specific modules they mostly live in today.
- I tried to convince Pydantic to properly encode/decode the existing native dataclass, but ran across https://github.com/pydantic/pydantic/issues/2531, which won't allow custom encoding/decoding of arbitrary types in Pydantic v1.
- I also messed with some other inheritance schemes, but in the end decided converting to a `NamedTuple` and dropping the type unwrapping was probably the best solution for now.

Issue: getsentry/team-ospo#196