### PR TITLE
ref: Raise ValueError on unrecognized constant values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ module = [
     "sentry.api.endpoints.integrations.sentry_apps.interaction",
     "sentry.api.endpoints.integrations.sentry_apps.internal_app_token.details",
     "sentry.api.endpoints.integrations.sentry_apps.internal_app_token.index",
-    "sentry.api.endpoints.integrations.sentry_apps.organization_sentry_apps",
     "sentry.api.endpoints.integrations.sentry_apps.publish_request",
     "sentry.api.endpoints.integrations.sentry_apps.requests",
     "sentry.api.endpoints.integrations.sentry_apps.stats.details",

--- a/src/sentry/api/endpoints/integrations/sentry_apps/organization_sentry_apps.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/organization_sentry_apps.py
@@ -28,8 +28,9 @@ class OrganizationSentryAppsEndpoint(ControlSiloOrganizationEndpoint):
     ) -> Response:
         queryset = SentryApp.objects.filter(owner_id=organization.id, application__isnull=False)
 
-        if SentryAppStatus.as_int(request.GET.get("status")) is not None:
-            queryset = queryset.filter(status=SentryAppStatus.as_int(request.GET.get("status")))
+        status = request.GET.get("status")
+        if status is not None:
+            queryset = queryset.filter(status=SentryAppStatus.as_int(status))
 
         return self.paginate(
             request=request,

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -502,7 +502,7 @@ class SentryAppStatus:
         )
 
     @classmethod
-    def as_str(cls, status: int) -> Optional[str]:
+    def as_str(cls, status: int) -> str:
         if status == cls.UNPUBLISHED:
             return cls.UNPUBLISHED_STR
         elif status == cls.PUBLISHED:
@@ -514,10 +514,10 @@ class SentryAppStatus:
         elif status == cls.DELETION_IN_PROGRESS:
             return cls.DELETION_IN_PROGRESS_STR
         else:
-            return None
+            raise ValueError(f"Not a SentryAppStatus int: {status!r}")
 
     @classmethod
-    def as_int(cls, status: str) -> Optional[int]:
+    def as_int(cls, status: str) -> int:
         if status == cls.UNPUBLISHED_STR:
             return cls.UNPUBLISHED
         elif status == cls.PUBLISHED_STR:
@@ -529,7 +529,7 @@ class SentryAppStatus:
         elif status == cls.DELETION_IN_PROGRESS_STR:
             return cls.DELETION_IN_PROGRESS
         else:
-            return None
+            raise ValueError(f"Not a SentryAppStatus str: {status!r}")
 
 
 class SentryAppInstallationStatus:
@@ -546,13 +546,13 @@ class SentryAppInstallationStatus:
         )
 
     @classmethod
-    def as_str(cls, status: int) -> Optional[str]:
+    def as_str(cls, status: int) -> str:
         if status == cls.PENDING:
             return cls.PENDING_STR
         elif status == cls.INSTALLED:
             return cls.INSTALLED_STR
         else:
-            return None
+            raise ValueError(f"Not a SentryAppInstallationStatus int: {status!r}")
 
 
 class ExportQueryType:
@@ -573,22 +573,22 @@ class ExportQueryType:
         )
 
     @classmethod
-    def as_str(cls, integer: int) -> Optional[str]:
+    def as_str(cls, integer: int) -> str:
         if integer == cls.ISSUES_BY_TAG:
             return cls.ISSUES_BY_TAG_STR
         elif integer == cls.DISCOVER:
             return cls.DISCOVER_STR
         else:
-            return None
+            raise ValueError(f"Not an ExportQueryType int: {integer!r}")
 
     @classmethod
-    def from_str(cls, string: str) -> Optional[int]:
+    def from_str(cls, string: str) -> int:
         if string == cls.ISSUES_BY_TAG_STR:
             return cls.ISSUES_BY_TAG
         elif string == cls.DISCOVER_STR:
             return cls.DISCOVER
         else:
-            return None
+            raise ValueError(f"Not an ExportQueryType str: {string!r}")
 
 
 StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -517,8 +517,10 @@ class SentryAppStatus:
             raise ValueError(f"Not a SentryAppStatus int: {status!r}")
 
     @classmethod
-    def as_int(cls, status: str) -> int:
-        if status == cls.UNPUBLISHED_STR:
+    def as_int(cls, status: Optional[str]) -> Optional[int]:
+        if status is None:
+            return None
+        elif status == cls.UNPUBLISHED_STR:
             return cls.UNPUBLISHED
         elif status == cls.PUBLISHED_STR:
             return cls.PUBLISHED

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -517,10 +517,8 @@ class SentryAppStatus:
             raise ValueError(f"Not a SentryAppStatus int: {status!r}")
 
     @classmethod
-    def as_int(cls, status: Optional[str]) -> Optional[int]:
-        if status is None:
-            return None
-        elif status == cls.UNPUBLISHED_STR:
+    def as_int(cls, status: str) -> int:
+        if status == cls.UNPUBLISHED_STR:
             return cls.UNPUBLISHED
         elif status == cls.PUBLISHED_STR:
             return cls.PUBLISHED


### PR DESCRIPTION
When converting between constant representations, require arguments to be recognized values and raise `ValueError` otherwise. Change return annotations to no longer be `Optional`.

Adjust the only call site that depended on being able to pass `None` as an argument.