### PR TITLE
fix(aggregate-waterfall): Missing ops breakdown in header

### DIFF
--- a/static/app/components/events/opsBreakdown.tsx
+++ b/static/app/components/events/opsBreakdown.tsx
@@ -58,7 +58,10 @@ function OpsBreakdown({
   hideHeader = false,
   topN = TOP_N_SPANS,
 }: Props) {
-  const transactionEvent = event.type === 'transaction' ? event : undefined;
+  const transactionEvent =
+    event.type === 'transaction' || event.type === 'aggregateTransaction'
+      ? event
+      : undefined;
 
   function generateStats(): OpBreakdownType {
     if (!transactionEvent) {


### PR DESCRIPTION
The ops breakdown was missing in the header of the aggregate waterfall because of a conditional check on the transaction type. We were ignoring events that were not of the type `transaction`, but aggregate transactions have the type `aggregateTransaction`.

### Before
![image](https://github.com/getsentry/sentry/assets/16740047/9b0ee549-88b2-48e2-b0e7-bc8261b8e483)

### After
![image](https://github.com/getsentry/sentry/assets/16740047/359e90d4-3fd4-454e-b348-fd5f1dbd835e)
