### PR TITLE
Properly delete `MonitorCheckIn` attachments

### DIFF
--- a/src/sentry/deletions/defaults/monitor.py
+++ b/src/sentry/deletions/defaults/monitor.py
@@ -1,4 +1,4 @@
-from ..base import BulkModelDeletionTask, ModelDeletionTask, ModelRelation
+from ..base import ModelDeletionTask, ModelRelation
 
 
 class MonitorDeletionTask(ModelDeletionTask):
@@ -6,8 +6,6 @@ class MonitorDeletionTask(ModelDeletionTask):
         from sentry.monitors import models
 
         return [
-            ModelRelation(
-                models.MonitorCheckIn, {"monitor_id": instance.id}, BulkModelDeletionTask
-            ),
+            ModelRelation(models.MonitorCheckIn, {"monitor_id": instance.id}, ModelDeletionTask),
             ModelRelation(models.MonitorEnvironment, {"monitor_id": instance.id}),
         ]

--- a/src/sentry/deletions/defaults/monitor_environment.py
+++ b/src/sentry/deletions/defaults/monitor_environment.py
@@ -1,4 +1,4 @@
-from ..base import BulkModelDeletionTask, ModelDeletionTask, ModelRelation
+from ..base import ModelDeletionTask, ModelRelation
 
 
 class MonitorEnvironmentDeletionTask(ModelDeletionTask):
@@ -9,6 +9,6 @@ class MonitorEnvironmentDeletionTask(ModelDeletionTask):
             ModelRelation(
                 models.MonitorCheckIn,
                 {"monitor_environment_id": instance.id},
-                BulkModelDeletionTask,
+                ModelDeletionTask,
             ),
         ]

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -9,7 +9,7 @@ import jsonschema
 import pytz
 from django.conf import settings
 from django.db import models
-from django.db.models.signals import pre_save
+from django.db.models.signals import post_delete, pre_save
 from django.dispatch import receiver
 from django.utils import timezone
 
@@ -445,6 +445,16 @@ class MonitorCheckIn(Model):
     # what we want to happen, so kill it here
     def _update_timestamps(self):
         pass
+
+
+def delete_file_for_monitorcheckin(instance: MonitorCheckIn, **kwargs):
+    if file_id := instance.attachment_id:
+        from sentry.models.files import File
+
+        File.objects.filter(file_id=file_id).delete()
+
+
+post_delete.connect(delete_file_for_monitorcheckin, sender=MonitorCheckIn)
 
 
 @region_silo_only_model

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -451,7 +451,7 @@ def delete_file_for_monitorcheckin(instance: MonitorCheckIn, **kwargs):
     if file_id := instance.attachment_id:
         from sentry.models.files import File
 
-        File.objects.filter(file_id=file_id).delete()
+        File.objects.filter(id=file_id).delete()
 
 
 post_delete.connect(delete_file_for_monitorcheckin, sender=MonitorCheckIn)

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -197,7 +197,6 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
             (models.GroupEmailThread, "date", None),
             (models.GroupRuleStatus, "date_added", None),
             (RuleFireHistory, "date_added", None),
-            (monitor_models.MonitorCheckIn, "date_added", None),
         ] + additional_bulk_query_deletes
 
         # Deletions that use the `deletions` code path (which handles their child relations)
@@ -206,6 +205,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
             (models.EventAttachment, "date_added", "date_added"),
             (replay_models.ReplayRecordingSegment, "date_added", "date_added"),
             (models.ArtifactBundle, "date_added", "date_added"),
+            (monitor_models.MonitorCheckIn, "date_added", "date_added"),
         ]
         # Deletions that we run per project. In some cases we can't use an index on just the date
         # column, so as an alternative we use `(project_id, <date_col>)` instead


### PR DESCRIPTION
The deletion was never hooked up to cascade down to the `File`, leaving orphaned files behind. This now correctly hooks up deletions so that a `MonitorCheckIn` will propagate to its attachment `File`.