### PR TITLE
feat(sdk): Add option for controlling upstream metrics propagation in SDK config

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3814,4 +3814,4 @@ SENTRY_METRICS_INTERFACE_BACKEND = "sentry.sentry_metrics.client.snuba.SnubaMetr
 SENTRY_METRICS_INTERFACE_BACKEND_OPTIONS: dict[str, Any] = {}
 
 # Controls whether the SDK will send the metrics upstream to the S4S transport.
-SENTRY_UPSTREAM_METRICS_ENABLED = False
+SENTRY_SDK_UPSTREAM_METRICS_ENABLED = False

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3812,3 +3812,6 @@ OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL: Optional[str] = None
 
 SENTRY_METRICS_INTERFACE_BACKEND = "sentry.sentry_metrics.client.snuba.SnubaMetricsBackend"
 SENTRY_METRICS_INTERFACE_BACKEND_OPTIONS: dict[str, Any] = {}
+
+# Controls whether the SDK will send the metrics upstream to the S4S transport.
+SENTRY_UPSTREAM_METRICS_ENABLED = False

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -424,7 +424,7 @@ def configure_sdk():
                 s4s_args = args
                 # We want to control whether we want to send metrics at the s4s upstream.
                 if (
-                    not settings.SENTRY_UPSTREAM_METRICS_ENABLED
+                    not settings.SENTRY_SDK_UPSTREAM_METRICS_ENABLED
                     and method_name == "capture_envelope"
                 ):
                     args_list = list(args)

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -422,15 +422,20 @@ def configure_sdk():
                 # if install_id:
                 #     event.setdefault('tags', {})['install-id'] = install_id
                 s4s_args = args
-                if method_name == "capture_envelope":
+                # We want to control whether we want to send metrics at the s4s upstream.
+                if (
+                    not settings.SENTRY_UPSTREAM_METRICS_ENABLED
+                    and method_name == "capture_envelope"
+                ):
                     args_list = list(args)
                     envelope = args_list[0]
-                    # Do not forward metrics to s4s
+                    # We filter out all the statsd envelope items, which contain custom metrics sent by the SDK.
                     safe_items = [x for x in envelope.items if x.data_category != "statsd"]
                     if len(safe_items) != len(envelope.items):
                         relay_envelope = copy.copy(envelope)
                         relay_envelope.items = safe_items
                         s4s_args = (relay_envelope, *args_list[1:])
+
                 getattr(sentry4sentry_transport, method_name)(*s4s_args, **kwargs)
 
             if sentry_saas_transport and options.get("store.use-relay-dsn-sample-rate") == 1:


### PR DESCRIPTION
This PR adds a new setting for configuring upstream metrics propagation, that is, for the `sentry4sentry_transport` we now have the option to choose whether or not we want to propagate metrics (identified by item of type `statsd` in the envelope).