### PR TITLE
fix(stacktrace-link): Fix for mobile platforms when code mapping has nonempty stack_root

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -233,18 +233,21 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         with configure_scope() as scope:
             set_top_tags(scope, project, ctx, len(configs) > 0)
             for config in configs:
-                # If all code mappings fail to match a stack_root it means that there's no working code mapping
-                if not filepath.startswith(config.stack_root):
-                    # This may be overwritten if a valid code mapping is found
-                    result["error"] = "stack_root_mismatch"
-                    continue
-
                 outcome = {}
                 munging_outcome = {}
+
                 # Munging is required for get_link to work with mobile platforms
                 if ctx["platform"] in ["java", "cocoa", "other"]:
                     munging_outcome = try_path_munging(config, filepath, ctx)
+                    if munging_outcome.get("error") == "stack_root_mismatch":
+                        result["error"] = "stack_root_mismatch"
+                        continue
+
                 if not munging_outcome:
+                    if not filepath.startswith(config.stack_root):
+                        # This may be overwritten if a valid code mapping is found
+                        result["error"] = "stack_root_mismatch"
+                        continue
                     outcome = get_link(config, filepath, ctx["commit_id"])
                     # XXX: I want to remove this whole block logic as I believe it is wrong
                     # In some cases the stack root matches and it can either be that we have
@@ -254,6 +257,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                         if munging_outcome:
                             # Report errors to Sentry for investigation
                             logger.error("We should never be able to reach this code.")
+
                 # Keep the original outcome if munging failed
                 if munging_outcome:
                     outcome = munging_outcome

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -270,17 +270,32 @@ class ProjectStacktraceLinkTest(BaseProjectStacktraceLink):
 class ProjectStacktraceLinkTestMobile(BaseProjectStacktraceLink):
     def setUp(self):
         BaseProjectStacktraceLink.setUp(self)
-        self.code_mapping1 = self.create_code_mapping(
+        self.android_code_mapping = self.create_code_mapping(
             organization_integration=self.oi,
             project=self.project,
             repo=self.repo,
-            stack_root="",
+            stack_root="usr/src/getsentry/",
+            source_root="src/getsentry/",
+        )
+        self.cocoa_code_mapping = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="SampleProject/",
+            source_root="",
+        )
+        self.flutter_code_mapping = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="a/b/",
             source_root="",
         )
 
     @patch.object(ExampleIntegration, "get_stacktrace_link")
     def test_munge_android_worked(self, mock_integration):
-        mock_integration.side_effect = [f"{example_base_url}/usr/src/getsentry/file.java"]
+        file_path = "src/getsentry/file.java"
+        mock_integration.side_effect = [f"{example_base_url}/{file_path}"]
         response = self.get_success_response(
             self.organization.slug,
             self.project.slug,
@@ -290,8 +305,7 @@ class ProjectStacktraceLinkTestMobile(BaseProjectStacktraceLink):
                 "platform": "java",
             },
         )
-        file_path = "usr/src/getsentry/file.java"
-        assert response.data["config"] == self.expected_configurations(self.code_mapping1)
+        assert response.data["config"] == self.expected_configurations(self.android_code_mapping)
         assert response.data["sourceUrl"] == f"{example_base_url}/{file_path}"
 
     @patch.object(ExampleIntegration, "get_stacktrace_link")
@@ -308,7 +322,7 @@ class ProjectStacktraceLinkTestMobile(BaseProjectStacktraceLink):
                 "platform": "cocoa",
             },
         )
-        assert response.data["config"] == self.expected_configurations(self.code_mapping1)
+        assert response.data["config"] == self.expected_configurations(self.cocoa_code_mapping)
         assert response.data["sourceUrl"] == f"{example_base_url}/{file_path}"
 
     @patch.object(ExampleIntegration, "get_stacktrace_link")
@@ -326,7 +340,7 @@ class ProjectStacktraceLinkTestMobile(BaseProjectStacktraceLink):
                 "sdkName": "sentry.dart.flutter",
             },
         )
-        assert response.data["config"] == self.expected_configurations(self.code_mapping1)
+        assert response.data["config"] == self.expected_configurations(self.flutter_code_mapping)
         assert response.data["sourceUrl"] == f"{example_base_url}/{file_path}"
 
 


### PR DESCRIPTION
File path munging was not given a chance to happen for mobile platforms when the stack_root wasn't empty. This is because of an early check of `stack_root` against `filepath` at the beginning of the config loop, which will be wrong for android/cocoa/flutter. It did work when `stack_root` was empty.

The tests used an empty string for `stack_root`, so they passed. I modified them to use non-empty values instead, which failed until the changes here were added.