### PR TITLE
chore: Remove suspect spans ingestion flag from backend

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -611,10 +611,6 @@ class PerformanceIssueTestCase(BaseTestCase):
             issue_type, "noise_config", new=NoiseConfig(noise_limit, timedelta(minutes=1))
         ), override_options(
             {"performance.issues.all.problem-detection": 1.0, detector_option: 1.0}
-        ), self.feature(
-            [
-                "projects:performance-suspect-spans-ingestion",
-            ]
         ):
             event = perf_event_manager.save(project_id)
             if mock_eventstream.call_args:

--- a/tests/acceptance/test_performance_issues.py
+++ b/tests/acceptance/test_performance_issues.py
@@ -19,7 +19,6 @@ from sentry.testutils.silo import no_silo_test
 from sentry.utils import json
 
 FEATURES = {
-    "projects:performance-suspect-spans-ingestion": True,
     "organizations:performance-n-plus-one-api-calls-detector": True,
 }
 

--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -8,7 +8,6 @@ from sentry.models.eventattachment import EventAttachment
 from sentry.spans.grouping.utils import hash_values
 from sentry.tasks.relay import invalidate_project_config
 from sentry.testutils.cases import TransactionTestCase
-from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now, iso_format, timestamp_format
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_kafka
@@ -189,38 +188,33 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
             ],
         }
 
-        with Feature(
-            {
-                "projects:performance-suspect-spans-ingestion": True,
-            }
-        ):
-            event = self.post_and_retrieve_event(event_data)
-            raw_event = event.get_raw_data()
+        event = self.post_and_retrieve_event(event_data)
+        raw_event = event.get_raw_data()
 
-            exclusive_times = [
-                pytest.approx(50, abs=2),
-                pytest.approx(0, abs=2),
-                pytest.approx(200, abs=2),
-                pytest.approx(0, abs=2),
-                pytest.approx(200, abs=2),
-            ]
-            for actual, expected, exclusive_time in zip(
-                raw_event["spans"], event_data["spans"], exclusive_times
-            ):
-                assert actual == dict(
-                    expected,
-                    exclusive_time=exclusive_time,
-                    hash=hash_values([expected["description"]]),
-                )
-            assert raw_event["breakdowns"] == {
-                "span_ops": {
-                    "ops.browser": {"unit": "millisecond", "value": pytest.approx(200, abs=2)},
-                    "ops.resource": {"unit": "millisecond", "value": pytest.approx(200, abs=2)},
-                    "ops.http": {"unit": "millisecond", "value": pytest.approx(200, abs=2)},
-                    "ops.db": {"unit": "millisecond", "value": pytest.approx(200, abs=2)},
-                    "total.time": {"unit": "millisecond", "value": pytest.approx(1050, abs=2)},
-                }
+        exclusive_times = [
+            pytest.approx(50, abs=2),
+            pytest.approx(0, abs=2),
+            pytest.approx(200, abs=2),
+            pytest.approx(0, abs=2),
+            pytest.approx(200, abs=2),
+        ]
+        for actual, expected, exclusive_time in zip(
+            raw_event["spans"], event_data["spans"], exclusive_times
+        ):
+            assert actual == dict(
+                expected,
+                exclusive_time=exclusive_time,
+                hash=hash_values([expected["description"]]),
+            )
+        assert raw_event["breakdowns"] == {
+            "span_ops": {
+                "ops.browser": {"unit": "millisecond", "value": pytest.approx(200, abs=2)},
+                "ops.resource": {"unit": "millisecond", "value": pytest.approx(200, abs=2)},
+                "ops.http": {"unit": "millisecond", "value": pytest.approx(200, abs=2)},
+                "ops.db": {"unit": "millisecond", "value": pytest.approx(200, abs=2)},
+                "total.time": {"unit": "millisecond", "value": pytest.approx(1050, abs=2)},
             }
+        }
 
     def test_project_config_compression(self):
         # Populate redis cache with compressed config:

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2364,11 +2364,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
     @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
     def test_perf_issue_no_associate_error_event(self):
         """Test that you can't associate an error event with a performance issue"""
-        with mock.patch("sentry_sdk.tracing.Span.containing_transaction"), self.feature(
-            {
-                "projects:performance-suspect-spans-ingestion": True,
-            }
-        ):
+        with mock.patch("sentry_sdk.tracing.Span.containing_transaction"):
             manager = EventManager(make_event())
             manager.normalize()
             event = manager.save(self.project.id)
@@ -2388,11 +2384,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
     @override_options({"performance.issues.all.problem-detection": 1.0})
     @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
     def test_perf_issue_creation_ignored(self):
-        with mock.patch("sentry_sdk.tracing.Span.containing_transaction"), self.feature(
-            {
-                "projects:performance-suspect-spans-ingestion": True,
-            }
-        ):
+        with mock.patch("sentry_sdk.tracing.Span.containing_transaction"):
             event = self.create_performance_issue(
                 event_data=make_event(**get_event("n-plus-one-in-django-index-view")),
                 noise_limit=2,
@@ -2403,11 +2395,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
     @override_options({"performance.issues.all.problem-detection": 1.0})
     @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
     def test_perf_issue_creation_over_ignored_threshold(self):
-        with mock.patch("sentry_sdk.tracing.Span.containing_transaction"), self.feature(
-            {
-                "projects:performance-suspect-spans-ingestion": True,
-            }
-        ):
+        with mock.patch("sentry_sdk.tracing.Span.containing_transaction"):
             event_1 = self.create_performance_issue(
                 event_data=make_event(**get_event("n-plus-one-in-django-index-view")), noise_limit=3
             )

--- a/tests/sentry/web/frontend/test_newest_performance_issue.py
+++ b/tests/sentry/web/frontend/test_newest_performance_issue.py
@@ -80,11 +80,7 @@ class NewestIssueViewTest(TestCase, PerformanceIssueTestCase):
     @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
     @with_feature("organizations:customer-domains")
     def test_simple_customer_domains(self):
-        with mock.patch("sentry_sdk.tracing.Span.containing_transaction"), self.feature(
-            {
-                "projects:performance-suspect-spans-ingestion": True,
-            }
-        ):
+        with mock.patch("sentry_sdk.tracing.Span.containing_transaction"):
             latest_event_time = time()
             older_event_time = latest_event_time - 300
 

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -73,8 +73,6 @@ class OrganizationEventsTraceEndpointBase(APITestCase, SnubaTestCase):
                     "performance.issues.all.problem-detection": 1.0,
                     "performance-file-io-main-thread-creation": 1.0,
                 }
-            ), self.feature(
-                ["projects:performance-suspect-spans-ingestion"]
             ):
                 return self.store_event(data, project_id=project_id, **kwargs)
 


### PR DESCRIPTION
This flag isnt needed anymore.