### PR TITLE
fix(merging): Clarify `Merged Issues` tab header text

### DIFF
--- a/static/app/views/issueDetails/groupMerged/index.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.tsx
@@ -135,7 +135,7 @@ class GroupMergedView extends Component<Props, State> {
         <Layout.Main fullWidth>
           <HeaderWrapper>
             <Title>
-              {tct('Merged fingerprints with latest event [count]', {
+              {tct('Fingerprints included in this issue [count]', {
                 count: <QueryCount count={fingerprintsWithLatestEvent.length} />,
               })}
             </Title>


### PR DESCRIPTION
Currently, the way we list issues on the Merged Issues tab is confusing. Specifically, it is counterintuitive for users that we include the current issue's fingerprint in the list of "merged" fingerprints. 

Because we do that, issues which have never undergone a merge nonetheless list a fingerprint on the tab, making it look like a merge has happened (with the listed fingerprint having been merged into the current issue, even though in reality they are one and the same). Similarly, even when a merge _has_ happened, we list one more issue than users intuitively think have been merged in.

From a theoretical perspective, including the original fingerprint actually makes sense, because when two issues merge, there really shouldn't be a "this" issue and a "merged in" issue, just two issues which have been glued together. Nonetheless, users [get confused](https://github.com/getsentry/sentry/issues/56334#issuecomment-1733692221).

This aims to fix that confusion by changing the wording on the tab's heading, to make it clearer that no merging needs to have happened for there to be a listing on that tab, and, conversely, that if merging has happened, all merged issues are listed. It also removes mention of the "latest event," since a) not all types of issues even have a link to the latest event (see https://github.com/getsentry/sentry/issues/57383), and b) even for those that do, it's not at all obvious that there's a link. If we want people to be able to click through to the latest event with a given fingerprint, we should give them a separate, labeled link to do so.