### PR TITLE
chore(metrics): New metrics and tags for spans resource module

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -158,6 +158,7 @@ SHARED_TAG_STRINGS = {
     "span.category": PREFIX + 254,
     "span.main_thread": PREFIX + 255,
     "device.class": PREFIX + 256,
+    "resource.render_blocking_status": PREFIX + 257,
     # More Transactions
     "has_profile": PREFIX + 260,
     "query_hash": PREFIX + 261,
@@ -181,6 +182,9 @@ SPAN_METRICS_NAMES = {
     "d:spans/exclusive_time_light@millisecond": PREFIX + 406,
     "d:spans/frames_frozen@none": PREFIX + 407,
     "d:spans/frames_slow@none": PREFIX + 408,
+    "d:spans/http.response_content_length@none": PREFIX + 409,
+    "d:spans/http.decoded_response_body_length@none": PREFIX + 410,
+    "d:spans/http.response_transfer_size@none": PREFIX + 411,
 }
 
 # 500-599


### PR DESCRIPTION
Add new static strings for common metric names and metric tag keys so we do not create a database entry for each string in every organization.