### PR TITLE
fix(metrics): Make empty values invalid as quota arguments

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1082,7 +1082,9 @@ register(
 )
 register(
     "sentry-metrics.cardinality-limiter.limits.releasehealth.per-org",
-    default=[],
+    default=[
+        {"window_seconds": 3600, "granularity_seconds": 600, "limit": 10000},
+    ],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
@@ -1094,7 +1096,9 @@ register(
 )
 register(
     "sentry-metrics.cardinality-limiter.limits.sessions.per-org",
-    default=[],
+    default=[
+        {"window_seconds": 3600, "granularity_seconds": 600, "limit": 10000},
+    ],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(

--- a/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
+++ b/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
@@ -56,13 +56,12 @@ def _construct_quotas(use_case_id: UseCaseID) -> Optional[Quota]:
             "sentry-metrics.cardinality-limiter.limits.generic-metrics.per-org"
         )
 
-    if quota_args:
-        if len(quota_args) > 1:
-            raise ValueError("multiple quotas are actually unsupported")
+    if not quota_args:
+        raise ValueError("quotas cannot be empty")
+    if len(quota_args) > 1:
+        raise ValueError("multiple quotas are actually unsupported")
 
-        return Quota(**quota_args[0])
-
-    return None
+    return Quota(**quota_args[0])
 
 
 class InboundMessage(TypedDict):


### PR DESCRIPTION
### Overview

An empty quota doesn't really make sense semantically as a quota argument. This pr disables this special case and updates default values from empty list to real quota values.

Closes [SNS-2485](https://getsentry.atlassian.net/browse/SNS-2485)

[SNS-2485]: https://getsentry.atlassian.net/browse/SNS-2485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ