### PR TITLE
fix(alerts): Fix display text of sessions alert filter in sidebar

### DIFF
--- a/static/app/views/alerts/rules/issue/details/textRule.spec.tsx
+++ b/static/app/views/alerts/rules/issue/details/textRule.spec.tsx
@@ -69,6 +69,24 @@ describe('AlertRuleDetails', () => {
       'Percent of sessions affected by an issue is 150% higher in 1h compared to 1d ago'
     );
   });
+
+  it('displays EventUniqueUserFrequencyCondition count', () => {
+    const wrapper = render(
+      <TextCondition
+        condition={{
+          id: 'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition',
+          comparisonType: 'count',
+          interval: '1d',
+          name: 'The issue is seen by more than 89 users in 1d',
+          value: 89,
+        }}
+      />
+    );
+    expect(wrapper.container).toHaveTextContent(
+      'Number of users affected by an issue is more than 89 in 1d'
+    );
+  });
+
   it('hides slack id and empty tags', () => {
     const wrapper = render(
       <TextAction

--- a/static/app/views/alerts/rules/issue/details/textRule.tsx
+++ b/static/app/views/alerts/rules/issue/details/textRule.tsx
@@ -9,7 +9,7 @@ import {
 } from 'sentry/types/alerts';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AlertRuleComparisonType} from 'sentry/views/alerts/rules/metric/types';
-import {CHANGE_ALERT_CONDITION_IDS} from 'sentry/views/alerts/utils/constants';
+import {CHANGE_ALERT_PLACEHOLDERS_LABELS} from 'sentry/views/alerts/utils/constants';
 
 /**
  * Translate Issue Alert Conditions to text
@@ -21,26 +21,18 @@ export function TextCondition({
 }) {
   const organization = useOrganization();
 
-  if (CHANGE_ALERT_CONDITION_IDS.includes(condition.id)) {
+  if (
+    condition.id === IssueAlertConditionType.EVENT_FREQUENCY_PERCENT ||
+    condition.id === IssueAlertConditionType.EVENT_FREQUENCY ||
+    condition.id === IssueAlertConditionType.EVENT_UNIQUE_USER_FREQUENCY
+  ) {
+    const subject = CHANGE_ALERT_PLACEHOLDERS_LABELS[condition.id];
     if (condition.comparisonType === AlertRuleComparisonType.PERCENT) {
-      if (condition.id === IssueAlertConditionType.EVENT_FREQUENCY_PERCENT) {
-        return (
-          <Fragment>
-            {t(
-              // Double %% escapes
-              'Percent of sessions affected by an issue is %s%% higher in %s compared to %s ago',
-              condition.value,
-              condition.interval,
-              condition.comparisonInterval
-            )}
-          </Fragment>
-        );
-      }
       return (
         <Fragment>
           {t(
-            // Double %% escapes
-            'Number of events in an issue is %s%% higher in %s compared to %s ago',
+            '%s %s%% higher in %s compared to %s ago',
+            subject,
             condition.value,
             condition.interval,
             condition.comparisonInterval
@@ -51,14 +43,11 @@ export function TextCondition({
 
     return (
       <Fragment>
-        {t(
-          'Number of events in an issue is more than %s in %s',
-          condition.value,
-          condition.interval
-        )}
+        {t('%s more than %s in %s', subject, condition.value, condition.interval)}
       </Fragment>
     );
   }
+
   if (
     condition.id === IssueAlertConditionType.REAPPEARED_EVENT &&
     organization.features.includes('escalating-issues')

--- a/static/app/views/alerts/rules/issue/details/textRule.tsx
+++ b/static/app/views/alerts/rules/issue/details/textRule.tsx
@@ -28,22 +28,19 @@ export function TextCondition({
   ) {
     const subject = CHANGE_ALERT_PLACEHOLDERS_LABELS[condition.id];
     if (condition.comparisonType === AlertRuleComparisonType.PERCENT) {
+      // This text does not translate well and should match the alert builder
       return (
         <Fragment>
-          {t(
-            '%s %s%% higher in %s compared to %s ago',
-            subject,
-            condition.value,
-            condition.interval,
-            condition.comparisonInterval
-          )}
+          {subject} {condition.value}% higher in {condition.interval} compared to{' '}
+          {condition.comparisonInterval} ago
         </Fragment>
       );
     }
 
     return (
+      // This text does not translate well and should match the alert builder
       <Fragment>
-        {t('%s more than %s in %s', subject, condition.value, condition.interval)}
+        {subject} more than {condition.value} in {condition.interval}
       </Fragment>
     );
   }

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -358,7 +358,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
       this.handleChange('conditions', [
         {
           id,
-          label: CHANGE_ALERT_PLACEHOLDERS_LABELS[id],
+          label: `${CHANGE_ALERT_PLACEHOLDERS_LABELS[id]}...`,
         },
       ]);
     }
@@ -877,7 +877,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
         CHANGE_ALERT_CONDITION_IDS.includes(condition.id)
           ? ({
               ...condition,
-              label: CHANGE_ALERT_PLACEHOLDERS_LABELS[condition.id],
+              label: `${CHANGE_ALERT_PLACEHOLDERS_LABELS[condition.id]}...`,
             } as IssueAlertRuleConditionTemplate)
           : condition
       ) ?? null

--- a/static/app/views/alerts/utils/constants.tsx
+++ b/static/app/views/alerts/utils/constants.tsx
@@ -1,3 +1,5 @@
+import {t} from 'sentry/locale';
+
 export const CHANGE_ALERT_CONDITION_IDS = [
   'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
   'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition',
@@ -5,12 +7,15 @@ export const CHANGE_ALERT_CONDITION_IDS = [
 ];
 
 export const CHANGE_ALERT_PLACEHOLDERS_LABELS = {
-  'sentry.rules.conditions.event_frequency.EventFrequencyCondition':
-    'Number of events in an issue is...',
-  'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition':
-    'Number of users affected by an issue is...',
-  'sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition':
-    'Percent of sessions affected by an issue is...',
+  'sentry.rules.conditions.event_frequency.EventFrequencyCondition': t(
+    'Number of events in an issue is'
+  ),
+  'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition': t(
+    'Number of users affected by an issue is'
+  ),
+  'sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition': t(
+    'Percent of sessions affected by an issue is'
+  ),
 };
 
 export const COMPARISON_TYPE_CHOICE_VALUES = {

--- a/static/app/views/alerts/utils/constants.tsx
+++ b/static/app/views/alerts/utils/constants.tsx
@@ -1,5 +1,3 @@
-import {t} from 'sentry/locale';
-
 export const CHANGE_ALERT_CONDITION_IDS = [
   'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
   'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition',
@@ -7,15 +5,12 @@ export const CHANGE_ALERT_CONDITION_IDS = [
 ];
 
 export const CHANGE_ALERT_PLACEHOLDERS_LABELS = {
-  'sentry.rules.conditions.event_frequency.EventFrequencyCondition': t(
-    'Number of events in an issue is'
-  ),
-  'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition': t(
-    'Number of users affected by an issue is'
-  ),
-  'sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition': t(
-    'Percent of sessions affected by an issue is'
-  ),
+  'sentry.rules.conditions.event_frequency.EventFrequencyCondition':
+    'Number of events in an issue is',
+  'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition':
+    'Number of users affected by an issue is',
+  'sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition':
+    'Percent of sessions affected by an issue is',
 };
 
 export const COMPARISON_TYPE_CHOICE_VALUES = {


### PR DESCRIPTION
fixes "percent of sessions affected by an issue" being displayed as "number of events in an issue"

fixes #49727

