### PR TITLE
fix(perf): Fix subspans hiding duration

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -1126,6 +1126,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
 
     return (
       <Fragment>
+        {subSpans}
         <RowRectangle
           spanBarType={spanBarType}
           style={{
@@ -1144,7 +1145,6 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
             {this.renderWarningText()}
           </DurationPill>
         </RowRectangle>
-        {subSpans}
       </Fragment>
     );
   }


### PR DESCRIPTION
### Summary
This re-arranges the dom elements so the text shows up, previously it was hidden by sub-spans.

### Screenshot
Before            |  After
:-------------------------:|:-------------------------:
![Screenshot 2023-10-10 at 10 18 59 AM](https://github.com/getsentry/sentry/assets/6111995/a2552729-c7be-4fbb-a5cf-ec68ebb643a2) | ![Screenshot 2023-10-10 at 10 19 05 AM](https://github.com/getsentry/sentry/assets/6111995/3c4396a1-ff02-4a12-9e44-3ba539d801ac) 

