### PR TITLE
feat(ddm): Add options for disabling allow list of specific metric types

### DIFF
--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -113,7 +113,7 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
     ) -> None:
-        if self._keep_metric(sample_rate):
+        if self._keep_metric(sample_rate) or options.get("delightful_metrics.allow_all_incr"):
             sentry_sdk.metrics.incr(
                 key=self._get_key(key),
                 value=amount,
@@ -128,7 +128,7 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
     ) -> None:
-        if self._keep_metric(sample_rate):
+        if self._keep_metric(sample_rate) or options.get("delightful_metrics.allow_all_timing"):
             sentry_sdk.metrics.distribution(
                 key=self._get_key(key), value=value, tags=tags, unit="second"
             )
@@ -141,6 +141,6 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
     ) -> None:
-        if self._keep_metric(sample_rate):
+        if self._keep_metric(sample_rate) or options.get("delightful_metrics.allow_all_gauge"):
             # XXX: make this into a gauge later
             sentry_sdk.metrics.incr(key=self._get_key(key), value=value, tags=tags)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1605,3 +1605,21 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "delightful_metrics.allow_all_incr",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
+    "delightful_metrics.allow_all_timing",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
+    "delightful_metrics.allow_all_gauge",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
This PR implements options for controlling the allow list for each method of the `MetricsBackend`.

Closes https://github.com/getsentry/sentry/issues/57763