### PR TITLE
fix(replays): filter out selectors with 0 dead clicks

### DIFF
--- a/static/app/utils/replays/hooks/useDeadRageSelectors.tsx
+++ b/static/app/utils/replays/hooks/useDeadRageSelectors.tsx
@@ -18,6 +18,7 @@ export default function useDeadRageSelectors(params: DeadRageSelectorQueryParams
         `/organizations/${organization.slug}/replay-selectors/`,
         {
           query: {
+            query: '!count_dead_clicks:0',
             cursor: params.cursor,
             environment: query.environment,
             project: query.project,


### PR DESCRIPTION
before:
<img width="1191" alt="SCR-20231011-mjby" src="https://github.com/getsentry/sentry/assets/56095982/92dec30c-f7fb-4177-a675-b7c9031deca8">

after:
<img width="1191" alt="SCR-20231011-mvzf" src="https://github.com/getsentry/sentry/assets/56095982/2fe465f2-78b5-46a0-b34b-4a6d371b58cf">
