### PR TITLE
fix(stat-detectors): Highlighting on breakpoint chart

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/lineChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/lineChart.tsx
@@ -16,11 +16,7 @@ import {
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import useRouter from 'sentry/utils/useRouter';
 import {transformEventStats} from 'sentry/views/performance/trends/chart';
-import {
-  NormalizedTrendsTransaction,
-  TrendChangeType,
-} from 'sentry/views/performance/trends/types';
-import {trendToColor} from 'sentry/views/performance/trends/utils';
+import {NormalizedTrendsTransaction} from 'sentry/views/performance/trends/types';
 import {getIntervalLine} from 'sentry/views/performance/utils';
 
 interface ChartProps {
@@ -35,15 +31,7 @@ function LineChart({statsData, evidenceData, start, end, chartLabel}: ChartProps
   const theme = useTheme();
   const router = useRouter();
 
-  const resultSeries = transformEventStats(statsData, chartLabel).map(values => {
-    return {
-      ...values,
-      color: trendToColor[TrendChangeType.REGRESSION].default,
-      lineStyle: {
-        opacity: 1,
-      },
-    };
-  });
+  const resultSeries = transformEventStats(statsData, chartLabel);
 
   const needsLabel = true;
   const intervalSeries = getIntervalLine(


### PR DESCRIPTION
The highlighting gets messed up when you assign a color for the timeseries. I removed this prior but it was accidentally added back when getting rid of series smoothing. I also removed the lineStyle definition because it was adding no value since the styling is set by the visualMap


https://github.com/getsentry/sentry/assets/22846452/bc70e427-fc5c-4a7a-a8f4-3cee1210b9ef

