### PR TITLE
fix(aggregate-waterfall): Crash when expanding root span

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -317,13 +317,12 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
       return null;
     }
 
-    const isAggregateSpan =
-      event.type === EventOrGroupType.AGGREGATE_TRANSACTION && span.type === 'aggregate';
+    const isAggregateEvent = event.type === EventOrGroupType.AGGREGATE_TRANSACTION;
 
-    if (isAggregateSpan) {
+    if (isAggregateEvent) {
       return (
         <AggregateSpanDetail
-          span={span}
+          span={span as AggregateSpanType}
           organization={organization}
           event={event}
           isRoot={!!isRoot}


### PR DESCRIPTION
The app would crash when expanding the root span in an aggregate waterfall, and also when expanding gap spans (missing instrumentation spans). This is because these spans do not have the type `aggregate` and so we were rendering the non aggregate version of `SpanDetails` when expanding them, which does not have the required data to be rendered in an aggregate context.