### PR TITLE
fix(docs): Correct model serializer ordering of body params

### DIFF
--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -46,10 +46,10 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
     """
 
     trigger_type = serializers.CharField(
-        help_text="""Type of the trigger that causes the notification. The only supported trigger right now is: `spike-protection`"""
+        help_text="""Type of the trigger that causes the notification. The only supported trigger right now is: `spike-protection`."""
     )
     service_type = serializers.CharField(
-        help_text="Service that is used for sending the notification\n"
+        help_text="Service that is used for sending the notification.\n"
         + """- `email`\n"""
         + """- `slack`\n"""
         + """- `sentry_notification`\n"""
@@ -80,7 +80,7 @@ Required if **service_type** is `slack` or `opsgenie`.
         required=False,
     )
     projects = serializers.ListField(
-        help_text="""List of projects slugs that the Notification Action is created for""",
+        help_text="""List of projects slugs that the Notification Action is created for.""",
         child=ProjectField(scope="project:read"),
         required=False,
     )

--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -28,6 +28,7 @@ INTEGRATION_SERVICES = {
 }
 
 
+# Note the ordering of fields affects the Spike Protection API Documentation
 class NotificationActionInputData(TypedDict):
     trigger_type: int
     service_type: int

--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -29,14 +29,14 @@ INTEGRATION_SERVICES = {
 
 
 class NotificationActionInputData(TypedDict):
-    integration_id: int
-    sentry_app_id: int
-    projects: List[Project]
-    service_type: int
     trigger_type: int
-    target_type: int
+    service_type: int
+    integration_id: int
     target_identifier: str
     target_display: str
+    projects: List[Project]
+    sentry_app_id: int
+    target_type: int
 
 
 @extend_schema_serializer(exclude_fields=["sentry_app_id", "target_type"])


### PR DESCRIPTION
Took me a bit but I finally found out that for model serializers, body params are specified by the order in which the fields are listed in the model serializer's `class Meta` section. The ordering is changing when I change the order of the TypedDict b/c the fields are defined by that TypedDict (see below)
https://github.com/getsentry/sentry/blob/cae2b6113536e44d5fe99a64ed642a7073fe05c9/src/sentry/api/serializers/rest_framework/notification_action.py#L348-L350

### New Body Params for Spike Protection (shared by Create + Updated)
<img width="484" alt="Screenshot 2023-10-10 at 6 45 46 PM" src="https://github.com/getsentry/sentry/assets/67301797/37cba172-3216-41e8-b0f8-85b2ad523126">
