### PR TITLE
chore(statistical-detectors): Remove smoothing from breakpoint charts

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
@@ -40,7 +40,7 @@ function EventBreakpointChart({event}: EventBreakpointChartProps) {
 
   const {start: beforeDateTime, end: afterDateTime} = useRelativeDateTime({
     anchor: breakpoint,
-    relativeDays: 7,
+    relativeDays: 14,
   });
 
   eventView.start = (beforeDateTime as Date).toISOString();

--- a/static/app/components/events/eventStatisticalDetector/functionBreakpointChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/functionBreakpointChart.tsx
@@ -61,7 +61,7 @@ function EventFunctionBreakpointChartInner({
 }: EventFunctionBreakpointChartInnerProps) {
   const datetime = useRelativeDateTime({
     anchor: breakpoint,
-    relativeDays: 7,
+    relativeDays: 14,
   });
 
   const functionStats = useProfileEventsStats({

--- a/static/app/components/events/eventStatisticalDetector/lineChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/lineChart.tsx
@@ -19,10 +19,7 @@ import {
   NormalizedTrendsTransaction,
   TrendChangeType,
 } from 'sentry/views/performance/trends/types';
-import {
-  transformEventStatsSmoothed,
-  trendToColor,
-} from 'sentry/views/performance/trends/utils';
+import {trendToColor} from 'sentry/views/performance/trends/utils';
 import {getIntervalLine} from 'sentry/views/performance/utils';
 
 interface ChartProps {
@@ -37,48 +34,27 @@ function LineChart({statsData, evidenceData, start, end, chartLabel}: ChartProps
   const theme = useTheme();
   const router = useRouter();
 
-  const results = transformEventStats(statsData, chartLabel);
-  const {smoothedResults, minValue, maxValue} = transformEventStatsSmoothed(
-    results,
-    chartLabel
-  );
-
-  const yMax = Math.max(
-    maxValue,
-    evidenceData?.aggregate_range_2 || 0,
-    evidenceData?.aggregate_range_1 || 0
-  );
-  const yMin = Math.min(
-    minValue,
-    evidenceData?.aggregate_range_1 || Number.MAX_SAFE_INTEGER,
-    evidenceData?.aggregate_range_2 || Number.MAX_SAFE_INTEGER
-  );
-
-  const smoothedSeries = smoothedResults
-    ? smoothedResults.map(values => {
-        return {
-          ...values,
-          color: trendToColor[TrendChangeType.REGRESSION].default,
-          lineStyle: {
-            opacity: 1,
-          },
-        };
-      })
-    : [];
+  const resultSeries = transformEventStats(statsData, chartLabel).map(values => {
+    return {
+      ...values,
+      color: trendToColor[TrendChangeType.REGRESSION].default,
+      lineStyle: {
+        opacity: 1,
+      },
+    };
+  });
 
   const needsLabel = true;
   const intervalSeries = getIntervalLine(
     theme,
-    smoothedResults || [],
+    resultSeries || [],
     0.5,
     needsLabel,
     evidenceData,
     true
   );
 
-  const yDiff = yMax - yMin;
-  const yMargin = yDiff * 0.1;
-  const series = [...smoothedSeries, ...intervalSeries];
+  const series = [...resultSeries, ...intervalSeries];
 
   const durationUnit = getDurationUnit(series);
 
@@ -89,8 +65,6 @@ function LineChart({statsData, evidenceData, start, end, chartLabel}: ChartProps
       },
     },
     yAxis: {
-      min: Math.max(0, yMin - yMargin),
-      max: yMax + yMargin,
       minInterval: durationUnit,
       axisLabel: {
         color: theme.chartLabel,


### PR DESCRIPTION
The smoothing is hiding some features of the breakpoint chart here. Let's remove it for now and we can reassess if we want to smooth it or not later.