### PR TITLE
feat(aggregate-waterfall): Add dismissable info banner to the aggregate waterfall page

### DIFF
--- a/static/app/components/events/interfaces/spans/aggregateSpans.tsx
+++ b/static/app/components/events/interfaces/spans/aggregateSpans.tsx
@@ -170,7 +170,7 @@ export function AggregateSpans({transaction}: Props) {
           trailingItems={<StyledCloseButton onClick={() => setIsBannerOpen(false)} />}
         >
           {tct(
-            'This is an aggregate view across [x] events. You can see how frequent each span appears in the aggregate and identify and outliers.',
+            'This is an aggregate view across [x] events. You can see how frequent each span appears in the aggregate and identify any outliers.',
             {x: event.count}
           )}
         </StyledAlert>

--- a/static/app/components/events/interfaces/spans/aggregateSpans.tsx
+++ b/static/app/components/events/interfaces/spans/aggregateSpans.tsx
@@ -1,15 +1,21 @@
-import {useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
+import Alert from 'sentry/components/alert';
 import TraceView from 'sentry/components/events/interfaces/spans/traceView';
 import {AggregateSpanType} from 'sentry/components/events/interfaces/spans/types';
 import WaterfallModel from 'sentry/components/events/interfaces/spans/waterfallModel';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Panel from 'sentry/components/panels/panel';
+import {IconClose} from 'sentry/icons';
+import {tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {AggregateEventTransaction, EntryType, EventOrGroupType} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -63,6 +69,11 @@ type Props = {
 export function AggregateSpans({transaction}: Props) {
   const organization = useOrganization();
   const {data, isLoading} = useAggregateSpans({transaction});
+
+  const [isBannerOpen, setIsBannerOpen] = useLocalStorageState<boolean>(
+    'aggregate-waterfall-info-banner',
+    true
+  );
 
   function formatSpan(span, total) {
     const {
@@ -151,13 +162,35 @@ export function AggregateSpans({transaction}: Props) {
   }
 
   return (
-    <Panel>
-      <TraceView
-        waterfallModel={waterfallModel}
-        organization={organization}
-        isEmbedded
-        isAggregate
-      />
-    </Panel>
+    <Fragment>
+      {isBannerOpen && (
+        <StyledAlert
+          type="info"
+          showIcon
+          trailingItems={<StyledCloseButton onClick={() => setIsBannerOpen(false)} />}
+        >
+          {tct(
+            'This is an aggregate view across [x] events. You can see how frequent each span appears in the aggregate and identify and outliers.',
+            {x: event.count}
+          )}
+        </StyledAlert>
+      )}
+      <Panel>
+        <TraceView
+          waterfallModel={waterfallModel}
+          organization={organization}
+          isEmbedded
+          isAggregate
+        />
+      </Panel>
+    </Fragment>
   );
 }
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: ${space(2)};
+`;
+
+const StyledCloseButton = styled(IconClose)`
+  cursor: pointer;
+`;


### PR DESCRIPTION
Adds an info banner that provides a bit more context as to what exactly an aggregate waterfall is, and how to use it. It is dismissable and uses localStorage, so dismissing the banner will ensure that it doesn't return later on.

![image](https://github.com/getsentry/sentry/assets/16740047/08d2d3e3-0d0a-4bd2-930f-6be59cecc0f0)
