### PR TITLE
ref(source-map-debugger): Turn UI element to open modal into a button and make it more visible

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -15,7 +15,7 @@ import {getThreadById} from 'sentry/components/events/interfaces/utils';
 import StrictClick from 'sentry/components/strictClick';
 import Tag from 'sentry/components/tag';
 import {SLOW_TOOLTIP_DELAY} from 'sentry/constants';
-import {IconChevron, IconQuestion, IconRefresh} from 'sentry/icons';
+import {IconChevron, IconOpen, IconRefresh} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import DebugMetaStore from 'sentry/stores/debugMetaStore';
 import {space} from 'sentry/styles/space';
@@ -407,7 +407,7 @@ export class DeprecatedLine extends Component<Props, State> {
                       ? t('Not your source code?')
                       : t('No source code?')}
                   </SourceMapDebuggerButtonText>
-                  <IconQuestion size="xs" />
+                  <IconOpen size="xs" />
                 </SourceMapDebuggerModalButton>
               </Fragment>
             ) : null}

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -1,4 +1,4 @@
-import {Component} from 'react';
+import {Component, Fragment} from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import scrollToElement from 'scroll-to-element';
@@ -15,7 +15,7 @@ import {getThreadById} from 'sentry/components/events/interfaces/utils';
 import StrictClick from 'sentry/components/strictClick';
 import Tag from 'sentry/components/tag';
 import {SLOW_TOOLTIP_DELAY} from 'sentry/constants';
-import {IconChevron, IconFlag, IconRefresh} from 'sentry/icons';
+import {IconChevron, IconQuestion, IconRefresh} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import DebugMetaStore from 'sentry/stores/debugMetaStore';
 import {space} from 'sentry/styles/space';
@@ -366,43 +366,50 @@ export class DeprecatedLine extends Component<Props, State> {
             ) : null}
             {stacktraceChangesEnabled ? this.renderShowHideToggle() : null}
             {shouldShowSourceMapDebuggerToggle ? (
-              <SourceMapDebuggerToggle
-                icon={<IconFlag />}
-                to=""
-                tooltipText={t(
-                  'Learn how to show the original source code for this stack frame.'
-                )}
-                onClick={e => {
-                  e.stopPropagation();
+              <Fragment>
+                <SourceMapDebuggerModalButton
+                  size="zero"
+                  priority="primary"
+                  title={t(
+                    'Click to learn how to show the original source code for this stack frame.'
+                  )}
+                  onClick={e => {
+                    e.stopPropagation();
 
-                  trackAnalytics(
-                    'source_map_debug_blue_thunder.modal_opened',
-                    sourceMapDebuggerAmplitudeData
-                  );
+                    trackAnalytics(
+                      'source_map_debug_blue_thunder.modal_opened',
+                      sourceMapDebuggerAmplitudeData
+                    );
 
-                  openModal(
-                    modalProps => (
-                      <SourceMapsDebuggerModal
-                        analyticsParams={sourceMapDebuggerAmplitudeData}
-                        sourceResolutionResults={this.props.frameSourceResolutionResults!}
-                        {...modalProps}
-                      />
-                    ),
-                    {
-                      onClose: () => {
-                        trackAnalytics(
-                          'source_map_debug_blue_thunder.modal_closed',
-                          sourceMapDebuggerAmplitudeData
-                        );
-                      },
-                    }
-                  );
-                }}
-              >
-                {hasContextSource(data)
-                  ? t('Not your source code?')
-                  : t('No source code?')}
-              </SourceMapDebuggerToggle>
+                    openModal(
+                      modalProps => (
+                        <SourceMapsDebuggerModal
+                          analyticsParams={sourceMapDebuggerAmplitudeData}
+                          sourceResolutionResults={
+                            this.props.frameSourceResolutionResults!
+                          }
+                          {...modalProps}
+                        />
+                      ),
+                      {
+                        onClose: () => {
+                          trackAnalytics(
+                            'source_map_debug_blue_thunder.modal_closed',
+                            sourceMapDebuggerAmplitudeData
+                          );
+                        },
+                      }
+                    );
+                  }}
+                >
+                  <SourceMapDebuggerButtonText>
+                    {hasContextSource(data)
+                      ? t('Not your source code?')
+                      : t('No source code?')}
+                  </SourceMapDebuggerButtonText>
+                  <IconQuestion size="xs" />
+                </SourceMapDebuggerModalButton>
+              </Fragment>
             ) : null}
             {!data.inApp ? (
               stacktraceChangesEnabled ? null : (
@@ -675,14 +682,13 @@ const ToggleButton = styled(Button)`
   }
 `;
 
-const SourceMapDebuggerToggle = styled(Tag)`
-  cursor: pointer;
-  span {
-    color: ${p => p.theme.gray300};
+const SourceMapDebuggerButtonText = styled('span')`
+  margin-right: ${space(0.5)};
+`;
 
-    &:hover {
-      text-decoration: underline;
-      text-decoration-color: ${p => p.theme.gray200};
-    }
-  }
+const SourceMapDebuggerModalButton = styled(Button)`
+  font-weight: normal;
+  height: 20px;
+  padding: 0 ${space(0.75)};
+  font-size: ${p => p.theme.fontSizeSmall};
 `;


### PR DESCRIPTION
Makes the button to open the modal brighter and look "more clickable".

Quotes and Feedback around this change (some of it I would just ignore, just to have some opinions here for posterity):

> Without the "Open Icon" it doesn't look clickable.

> the "open external" is still the best so far I'd say

> open icon gud

> i like question mark the best, open external not opening a link would be super confusing for me

> The designers might get a stroke.

> I wouldn't do it (in this color)

![Screenshot 2023-10-11 at 16 46 01](https://github.com/getsentry/sentry/assets/8118419/8cd312a3-5776-48ee-8dda-9fbfb6a0c1f9)

![Screenshot 2023-10-11 at 16 46 14](https://github.com/getsentry/sentry/assets/8118419/1491dab0-da08-4efb-8007-2fd7c8495b7f)
