### PR TITLE
chore(statistical-detectors): Function regression percentage differen…

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
+++ b/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
@@ -94,7 +94,7 @@ function EventStatisticalDetectorRegressedFunctionMessage({
           'There was [change] in duration (P95) from [before] to [after] around [date] at [time]. The example profiles may indicate what changed in the regression.',
           {
             change: defined(percentageChange)
-              ? t('a %s increase', formatPercentage(percentageChange))
+              ? t('a %s increase', formatPercentage(percentageChange - 1))
               : t('an increase'),
             before: (
               <PerformanceDuration nanoseconds={evidenceData?.aggregateRange1 ?? 0} />


### PR DESCRIPTION
…ce off by 1

We need to subtract the percentage difference by 1 because it's returning the ratio between the before and after and we're only interested in the relative difference.