### PR TITLE
feat(statistical-detectors): Add sparkline to impacted transactions

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/eventAffectedTransactions.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventAffectedTransactions.tsx
@@ -1,7 +1,8 @@
-import {Fragment, useEffect} from 'react';
+import {Fragment, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
+import {LineChart} from 'sentry/components/charts/lineChart';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import Link from 'sentry/components/links/link';
 import PerformanceDuration from 'sentry/components/performanceDuration';
@@ -10,12 +11,16 @@ import {IconArrow} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Event, Group, Project} from 'sentry/types';
+import {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
-import {Container} from 'sentry/utils/discover/styles';
+import {tooltipFormatter} from 'sentry/utils/discover/charts';
+import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {getDuration} from 'sentry/utils/formatters';
 import {useProfileFunctions} from 'sentry/utils/profiling/hooks/useProfileFunctions';
+import {useProfileTopEventsStats} from 'sentry/utils/profiling/hooks/useProfileTopEventsStats';
 import {useRelativeDateTime} from 'sentry/utils/profiling/hooks/useRelativeDateTime';
 import {generateProfileSummaryRouteWithQuery} from 'sentry/utils/profiling/routes';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface EventAffectedTransactionsProps {
@@ -64,6 +69,8 @@ export function EventAffectedTransactions({
   );
 }
 
+const TRANSACTIONS_LIMIT = 5;
+
 interface EventAffectedTransactionsInnerProps {
   breakpoint: number;
   fingerprint: number;
@@ -79,7 +86,7 @@ function EventAffectedTransactionsInner({
 
   const datetime = useRelativeDateTime({
     anchor: breakpoint,
-    relativeDays: 7,
+    relativeDays: 14,
   });
 
   const percentileBefore = `percentile_before(function.duration, 0.95, ${breakpoint})`;
@@ -95,14 +102,105 @@ function EventAffectedTransactionsInner({
     },
     query: `fingerprint:${fingerprint} ${percentileDelta}:>0`,
     projects: [project.id],
-    limit: 5,
+    limit: TRANSACTIONS_LIMIT,
     referrer: 'api.profiling.functions.regression.transactions',
   });
+
+  const query = useMemo(() => {
+    const data = transactionsDeltaQuery.data?.data ?? [];
+    if (!data.length) {
+      return null;
+    }
+
+    const conditions = new MutableSearch('');
+    conditions.addFilterValue('fingerprint', String(fingerprint), true);
+    conditions.addOp('(');
+    for (let i = 0; i < data.length; i++) {
+      if (i > 0) {
+        conditions.addOp('OR');
+      }
+      conditions.addFilterValue('transaction', data[i].transaction as string, true);
+    }
+    conditions.addOp(')');
+    return conditions.formatString();
+  }, [fingerprint, transactionsDeltaQuery]);
+
+  const functionStats = useProfileTopEventsStats({
+    dataset: 'profileFunctions',
+    datetime,
+    fields: ['transaction', 'count()'],
+    query: query ?? '',
+    enabled: defined(query),
+    others: false,
+    referrer: 'api.profiling.functions.regression.stats', // TODO: update this
+    topEvents: TRANSACTIONS_LIMIT,
+    yAxes: ['p95()', 'worst()'],
+  });
+
+  const timeseriesByTransaction: Record<string, Series> = useMemo(() => {
+    const allTimeseries: Record<string, Series> = {};
+    if (!defined(functionStats.data)) {
+      return allTimeseries;
+    }
+
+    const timestamps = functionStats.data.timestamps;
+
+    transactionsDeltaQuery.data?.data?.forEach(row => {
+      const transaction = row.transaction as string;
+      const data = functionStats.data.data.find(
+        ({axis, label}) => axis === 'p95()' && label === transaction
+      );
+      if (!defined(data)) {
+        return;
+      }
+
+      allTimeseries[transaction] = {
+        data: timestamps.map((timestamp, i) => {
+          return {
+            name: timestamp * 1000,
+            value: data.values[i],
+          };
+        }),
+        seriesName: 'p95()',
+      };
+    });
+
+    return allTimeseries;
+  }, [transactionsDeltaQuery, functionStats]);
+
+  const chartOptions = useMemo(() => {
+    return {
+      width: 300,
+      height: 20,
+      grid: {
+        top: '2px',
+        left: '2px',
+        right: '2px',
+        bottom: '2px',
+        containLabel: false,
+      },
+      xAxis: {
+        show: false,
+        type: 'time' as const,
+      },
+      yAxis: {
+        show: false,
+      },
+      tooltip: {
+        valueFormatter: value => tooltipFormatter(value, 'duration'),
+      },
+    };
+  }, []);
 
   return (
     <EventDataSection type="transactions-impacted" title={t('Transactions Impacted')}>
       <ListContainer>
         {(transactionsDeltaQuery.data?.data ?? []).map(transaction => {
+          const series = timeseriesByTransaction[transaction.transaction as string] ?? {
+            seriesName: 'p95()',
+            data: [],
+          };
+
           const summaryTarget = generateProfileSummaryRouteWithQuery({
             orgSlug: organization.slug,
             projectSlug: project.slug,
@@ -113,7 +211,13 @@ function EventAffectedTransactionsInner({
               <Container>
                 <Link to={summaryTarget}>{transaction.transaction}</Link>
               </Container>
-              <Container>
+              <LineChart
+                {...chartOptions}
+                series={[series]}
+                isGroupedByDate
+                showTimeInTooltip
+              />
+              <NumberContainer>
                 <Tooltip
                   title={tct(
                     'The function duration in this transaction increased from [before] to [after]',
@@ -144,7 +248,7 @@ function EventAffectedTransactionsInner({
                     />
                   </DurationChange>
                 </Tooltip>
-              </Container>
+              </NumberContainer>
             </Fragment>
           );
         })}
@@ -155,7 +259,7 @@ function EventAffectedTransactionsInner({
 
 const ListContainer = styled('div')`
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr auto auto;
   gap: ${space(1)};
 `;
 

--- a/static/app/components/events/eventStatisticalDetector/eventFunctionComparisonList.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventFunctionComparisonList.tsx
@@ -2,12 +2,10 @@ import {Fragment, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
-import DateTime from 'sentry/components/dateTime';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import Link from 'sentry/components/links/link';
 import PerformanceDuration from 'sentry/components/performanceDuration';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Event, Group, Organization, Project} from 'sentry/types';
@@ -144,7 +142,7 @@ function EventComparisonListInner({
 
   const profilesQuery = useProfileEvents({
     datetime,
-    fields: ['id', 'transaction', 'timestamp', 'profile.duration'],
+    fields: ['id', 'transaction', 'profile.duration'],
     query: `id:[${[...beforeProfileIds, ...afterProfileIds].join(', ')}]`,
     sort: {
       key: 'profile.duration',
@@ -232,7 +230,7 @@ function EventList({
         <strong>{t('Profile ID')}</strong>
       </Container>
       <Container>
-        <strong>{t('Timestamp')}</strong>
+        <strong>{t('Transaction')}</strong>
       </Container>
       <NumberContainer>
         <strong>{t('Duration')} </strong>
@@ -252,23 +250,19 @@ function EventList({
         return (
           <Fragment key={item.id}>
             <Container>
-              <Tooltip title={item.transaction} position="top">
-                <Link
-                  to={target}
-                  onClick={() => {
-                    trackAnalytics('profiling_views.go_to_flamegraph', {
-                      organization,
-                      source: 'profiling.issue.function_regression',
-                    });
-                  }}
-                >
-                  {getShortEventId(item.id)}
-                </Link>
-              </Tooltip>
+              <Link
+                to={target}
+                onClick={() => {
+                  trackAnalytics('profiling_views.go_to_flamegraph', {
+                    organization,
+                    source: 'profiling.issue.function_regression',
+                  });
+                }}
+              >
+                {getShortEventId(item.id)}
+              </Link>
             </Container>
-            <Container>
-              <DateTime date={item.timestamp} year seconds timeZone />
-            </Container>
+            <Container>{item.transaction}</Container>
             <NumberContainer>
               <PerformanceDuration nanoseconds={item['profile.duration']} abbreviation />
             </NumberContainer>

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -292,6 +292,7 @@ export type EventsStatsSeries<F extends string> = {
   data: {
     axis: F;
     values: number[];
+    label?: string;
   }[];
   meta: {
     dataset: string;

--- a/static/app/utils/profiling/hooks/useProfileEventsStats.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEventsStats.tsx
@@ -9,7 +9,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
-interface UseEventsStatsOptions<F> {
+interface UseProfileEventsStatsOptions<F> {
   dataset: 'discover' | 'profiles' | 'profileFunctions';
   referrer: string;
   yAxes: readonly F[];
@@ -25,7 +25,7 @@ export function useProfileEventsStats<F extends string>({
   query,
   referrer,
   yAxes,
-}: UseEventsStatsOptions<F>) {
+}: UseProfileEventsStatsOptions<F>) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
 
@@ -61,8 +61,8 @@ export function useProfileEventsStats<F extends string>({
   });
 
   const transformed = useMemo(
-    () => data && transformStatsResponse(yAxes, data),
-    [yAxes, data]
+    () => data && transformStatsResponse(dataset, yAxes, data),
+    [yAxes, data, dataset]
   );
 
   return {
@@ -72,6 +72,7 @@ export function useProfileEventsStats<F extends string>({
 }
 
 export function transformStatsResponse<F extends string>(
+  dataset: 'discover' | 'profiles' | 'profileFunctions',
   yAxes: readonly F[],
   rawData: any
 ): EventsStatsSeries<F> {
@@ -82,7 +83,7 @@ export function transformStatsResponse<F extends string>(
     return {
       data: [],
       meta: {
-        dataset: 'profiles',
+        dataset,
         end: 0,
         start: 0,
       },
@@ -91,7 +92,7 @@ export function transformStatsResponse<F extends string>(
   }
 
   if (yAxes.length === 1) {
-    const {series, meta, timestamps} = transformSingleSeries(yAxes[0], rawData);
+    const {series, meta, timestamps} = transformSingleSeries(dataset, yAxes[0], rawData);
     return {
       data: [series],
       meta,
@@ -101,7 +102,7 @@ export function transformStatsResponse<F extends string>(
 
   const data: EventsStatsSeries<F>['data'] = [];
   let meta: EventsStatsSeries<F>['meta'] = {
-    dataset: 'profiles',
+    dataset,
     end: -1,
     start: -1,
   };
@@ -114,7 +115,7 @@ export function transformStatsResponse<F extends string>(
     if (!defined(dataForYAxis)) {
       continue;
     }
-    const transformed = transformSingleSeries(yAxis, dataForYAxis);
+    const transformed = transformSingleSeries(dataset, yAxis, dataForYAxis);
 
     if (firstAxis) {
       meta = transformed.meta;
@@ -143,25 +144,34 @@ export function transformStatsResponse<F extends string>(
   };
 }
 
-function transformSingleSeries<F extends string>(yAxis: F, rawSeries: any) {
-  const type =
-    rawSeries.meta.fields[yAxis] ?? rawSeries.meta.fields[getAggregateAlias(yAxis)];
-  const formatter =
-    type === 'duration'
-      ? makeFormatTo(
-          rawSeries.meta.units[yAxis] ??
-            rawSeries.meta.units[getAggregateAlias(yAxis)] ??
-            'nanoseconds',
-          'milliseconds'
-        )
-      : value => value;
+export function transformSingleSeries<F extends string>(
+  dataset: 'discover' | 'profiles' | 'profileFunctions',
+  yAxis: F,
+  rawSeries: any,
+  label?: string,
+  formatter?: any
+) {
+  if (!defined(formatter)) {
+    const type =
+      rawSeries.meta.fields[yAxis] ?? rawSeries.meta.fields[getAggregateAlias(yAxis)];
+    formatter =
+      type === 'duration'
+        ? makeFormatTo(
+            rawSeries.meta.units[yAxis] ??
+              rawSeries.meta.units[getAggregateAlias(yAxis)] ??
+              'nanoseconds',
+            'milliseconds'
+          )
+        : value => value;
+  }
 
   const series: EventsStatsSeries<F>['data'][number] = {
     axis: yAxis,
     values: [],
+    label,
   };
   const meta: EventsStatsSeries<F>['meta'] = {
-    dataset: 'profiles',
+    dataset,
     end: rawSeries.end,
     start: rawSeries.start,
   };

--- a/static/app/utils/profiling/hooks/useProfileTopEventsStats.tsx
+++ b/static/app/utils/profiling/hooks/useProfileTopEventsStats.tsx
@@ -1,0 +1,150 @@
+import {useMemo} from 'react';
+
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {EventsStatsSeries, PageFilters} from 'sentry/types';
+import {defined} from 'sentry/utils';
+import {transformSingleSeries} from 'sentry/utils/profiling/hooks/useProfileEventsStats';
+import {makeFormatTo} from 'sentry/utils/profiling/units/units';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+
+interface UseProfileTopEventsStatsOptions<F> {
+  dataset: 'profileFunctions';
+  fields: string[];
+  others: boolean;
+  referrer: string;
+  topEvents: number;
+  yAxes: readonly F[];
+  datetime?: PageFilters['datetime'];
+  enabled?: boolean;
+  interval?: string;
+  query?: string;
+}
+
+export function useProfileTopEventsStats<F extends string>({
+  dataset,
+  datetime,
+  fields,
+  interval,
+  others,
+  query,
+  referrer,
+  topEvents,
+  yAxes,
+  enabled = true,
+}: UseProfileTopEventsStatsOptions<F>) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const path = `/organizations/${organization.slug}/events-stats/`;
+  const endpointOptions = {
+    query: {
+      dataset,
+      field: fields,
+      referrer,
+      project: selection.projects,
+      environment: selection.environments,
+      ...normalizeDateTimeParams(datetime ?? selection.datetime),
+      yAxis: yAxes,
+      interval,
+      query,
+      topEvents,
+      excludeOther: others ? '0' : '1',
+    },
+  };
+
+  const {data, ...rest} = useApiQuery<any>([path, endpointOptions], {
+    staleTime: Infinity,
+    enabled,
+  });
+
+  const transformed = useMemo(
+    () => data && transformTopEventsStatsResponse(dataset, yAxes, data),
+    [yAxes, data, dataset]
+  );
+
+  return {
+    data: transformed,
+    ...rest,
+  };
+}
+
+function transformTopEventsStatsResponse<F extends string>(
+  dataset: 'profileFunctions',
+  yAxes: readonly F[],
+  rawData: any
+): EventsStatsSeries<F> {
+  // the events stats endpoint has a legacy response format so here we transform it
+  // into the proposed update for forward compatibility and ease of use
+  if (yAxes.length === 0) {
+    return {
+      data: [],
+      meta: {
+        dataset,
+        end: 0,
+        start: 0,
+      },
+      timestamps: [],
+    };
+  }
+
+  const data: EventsStatsSeries<F>['data'] = [];
+  let meta: EventsStatsSeries<F>['meta'] = {
+    dataset,
+    end: -1,
+    start: -1,
+  };
+  let timestamps: EventsStatsSeries<F>['timestamps'] = [];
+
+  let firstSeries = true;
+
+  // TODO: the formatter should be inferred but the response does
+  // not contain the meta at this time
+  const formatter = makeFormatTo('nanoseconds', 'milliseconds');
+
+  for (const label of Object.keys(rawData)) {
+    for (const yAxis of yAxes) {
+      let dataForYAxis = rawData[label];
+      if (yAxes.length > 1) {
+        dataForYAxis = dataForYAxis[yAxis];
+      }
+      if (!defined(dataForYAxis)) {
+        continue;
+      }
+
+      const transformed = transformSingleSeries(
+        dataset,
+        yAxis,
+        dataForYAxis,
+        label,
+        formatter
+      );
+
+      if (firstSeries) {
+        meta = transformed.meta;
+        timestamps = transformed.timestamps;
+      } else if (
+        meta.start !== transformed.meta.start ||
+        meta.end !== transformed.meta.end
+      ) {
+        throw new Error('Mismatching start/end times');
+      } else if (
+        timestamps.length !== transformed.timestamps.length ||
+        timestamps.some((ts, i) => ts !== transformed.timestamps[i])
+      ) {
+        throw new Error('Mismatching timestamps');
+      }
+
+      data.push(transformed.series);
+
+      firstSeries = false;
+    }
+  }
+
+  return {
+    data,
+    meta,
+    timestamps,
+  };
+}


### PR DESCRIPTION
This adds a sparkline of the function duration broken down by the transaction to help illustrate the how it may affect different transactions differently.

# Screenshot

![image](https://github.com/getsentry/sentry/assets/10239353/a48628dd-1fce-4ff4-b55b-c392106bcd8b)
