### PR TITLE
ref(crons): Add flex-wrap to platform picker panel

### DIFF
--- a/static/app/views/monitors/components/platformPickerPanel.tsx
+++ b/static/app/views/monitors/components/platformPickerPanel.tsx
@@ -88,6 +88,7 @@ const SectionTitle = styled('h5')`
 const Actions = styled('div')`
   display: flex;
   gap: ${space(2)};
+  flex-wrap: wrap;
 `;
 
 const PlatformButton = styled(Button)`


### PR DESCRIPTION
Instead of overflowing off the side of the panel like in:
![image](https://github.com/getsentry/sentry/assets/9372512/171f1a16-e999-4ebf-a0bd-0f440735ef4e)


After (artificially adding multiple python entries to demonstrate the wrapping):
<img width="1250" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/252b8d0b-479f-42fc-b057-71acd24fff68">
