### PR TITLE
fix(spans): HTTP metrics have unit `byte`

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -182,9 +182,9 @@ SPAN_METRICS_NAMES = {
     "d:spans/exclusive_time_light@millisecond": PREFIX + 406,
     "d:spans/frames_frozen@none": PREFIX + 407,
     "d:spans/frames_slow@none": PREFIX + 408,
-    "d:spans/http.response_content_length@none": PREFIX + 409,
-    "d:spans/http.decoded_response_body_length@none": PREFIX + 410,
-    "d:spans/http.response_transfer_size@none": PREFIX + 411,
+    "d:spans/http.response_content_length@byte": PREFIX + 409,
+    "d:spans/http.decoded_response_body_length@byte": PREFIX + 410,
+    "d:spans/http.response_transfer_size@byte": PREFIX + 411,
 }
 
 # 500-599


### PR DESCRIPTION
I got the unit wrong [in a previous PR](https://github.com/getsentry/sentry/pull/57770). Changing it should not break anything, because the [Relay counterpart](https://github.com/getsentry/relay/pull/2578) has not been merged yet.

Do not merge until correctness of the units has been confirmed.