### PR TITLE
fix(alerts): Skip if action is none

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -110,6 +110,9 @@ class AlertRuleSerializer(Serializer):
                 "triggers", []
             )
             for action in serialized.get("actions", []):
+                if action is None:
+                    continue
+
                 sentry_app_id = str(action.get("sentryAppId"))
                 install = None
                 if sentry_app_id:


### PR DESCRIPTION
Fixes SENTRY-16FT ([link](https://sentry.sentry.io/issues/4538974636/?project=1&referrer=github-pr-bot)) though it's weird `actions` would ever be `[None]`. 