### PR TITLE
feat(replay): Implement a basic a11y table for replay details

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -13,18 +13,12 @@ import Stacked from 'sentry/components/replays/breadcrumbs/stacked';
 import {TimelineScrubber} from 'sentry/components/replays/player/scrubber';
 import useScrubberMouseTracking from 'sentry/components/replays/player/useScrubberMouseTracking';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import getFrameDetails from 'sentry/utils/replays/getFrameDetails';
-import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
-import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import {useDimensions} from 'sentry/utils/useDimensions';
 
 type Props = {};
 
 function ReplayTimeline({}: Props) {
   const {replay} = useReplayContext();
-  const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
-
-  const {setActiveTab} = useActiveReplayTab();
 
   const panelRef = useRef<HTMLDivElement>(null);
   const mouseTrackingProps = useScrubberMouseTracking({elem: panelRef});
@@ -58,12 +52,6 @@ function ReplayTimeline({}: Props) {
           <ReplayTimelineEvents
             durationMs={durationMs}
             frames={chapterFrames}
-            onMouseEnter={onMouseEnter}
-            onMouseLeave={onMouseLeave}
-            onClickTimestamp={frame => {
-              onClickTimestamp(frame);
-              setActiveTab(getFrameDetails(frame).tabKey);
-            }}
             startTimestampMs={startTimestampMs}
             width={width}
           />

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -8,13 +8,14 @@ import {getFramesByColumn} from 'sentry/components/replays/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
 import getFrameDetails from 'sentry/utils/replays/getFrameDetails';
-import type useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
+import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import type {ReplayFrame} from 'sentry/utils/replays/types';
 import type {Color} from 'sentry/utils/theme';
 
 const NODE_SIZES = [8, 12, 16];
 
-interface Props extends ReturnType<typeof useCrumbHandlers> {
+interface Props {
   durationMs: number;
   frames: ReplayFrame[];
   startTimestampMs: number;
@@ -26,9 +27,6 @@ function ReplayTimelineEvents({
   className,
   durationMs,
   frames,
-  onMouseEnter,
-  onMouseLeave,
-  onClickTimestamp,
   startTimestampMs,
   width,
 }: Props) {
@@ -43,10 +41,7 @@ function ReplayTimelineEvents({
         <EventColumn key={column} column={column}>
           <Event
             frames={colFrames}
-            onMouseEnter={onMouseEnter}
-            onMouseLeave={onMouseLeave}
             markerWidth={markerWidth}
-            onClickTimestamp={onClickTimestamp}
             startTimestampMs={startTimestampMs}
           />
         </EventColumn>
@@ -69,23 +64,25 @@ const EventColumn = styled(Timeline.Col)<{column: number}>`
 
 function Event({
   frames,
-  onMouseEnter,
-  onMouseLeave,
   markerWidth,
-  onClickTimestamp,
   startTimestampMs,
 }: {
   frames: ReplayFrame[];
   markerWidth: number;
   startTimestampMs: number;
-} & ReturnType<typeof useCrumbHandlers>) {
+}) {
   const theme = useTheme();
+  const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
+  const {setActiveTab} = useActiveReplayTab();
 
   const buttons = frames.map((frame, i) => (
     <BreadcrumbItem
       frame={frame}
       key={i}
-      onClick={onClickTimestamp}
+      onClick={() => {
+        onClickTimestamp(frame);
+        setActiveTab(getFrameDetails(frame).tabKey);
+      }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       startTimestampMs={startTimestampMs}

--- a/static/app/components/replays/virtualizedGrid/bodyCell.tsx
+++ b/static/app/components/replays/virtualizedGrid/bodyCell.tsx
@@ -1,6 +1,7 @@
 import {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {space} from 'sentry/styles/space';
 
 const cellBackground = (p: CellProps & {theme: Theme}) => {
@@ -69,6 +70,16 @@ export const Text = styled('div')`
   padding: ${space(0.75)} ${space(1.5)};
   display: flex;
   gap: ${space(0.5)};
+`;
+
+export const CodeHighlightCell = styled(CodeSnippet)`
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  padding: ${space(0.75)} ${space(1.5)};
+  display: flex;
+  gap: ${space(0.5)};
+  --prism-block-background: transparent;
 `;
 
 export const AvatarWrapper = styled('div')`

--- a/static/app/components/replays/virtualizedGrid/headerCell.tsx
+++ b/static/app/components/replays/virtualizedGrid/headerCell.tsx
@@ -4,31 +4,19 @@ import styled from '@emotion/styled';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconArrow, IconInfo} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
-import type {Crumb} from 'sentry/types/breadcrumbs';
-import type {BreadcrumbFrame, SpanFrame} from 'sentry/utils/replays/types';
 
-interface SortCrumbs {
+type BaseRecord = Record<string, unknown>;
+interface SortConfig<RecordType extends BaseRecord> {
   asc: boolean;
-  by: keyof Crumb | string;
-  getValue: (row: Crumb) => any;
+  by: keyof RecordType | string;
+  getValue: (row: RecordType) => any;
 }
 
-interface SortBreadcrumbFrame {
-  asc: boolean;
-  by: keyof BreadcrumbFrame | string;
-  getValue: (row: BreadcrumbFrame) => any;
-}
-interface SortSpanFrame {
-  asc: boolean;
-  by: keyof SpanFrame | string;
-  getValue: (row: SpanFrame) => any;
-}
-
-type Props = {
+type Props<SortableRecord extends BaseRecord> = {
   field: string;
   handleSort: (fieldName: string) => void;
   label: ReactNode;
-  sortConfig: SortCrumbs | SortBreadcrumbFrame | SortSpanFrame;
+  sortConfig: SortConfig<SortableRecord>;
   style: CSSProperties;
   tooltipTitle: undefined | ReactNode;
 };
@@ -41,8 +29,11 @@ function CatchClicks({children}: {children: ReactNode}) {
   return <div onClick={e => e.stopPropagation()}>{children}</div>;
 }
 
-const HeaderCell = forwardRef<HTMLButtonElement, Props>(
-  ({field, handleSort, label, sortConfig, style, tooltipTitle}: Props, ref) => (
+function HeaderCell(
+  {field, handleSort, label, sortConfig, style, tooltipTitle}: Props<BaseRecord>,
+  ref
+) {
+  return (
     <HeaderButton style={style} onClick={() => handleSort(field)} ref={ref}>
       {label}
       {tooltipTitle ? (
@@ -57,8 +48,8 @@ const HeaderCell = forwardRef<HTMLButtonElement, Props>(
         style={{visibility: sortConfig.by === field ? 'visible' : 'hidden'}}
       />
     </HeaderButton>
-  )
-);
+  );
+}
 
 const HeaderButton = styled('button')`
   border: 0;
@@ -84,4 +75,8 @@ const HeaderButton = styled('button')`
   }
 `;
 
-export default HeaderCell;
+export default forwardRef<HTMLButtonElement, Props<BaseRecord>>(HeaderCell) as <
+  T extends BaseRecord,
+>(
+  props: Props<T> & {ref?: React.ForwardedRef<HTMLButtonElement>}
+) => ReturnType<typeof HeaderCell>;

--- a/static/app/utils/replays/hooks/mockA11yData.ts
+++ b/static/app/utils/replays/hooks/mockA11yData.ts
@@ -1,0 +1,121 @@
+export function A11yData(startTimestampMs: number) {
+  return [
+    {
+      elements: [
+        {
+          alternatives: [
+            {
+              id: 'button-has-visible-text',
+              message:
+                'Element does not have inner text that is visible to screen readers',
+            },
+            {
+              id: 'aria-label',
+              message: 'aria-label attribute does not exist or is empty',
+            },
+            {
+              id: 'aria-labelledby',
+              message:
+                'aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty',
+            },
+            {
+              id: 'non-empty-title',
+              message: 'Element has no title attribute',
+            },
+            {
+              id: 'presentational-role',
+              message:
+                'Element\'s default semantics were not overridden with role="none" or role="presentation"',
+            },
+          ],
+          element: '<button class="svelte-19ke1iv">',
+          target: ['button:nth-child(1)'],
+        },
+      ],
+      help_url:
+        'https://dequeuniversity.com/rules/axe/4.8/button-name?application=playwright',
+      help: 'Buttons must have discernible text',
+      id: 'button-name',
+      impact: 'critical' as const,
+      timestamp: startTimestampMs + 1000,
+    },
+    {
+      elements: [
+        {
+          alternatives: [
+            {
+              id: 'button-has-visible-text',
+              message:
+                'Element does not have inner text that is visible to screen readers',
+            },
+            {
+              id: 'aria-label',
+              message: 'aria-label attribute does not exist or is empty',
+            },
+            {
+              id: 'aria-labelledby',
+              message:
+                'aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty',
+            },
+            {
+              id: 'non-empty-title',
+              message: 'Element has no title attribute',
+            },
+            {
+              id: 'presentational-role',
+              message:
+                'Element\'s default semantics were not overridden with role="none" or role="presentation"',
+            },
+          ],
+          element: '<button class="svelte-19ke1iv">',
+          target: ['button:nth-child(1)'],
+        },
+      ],
+      help_url:
+        'https://dequeuniversity.com/rules/axe/4.8/button-name?application=playwright',
+      help: 'Buttons must have discernible text',
+      id: 'button-name',
+      impact: 'serious' as const,
+      timestamp: startTimestampMs + 2000,
+    },
+    {
+      elements: [
+        {
+          alternatives: [
+            {
+              id: 'button-has-visible-text',
+              message:
+                'Element does not have inner text that is visible to screen readers',
+            },
+            {
+              id: 'aria-label',
+              message: 'aria-label attribute does not exist or is empty',
+            },
+            {
+              id: 'aria-labelledby',
+              message:
+                'aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty',
+            },
+            {
+              id: 'non-empty-title',
+              message: 'Element has no title attribute',
+            },
+            {
+              id: 'presentational-role',
+              message:
+                'Element\'s default semantics were not overridden with role="none" or role="presentation"',
+            },
+          ],
+          element: '<button class="svelte-19ke1iv">',
+          target: ['button:nth-child(1)'],
+        },
+      ],
+      help_url:
+        'https://dequeuniversity.com/rules/axe/4.8/button-name?application=playwright',
+      help: 'Buttons must have discernible text',
+      id: 'button-name',
+      impact: 'moderate' as const,
+      timestamp: startTimestampMs + 3000,
+    },
+  ];
+}

--- a/static/app/utils/replays/hooks/useMockA11yData.tsx
+++ b/static/app/utils/replays/hooks/useMockA11yData.tsx
@@ -1,11 +1,10 @@
+import {useEffect, useState} from 'react';
+
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import hydrateA11yIssue, {A11yIssue} from 'sentry/utils/replays/hydrateA11yRecord';
-import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
 export default function useA11yData() {
-  const organization = useOrganization();
   const {replay} = useReplayContext();
   const {projects} = useProjects();
 
@@ -13,15 +12,12 @@ export default function useA11yData() {
   const startTimestampMs = replayRecord?.started_at.getTime();
   const project = projects.find(p => p.id === replayRecord?.project_id);
 
-  const {data} = useApiQuery<A11yIssue[]>(
-    [
-      `/projects/${organization.slug}/${project?.slug}/replays/${replayRecord?.id}/accessibility-issues/`,
-    ],
-    {
-      staleTime: 0,
-      enabled: Boolean(project) && Boolean(replayRecord),
+  const [data, setData] = useState<undefined | A11yIssue[]>(undefined);
+  useEffect(() => {
+    if (startTimestampMs) {
+      import('./mockA11yData').then(({A11yData}) => setData(A11yData(startTimestampMs)));
     }
-  );
+  }, [startTimestampMs]);
 
   if (project && replayRecord && startTimestampMs) {
     return data?.map(record => hydrateA11yIssue(record));

--- a/static/app/utils/replays/hydrateA11yRecord.tsx
+++ b/static/app/utils/replays/hydrateA11yRecord.tsx
@@ -28,7 +28,7 @@ export type HydratedA11yIssue = Overwrite<
      */
     offsetMs: number;
     /**
-     * The Date when the breadcrumb happened
+     * The Date when the a11yIssue happened
      */
     timestamp: Date;
     /**
@@ -38,15 +38,12 @@ export type HydratedA11yIssue = Overwrite<
   }
 >;
 
-export default function hydrateA11yIssue(
-  raw: A11yIssue,
-  startTimestampMs: number
-): HydratedA11yIssue {
+export default function hydrateA11yIssue(raw: A11yIssue): HydratedA11yIssue {
   const timestamp = new Date(raw.timestamp);
   return {
     ...raw,
     offsetMs: 0,
     timestamp,
-    timestampMs: Math.abs(timestamp.getTime() - startTimestampMs),
+    timestampMs: timestamp.getTime(),
   };
 }

--- a/static/app/views/replays/detail/accessibility/accessibilityHeaderCell.tsx
+++ b/static/app/views/replays/detail/accessibility/accessibilityHeaderCell.tsx
@@ -1,0 +1,53 @@
+import {ComponentProps, CSSProperties, forwardRef, ReactNode} from 'react';
+
+import HeaderCell from 'sentry/components/replays/virtualizedGrid/headerCell';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+import useSortAccessibility from 'sentry/views/replays/detail/accessibility/useSortAccessibility';
+
+type SortConfig = ReturnType<typeof useSortAccessibility>['sortConfig'];
+type Props = {
+  handleSort: ReturnType<typeof useSortAccessibility>['handleSort'];
+  index: number;
+  sortConfig: SortConfig;
+  style: CSSProperties;
+};
+
+const COLUMNS: {
+  field: SortConfig['by'];
+  label: ReactNode;
+  tooltipTitle?: ComponentProps<typeof Tooltip>['title'];
+}[] = [
+  {
+    field: 'impact',
+    label: '',
+  },
+  {
+    field: 'id',
+    label: t('Type'),
+  },
+  {field: 'element', label: t('Path')},
+
+  {field: 'timestampMs', label: t('Timestamp')},
+];
+
+export const COLUMN_COUNT = COLUMNS.length;
+
+const AccessibilityHeaderCell = forwardRef<HTMLButtonElement, Props>(
+  ({handleSort, index, sortConfig, style}: Props, ref) => {
+    const {field, label, tooltipTitle} = COLUMNS[index];
+    return (
+      <HeaderCell
+        ref={ref}
+        handleSort={handleSort}
+        field={field}
+        label={label}
+        tooltipTitle={tooltipTitle}
+        sortConfig={sortConfig}
+        style={style}
+      />
+    );
+  }
+);
+
+export default AccessibilityHeaderCell;

--- a/static/app/views/replays/detail/accessibility/accessibilityHeaderCell.tsx
+++ b/static/app/views/replays/detail/accessibility/accessibilityHeaderCell.tsx
@@ -26,7 +26,7 @@ const COLUMNS: {
     field: 'id',
     label: t('Type'),
   },
-  {field: 'element', label: t('Path')},
+  {field: 'element', label: t('Element')},
 
   {field: 'timestampMs', label: t('Timestamp')},
 ];

--- a/static/app/views/replays/detail/accessibility/accessibilityTableCell.tsx
+++ b/static/app/views/replays/detail/accessibility/accessibilityTableCell.tsx
@@ -105,7 +105,7 @@ const AccessibilityTableCell = forwardRef<HTMLDivElement, Props>(
         <Cell {...columnProps}>
           <Text>
             {a11yIssue.impact ? (
-              <Tooltip title={a11yIssue.impact ?? 'unknown'}>
+              <Tooltip title={a11yIssue.impact ?? EMPTY_CELL}>
                 {IMPACT_ICON_MAPPING[a11yIssue.impact]}
               </Tooltip>
             ) : (
@@ -116,7 +116,7 @@ const AccessibilityTableCell = forwardRef<HTMLDivElement, Props>(
       ),
       () => (
         <Cell {...columnProps}>
-          <Text>{a11yIssue.id ?? 'unknown'}</Text>
+          <Text>{a11yIssue.id ?? EMPTY_CELL}</Text>
         </Cell>
       ),
       () => (

--- a/static/app/views/replays/detail/accessibility/accessibilityTableCell.tsx
+++ b/static/app/views/replays/detail/accessibility/accessibilityTableCell.tsx
@@ -1,0 +1,148 @@
+import {ComponentProps, CSSProperties, forwardRef} from 'react';
+import classNames from 'classnames';
+
+import {
+  ButtonWrapper,
+  Cell,
+  Text,
+} from 'sentry/components/replays/virtualizedGrid/bodyCell';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconFire, IconInfo, IconWarning} from 'sentry/icons';
+import type useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import {HydratedA11yIssue} from 'sentry/utils/replays/hydrateA11yRecord';
+import {Color} from 'sentry/utils/theme';
+import useUrlParams from 'sentry/utils/useUrlParams';
+import useSortAccessibility from 'sentry/views/replays/detail/accessibility/useSortAccessibility';
+import TimestampButton from 'sentry/views/replays/detail/timestampButton';
+
+const EMPTY_CELL = '--';
+
+const IMPACT_ICON_MAPPING: Record<keyof HydratedA11yIssue['impact'], Color> = {
+  minor: <IconInfo size="xs" />,
+  moderate: <IconInfo size="xs" />,
+  serious: <IconWarning size="xs" color="yellow400" />,
+  critical: <IconFire size="xs" color="red400" />,
+};
+
+interface Props extends ReturnType<typeof useCrumbHandlers> {
+  a11yIssue: HydratedA11yIssue;
+  columnIndex: number;
+  currentHoverTime: number | undefined;
+  currentTime: number;
+  onClickCell: (props: {dataIndex: number; rowIndex: number}) => void;
+  rowIndex: number;
+  sortConfig: ReturnType<typeof useSortAccessibility>['sortConfig'];
+  startTimestampMs: number;
+  style: CSSProperties;
+}
+
+const AccessibilityTableCell = forwardRef<HTMLDivElement, Props>(
+  (
+    {
+      a11yIssue,
+      columnIndex,
+      currentHoverTime,
+      currentTime,
+      onClickCell,
+      onClickTimestamp,
+      onMouseEnter,
+      onMouseLeave,
+      rowIndex,
+      sortConfig,
+      startTimestampMs,
+      style,
+    }: Props,
+    ref
+  ) => {
+    // Rows include the sortable header, the dataIndex does not
+    const dataIndex = rowIndex - 1;
+
+    const {getParamValue} = useUrlParams('a_detail_row', '');
+    const isSelected = getParamValue() === String(dataIndex);
+
+    const hasOccurred = currentTime >= a11yIssue.offsetMs;
+    const isBeforeHover =
+      currentHoverTime === undefined || currentHoverTime >= a11yIssue.offsetMs;
+
+    const isByTimestamp = sortConfig.by === 'startTimestamp';
+    const isAsc = isByTimestamp ? sortConfig.asc : undefined;
+    const columnProps = {
+      className: classNames({
+        beforeCurrentTime: isByTimestamp
+          ? isAsc
+            ? hasOccurred
+            : !hasOccurred
+          : undefined,
+        afterCurrentTime: isByTimestamp
+          ? isAsc
+            ? !hasOccurred
+            : hasOccurred
+          : undefined,
+        beforeHoverTime:
+          isByTimestamp && currentHoverTime !== undefined
+            ? isAsc
+              ? isBeforeHover
+              : !isBeforeHover
+            : undefined,
+        afterHoverTime:
+          isByTimestamp && currentHoverTime !== undefined
+            ? isAsc
+              ? !isBeforeHover
+              : isBeforeHover
+            : undefined,
+      }),
+      hasOccurred: isByTimestamp ? hasOccurred : undefined,
+      isSelected,
+      onClick: () => onClickCell({dataIndex, rowIndex}),
+      onMouseEnter: () => onMouseEnter(a11yIssue),
+      onMouseLeave: () => onMouseLeave(a11yIssue),
+      ref,
+      style,
+    } as ComponentProps<typeof Cell>;
+
+    const renderFns = [
+      () => (
+        <Cell {...columnProps}>
+          <Text>
+            {a11yIssue.impact ? (
+              <Tooltip title={a11yIssue.impact ?? 'unknown'}>
+                {IMPACT_ICON_MAPPING[a11yIssue.impact]}
+              </Tooltip>
+            ) : (
+              EMPTY_CELL
+            )}
+          </Text>
+        </Cell>
+      ),
+      () => (
+        <Cell {...columnProps}>
+          <Text>{a11yIssue.id ?? 'unknown'}</Text>
+        </Cell>
+      ),
+      () => (
+        <Cell {...columnProps}>
+          <Text>{a11yIssue.elements?.[0].element ?? EMPTY_CELL}</Text>
+        </Cell>
+      ),
+      () => (
+        <Cell {...columnProps} numeric>
+          <ButtonWrapper>
+            <TimestampButton
+              format="mm:ss.SSS"
+              onClick={event => {
+                event.stopPropagation();
+                onClickTimestamp(a11yIssue);
+              }}
+              startTimestampMs={startTimestampMs}
+              timestampMs={a11yIssue.timestampMs}
+            />
+          </ButtonWrapper>
+        </Cell>
+      ),
+    ];
+
+    return renderFns[columnIndex]();
+  }
+);
+
+export default AccessibilityTableCell;

--- a/static/app/views/replays/detail/accessibility/accessibilityTableCell.tsx
+++ b/static/app/views/replays/detail/accessibility/accessibilityTableCell.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import {
   ButtonWrapper,
   Cell,
+  CodeHighlightCell,
   Text,
 } from 'sentry/components/replays/virtualizedGrid/bodyCell';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -121,7 +122,9 @@ const AccessibilityTableCell = forwardRef<HTMLDivElement, Props>(
       ),
       () => (
         <Cell {...columnProps}>
-          <Text>{a11yIssue.elements?.[0].element ?? EMPTY_CELL}</Text>
+          <CodeHighlightCell language="html" hideCopyButton>
+            {a11yIssue.elements?.[0].element ?? EMPTY_CELL}
+          </CodeHighlightCell>
         </Cell>
       ),
       () => (

--- a/static/app/views/replays/detail/accessibility/accessibilityTableCell.tsx
+++ b/static/app/views/replays/detail/accessibility/accessibilityTableCell.tsx
@@ -64,7 +64,7 @@ const AccessibilityTableCell = forwardRef<HTMLDivElement, Props>(
     const isBeforeHover =
       currentHoverTime === undefined || currentHoverTime >= a11yIssue.offsetMs;
 
-    const isByTimestamp = sortConfig.by === 'startTimestamp';
+    const isByTimestamp = sortConfig.by === 'timestampMs';
     const isAsc = isByTimestamp ? sortConfig.asc : undefined;
     const columnProps = {
       className: classNames({

--- a/static/app/views/replays/detail/accessibility/index.tsx
+++ b/static/app/views/replays/detail/accessibility/index.tsx
@@ -62,8 +62,7 @@ function AccessibilityList() {
   // `undefined` which then gets set into the hook and doesn't update.
   const initialSize = Math.max(150, window.innerHeight * 0.4);
 
-  // eslint-disable-next-line
-  const {size: containerSize, ...resizableDrawerProps} = useResizableDrawer({
+  const {size: containerSize} = useResizableDrawer({
     direction: 'up',
     initialSize,
     min: 0,

--- a/static/app/views/replays/detail/accessibility/index.tsx
+++ b/static/app/views/replays/detail/accessibility/index.tsx
@@ -1,13 +1,272 @@
-import useA11yData from 'sentry/utils/replays/hooks/useA11yData';
+import {useCallback, useMemo, useRef, useState} from 'react';
+import {AutoSizer, CellMeasurer, GridCellProps, MultiGrid} from 'react-virtualized';
+import styled from '@emotion/styled';
 
-type Props = {};
+import Placeholder from 'sentry/components/placeholder';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {t} from 'sentry/locale';
+// import useA11yData from 'sentry/utils/replays/hooks/useA11yData';
+import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import useMockA11yData from 'sentry/utils/replays/hooks/useMockA11yData';
+import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
+import useUrlParams from 'sentry/utils/useUrlParams';
+// import AccessibilityFilters from 'sentry/views/replays/detail/accessibility/accessibilityFilters';
+import AccessibilityHeaderCell, {
+  COLUMN_COUNT,
+} from 'sentry/views/replays/detail/accessibility/accessibilityHeaderCell';
+import AccessibilityTableCell from 'sentry/views/replays/detail/accessibility/accessibilityTableCell';
+// import AccessibilityDetails from 'sentry/views/replays/detail/accessibility/details';
+// import useAccessibilityFilters from 'sentry/views/replays/detail/accessibility/useAccessibilityFilters';
+import useSortAccessibility from 'sentry/views/replays/detail/accessibility/useSortAccessibility';
+import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
+import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
+import useVirtualizedGrid from 'sentry/views/replays/detail/useVirtualizedGrid';
 
-function A11y({}: Props) {
-  const data = useA11yData();
-  // eslint-disable-next-line no-console
-  console.log(data);
+const HEADER_HEIGHT = 25;
+const BODY_HEIGHT = 25;
 
-  return <div />;
+const RESIZEABLE_HANDLE_HEIGHT = 105;
+
+const cellMeasurer = {
+  defaultHeight: BODY_HEIGHT,
+  defaultWidth: 100,
+  fixedHeight: true,
+};
+
+function AccessibilityList() {
+  const {currentTime, currentHoverTime, replay} = useReplayContext();
+  const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
+
+  const accessibilityData = useMockA11yData();
+  const startTimestampMs = replay?.getReplay()?.started_at?.getTime() || 0;
+
+  const [scrollToRow, setScrollToRow] = useState<undefined | number>(undefined);
+
+  const filteredItems = accessibilityData || [];
+  const clearSearchTerm = () => {};
+  const {handleSort, items, sortConfig} = useSortAccessibility({items: filteredItems});
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const gridRef = useRef<MultiGrid>(null);
+  const deps = useMemo(() => [items], [items]);
+  const {cache, getColumnWidth, onScrollbarPresenceChange, onWrapperResize} =
+    useVirtualizedGrid({
+      cellMeasurer,
+      gridRef,
+      columnCount: COLUMN_COUNT,
+      dynamicColumnIndex: 2,
+      deps,
+    });
+
+  // `initialSize` cannot depend on containerRef because the ref starts as
+  // `undefined` which then gets set into the hook and doesn't update.
+  const initialSize = Math.max(150, window.innerHeight * 0.4);
+
+  // eslint-disable-next-line
+  const {size: containerSize, ...resizableDrawerProps} = useResizableDrawer({
+    direction: 'up',
+    initialSize,
+    min: 0,
+    onResize: () => {},
+  });
+  const {getParamValue: getDetailRow, setParamValue: setDetailRow} = useUrlParams(
+    'n_detail_row',
+    ''
+  );
+  const detailDataIndex = getDetailRow();
+
+  const maxContainerHeight =
+    (containerRef.current?.clientHeight || window.innerHeight) - RESIZEABLE_HANDLE_HEIGHT;
+  const splitSize =
+    accessibilityData && detailDataIndex
+      ? Math.min(maxContainerHeight, containerSize)
+      : undefined;
+
+  const onClickCell = useCallback(
+    ({}: {dataIndex: number; rowIndex: number}) => {
+      // eslint-disable-line
+      // if (getDetailRow() === String(dataIndex)) {
+      //   setDetailRow('');
+      // } else {
+      //   setDetailRow(String(dataIndex));
+      //   setScrollToRow(rowIndex);
+      // }
+    },
+    // eslint-disable-next-line
+    [getDetailRow, setDetailRow]
+  );
+
+  const cellRenderer = ({columnIndex, rowIndex, key, style, parent}: GridCellProps) => {
+    const a11yIssue = items[rowIndex - 1];
+
+    return (
+      <CellMeasurer
+        cache={cache}
+        columnIndex={columnIndex}
+        key={key}
+        parent={parent}
+        rowIndex={rowIndex}
+      >
+        {({
+          measure: _,
+          registerChild,
+        }: {
+          measure: () => void;
+          registerChild?: (element?: Element) => void;
+        }) =>
+          rowIndex === 0 ? (
+            <AccessibilityHeaderCell
+              ref={e => e && registerChild?.(e)}
+              handleSort={handleSort}
+              index={columnIndex}
+              sortConfig={sortConfig}
+              style={{...style, height: HEADER_HEIGHT}}
+            />
+          ) : (
+            <AccessibilityTableCell
+              columnIndex={columnIndex}
+              currentHoverTime={currentHoverTime}
+              currentTime={currentTime}
+              a11yIssue={a11yIssue}
+              onMouseEnter={onMouseEnter}
+              onMouseLeave={onMouseLeave}
+              onClickCell={onClickCell}
+              onClickTimestamp={onClickTimestamp}
+              ref={e => e && registerChild?.(e)}
+              rowIndex={rowIndex}
+              sortConfig={sortConfig}
+              startTimestampMs={startTimestampMs}
+              style={{...style, height: BODY_HEIGHT}}
+            />
+          )
+        }
+      </CellMeasurer>
+    );
+  };
+
+  return (
+    <FluidHeight>
+      {/* <AccessibilityFilters accessibilityData={accessibilityData} {...filterProps} /> */}
+      <AccessibilityTable
+        ref={containerRef}
+        data-test-id="replay-details-accessibility-tab"
+      >
+        <SplitPanel
+          style={{
+            gridTemplateRows: splitSize !== undefined ? `1fr auto ${splitSize}px` : '1fr',
+          }}
+        >
+          {accessibilityData ? (
+            <OverflowHidden>
+              <AutoSizer onResize={onWrapperResize}>
+                {({height, width}) => (
+                  <MultiGrid
+                    ref={gridRef}
+                    cellRenderer={cellRenderer}
+                    columnCount={COLUMN_COUNT}
+                    columnWidth={getColumnWidth(width)}
+                    deferredMeasurementCache={cache}
+                    estimatedColumnSize={100}
+                    estimatedRowSize={BODY_HEIGHT}
+                    fixedRowCount={1}
+                    height={height}
+                    noContentRenderer={() => (
+                      <NoRowRenderer
+                        unfilteredItems={accessibilityData}
+                        clearSearchTerm={clearSearchTerm}
+                      >
+                        {t('No accessibility problems detected')}
+                      </NoRowRenderer>
+                    )}
+                    onScrollbarPresenceChange={onScrollbarPresenceChange}
+                    onScroll={() => {
+                      if (scrollToRow !== undefined) {
+                        setScrollToRow(undefined);
+                      }
+                    }}
+                    scrollToRow={scrollToRow}
+                    overscanColumnCount={COLUMN_COUNT}
+                    overscanRowCount={5}
+                    rowCount={items.length + 1}
+                    rowHeight={({index}) => (index === 0 ? HEADER_HEIGHT : BODY_HEIGHT)}
+                    width={width}
+                  />
+                )}
+              </AutoSizer>
+            </OverflowHidden>
+          ) : (
+            <Placeholder height="100%" />
+          )}
+          {/* <AccessibilityDetails
+            {...resizableDrawerProps}
+            item={detailDataIndex ? items[detailDataIndex] : null}
+            onClose={() => {
+              setDetailRow('');
+            }}
+            projectId="1"
+            startTimestampMs={startTimestampMs}
+          /> */}
+        </SplitPanel>
+      </AccessibilityTable>
+    </FluidHeight>
+  );
 }
 
-export default A11y;
+const SplitPanel = styled('div')`
+  width: 100%;
+  height: 100%;
+
+  position: relative;
+  display: grid;
+  overflow: auto;
+`;
+
+const OverflowHidden = styled('div')`
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+  display: grid;
+`;
+
+const AccessibilityTable = styled(FluidHeight)`
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+
+  .beforeHoverTime + .afterHoverTime:before {
+    border-top: 1px solid ${p => p.theme.purple200};
+    content: '';
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 999999999%;
+  }
+
+  .beforeHoverTime:last-child:before {
+    border-bottom: 1px solid ${p => p.theme.purple200};
+    content: '';
+    right: 0;
+    position: absolute;
+    bottom: 0;
+    width: 999999999%;
+  }
+
+  .beforeCurrentTime + .afterCurrentTime:before {
+    border-top: 1px solid ${p => p.theme.purple300};
+    content: '';
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 999999999%;
+  }
+
+  .beforeCurrentTime:last-child:before {
+    border-bottom: 1px solid ${p => p.theme.purple300};
+    content: '';
+    right: 0;
+    position: absolute;
+    bottom: 0;
+    width: 999999999%;
+  }
+`;
+
+export default AccessibilityList;

--- a/static/app/views/replays/detail/accessibility/useSortAccessibility.tsx
+++ b/static/app/views/replays/detail/accessibility/useSortAccessibility.tsx
@@ -1,0 +1,112 @@
+import {useCallback, useMemo} from 'react';
+
+import {HydratedA11yIssue} from 'sentry/utils/replays/hydrateA11yRecord';
+import useUrlParams from 'sentry/utils/useUrlParams';
+
+interface SortConfig {
+  asc: boolean;
+  by: keyof HydratedA11yIssue | string;
+  getValue: (row: HydratedA11yIssue) => any;
+}
+
+const IMPACT_SORT = {
+  minor: 0,
+  moderate: 1,
+  serious: 2,
+  critical: 3,
+};
+
+const SortStrategies: Record<string, (row) => any> = {
+  impact: row => IMPACT_SORT[row.impact],
+  id: row => row.id,
+  element: row => row.element,
+  timestampMs: row => row.timestampMs,
+};
+
+const DEFAULT_ASC = 'false';
+const DEFAULT_BY = 'impact';
+
+type Opts = {items: HydratedA11yIssue[]};
+
+function useSortAccessibility({items}: Opts) {
+  const {getParamValue: getSortAsc, setParamValue: setSortAsc} = useUrlParams(
+    's_a_asc',
+    DEFAULT_ASC
+  );
+  const {getParamValue: getSortBy, setParamValue: setSortBy} = useUrlParams(
+    's_a_by',
+    DEFAULT_BY
+  );
+  const {setParamValue: setDetailRow} = useUrlParams('a_detail_row', '');
+
+  const sortAsc = getSortAsc();
+  const sortBy = getSortBy();
+
+  const sortConfig = useMemo(
+    () =>
+      ({
+        asc: sortAsc === 'true',
+        by: sortBy,
+        getValue: SortStrategies[sortBy],
+      }) as SortConfig,
+    [sortAsc, sortBy]
+  );
+
+  const sortedItems = useMemo(
+    () => sortAccessibility(items, sortConfig),
+    [items, sortConfig]
+  );
+
+  const handleSort = useCallback(
+    (fieldName: keyof typeof SortStrategies) => {
+      if (sortConfig.by === fieldName) {
+        setSortAsc(sortConfig.asc ? 'false' : 'true');
+      } else {
+        setSortAsc('true');
+        setSortBy(fieldName);
+      }
+      setDetailRow('');
+    },
+    [sortConfig, setSortAsc, setSortBy, setDetailRow]
+  );
+
+  return {
+    handleSort,
+    items: sortedItems,
+    sortConfig,
+  };
+}
+
+function sortAccessibility(
+  accessibility: HydratedA11yIssue[],
+  sortConfig: SortConfig
+): HydratedA11yIssue[] {
+  return [...accessibility].sort((a, b) => {
+    let valueA = sortConfig.getValue(a);
+    let valueB = sortConfig.getValue(b);
+
+    valueA = typeof valueA === 'string' ? valueA.toUpperCase() : valueA;
+    valueB = typeof valueB === 'string' ? valueB.toUpperCase() : valueB;
+
+    // if the values are not defined, we want to push them to the bottom of the list
+    if (valueA === undefined) {
+      return 1;
+    }
+
+    if (valueB === undefined) {
+      return -1;
+    }
+
+    if (valueA === valueB) {
+      return 0;
+    }
+
+    if (sortConfig.asc) {
+      return valueA > valueB ? 1 : -1;
+    }
+
+    return valueB > valueA ? 1 : -1;
+  });
+}
+
+export default useSortAccessibility;

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -82,9 +82,9 @@ function Breadcrumbs({frames, startTimestampMs}: Props) {
           startTimestampMs={startTimestampMs}
           style={style}
           expandPaths={Array.from(expandPathsRef.current?.get(index) || [])}
-          onClick={frame => {
-            onClickTimestamp(frame);
-            setActiveTab(getFrameDetails(frame).tabKey);
+          onClick={() => {
+            onClickTimestamp(item);
+            setActiveTab(getFrameDetails(item).tabKey);
           }}
           onDimensionChange={handleDimensionChange}
         />


### PR DESCRIPTION
Here's the new table, with mock data, sorted by timestamp: 

![SCR-20231012-jttt](https://github.com/getsentry/sentry/assets/187460/8d89dbed-5a70-4b57-b838-2e2890e5db8f)
![SCR-20231012-juao](https://github.com/getsentry/sentry/assets/187460/1074d4d2-70c9-4fac-ad02-7766b05612ab)


