### PR TITLE
ref(merging): Include 24-hr wait time in disclaimer on Merged Issues tab

### DIFF
--- a/static/app/views/issueDetails/groupMerged/index.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.tsx
@@ -140,9 +140,13 @@ class GroupMergedView extends Component<Props, State> {
               })}
             </Title>
             <small>
-              {t(
-                'This is an experimental feature. Data may not be immediately available while we process unmerges.'
-              )}
+              {
+                // TODO: Once clickhouse is upgraded and the lag is no longer an issue, revisit this wording.
+                // See https://github.com/getsentry/sentry/issues/56334.
+                t(
+                  'This is an experimental feature. All changes may take up to 24 hours take effect.'
+                )
+              }
             </small>
           </HeaderWrapper>
 


### PR DESCRIPTION
Because of a quirk in our current version of clickhouse, it sometimes takes [up to 24 hours](https://github.com/getsentry/sentry/issues/56334#issuecomment-1747820319) for unmerging to be fully reflected in both the Merged Issues tab and the All Events tab. This edits the disclaimer on the Merged Issues tab to include this information, so that more customers don't write in thinking the feature is broken.