### PR TITLE
feat(browser-starfish): add ability to query for http.response_content_length in discover

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -304,6 +304,11 @@ SPAN_METRIC_DURATION_COLUMNS = {
     for key, value in SPAN_METRICS_MAP.items()
     if value.endswith("@millisecond") and value.startswith("d:")
 }
+SPAN_METRIC_BYTES_COLUMNS = {
+    key
+    for key, value in SPAN_METRICS_MAP.items()
+    if value.endswith("@byte") and value.startswith("d:")
+}
 METRIC_PERCENTILES = {
     0.25,
     0.5,

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -280,6 +280,7 @@ SPAN_METRICS_MAP = {
     "user": "s:spans/user@none",
     "span.self_time": "d:spans/exclusive_time@millisecond",
     "span.duration": "d:spans/duration@millisecond",
+    "http.response_content_length": "d:spans/http.response_content_length@byte",
 }
 SELF_TIME_LIGHT = "d:spans/exclusive_time_light@millisecond"
 # 50 to match the size of tables in the UI + 1 for pagination reasons

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -271,6 +271,29 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     default_result_type="duration",
                 ),
                 fields.MetricsFunction(
+                    "avg",
+                    optional_args=[
+                        fields.with_default(
+                            "http.response_content_length",
+                            fields.MetricArg(
+                                "column", allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS
+                            ),
+                        ),
+                    ],
+                    calculated_args=[resolve_metric_id],
+                    snql_distribution=lambda args, alias: Function(
+                        "avgIf",
+                        [
+                            Column("value"),
+                            Function("equals", [Column("metric_id"), args["metric_id"]]),
+                        ],
+                        alias,
+                    ),
+                    is_percentile=True,
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="integer",
+                ),
+                fields.MetricsFunction(
                     "time_spent_percentage",
                     optional_args=[
                         fields.with_default(

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -141,7 +141,10 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                         fields.with_default(
                             "span.self_time",
                             fields.MetricArg(
-                                "column", allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS
+                                "column",
+                                allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS.union(
+                                    constants.SPAN_METRIC_BYTES_COLUMNS
+                                ),
                             ),
                         ),
                     ],
@@ -269,29 +272,6 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     ),
                     is_percentile=True,
                     default_result_type="duration",
-                ),
-                fields.MetricsFunction(
-                    "avg",
-                    optional_args=[
-                        fields.with_default(
-                            "http.response_content_length",
-                            fields.MetricArg(
-                                "column", allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS
-                            ),
-                        ),
-                    ],
-                    calculated_args=[resolve_metric_id],
-                    snql_distribution=lambda args, alias: Function(
-                        "avgIf",
-                        [
-                            Column("value"),
-                            Function("equals", [Column("metric_id"), args["metric_id"]]),
-                        ],
-                        alias,
-                    ),
-                    is_percentile=True,
-                    result_type_fn=self.reflective_result_type(),
-                    default_result_type="integer",
                 ),
                 fields.MetricsFunction(
                     "time_spent_percentage",

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1747,6 +1747,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         "transaction.duration": "metrics_distributions",
         "span.duration": "metrics_distributions",
         "span.self_time": "metrics_distributions",
+        "http.response_content_length": "metrics_distributions",
         "measurements.lcp": "metrics_distributions",
         "measurements.fp": "metrics_distributions",
         "measurements.fcp": "metrics_distributions",

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
@@ -4,44 +4,26 @@ import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {getDurationChartTitle} from 'sentry/views/starfish/views/spans/types';
-import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
+import {Block} from 'sentry/views/starfish/views/spanSummaryPage/block';
 
 function ResourceSummaryCharts(props: {groupId: string}) {
   const {data: spanMetricsSeriesData, isLoading: areSpanMetricsSeriesLoading} =
-    useSpanMetricsSeries(props.groupId, {}, [
-      `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
-      `avg(http.response_content_length)`,
-    ]);
+    useSpanMetricsSeries(props.groupId, {}, [`avg(${SpanMetricsField.SPAN_SELF_TIME})`]);
 
   return (
-    <BlockContainer>
-      <Block>
-        <ChartPanel title={getDurationChartTitle('http')}>
-          <Chart
-            height={160}
-            data={[spanMetricsSeriesData?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]]}
-            loading={areSpanMetricsSeriesLoading}
-            utc={false}
-            chartColors={[AVG_COLOR]}
-            isLineChart
-            definedAxisTicks={4}
-          />
-        </ChartPanel>
-      </Block>
-      <Block>
-        <ChartPanel title="Resource Size">
-          <Chart
-            height={160}
-            data={[spanMetricsSeriesData?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]]}
-            loading={areSpanMetricsSeriesLoading}
-            utc={false}
-            chartColors={[AVG_COLOR]}
-            isLineChart
-            definedAxisTicks={4}
-          />
-        </ChartPanel>
-      </Block>
-    </BlockContainer>
+    <Block>
+      <ChartPanel title={getDurationChartTitle('http')}>
+        <Chart
+          height={160}
+          data={[spanMetricsSeriesData?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]]}
+          loading={areSpanMetricsSeriesLoading}
+          utc={false}
+          chartColors={[AVG_COLOR]}
+          isLineChart
+          definedAxisTicks={4}
+        />
+      </ChartPanel>
+    </Block>
   );
 }
 

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
@@ -4,26 +4,44 @@ import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {getDurationChartTitle} from 'sentry/views/starfish/views/spans/types';
-import {Block} from 'sentry/views/starfish/views/spanSummaryPage/block';
+import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 
 function ResourceSummaryCharts(props: {groupId: string}) {
   const {data: spanMetricsSeriesData, isLoading: areSpanMetricsSeriesLoading} =
-    useSpanMetricsSeries(props.groupId, {}, [`avg(${SpanMetricsField.SPAN_SELF_TIME})`]);
+    useSpanMetricsSeries(props.groupId, {}, [
+      `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
+      `avg(http.response_content_length)`,
+    ]);
 
   return (
-    <Block>
-      <ChartPanel title={getDurationChartTitle('http')}>
-        <Chart
-          height={160}
-          data={[spanMetricsSeriesData?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]]}
-          loading={areSpanMetricsSeriesLoading}
-          utc={false}
-          chartColors={[AVG_COLOR]}
-          isLineChart
-          definedAxisTicks={4}
-        />
-      </ChartPanel>
-    </Block>
+    <BlockContainer>
+      <Block>
+        <ChartPanel title={getDurationChartTitle('http')}>
+          <Chart
+            height={160}
+            data={[spanMetricsSeriesData?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]]}
+            loading={areSpanMetricsSeriesLoading}
+            utc={false}
+            chartColors={[AVG_COLOR]}
+            isLineChart
+            definedAxisTicks={4}
+          />
+        </ChartPanel>
+      </Block>
+      <Block>
+        <ChartPanel title="Resource Size">
+          <Chart
+            height={160}
+            data={[spanMetricsSeriesData?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]]}
+            loading={areSpanMetricsSeriesLoading}
+            utc={false}
+            chartColors={[AVG_COLOR]}
+            isLineChart
+            definedAxisTicks={4}
+          />
+        </ChartPanel>
+      </Block>
+    </BlockContainer>
   );
 }
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -193,15 +193,13 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
         assert response.data["Other"]["meta"]["dataset"] == "spansMetrics"
 
     def test_resource_size(self):
-        # Each of these denotes how many events to create in each minute
-        for transaction in ["foo"]:
-            for i in range(10):
-                self.store_span_metric(
-                    4 if i > 3 else 2,
-                    metric="http.response_content_length",
-                    timestamp=self.day_ago + timedelta(minutes=i),
-                    tags={"transaction": transaction},
-                )
+        for i in range(10):
+            self.store_span_metric(
+                4 if i > 3 else 2,
+                metric="http.response_content_length",
+                timestamp=self.day_ago + timedelta(minutes=i),
+                tags={"transaction": "foo"},
+            )
 
         response = self.do_request(
             data={

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -193,18 +193,17 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
         assert response.data["Other"]["meta"]["dataset"] == "spansMetrics"
 
     def test_resource_size(self):
-        for i in range(10):
-            self.store_span_metric(
-                4 if i > 3 else 2,
-                metric="http.response_content_length",
-                timestamp=self.day_ago + timedelta(minutes=i),
-                tags={"transaction": "foo"},
-            )
+        self.store_span_metric(
+            4,
+            metric="http.response_content_length",
+            timestamp=self.day_ago + timedelta(minutes=1),
+            tags={"transaction": "foo"},
+        )
 
         response = self.do_request(
             data={
                 "start": iso_format(self.day_ago),
-                "end": iso_format(self.day_ago + timedelta(minutes=6)),
+                "end": iso_format(self.day_ago + timedelta(minutes=2)),
                 "interval": "1m",
                 "yAxis": "avg(http.response_content_length)",
                 "project": self.project.id,
@@ -215,14 +214,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
 
         data = response.data["data"]
         assert response.status_code == 200
-        assert data == [
-            (1697018400, [{"count": 2.0}]),
-            (1697018460, [{"count": 2.0}]),
-            (1697018520, [{"count": 2.0}]),
-            (1697018580, [{"count": 2.0}]),
-            (1697018640, [{"count": 4.0}]),
-            (1697018700, [{"count": 4.0}]),
-        ]
+        assert data == [(1697364000, [{"count": 0}]), (1697364060, [{"count": 4.0}])]
 
 
 class OrganizationEventsStatsSpansMetricsEndpointTestWithMetricLayer(

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -197,9 +197,9 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
         for transaction in ["foo"]:
             for i in range(10):
                 self.store_span_metric(
-                    2,
+                    4 if i > 3 else 2,
                     metric="http.response_content_length",
-                    timestamp=self.day_ago + timedelta(minutes=0.5),
+                    timestamp=self.day_ago + timedelta(minutes=i),
                     tags={"transaction": transaction},
                 )
 
@@ -216,13 +216,14 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
         )
 
         data = response.data["data"]
+        assert response.status_code == 200
         assert data == [
-            (1697018400, [{"count": 0}]),
+            (1697018400, [{"count": 2.0}]),
             (1697018460, [{"count": 2.0}]),
-            (1697018520, [{"count": 0}]),
-            (1697018580, [{"count": 0}]),
-            (1697018640, [{"count": 0}]),
-            (1697018700, [{"count": 0}]),
+            (1697018520, [{"count": 2.0}]),
+            (1697018580, [{"count": 2.0}]),
+            (1697018640, [{"count": 4.0}]),
+            (1697018700, [{"count": 4.0}]),
         ]
 
 


### PR DESCRIPTION
Now that we are ingesting http.response_content_length from resource spans see (https://github.com/getsentry/relay/pull/2578/files), we need to be able to query for its avg timeseries in discover.

fyi, i'm not entirely sure if this is all the changes needed to do so, please lmk if there's anything missed.
