### PR TITLE
feat(backup): Enable export over RPC

### DIFF
--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum, auto, unique
 from functools import lru_cache
-from typing import Dict, FrozenSet, NamedTuple, Optional, Set, Tuple, Type
+from typing import NamedTuple, Optional, Tuple, Type
 
 from django.db import models
 from django.db.models.fields.related import ForeignKey, OneToOneField
@@ -150,6 +150,9 @@ class ModelRelations:
             return self.model.get_possible_relocation_scopes()
         return set()
 
+    def get_dependencies_for_relocation(self) -> set[Type[models.base.Model]]:
+        return self.flatten().union(self.relocation_dependencies)
+
     def get_uniques_without_foreign_keys(self) -> list[frozenset[str]]:
         """
         Gets all unique sets (that is, either standalone fields that are marked `unique=True`, or
@@ -177,7 +180,7 @@ class ModelRelations:
         return out
 
 
-def get_model_name(model: type[models.Model] | models.Model) -> NormalizedModelName:
+def get_model_name(model: Type[models.Model] | models.Model) -> NormalizedModelName:
     return NormalizedModelName(f"{model._meta.app_label}.{model._meta.object_name}")
 
 
@@ -217,7 +220,7 @@ class DependenciesJSONEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
-class ImportKind(Enum):
+class ImportKind(str, Enum):
     """
     When importing a given model, we may create a new copy of it (`Inserted`), merely re-use an
     `Existing` copy that has the same already-used globally unique identifier (ex: `username` for
@@ -227,9 +230,9 @@ class ImportKind(Enum):
     if they are dealing with a new or re-used model.
     """
 
-    Inserted = auto()
-    Existing = auto()
-    Overwrite = auto()
+    Inserted = "Inserted"
+    Existing = "Existing"
+    Overwrite = "Overwrite"
 
 
 class PrimaryKeyMap:
@@ -244,7 +247,7 @@ class PrimaryKeyMap:
     keys are not supported!
     """
 
-    mapping: Dict[str, Dict[int, Tuple[int, ImportKind, Optional[str]]]]
+    mapping: dict[str, dict[int, Tuple[int, ImportKind, Optional[str]]]]
 
     def __init__(self):
         self.mapping = defaultdict(dict)
@@ -264,7 +267,7 @@ class PrimaryKeyMap:
 
         return entry[0]
 
-    def get_pks(self, model_name: NormalizedModelName) -> Set[int]:
+    def get_pks(self, model_name: NormalizedModelName) -> set[int]:
         """
         Get a list of all of the pks for a specific model.
         """
@@ -315,6 +318,31 @@ class PrimaryKeyMap:
 
         self.mapping[str(model_name)][old] = (new, kind, slug)
 
+    def extend(self, other: PrimaryKeyMap) -> None:
+        """
+        Insert all values from another map into this one, without mutating the original map.
+        """
+
+        for model_name_str, mappings in other.mapping.items():
+            for old_pk, new_entry in mappings.items():
+                self.mapping[model_name_str][old_pk] = new_entry
+
+    def partition(self, model_names: set[NormalizedModelName]) -> PrimaryKeyMap:
+        """
+        Create a new map with only the specified model kinds retained.
+        """
+
+        building = PrimaryKeyMap()
+        for model_name_str, mappings in self.mapping.items():
+            model_name = NormalizedModelName(model_name_str)
+            if model_name not in model_names:
+                continue
+
+            for old_pk, new_entry in mappings.items():
+                building.mapping[model_name_str][old_pk] = new_entry
+
+        return building
+
 
 # No arguments, so we lazily cache the result after the first calculation.
 @lru_cache(maxsize=1)
@@ -336,7 +364,7 @@ def dependencies() -> dict[NormalizedModelName, ModelRelations]:
     from sentry.models.team import Team
 
     # Process the list of models, and get the list of dependencies.
-    model_dependencies_dict: Dict[NormalizedModelName, ModelRelations] = {}
+    model_dependencies_dict: dict[NormalizedModelName, ModelRelations] = {}
     app_configs = apps.get_app_configs()
     models_from_names = {
         get_model_name(model): model
@@ -351,8 +379,8 @@ def dependencies() -> dict[NormalizedModelName, ModelRelations]:
         model_iterator = app_config.get_models()
 
         for model in model_iterator:
-            foreign_keys: Dict[str, ForeignField] = dict()
-            uniques: Set[FrozenSet[str]] = {
+            foreign_keys: dict[str, ForeignField] = dict()
+            uniques: set[frozenset[str]] = {
                 frozenset(combo) for combo in model._meta.unique_together
             }
 
@@ -485,7 +513,7 @@ def dependencies() -> dict[NormalizedModelName, ModelRelations]:
     # models non-dangling, then traversing from every other model to a (possible) root model
     # recursively. At this point there should be no circular reference chains, so if we encounter
     # them, fail immediately.
-    def resolve_dangling(seen: Set[NormalizedModelName], model_name: NormalizedModelName) -> bool:
+    def resolve_dangling(seen: set[NormalizedModelName], model_name: NormalizedModelName) -> bool:
         model_relations = model_dependencies_dict[model_name]
         model_name = get_model_name(model_relations.model)
         if model_name in seen:
@@ -557,7 +585,7 @@ def sorted_dependencies() -> list[Type[models.base.Model]]:
         changed = False
         while model_dependencies_remaining:
             model_deps = model_dependencies_remaining.pop()
-            deps = model_deps.flatten().union(model_deps.relocation_dependencies)
+            deps = model_deps.get_dependencies_for_relocation()
             model = model_deps.model
 
             # If all of the models in the dependency list are either already

--- a/src/sentry/backup/exports.py
+++ b/src/sentry/backup/exports.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from typing import Type
 
 import click
-from django.core.serializers import serialize
-from django.core.serializers.json import DjangoJSONEncoder
-from django.db.models import Q
+from django.db.models.base import Model
 
 from sentry.backup.dependencies import (
-    ImportKind,
     PrimaryKeyMap,
     dependencies,
     get_model_name,
@@ -16,11 +13,21 @@ from sentry.backup.dependencies import (
 )
 from sentry.backup.helpers import Filter
 from sentry.backup.scopes import ExportScope
-
-UTC_0 = timezone(timedelta(hours=0))
+from sentry.services.hybrid_cloud.import_export.model import (
+    RpcExportError,
+    RpcExportScope,
+    RpcFilter,
+    RpcPrimaryKeyMap,
+)
+from sentry.services.hybrid_cloud.import_export.service import (
+    ImportExportService,
+    import_export_service,
+)
+from sentry.silo.base import SiloMode
+from sentry.utils import json
 
 __all__ = (
-    "DatetimeSafeDjangoJSONEncoder",
+    "ExportingError",
     "export_in_user_scope",
     "export_in_organization_scope",
     "export_in_config_scope",
@@ -28,15 +35,9 @@ __all__ = (
 )
 
 
-class DatetimeSafeDjangoJSONEncoder(DjangoJSONEncoder):
-    """A wrapper around the default `DjangoJSONEncoder` that always retains milliseconds, even when
-    their implicit value is `.000`. This is necessary because the ECMA-262 compatible
-    `DjangoJSONEncoder` drops these by default."""
-
-    def default(self, obj):
-        if isinstance(obj, datetime):
-            return obj.astimezone(UTC_0).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
-        return super().default(obj)
+class ExportingError(Exception):
+    def __init__(self, context: RpcExportError) -> None:
+        self.context = context
 
 
 def _export(
@@ -58,10 +59,14 @@ def _export(
     from sentry.models.organizationmember import OrganizationMember
     from sentry.models.user import User
 
-    allowed_relocation_scopes = scope.value
-    pk_map = PrimaryKeyMap()
-    deps = dependencies()
+    if SiloMode.get_current_mode() == SiloMode.CONTROL:
+        errText = "Exports must be run in REGION or MONOLITH instances only"
+        printer(errText, err=True)
+        raise RuntimeError(errText)
 
+    final = []
+    pk_map = PrimaryKeyMap()
+    allowed_relocation_scopes = scope.value
     filters = []
     if filter_by is not None:
         filters.append(filter_by)
@@ -86,92 +91,67 @@ def _export(
         else:
             raise ValueError("Filter arguments must only apply to `Organization` or `User` models")
 
-    def filter_objects(queryset_iterator):
-        # Intercept each value from the queryset iterator, ensure that it has the correct relocation
-        # scope and that all of its dependencies have already been exported. If they have, store it
-        # in the `pk_map`, and then yield it again. If they have not, we know that some upstream
-        # model was filtered out, so we ignore this one as well.
-        for item in queryset_iterator:
-            if not item.get_relocation_scope() in allowed_relocation_scopes:
-                continue
+    def get_exporter_for_model(model: Type[Model]):
+        if SiloMode.CONTROL in model._meta.silo_limit.modes:  # type: ignore
+            return import_export_service.export_by_model
+        return ImportExportService.get_local_implementation().export_by_model  # type: ignore
 
-            model = type(item)
-            model_name = get_model_name(model)
-
-            # Make sure this model is not explicitly being filtered.
-            for f in filters:
-                if f.model == model and getattr(item, f.field, None) not in f.values:
-                    break
-            else:
-                # Now make sure its not transitively filtered either.
-                for field, foreign_field in deps[model_name].foreign_keys.items():
-                    dependency_model_name = get_model_name(foreign_field.model)
-                    field_id = field if field.endswith("_id") else f"{field}_id"
-                    fk = getattr(item, field_id, None)
-                    if fk is None:
-                        # Null deps are allowed.
-                        continue
-                    if pk_map.get_pk(dependency_model_name, fk) is None:
-                        # The foreign key value exists, but not found! An upstream model must have
-                        # been filtered out, so we can filter this one out as well.
-                        break
-                else:
-                    pk_map.insert(model_name, item.pk, item.pk, ImportKind.Inserted)
-                    yield item
-
-    def yield_objects():
+    # TODO(getsentry/team-ospo#190): Another optimization opportunity to use a generator with ijson # to print the JSON objects in a streaming manner.
+    for model in sorted_dependencies():
         from sentry.db.models.base import BaseModel
 
-        # Collate the objects to be serialized.
-        for model in sorted_dependencies():
-            if not issubclass(model, BaseModel):
-                continue
+        if not issubclass(model, BaseModel):
+            continue
 
-            possible_relocation_scopes = model.get_possible_relocation_scopes()
-            includable = possible_relocation_scopes & allowed_relocation_scopes
-            if not includable or model._meta.proxy:
-                continue
+        possible_relocation_scopes = model.get_possible_relocation_scopes()
+        includable = possible_relocation_scopes & allowed_relocation_scopes
+        if not includable or model._meta.proxy:
+            continue
 
-            q = Q()
+        model_name = get_model_name(model)
+        model_relations = dependencies().get(model_name)
+        if not model_relations:
+            continue
 
-            # Only do database query filtering if this is a non-global export. If it is a global
-            # export, we want absolutely every relocatable model, so no need to filter.
-            if scope != ExportScope.Global:
-                # Create a Django filter from the relevant `filter_by` clauses.
-                query = dict()
-                for f in filters:
-                    if f.model == model:
-                        query[f.field + "__in"] = f.values
-                q &= Q(**query)
-                q = model.query_for_relocation_export(q, pk_map)
+        dep_models = {get_model_name(d) for d in model_relations.get_dependencies_for_relocation()}
+        export_by_model = get_exporter_for_model(model)
+        result = export_by_model(
+            model_name=str(model_name),
+            scope=RpcExportScope.into_rpc(scope),
+            from_pk=0,
+            filter_by=[RpcFilter.into_rpc(f) for f in filters],
+            pk_map=RpcPrimaryKeyMap.into_rpc(pk_map.partition(dep_models)),
+            indent=indent,
+        )
 
-            pk_name = model._meta.pk.name  # type: ignore
-            queryset = model._base_manager.filter(q).order_by(pk_name)
-            yield from filter_objects(queryset.iterator())
+        if isinstance(result, RpcExportError):
+            printer(result.pretty(), err=True)
+            raise ExportingError(result)
 
-    serialize(
-        "json",
-        yield_objects(),
-        indent=indent,
-        stream=dest,
-        use_natural_foreign_keys=False,
-        cls=DatetimeSafeDjangoJSONEncoder,
-    )
+        pk_map.extend(result.mapped_pks.from_rpc())
+
+        # TODO(getsentry/team-ospo#190): Since the structure of this data is very predictable (an
+        # array of serialized model objects), we could probably avoid re-ingesting the JSON string
+        # as a future optimization.
+        for json_model in json.loads(result.json_data):
+            final.append(json_model)
+
+    json.dump(final, dest)
 
 
 def export_in_user_scope(
-    src, *, user_filter: set[str] | None = None, indent: int = 2, printer=click.echo
+    dest, *, user_filter: set[str] | None = None, indent: int = 2, printer=click.echo
 ):
     """
     Perform an export in the `User` scope, meaning that only models with `RelocationScope.User` will
-    be exported from the provided `src` file.
+    be exported from the provided `dest` file.
     """
 
     # Import here to prevent circular module resolutions.
     from sentry.models.user import User
 
     return _export(
-        src,
+        dest,
         ExportScope.User,
         filter_by=Filter(User, "username", user_filter) if user_filter is not None else None,
         indent=indent,
@@ -180,19 +160,19 @@ def export_in_user_scope(
 
 
 def export_in_organization_scope(
-    src, *, org_filter: set[str] | None = None, indent: int = 2, printer=click.echo
+    dest, *, org_filter: set[str] | None = None, indent: int = 2, printer=click.echo
 ):
     """
     Perform an export in the `Organization` scope, meaning that only models with
     `RelocationScope.User` or `RelocationScope.Organization` will be exported from the provided
-    `src` file.
+    `dest` file.
     """
 
     # Import here to prevent circular module resolutions.
     from sentry.models.organization import Organization
 
     return _export(
-        src,
+        dest,
         ExportScope.Organization,
         filter_by=Filter(Organization, "slug", org_filter) if org_filter is not None else None,
         indent=indent,
@@ -200,7 +180,7 @@ def export_in_organization_scope(
     )
 
 
-def export_in_config_scope(src, *, indent: int = 2, printer=click.echo):
+def export_in_config_scope(dest, *, indent: int = 2, printer=click.echo):
     """
     Perform an export in the `Config` scope, meaning that only models directly related to the global
     configuration and administration of an entire Sentry instance will be exported.
@@ -208,29 +188,19 @@ def export_in_config_scope(src, *, indent: int = 2, printer=click.echo):
 
     # Import here to prevent circular module resolutions.
     from sentry.models.user import User
-    from sentry.models.userpermission import UserPermission
-    from sentry.models.userrole import UserRoleUser
-
-    # Pick out all users with admin privileges.
-    admin_user_pks: set[int] = set()
-    admin_user_pks.update(
-        User.objects.filter(Q(is_staff=True) | Q(is_superuser=True)).values_list("id", flat=True)
-    )
-    admin_user_pks.update(UserPermission.objects.values_list("user_id", flat=True))
-    admin_user_pks.update(UserRoleUser.objects.values_list("user_id", flat=True))
 
     return _export(
-        src,
+        dest,
         ExportScope.Config,
-        filter_by=Filter(User, "pk", admin_user_pks),
+        filter_by=Filter(User, "pk", import_export_service.get_all_globally_privileged_users()),
         indent=indent,
         printer=printer,
     )
 
 
-def export_in_global_scope(src, *, indent: int = 2, printer=click.echo):
+def export_in_global_scope(dest, *, indent: int = 2, printer=click.echo):
     """
     Perform an export in the `Global` scope, meaning that all models will be exported from the
     provided source file.
     """
-    return _export(src, ExportScope.Global, indent=indent, printer=printer)
+    return _export(dest, ExportScope.Global, indent=indent, printer=printer)

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -3,12 +3,6 @@ from __future__ import annotations
 import click
 
 from sentry.backup.comparators import get_default_comparators
-from sentry.backup.exports import (
-    export_in_config_scope,
-    export_in_global_scope,
-    export_in_organization_scope,
-    export_in_user_scope,
-)
 from sentry.backup.findings import FindingJSONEncoder
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.imports import (
@@ -237,6 +231,8 @@ def export_users(dest, silent, indent, filter_usernames):
     Export all Sentry users in the JSON format.
     """
 
+    from sentry.backup.exports import export_in_user_scope
+
     export_in_user_scope(
         dest,
         indent=indent,
@@ -268,6 +264,8 @@ def export_organizations(dest, silent, indent, filter_org_slugs):
     Export all Sentry organizations, and their constituent users, in the JSON format.
     """
 
+    from sentry.backup.exports import export_in_organization_scope
+
     export_in_organization_scope(
         dest,
         indent=indent,
@@ -291,6 +289,8 @@ def export_config(dest, silent, indent):
     Export all configuration and administrator accounts needed to set up this Sentry instance.
     """
 
+    from sentry.backup.exports import export_in_config_scope
+
     export_in_config_scope(
         dest,
         indent=indent,
@@ -312,6 +312,8 @@ def export_global(dest, silent, indent):
     """
     Export all Sentry data in the JSON format.
     """
+
+    from sentry.backup.exports import export_in_global_scope
 
     export_in_global_scope(
         dest,

--- a/src/sentry/services/hybrid_cloud/import_export/__init__.py
+++ b/src/sentry/services/hybrid_cloud/import_export/__init__.py
@@ -1,0 +1,2 @@
+from .model import *  # noqa
+from .service import *  # noqa

--- a/src/sentry/services/hybrid_cloud/import_export/impl.py
+++ b/src/sentry/services/hybrid_cloud/import_export/impl.py
@@ -1,0 +1,197 @@
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
+
+from typing import List, Optional, Set
+
+from django.core.serializers import serialize
+from django.db.models import Q
+
+from sentry.backup.dependencies import (
+    ImportKind,
+    NormalizedModelName,
+    PrimaryKeyMap,
+    dependencies,
+    get_model,
+    get_model_name,
+)
+from sentry.backup.findings import InstanceID
+from sentry.backup.helpers import DatetimeSafeDjangoJSONEncoder, Filter
+from sentry.backup.scopes import ExportScope
+from sentry.models.user import User
+from sentry.models.userpermission import UserPermission
+from sentry.models.userrole import UserRoleUser
+from sentry.services.hybrid_cloud.import_export.model import (
+    RpcExportError,
+    RpcExportErrorKind,
+    RpcExportOk,
+    RpcExportResult,
+    RpcExportScope,
+    RpcFilter,
+    RpcPrimaryKeyMap,
+)
+from sentry.services.hybrid_cloud.import_export.service import ImportExportService
+from sentry.silo.base import SiloMode
+
+
+class UniversalImportExportService(ImportExportService):
+    """
+    This implementation is universal regardless of which mode (CONTROL, REGION, or MONOLITH) it is
+    run in. All import/export codepaths must be executed in REGION or MONOLITH instances only, so
+    the only case in which the caller should use the remote implementation are when trying to
+    import/export a CONTROL model from a REGION instance. In such cases, it is up to the caller to
+    manually select the correct remote/local instance based on the model being being
+    imported/exported with a block of code like:
+
+        if SiloMode.CONTROL in model._meta.silo_limit.modes:
+            import_export_service.export_by_model(...)
+        else:
+            ImportExportService.get_local_implementation().export_by_model(...)
+    """
+
+    def export_by_model(
+        self,
+        *,
+        model_name: str = "",
+        from_pk: int = 0,
+        scope: Optional[RpcExportScope] = None,
+        filter_by: List[RpcFilter],
+        pk_map: RpcPrimaryKeyMap,
+        indent: int = 2,
+    ) -> RpcExportResult:
+        try:
+            from sentry.db.models.base import BaseModel
+
+            deps = dependencies()
+            batch_model_name = NormalizedModelName(model_name)
+            model = get_model(batch_model_name)
+            if model is None or not issubclass(model, BaseModel):
+                return RpcExportError(
+                    kind=RpcExportErrorKind.UnknownModel,
+                    on=InstanceID(model_name),
+                    reason=f"The model `{model_name}` could not be found",
+                )
+
+            silo_mode = SiloMode.get_current_mode()
+            model_modes = model._meta.silo_limit.modes  # type: ignore
+            if silo_mode != SiloMode.MONOLITH and silo_mode not in model_modes:
+                return RpcExportError(
+                    kind=RpcExportErrorKind.IncorrectSiloModeForModel,
+                    on=InstanceID(model_name),
+                    reason=f"The model `{model_name}` was forwarded to the incorrect silo (it cannot be exported from the {silo_mode} silo)",
+                )
+
+            if scope is None:
+                return RpcExportError(
+                    kind=RpcExportErrorKind.UnspecifiedScope,
+                    on=InstanceID(model_name),
+                    reason="The RPC was called incorrectly, please set an `ExportScope` parameter",
+                )
+
+            export_scope = scope.from_rpc()
+            in_pk_map = pk_map.from_rpc()
+            allowed_relocation_scopes = export_scope.value
+            possible_relocation_scopes = model.get_possible_relocation_scopes()
+            includable = possible_relocation_scopes & allowed_relocation_scopes
+            if not includable or model._meta.proxy:
+                return RpcExportError(
+                    kind=RpcExportErrorKind.UnexportableModel,
+                    on=InstanceID(model_name),
+                    reason=f"The model `{str(batch_model_name)}` is not exportable",
+                )
+
+            max_pk = from_pk
+            out_pk_map = PrimaryKeyMap()
+            filters: List[Filter] = []
+            for fb in filter_by:
+                if NormalizedModelName(fb.model_name) == batch_model_name:
+                    filters.append(fb.from_rpc())
+
+            def filter_objects(queryset_iterator):
+                # Intercept each value from the queryset iterator, ensure that it has the correct
+                # relocation scope and that all of its dependencies have already been exported. If
+                # they have, store it in the `pk_map`, and then yield it again. If they have not, we
+                # know that some upstream model was filtered out, so we ignore this one as well.
+                for item in queryset_iterator:
+                    if not item.get_relocation_scope() in allowed_relocation_scopes:
+                        continue
+
+                    model = type(item)
+                    model_name = get_model_name(model)
+
+                    # Make sure this model is not explicitly being filtered.
+                    for f in filters:
+                        if f.model == model and getattr(item, f.field, None) not in f.values:
+                            break
+                    else:
+                        # Now make sure its not transitively filtered either.
+                        for field, foreign_field in deps[model_name].foreign_keys.items():
+                            dependency_model_name = get_model_name(foreign_field.model)
+                            field_id = field if field.endswith("_id") else f"{field}_id"
+                            fk = getattr(item, field_id, None)
+                            if fk is None:
+                                # Null deps are allowed.
+                                continue
+                            if in_pk_map.get_pk(dependency_model_name, fk) is None:
+                                # The foreign key value exists, but not found! An upstream model
+                                # must have been filtered out, so we can filter this one out as
+                                # well.
+                                break
+                        else:
+                            # For models that may have circular references to themselves (unlikely),
+                            # keep track of the new pk in the input map as well.
+                            nonlocal max_pk
+                            max_pk = item.pk
+                            in_pk_map.insert(model_name, item.pk, item.pk, ImportKind.Inserted)
+                            out_pk_map.insert(model_name, item.pk, item.pk, ImportKind.Inserted)
+                            yield item
+
+            def yield_objects():
+                q = Q(pk__gt=from_pk)
+
+                # Only do database query filtering if this is a non-global export. If it is a
+                # global export, we want absolutely every relocatable model, so no need to
+                # filter.
+                if export_scope != ExportScope.Global:
+                    # Create a Django filter from the relevant `filter_by` clauses.
+                    query = dict()
+                    for f in filters:
+                        if f.model == model:
+                            query[f.field + "__in"] = f.values
+                    q &= Q(**query)
+                    q = model.query_for_relocation_export(q, in_pk_map)
+
+                pk_name = model._meta.pk.name  # type: ignore
+                queryset = model._base_manager.filter(q).order_by(pk_name)
+                return filter_objects(queryset.iterator())
+
+            json_data = serialize(
+                "json",
+                yield_objects(),
+                indent=indent,
+                use_natural_foreign_keys=False,
+                cls=DatetimeSafeDjangoJSONEncoder,
+            )
+
+            return RpcExportOk(
+                mapped_pks=RpcPrimaryKeyMap.into_rpc(out_pk_map), max_pk=max_pk, json_data=json_data
+            )
+
+        except Exception as e:
+            return RpcExportError(
+                kind=RpcExportErrorKind.Unknown,
+                on=InstanceID(model_name),
+                reason=f"Unknown internal error occurred: {e}",
+            )
+
+    def get_all_globally_privileged_users(self) -> Set[int]:
+        admin_user_pks: Set[int] = set()
+        admin_user_pks.update(
+            User.objects.filter(Q(is_staff=True) | Q(is_superuser=True)).values_list(
+                "id", flat=True
+            )
+        )
+        admin_user_pks.update(UserPermission.objects.values_list("user_id", flat=True))
+        admin_user_pks.update(UserRoleUser.objects.values_list("user_id", flat=True))
+        return admin_user_pks

--- a/src/sentry/services/hybrid_cloud/import_export/model.py
+++ b/src/sentry/services/hybrid_cloud/import_export/model.py
@@ -1,0 +1,139 @@
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
+
+from collections import defaultdict
+from enum import Enum, unique
+from typing import Dict, Literal, Optional, Set, Tuple, Union
+
+from pydantic import Field, StrictInt, StrictStr
+from typing_extensions import Annotated
+
+from sentry.backup.dependencies import (
+    ImportKind,
+    NormalizedModelName,
+    PrimaryKeyMap,
+    get_model,
+    get_model_name,
+)
+from sentry.backup.findings import Finding, InstanceID
+from sentry.backup.helpers import Filter
+from sentry.backup.scopes import ExportScope
+from sentry.services.hybrid_cloud import RpcModel
+
+
+class RpcFilter(RpcModel):
+    """
+    Shadows `sentry.backup.helpers.Filter` for the purpose of passing it over an RPC boundary.
+    """
+
+    model_name: str
+    field: str
+
+    # While on the original `Filter` type these can be any kind, in practice we only use integers or
+    # strings here.
+    #
+    # TODO(getsentry/team-ospo#190): Unify with the base filter type.
+    values: Set[Union[StrictStr, StrictInt]]
+
+    def from_rpc(self) -> Filter:
+        model = get_model(NormalizedModelName(self.model_name))
+        if model is None:
+            raise ValueError("model not found")
+
+        return Filter(model, self.field, self.values)
+
+    @classmethod
+    def into_rpc(cls, base_filter: Filter) -> "RpcFilter":
+        return cls(
+            model_name=str(get_model_name(base_filter.model)),
+            field=base_filter.field,
+            values=base_filter.values,
+        )
+
+
+class RpcPrimaryKeyMap(RpcModel):
+    """
+    Shadows `sentry.backup.dependencies.PrimaryKeyMap` for the purpose of passing it over an RPC boundary. The primary difference between this class and the one it shadows is that the original `PrimaryKeyMap` uses `defaultdict` for ergonomics purposes, whereas this one uses a regular dict but provides no mutation methods - it is only intended for data interchange, and should be converted to and from `PrimaryKeyMap` immediately on either side of the RPC call.
+    """
+
+    # Pydantic duplicates global default models on a per-instance basis, so using `{}` here is safe.
+    mapping: Dict[str, Dict[int, Tuple[int, ImportKind, Optional[str]]]] = {}
+
+    def from_rpc(self) -> PrimaryKeyMap:
+        pk_map = PrimaryKeyMap()
+        pk_map.mapping = defaultdict(dict, self.mapping)
+        return pk_map
+
+    @classmethod
+    def into_rpc(cls, base_map: PrimaryKeyMap) -> "RpcPrimaryKeyMap":
+        converted = cls()
+        converted.mapping = dict(base_map.mapping)
+        return converted
+
+
+class RpcExportScope(str, Enum):
+    """
+    Scope values are rendered as strings for JSON interchange, but can easily be mapped back to their set-based values when necessary.
+    """
+
+    User = "User"
+    Organization = "Organization"
+    Config = "Config"
+    Global = "Global"
+
+    def from_rpc(self) -> ExportScope:
+        return ExportScope[self.name]
+
+    @classmethod
+    def into_rpc(cls, base_scope: ExportScope) -> "RpcExportScope":
+        return RpcExportScope[base_scope.name]
+
+
+class RpcExportOk(RpcModel):
+    """
+    Information about a successful export: the mapping of old pks to new ones, the maximum pk
+    exported, and the JSON string of the exported models.
+    """
+
+    is_err: Literal[False] = False
+    mapped_pks: RpcPrimaryKeyMap
+    max_pk: int = 0
+    json_data: str = "[]"
+
+
+# Using strings, rather than `auto()` integers, makes this more (though not completely) robust to
+# version skew.
+@unique
+class RpcExportErrorKind(str, Enum):
+    Unknown = "Unknown"
+
+    IncorrectSiloModeForModel = "IncorrectSiloModeForModel"
+    UnknownModel = "UnknownModel"
+    UnexportableModel = "UnexportableModel"
+    UnspecifiedScope = "UnspecifiedScope"
+
+
+class RpcExportError(RpcModel, Finding):
+    """
+    A Pydantic and RPC friendly error container that also inherits from the base `Finding` class.
+    """
+
+    is_err: Literal[True] = True
+    kind: RpcExportErrorKind = RpcExportErrorKind.Unknown
+
+    # Include fields from `Finding` in this `RpcModel` derivative.
+    on: InstanceID
+    left_pk: Optional[int] = None
+    right_pk: Optional[int] = None
+    reason: str = ""
+
+    def get_kind(self) -> RpcExportErrorKind:
+        return RpcExportErrorKind(self.kind)
+
+    def pretty(self) -> str:
+        return f"RpcExportError(\n\tkind: {self.get_kind()},{self._pretty_inner()}\n)"
+
+
+RpcExportResult = Annotated[Union[RpcExportOk, RpcExportError], Field(discriminator="is_err")]

--- a/src/sentry/services/hybrid_cloud/import_export/service.py
+++ b/src/sentry/services/hybrid_cloud/import_export/service.py
@@ -1,0 +1,66 @@
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
+
+from abc import abstractmethod
+from typing import List, Optional, Set, cast
+
+from sentry.services.hybrid_cloud.import_export.model import (
+    RpcExportResult,
+    RpcExportScope,
+    RpcFilter,
+    RpcPrimaryKeyMap,
+)
+from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
+from sentry.silo import SiloMode
+
+
+class ImportExportService(RpcService):
+    key = "import_export"
+    local_mode = SiloMode.CONTROL
+
+    @classmethod
+    def get_local_implementation(cls) -> RpcService:
+        from sentry.services.hybrid_cloud.import_export.impl import UniversalImportExportService
+
+        return UniversalImportExportService()
+
+    @rpc_method
+    @abstractmethod
+    def export_by_model(
+        self,
+        *,
+        model_name: str = "",
+        from_pk: int = 0,
+        scope: Optional[RpcExportScope] = None,
+        filter_by: List[RpcFilter],
+        pk_map: RpcPrimaryKeyMap,
+        indent: int = 2,
+    ) -> RpcExportResult:
+        """
+        Export models of a certain kind to JSON.
+        """
+        pass
+
+    @rpc_method
+    @abstractmethod
+    def get_all_globally_privileged_users(self) -> Set[int]:
+        """
+        Retrieves all of the "administrators" of the current instance.
+
+        A user is defined as a "globally privileged" administrator if one of the following is true about them:
+
+            - Their `User` model has the `is_staff` flag set to `True`.
+            - Their `User` model has the `is_superuser` flag set to `True`.
+            - Their `User.id` is mentioned at least once in the `UserPermission` table (ie, they
+              have at least one global permission).
+            - Their `User.id` is mentioned at least once in the `UserRoleUser` table (ie, they have
+              at least one global user role).
+        """
+        pass
+
+
+import_export_service: ImportExportService = cast(
+    ImportExportService, ImportExportService.create_delegation()
+)

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import tempfile
+from copy import deepcopy
 from datetime import datetime, timedelta
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from pathlib import Path
 from uuid import uuid4
 
@@ -74,8 +75,10 @@ from sentry.models.userrole import UserRole, UserRoleUser
 from sentry.monitors.models import Monitor, MonitorType, ScheduleType
 from sentry.sentry_apps.apps import SentryAppUpdater
 from sentry.silo import unguarded_write
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json
 from sentry.utils.json import JSONData
 
@@ -228,6 +231,7 @@ class BackupTestCase(TransactionTestCase):
     """Instruments a database state that includes an instance of every Sentry model with every field
     set to a non-default, non-null value. This is useful for exhaustive conformance testing."""
 
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def create_exhaustive_user(
         self,
         username: str,
@@ -257,6 +261,7 @@ class BackupTestCase(TransactionTestCase):
 
         return user
 
+    @assume_test_silo_mode(SiloMode.REGION)
     def create_exhaustive_organization(
         self, slug: str, owner: User, invitee: User, other: list[User] | None = None
     ) -> Organization:
@@ -269,21 +274,6 @@ class BackupTestCase(TransactionTestCase):
 
         OrganizationOption.objects.create(
             organization=org, key="sentry:account-rate-limit", value=0
-        )
-
-        # Auth*
-        ApiKey.objects.create(key=uuid4().hex, organization_id=org.id)
-        auth_provider = AuthProvider.objects.create(organization_id=org.id, provider="sentry")
-        AuthIdentity.objects.create(
-            user=owner,
-            auth_provider=auth_provider,
-            ident=f"123456789{slug}",
-            data={
-                "key1": "value1",
-                "key2": 42,
-                "key3": [1, 2, 3],
-                "key4": {"nested_key": "nested_value"},
-            },
         )
 
         # Team
@@ -301,27 +291,15 @@ class BackupTestCase(TransactionTestCase):
         ProjectRedirect.record(project, f"project_slug_in_{slug}")
         self.create_notification_action(organization=org, projects=[project])
 
-        # OrgAuthToken
-        OrgAuthToken.objects.create(
-            organization_id=org.id,
-            name=f"token 1 for {slug}",
-            token_hashed=f"ABCDEF{slug}",
-            token_last_characters="xyz1",
-            scope_list=["org:ci"],
-            date_last_used=None,
-            project_last_used_id=project.id,
-        )
+        # Auth*
+        self.create_exhaustive_organization_auth(owner, org, project)
 
         # Integration*
-        integration = Integration.objects.create(
-            provider="slack", name=f"Slack for {slug}", external_id=f"slack:{slug}"
-        )
-        OrganizationIntegration.objects.create(
-            organization_id=org.id, integration=integration, config='{"hello":"hello"}'
-        )
+        org_integration = self.create_exhaustive_organization_integration(org)
+        integration_id = org_integration.integration.id
         # Note: this model is deprecated, and can safely be removed from this test when it is finally removed. Until then, it is included for completeness.
         ProjectIntegration.objects.create(
-            project=project, integration_id=integration.id, config='{"hello":"hello"}'
+            project=project, integration_id=integration_id, config='{"hello":"hello"}'
         )
 
         # Rule*
@@ -431,12 +409,47 @@ class BackupTestCase(TransactionTestCase):
             project=project,
             name="getsentry/getsentry",
             provider="integrations:github",
-            integration_id=integration.id,
+            integration_id=integration_id,
             url="https://github.com/getsentry/getsentry",
         )
 
         return org
 
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def create_exhaustive_organization_auth(self, owner: User, org: Organization, project: Project):
+        ApiKey.objects.create(key=uuid4().hex, organization_id=org.id)
+        auth_provider = AuthProvider.objects.create(organization_id=org.id, provider="sentry")
+        AuthIdentity.objects.create(
+            user=owner,
+            auth_provider=auth_provider,
+            ident=f"123456789{org.slug}",
+            data={
+                "key1": "value1",
+                "key2": 42,
+                "key3": [1, 2, 3],
+                "key4": {"nested_key": "nested_value"},
+            },
+        )
+        OrgAuthToken.objects.create(
+            organization_id=org.id,
+            name=f"token 1 for {org.slug}",
+            token_hashed=f"ABCDEF{org.slug}",
+            token_last_characters="xyz1",
+            scope_list=["org:ci"],
+            date_last_used=None,
+            project_last_used_id=project.id,
+        )
+
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def create_exhaustive_organization_integration(self, org: Organization):
+        integration = Integration.objects.create(
+            provider="slack", name=f"Slack for {org.slug}", external_id=f"slack:{org.slug}"
+        )
+        return OrganizationIntegration.objects.create(
+            organization_id=org.id, integration=integration, config='{"hello":"hello"}'
+        )
+
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def create_exhaustive_sentry_app(self, name: str, owner: User, org: Organization) -> SentryApp:
         # SentryApp*
         app = self.create_sentry_app(name=name, organization=org)
@@ -467,25 +480,29 @@ class BackupTestCase(TransactionTestCase):
         )
 
         # NotificationAction
-        project = Project.objects.filter(organization=org).first()
-        self.create_notification_action(organization=org, sentry_app_id=app.id, projects=[project])
+        self.create_exhaustive_sentry_app_notification(app, org)
 
         return app
 
-    def create_exhaustive_global_configs(self, owner: User):
-        # *Options
-        Option.objects.create(key="foo", value="a")
-        ControlOption.objects.create(key="bar", value="b")
+    @assume_test_silo_mode(SiloMode.REGION)
+    def create_exhaustive_sentry_app_notification(self, app: SentryApp, org: Organization):
+        project = Project.objects.filter(organization=org).first()
+        self.create_notification_action(organization=org, sentry_app_id=app.id, projects=[project])
 
-        # Relay*
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def create_exhaustive_global_configs(self, owner: User):
+        self.create_exhaustive_global_configs_regional()
+        ControlOption.objects.create(key="bar", value="b")
+        ApiAuthorization.objects.create(user=owner)
+        ApiToken.objects.create(user=owner, token=uuid4().hex, expires_at=None)
+
+    @assume_test_silo_mode(SiloMode.REGION)
+    def create_exhaustive_global_configs_regional(self):
         _, public_key = generate_key_pair()
         relay = str(uuid4())
         Relay.objects.create(relay_id=relay, public_key=str(public_key), is_internal=True)
         RelayUsage.objects.create(relay_id=relay, version="0.0.1", public_key=public_key)
-
-        # Global Api*
-        ApiAuthorization.objects.create(user=owner)
-        ApiToken.objects.create(user=owner, token=uuid4().hex, expires_at=None)
+        Option.objects.create(key="foo", value="a")
 
     def create_exhaustive_instance(self, *, is_superadmin: bool = False):
         """
@@ -502,3 +519,68 @@ class BackupTestCase(TransactionTestCase):
 
     def import_export_then_validate(self, out_name, *, reset_pks: bool = True) -> JSONData:
         return import_export_then_validate(out_name, reset_pks=reset_pks)
+
+    @cached_property
+    def _json_of_exhaustive_user_with_maximum_privileges(self) -> JSONData:
+        with open(get_fixture_path("backup", "user-with-maximum-privileges.json")) as backup_file:
+            return json.load(backup_file)
+
+    def json_of_exhaustive_user_with_maximum_privileges(self) -> JSONData:
+        return deepcopy(self._json_of_exhaustive_user_with_maximum_privileges)
+
+    @cached_property
+    def _json_of_exhaustive_user_with_minimum_privileges(self) -> JSONData:
+        with open(get_fixture_path("backup", "user-with-minimum-privileges.json")) as backup_file:
+            return json.load(backup_file)
+
+    def json_of_exhaustive_user_with_minimum_privileges(self) -> JSONData:
+        return deepcopy(self._json_of_exhaustive_user_with_minimum_privileges)
+
+    @staticmethod
+    def copy_user(exhaustive_user: JSONData, username: str) -> JSONData:
+        user = deepcopy(exhaustive_user)
+
+        for model in user:
+            if model["model"] == "sentry.user":
+                model["fields"]["username"] = username
+
+        return user
+
+    def generate_tmp_users_json(self) -> JSONData:
+        """
+        Generates an in-memory JSON array of users with different combinations of admin privileges.
+        """
+
+        # A user with the maximal amount of "evil" settings.
+        max_user = self.copy_user(
+            self.json_of_exhaustive_user_with_maximum_privileges(), "max_user"
+        )
+
+        # A user with no "evil" settings.
+        min_user = self.copy_user(
+            self.json_of_exhaustive_user_with_minimum_privileges(), "min_user"
+        )
+
+        # A copy of the `min_user`, but with a maximal `UserPermissions` attached.
+        permission_user = self.copy_user(min_user, "permission_user") + deepcopy(
+            list(filter(lambda mod: mod["model"] == "sentry.userpermission", max_user))
+        )
+
+        # A copy of the `min_user`, but with all of the "evil" flags set to `True`.
+        superadmin_user = self.copy_user(min_user, "superadmin_user")
+        for model in superadmin_user:
+            if model["model"] == "sentry.user":
+                model["fields"]["is_managed"] = True
+                model["fields"]["is_staff"] = True
+                model["fields"]["is_superuser"] = True
+
+        return max_user + min_user + permission_user + superadmin_user
+
+    def generate_tmp_users_json_file(self, tmp_path: Path) -> JSONData:
+        """
+        Generates a file filled with users with different combinations of admin privileges.
+        """
+
+        data = self.generate_tmp_users_json()
+        with open(tmp_path, "w+") as tmp_file:
+            json.dump(data, tmp_file)

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -249,7 +249,7 @@ run twice as both REGION and MONOLITH modes.
 
 
 @contextmanager
-def assume_test_silo_mode(desired_silo: SiloMode) -> Any:
+def assume_test_silo_mode(desired_silo: SiloMode, can_be_monolith: bool = True) -> Any:
     """Potential swap the silo mode in a test class or factory, useful for creating multi SiloMode models and executing
     test code in a special silo context.
     In monolith mode, this context manager has no effect.
@@ -262,7 +262,7 @@ def assume_test_silo_mode(desired_silo: SiloMode) -> Any:
     given test mode.
     """
     # Only swapping the silo mode if we are already in a silo mode.
-    if SiloMode.get_current_mode() == SiloMode.MONOLITH:
+    if can_be_monolith and SiloMode.get_current_mode() == SiloMode.MONOLITH:
         desired_silo = SiloMode.MONOLITH
 
     overrides: MutableMapping[str, Any] = {}

--- a/tests/sentry/backup/__init__.py
+++ b/tests/sentry/backup/__init__.py
@@ -11,8 +11,7 @@ from sentry.backup.dependencies import (
     get_model_name,
     sorted_dependencies,
 )
-from sentry.backup.exports import DatetimeSafeDjangoJSONEncoder
-from sentry.backup.helpers import get_exportable_sentry_models
+from sentry.backup.helpers import DatetimeSafeDjangoJSONEncoder, get_exportable_sentry_models
 
 
 def targets(expected_models: list[Type[models.Model]]):

--- a/tests/sentry/backup/test_exports.py
+++ b/tests/sentry/backup/test_exports.py
@@ -17,6 +17,7 @@ from sentry.models.userip import UserIP
 from sentry.models.userpermission import UserPermission
 from sentry.models.userrole import UserRole, UserRoleUser
 from sentry.testutils.helpers.backups import BackupTestCase, export_to_file
+from sentry.testutils.silo import region_silo_test
 from sentry.utils.json import JSONData
 from tests.sentry.backup import get_matching_exportable_models
 
@@ -27,6 +28,7 @@ class ExportTestCase(BackupTestCase):
         return export_to_file(tmp_path, **kwargs)
 
 
+@region_silo_test(stable=True)
 class ScopingTests(ExportTestCase):
     """
     Ensures that only models with the allowed relocation scopes are actually exported.
@@ -85,6 +87,7 @@ class ScopingTests(ExportTestCase):
             self.verify_model_inclusion(data, ExportScope.Global)
 
 
+@region_silo_test(stable=True)
 class FilteringTests(ExportTestCase):
     """
     Ensures that filtering operations include the correct models.
@@ -156,7 +159,7 @@ class FilteringTests(ExportTestCase):
         self.create_exhaustive_user("user_2")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            data = self.export(tmp_dir, scope=ExportScope.User, filter_by={})
+            data = self.export(tmp_dir, scope=ExportScope.User, filter_by=set())
 
             assert len(data) == 0
 
@@ -249,7 +252,7 @@ class FilteringTests(ExportTestCase):
             data = self.export(
                 tmp_dir,
                 scope=ExportScope.Organization,
-                filter_by={},
+                filter_by=set(),
             )
 
             assert len(data) == 0

--- a/tests/sentry/backup/test_rpc.py
+++ b/tests/sentry/backup/test_rpc.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from sentry.backup.dependencies import get_model_name
+from sentry.models.project import Project
+from sentry.models.user import User
+from sentry.services.hybrid_cloud.import_export import import_export_service
+from sentry.services.hybrid_cloud.import_export.model import (
+    RpcExportError,
+    RpcExportErrorKind,
+    RpcExportScope,
+    RpcPrimaryKeyMap,
+)
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode
+
+USER_MODEL_NAME = get_model_name(User)
+PROJECT_MODEL_NAME = get_model_name(Project)
+
+
+class RpcExportErrorTests(TestCase):
+    """Validate errors related to the `export_by_model()` RPC method."""
+
+    def test_bad_unknown_model(self):
+        result = import_export_service.export_by_model(
+            model_name="sentry.doesnotexist",
+            scope=RpcExportScope.Global,
+            from_pk=0,
+            filter_by=[],
+            pk_map=RpcPrimaryKeyMap(),
+            indent=2,
+        )
+
+        assert isinstance(result, RpcExportError)
+        assert result.get_kind() == RpcExportErrorKind.UnknownModel
+
+    def test_bad_unexportable_model(self):
+        result = import_export_service.export_by_model(
+            model_name="sentry.controloutbox",
+            scope=RpcExportScope.Global,
+            from_pk=0,
+            filter_by=[],
+            pk_map=RpcPrimaryKeyMap(),
+            indent=2,
+        )
+
+        assert isinstance(result, RpcExportError)
+        assert result.get_kind() == RpcExportErrorKind.UnexportableModel
+
+    @assume_test_silo_mode(SiloMode.CONTROL, can_be_monolith=False)
+    def test_bad_incorrect_silo_mode_for_model(self):
+        result = import_export_service.export_by_model(
+            model_name=str(PROJECT_MODEL_NAME),
+            scope=RpcExportScope.Global,
+            from_pk=0,
+            filter_by=[],
+            pk_map=RpcPrimaryKeyMap(),
+            indent=2,
+        )
+
+        assert isinstance(result, RpcExportError)
+        assert result.get_kind() == RpcExportErrorKind.IncorrectSiloModeForModel
+
+    def test_bad_unspecified_scope(self):
+        result = import_export_service.export_by_model(
+            model_name=str(USER_MODEL_NAME),
+            scope=None,
+            from_pk=0,
+            filter_by=[],
+            pk_map=RpcPrimaryKeyMap(),
+            indent=2,
+        )
+
+        assert isinstance(result, RpcExportError)
+        assert result.get_kind() == RpcExportErrorKind.UnspecifiedScope

--- a/tests/sentry/runner/commands/test_backup.py
+++ b/tests/sentry/runner/commands/test_backup.py
@@ -7,9 +7,10 @@ from click.testing import CliRunner
 from django.db import IntegrityError
 
 from sentry.runner.commands.backup import compare, export, import_
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase, TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
-from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json
 
 GOOD_FILE_PATH = get_fixture_path("backup", "fresh-install.json")
@@ -113,8 +114,7 @@ class GoodImportExportCommandTests(TransactionTestCase):
         cli_import_then_export("users", export_args=["--filter_usernames", "testing@example.com"])
 
 
-class BadImportExportCommandTests(TransactionTestCase):
-    @django_db_all(transaction=True)
+class BadImportExportDomainErrorTests(TransactionTestCase):
     def test_import_integrity_error_exit_code(self):
         # First import should succeed.
         rv = CliRunner().invoke(import_, ["global", GOOD_FILE_PATH] + [])
@@ -129,10 +129,15 @@ class BadImportExportCommandTests(TransactionTestCase):
         assert isinstance(rv.exception, IntegrityError)
         assert rv.exit_code == 1, rv.output
 
+
+class BadImportExportCommandTests(TestCase):
     def test_import_file_read_error_exit_code(self):
         rv = CliRunner().invoke(import_, ["global", NONEXISTENT_FILE_PATH])
         assert not isinstance(rv.exception, IntegrityError)
         assert rv.exit_code == 2, rv.output
 
-
-# TODO(getsentry/team-ospo#199): Add bad compare tests.
+    @assume_test_silo_mode(SiloMode.CONTROL, can_be_monolith=False)
+    def test_export_in_control_silo(self):
+        rv = CliRunner().invoke(export, ["global", NONEXISTENT_FILE_PATH])
+        assert isinstance(rv.exception, RuntimeError)
+        assert "Exports must be run in REGION or MONOLITH instances only" in rv.output


### PR DESCRIPTION
Exports are already done on a sequential, per-model basis, going in reverse dependency order. This change modifies that scheme to work across an RPC boundary: code running on REGION instances (the only kind of instance that may perform import/export operations) requests the exports using either the local implementation (if the model is REGION as well), or by sending an RPC call to the same method on the remote CONTROL silo instance. Code executed in MONOLITH mode (aka, self-hosted and single tenant instances) does all exporting locally.

The new `import_export_service` is thus a bit different from some of the others in `hybrid_cloud`. Whereas existing services like `Access` provide a means to get the same information using different logic depending on which Silo they are located in (ex: using `Organization` or `OrganizationMapping` as the source of truth), this service executes identical logic in all silo kinds, and requires users to pick the implementation themselves. That is, users must examine the model they are about to request be exported, and make their own decision as to which implementation, remote or local, to use. This is a bit unergonomic compared to other `hybrid_cloud` services, but it is only used by one rather unique endpoint (the import/export functions) for a very specific purpose, making this API a bit easier to swallow.

Issue: getsentry/team-ospo#196