### PR TITLE
fix(notifications): hide provider option for weekly reports and fix org specific settings

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
@@ -236,11 +236,15 @@ function NotificationSettingsByEntity(props: Props) {
     <Fragment>
       <Panel>
         <StyledPanelHeader>
-          <OrganizationSelectHeader
-            organizations={organizations}
-            organizationId={orgId}
-            handleOrgChange={handleOrgChange}
-          />
+          {entityType === 'project' ? (
+            <OrganizationSelectHeader
+              organizations={organizations}
+              organizationId={orgId}
+              handleOrgChange={handleOrgChange}
+            />
+          ) : (
+            t('Settings for Organizations')
+          )}
         </StyledPanelHeader>
         <Item>
           {/* TODO: enable search for sentry projects */}

--- a/static/app/views/settings/account/notifications/notificationSettingsByTypeV2.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByTypeV2.tsx
@@ -332,14 +332,16 @@ class NotificationSettingsByTypeV2 extends DeprecatedAsyncComponent<Props, State
             fields={this.getFields()}
           />
         </Form>
-        <Form
-          saveOnBlur
-          apiMethod="PUT"
-          apiEndpoint="/users/me/notification-providers/"
-          initialData={this.getProviderInitialData()}
-        >
-          <BottomJsonForm fields={this.getProviderFields()} />
-        </Form>
+        {notificationType !== 'reports' ? (
+          <Form
+            saveOnBlur
+            apiMethod="PUT"
+            apiEndpoint="/users/me/notification-providers/"
+            initialData={this.getProviderInitialData()}
+          >
+            <BottomJsonForm fields={this.getProviderFields()} />
+          </Form>
+        ) : null}
         <NotificationSettingsByEntity
           notificationType={notificationType}
           notificationOptions={notificationOptions}


### PR DESCRIPTION
We only support the email provider for weekly reports. Also, we can hide the dropdown for organization for deploy notifications.

Before:

<img width="1009" alt="Screen Shot 2023-10-12 at 11 32 01 AM" src="https://github.com/getsentry/sentry/assets/8533851/972b7d0a-f4f0-4c07-bf71-627d022d60c4">

<img width="1018" alt="Screen Shot 2023-10-12 at 11 31 08 AM" src="https://github.com/getsentry/sentry/assets/8533851/d1540c5e-53c5-4aad-8a0d-4b863c90edae">



After:
<img width="1103" alt="Screen Shot 2023-10-12 at 11 11 01 AM" src="https://github.com/getsentry/sentry/assets/8533851/8a7411e7-c3df-4f9f-b890-d2db7330c277">



<img width="1069" alt="Screen Shot 2023-10-12 at 11 26 05 AM" src="https://github.com/getsentry/sentry/assets/8533851/d0078354-0255-467d-bbd4-cdd35dd3ae6d">
