### PR TITLE
feat(minimetrics): Disable noop on emit

### DIFF
--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -40,7 +40,6 @@ def patch_sentry_sdk():
         report_tracked_add(ty)
 
     @wraps(real_emit)
-    @metrics_noop
     def patched_emit(self, flushable_buckets: Iterable[Tuple[int, Dict[Any, Metric]]]):
         flushable_metrics = []
         stats_by_type: Any = {}


### PR DESCRIPTION
Fixes the broken tests / behavior change after upgrade to https://github.com/getsentry/sentry-python/pull/2428

The Python SDK now has a consistent flush recursion protection. The issue here is that the sentry side had a (broken) workaround for the lack of it. When the tests are run with a Python SDK that is running the code changes from the linked PR (https://github.com/getsentry/sentry-python/pull/2428) they should now fail.

This means that these changes need to land together with this fix. It's not clear to me right now how to merge this yet. Presumably the moment the Python pin is moved up to a fixed SDK version, the getsentry tests should fail. Ideally the merge of the requirements file there also goes hand in hand with the move of the sentry master to this version.

(Alternative: potentially those tests don't properly run in CI at all at the moment and we're good - in a bad way?)