### PR TITLE
fix(profiling): Remove aggregate fields from profiles events table

### DIFF
--- a/static/app/views/profiling/profileSummary/content.tsx
+++ b/static/app/views/profiling/profileSummary/content.tsx
@@ -133,7 +133,15 @@ export function getProfilesTableFields(platform: Project['platform']) {
   return DEFAULT_FIELDS;
 }
 
-const MOBILE_FIELDS: ProfilingFieldType[] = [...ALL_FIELDS];
+const MOBILE_FIELDS: ProfilingFieldType[] = [
+  'profile.id',
+  'timestamp',
+  'release',
+  'device.model',
+  'device.classification',
+  'device.arch',
+  'transaction.duration',
+];
 const DEFAULT_FIELDS: ProfilingFieldType[] = [
   'profile.id',
   'timestamp',


### PR DESCRIPTION
This was showing aggregate fields on mobile platforms and also breaking the profile id links because it no longer was returning the project.