### PR TITLE
fix(source-map-debugger): Check for None frames in scraping logic

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
+++ b/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
@@ -291,7 +291,7 @@ class SourceMapDebugBlueThunderEditionEndpoint(ProjectEndpoint):
 
 
 def get_scraping_data_for_frame(scraping_attempt_map, frame):
-    abs_path = frame.get("abs_path")
+    abs_path = get_path(frame, "abs_path")
     if abs_path is None:
         return {"source_file": None, "source_map": None}
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/57890