### PR TITLE
fix(ddm): Fix lack of support for metric counters

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -216,7 +216,11 @@ def _get_entity_of_metric_mri(
     entity_keys_set: frozenset[EntityKey]
     if use_case_id is UseCaseID.TRANSACTIONS:
         entity_keys_set = frozenset(
-            {EntityKey.GenericMetricsSets, EntityKey.GenericMetricsDistributions}
+            {
+                EntityKey.GenericMetricsCounters,
+                EntityKey.GenericMetricsSets,
+                EntityKey.GenericMetricsDistributions,
+            }
         )
     elif use_case_id is UseCaseID.SESSIONS:
         entity_keys_set = frozenset(

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -54,9 +54,9 @@ class MetricField:
             object.__setattr__(self, "alias", key)
 
     @property
-    def _metric_name(self):
+    def _metric_name(self) -> str:
         if self.allow_private:
-            return {self.metric_mri}
+            return self.metric_mri
 
         return get_public_name_from_mri(self.metric_mri)
 

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -49,18 +49,19 @@ class MetricField:
         if parsed_mri is None:
             raise InvalidParams(f"Invalid Metric MRI: {self.metric_mri}")
 
-        # Validates that the MRI requested is an MRI the metrics layer exposes
-        metric_name = f"pm_{self.metric_mri}"
-        if not self.allow_private:
-            metric_name = get_public_name_from_mri(self.metric_mri)
-
         if not self.alias:
-            key = f"{self.op}({metric_name})" if self.op is not None else metric_name
+            key = f"{self.op}({self._metric_name})" if self.op is not None else self._metric_name
             object.__setattr__(self, "alias", key)
 
+    @property
+    def _metric_name(self):
+        if self.allow_private:
+            return {self.metric_mri}
+
+        return get_public_name_from_mri(self.metric_mri)
+
     def __str__(self) -> str:
-        metric_name = get_public_name_from_mri(self.metric_mri)
-        return f"{self.op}({metric_name})" if self.op else metric_name
+        return f"{self.op}({self._metric_name})" if self.op else self._metric_name
 
     def __eq__(self, other: object) -> bool:
         # The equal method is called after the hash method to verify for equality of objects to insert
@@ -198,8 +199,13 @@ class MetricsQuery(MetricsQueryValidationRunner):
                     f"Invalid operation '{field.op}'. Must be one of {', '.join(OPERATIONS)}"
                 )
             if field.metric_mri in derived_metrics_mri:
+                metric_name = (
+                    field.metric_mri
+                    if field.allow_private
+                    else get_public_name_from_mri(field.metric_mri)
+                )
                 raise DerivedMetricParseException(
-                    f"Failed to parse {field.op}({get_public_name_from_mri(field.metric_mri)}). No operations can be "
+                    f"Failed to parse {field.op}({metric_name}). No operations can be "
                     f"applied on this field as it is already a derived metric with an "
                     f"aggregation applied to it."
                 )

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -49,8 +49,10 @@ class MetricField:
         if parsed_mri is None:
             raise InvalidParams(f"Invalid Metric MRI: {self.metric_mri}")
 
+        # We compute the metric name before the alias, since we want to make sure it's a public facing metric.
+        metric_name = self._metric_name
         if not self.alias:
-            key = f"{self.op}({self._metric_name})" if self.op is not None else self._metric_name
+            key = f"{self.op}({metric_name})" if self.op is not None else metric_name
             object.__setattr__(self, "alias", key)
 
     @property

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -500,7 +500,7 @@ class QueryDefinition:
             parse_field(
                 key,
                 allow_mri=allow_mri,
-                allow_private=bool(query_params.get("allowPrivate", False)),
+                allow_private=query_params.get("allowPrivate") == "true",
             )
             for key in query_params.getlist("field", [])
         ]

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -111,7 +111,6 @@ def _strip_project_id(condition: Condition) -> Optional[Condition]:
 
 
 def parse_field(field: str, allow_mri: bool = False, allow_private: bool = False) -> MetricField:
-
     if allow_mri:
         mri_matches = MRI_SCHEMA_REGEX.match(field) or MRI_EXPRESSION_REGEX.match(field)
         if mri_matches:


### PR DESCRIPTION
This PR fixes the lack of support for counters in the `UseCaseID.Transactions` and improves the implementation of the `allowPrivate` parameter.