### PR TITLE
feat(replays): deeplink to rage/dead click

### DIFF
--- a/static/app/utils/replays/hooks/useInitialTimeOffsetMs.tsx
+++ b/static/app/utils/replays/hooks/useInitialTimeOffsetMs.tsx
@@ -105,7 +105,12 @@ async function fromListPageQuery({
 
   // Check if there is even any `click.*` fields in the query string
   const search = new MutableSearch(listPageQuery);
-  const isClickSearch = search.getFilterKeys().some(key => key.startsWith('click.'));
+  const isClickSearch = search
+    .getFilterKeys()
+    .some(
+      key =>
+        key.startsWith('click.') || key.startsWith('rage.') || key.startsWith('dead.')
+    );
   if (!isClickSearch) {
     // There was a search, but not for clicks, so lets skip this strategy.
     return undefined;
@@ -127,6 +132,7 @@ async function fromListPageQuery({
     replayId,
     query: listPageQuery,
   });
+
   if (!results.clicks.length) {
     return ZERO_OFFSET;
   }


### PR DESCRIPTION
Deeplink from `dead.selector` search (goes to breadcrumbs tab):

https://github.com/getsentry/sentry/assets/56095982/ef6078c5-9158-475a-9ffd-e0beed8edb71

Deeplink from `rage.selector` search (goes to breadcrumbs tab):

https://github.com/getsentry/sentry/assets/56095982/e901213a-b2cd-472e-83e6-9b52c7a37b4e

Deeplink from widget (goes to DOM events tab): 

https://github.com/getsentry/sentry/assets/56095982/8c92820c-7fc4-4fd7-a7a2-c30506c3d62a


Closes https://github.com/getsentry/team-replay/issues/238
