### PR TITLE
feat(minimetrics): Add internal recursion protection

### DIFF
--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -2,13 +2,12 @@
 
 import random
 from functools import wraps
-from threading import local
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 import sentry_sdk
 
 try:
-    from sentry_sdk.metrics import Metric, MetricsAggregator  # type: ignore
+    from sentry_sdk.metrics import Metric, MetricsAggregator, metrics_noop  # type: ignore
 
     have_minimetrics = True
 except ImportError:
@@ -18,25 +17,6 @@ from sentry import options
 from sentry.metrics.base import MetricsBackend, Tags
 from sentry.utils import metrics
 
-_thread_local = local()
-
-
-def metrics_noop(func: Any) -> Any:
-    @wraps(func)
-    def new_func(*args: Any, **kwargs: Any) -> Any:
-        try:
-            in_metrics = _thread_local.in_metrics
-        except AttributeError:
-            in_metrics = False
-        _thread_local.in_metrics = True
-        try:
-            if not in_metrics:
-                return func(*args, **kwargs)
-        finally:
-            _thread_local.in_metrics = in_metrics
-
-    return new_func
-
 
 def patch_sentry_sdk():
     if not have_minimetrics:
@@ -45,16 +25,19 @@ def patch_sentry_sdk():
     real_add = MetricsAggregator.add
     real_emit = MetricsAggregator._emit
 
-    @wraps(real_add)
     @metrics_noop
-    def tracked_add(self, ty, *args, **kwargs):
-        real_add(self, ty, *args, **kwargs)
+    def report_tracked_add(ty):
         metrics.incr(
             key="minimetrics.add",
             amount=1,
             tags={"metric_type": ty},
             sample_rate=1.0,
         )
+
+    @wraps(real_add)
+    def tracked_add(self, ty, *args, **kwargs):
+        real_add(self, ty, *args, **kwargs)
+        report_tracked_add(ty)
 
     @wraps(real_emit)
     @metrics_noop

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -88,6 +88,10 @@ def hub():
 
 @pytest.fixture(scope="function")
 def backend():
+    # Make sure we also patch the global metrics backend as the backend
+    # will forward internal metrics to it (back into itself).  If we don't
+    # set this up correctly, we might accidentally break our recursion
+    # protection and not see these tests fail.
     rv = MiniMetricsMetricsBackend(prefix="sentrytest.")
     with mock.patch("sentry.utils.metrics.backend", new=rv):
         yield rv

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -212,7 +212,7 @@ def test_composite_backend_does_not_recurse(hub):
 
     # make sure the backend feeds back to itself
     with mock.patch("sentry.utils.metrics.backend", new=TrackingCompositeBackend()):
-        composite_backend.incr(key="sentrytest.composite", tags={"x": ["bar", "baz"]})
+        composite_backend.incr(key="sentrytest.composite", tags={"x": "bar"})
         full_flush(hub)
 
     # make sure that we did actually internally forward to the composite
@@ -225,7 +225,7 @@ def test_composite_backend_does_not_recurse(hub):
     # the minimetrics.add metric must not show up
     assert len(metrics) == 1
     assert metrics[0][1] == "sentry.sentrytest.composite@none"
-    assert metrics[0][4]["x"] == ["bar", "baz"]
+    assert metrics[0][4]["x"] == "bar"
 
     assert len(hub.client.metrics_aggregator.buckets) == 0
 


### PR DESCRIPTION
This fixes an issue where metrics can feed back into themselves. It was assumed that this has been correctly prevented as the tests did not surface the internal metrics.  However the tests were incorrect as the internal recursion did not go to the test's backend, but the default metrics backend.

For the regular minimetrics backend the fixture was thus changed to patch the global backend:

```python
@pytest.fixture(scope="function")
def backend():
    rv = MiniMetricsMetricsBackend(prefix="sentrytest.")
    with mock.patch("sentry.utils.metrics.backend", new=rv):
        yield rv
```

I temporarily considered moving `metrics_noop` to sentry itself, but the protection still makes sense in the main SDK. Reason being that the transport is in parts (via client) invoked from the flush logic and this can create metrics cycles even without the sentry specific metrics system.

Refs INC-528