### PR TITLE
fix(getting-started): Fix Remix getting started code snippet

### DIFF
--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -33,9 +33,7 @@ const performanceOtherConfig = `
 tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
 `;
 
-const prismaConfig = `
-new Sentry.Integrations.Prisma({ client: prisma })
-`;
+const prismaIntegration = `new Sentry.Integrations.Prisma({ client: prisma }),`;
 
 export const steps = ({
   sentryInitContent,
@@ -79,8 +77,15 @@ export const steps = ({
   },
   {
     type: StepType.CONFIGURE,
-    description: t(
-      'Import and initialize Sentry in your Remix entry points for both the client and server:'
+    description: (
+      <p>
+        {tct(
+          'Import and initialize Sentry in your Remix entry points for the client ([clientFile:entry.client.tsx]):',
+          {
+            clientFile: <code />,
+          }
+        )}
+      </p>
     ),
     configurations: [
       {
@@ -100,7 +105,7 @@ export const steps = ({
         description: (
           <p>
             {tct(
-              `Initialize Sentry in your entry point for the server to capture exceptions and get performance metrics for your [action] and [loader] functions. You can also initialize Sentry's database integrations, such as Prisma, to get spans for your database calls:`,
+              `Initialize Sentry in your entry point for the server ([serverFile:entry.server.tsx]) to capture exceptions and get performance metrics for your [action] and [loader] functions. You can also initialize Sentry's database integrations, such as Prisma, to get spans for your database calls:`,
               {
                 action: (
                   <ExternalLink href="https://remix.run/docs/en/v1/api/conventions#action" />
@@ -108,6 +113,7 @@ export const steps = ({
                 loader: (
                   <ExternalLink href="https://remix.run/docs/en/1.18.1/api/conventions#loader" />
                 ),
+                serverFile: <code />,
               }
             )}
           </p>
@@ -172,9 +178,11 @@ export default withSentry(App);
     ),
     configurations: [
       {
-        language: 'javascript',
+        language: 'jsx',
         code: `
-        return <button onClick={() => methodDoesNotExist()}>Break the world</button>;
+<button type="button" onClick={() => { throw new Error("Sentry Frontend Error") }}>
+  Throw Test Error
+</button>
         `,
       },
     ],
@@ -215,14 +223,16 @@ export function GettingStartedWithRemix({
   const integrations: string[] = [];
   const otherConfigs: string[] = [];
 
+  const serverIntegrations: string[] = [];
+  const otherConfigsServer: string[] = [];
+
   let nextStepDocs = [...nextSteps];
-  const sentryInitContentServer: string[] = [`dsn: "${dsn}",`];
 
   if (activeProductSelection.includes(ProductSolution.PERFORMANCE_MONITORING)) {
     integrations.push(performanceIntegration.trim());
     otherConfigs.push(performanceOtherConfig.trim());
-    sentryInitContentServer.push(prismaConfig.trim());
-    sentryInitContentServer.push(performanceOtherConfig.trim());
+    serverIntegrations.push(prismaIntegration.trim());
+    otherConfigsServer.push(performanceOtherConfig.trim());
     nextStepDocs = nextStepDocs.filter(
       step => step.id !== ProductSolution.PERFORMANCE_MONITORING
     );
@@ -237,13 +247,26 @@ export function GettingStartedWithRemix({
   }
 
   let sentryInitContent: string[] = [`dsn: "${dsn}",`];
+  let sentryInitContentServer: string[] = [`dsn: "${dsn}",`];
 
   if (integrations.length > 0) {
     sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
   }
 
+  if (serverIntegrations.length) {
+    sentryInitContentServer = sentryInitContentServer.concat(
+      'integrations: [',
+      serverIntegrations,
+      '],'
+    );
+  }
+
   if (otherConfigs.length > 0) {
     sentryInitContent = sentryInitContent.concat(otherConfigs);
+  }
+
+  if (otherConfigsServer.length) {
+    sentryInitContentServer = sentryInitContentServer.concat(otherConfigsServer);
   }
 
   return (


### PR DESCRIPTION
This PR fixes a wrong code snippet in the Remix getting started page. We incorrectly initialized the Prisma integration as a top-level option instead of putting it into the `integrations` array.

While doing this, I additionally
* Cleaned up the client vs. server integration snippet creation a little because previously it was a bit confusing to me. 
* Added the missing file names for client and server entry points
* Added a better verification snippet that won't trigger a TypeScript error (taken from [docs](https://docs.sentry.io/platforms/javascript/guides/remix/#verify))

resolves https://twitter.com/muningis/status/1711107284657394023?s=46&t=TgC-9kCE5v9qkU7-BrXBDA