### PR TITLE
fix(replays): don't show null for OS/Browser

### DIFF
--- a/static/app/views/replays/detail/browserOSIcons.tsx
+++ b/static/app/views/replays/detail/browserOSIcons.tsx
@@ -10,14 +10,18 @@ export default function BrowserOSIcons() {
 
   return (
     <Fragment>
-      <Tooltip title={`${replayRecord?.os.name} ${replayRecord?.os.version}`}>
+      <Tooltip title={`${replayRecord?.os.name ?? ''} ${replayRecord?.os.version ?? ''}`}>
         <ContextIcon
           name={replayRecord?.os.name ?? ''}
           version={replayRecord?.os.version ?? undefined}
           showVersion
         />
       </Tooltip>
-      <Tooltip title={`${replayRecord?.browser.name} ${replayRecord?.browser.version}`}>
+      <Tooltip
+        title={`${replayRecord?.browser.name ?? ''} ${
+          replayRecord?.browser.version ?? ''
+        }`}
+      >
         <ContextIcon
           name={replayRecord?.browser.name ?? ''}
           version={replayRecord?.browser.version ?? undefined}

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -465,7 +465,7 @@ export function OSCell({replay, showDropdownFilters}: Props) {
   return (
     <Item>
       <Container>
-        <Tooltip title={`${name} ${version}`}>
+        <Tooltip title={`${name ?? ''} ${version ?? ''}`}>
           <ContextIcon
             name={name ?? ''}
             version={version && hasRoomForColumns ? version : undefined}


### PR DESCRIPTION
Hide `null` from Replay index and details if either the name or version of OS/Browser is undefined
Closes https://github.com/getsentry/team-replay/issues/220 

Before: 
<img width="149" alt="SCR-20231012-jaeq" src="https://github.com/getsentry/sentry/assets/56095982/95029975-38ee-4728-b145-4879d32702a3">

After:
<img width="218" alt="SCR-20231012-jctu" src="https://github.com/getsentry/sentry/assets/56095982/e49bf263-81a8-46b7-ae03-bcaf854bfd24">
<img width="136" alt="SCR-20231012-jadu" src="https://github.com/getsentry/sentry/assets/56095982/f871d7bc-f337-4b0c-97e2-2190e920fed5">
