### PR TITLE
fix(replays): Remove empty classes from selector aggregation output

### DIFF
--- a/tests/sentry/replays/test_organization_selector_index.py
+++ b/tests/sentry/replays/test_organization_selector_index.py
@@ -72,7 +72,7 @@ class OrganizationSelectorIndexTest(APITestCase, ReplaysSnubaTestCase):
                 node_id=1,
                 tag="div",
                 id="myid",
-                class_=["class1", "class2"],
+                class_=["class1", "class2", ""],
                 role="button",
                 testid="1",
                 alt="Alt",


### PR DESCRIPTION
Closes: https://github.com/getsentry/team-replay/issues/229