### PR TITLE
ref(metrics): Use usage metric in the billing consumer

### DIFF
--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -87,12 +87,11 @@ class MetricsBucket(TypedDict):
 class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
     """A metrics consumer that generates a billing outcome for each processed
     transaction, processing a bucket at a time. The transaction count is
-    computed from the amount of values from `d:transactions/duration@millisecond`
-    buckets.
+    directly taken from the `c:transactions/usage@none` counter metric.
     """
 
     #: The ID of the metric used to count transactions
-    metric_id = TRANSACTION_METRICS_NAMES["d:transactions/duration@millisecond"]
+    metric_id = TRANSACTION_METRICS_NAMES["c:transactions/usage@none"]
     profile_tag_key = str(SHARED_TAG_STRINGS["has_profile"])
 
     def __init__(
@@ -127,7 +126,7 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
             return {}
         value = bucket_payload["value"]
         try:
-            quantity = len(value)
+            quantity = max(int(value), 0)
         except TypeError:
             # Unexpected value type for this metric ID, skip.
             return {}

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -589,8 +589,8 @@ def _filter_option_to_config_setting(flt: _FilterSpec, setting: str) -> Mapping[
 #: Version of the transaction metrics extraction.
 #: When you increment this version, outdated Relays will stop extracting
 #: transaction metrics.
-#: See https://github.com/getsentry/relay/blob/4f3e224d5eeea8922fe42163552e8f20db674e86/relay-server/src/metrics_extraction/transactions.rs#L71
-TRANSACTION_METRICS_EXTRACTION_VERSION = 2
+#: See https://github.com/getsentry/relay/blob/6181c6e80b9485ed394c40bc860586ae934704e2/relay-dynamic-config/src/metrics.rs#L85
+TRANSACTION_METRICS_EXTRACTION_VERSION = 3
 
 
 class CustomMeasurementSettings(TypedDict):

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -90,6 +90,7 @@ TRANSACTION_METRICS_NAMES = {
     "g:transactions/alert@none": PREFIX + 135,
     "d:transactions/duration_light@millisecond": PREFIX + 136,
     "c:transactions/usage@none": PREFIX + 137,
+    # Last possible index: 199
 }
 
 # 200 - 399

--- a/tests/sentry/ingest/billing_metrics_consumer/test_billing_metrics_consumer_kafka.py
+++ b/tests/sentry/ingest/billing_metrics_consumer/test_billing_metrics_consumer_kafka.py
@@ -11,7 +11,7 @@ from sentry.ingest.billing_metrics_consumer import (
     BillingTxCountMetricConsumerStrategy,
     MetricsBucket,
 )
-from sentry.sentry_metrics.indexer.strings import TRANSACTION_METRICS_NAMES
+from sentry.sentry_metrics.indexer.strings import SHARED_TAG_STRINGS, TRANSACTION_METRICS_NAMES
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils import json
 from sentry.utils.outcomes import Outcome
@@ -24,7 +24,12 @@ def test_outcomes_consumed(track_outcome):
 
     topic = Topic("snuba-generic-metrics")
 
+    # NOTE: For a more realistic test, the usage metric is always emitted
+    # alongside the transaction duration metric. Formerly, the consumer used the
+    # duration metric to generate outcomes.
+
     empty_tags: dict[str, str] = {}
+    profile_tags: dict[str, str] = {str(SHARED_TAG_STRINGS["has_profile"]): "true"}
     buckets: list[MetricsBucket] = [
         {  # Counter metric with wrong ID will not generate an outcome
             "metric_id": 123,
@@ -44,8 +49,18 @@ def test_outcomes_consumed(track_outcome):
             "value": [1.0, 2.0],
             "tags": empty_tags,
         },
-        {  # Empty distribution will not generate an outcome
-            # NOTE: Should not be emitted by Relay anyway
+        # Usage with `0.0` will not generate an outcome
+        # NOTE: Should not be emitted by Relay anyway
+        {
+            "metric_id": TRANSACTION_METRICS_NAMES["c:transactions/usage@none"],
+            "type": "c",
+            "org_id": 1,
+            "project_id": 2,
+            "timestamp": 123456,
+            "value": 0.0,
+            "tags": empty_tags,
+        },
+        {
             "metric_id": TRANSACTION_METRICS_NAMES["d:transactions/duration@millisecond"],
             "type": "d",
             "org_id": 1,
@@ -54,7 +69,17 @@ def test_outcomes_consumed(track_outcome):
             "value": [],
             "tags": empty_tags,
         },
-        {  # Valid distribution bucket emits an outcome
+        # Usage buckets with positive counter emit an outcome
+        {
+            "metric_id": TRANSACTION_METRICS_NAMES["c:transactions/usage@none"],
+            "type": "c",
+            "org_id": 1,
+            "project_id": 2,
+            "timestamp": 123456,
+            "value": 3.0,
+            "tags": empty_tags,
+        },
+        {
             "metric_id": TRANSACTION_METRICS_NAMES["d:transactions/duration@millisecond"],
             "type": "d",
             "org_id": 1,
@@ -72,14 +97,24 @@ def test_outcomes_consumed(track_outcome):
             "value": 123.4,
             "tags": empty_tags,
         },
-        {  # Bucket with profiles
+        # Bucket with profiles
+        {
+            "metric_id": TRANSACTION_METRICS_NAMES["c:transactions/usage@none"],
+            "type": "c",
+            "org_id": 1,
+            "project_id": 2,
+            "timestamp": 123456,
+            "value": 1.0,
+            "tags": profile_tags,
+        },
+        {
             "metric_id": TRANSACTION_METRICS_NAMES["d:transactions/duration@millisecond"],
             "type": "d",
             "org_id": 1,
             "project_id": 2,
             "timestamp": 123456,
             "value": [4.0],
-            "tags": {f"{(1 << 63) + 260}": "true"},
+            "tags": profile_tags,
         },
     ]
 
@@ -118,9 +153,9 @@ def test_outcomes_consumed(track_outcome):
         strategy.submit(generate_kafka_message(bucket))
         # commit is called for every message, and later debounced by arroyo's policy
         assert fake_commit.call_count == (i + 1)
-        if i < 3:
+        if i < 4:
             assert track_outcome.call_count == 0
-        elif i < 5:
+        elif i < 7:
             assert track_outcome.mock_calls == [
                 mock.call(
                     org_id=1,
@@ -160,9 +195,9 @@ def test_outcomes_consumed(track_outcome):
                 ),
             ]
 
-    assert fake_commit.call_count == 6
+    assert fake_commit.call_count == 9
 
     # Joining should commit the offset of the last message:
     strategy.join()
 
-    assert fake_commit.call_count == 7
+    assert fake_commit.call_count == 10

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/MONOLITH/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/MONOLITH/with_metrics.pysnap
@@ -920,4 +920,4 @@ transactionMetrics:
   customMeasurements:
     limit: 10
   extractCustomTags: []
-  version: 2
+  version: 3

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/REGION/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/REGION/with_metrics.pysnap
@@ -920,4 +920,4 @@ transactionMetrics:
   customMeasurements:
     limit: 10
   extractCustomTags: []
-  version: 2
+  version: 3


### PR DESCRIPTION
Follow-up to #57666 and getsentry/relay#2571.

Uses the new usage metric in the billing consumer. This also updates the metric
extraction version to 3 so that the usage metric is used for rate limiting.

