### PR TITLE
feat(issues): Add app.in_foreground as a known field

### DIFF
--- a/static/app/components/events/contexts/app/getAppKnownDataDetails.spec.tsx
+++ b/static/app/components/events/contexts/app/getAppKnownDataDetails.spec.tsx
@@ -32,6 +32,7 @@ describe('getAppKnownDataDetails', function () {
       {subject: 'Build Name', value: ''},
       {subject: 'Version', value: '7.1.3'},
       {subject: 'App Build', value: '1'},
+      {subject: 'In Foreground', value: false},
     ]);
   });
 });

--- a/static/app/components/events/contexts/app/getAppKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/app/getAppKnownDataDetails.tsx
@@ -61,6 +61,11 @@ export function getAppKnownDataDetails({data, event, type}: Props): Output | und
         subject: t('App Build'),
         value: data.app_build,
       };
+    case AppKnownDataType.IN_FOREGROUND:
+      return {
+        subject: t('In Foreground'),
+        value: data.in_foreground,
+      };
     default:
       return undefined;
   }

--- a/static/app/components/events/contexts/app/index.spec.tsx
+++ b/static/app/components/events/contexts/app/index.spec.tsx
@@ -15,6 +15,7 @@ export const appMockData: AppData = {
   app_build: '1',
   app_id: '3145EA1A-0EAE-3F8C-969A-13A01394D3EA',
   type: 'app',
+  in_foreground: false,
 };
 
 export const appMetaMockData = {

--- a/static/app/components/events/contexts/app/index.tsx
+++ b/static/app/components/events/contexts/app/index.tsx
@@ -21,6 +21,7 @@ export const appKnownDataValues = [
   AppKnownDataType.NAME,
   AppKnownDataType.VERSION,
   AppKnownDataType.BUILD,
+  AppKnownDataType.IN_FOREGROUND,
 ];
 
 const appIgnoredDataValues = [];

--- a/static/app/components/events/contexts/app/types.tsx
+++ b/static/app/components/events/contexts/app/types.tsx
@@ -7,6 +7,7 @@ export enum AppKnownDataType {
   NAME = 'app_name',
   VERSION = 'app_version',
   BUILD = 'app_build',
+  IN_FOREGROUND = 'in_foreground',
 }
 
 export type AppData = {
@@ -19,4 +20,5 @@ export type AppData = {
   app_version?: string;
   build_type?: string;
   device_app_hash?: string;
+  in_foreground?: boolean;
 };


### PR DESCRIPTION
true will display because we allow any additional properties, but this allows false to display as well
