### PR TITLE
fix(ddm): Fix wrong condition for the metrics backend

### DIFF
--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -50,7 +50,7 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
     ) -> None:
         self._primary_backend.incr(key, instance, tags, amount, sample_rate)
-        if self._is_allowed(key):
+        if self._is_allowed(key) or options.get("delightful_metrics.allow_all_incr"):
             self._minimetrics.incr(key, instance, tags, amount, self._minimetrics_sample_rate())
 
     def timing(
@@ -62,7 +62,7 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
     ) -> None:
         self._primary_backend.timing(key, value, instance, tags, sample_rate)
-        if self._is_allowed(key):
+        if self._is_allowed(key) or options.get("delightful_metrics.allow_all_timing"):
             self._minimetrics.timing(key, value, instance, tags, self._minimetrics_sample_rate())
 
     def gauge(
@@ -74,5 +74,5 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
     ) -> None:
         self._primary_backend.gauge(key, value, instance, tags, sample_rate)
-        if self._is_allowed(key):
+        if self._is_allowed(key) or options.get("delightful_metrics.allow_all_gauge"):
             self._minimetrics.gauge(key, value, instance, tags, self._minimetrics_sample_rate())

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -113,7 +113,7 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
     ) -> None:
-        if self._keep_metric(sample_rate) or options.get("delightful_metrics.allow_all_incr"):
+        if self._keep_metric(sample_rate):
             sentry_sdk.metrics.incr(
                 key=self._get_key(key),
                 value=amount,
@@ -128,7 +128,7 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
     ) -> None:
-        if self._keep_metric(sample_rate) or options.get("delightful_metrics.allow_all_timing"):
+        if self._keep_metric(sample_rate):
             sentry_sdk.metrics.distribution(
                 key=self._get_key(key), value=value, tags=tags, unit="second"
             )
@@ -141,6 +141,6 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
     ) -> None:
-        if self._keep_metric(sample_rate) or options.get("delightful_metrics.allow_all_gauge"):
+        if self._keep_metric(sample_rate):
             # XXX: make this into a gauge later
             sentry_sdk.metrics.incr(key=self._get_key(key), value=value, tags=tags)


### PR DESCRIPTION
This PR fixes a problem introduced in (https://github.com/getsentry/sentry/pull/57762) in which the options checking was done at the wrong level.