### PR TITLE
feat(browser-starfish): add sample sidebar and sorting of resource summary

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -8,6 +8,7 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {t} from 'sentry/locale';
 import {RateUnits} from 'sentry/utils/discover/fields';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
@@ -21,10 +22,14 @@ import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
+import {SampleList} from 'sentry/views/starfish/views/spanSummaryPage/sampleList';
 
 function ResourceSummary() {
   const organization = useOrganization();
   const {groupId} = useParams();
+  const {
+    query: {transaction},
+  } = useLocation();
   const {data: spanMetrics} = useSpanMetrics(groupId, {}, [
     'avg(span.self_time)',
     'spm()',
@@ -90,6 +95,7 @@ function ResourceSummary() {
           </HeaderContainer>
           <ResourceSummaryCharts groupId={groupId} />
           <ResourceSummaryTable />
+          <SampleList groupId={groupId} transactionName={transaction as string} />
         </Layout.Main>
       </Layout.Body>
     </ModulePageProviders>

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {Link} from 'react-router';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
@@ -9,6 +10,7 @@ import {RateUnits} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
 import {useResourcePagesQuery} from 'sentry/views/performance/browser/resources/utils/useResourcePageQuery';
+import {useResourceSummarySort} from 'sentry/views/performance/browser/resources/utils/useResourceSummarySort';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
@@ -24,7 +26,8 @@ type Column = GridColumnHeader<keyof Row>;
 function ResourceSummaryTable() {
   const location = useLocation();
   const {groupId} = useParams();
-  const {data, isLoading} = useResourcePagesQuery(groupId);
+  const sort = useResourceSummarySort();
+  const {data, isLoading} = useResourcePagesQuery(groupId, {sort});
 
   const columnOrder: GridColumnOrder<keyof Row>[] = [
     {key: 'transaction', width: COL_WIDTH_UNDEFINED, name: 'Found on page'},
@@ -48,6 +51,21 @@ function ResourceSummaryTable() {
     if (key === 'avg(span.self_time)') {
       return <DurationCell milliseconds={row[key]} />;
     }
+    if (key === 'transaction') {
+      return (
+        <Link
+          to={{
+            pathname: location.pathname,
+            query: {
+              ...location.query,
+              transaction: row[key],
+            },
+          }}
+        >
+          {row[key]}
+        </Link>
+      );
+    }
     return <span>{row[key]}</span>;
   };
 
@@ -59,8 +77,8 @@ function ResourceSummaryTable() {
         columnOrder={columnOrder}
         columnSortBy={[
           {
-            key: 'avg(span.self_time)',
-            order: 'desc',
+            key: sort.field,
+            order: sort.kind,
           },
         ]}
         grid={{
@@ -68,10 +86,7 @@ function ResourceSummaryTable() {
             renderHeadCell({
               column,
               location,
-              sort: {
-                field: 'avg(span.self_time)',
-                kind: 'desc',
-              },
+              sort,
             }),
           renderBodyCell,
         }}

--- a/static/app/views/performance/browser/resources/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceTable.tsx
@@ -25,7 +25,7 @@ type Row = {
   'resource.render_blocking_status': string;
   'span.description': string;
   'span.group': string;
-  'span.op': 'resource.script' | 'resource.img';
+  'span.op': `resource.${string}`;
   'spm()': number;
 };
 
@@ -94,7 +94,12 @@ function ResourceTable({sort}: Props) {
       return <DurationCell milliseconds={row[key]} />;
     }
     if (key === 'span.op') {
-      const opName = row[key] === 'resource.script' ? t('Javascript') : t('Image');
+      const opNameMap = {
+        'resource.script': t('Javascript'),
+        'resource.img': t('Image'),
+        'resource.iframe': t('Javascript (iframe)'),
+      };
+      const opName = opNameMap[row[key]] || row[key];
       return <span>{opName}</span>;
     }
     if (key === 'http.decoded_response_content_length') {

--- a/static/app/views/performance/browser/resources/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceTable.tsx
@@ -25,7 +25,7 @@ type Row = {
   'resource.render_blocking_status': string;
   'span.description': string;
   'span.group': string;
-  'span.op': `resource.${string}`;
+  'span.op': `resource.${'script' | 'img' | 'css' | 'iframe' | string}`;
   'spm()': number;
 };
 
@@ -98,6 +98,9 @@ function ResourceTable({sort}: Props) {
         'resource.script': t('Javascript'),
         'resource.img': t('Image'),
         'resource.iframe': t('Javascript (iframe)'),
+        'resource.css': t('Stylesheet'),
+        'resource.video': t('Video'),
+        'resource.audio': t('Audio'),
       };
       const opName = opNameMap[row[key]] || row[key];
       return <span>{opName}</span>;

--- a/static/app/views/performance/browser/resources/utils/useResourcePageQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcePageQuery.ts
@@ -1,6 +1,6 @@
+import {Sort} from 'sentry/utils/discover/fields';
 import {useSpanTransactionMetrics} from 'sentry/views/starfish/queries/useSpanTransactionMetrics';
 
-export const useResourcePagesQuery = (groupId: string) => {
-  // We'll do more this when we have the transaction tag on resource spans.
-  return useSpanTransactionMetrics({'span.group': groupId});
+export const useResourcePagesQuery = (groupId: string, {sort}: {sort: Sort}) => {
+  return useSpanTransactionMetrics({'span.group': groupId}, [sort]);
 };

--- a/static/app/views/performance/browser/resources/utils/useResourceSummarySort.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceSummarySort.ts
@@ -1,0 +1,36 @@
+import {fromSorts} from 'sentry/utils/discover/eventView';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {useLocation} from 'sentry/utils/useLocation';
+import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
+
+type Query = {
+  sort?: string;
+};
+
+const SORTABLE_FIELDS = ['avg(span.self_time)', 'spm()'] as const;
+
+export type ValidSort = Sort & {
+  field: (typeof SORTABLE_FIELDS)[number];
+};
+
+/**
+ * Parses a `Sort` object from the URL. In case of multiple specified sorts
+ * picks the first one, since span module UIs only support one sort at a time.
+ */
+export function useResourceSummarySort(
+  sortParameterName: QueryParameterNames | 'sort' = 'sort',
+  fallback: Sort = DEFAULT_SORT
+) {
+  const location = useLocation<Query>();
+
+  return fromSorts(location.query[sortParameterName]).filter(isAValidSort)[0] ?? fallback;
+}
+
+const DEFAULT_SORT: Sort = {
+  kind: 'desc',
+  field: SORTABLE_FIELDS[0],
+};
+
+function isAValidSort(sort: Sort): sort is ValidSort {
+  return (SORTABLE_FIELDS as unknown as string[]).includes(sort.field);
+}

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -54,7 +54,10 @@ export const useResourcesQuery = ({sort}: {sort: ValidSort}) => {
     'count()': row['count()'] as number,
     'spm()': row['spm()'] as number,
     'span.group': row['span.group'].toString(),
-    'resource.render_blocking_status': row['resource.render_blocking_status'] as string,
+    'resource.render_blocking_status': row['resource.render_blocking_status'] as
+      | ''
+      | 'non-blocking'
+      | 'blocking',
   }));
 
   return {...result, data: data || []};

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -30,6 +30,7 @@ export const useResourcesQuery = ({sort}: {sort: ValidSort}) => {
         'spm()',
         'span.group',
         'resource.render_blocking_status',
+        'span.domain',
       ],
       name: 'Resource module - resource table',
       query: queryConditions.join(' '),
@@ -53,10 +54,7 @@ export const useResourcesQuery = ({sort}: {sort: ValidSort}) => {
     'count()': row['count()'] as number,
     'spm()': row['spm()'] as number,
     'span.group': row['span.group'].toString(),
-    'resource.render_blocking_status': row['resource.render_blocking_status'] as
-      | ''
-      | 'non-blocking'
-      | 'blocking',
+    'resource.render_blocking_status': row['resource.render_blocking_status'] as string,
   }));
 
   return {...result, data: data || []};


### PR DESCRIPTION
1. Adds ability to sort in resource summary page
2. Adds the existing span sample sidebar, activated when you click on a page.
3. Add mapping between resource op and UI friendly op name
![image](https://github.com/getsentry/sentry/assets/44422760/77f78d6c-a001-4878-9031-f1953b01f4a3)
