### PR TITLE
feat(starfish): Optionally show span description in sample list

### DIFF
--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -31,6 +31,7 @@ type Query = {
   spanGroup: string;
   transaction: string;
   [QueryParameterNames.SPANS_SORT]: string;
+  spanDescription?: string;
 };
 
 function ScreenLoadSpans() {
@@ -63,6 +64,7 @@ function ScreenLoadSpans() {
     primaryRelease,
     secondaryRelease,
     transaction: transactionName,
+    spanDescription,
   } = location.query;
 
   return (
@@ -100,6 +102,7 @@ function ScreenLoadSpans() {
                 <SampleList
                   groupId={spanGroup}
                   transactionName={transactionName}
+                  spanDescription={spanDescription}
                   onClose={() => {
                     router.replace({
                       pathname: router.location.pathname,

--- a/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
@@ -118,6 +118,7 @@ export function ScreenLoadSpansTable({
         ...location.query,
         transaction,
         spanGroup: row[SpanMetricsField.SPAN_GROUP],
+        spanDescription: row[SpanMetricsField.SPAN_DESCRIPTION],
       };
 
       return (

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -25,6 +25,7 @@ type Props = {
   groupId: string;
   transactionName: string;
   onClose?: () => void;
+  spanDescription?: string;
   transactionMethod?: string;
 };
 
@@ -32,6 +33,7 @@ export function SampleList({
   groupId,
   transactionName,
   transactionMethod,
+  spanDescription,
   onClose,
 }: Props) {
   const router = useRouter();
@@ -94,18 +96,23 @@ export function SampleList({
         }}
         onOpen={onOpenDetailPanel}
       >
-        {project && (
-          <SpanSummaryProjectAvatar
-            project={project}
-            direction="left"
-            size={40}
-            hasTooltip
-            tooltip={project.slug}
-          />
-        )}
-        <h3>
-          <Link to={link}>{label}</Link>
-        </h3>
+        <HeaderContainer>
+          {project && (
+            <SpanSummaryProjectAvatar
+              project={project}
+              direction="left"
+              size={40}
+              hasTooltip
+              tooltip={project.slug}
+            />
+          )}
+          <TitleContainer>
+            {spanDescription && <span>{spanDescription}</span>}
+            <Title>
+              <Link to={link}>{label}</Link>
+            </Title>
+          </TitleContainer>
+        </HeaderContainer>
         <PageErrorAlert />
 
         <SampleInfo
@@ -142,6 +149,24 @@ export function SampleList({
 }
 
 const SpanSummaryProjectAvatar = styled(ProjectAvatar)`
-  padding-top: ${space(1)};
+  padding-right: ${space(1)};
+`;
+
+const HeaderContainer = styled('div')`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
   padding-bottom: ${space(2)};
+  padding-top: ${space(1)};
+`;
+
+const TitleContainer = styled('div')`
+  width: 100%;
+  position: relative;
+`;
+
+const Title = styled('h4')`
+  position: absolute;
+  bottom: 0;
+  margin-bottom: 0;
 `;

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -107,7 +107,7 @@ export function SampleList({
             />
           )}
           <TitleContainer>
-            {spanDescription && <span>{spanDescription}</span>}
+            {spanDescription && <SpanDescription>{spanDescription}</SpanDescription>}
             <Title>
               <Link to={link}>{label}</Link>
             </Title>
@@ -169,4 +169,11 @@ const Title = styled('h4')`
   position: absolute;
   bottom: 0;
   margin-bottom: 0;
+`;
+
+const SpanDescription = styled('span')`
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;


### PR DESCRIPTION
Places transaction name next to the project avatar
![Screenshot 2023-10-10 at 4 48 45 PM](https://github.com/getsentry/sentry/assets/63818634/daa476d7-7313-40e7-8609-4e2a227b6323)
And renders span description if provided
![Screenshot 2023-10-10 at 4 49 17 PM](https://github.com/getsentry/sentry/assets/63818634/734acb73-bb69-4d4c-8394-9295b8287627)