### PR TITLE
feat(profiling): allow disjunct rendering and syncing lists

### DIFF
--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -25,7 +25,7 @@ function getNodeLabel({identifier, type}: ViewHierarchyWindow) {
 
 function onScrollToNode(
   node: VirtualizedTreeRenderedRow<ViewHierarchyWindow>,
-  scrollContainer: HTMLElement | null,
+  scrollContainer: HTMLElement | HTMLElement[] | null,
   coordinates: {depth: number; top: number} | undefined
 ) {
   if (node) {
@@ -41,9 +41,17 @@ function onScrollToNode(
     // When a user clicks on a wireframe node that's not rendered in the "overscroll"
     // we need to scroll to where the node would be rendered
     const left = coordinates.depth * 16;
-    scrollContainer?.scrollBy({
-      left,
-    });
+    if (Array.isArray(scrollContainer)) {
+      scrollContainer.forEach(container => {
+        container.scrollBy({
+          left,
+        });
+      });
+    } else if (scrollContainer) {
+      scrollContainer.scrollBy({
+        left,
+      });
+    }
   }
 }
 

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
@@ -26,13 +26,12 @@ import {
   useVirtualizedTree,
   UseVirtualizedTreeProps,
 } from 'sentry/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree';
+import {VirtualizedTree} from 'sentry/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree';
 import {VirtualizedTreeNode} from 'sentry/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode';
 import {VirtualizedTreeRenderedRow} from 'sentry/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils';
 import {invertCallTree} from 'sentry/utils/profiling/profile/utils';
 import {useFlamegraph} from 'sentry/views/profiling/flamegraphProvider';
 import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
-
-import {VirtualizedTree} from '../../../utils/profiling/hooks/useVirtualizedTree/VirtualizedTree';
 
 import {FlamegraphTreeContextMenu} from './flamegraphDrawer/flamegraphTreeContextMenu';
 
@@ -278,8 +277,8 @@ export function AggregateFlamegraphTreeTable({
             ref={n => {
               r.ref = n;
             }}
-            isSelected={selectedNodeIndex === r.key}
             style={r.styles}
+            isSelected={selectedNodeIndex === r.key}
           >
             <FrameCallersFunctionRow
               node={r.item}
@@ -342,6 +341,14 @@ export function AggregateFlamegraphTreeTable({
     return VirtualizedTree.fromRoots(tree ?? []);
   }, [tree]);
 
+  const dynamicScrollContainers = useMemo(() => {
+    return dynamicScrollContainerRef ? [dynamicScrollContainerRef] : [];
+  }, [dynamicScrollContainerRef]);
+
+  const fixedScrollContainers = useMemo(() => {
+    return fixedScrollContainerRef ? [fixedScrollContainerRef] : [];
+  }, [fixedScrollContainerRef]);
+
   const {
     renderedItems: fixedColumnRenderedItems,
     scrollContainerStyles: fixedScrollContainerStyles,
@@ -360,6 +367,7 @@ export function AggregateFlamegraphTreeTable({
     rowHeight: 24,
     tree,
     virtualizedTree,
+    syncScrollContainers: dynamicScrollContainers,
   });
 
   const {
@@ -380,6 +388,7 @@ export function AggregateFlamegraphTreeTable({
     rowHeight: 24,
     tree,
     virtualizedTree,
+    syncScrollContainers: fixedScrollContainers,
   });
 
   const onSortChange = useCallback(

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
@@ -411,6 +411,7 @@ const LayoutSelectionContainer = styled('div')`
 
 const FRAME_WEIGHT_CELL_WIDTH_PX = 164;
 export const FrameCallersTableCell = styled('div')<{
+  bordered?: boolean;
   isSelected?: boolean;
   noPadding?: boolean;
   textAlign?: React.CSSProperties['textAlign'];
@@ -421,6 +422,7 @@ export const FrameCallersTableCell = styled('div')<{
   flex-shrink: 0;
   padding: 0 ${p => (p.noPadding ? 0 : space(1))} 0 0;
   text-align: ${p => p.textAlign ?? 'initial'};
+  border-right: 1px solid ${p => (p.bordered ? p.theme.border : 'transparent')};
 
   &:first-child,
   &:nth-child(2) {
@@ -434,10 +436,6 @@ export const FrameCallersTableCell = styled('div')<{
   }
   &:nth-child(2) {
     left: ${FRAME_WEIGHT_CELL_WIDTH_PX}px;
-  }
-
-  &:not(:last-child) {
-    border-right: 1px solid ${p => p.theme.border};
   }
 `;
 

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
@@ -422,7 +422,6 @@ export const FrameCallersTableCell = styled('div')<{
   flex-shrink: 0;
   padding: 0 ${p => (p.noPadding ? 0 : space(1))} 0 0;
   text-align: ${p => p.textAlign ?? 'initial'};
-  border-right: 1px solid ${p => (p.bordered ? p.theme.border : 'transparent')};
 
   &:first-child,
   &:nth-child(2) {
@@ -436,6 +435,10 @@ export const FrameCallersTableCell = styled('div')<{
   }
   &:nth-child(2) {
     left: ${FRAME_WEIGHT_CELL_WIDTH_PX}px;
+  }
+
+  &:not(:last-child) {
+    border-right: 1px solid ${p => p.theme.border};
   }
 `;
 

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
@@ -336,8 +336,8 @@ export function FlamegraphTreeTable({
               This is useful when number of rows does not fill up the entire table height.
              */}
               <GhostRowContainer>
-                <FrameCallersTableCell />
-                <FrameCallersTableCell />
+                <FrameCallersTableCell bordered />
+                <FrameCallersTableCell bordered />
                 <FrameCallersTableCell style={{width: '100%'}} />
               </GhostRowContainer>
             </div>

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
@@ -191,7 +191,7 @@ export function FlamegraphTreeTable({
     useCallback(
       (
         node: VirtualizedTreeRenderedRow<FlamegraphFrame> | undefined,
-        scrollContainer: HTMLElement | null,
+        scrollContainer: HTMLElement | HTMLElement[] | null,
         coordinates?: {depth: number; top: number}
       ) => {
         if (node) {
@@ -205,15 +205,32 @@ export function FlamegraphTreeTable({
             });
 
             const left = -328 + (node.item.depth * 14 + 8);
+            if (Array.isArray(scrollContainer)) {
+              scrollContainer.forEach(container => {
+                container.scrollBy({
+                  left,
+                });
+              });
+            } else {
+              scrollContainer?.scrollBy({
+                left,
+              });
+            }
+          }
+        } else if (coordinates) {
+          const left = -328 + (coordinates.depth * 14 + 8);
+
+          if (Array.isArray(scrollContainer)) {
+            scrollContainer.forEach(container => {
+              container.scrollBy({
+                left,
+              });
+            });
+          } else {
             scrollContainer?.scrollBy({
               left,
             });
           }
-        } else if (coordinates) {
-          const left = -328 + (coordinates.depth * 14 + 8);
-          scrollContainer?.scrollBy({
-            left,
-          });
         }
       },
       []

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTableRow.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTableRow.tsx
@@ -1,4 +1,4 @@
-import {forwardRef, useCallback} from 'react';
+import {forwardRef, Fragment, useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import {IconSettings, IconUser} from 'sentry/icons';
@@ -38,97 +38,99 @@ interface FlamegraphTreeTableRowProps {
 export const FlamegraphTreeTableRow = forwardRef<
   HTMLDivElement,
   FlamegraphTreeTableRowProps
->(
-  (
-    {
-      node,
-      referenceNode,
-      onExpandClick,
-      onContextMenu,
-      formatDuration,
-      frameColor,
-      tabIndex,
-      onKeyDown,
-      onClick,
-      onMouseEnter,
-      style,
+>((props, ref) => {
+  return (
+    <FrameCallersRow
+      ref={ref}
+      style={props.style}
+      onContextMenu={props.onContextMenu}
+      tabIndex={props.tabIndex}
+      isSelected={props.tabIndex === 0}
+      onKeyDown={props.onKeyDown}
+      onClick={props.onClick}
+      onMouseEnter={props.onMouseEnter}
+    >
+      <FrameCallersFixedRows {...props} />
+      <FrameCallersFunctionRow {...props} />
+    </FrameCallersRow>
+  );
+});
+
+export function FrameCallersFunctionRow(
+  props: Omit<FlamegraphTreeTableRowProps, 'style'>
+) {
+  const handleExpanding = useCallback(
+    (evt: React.MouseEvent) => {
+      evt.stopPropagation();
+      props.onExpandClick(props.node, !props.node.expanded, {
+        expandChildren: evt.metaKey,
+      });
     },
-    ref
-  ) => {
-    const handleExpanding = useCallback(
-      (evt: React.MouseEvent) => {
-        evt.stopPropagation();
-        onExpandClick(node, !node.expanded, {expandChildren: evt.metaKey});
-      },
-      [node, onExpandClick]
-    );
+    [props]
+  );
 
-    const isSelected = tabIndex === 0;
-    return (
-      <FrameCallersRow
-        ref={ref}
-        style={style}
-        onContextMenu={onContextMenu}
-        tabIndex={tabIndex}
-        isSelected={isSelected}
-        onKeyDown={onKeyDown}
-        onClick={onClick}
-        onMouseEnter={onMouseEnter}
-      >
-        <FrameCallersTableCell isSelected={isSelected} textAlign="right">
-          {formatDuration(node.node.node.selfWeight)}
-          <Weight
-            isSelected={isSelected}
-            weight={computeRelativeWeight(
-              referenceNode.node.totalWeight,
-              node.node.node.selfWeight
-            )}
-          />
-        </FrameCallersTableCell>
-        <FrameCallersTableCell isSelected={isSelected} noPadding textAlign="right">
-          <FrameWeightTypeContainer>
-            <FrameWeightContainer>
-              {formatDuration(node.node.node.totalWeight)}
-              <Weight
-                padded
-                isSelected={isSelected}
-                weight={computeRelativeWeight(
-                  referenceNode.node.totalWeight,
-                  node.node.node.totalWeight
-                )}
-              />
-            </FrameWeightContainer>
-            <FrameTypeIndicator isSelected={isSelected}>
-              {node.node.node.frame.is_application ? (
-                <IconUser size="xs" />
-              ) : (
-                <IconSettings size="xs" />
-              )}
-            </FrameTypeIndicator>
-          </FrameWeightTypeContainer>
-        </FrameCallersTableCell>
-        <FrameCallersTableCell
-          // We stretch this table to 100% width.
-          style={{paddingLeft: node.depth * 14 + 8, width: '100%'}}
+  return (
+    <FrameCallersTableCell
+      // We stretch this table to 100% width.
+      style={{paddingLeft: props.node.depth * 14 + 8, width: '100%'}}
+    >
+      <FrameNameContainer>
+        <FrameColorIndicator style={{backgroundColor: props.frameColor}} />
+        <FrameChildrenIndicator
+          tabIndex={-1}
+          onClick={handleExpanding}
+          open={props.node.expanded}
         >
-          <FrameNameContainer>
-            {/* @TODO FIX COLOR */}
-            <FrameColorIndicator style={{backgroundColor: frameColor}} />
-            <FrameChildrenIndicator
-              tabIndex={-1}
-              onClick={handleExpanding}
-              open={node.expanded}
-            >
-              {node.node.children.length > 0 ? '\u203A' : null}
-            </FrameChildrenIndicator>
-            <FrameName>{node.node.frame.name}</FrameName>
-          </FrameNameContainer>
-        </FrameCallersTableCell>
-      </FrameCallersRow>
-    );
-  }
-);
+          {props.node.node.children.length > 0 ? '\u203A' : null}
+        </FrameChildrenIndicator>
+        <FrameName>{props.node.node.frame.name}</FrameName>
+      </FrameNameContainer>
+    </FrameCallersTableCell>
+  );
+}
 
+export function FrameCallersFixedRows(props: Omit<FlamegraphTreeTableRowProps, 'style'>) {
+  return (
+    <Fragment>
+      <FrameCallersTableCell isSelected={props.tabIndex === 0} textAlign="right">
+        {props.formatDuration(props.node.node.node.selfWeight)}
+        <Weight
+          isSelected={props.tabIndex === 0}
+          weight={computeRelativeWeight(
+            props.referenceNode.node.totalWeight,
+            props.node.node.node.selfWeight
+          )}
+        />
+      </FrameCallersTableCell>
+      <FrameCallersTableCell
+        isSelected={props.tabIndex === 0}
+        noPadding
+        textAlign="right"
+      >
+        <FrameWeightTypeContainer>
+          <FrameWeightContainer>
+            {props.formatDuration(props.node.node.node.totalWeight)}
+            <Weight
+              padded
+              isSelected={props.tabIndex === 0}
+              weight={computeRelativeWeight(
+                props.referenceNode.node.totalWeight,
+                props.node.node.node.totalWeight
+              )}
+            />
+          </FrameWeightContainer>
+          <FrameTypeIndicator isSelected={props.tabIndex === 0}>
+            {props.node.node.node.frame.is_application ? (
+              <IconUser size="xs" />
+            ) : (
+              <IconSettings size="xs" />
+            )}
+          </FrameTypeIndicator>
+        </FrameWeightTypeContainer>
+      </FrameCallersTableCell>
+    </Fragment>
+  );
+}
 const Weight = styled(
   (props: {isSelected: boolean; weight: number; padded?: boolean}) => {
     const {weight, padded: __, isSelected: _, ...rest} = props;
@@ -185,9 +187,8 @@ const BackgroundWeightBar = styled('div')`
   width: 100%;
 `;
 
-const FrameCallersRow = styled('div')<{isSelected: boolean}>`
+export const FrameCallersRow = styled('div')<{isSelected: boolean}>`
   display: flex;
-  width: 100%;
   color: ${p => (p.isSelected ? p.theme.white : 'inherit')};
   font-size: ${p => p.theme.fontSizeSmall};
   line-height: 24px;

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTableRow.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTableRow.tsx
@@ -75,6 +75,7 @@ export function FrameCallersFunctionRow(
       style={{paddingLeft: props.node.depth * 14 + 8, width: '100%'}}
     >
       <FrameNameContainer>
+        {/* @TODO FIX COLOR */}
         <FrameColorIndicator style={{backgroundColor: props.frameColor}} />
         <FrameChildrenIndicator
           tabIndex={-1}
@@ -189,6 +190,7 @@ const BackgroundWeightBar = styled('div')`
 
 export const FrameCallersRow = styled('div')<{isSelected: boolean}>`
   display: flex;
+  width: 100%;
   color: ${p => (p.isSelected ? p.theme.white : 'inherit')};
   font-size: ${p => p.theme.fontSizeSmall};
   line-height: 24px;

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
@@ -176,7 +176,7 @@ export class VirtualizedTree<T extends TreeLike> {
   }
 
   getAllExpandedNodes(previouslyExpandedNodes: Set<T>): Set<T> {
-    const expandedNodes = new Set<T>([...previouslyExpandedNodes]);
+    const expandedNodes = new Set<T>(previouslyExpandedNodes);
 
     function visit(node: VirtualizedTreeNode<T>) {
       if (node.expanded) {

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -51,6 +51,7 @@ export interface UseVirtualizedTreeProps<T extends TreeLike> {
   overscroll?: number;
   skipFunction?: (node: VirtualizedTreeNode<T>) => boolean;
   sortFunction?: (a: VirtualizedTreeNode<T>, b: VirtualizedTreeNode<T>) => number;
+  syncScrollContainers?: HTMLElement[];
   virtualizedTree?: VirtualizedTree<T>;
 }
 
@@ -177,6 +178,12 @@ export function useVirtualizedTree<T extends TreeLike>(
       const scrollTop = Math.max(0, evt.target.scrollTop);
       dispatch({type: 'set scroll top', payload: scrollTop});
 
+      if (props.syncScrollContainers) {
+        for (let i = 0; i < props.syncScrollContainers.length; i++) {
+          props.syncScrollContainers[i].scrollTop = scrollTop;
+        }
+      }
+
       if (scrollEndTimeoutId.current !== undefined) {
         cancelAnimationTimeout(scrollEndTimeoutId.current);
       }
@@ -215,7 +222,7 @@ export function useVirtualizedTree<T extends TreeLike>(
     return () => {
       scrollContainer.removeEventListener('scroll', handleScroll, scrollListenerOptions);
     };
-  }, [props.scrollContainer, props.rowHeight, theme]);
+  }, [props.scrollContainer, props.rowHeight, props.syncScrollContainers, theme]);
 
   useEffect(() => {
     const scrollContainer = props.scrollContainer;

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -17,6 +17,74 @@ import {
   VirtualizedTreeRenderedRow,
 } from './virtualizedTreeUtils';
 
+type MaybeContainers = HTMLElement | HTMLElement[] | null;
+function getMaxScrollHeight(containers: MaybeContainers) {
+  if (!containers) {
+    return 0;
+  }
+  if (!Array.isArray(containers)) {
+    return containers.getBoundingClientRect()?.height ?? 0;
+  }
+  return Math.max(
+    ...containers.map(container => container.getBoundingClientRect().height)
+  );
+}
+
+function getMinScrollTop(containers: MaybeContainers) {
+  if (!containers) {
+    return 0;
+  }
+  if (!Array.isArray(containers)) {
+    return containers.scrollTop;
+  }
+  return Math.min(...containers.map(container => container.scrollTop));
+}
+
+function scrollToTop(top: number, containers: MaybeContainers) {
+  if (!containers) {
+    return;
+  }
+  if (!Array.isArray(containers)) {
+    containers.scrollTop = top;
+    return;
+  }
+  containers.forEach(container => {
+    container.scrollTop = top;
+  });
+}
+
+function addListenerToContainer(
+  container: MaybeContainers,
+  type: string,
+  listener: (evt: any) => void,
+  options?: AddEventListenerOptions & EventListenerOptions
+) {
+  if (!container) {
+    return;
+  }
+  if (Array.isArray(container)) {
+    container.forEach(c => c.addEventListener(type, listener, options));
+    return;
+  }
+  container.addEventListener(type, listener, options);
+}
+
+function removeListenerFromContainer(
+  container: MaybeContainers,
+  type: string,
+  listener: (evt: any) => void,
+  options?: AddEventListenerOptions & EventListenerOptions
+) {
+  if (!container) {
+    return;
+  }
+  if (Array.isArray(container)) {
+    container.forEach(c => c.removeEventListener(type, listener, options));
+    return;
+  }
+  container.removeEventListener(type, listener, options);
+}
+
 export interface TreeLike {
   children?: TreeLike[];
 }
@@ -24,7 +92,18 @@ export interface TreeLike {
 const DEFAULT_OVERSCROLL_ITEMS = 5;
 
 export interface UseVirtualizedTreeProps<T extends TreeLike> {
-  renderRow: (
+  rowHeight: number;
+  scrollContainer: MaybeContainers;
+  tree: T[];
+  expanded?: boolean;
+  initialSelectedNodeIndex?: number;
+  onScrollToNode?: (
+    node: VirtualizedTreeRenderedRow<T>,
+    scrollContainer: MaybeContainers,
+    coordinates?: {depth: number; top: number}
+  ) => void;
+  overscroll?: number;
+  renderRow?: (
     item: VirtualizedTreeRenderedRow<T>,
     itemHandlers: {
       handleExpandTreeNode: (
@@ -38,28 +117,15 @@ export interface UseVirtualizedTreeProps<T extends TreeLike> {
       selectedNodeIndex: number | null;
     }
   ) => React.ReactNode;
-  rowHeight: number;
-  scrollContainer: HTMLElement | null;
-  tree: T[];
-  expanded?: boolean;
-  initialSelectedNodeIndex?: number;
-  onScrollToNode?: (
-    node: VirtualizedTreeRenderedRow<T>,
-    scrollContainer: HTMLElement | null,
-    coordinates?: {depth: number; top: number}
-  ) => void;
-  overscroll?: number;
   skipFunction?: (node: VirtualizedTreeNode<T>) => boolean;
   sortFunction?: (a: VirtualizedTreeNode<T>, b: VirtualizedTreeNode<T>) => number;
-  syncScrollContainers?: HTMLElement[];
   virtualizedTree?: VirtualizedTree<T>;
 }
 
 export function useVirtualizedTree<T extends TreeLike>(
   props: UseVirtualizedTreeProps<T>
 ) {
-  const {onScrollToNode} = props;
-
+  const onScrollToNode = props.onScrollToNode;
   const theme = useTheme();
   const clickedGhostRowRef = useRef<HTMLDivElement | null>(null);
   const hoveredGhostRowRef = useRef<HTMLDivElement | null>(null);
@@ -69,7 +135,7 @@ export function useVirtualizedTree<T extends TreeLike>(
     selectedNodeIndex: props.initialSelectedNodeIndex ?? null,
     scrollTop: 0,
     overscroll: props.overscroll ?? DEFAULT_OVERSCROLL_ITEMS,
-    scrollHeight: props.scrollContainer?.getBoundingClientRect()?.height ?? 0,
+    scrollHeight: getMaxScrollHeight(props.scrollContainer),
   });
 
   const [tree, setTree] = useState(() => {
@@ -132,11 +198,8 @@ export function useVirtualizedTree<T extends TreeLike>(
       newTree
     );
 
-    const scroll = props.scrollContainer?.scrollTop ?? 0;
-
-    if (props.scrollContainer) {
-      props.scrollContainer.scrollTo({top: scroll});
-    }
+    const scroll = getMinScrollTop(props.scrollContainer);
+    scrollToTop(scroll, props.scrollContainer);
 
     dispatch({type: 'set selected node index', payload: selectedNodeIndex});
     setTree(newTree);
@@ -175,13 +238,18 @@ export function useVirtualizedTree<T extends TreeLike>(
     }
 
     function handleScroll(evt) {
+      if (!props.scrollContainer) {
+        return;
+      }
       const scrollTop = Math.max(0, evt.target.scrollTop);
       dispatch({type: 'set scroll top', payload: scrollTop});
 
-      if (props.syncScrollContainers) {
-        for (let i = 0; i < props.syncScrollContainers.length; i++) {
-          props.syncScrollContainers[i].scrollTop = scrollTop;
+      if (Array.isArray(props.scrollContainer)) {
+        for (let i = 0; i < props.scrollContainer.length; i++) {
+          props.scrollContainer[i].scrollTop = scrollTop;
         }
+      } else {
+        props.scrollContainer.scrollTop = scrollTop;
       }
 
       if (scrollEndTimeoutId.current !== undefined) {
@@ -217,12 +285,36 @@ export function useVirtualizedTree<T extends TreeLike>(
     const scrollListenerOptions: AddEventListenerOptions & EventListenerOptions = {
       passive: true,
     };
-    scrollContainer.addEventListener('scroll', handleScroll, scrollListenerOptions);
+
+    if (Array.isArray(props.scrollContainer)) {
+      props.scrollContainer.forEach(container => {
+        container.addEventListener('scroll', handleScroll, scrollListenerOptions);
+      });
+    } else if (scrollContainer) {
+      (scrollContainer as HTMLElement).addEventListener(
+        'scroll',
+        handleScroll,
+        scrollListenerOptions
+      );
+    }
 
     return () => {
-      scrollContainer.removeEventListener('scroll', handleScroll, scrollListenerOptions);
+      if (!scrollContainer) {
+        return;
+      }
+      if (Array.isArray(props.scrollContainer)) {
+        props.scrollContainer.forEach(container => {
+          container.removeEventListener('scroll', handleScroll, scrollListenerOptions);
+        });
+      } else {
+        (scrollContainer as HTMLElement).removeEventListener(
+          'scroll',
+          handleScroll,
+          scrollListenerOptions
+        );
+      }
     };
-  }, [props.scrollContainer, props.rowHeight, props.syncScrollContainers, theme]);
+  }, [props.scrollContainer, props.rowHeight, theme]);
 
   useEffect(() => {
     const scrollContainer = props.scrollContainer;
@@ -284,12 +376,12 @@ export function useVirtualizedTree<T extends TreeLike>(
       }
     };
 
-    scrollContainer.addEventListener('click', handleClick);
-    scrollContainer.addEventListener('mousemove', handleMouseMove);
+    addListenerToContainer(scrollContainer, 'click', handleClick);
+    addListenerToContainer(scrollContainer, 'mousemove', handleMouseMove);
 
     return () => {
-      scrollContainer.removeEventListener('click', handleClick);
-      scrollContainer.removeEventListener('mousemove', handleMouseMove);
+      removeListenerFromContainer(scrollContainer, 'click', handleClick);
+      removeListenerFromContainer(scrollContainer, 'mousemove', handleMouseMove);
     };
   }, [props.rowHeight, props.scrollContainer, theme]);
 
@@ -310,12 +402,13 @@ export function useVirtualizedTree<T extends TreeLike>(
       });
     }
 
-    container.addEventListener('mouseleave', onMouseLeave, {
+    const options = {
       passive: true,
-    });
+    };
+    addListenerToContainer(container, 'mouseleave', onMouseLeave, options);
 
     return () => {
-      container.removeEventListener('mouseleave', onMouseLeave);
+      removeListenerFromContainer(container, 'mouseleave', onMouseLeave, options);
     };
   }, [props.scrollContainer, theme, props.rowHeight]);
 
@@ -569,6 +662,9 @@ export function useVirtualizedTree<T extends TreeLike>(
 
   const handleScrollTo = useCallback(
     (matcher: (item: T) => boolean) => {
+      if (!props.scrollContainer) {
+        return;
+      }
       const node = latestTreeRef.current.findNode(matcher);
       // If we cant find, noop
       if (!node) {
@@ -636,31 +732,49 @@ export function useVirtualizedTree<T extends TreeLike>(
       // When a new view is larger than the previous view, we need to update the scroll height
       // synchronously so that the view can be scrolled to its new position. If we don't do this,
       // then the scrollTo(newScrollTop) will be clamped to the previous scroll height.
-      if (props.scrollContainer?.childNodes[0]) {
-        // Not exactly sure why we need the cast here, maybe we should limit HTMLElement to HTMLDivElement.
-        // https://stackoverflow.com/questions/58773652/ts2339-property-style-does-not-exist-on-type-element
-        const firstChild = props.scrollContainer?.childNodes?.[0] as
-          | HTMLElement
-          | undefined;
+      if (Array.isArray(props.scrollContainer)) {
+        props.scrollContainer.forEach(container => {
+          const firstChild = container?.childNodes?.[0] as HTMLElement | undefined;
+          if (!firstChild) {
+            return;
+          }
 
-        if (!firstChild) {
-          return;
+          firstChild.style.height = `${newMaxHeight}px`;
+          firstChild.style.maxHeight = `${newMaxHeight}px`;
+        });
+      } else {
+        if (props.scrollContainer?.childNodes[0]) {
+          // Not exactly sure why we need the cast here, maybe we should limit HTMLElement to HTMLDivElement.
+          // https://stackoverflow.com/questions/58773652/ts2339-property-style-does-not-exist-on-type-element
+          const firstChild = props.scrollContainer?.childNodes?.[0] as
+            | HTMLElement
+            | undefined;
+
+          if (!firstChild) {
+            return;
+          }
+          firstChild.style.height = `${newMaxHeight}px`;
+          firstChild.style.maxHeight = `${newMaxHeight}px`;
         }
-        firstChild.style.height = `${newMaxHeight}px`;
-        firstChild.style.maxHeight = `${newMaxHeight}px`;
       }
-      if (props.scrollContainer) {
+
+      if (Array.isArray(props.scrollContainer)) {
+        props.scrollContainer.forEach(container => {
+          container.scrollTo({
+            top: newScrollTop,
+          });
+        });
+      } else {
         props.scrollContainer.scrollTo({
           top: newScrollTop,
         });
+      }
 
-        if (onScrollToNode) {
-          onScrollToNode(
-            latestItemsRef.current[newlyVisibleIndex],
-            props.scrollContainer,
-            {top: newScrollTop, depth: node.depth}
-          );
-        }
+      if (onScrollToNode) {
+        onScrollToNode(latestItemsRef.current[newlyVisibleIndex], props.scrollContainer, {
+          top: newScrollTop,
+          depth: node.depth,
+        });
       }
     },
 
@@ -685,7 +799,11 @@ export function useVirtualizedTree<T extends TreeLike>(
   }, [tree.flattened.length, props.rowHeight]);
 
   const renderRow = props.renderRow;
+
   const renderedItems: React.ReactNode[] = useMemo(() => {
+    if (!renderRow) {
+      return [];
+    }
     const renderered: React.ReactNode[] = [];
 
     // It is important that we do not create a copy of item
@@ -734,7 +852,13 @@ export function useVirtualizedTree<T extends TreeLike>(
       });
     });
 
-    resizeObserver.observe(props.scrollContainer);
+    if (Array.isArray(props.scrollContainer)) {
+      props.scrollContainer.forEach(container => {
+        resizeObserver.observe(container);
+      });
+    } else {
+      resizeObserver.observe(props.scrollContainer);
+    }
 
     return () => {
       if (typeof rafId === 'number') {

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -51,6 +51,7 @@ export interface UseVirtualizedTreeProps<T extends TreeLike> {
   overscroll?: number;
   skipFunction?: (node: VirtualizedTreeNode<T>) => boolean;
   sortFunction?: (a: VirtualizedTreeNode<T>, b: VirtualizedTreeNode<T>) => number;
+  virtualizedTree?: VirtualizedTree<T>;
 }
 
 export function useVirtualizedTree<T extends TreeLike>(
@@ -71,11 +72,9 @@ export function useVirtualizedTree<T extends TreeLike>(
   });
 
   const [tree, setTree] = useState(() => {
-    const initialTree = VirtualizedTree.fromRoots(
-      props.tree,
-      props.expanded,
-      props.skipFunction
-    );
+    const initialTree =
+      props.virtualizedTree ||
+      VirtualizedTree.fromRoots(props.tree, props.expanded, props.skipFunction);
 
     if (props.sortFunction) {
       initialTree.sort(props.sortFunction);


### PR DESCRIPTION
Due to sticky column limitations, the proper way to virtualize a table with sticky columns is to virtualize the columns separately and keep the scroll synced. This PR extends useVirtualizedTree in such a way where we support multiple scroll containers. We also defer to user rendering by making renderRow an optional prop (render items are already returned)

There is still a noticeable lag between the lists (https://github.com/bvaughn/react-virtualized/issues/369 is a hint towards why it happens and how to fix it). Right now, our main bottleneck emotion's serializeStyles, so in the next PR I will split some of these components in a way where instead of defining them as styled, we will inline the style via a react prop. If we can get rendering under 16ms, the lag should pretty much disappear. That said, before I do that, I would like to see the performance of this when built with react production env flag to see how much of an issue is in production.

https://github.com/getsentry/sentry/assets/9317857/3fb92df3-bc65-4abd-b51a-5a76789ebe28

