### PR TITLE
feat(feedback): Add github feedback components

### DIFF
--- a/static/app/components/githubFeedbackButton.spec.tsx
+++ b/static/app/components/githubFeedbackButton.spec.tsx
@@ -1,0 +1,26 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {GithubFeedbackButton} from 'sentry/components/githubFeedbackButton';
+
+describe('GithubFeedbackButton', function () {
+  it('renders', async function () {
+    render(
+      <GithubFeedbackButton href="https://example.com/my-test-url">
+        My button label
+      </GithubFeedbackButton>
+    );
+
+    const anchor = screen.getByRole<HTMLAnchorElement>('button', {
+      name: 'My button label',
+    });
+
+    // Renders a link with given href
+    expect(anchor).toBeInTheDocument();
+    expect(anchor.tagName).toBe('A');
+    expect(anchor.href).toBe('https://example.com/my-test-url');
+
+    // Renders tooltip
+    await userEvent.hover(anchor);
+    expect(await screen.findByText('Give us feedback on GitHub')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/githubFeedbackButton.spec.tsx
+++ b/static/app/components/githubFeedbackButton.spec.tsx
@@ -4,14 +4,10 @@ import {GithubFeedbackButton} from 'sentry/components/githubFeedbackButton';
 
 describe('GithubFeedbackButton', function () {
   it('renders', async function () {
-    render(
-      <GithubFeedbackButton href="https://example.com/my-test-url">
-        My button label
-      </GithubFeedbackButton>
-    );
+    render(<GithubFeedbackButton href="https://example.com/my-test-url" />);
 
     const anchor = screen.getByRole<HTMLAnchorElement>('button', {
-      name: 'My button label',
+      name: 'Give Feedback',
     });
 
     // Renders a link with given href
@@ -22,5 +18,29 @@ describe('GithubFeedbackButton', function () {
     // Renders tooltip
     await userEvent.hover(anchor);
     expect(await screen.findByText('Give us feedback on GitHub')).toBeInTheDocument();
+  });
+
+  it('renders with custom label', function () {
+    render(
+      <GithubFeedbackButton href="https://example.com/my-test-url" label="My label" />
+    );
+
+    expect(
+      screen.getByRole<HTMLAnchorElement>('button', {
+        name: 'My label',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('renders without label', function () {
+    render(<GithubFeedbackButton href="https://example.com/my-test-url" label={null} />);
+
+    // Renders button without text content
+    const button = screen.getByRole<HTMLAnchorElement>('button', {
+      name: 'Give Feedback',
+    });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('');
+    expect(button).toHaveAttribute('aria-label', 'Give Feedback');
   });
 });

--- a/static/app/components/githubFeedbackButton.tsx
+++ b/static/app/components/githubFeedbackButton.tsx
@@ -6,7 +6,7 @@ import {t} from 'sentry/locale';
 type GithubFeedbackButtonProps = Omit<LinkButtonProps, 'children' | 'aria-label'> & {
   href: string;
   ['aria-label']?: string;
-  label?: string;
+  label?: string | null;
 };
 
 export function GithubFeedbackButton({

--- a/static/app/components/githubFeedbackButton.tsx
+++ b/static/app/components/githubFeedbackButton.tsx
@@ -3,14 +3,27 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconGithub} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
-type GithubFeedbackButtonProps = LinkButtonProps & {href: string};
+type GithubFeedbackButtonProps = Omit<LinkButtonProps, 'children' | 'aria-label'> & {
+  href: string;
+  ['aria-label']?: string;
+  label?: string;
+};
 
-const title = t('Give us feedback on GitHub');
-
-export function GithubFeedbackButton(props: GithubFeedbackButtonProps) {
+export function GithubFeedbackButton({
+  label = t('Give Feedback'),
+  ...props
+}: GithubFeedbackButtonProps) {
   return (
-    <Tooltip title={title}>
-      <LinkButton size="sm" external icon={<IconGithub />} {...props} />
+    <Tooltip title={t('Give us feedback on GitHub')}>
+      <LinkButton
+        aria-label={label ?? t('Give Feedback')}
+        size="sm"
+        external
+        icon={<IconGithub />}
+        {...props}
+      >
+        {label}
+      </LinkButton>
     </Tooltip>
   );
 }

--- a/static/app/components/githubFeedbackButton.tsx
+++ b/static/app/components/githubFeedbackButton.tsx
@@ -1,0 +1,16 @@
+import {LinkButton, LinkButtonProps} from 'sentry/components/button';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconGithub} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+type GithubFeedbackButtonProps = LinkButtonProps & {href: string};
+
+const title = t('Give us feedback on GitHub');
+
+export function GithubFeedbackButton(props: GithubFeedbackButtonProps) {
+  return (
+    <Tooltip title={title}>
+      <LinkButton size="sm" external icon={<IconGithub />} {...props} />
+    </Tooltip>
+  );
+}

--- a/static/app/components/githubFeedbackTooltip.spec.tsx
+++ b/static/app/components/githubFeedbackTooltip.spec.tsx
@@ -1,0 +1,27 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {GithubFeedbackTooltip} from 'sentry/components/githubFeedbackTooltip';
+
+describe('GithubFeedbackTooltip', function () {
+  it('renders', async function () {
+    render(
+      <GithubFeedbackTooltip
+        title="My custom title text"
+        href="https://example.com/my-test-url"
+      >
+        <span data-test-id="anchor" />
+      </GithubFeedbackTooltip>
+    );
+
+    const anchor = screen.getByTestId('anchor');
+    await userEvent.hover(anchor);
+
+    // Renders custom title text
+    expect(await screen.findByText('My custom title text')).toBeInTheDocument();
+
+    // Renders link with given href
+    const link = screen.getByRole<HTMLAnchorElement>('link', {name: 'GitHub'});
+    expect(link).toBeInTheDocument();
+    expect(link.href).toBe('https://example.com/my-test-url');
+  });
+});

--- a/static/app/components/githubFeedbackTooltip.tsx
+++ b/static/app/components/githubFeedbackTooltip.tsx
@@ -1,0 +1,56 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Tooltip, TooltipProps} from 'sentry/components/tooltip';
+import {IconGithub} from 'sentry/icons';
+import {tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+type GithubFeedbackTooltipProps = TooltipProps & {
+  href: string;
+  title?: React.ReactNode;
+};
+
+export function GithubFeedbackTooltip({
+  href,
+  title,
+  ...props
+}: GithubFeedbackTooltipProps) {
+  return (
+    <Tooltip
+      isHoverable
+      title={
+        <Fragment>
+          {title}
+          <FeedbackLine hasTitle={!!title}>
+            {tct('Give us feedback on [githubLink]', {
+              githubLink: (
+                <GithubLink href={href}>
+                  GitHub <IconGithub size="xs" />
+                </GithubLink>
+              ),
+            })}
+          </FeedbackLine>
+        </Fragment>
+      }
+      {...props}
+    />
+  );
+}
+
+const FeedbackLine = styled('div')<{hasTitle: boolean}>`
+  ${p => p.hasTitle && `padding-top: ${space(1)};`}
+`;
+
+const GithubLink = styled(ExternalLink)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${space(0.5)};
+  line-height: 0px;
+
+  & > svg {
+    margin-top: -1px;
+  }
+`;


### PR DESCRIPTION
Add pre-styled components to  ask users for feedback on GitHub.
Add `GithubFeedbackButton`
Add `GithubFeedbackTooltip`

<img width="214" alt="Screenshot 2023-10-10 at 13 12 28" src="https://github.com/getsentry/sentry/assets/7033940/556ed17c-19f5-440b-b465-adae5d51bb37">
<img width="248" alt="Screenshot 2023-10-10 at 13 12 36" src="https://github.com/getsentry/sentry/assets/7033940/1d9f947d-8977-424e-bc3b-995f4fadc1d4">


- Closes https://github.com/getsentry/sentry/issues/57778