### PR TITLE
feat(metrics):Add the ability to select the dataset in OrganizationProjectsEndpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -28,6 +28,7 @@ from sentry.snuba import discover, metrics_enhanced_performance, metrics_perform
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '14d', and '30d'"
 
 DATASETS = {
+    "": discover,  # in case they pass an empty query string fall back on default
     "discover": discover,
     "metricsEnhanced": metrics_enhanced_performance,
     "metrics": metrics_performance,

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -1,7 +1,8 @@
-from typing import List
+from typing import Any, List
 
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema
+from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -22,8 +23,21 @@ from sentry.constants import ObjectStatus
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.search.utils import tokenize_query
+from sentry.snuba import discover, metrics_enhanced_performance, metrics_performance
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '14d', and '30d'"
+
+DATASETS = {
+    "discover": discover,
+    "metricsEnhanced": metrics_enhanced_performance,
+    "metrics": metrics_performance,
+}
+
+
+def get_dataset(dataset_label: str) -> Any:
+    if dataset_label not in DATASETS:
+        raise ParseError(detail=f"dataset must be one of: {', '.join(DATASETS.keys())}")
+    return DATASETS[dataset_label]
 
 
 @extend_schema(tags=["Organizations"])
@@ -61,6 +75,9 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         elif not stats_period:
             # disable stats
             stats_period = None
+
+        datasetName = request.GET.get("dataset", "discover")
+        dataset = get_dataset(datasetName)
 
         if request.auth and not request.user.is_authenticated:
             # TODO: remove this, no longer supported probably
@@ -122,7 +139,11 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         if get_all_projects:
             queryset = queryset.order_by("slug").select_related("organization")
             return Response(
-                serialize(list(queryset), request.user, ProjectSummarySerializer(collapse=collapse))
+                serialize(
+                    list(queryset),
+                    request.user,
+                    ProjectSummarySerializer(collapse=collapse, dataset=dataset),
+                )
             )
         else:
             expand = set()
@@ -143,6 +164,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                     expand=expand,
                     expand_context=expand_context,
                     collapse=collapse,
+                    dataset=dataset,
                 )
                 return serialize(result, request.user, serializer)
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -280,9 +280,15 @@ class ProjectSerializer(Serializer):
         expand: Iterable[str] | None = None,
         expand_context: Mapping[str, Any] | None = None,
         collapse: Iterable[str] | None = None,
+        dataset: Any | None = None,
     ) -> None:
         if stats_period is not None:
             assert stats_period in STATS_PERIOD_CHOICES
+
+        if dataset is None:
+            self.dataset = discover
+        else:
+            self.dataset = dataset
 
         self.environment_id = environment_id
         self.stats_period = stats_period
@@ -429,7 +435,7 @@ class ProjectSerializer(Serializer):
 
         # Generate a query result to skip the top_events.find query
         top_events = {"data": [{"project_id": p} for p in project_ids]}
-        stats = discover.top_events_timeseries(
+        stats = self.dataset.top_events_timeseries(
             timeseries_columns=["count()"],
             selected_columns=["project_id"],
             user_query=query,


### PR DESCRIPTION
This PR adds the ability to select the dataset use by the `OrganizationProjectsEndpoint`
ie. `api/0/organizations/{org_id}/projects`

It accepts a new optional query parameter `dataset` with the following options:
- `discover` - (default) uses the old discover backend
- `metrics` - uses the metrics backend
- `metricsEnhanced` - tries to use the metrics backend but falls back on discover if not avialable

 Resolves https://github.com/getsentry/sentry/issues/57897
 Resolves https://github.com/getsentry/sentry/issues/56819 

