### PR TITLE
fix(metrics) Hard-code the investigation rule duration to 2 days

### DIFF
--- a/src/sentry/api/endpoints/custom_rules.py
+++ b/src/sentry/api/endpoints/custom_rules.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional, cast
+from typing import List, Optional
 
 import sentry_sdk
 from django.db import DatabaseError
@@ -127,12 +127,11 @@ class CustomRulesEndpoint(OrganizationEndpoint):
 
         query = serializer.validated_data["query"]
         projects = serializer.validated_data.get("projects")
-        period = serializer.validated_data.get("period")
         try:
             condition = get_condition(query)
 
-            # the parsing must succeed (it passed validation)
-            delta = cast(timedelta, parse_stats_period(period))
+            # for now delta it is fixed at 2 days (maybe in the future will base it on the query period)
+            delta = timedelta(days=2)
             now = datetime.now(tz=timezone.utc)
             start = now
             end = now + delta

--- a/tests/sentry/api/endpoints/test_custom_rules.py
+++ b/tests/sentry/api/endpoints/test_custom_rules.py
@@ -224,7 +224,7 @@ class CustomRulesEndpoint(APITestCase):
 
         start_date = datetime.strptime(data["startDate"], CUSTOM_RULE_DATE_FORMAT)
         end_date = datetime.strptime(data["endDate"], CUSTOM_RULE_DATE_FORMAT)
-        assert end_date - start_date == timedelta(hours=1)
+        assert end_date - start_date == timedelta(days=2)
         projects = data["projects"]
         assert projects == [self.project.id]
         org_id = data["orgId"]
@@ -252,7 +252,7 @@ class CustomRulesEndpoint(APITestCase):
 
         start_date = datetime.strptime(data["startDate"], CUSTOM_RULE_DATE_FORMAT)
         end_date = datetime.strptime(data["endDate"], CUSTOM_RULE_DATE_FORMAT)
-        assert end_date - start_date == timedelta(hours=1)
+        assert end_date - start_date == timedelta(days=2)  # hard coded at 2 days
         projects = data["projects"]
         assert projects == [self.project.id]
         org_id = data["orgId"]
@@ -289,7 +289,7 @@ class CustomRulesEndpoint(APITestCase):
         rule_id = data["ruleId"]
         start_date = datetime.strptime(data["startDate"], CUSTOM_RULE_DATE_FORMAT)
         end_date = datetime.strptime(data["endDate"], CUSTOM_RULE_DATE_FORMAT)
-        assert end_date - start_date == timedelta(hours=1)
+        assert end_date - start_date == timedelta(days=2)
 
         request_data = {
             "query": "event.type:transaction",
@@ -306,7 +306,7 @@ class CustomRulesEndpoint(APITestCase):
 
         start_date = datetime.strptime(data["startDate"], CUSTOM_RULE_DATE_FORMAT)
         end_date = datetime.strptime(data["endDate"], CUSTOM_RULE_DATE_FORMAT)
-        assert end_date - start_date >= timedelta(hours=2)
+        assert end_date - start_date >= timedelta(days=2)
 
         projects = data["projects"]
         assert projects == [self.project.id]


### PR DESCRIPTION
This PR changes the investigation rule duration to 2 days, previously was the same as the period for
the query.

Resolves https://github.com/getsentry/sentry/issues/57756