### PR TITLE
fix(source-map-debugger): Correctly check for minimum version of Electron SDK

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
+++ b/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
@@ -41,6 +41,7 @@ from sentry.utils.urls import non_standard_url_join
 
 MIN_JS_SDK_VERSION_FOR_DEBUG_IDS = "7.56.0"
 MIN_REACT_NATIVE_SDK_VERSION_FOR_DEBUG_IDS = "5.11.1"
+MIN_ELECTRON_SDK_VERSION_FOR_DEBUG_IDS = "4.6.0"
 
 NO_DEBUG_ID_SDKS = {
     "sentry.javascript.capacitor",
@@ -670,6 +671,13 @@ def get_sdk_debug_id_support(event_data):
         return (
             "full"
             if Version(sdk_version) >= Version(MIN_REACT_NATIVE_SDK_VERSION_FOR_DEBUG_IDS)
+            else "needs-upgrade"
+        )
+
+    if sdk_name == "sentry.javascript.electron":
+        return (
+            "full"
+            if Version(sdk_version) >= Version(MIN_ELECTRON_SDK_VERSION_FOR_DEBUG_IDS)
             else "needs-upgrade"
         )
 


### PR DESCRIPTION
Electron needs special casing here.