### PR TITLE
ref(replays): accordion closes

### DIFF
--- a/static/app/views/performance/landing/widgets/components/accordion.tsx
+++ b/static/app/views/performance/landing/widgets/components/accordion.tsx
@@ -62,7 +62,7 @@ function AccordionItem({
       <ButtonLeftListItemContainer>
         <Button
           icon={<IconChevron size="xs" direction={isExpanded ? 'up' : 'down'} />}
-          aria-label={t('Expand')}
+          aria-label={isExpanded ? t('Collapse') : t('Expand')}
           aria-expanded={isExpanded}
           size="zero"
           borderless

--- a/static/app/views/performance/landing/widgets/components/accordion.tsx
+++ b/static/app/views/performance/landing/widgets/components/accordion.tsx
@@ -66,7 +66,9 @@ function AccordionItem({
           aria-expanded={isExpanded}
           size="zero"
           borderless
-          onClick={() => setExpandedIndex(index)}
+          onClick={() => {
+            isExpanded ? setExpandedIndex(-1) : setExpandedIndex(index);
+          }}
         />
         {children}
       </ButtonLeftListItemContainer>

--- a/static/app/views/performance/landing/widgets/components/accordion.tsx
+++ b/static/app/views/performance/landing/widgets/components/accordion.tsx
@@ -82,6 +82,7 @@ function AccordionItem({
           icon={<IconChevron size="xs" direction={isExpanded ? 'up' : 'down'} />}
           aria-label={t('Expand')}
           aria-expanded={isExpanded}
+          disabled={isExpanded}
           size="zero"
           borderless
           onClick={() => setExpandedIndex(index)}


### PR DESCRIPTION
Only applies for the button on left case, which is currently only being used by Replays. 

https://github.com/getsentry/sentry/assets/56095982/17c69745-350e-404e-a518-d07623c0faa1

Disabled button when panel is expanded for performance use case:

https://github.com/getsentry/sentry/assets/56095982/b18863bd-ab56-4c1a-ab67-9425e80382e5


