### PR TITLE
feat(issue-stream): Add "unhandled" as collapsable parameter

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -228,7 +228,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                                           issues belong to.
         :auth: required
         :qparam list expand: an optional list of strings to opt in to additional data. Supports `inbox`
-        :qparam list collapse: an optional list of strings to opt out of certain pieces of data. Supports `stats`, `lifetime`, `base`
+        :qparam list collapse: an optional list of strings to opt out of certain pieces of data. Supports `stats`, `lifetime`, `base`, `unhandled`
         """
         stats_period = request.GET.get("groupStatsPeriod")
         try:

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -289,9 +289,7 @@ class GroupSerializerBase(Serializer, ABC):
         ):
             merge_list_dictionaries(annotations_by_group_id, annotations_by_group)
 
-        snuba_stats = {}
-        if not self._collapse("unhandled"):
-            snuba_stats = self._get_group_snuba_stats(item_list, seen_stats)
+        snuba_stats = self._get_group_snuba_stats(item_list, seen_stats)
 
         result = {}
         for item in item_list:
@@ -327,7 +325,7 @@ class GroupSerializerBase(Serializer, ABC):
                 "share_id": share_ids.get(item.id),
                 "authorized": authorized,
             }
-            if not self._collapse("unhandled"):
+            if snuba_stats is not None:
                 result[item]["is_unhandled"] = bool(snuba_stats.get(item.id, {}).get("unhandled"))
 
             if seen_stats:
@@ -495,6 +493,8 @@ class GroupSerializerBase(Serializer, ABC):
     def _get_group_snuba_stats(
         self, item_list: Sequence[Group], seen_stats: Optional[Mapping[Group, SeenStats]]
     ):
+        if self._collapse("unhandled"):
+            return None
         start = self._get_start_from_seen_stats(seen_stats)
         unhandled = {}
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -289,7 +289,9 @@ class GroupSerializerBase(Serializer, ABC):
         ):
             merge_list_dictionaries(annotations_by_group_id, annotations_by_group)
 
-        snuba_stats = self._get_group_snuba_stats(item_list, seen_stats)
+        snuba_stats = {}
+        if not self._collapse("unhandled"):
+            snuba_stats = self._get_group_snuba_stats(item_list, seen_stats)
 
         result = {}
         for item in item_list:
@@ -325,8 +327,8 @@ class GroupSerializerBase(Serializer, ABC):
                 "share_id": share_ids.get(item.id),
                 "authorized": authorized,
             }
-
-            result[item]["is_unhandled"] = bool(snuba_stats.get(item.id, {}).get("unhandled"))
+            if not self._collapse("unhandled"):
+                result[item]["is_unhandled"] = bool(snuba_stats.get(item.id, {}).get("unhandled"))
 
             if seen_stats:
                 result[item].update(seen_stats.get(item, {}))

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1917,6 +1917,20 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert len(response.data) == 1
         assert int(response.data[0]["id"]) == event.group.id
 
+    def test_collapse_unhandled(self):
+        event = self.store_event(
+            data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
+            project_id=self.project.id,
+        )
+        self.login_as(user=self.user)
+        response = self.get_response(
+            sort_by="date", limit=10, query="is:unresolved", collapse=["unhandled"]
+        )
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert int(response.data[0]["id"]) == event.group.id
+        assert "isUnhandled" not in response.data[0]
+
     def test_query_status_and_substatus_overlapping(self):
         event = self.store_event(
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},


### PR DESCRIPTION
this pr adds in "unhandled" as a collapsable parameter for the issues stream request. right now, the issue stream request has to wait for the unhandled stats to be found, which slows things down. to get around this, we will collapse "unhandled" and make a separate request to find the "unhandled" information , similar to how we treat "stats". 


closes https://github.com/getsentry/sentry/issues/57844