### PR TITLE
fix(adv-analysis): Assign score_delta default value

### DIFF
--- a/src/sentry/api/helpers/span_analysis.py
+++ b/src/sentry/api/helpers/span_analysis.py
@@ -57,7 +57,7 @@ def span_analysis(data: List[Row]):
         row1 = span_data_p0.get(key)
         row2 = span_data_p1.get(key)
         new_span = False
-        score_delta = 0
+        score_delta = 0.0
 
         if row1 and row2:
             score_delta = row2["score"] - row1["score"]

--- a/src/sentry/api/helpers/span_analysis.py
+++ b/src/sentry/api/helpers/span_analysis.py
@@ -57,6 +57,7 @@ def span_analysis(data: List[Row]):
         row1 = span_data_p0.get(key)
         row2 = span_data_p1.get(key)
         new_span = False
+        score_delta = 0
 
         if row1 and row2:
             score_delta = row2["score"] - row1["score"]


### PR DESCRIPTION
We aren't handling the case for removed spans properly so the `score_delta` value isn't being set before evaluation. Set a default to 0 for now because we're not showing removed spans currently.

Fixes SENTRY-16CE