### PR TITLE
feat(escalating-issues): Auto-transition tasks smaller batch size

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -12,7 +12,7 @@ from operator import or_
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
 
 from django.core.cache import cache
-from django.db import models, router, transaction
+from django.db import models
 from django.db.models import Q, QuerySet
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
@@ -424,17 +424,16 @@ class GroupManager(BaseManager):
         from sentry.models.activity import Activity
 
         modified_groups_list = []
-        with transaction.atomic(router.db_for_write(Group)):
-            selected_groups = Group.objects.filter(id__in=[g.id for g in groups]).exclude(
-                status=status, substatus=substatus
-            )
+        selected_groups = Group.objects.filter(id__in=[g.id for g in groups]).exclude(
+            status=status, substatus=substatus
+        )
 
-            for group in selected_groups:
-                group.status = status
-                group.substatus = substatus
-                modified_groups_list.append(group)
+        for group in selected_groups:
+            group.status = status
+            group.substatus = substatus
+            modified_groups_list.append(group)
 
-            Group.objects.bulk_update(modified_groups_list, ["status", "substatus"])
+        Group.objects.bulk_update(modified_groups_list, ["status", "substatus"])
 
         for group in modified_groups_list:
             Activity.objects.create_group_activity(

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -425,10 +425,8 @@ class GroupManager(BaseManager):
 
         modified_groups_list = []
         with transaction.atomic(router.db_for_write(Group)):
-            selected_groups = (
-                Group.objects.filter(id__in=[g.id for g in groups])
-                .exclude(status=status, substatus=substatus)
-                .select_for_update()
+            selected_groups = Group.objects.filter(id__in=[g.id for g in groups]).exclude(
+                status=status, substatus=substatus
             )
 
             for group in selected_groups:

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -148,7 +148,7 @@ def schedule_auto_transition_issues_new_to_ongoing(
             RangeQuerySetWrapper(
                 base_queryset._clone().values_list("id", flat=True),
                 step=ITERATOR_CHUNK,
-                limit=ITERATOR_CHUNK * 500,
+                limit=ITERATOR_CHUNK * 250,
                 result_value_getter=lambda item: item,
                 callbacks=[get_total_count],
             ),
@@ -236,7 +236,7 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
             RangeQuerySetWrapper(
                 base_queryset._clone().values_list("id", flat=True),
                 step=ITERATOR_CHUNK,
-                limit=ITERATOR_CHUNK * 500,
+                limit=ITERATOR_CHUNK * 250,
                 result_value_getter=lambda item: item,
                 callbacks=[get_total_count],
             ),
@@ -324,7 +324,7 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
             RangeQuerySetWrapper(
                 base_queryset._clone().values_list("id", flat=True),
                 step=ITERATOR_CHUNK,
-                limit=ITERATOR_CHUNK * 500,
+                limit=ITERATOR_CHUNK * 250,
                 result_value_getter=lambda item: item,
                 callbacks=[get_total_count],
             ),

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 TRANSITION_AFTER_DAYS = 7
 ITERATOR_CHUNK = 500
+CHILD_TASK_COUNT = 250
 
 
 def log_error_if_queue_has_items(func):
@@ -148,7 +149,7 @@ def schedule_auto_transition_issues_new_to_ongoing(
             RangeQuerySetWrapper(
                 base_queryset._clone().values_list("id", flat=True),
                 step=ITERATOR_CHUNK,
-                limit=ITERATOR_CHUNK * 250,
+                limit=ITERATOR_CHUNK * CHILD_TASK_COUNT,
                 result_value_getter=lambda item: item,
                 callbacks=[get_total_count],
             ),
@@ -236,7 +237,7 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
             RangeQuerySetWrapper(
                 base_queryset._clone().values_list("id", flat=True),
                 step=ITERATOR_CHUNK,
-                limit=ITERATOR_CHUNK * 250,
+                limit=ITERATOR_CHUNK * CHILD_TASK_COUNT,
                 result_value_getter=lambda item: item,
                 callbacks=[get_total_count],
             ),
@@ -324,7 +325,7 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
             RangeQuerySetWrapper(
                 base_queryset._clone().values_list("id", flat=True),
                 step=ITERATOR_CHUNK,
-                limit=ITERATOR_CHUNK * 250,
+                limit=ITERATOR_CHUNK * CHILD_TASK_COUNT,
                 result_value_getter=lambda item: item,
                 callbacks=[get_total_count],
             ),

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -144,6 +144,7 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
     @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.utils.metrics.incr")
     @mock.patch("sentry.tasks.auto_ongoing_issues.ITERATOR_CHUNK", new=2)
+    @mock.patch("sentry.tasks.auto_ongoing_issues.CHILD_TASK_COUNT", new=50)
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_not_all_groups_get_updated(self, mock_backend, mock_metrics_incr):
         now = datetime.now(tz=timezone.utc)
@@ -249,6 +250,7 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
     @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.utils.metrics.incr")
     @mock.patch("sentry.tasks.auto_ongoing_issues.ITERATOR_CHUNK", new=2)
+    @mock.patch("sentry.tasks.auto_ongoing_issues.CHILD_TASK_COUNT", new=50)
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_not_all_groups_get_updated(self, mock_backend, mock_metrics_incr):
         now = datetime.now(tz=timezone.utc)
@@ -352,6 +354,7 @@ class ScheduleAutoEscalatingOngoingIssuesTest(TestCase):
     @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.utils.metrics.incr")
     @mock.patch("sentry.tasks.auto_ongoing_issues.ITERATOR_CHUNK", new=2)
+    @mock.patch("sentry.tasks.auto_ongoing_issues.CHILD_TASK_COUNT", new=50)
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
     def test_not_all_groups_get_updated(self, mock_backend, mock_metrics_incr):
         now = datetime.now(tz=timezone.utc)


### PR DESCRIPTION
## Objective:

We are still seeing query timeouts. The 10k row update is huge transaction for postgres, so I am lowering it down to 500 rows. I removed the retry on OperationalError and increased the potential number of child tasks to 250.